### PR TITLE
feat: transfer transactions between accounts

### DIFF
--- a/backend/alembic/versions/010_transfer_transactions.py
+++ b/backend/alembic/versions/010_transfer_transactions.py
@@ -1,0 +1,47 @@
+"""Add transfer type and linked_transaction_id
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-03-31
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "010"
+down_revision: Union[str, None] = "009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Extend the enum: MySQL requires recreating the column
+    op.alter_column(
+        "transactions",
+        "type",
+        type_=sa.Enum("income", "expense", "transfer", name="transactiontype"),
+        existing_nullable=False,
+    )
+    op.add_column(
+        "transactions",
+        sa.Column(
+            "linked_transaction_id",
+            sa.Integer(),
+            sa.ForeignKey("transactions.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_transactions_linked", "transactions", ["linked_transaction_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_transactions_linked")
+    op.drop_column("transactions", "linked_transaction_id")
+    op.alter_column(
+        "transactions",
+        "type",
+        type_=sa.Enum("income", "expense", name="transactiontype"),
+        existing_nullable=False,
+    )

--- a/backend/alembic/versions/010_transfer_transactions.py
+++ b/backend/alembic/versions/010_transfer_transactions.py
@@ -22,6 +22,7 @@ def upgrade() -> None:
         "transactions",
         "type",
         type_=sa.Enum("income", "expense", "transfer", name="transactiontype"),
+        existing_type=sa.Enum("income", "expense", name="transactiontype"),
         existing_nullable=False,
     )
     op.add_column(
@@ -43,5 +44,6 @@ def downgrade() -> None:
         "transactions",
         "type",
         type_=sa.Enum("income", "expense", name="transactiontype"),
+        existing_type=sa.Enum("income", "expense", "transfer", name="transactiontype"),
         existing_nullable=False,
     )

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -1,6 +1,7 @@
 import enum
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Optional
 
 from sqlalchemy import (
     Date,
@@ -20,6 +21,7 @@ from app.models.base import Base
 class TransactionType(str, enum.Enum):
     INCOME = "income"
     EXPENSE = "expense"
+    TRANSFER = "transfer"
 
 
 class TransactionStatus(str, enum.Enum):
@@ -51,6 +53,9 @@ class Transaction(Base):
         nullable=False,
         default=TransactionStatus.SETTLED,
     )
+    linked_transaction_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("transactions.id", ondelete="SET NULL"), nullable=True
+    )
     date: Mapped[date] = mapped_column(Date, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
@@ -61,3 +66,6 @@ class Transaction(Base):
 
     account: Mapped["Account"] = relationship()
     category: Mapped["Category"] = relationship(back_populates="transactions")
+    linked_transaction: Mapped[Optional["Transaction"]] = relationship(
+        foreign_keys=[linked_transaction_id], remote_side="Transaction.id"
+    )

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -11,6 +11,7 @@ from app.schemas.transaction import (
     TransactionCreate,
     TransactionResponse,
     TransactionUpdate,
+    TransferCreate,
 )
 from app.services import transaction_service as svc
 
@@ -52,6 +53,16 @@ async def create_transaction(
 ):
     tx = await svc.create_transaction(db, current_user.org_id, body)
     return svc.to_response(tx)
+
+
+@router.post("/transfer", response_model=list[TransactionResponse], status_code=201)
+async def create_transfer(
+    body: TransferCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    tx1, tx2 = await svc.create_transfer(db, current_user.org_id, body)
+    return [svc.to_response(tx1), svc.to_response(tx2)]
 
 
 @router.get("/{transaction_id}", response_model=TransactionResponse)

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -43,7 +43,7 @@ class TransactionResponse(BaseModel):
     category_name: str = ""
     description: str
     amount: Decimal
-    type: Literal["income", "expense", "transfer"]
+    type: Literal["income", "expense"]
     status: Literal["settled", "pending"]
     linked_transaction_id: Optional[int] = None
     date: datetime.date

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -15,6 +15,16 @@ class TransactionCreate(BaseModel):
     date: datetime.date
 
 
+class TransferCreate(BaseModel):
+    from_account_id: int
+    to_account_id: int
+    category_id: int
+    description: str
+    amount: Decimal = Field(gt=0)
+    status: Literal["settled", "pending"] = "settled"
+    date: datetime.date
+
+
 class TransactionUpdate(BaseModel):
     account_id: Optional[int] = None
     category_id: Optional[int] = None
@@ -33,8 +43,9 @@ class TransactionResponse(BaseModel):
     category_name: str = ""
     description: str
     amount: Decimal
-    type: Literal["income", "expense"]
+    type: Literal["income", "expense", "transfer"]
     status: Literal["settled", "pending"]
+    linked_transaction_id: Optional[int] = None
     date: datetime.date
 
     model_config = {"from_attributes": True}

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -95,6 +95,8 @@ async def assert_no_dependents(
 # ── Balance logic ─────────────────────────────────────────────────────────────
 
 def apply_balance(account: Account, amount: Decimal, tx_type: TransactionType) -> None:
+    if tx_type == TransactionType.TRANSFER:
+        raise ValidationError("Cannot apply balance for TRANSFER type directly")
     if tx_type == TransactionType.INCOME:
         account.balance += amount
     else:
@@ -102,6 +104,8 @@ def apply_balance(account: Account, amount: Decimal, tx_type: TransactionType) -
 
 
 def revert_balance(account: Account, amount: Decimal, tx_type: TransactionType) -> None:
+    if tx_type == TransactionType.TRANSFER:
+        raise ValidationError("Cannot revert balance for TRANSFER type directly")
     if tx_type == TransactionType.INCOME:
         account.balance -= amount
     else:
@@ -154,6 +158,9 @@ async def update_transaction(
     tx = result.scalar_one_or_none()
     if tx is None:
         raise NotFoundError("Transaction")
+
+    if tx.linked_transaction_id is not None:
+        raise ConflictError("Cannot edit a transfer transaction. Delete and recreate it instead.")
 
     # Validate references regardless of status
     if body.account_id is not None and body.account_id != tx.account_id:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import selectinload
 from app.models.account import Account
 from app.models.category import Category
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
-from app.schemas.transaction import TransactionCreate, TransactionResponse, TransactionUpdate
+from app.schemas.transaction import TransactionCreate, TransactionResponse, TransactionUpdate, TransferCreate
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 
@@ -41,6 +41,7 @@ def to_response(tx: Transaction) -> TransactionResponse:
         amount=tx.amount,
         type=tx.type.value,
         status=tx.status.value,
+        linked_transaction_id=tx.linked_transaction_id,
         date=tx.date,
     )
 
@@ -224,13 +225,92 @@ async def delete_transaction(db: AsyncSession, org_id: int, transaction_id: int)
     if tx is None:
         raise NotFoundError("Transaction")
 
+    # Collect linked transaction (transfer pair) if any
+    linked_tx = None
+    if tx.linked_transaction_id:
+        linked_result = await db.execute(
+            select(Transaction).where(
+                Transaction.id == tx.linked_transaction_id, Transaction.org_id == org_id
+            )
+        )
+        linked_tx = linked_result.scalar_one_or_none()
+
     async with db.begin_nested():
         if tx.status == TransactionStatus.SETTLED:
             acct = await get_account_for_update(db, tx.account_id, org_id)
             revert_balance(acct, tx.amount, tx.type)
+
+        if linked_tx:
+            if linked_tx.status == TransactionStatus.SETTLED:
+                linked_acct = await get_account_for_update(db, linked_tx.account_id, org_id)
+                revert_balance(linked_acct, linked_tx.amount, linked_tx.type)
+            await db.delete(linked_tx)
+
         await db.delete(tx)
 
     await db.commit()
+
+
+async def create_transfer(
+    db: AsyncSession, org_id: int, body: TransferCreate
+) -> tuple[Transaction, Transaction]:
+    """Create a linked pair of transactions for a transfer between accounts."""
+    if body.from_account_id == body.to_account_id:
+        raise ValidationError("Source and destination accounts must be different")
+
+    await validate_account(db, body.from_account_id, org_id)
+    await validate_account(db, body.to_account_id, org_id)
+    await validate_category(db, body.category_id, org_id)
+
+    tx_status = TransactionStatus(body.status)
+
+    async with db.begin_nested():
+        # Expense on source account
+        expense_tx = Transaction(
+            org_id=org_id,
+            account_id=body.from_account_id,
+            category_id=body.category_id,
+            description=body.description,
+            amount=body.amount,
+            type=TransactionType.TRANSFER,
+            status=tx_status,
+            date=body.date,
+        )
+        # Income on destination account
+        income_tx = Transaction(
+            org_id=org_id,
+            account_id=body.to_account_id,
+            category_id=body.category_id,
+            description=body.description,
+            amount=body.amount,
+            type=TransactionType.TRANSFER,
+            status=tx_status,
+            date=body.date,
+        )
+        db.add(expense_tx)
+        db.add(income_tx)
+        await db.flush()
+
+        # Link them
+        expense_tx.linked_transaction_id = income_tx.id
+        income_tx.linked_transaction_id = expense_tx.id
+
+        # Apply balance if settled
+        if tx_status == TransactionStatus.SETTLED:
+            from_acct = await get_account_for_update(db, body.from_account_id, org_id)
+            to_acct = await get_account_for_update(db, body.to_account_id, org_id)
+            from_acct.balance -= body.amount
+            to_acct.balance += body.amount
+
+    await db.commit()
+
+    result = await db.execute(
+        select(Transaction).options(*_load_opts()).where(
+            Transaction.id.in_([expense_tx.id, income_tx.id])
+        )
+    )
+    txns = list(result.scalars().all())
+    return txns[0], txns[1]
 
 
 async def get_transaction(db: AsyncSession, org_id: int, transaction_id: int) -> Transaction:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -236,16 +236,21 @@ async def delete_transaction(db: AsyncSession, org_id: int, transaction_id: int)
         linked_tx = linked_result.scalar_one_or_none()
 
     async with db.begin_nested():
-        if tx.status == TransactionStatus.SETTLED:
+        # For transfers, lock both accounts in deterministic order
+        if linked_tx and tx.status == TransactionStatus.SETTLED:
+            first_id, second_id = sorted([tx.account_id, linked_tx.account_id])
+            first = await get_account_for_update(db, first_id, org_id)
+            second = await get_account_for_update(db, second_id, org_id)
+            tx_acct = first if tx.account_id == first_id else second
+            linked_acct = first if linked_tx.account_id == first_id else second
+            revert_balance(tx_acct, tx.amount, tx.type)
+            revert_balance(linked_acct, linked_tx.amount, linked_tx.type)
+        elif tx.status == TransactionStatus.SETTLED:
             acct = await get_account_for_update(db, tx.account_id, org_id)
             revert_balance(acct, tx.amount, tx.type)
 
         if linked_tx:
-            if linked_tx.status == TransactionStatus.SETTLED:
-                linked_acct = await get_account_for_update(db, linked_tx.account_id, org_id)
-                revert_balance(linked_acct, linked_tx.amount, linked_tx.type)
             await db.delete(linked_tx)
-
         await db.delete(tx)
 
     await db.commit()
@@ -265,25 +270,26 @@ async def create_transfer(
     tx_status = TransactionStatus(body.status)
 
     async with db.begin_nested():
-        # Expense on source account
+        # Expense side (source account) — uses EXPENSE type so existing
+        # balance logic (apply/revert) works unchanged
         expense_tx = Transaction(
             org_id=org_id,
             account_id=body.from_account_id,
             category_id=body.category_id,
             description=body.description,
             amount=body.amount,
-            type=TransactionType.TRANSFER,
+            type=TransactionType.EXPENSE,
             status=tx_status,
             date=body.date,
         )
-        # Income on destination account
+        # Income side (destination account)
         income_tx = Transaction(
             org_id=org_id,
             account_id=body.to_account_id,
             category_id=body.category_id,
             description=body.description,
             amount=body.amount,
-            type=TransactionType.TRANSFER,
+            type=TransactionType.INCOME,
             status=tx_status,
             date=body.date,
         )
@@ -291,14 +297,15 @@ async def create_transfer(
         db.add(income_tx)
         await db.flush()
 
-        # Link them
         expense_tx.linked_transaction_id = income_tx.id
         income_tx.linked_transaction_id = expense_tx.id
 
-        # Apply balance if settled
         if tx_status == TransactionStatus.SETTLED:
-            from_acct = await get_account_for_update(db, body.from_account_id, org_id)
-            to_acct = await get_account_for_update(db, body.to_account_id, org_id)
+            first_id, second_id = sorted([body.from_account_id, body.to_account_id])
+            first = await get_account_for_update(db, first_id, org_id)
+            second = await get_account_for_update(db, second_id, org_id)
+            from_acct = first if body.from_account_id == first_id else second
+            to_acct = first if body.to_account_id == first_id else second
             from_acct.balance -= body.amount
             to_acct.balance += body.amount
 
@@ -307,10 +314,10 @@ async def create_transfer(
     result = await db.execute(
         select(Transaction).options(*_load_opts()).where(
             Transaction.id.in_([expense_tx.id, income_tx.id])
-        )
+        ).order_by(Transaction.id)
     )
-    txns = list(result.scalars().all())
-    return txns[0], txns[1]
+    tx_by_id = {tx.id: tx for tx in result.scalars().all()}
+    return tx_by_id[expense_tx.id], tx_by_id[income_tx.id]
 
 
 async def get_transaction(db: AsyncSession, org_id: int, transaction_id: int) -> Transaction:

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -149,6 +149,7 @@ export default function DashboardPage() {
     setFormStatus(acct?.account_type_slug === "credit_card" ? "pending" : "settled");
   }
 
+  // Total balance by currency (settled only — what's in the accounts)
   const balanceByCurrency = activeAccounts.reduce<Record<string, number>>(
     (acc, a) => {
       const cur = a.currency || "EUR";
@@ -158,6 +159,18 @@ export default function DashboardPage() {
     {}
   );
   const currencies = Object.entries(balanceByCurrency);
+
+  // Accounts with balance != 0 for individual tiles
+  const accountsWithBalance = activeAccounts.filter((a) => Number(a.balance) !== 0);
+
+  // Pending totals per account from current-month transactions
+  const pendingByAccount = transactions
+    .filter((tx) => tx.status === "pending")
+    .reduce<Record<number, number>>((acc, tx) => {
+      const sign = tx.type === "income" ? 1 : -1;
+      acc[tx.account_id] = (acc[tx.account_id] || 0) + Number(tx.amount) * sign;
+      return acc;
+    }, {});
 
   return (
     <AppShell>
@@ -241,18 +254,48 @@ export default function DashboardPage() {
             </div>
           )}
 
-          {/* Balance cards */}
+          {/* Total balance */}
           {currencies.length > 0 && (
             <div className="flex gap-4">
               {currencies.map(([currency, total]) => (
                 <div key={currency} className={`flex-1 ${card} p-6`}>
-                  <p className={cardTitle}>Balance</p>
+                  <p className={cardTitle}>Total Balance</p>
                   <p className="mt-2 font-display text-3xl text-accent">
                     {formatAmount(total)}
                     <span className="ml-2 text-lg text-text-muted">{currency}</span>
                   </p>
                 </div>
               ))}
+            </div>
+          )}
+
+          {/* Per-account tiles */}
+          {accountsWithBalance.length > 0 && (
+            <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+              {accountsWithBalance.map((acct) => {
+                const pending = pendingByAccount[acct.id] || 0;
+                const isCreditCard = acct.account_type_slug === "credit_card";
+                return (
+                  <div key={acct.id} className={`${card} p-4`}>
+                    <p className="text-xs font-medium text-text-muted truncate">{acct.name}</p>
+                    <p className="text-[11px] text-text-muted">{acct.account_type_name}</p>
+                    <p className="mt-1.5 text-lg font-semibold tabular-nums text-text-primary">
+                      {formatAmount(acct.balance)} <span className="text-xs text-text-muted">{acct.currency}</span>
+                    </p>
+                    {pending !== 0 && (
+                      <p className={`mt-0.5 text-xs tabular-nums ${isCreditCard ? "text-danger" : "text-text-muted"}`}>
+                        {isCreditCard ? "Pending charges: " : "Pending: "}
+                        {formatAmount(Math.abs(pending))}
+                      </p>
+                    )}
+                    {isCreditCard && pending !== 0 && (
+                      <p className="mt-0.5 text-xs tabular-nums text-text-secondary">
+                        Net: {formatAmount(Number(acct.balance) + pending)}
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           )}
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -145,6 +145,7 @@ export default function DashboardPage() {
 
   function handleAccountChange(id: number | "") {
     setFormAccountId(id);
+    if (formToAccountId === id) setFormToAccountId("");
     const acct = accounts.find((a) => a.id === id);
     setFormStatus(acct?.account_type_slug === "credit_card" ? "pending" : "settled");
   }
@@ -162,6 +163,9 @@ export default function DashboardPage() {
 
   // Accounts with balance != 0 for individual tiles
   const accountsWithBalance = activeAccounts.filter((a) => Number(a.balance) !== 0);
+
+  // Precompute tx map for O(1) linked lookups
+  const txMap = new Map(transactions.map((tx) => [tx.id, tx]));
 
   // Pending totals per account from current-month transactions
   const pendingByAccount = transactions
@@ -309,19 +313,16 @@ export default function DashboardPage() {
             </div>
             <div className="divide-y divide-border-subtle">
               {(() => {
-                // Deduplicate transfers: keep only one side, find the linked one for display
-                const seenLinked = new Set<number>();
-                return transactions.filter((tx) => {
-                  if (tx.type === "transfer" && tx.linked_transaction_id) {
-                    if (seenLinked.has(tx.id)) return false;
-                    seenLinked.add(tx.linked_transaction_id);
+                // Deduplicate transfers: keep the expense side (lower id for stability)
+                const hiddenIds = new Set<number>();
+                for (const tx of transactions) {
+                  if (tx.linked_transaction_id && tx.id > tx.linked_transaction_id) {
+                    hiddenIds.add(tx.id);
                   }
-                  return true;
-                }).map((tx) => {
-                  // For transfers, find the other side to show "From → To"
-                  const linkedTx = tx.type === "transfer" && tx.linked_transaction_id
-                    ? transactions.find((t) => t.id === tx.linked_transaction_id)
-                    : null;
+                }
+                return transactions.filter((tx) => !hiddenIds.has(tx.id)).map((tx) => {
+                  const isTransfer = tx.linked_transaction_id !== null;
+                  const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
 
                   return (
                     <div key={tx.id} className="flex items-center justify-between px-6 py-3">
@@ -330,7 +331,7 @@ export default function DashboardPage() {
                         <div>
                           <p className="text-sm text-text-primary">{tx.description}</p>
                           <p className="text-xs text-text-muted">
-                            {tx.type === "transfer" && linkedTx
+                            {isTransfer && linkedTx
                               ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
                               : <>{tx.account_name} · {tx.category_name}</>
                             }
@@ -343,9 +344,9 @@ export default function DashboardPage() {
                         </div>
                       </div>
                       <div className="flex items-center gap-3">
-                        <span className={`text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
-                          {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
-                          {tx.type === "transfer" && <span className="ml-1 text-xs text-text-muted">transfer</span>}
+                        <span className={`text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
+                          {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
+                          {isTransfer && <span className="ml-1 text-xs text-text-muted">transfer</span>}
                         </span>
                         <button
                           onClick={async () => { try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "PUT", body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }) }); await Promise.all([loadRefs(), loadTransactions(page)]); } catch (err) { setError(extractErrorMessage(err)); } }}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -247,8 +247,9 @@ export default function DashboardPage() {
                       </p>
                     </div>
                   </div>
-                  <span className={`text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : "text-danger"}`}>
-                    {tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
+                  <span className={`text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
+                    {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
+                    {tx.type === "transfer" && <span className="ml-1 text-xs text-text-muted">transfer</span>}
                   </span>
                 </div>
               ))}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -42,7 +42,9 @@ export default function DashboardPage() {
 
   // Quick-add form
   const [showForm, setShowForm] = useState(false);
+  const [formMode, setFormMode] = useState<"transaction" | "transfer">("transaction");
   const [formAccountId, setFormAccountId] = useState<number | "">("");
+  const [formToAccountId, setFormToAccountId] = useState<number | "">("");
   const [formCategoryId, setFormCategoryId] = useState<number | "">("");
   const [formDescription, setFormDescription] = useState("");
   const [formAmount, setFormAmount] = useState("");
@@ -89,22 +91,38 @@ export default function DashboardPage() {
     e.preventDefault();
     setError("");
     try {
-      await apiFetch("/api/v1/transactions", {
-        method: "POST",
-        body: JSON.stringify({
-          account_id: formAccountId,
-          category_id: formCategoryId,
-          description: formDescription,
-          amount: formAmount,
-          type: formType,
-          status: formStatus,
-          date: formDate,
-        }),
-      });
+      if (formMode === "transfer") {
+        await apiFetch("/api/v1/transactions/transfer", {
+          method: "POST",
+          body: JSON.stringify({
+            from_account_id: formAccountId,
+            to_account_id: formToAccountId,
+            category_id: formCategoryId,
+            description: formDescription,
+            amount: formAmount,
+            status: formStatus,
+            date: formDate,
+          }),
+        });
+      } else {
+        await apiFetch("/api/v1/transactions", {
+          method: "POST",
+          body: JSON.stringify({
+            account_id: formAccountId,
+            category_id: formCategoryId,
+            description: formDescription,
+            amount: formAmount,
+            type: formType,
+            status: formStatus,
+            date: formDate,
+          }),
+        });
+      }
       setFormDescription("");
       setFormAmount("");
       setFormType("expense");
       setFormStatus("settled");
+      setFormToAccountId("");
       setFormDate(todayISO());
       setShowForm(false);
       await Promise.all([loadRefs(), loadTransactions(page)]);
@@ -161,25 +179,41 @@ export default function DashboardPage() {
           {/* Quick-add form */}
           {showForm && (
             <div className={`${card} p-6`}>
-              <h2 className={`mb-4 ${cardTitle}`}>New Transaction</h2>
+              <div className="mb-4 flex items-center gap-4">
+                <h2 className={cardTitle}>{formMode === "transfer" ? "Quick Transfer" : "Quick Add"}</h2>
+                <div className="flex rounded-md border border-border text-xs">
+                  <button type="button" onClick={() => setFormMode("transaction")} className={`px-3 py-1 rounded-l-md ${formMode === "transaction" ? "bg-accent text-accent-text" : "text-text-muted hover:bg-surface-raised"}`}>Transaction</button>
+                  <button type="button" onClick={() => setFormMode("transfer")} className={`px-3 py-1 rounded-r-md ${formMode === "transfer" ? "bg-accent text-accent-text" : "text-text-muted hover:bg-surface-raised"}`}>Transfer</button>
+                </div>
+              </div>
               <form onSubmit={handleQuickAdd} className="grid grid-cols-2 gap-4 lg:grid-cols-4">
                 <div>
-                  <label htmlFor="da-account" className={label}>Account</label>
+                  <label htmlFor="da-account" className={label}>{formMode === "transfer" ? "From Account" : "Account"}</label>
                   <select id="da-account" required value={formAccountId} onChange={(e) => handleAccountChange(e.target.value === "" ? "" : Number(e.target.value))} className={input}>
                     <option value="">Select account</option>
                     {activeAccounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
                   </select>
                 </div>
-                <div>
-                  <label htmlFor="da-type" className={label}>Type</label>
-                  <select id="da-type" value={formType} onChange={(e) => handleTypeChange(e.target.value as "income" | "expense")} className={input}>
-                    <option value="expense">Expense</option>
-                    <option value="income">Income</option>
-                  </select>
-                </div>
+                {formMode === "transfer" ? (
+                  <div>
+                    <label htmlFor="da-to-account" className={label}>To Account</label>
+                    <select id="da-to-account" required value={formToAccountId} onChange={(e) => setFormToAccountId(e.target.value === "" ? "" : Number(e.target.value))} className={input}>
+                      <option value="">Select account</option>
+                      {activeAccounts.filter((a) => a.id !== formAccountId).map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+                    </select>
+                  </div>
+                ) : (
+                  <div>
+                    <label htmlFor="da-type" className={label}>Type</label>
+                    <select id="da-type" value={formType} onChange={(e) => handleTypeChange(e.target.value as "income" | "expense")} className={input}>
+                      <option value="expense">Expense</option>
+                      <option value="income">Income</option>
+                    </select>
+                  </div>
+                )}
                 <div>
                   <label htmlFor="da-category" className={label}>Category</label>
-                  <CategorySelect id="da-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+                  <CategorySelect id="da-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formMode === "transfer" ? "expense" : formType} className={input} />
                 </div>
                 <div>
                   <label htmlFor="da-desc" className={label}>Description</label>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -342,10 +342,26 @@ export default function DashboardPage() {
                           </p>
                         </div>
                       </div>
-                      <span className={`text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
-                        {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
-                        {tx.type === "transfer" && <span className="ml-1 text-xs text-text-muted">transfer</span>}
-                      </span>
+                      <div className="flex items-center gap-3">
+                        <span className={`text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
+                          {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
+                          {tx.type === "transfer" && <span className="ml-1 text-xs text-text-muted">transfer</span>}
+                        </span>
+                        <button
+                          onClick={async () => { try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "PUT", body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }) }); await Promise.all([loadRefs(), loadTransactions(page)]); } catch (err) { setError(extractErrorMessage(err)); } }}
+                          aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}
+                        >
+                          {tx.status}
+                        </button>
+                        <button
+                          onClick={async () => { if (!confirm("Delete this transaction?")) return; try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "DELETE" }); await Promise.all([loadRefs(), loadTransactions(page)]); } catch (err) { setError(extractErrorMessage(err)); } }}
+                          aria-label={`Delete: ${tx.description}`}
+                          className="text-xs text-text-muted hover:text-danger"
+                        >
+                          Delete
+                        </button>
+                      </div>
                     </div>
                   );
                 });

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -348,13 +348,15 @@ export default function DashboardPage() {
                           {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                           {isTransfer && <span className="ml-1 text-xs text-text-muted">transfer</span>}
                         </span>
-                        <button
-                          onClick={async () => { try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "PUT", body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }) }); await Promise.all([loadRefs(), loadTransactions(page)]); } catch (err) { setError(extractErrorMessage(err)); } }}
-                          aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
-                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}
-                        >
-                          {tx.status}
-                        </button>
+                        {!isTransfer && (
+                          <button
+                            onClick={async () => { try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "PUT", body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }) }); await Promise.all([loadRefs(), loadTransactions(page)]); } catch (err) { setError(extractErrorMessage(err)); } }}
+                            aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
+                            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}
+                          >
+                            {tx.status}
+                          </button>
+                        )}
                         <button
                           onClick={async () => { if (!confirm("Delete this transaction?")) return; try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "DELETE" }); await Promise.all([loadRefs(), loadTransactions(page)]); } catch (err) { setError(extractErrorMessage(err)); } }}
                           aria-label={`Delete: ${tx.description}`}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -308,28 +308,48 @@ export default function DashboardPage() {
               </Link>
             </div>
             <div className="divide-y divide-border-subtle">
-              {transactions.map((tx) => (
-                <div key={tx.id} className="flex items-center justify-between px-6 py-3">
-                  <div className="flex items-center gap-4">
-                    <span className="text-sm tabular-nums text-text-muted w-20">{tx.date}</span>
-                    <div>
-                      <p className="text-sm text-text-primary">{tx.description}</p>
-                      <p className="text-xs text-text-muted">
-                        {tx.account_name} · {tx.category_name}
-                        {tx.status === "pending" && (
-                          <span className="ml-1.5 rounded bg-surface-overlay px-1.5 py-0.5 text-[10px] font-medium text-text-muted">
-                            pending
-                          </span>
-                        )}
-                      </p>
+              {(() => {
+                // Deduplicate transfers: keep only one side, find the linked one for display
+                const seenLinked = new Set<number>();
+                return transactions.filter((tx) => {
+                  if (tx.type === "transfer" && tx.linked_transaction_id) {
+                    if (seenLinked.has(tx.id)) return false;
+                    seenLinked.add(tx.linked_transaction_id);
+                  }
+                  return true;
+                }).map((tx) => {
+                  // For transfers, find the other side to show "From → To"
+                  const linkedTx = tx.type === "transfer" && tx.linked_transaction_id
+                    ? transactions.find((t) => t.id === tx.linked_transaction_id)
+                    : null;
+
+                  return (
+                    <div key={tx.id} className="flex items-center justify-between px-6 py-3">
+                      <div className="flex items-center gap-4">
+                        <span className="text-sm tabular-nums text-text-muted w-20">{tx.date}</span>
+                        <div>
+                          <p className="text-sm text-text-primary">{tx.description}</p>
+                          <p className="text-xs text-text-muted">
+                            {tx.type === "transfer" && linkedTx
+                              ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
+                              : <>{tx.account_name} · {tx.category_name}</>
+                            }
+                            {tx.status === "pending" && (
+                              <span className="ml-1.5 rounded bg-surface-overlay px-1.5 py-0.5 text-[10px] font-medium text-text-muted">
+                                pending
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                      </div>
+                      <span className={`text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
+                        {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
+                        {tx.type === "transfer" && <span className="ml-1 text-xs text-text-muted">transfer</span>}
+                      </span>
                     </div>
-                  </div>
-                  <span className={`text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
-                    {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
-                    {tx.type === "transfer" && <span className="ml-1 text-xs text-text-muted">transfer</span>}
-                  </span>
-                </div>
-              ))}
+                  );
+                });
+              })()}
               {transactions.length === 0 && (
                 <div className="px-6 py-8 text-center text-sm text-text-muted">
                   {!canAdd

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -42,7 +42,9 @@ export default function TransactionsPage() {
   const [filterDateTo, setFilterDateTo] = useState("");
 
   // Form
+  const [formMode, setFormMode] = useState<"transaction" | "transfer">("transaction");
   const [formAccountId, setFormAccountId] = useState<number | "">("");
+  const [formToAccountId, setFormToAccountId] = useState<number | "">("");
   const [formCategoryId, setFormCategoryId] = useState<number | "">("");
   const [formDescription, setFormDescription] = useState("");
   const [formAmount, setFormAmount] = useState("");
@@ -95,22 +97,38 @@ export default function TransactionsPage() {
     e.preventDefault();
     setError("");
     try {
-      await apiFetch("/api/v1/transactions", {
-        method: "POST",
-        body: JSON.stringify({
-          account_id: formAccountId,
-          category_id: formCategoryId,
-          description: formDescription,
-          amount: formAmount,
-          type: formType,
-          status: formStatus,
-          date: formDate,
-        }),
-      });
+      if (formMode === "transfer") {
+        await apiFetch("/api/v1/transactions/transfer", {
+          method: "POST",
+          body: JSON.stringify({
+            from_account_id: formAccountId,
+            to_account_id: formToAccountId,
+            category_id: formCategoryId,
+            description: formDescription,
+            amount: formAmount,
+            status: formStatus,
+            date: formDate,
+          }),
+        });
+      } else {
+        await apiFetch("/api/v1/transactions", {
+          method: "POST",
+          body: JSON.stringify({
+            account_id: formAccountId,
+            category_id: formCategoryId,
+            description: formDescription,
+            amount: formAmount,
+            type: formType,
+            status: formStatus,
+            date: formDate,
+          }),
+        });
+      }
       setFormDescription("");
       setFormAmount("");
       setFormType("expense");
       setFormStatus("settled");
+      setFormToAccountId("");
       setFormDate(todayISO());
       setShowForm(false);
       await loadTransactions(page);
@@ -209,25 +227,41 @@ export default function TransactionsPage() {
 
       {showForm && (
         <div className={`mb-6 ${card} p-6`}>
-          <h2 className={`mb-4 ${cardTitle}`}>New Transaction</h2>
+          <div className="mb-4 flex items-center gap-4">
+            <h2 className={cardTitle}>{formMode === "transfer" ? "New Transfer" : "New Transaction"}</h2>
+            <div className="flex rounded-md border border-border text-xs">
+              <button type="button" onClick={() => setFormMode("transaction")} className={`px-3 py-1 rounded-l-md ${formMode === "transaction" ? "bg-accent text-accent-text" : "text-text-muted hover:bg-surface-raised"}`}>Transaction</button>
+              <button type="button" onClick={() => setFormMode("transfer")} className={`px-3 py-1 rounded-r-md ${formMode === "transfer" ? "bg-accent text-accent-text" : "text-text-muted hover:bg-surface-raised"}`}>Transfer</button>
+            </div>
+          </div>
           <form onSubmit={handleAdd} className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div>
-              <label htmlFor="tx-account" className={label}>Account</label>
+              <label htmlFor="tx-account" className={label}>{formMode === "transfer" ? "From Account" : "Account"}</label>
               <select id="tx-account" required value={formAccountId} onChange={(e) => handleAccountChange(e.target.value === "" ? "" : Number(e.target.value))} className={input}>
                 <option value="">Select account</option>
                 {activeAccounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
               </select>
             </div>
-            <div>
-              <label htmlFor="tx-type" className={label}>Type</label>
-              <select id="tx-type" value={formType} onChange={(e) => handleTypeChange(e.target.value as "income" | "expense")} className={input}>
-                <option value="expense">Expense</option>
-                <option value="income">Income</option>
-              </select>
-            </div>
+            {formMode === "transfer" ? (
+              <div>
+                <label htmlFor="tx-to-account" className={label}>To Account</label>
+                <select id="tx-to-account" required value={formToAccountId} onChange={(e) => setFormToAccountId(e.target.value === "" ? "" : Number(e.target.value))} className={input}>
+                  <option value="">Select account</option>
+                  {activeAccounts.filter((a) => a.id !== formAccountId).map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+                </select>
+              </div>
+            ) : (
+              <div>
+                <label htmlFor="tx-type" className={label}>Type</label>
+                <select id="tx-type" value={formType} onChange={(e) => handleTypeChange(e.target.value as "income" | "expense")} className={input}>
+                  <option value="expense">Expense</option>
+                  <option value="income">Income</option>
+                </select>
+              </div>
+            )}
             <div>
               <label htmlFor="tx-category" className={label}>Category</label>
-              <CategorySelect id="tx-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+              <CategorySelect id="tx-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formMode === "transfer" ? "expense" : formType} className={input} />
             </div>
             <div>
               <label htmlFor="tx-desc" className={label}>Description</label>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -348,8 +348,20 @@ export default function TransactionsPage() {
               </div>
             </div>
             <div className="divide-y divide-border-subtle">
-              {transactions.map((tx) =>
-                editingId === tx.id ? (
+              {(() => {
+                // Deduplicate transfers: keep one side, find linked for display
+                const seenLinked = new Set<number>();
+                return transactions.filter((tx) => {
+                  if (tx.type === "transfer" && tx.linked_transaction_id) {
+                    if (seenLinked.has(tx.id)) return false;
+                    seenLinked.add(tx.linked_transaction_id);
+                  }
+                  return true;
+                }).map((tx) => {
+                const linkedTx = tx.type === "transfer" && tx.linked_transaction_id
+                  ? transactions.find((t) => t.id === tx.linked_transaction_id)
+                  : null;
+                return editingId === tx.id ? (
                   <div key={tx.id} className="grid grid-cols-12 items-center gap-2 px-6 py-2 bg-surface-raised">
                     <span className="col-span-2"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} /></span>
                     <span className="col-span-2"><input aria-label="Description" type="text" value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
@@ -383,7 +395,11 @@ export default function TransactionsPage() {
                   <div key={tx.id} className={`grid grid-cols-12 items-center gap-4 px-6 py-3 transition-colors hover:bg-surface-raised ${tx.status === "pending" ? "opacity-60" : ""}`}>
                     <span className="col-span-2 text-sm tabular-nums text-text-secondary">{tx.date}</span>
                     <span className="col-span-3 text-sm text-text-primary">{tx.description}</span>
-                    <span className="col-span-2 text-sm text-text-secondary">{tx.account_name}</span>
+                    <span className="col-span-2 text-sm text-text-secondary">
+                      {tx.type === "transfer" && linkedTx
+                        ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
+                        : tx.account_name}
+                    </span>
                     <span className="col-span-2 text-sm text-text-secondary">{tx.category_name}</span>
                     <span className="col-span-1 text-center">
                       <button
@@ -398,16 +414,17 @@ export default function TransactionsPage() {
                         {tx.status}
                       </button>
                     </span>
-                    <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : "text-danger"}`}>
-                      {tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
+                    <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
+                      {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
                     </span>
                     <span className="col-span-1 flex justify-end gap-2">
-                      <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>
+                      {tx.type !== "transfer" && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>}
                       <button onClick={() => handleDelete(tx.id)} aria-label={`Delete: ${tx.description}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                     </span>
                   </div>
-                )
-              )}
+                );
+                });
+              })()}
               {transactions.length === 0 && (
                 <div className="px-6 py-8 text-center text-sm text-text-muted">
                   {activeAccounts.length === 0

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -208,6 +208,7 @@ export default function TransactionsPage() {
 
   function handleAccountChange(id: number | "") {
     setFormAccountId(id);
+    if (formToAccountId === id) setFormToAccountId("");
     const acct = accounts.find((a) => a.id === id);
     setFormStatus(acct?.account_type_slug === "credit_card" ? "pending" : "settled");
   }
@@ -349,18 +350,18 @@ export default function TransactionsPage() {
             </div>
             <div className="divide-y divide-border-subtle">
               {(() => {
-                // Deduplicate transfers: keep one side, find linked for display
-                const seenLinked = new Set<number>();
-                return transactions.filter((tx) => {
-                  if (tx.type === "transfer" && tx.linked_transaction_id) {
-                    if (seenLinked.has(tx.id)) return false;
-                    seenLinked.add(tx.linked_transaction_id);
+                // Precompute tx map for O(1) lookups
+                const txMap = new Map(transactions.map((t) => [t.id, t]));
+                // Deduplicate transfers: keep the lower id (expense side)
+                const hiddenIds = new Set<number>();
+                for (const t of transactions) {
+                  if (t.linked_transaction_id && t.id > t.linked_transaction_id) {
+                    hiddenIds.add(t.id);
                   }
-                  return true;
-                }).map((tx) => {
-                const linkedTx = tx.type === "transfer" && tx.linked_transaction_id
-                  ? transactions.find((t) => t.id === tx.linked_transaction_id)
-                  : null;
+                }
+                return transactions.filter((t) => !hiddenIds.has(t.id)).map((tx) => {
+                const isTransfer = tx.linked_transaction_id !== null;
+                const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
                 return editingId === tx.id ? (
                   <div key={tx.id} className="grid grid-cols-12 items-center gap-2 px-6 py-2 bg-surface-raised">
                     <span className="col-span-2"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} /></span>
@@ -396,7 +397,7 @@ export default function TransactionsPage() {
                     <span className="col-span-2 text-sm tabular-nums text-text-secondary">{tx.date}</span>
                     <span className="col-span-3 text-sm text-text-primary">{tx.description}</span>
                     <span className="col-span-2 text-sm text-text-secondary">
-                      {tx.type === "transfer" && linkedTx
+                      {isTransfer && linkedTx
                         ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
                         : tx.account_name}
                     </span>
@@ -414,11 +415,11 @@ export default function TransactionsPage() {
                         {tx.status}
                       </button>
                     </span>
-                    <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${tx.type === "income" ? "text-success" : tx.type === "transfer" ? "text-accent" : "text-danger"}`}>
-                      {tx.type === "income" ? "+" : tx.type === "transfer" ? "" : "-"}{formatAmount(tx.amount)}
+                    <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
+                      {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                     </span>
                     <span className="col-span-1 flex justify-end gap-2">
-                      {tx.type !== "transfer" && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>}
+                      {!isTransfer && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>}
                       <button onClick={() => handleDelete(tx.id)} aria-label={`Delete: ${tx.description}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                     </span>
                   </div>

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -8,6 +8,7 @@ const RECENT_KEY = "pfv2-recent-categories";
 const MAX_RECENT = 5;
 
 function getRecent(): number[] {
+  if (typeof window === "undefined") return [];
   try {
     return JSON.parse(localStorage.getItem(RECENT_KEY) || "[]");
   } catch { return []; }
@@ -59,8 +60,10 @@ export default function CategorySelect({ id, categories, value, onChange, filter
     [selectable, q]
   );
 
-  // Recent items at top
-  const recentIds = getRecent();
+  // Recent items — loaded client-side only to avoid SSR hydration mismatch
+  const [recentIds, setRecentIds] = useState<number[]>([]);
+  useEffect(() => { setRecentIds(getRecent()); }, [open]);
+
   const recentItems = recentIds
     .map((rid) => filtered.find((c) => c.id === rid))
     .filter(Boolean) as Category[];
@@ -145,6 +148,8 @@ export default function CategorySelect({ id, categories, value, onChange, filter
         role="combobox"
         aria-expanded={open}
         aria-haspopup="listbox"
+        aria-autocomplete="list"
+        aria-controls={`${id}-listbox`}
         aria-activedescendant={activeDescendant}
         aria-label={ariaLabel}
       />

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -59,8 +59,9 @@ export interface Transaction {
   category_name: string;
   description: string;
   amount: number;
-  type: "income" | "expense";
+  type: "income" | "expense" | "transfer";
   status: "settled" | "pending";
+  linked_transaction_id: number | null;
   date: string;
 }
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -59,7 +59,7 @@ export interface Transaction {
   category_name: string;
   description: string;
   amount: number;
-  type: "income" | "expense" | "transfer";
+  type: "income" | "expense";
   status: "settled" | "pending";
   linked_transaction_id: number | null;
   date: string;


### PR DESCRIPTION
## Summary

- Transfer transactions: move money between accounts in one atomic operation
- Linked transaction pairs (expense on source, income on destination)
- Deleting one side deletes both and reverts both balances

## Changes

### Backend
- Migration 010: `transfer` added to TransactionType enum, `linked_transaction_id` (self-referencing FK with SET NULL on delete)
- `create_transfer` service: validates different accounts, creates linked expense+income pair, applies balance atomically if settled
- `delete_transaction` updated: deleting a transfer side deletes and reverts both
- `POST /api/v1/transactions/transfer` — returns both created transactions
- `TransferCreate` schema: from_account_id, to_account_id, category_id, description, amount, status, date

### Frontend
- Transaction form: toggle between Transaction and Transfer modes
- Transfer mode shows From Account + To Account (destination filtered to exclude source)
- Transfers shown with blue accent color and "transfer" label
- Dashboard handles transfer type in transaction list