### PR TITLE
feat: budgets — monthly allocations per master category

### DIFF
--- a/backend/alembic/versions/013_budgets.py
+++ b/backend/alembic/versions/013_budgets.py
@@ -1,0 +1,44 @@
+"""Add budgets table
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-04-02
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "013"
+down_revision: Union[str, None] = "012"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "budgets",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("org_id", sa.Integer(), nullable=False),
+        sa.Column("category_id", sa.Integer(), nullable=False),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("period_start", sa.Date(), nullable=False),
+        sa.Column("period_end", sa.Date(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"]),
+        sa.ForeignKeyConstraint(["category_id"], ["categories.id"]),
+        sa.UniqueConstraint("org_id", "category_id", "period_start", name="uq_budget_org_cat_period"),
+    )
+    op.create_index("ix_budgets_org_period", "budgets", ["org_id", "period_start"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_budgets_org_period")
+    op.drop_table("budgets")

--- a/backend/alembic/versions/014_billing_periods.py
+++ b/backend/alembic/versions/014_billing_periods.py
@@ -1,0 +1,37 @@
+"""Add billing_periods table
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-04-02
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "014"
+down_revision: Union[str, None] = "013"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "billing_periods",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("org_id", sa.Integer(), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"]),
+    )
+    op.create_index("ix_billing_periods_org", "billing_periods", ["org_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_billing_periods_org")
+    op.drop_table("billing_periods")

--- a/backend/alembic/versions/015_budget_period_end_nullable.py
+++ b/backend/alembic/versions/015_budget_period_end_nullable.py
@@ -1,0 +1,34 @@
+"""Make budget.period_end nullable for open periods
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-04-02
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "015"
+down_revision: Union[str, None] = "014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "budgets",
+        "period_end",
+        existing_type=sa.Date(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "budgets",
+        "period_end",
+        existing_type=sa.Date(),
+        nullable=False,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from app.config import settings as app_settings
 from app.database import engine
 from app.logging import setup_logging
-from app.routers import account_types, accounts, auth, categories, recurring, settings, transactions, users
+from app.routers import account_types, accounts, auth, budgets, categories, recurring, settings, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -77,6 +77,7 @@ app.include_router(accounts.router)
 app.include_router(categories.router)
 app.include_router(transactions.router)
 app.include_router(recurring.router)
+app.include_router(budgets.router)
 app.include_router(settings.router)
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.account import AccountType, Account
 from app.models.category import Category, CategoryType
 from app.models.transaction import Transaction, TransactionType, TransactionStatus
 from app.models.recurring import RecurringTransaction, Frequency
+from app.models.budget import Budget
 from app.models.settings import OrgSetting
 
 __all__ = [
@@ -19,5 +20,6 @@ __all__ = [
     "TransactionStatus",
     "RecurringTransaction",
     "Frequency",
+    "Budget",
     "OrgSetting",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.category import Category, CategoryType
 from app.models.transaction import Transaction, TransactionType, TransactionStatus
 from app.models.recurring import RecurringTransaction, Frequency
 from app.models.budget import Budget
+from app.models.billing import BillingPeriod
 from app.models.settings import OrgSetting
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "RecurringTransaction",
     "Frequency",
     "Budget",
+    "BillingPeriod",
     "OrgSetting",
 ]

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -1,0 +1,21 @@
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class BillingPeriod(Base):
+    __tablename__ = "billing_periods"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("organizations.id"), nullable=False
+    )
+    start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    end_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Optional
 
 from sqlalchemy import Date, DateTime, ForeignKey, Integer, Numeric, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -22,7 +23,7 @@ class Budget(Base):
     )
     amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
     period_start: Mapped[date] = mapped_column(Date, nullable=False)
-    period_end: Mapped[date] = mapped_column(Date, nullable=False)
+    period_end: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -1,0 +1,33 @@
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, Numeric, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class Budget(Base):
+    __tablename__ = "budgets"
+    __table_args__ = (
+        UniqueConstraint("org_id", "category_id", "period_start", name="uq_budget_org_cat_period"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("organizations.id"), nullable=False
+    )
+    category_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("categories.id"), nullable=False
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    period_end: Mapped[date] = mapped_column(Date, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    category: Mapped["Category"] = relationship()

--- a/backend/app/routers/budgets.py
+++ b/backend/app/routers/budgets.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.user import User
+from app.schemas.budget import BudgetCreate, BudgetResponse, BudgetUpdate
+from app.services import budget_service as svc
+
+router = APIRouter(prefix="/api/v1/budgets", tags=["budgets"])
+
+
+@router.get("", response_model=list[BudgetResponse])
+async def list_budgets(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.list_budgets(db, current_user.org_id)
+
+
+@router.post("", response_model=BudgetResponse, status_code=201)
+async def create_budget(
+    body: BudgetCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.create_budget(db, current_user.org_id, body)
+
+
+@router.put("/{budget_id}", response_model=BudgetResponse)
+async def update_budget(
+    budget_id: int,
+    body: BudgetUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.update_budget(db, current_user.org_id, budget_id, body)
+
+
+@router.delete("/{budget_id}", status_code=204)
+async def delete_budget(
+    budget_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await svc.delete_budget(db, current_user.org_id, budget_id)

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -8,6 +8,7 @@ from app.deps import get_current_user
 from app.models.settings import OrgSetting
 from app.models.user import Organization, Role, User
 from app.schemas.settings import BillingCycleUpdate, OrgSettingResponse, OrgSettingUpdate
+from app.services import billing_service
 
 router = APIRouter(prefix="/api/v1/settings", tags=["settings"])
 
@@ -127,3 +128,49 @@ async def update_billing_cycle(
     org.billing_cycle_day = body.billing_cycle_day
     await db.commit()
     return {"billing_cycle_day": org.billing_cycle_day}
+
+
+@router.get("/billing-period")
+async def get_current_period(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    period = await billing_service.get_current_period(db, current_user.org_id)
+    return {
+        "id": period.id,
+        "start_date": period.start_date.isoformat(),
+        "end_date": period.end_date.isoformat() if period.end_date else None,
+    }
+
+
+@router.get("/billing-periods")
+async def list_periods(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    periods = await billing_service.list_periods(db, current_user.org_id)
+    return [
+        {
+            "id": p.id,
+            "start_date": p.start_date.isoformat(),
+            "end_date": p.end_date.isoformat() if p.end_date else None,
+        }
+        for p in periods
+    ]
+
+
+@router.post("/billing-period/close")
+async def close_period(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    close_date: str | None = None,
+):
+    _require_admin(current_user)
+    import datetime
+    cd = datetime.date.fromisoformat(close_date) if close_date else None
+    new_period = await billing_service.close_period(db, current_user.org_id, cd)
+    return {
+        "id": new_period.id,
+        "start_date": new_period.start_date.isoformat(),
+        "end_date": None,
+    }

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -126,6 +126,21 @@ async def update_billing_cycle(
     )
     org = result.scalar_one()
     org.billing_cycle_day = body.billing_cycle_day
+
+    # Recalculate the current open period to match the new cycle day
+    current_period = await billing_service.get_current_period(db, current_user.org_id)
+    if current_period.end_date is None:
+        import datetime
+        today = datetime.date.today()
+        new_day = body.billing_cycle_day
+        y, m, d = today.year, today.month, today.day
+        if d >= new_day:
+            new_start = datetime.date(y, m, new_day)
+        else:
+            prev = datetime.date(y, m, 1) - datetime.timedelta(days=1)
+            new_start = datetime.date(prev.year, prev.month, new_day)
+        current_period.start_date = new_start
+
     await db.commit()
     return {"billing_cycle_day": org.billing_cycle_day}
 

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,3 +1,5 @@
+import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -178,12 +180,10 @@ async def list_periods(
 async def close_period(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    close_date: str | None = None,
+    close_date: datetime.date | None = None,
 ):
     _require_admin(current_user)
-    import datetime
-    cd = datetime.date.fromisoformat(close_date) if close_date else None
-    new_period = await billing_service.close_period(db, current_user.org_id, cd)
+    new_period = await billing_service.close_period(db, current_user.org_id, close_date)
     return {
         "id": new_period.id,
         "start_date": new_period.start_date.isoformat(),

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -28,6 +28,7 @@ async def list_transactions(
     status: Literal["settled", "pending"] | None = Query(default=None),
     date_from: datetime.date | None = Query(default=None),
     date_to: datetime.date | None = Query(default=None),
+    search: str | None = Query(default=None),
     limit: int = Query(default=50, le=200),
     offset: int = Query(default=0, ge=0),
 ):
@@ -39,6 +40,7 @@ async def list_transactions(
         status=status,
         date_from=date_from,
         date_to=date_to,
+        search=search,
         limit=limit,
         offset=offset,
     )

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -23,6 +23,6 @@ class BudgetResponse(BaseModel):
     remaining: Decimal = Decimal("0.00")
     percent_used: float = 0.0
     period_start: datetime.date
-    period_end: datetime.date
+    period_end: Optional[datetime.date] = None
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -1,0 +1,28 @@
+import datetime
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class BudgetCreate(BaseModel):
+    category_id: int
+    amount: Decimal = Field(gt=0)
+
+
+class BudgetUpdate(BaseModel):
+    amount: Optional[Decimal] = Field(default=None, gt=0)
+
+
+class BudgetResponse(BaseModel):
+    id: int
+    category_id: int
+    category_name: str = ""
+    amount: Decimal
+    spent: Decimal = Decimal("0.00")
+    remaining: Decimal = Decimal("0.00")
+    percent_used: float = 0.0
+    period_start: datetime.date
+    period_end: datetime.date
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -1,0 +1,85 @@
+"""Billing period service — manage explicit billing periods.
+
+Periods are explicit records: each has a start_date, and an optional
+end_date (null = currently open). Closing a period sets its end_date
+and opens a new period starting the next day.
+
+The org's billing_cycle_day is used as a hint to auto-create the first
+period, but the user has full control over when to close.
+"""
+
+import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing import BillingPeriod
+from app.models.user import Organization
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+async def get_current_period(db: AsyncSession, org_id: int) -> BillingPeriod:
+    """Get the currently open period. If none exists, auto-create one."""
+    result = await db.execute(
+        select(BillingPeriod).where(
+            BillingPeriod.org_id == org_id,
+            BillingPeriod.end_date.is_(None),
+        )
+    )
+    period = result.scalar_one_or_none()
+
+    if period is None:
+        # Auto-create first period based on org's billing_cycle_day
+        org = await db.scalar(select(Organization).where(Organization.id == org_id))
+        cycle_day = org.billing_cycle_day if org else 1
+
+        today = datetime.date.today()
+        y, m, d = today.year, today.month, today.day
+        if d >= cycle_day:
+            start = datetime.date(y, m, cycle_day)
+        else:
+            start = datetime.date(y, m - 1 if m > 1 else 12, cycle_day)
+            if m == 1:
+                start = datetime.date(y - 1, 12, cycle_day)
+
+        period = BillingPeriod(org_id=org_id, start_date=start)
+        db.add(period)
+        await db.commit()
+        await db.refresh(period)
+
+    return period
+
+
+async def list_periods(db: AsyncSession, org_id: int) -> list[BillingPeriod]:
+    result = await db.execute(
+        select(BillingPeriod)
+        .where(BillingPeriod.org_id == org_id)
+        .order_by(BillingPeriod.start_date.desc())
+        .limit(12)
+    )
+    return list(result.scalars().all())
+
+
+async def close_period(db: AsyncSession, org_id: int, close_date: datetime.date | None = None) -> BillingPeriod:
+    """Close the current period and open a new one.
+    close_date defaults to yesterday (salary came today, close yesterday).
+    Returns the NEW (open) period."""
+    current = await get_current_period(db, org_id)
+
+    if close_date is None:
+        close_date = datetime.date.today() - datetime.timedelta(days=1)
+
+    if close_date < current.start_date:
+        raise ValidationError("Close date cannot be before the period start date")
+
+    current.end_date = close_date
+
+    # Open new period starting the day after close
+    new_period = BillingPeriod(
+        org_id=org_id,
+        start_date=close_date + datetime.timedelta(days=1),
+    )
+    db.add(new_period)
+    await db.commit()
+    await db.refresh(new_period)
+    return new_period

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -118,7 +118,7 @@ async def create_budget(db: AsyncSession, org_id: int, body: BudgetCreate) -> Bu
         category_id=body.category_id,
         amount=body.amount,
         period_start=period.start_date,
-        period_end=period.end_date or period.start_date,
+        period_end=period.end_date,
     )
     db.add(budget)
     await db.commit()
@@ -144,7 +144,10 @@ async def update_budget(
     await db.commit()
     await db.refresh(budget, ["category"])
 
-    spent = await _compute_spent(db, org_id, budget.category_id, budget.period_start, budget.period_end)
+    # Use the live period end_date (not the stored one) for open periods
+    period = await get_current_period(db, org_id)
+    end = period.end_date if period.start_date == budget.period_start else budget.period_end
+    spent = await _compute_spent(db, org_id, budget.category_id, budget.period_start, end)
     return _to_response(budget, spent)
 
 

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -1,72 +1,49 @@
 """Budget service — CRUD and spend computation.
 
-Budgets are allocated at the master category level. Spend is computed
-by summing settled expense transactions across all subcategories of
-that master within the budget period.
+Budgets are allocated at the master category level per billing period.
+Spend is computed by summing settled expense transactions across all
+subcategories of that master within the period dates.
 """
 
 import datetime
 from decimal import Decimal
 
-from dateutil.relativedelta import relativedelta
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.budget import Budget
 from app.models.category import Category
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
-from app.models.user import Organization
 from app.schemas.budget import BudgetCreate, BudgetResponse, BudgetUpdate
+from app.services.billing_service import get_current_period
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
-
-
-def _current_period(billing_cycle_day: int) -> tuple[datetime.date, datetime.date]:
-    """Compute the current billing period based on the org's cycle day."""
-    today = datetime.date.today()
-    y, m, d = today.year, today.month, today.day
-
-    if d >= billing_cycle_day:
-        start = datetime.date(y, m, billing_cycle_day)
-        end_date = start + relativedelta(months=1) - datetime.timedelta(days=1)
-    else:
-        start = datetime.date(y, m, billing_cycle_day) - relativedelta(months=1)
-        end_date = datetime.date(y, m, billing_cycle_day) - datetime.timedelta(days=1)
-
-    return start, end_date
-
-
-async def _get_billing_cycle_day(db: AsyncSession, org_id: int) -> int:
-    result = await db.scalar(
-        select(Organization.billing_cycle_day).where(Organization.id == org_id)
-    )
-    return result or 1
 
 
 async def _compute_spent(
     db: AsyncSession, org_id: int, master_category_id: int,
-    period_start: datetime.date, period_end: datetime.date,
+    period_start: datetime.date, period_end: datetime.date | None,
 ) -> Decimal:
     """Sum settled expense transactions for a master category and all its subcategories."""
-    # Get all subcategory IDs under this master
     sub_ids_result = await db.execute(
         select(Category.id).where(
             Category.parent_id == master_category_id, Category.org_id == org_id
         )
     )
     sub_ids = [r[0] for r in sub_ids_result.all()]
-    # Include the master itself (for direct transactions)
     all_cat_ids = [master_category_id] + sub_ids
 
-    spent = await db.scalar(
-        select(func.coalesce(func.sum(Transaction.amount), 0)).where(
-            Transaction.org_id == org_id,
-            Transaction.category_id.in_(all_cat_ids),
-            Transaction.type == TransactionType.EXPENSE,
-            Transaction.status == TransactionStatus.SETTLED,
-            Transaction.date >= period_start,
-            Transaction.date <= period_end,
-        )
+    q = select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+        Transaction.org_id == org_id,
+        Transaction.category_id.in_(all_cat_ids),
+        Transaction.type == TransactionType.EXPENSE,
+        Transaction.status == TransactionStatus.SETTLED,
+        Transaction.date >= period_start,
     )
+    # If period is still open (no end_date), include all from start_date onward
+    if period_end is not None:
+        q = q.where(Transaction.date <= period_end)
+
+    spent = await db.scalar(q)
     return Decimal(str(spent))
 
 
@@ -90,26 +67,24 @@ def _to_response(budget: Budget, spent: Decimal) -> BudgetResponse:
 
 async def list_budgets(db: AsyncSession, org_id: int) -> list[BudgetResponse]:
     """List budgets for the current billing period with spend computation."""
-    cycle_day = await _get_billing_cycle_day(db, org_id)
-    period_start, period_end = _current_period(cycle_day)
+    period = await get_current_period(db, org_id)
 
     result = await db.execute(
         select(Budget)
         .where(
             Budget.org_id == org_id,
-            Budget.period_start == period_start,
+            Budget.period_start == period.start_date,
         )
         .order_by(Budget.category_id)
     )
     budgets = list(result.scalars().all())
 
-    # Eager load categories
     for b in budgets:
         await db.refresh(b, ["category"])
 
     responses = []
     for b in budgets:
-        spent = await _compute_spent(db, org_id, b.category_id, period_start, period_end)
+        spent = await _compute_spent(db, org_id, b.category_id, period.start_date, period.end_date)
         responses.append(_to_response(b, spent))
 
     return responses
@@ -117,7 +92,6 @@ async def list_budgets(db: AsyncSession, org_id: int) -> list[BudgetResponse]:
 
 async def create_budget(db: AsyncSession, org_id: int, body: BudgetCreate) -> BudgetResponse:
     """Create a budget for the current period. Only master categories allowed."""
-    # Validate category is a master (no parent)
     cat_result = await db.execute(
         select(Category).where(Category.id == body.category_id, Category.org_id == org_id)
     )
@@ -127,15 +101,13 @@ async def create_budget(db: AsyncSession, org_id: int, body: BudgetCreate) -> Bu
     if cat.parent_id is not None:
         raise ValidationError("Budgets can only be set for master categories, not subcategories")
 
-    cycle_day = await _get_billing_cycle_day(db, org_id)
-    period_start, period_end = _current_period(cycle_day)
+    period = await get_current_period(db, org_id)
 
-    # Check for existing budget
     existing = await db.scalar(
         select(Budget.id).where(
             Budget.org_id == org_id,
             Budget.category_id == body.category_id,
-            Budget.period_start == period_start,
+            Budget.period_start == period.start_date,
         )
     )
     if existing:
@@ -145,14 +117,14 @@ async def create_budget(db: AsyncSession, org_id: int, body: BudgetCreate) -> Bu
         org_id=org_id,
         category_id=body.category_id,
         amount=body.amount,
-        period_start=period_start,
-        period_end=period_end,
+        period_start=period.start_date,
+        period_end=period.end_date or period.start_date,
     )
     db.add(budget)
     await db.commit()
     await db.refresh(budget, ["category"])
 
-    spent = await _compute_spent(db, org_id, budget.category_id, period_start, period_end)
+    spent = await _compute_spent(db, org_id, budget.category_id, period.start_date, period.end_date)
     return _to_response(budget, spent)
 
 

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -1,0 +1,187 @@
+"""Budget service — CRUD and spend computation.
+
+Budgets are allocated at the master category level. Spend is computed
+by summing settled expense transactions across all subcategories of
+that master within the budget period.
+"""
+
+import datetime
+from decimal import Decimal
+
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import Budget
+from app.models.category import Category
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization
+from app.schemas.budget import BudgetCreate, BudgetResponse, BudgetUpdate
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+def _current_period(billing_cycle_day: int) -> tuple[datetime.date, datetime.date]:
+    """Compute the current billing period based on the org's cycle day."""
+    today = datetime.date.today()
+    y, m, d = today.year, today.month, today.day
+
+    if d >= billing_cycle_day:
+        start = datetime.date(y, m, billing_cycle_day)
+        end_date = start + relativedelta(months=1) - datetime.timedelta(days=1)
+    else:
+        start = datetime.date(y, m, billing_cycle_day) - relativedelta(months=1)
+        end_date = datetime.date(y, m, billing_cycle_day) - datetime.timedelta(days=1)
+
+    return start, end_date
+
+
+async def _get_billing_cycle_day(db: AsyncSession, org_id: int) -> int:
+    result = await db.scalar(
+        select(Organization.billing_cycle_day).where(Organization.id == org_id)
+    )
+    return result or 1
+
+
+async def _compute_spent(
+    db: AsyncSession, org_id: int, master_category_id: int,
+    period_start: datetime.date, period_end: datetime.date,
+) -> Decimal:
+    """Sum settled expense transactions for a master category and all its subcategories."""
+    # Get all subcategory IDs under this master
+    sub_ids_result = await db.execute(
+        select(Category.id).where(
+            Category.parent_id == master_category_id, Category.org_id == org_id
+        )
+    )
+    sub_ids = [r[0] for r in sub_ids_result.all()]
+    # Include the master itself (for direct transactions)
+    all_cat_ids = [master_category_id] + sub_ids
+
+    spent = await db.scalar(
+        select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+            Transaction.org_id == org_id,
+            Transaction.category_id.in_(all_cat_ids),
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.date >= period_start,
+            Transaction.date <= period_end,
+        )
+    )
+    return Decimal(str(spent))
+
+
+def _to_response(budget: Budget, spent: Decimal) -> BudgetResponse:
+    remaining = budget.amount - spent
+    pct = float(spent / budget.amount * 100) if budget.amount > 0 else 0.0
+    return BudgetResponse(
+        id=budget.id,
+        category_id=budget.category_id,
+        category_name=budget.category.name if budget.category else "",
+        amount=budget.amount,
+        spent=spent,
+        remaining=remaining,
+        percent_used=round(pct, 1),
+        period_start=budget.period_start,
+        period_end=budget.period_end,
+    )
+
+
+# ── CRUD ──────────────────────────────────────────────────────────────────────
+
+async def list_budgets(db: AsyncSession, org_id: int) -> list[BudgetResponse]:
+    """List budgets for the current billing period with spend computation."""
+    cycle_day = await _get_billing_cycle_day(db, org_id)
+    period_start, period_end = _current_period(cycle_day)
+
+    result = await db.execute(
+        select(Budget)
+        .where(
+            Budget.org_id == org_id,
+            Budget.period_start == period_start,
+        )
+        .order_by(Budget.category_id)
+    )
+    budgets = list(result.scalars().all())
+
+    # Eager load categories
+    for b in budgets:
+        await db.refresh(b, ["category"])
+
+    responses = []
+    for b in budgets:
+        spent = await _compute_spent(db, org_id, b.category_id, period_start, period_end)
+        responses.append(_to_response(b, spent))
+
+    return responses
+
+
+async def create_budget(db: AsyncSession, org_id: int, body: BudgetCreate) -> BudgetResponse:
+    """Create a budget for the current period. Only master categories allowed."""
+    # Validate category is a master (no parent)
+    cat_result = await db.execute(
+        select(Category).where(Category.id == body.category_id, Category.org_id == org_id)
+    )
+    cat = cat_result.scalar_one_or_none()
+    if cat is None:
+        raise ValidationError("Invalid category")
+    if cat.parent_id is not None:
+        raise ValidationError("Budgets can only be set for master categories, not subcategories")
+
+    cycle_day = await _get_billing_cycle_day(db, org_id)
+    period_start, period_end = _current_period(cycle_day)
+
+    # Check for existing budget
+    existing = await db.scalar(
+        select(Budget.id).where(
+            Budget.org_id == org_id,
+            Budget.category_id == body.category_id,
+            Budget.period_start == period_start,
+        )
+    )
+    if existing:
+        raise ConflictError("Budget already exists for this category in the current period")
+
+    budget = Budget(
+        org_id=org_id,
+        category_id=body.category_id,
+        amount=body.amount,
+        period_start=period_start,
+        period_end=period_end,
+    )
+    db.add(budget)
+    await db.commit()
+    await db.refresh(budget, ["category"])
+
+    spent = await _compute_spent(db, org_id, budget.category_id, period_start, period_end)
+    return _to_response(budget, spent)
+
+
+async def update_budget(
+    db: AsyncSession, org_id: int, budget_id: int, body: BudgetUpdate
+) -> BudgetResponse:
+    result = await db.execute(
+        select(Budget).where(Budget.id == budget_id, Budget.org_id == org_id)
+    )
+    budget = result.scalar_one_or_none()
+    if budget is None:
+        raise NotFoundError("Budget")
+
+    if body.amount is not None:
+        budget.amount = body.amount
+
+    await db.commit()
+    await db.refresh(budget, ["category"])
+
+    spent = await _compute_spent(db, org_id, budget.category_id, budget.period_start, budget.period_end)
+    return _to_response(budget, spent)
+
+
+async def delete_budget(db: AsyncSession, org_id: int, budget_id: int) -> None:
+    result = await db.execute(
+        select(Budget).where(Budget.id == budget_id, Budget.org_id == org_id)
+    )
+    budget = result.scalar_one_or_none()
+    if budget is None:
+        raise NotFoundError("Budget")
+    await db.delete(budget)
+    await db.commit()

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -349,6 +349,7 @@ async def list_transactions(
     status: str | None = None,
     date_from: datetime.date | None = None,
     date_to: datetime.date | None = None,
+    search: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[Transaction]:
@@ -369,6 +370,8 @@ async def list_transactions(
         q = q.where(Transaction.date >= date_from)
     if date_to is not None:
         q = q.where(Transaction.date <= date_to)
+    if search is not None:
+        q = q.where(Transaction.description.ilike(f"%{search}%"))
     q = q.order_by(Transaction.date.desc(), Transaction.id.desc())
     q = q.limit(limit).offset(offset)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ bcrypt==4.3.0
 python-multipart==0.0.20
 structlog==25.1.0
 python-dateutil==2.9.0
+httpx==0.28.1

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -13,25 +13,30 @@ import httpx
 
 BASE = "http://localhost:8000"
 
-# Test user
-USER = {"username": "demo", "email": "demo@example.com", "password": "demo1234", "org_name": "Demo Household"}
+# Default user — override with env vars SEED_USERNAME / SEED_PASSWORD
+import os
+USER = {
+    "username": os.getenv("SEED_USERNAME", "demo"),
+    "email": os.getenv("SEED_EMAIL", "demo@example.com"),
+    "password": os.getenv("SEED_PASSWORD", "demo1234"),
+    "org_name": os.getenv("SEED_ORG", "Demo Household"),
+}
 
 
 async def main():
     async with httpx.AsyncClient(base_url=BASE) as c:
         print("=== PFV2 Seed Script ===\n")
 
-        # Register
-        print("1. Registering user...")
-        r = await c.post("/api/v1/auth/register", json=USER)
-        if r.status_code == 409:
-            print("   User already exists, logging in...")
-        elif r.status_code != 201:
-            print(f"   Registration failed: {r.text}")
-            return
-
-        # Login
+        # Register (skip if user exists)
+        print("1. Authenticating...")
         r = await c.post("/api/v1/auth/login", json={"username": USER["username"], "password": USER["password"]})
+        if r.status_code != 200:
+            print("   User not found, registering...")
+            r = await c.post("/api/v1/auth/register", json=USER)
+            if r.status_code != 201:
+                print(f"   Registration failed: {r.text}")
+                return
+            r = await c.post("/api/v1/auth/login", json={"username": USER["username"], "password": USER["password"]})
         token = r.json()["access_token"]
         headers = {"Authorization": f"Bearer {token}"}
         print(f"   Logged in as {USER['username']}")

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,0 +1,212 @@
+"""Seed script — populate the system with realistic mock data for testing.
+
+Run with: docker compose exec backend python seed.py
+Or via: ./pfv seed
+"""
+
+import asyncio
+import random
+from datetime import date, timedelta
+from decimal import Decimal
+
+import httpx
+
+BASE = "http://localhost:8000"
+
+# Test user
+USER = {"username": "demo", "email": "demo@example.com", "password": "demo1234", "org_name": "Demo Household"}
+
+
+async def main():
+    async with httpx.AsyncClient(base_url=BASE) as c:
+        print("=== PFV2 Seed Script ===\n")
+
+        # Register
+        print("1. Registering user...")
+        r = await c.post("/api/v1/auth/register", json=USER)
+        if r.status_code == 409:
+            print("   User already exists, logging in...")
+        elif r.status_code != 201:
+            print(f"   Registration failed: {r.text}")
+            return
+
+        # Login
+        r = await c.post("/api/v1/auth/login", json={"username": USER["username"], "password": USER["password"]})
+        token = r.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        print(f"   Logged in as {USER['username']}")
+
+        # Get account types
+        r = await c.get("/api/v1/account-types", headers=headers)
+        account_types = {at["slug"]: at["id"] for at in r.json() if at["slug"]}
+        print(f"   Account types: {list(account_types.keys())}")
+
+        # Create accounts
+        print("\n2. Creating accounts...")
+        accounts = {}
+        acct_defs = [
+            {"name": "ING Checking", "type": "checking", "balance": "5000.00", "currency": "EUR"},
+            {"name": "ING Savings", "type": "savings", "balance": "12000.00", "currency": "EUR"},
+            {"name": "Amex Platinum", "type": "credit_card", "balance": "0.00", "currency": "EUR", "close_day": 15},
+            {"name": "Revolut", "type": "checking", "balance": "800.00", "currency": "EUR"},
+            {"name": "Degiro", "type": "investment", "balance": "25000.00", "currency": "EUR"},
+        ]
+        for ad in acct_defs:
+            r = await c.post("/api/v1/accounts", headers=headers, json={
+                "name": ad["name"],
+                "account_type_id": account_types[ad["type"]],
+                "balance": ad["balance"],
+                "currency": ad["currency"],
+                "close_day": ad.get("close_day"),
+            })
+            if r.status_code == 201:
+                acct = r.json()
+                accounts[ad["name"]] = acct["id"]
+                print(f"   Created: {ad['name']} ({ad['balance']} {ad['currency']})")
+
+        # Set default account
+        if "ING Checking" in accounts:
+            await c.put(f"/api/v1/accounts/{accounts['ING Checking']}", headers=headers,
+                        json={"is_default": True})
+            print("   Set ING Checking as default")
+
+        # Get categories (subcategories for transactions)
+        r = await c.get("/api/v1/categories", headers=headers)
+        cats = {cat["slug"]: cat["id"] for cat in r.json() if cat["slug"]}
+        master_cats = {cat["slug"]: cat["id"] for cat in r.json() if cat["parent_id"] is None and cat["slug"]}
+        print(f"\n3. Categories loaded: {len(cats)} subcategories")
+
+        # Create transactions — 3 months of data
+        print("\n4. Creating transactions...")
+        today = date.today()
+        tx_count = 0
+
+        # Monthly recurring patterns
+        monthly_expenses = [
+            {"acct": "ING Checking", "cat": "rent_mortgage", "desc": "Rent - Apartment", "amount": "1200.00", "day": 1},
+            {"acct": "ING Checking", "cat": "electricity", "desc": "Vattenfall Electricity", "amount": "85.00", "day": 3},
+            {"acct": "ING Checking", "cat": "water", "desc": "Water Board", "amount": "35.00", "day": 3},
+            {"acct": "ING Checking", "cat": "internet", "desc": "KPN Internet", "amount": "49.99", "day": 5},
+            {"acct": "ING Checking", "cat": "phone", "desc": "T-Mobile Plan", "amount": "29.99", "day": 5},
+            {"acct": "ING Checking", "cat": "health_insurance", "desc": "Zilveren Kruis", "amount": "135.00", "day": 1},
+            {"acct": "ING Checking", "cat": "gym", "desc": "BasicFit Membership", "amount": "29.99", "day": 1},
+            {"acct": "ING Checking", "cat": "streaming", "desc": "Netflix", "amount": "17.99", "day": 10},
+            {"acct": "ING Checking", "cat": "streaming", "desc": "Spotify Family", "amount": "16.99", "day": 10},
+            {"acct": "ING Checking", "cat": "auto_insurance", "desc": "ANWB Car Insurance", "amount": "78.00", "day": 15},
+        ]
+
+        # Variable expenses (credit card and checking)
+        variable_expenses = [
+            {"acct": "Amex Platinum", "cat": "groceries", "desc": "Albert Heijn", "min": 40, "max": 120},
+            {"acct": "Amex Platinum", "cat": "groceries", "desc": "Jumbo Supermarket", "min": 30, "max": 80},
+            {"acct": "Amex Platinum", "cat": "restaurants", "desc": "Restaurant dinner", "min": 35, "max": 90},
+            {"acct": "Amex Platinum", "cat": "coffee_shops", "desc": "Coffee & pastry", "min": 5, "max": 15},
+            {"acct": "Amex Platinum", "cat": "fast_food", "desc": "Thuisbezorgd delivery", "min": 15, "max": 40},
+            {"acct": "Amex Platinum", "cat": "fuel", "desc": "Shell fuel", "min": 50, "max": 90},
+            {"acct": "Amex Platinum", "cat": "clothing", "desc": "H&M / Zara", "min": 30, "max": 120},
+            {"acct": "ING Checking", "cat": "parking_tolls", "desc": "Parking garage", "min": 5, "max": 20},
+            {"acct": "Revolut", "cat": "entertainment", "desc": "Cinema tickets", "min": 15, "max": 30},
+            {"acct": "Revolut", "cat": "books_media", "desc": "Amazon Kindle", "min": 8, "max": 25},
+        ]
+
+        for month_offset in range(3, 0, -1):
+            month_start = date(today.year, today.month - month_offset, 1) if today.month > month_offset else date(today.year - 1, 12 - (month_offset - today.month), 1)
+
+            # Salary
+            salary_day = random.choice([23, 24, 25])
+            tx_date = date(month_start.year, month_start.month, salary_day)
+            if tx_date <= today:
+                await c.post("/api/v1/transactions", headers=headers, json={
+                    "account_id": accounts["ING Checking"], "category_id": cats["paycheck"],
+                    "description": "W&B Monthly Salary", "amount": "6500.00",
+                    "type": "income", "status": "settled", "date": tx_date.isoformat(),
+                })
+                tx_count += 1
+
+            # Monthly fixed expenses
+            for exp in monthly_expenses:
+                tx_date = date(month_start.year, month_start.month, min(exp["day"], 28))
+                if tx_date <= today and exp["cat"] in cats:
+                    await c.post("/api/v1/transactions", headers=headers, json={
+                        "account_id": accounts[exp["acct"]], "category_id": cats[exp["cat"]],
+                        "description": exp["desc"], "amount": exp["amount"],
+                        "type": "expense", "status": "settled", "date": tx_date.isoformat(),
+                    })
+                    tx_count += 1
+
+            # Variable expenses (8-15 per month)
+            for _ in range(random.randint(8, 15)):
+                exp = random.choice(variable_expenses)
+                day = random.randint(1, 28)
+                tx_date = date(month_start.year, month_start.month, day)
+                if tx_date <= today and exp["cat"] in cats:
+                    amount = round(random.uniform(exp["min"], exp["max"]), 2)
+                    status = "pending" if exp["acct"] == "Amex Platinum" and month_offset == 1 else "settled"
+                    await c.post("/api/v1/transactions", headers=headers, json={
+                        "account_id": accounts[exp["acct"]], "category_id": cats[exp["cat"]],
+                        "description": exp["desc"], "amount": str(amount),
+                        "type": "expense", "status": status, "date": tx_date.isoformat(),
+                    })
+                    tx_count += 1
+
+        # Monthly savings transfer
+        for month_offset in range(3, 0, -1):
+            month_start = date(today.year, today.month - month_offset, 1) if today.month > month_offset else date(today.year - 1, 12 - (month_offset - today.month), 1)
+            tx_date = date(month_start.year, month_start.month, 26)
+            if tx_date <= today:
+                await c.post("/api/v1/transactions/transfer", headers=headers, json={
+                    "from_account_id": accounts["ING Checking"],
+                    "to_account_id": accounts["ING Savings"],
+                    "category_id": cats.get("general_savings", list(cats.values())[0]),
+                    "description": "Monthly savings", "amount": "500.00",
+                    "status": "settled", "date": tx_date.isoformat(),
+                })
+                tx_count += 2  # two sides
+
+        print(f"   Created {tx_count} transactions")
+
+        # Create recurring transactions
+        print("\n5. Creating recurring transactions...")
+        recurring_defs = [
+            {"acct": "ING Checking", "cat": "rent_mortgage", "desc": "Rent - Apartment", "amount": "1200.00", "freq": "monthly", "day": 1},
+            {"acct": "ING Checking", "cat": "gym", "desc": "BasicFit Membership", "amount": "29.99", "freq": "monthly", "day": 1},
+            {"acct": "ING Checking", "cat": "streaming", "desc": "Netflix", "amount": "17.99", "freq": "monthly", "day": 10},
+            {"acct": "ING Checking", "cat": "streaming", "desc": "Spotify Family", "amount": "16.99", "freq": "monthly", "day": 10},
+        ]
+        for rd in recurring_defs:
+            next_month = date(today.year, today.month + 1, 1) if today.month < 12 else date(today.year + 1, 1, 1)
+            next_due = date(next_month.year, next_month.month, min(rd["day"], 28))
+            if rd["cat"] in cats:
+                await c.post("/api/v1/recurring", headers=headers, json={
+                    "account_id": accounts[rd["acct"]], "category_id": cats[rd["cat"]],
+                    "description": rd["desc"], "amount": rd["amount"],
+                    "type": "expense", "frequency": rd["freq"],
+                    "next_due_date": next_due.isoformat(), "auto_settle": True,
+                })
+        print(f"   Created {len(recurring_defs)} recurring templates")
+
+        # Create budgets
+        print("\n6. Creating budgets...")
+        budget_defs = [
+            {"cat": "housing", "amount": "1400.00"},
+            {"cat": "utilities", "amount": "250.00"},
+            {"cat": "food_dining", "amount": "600.00"},
+            {"cat": "transportation", "amount": "200.00"},
+            {"cat": "health", "amount": "200.00"},
+            {"cat": "lifestyle", "amount": "150.00"},
+            {"cat": "personal_care", "amount": "100.00"},
+        ]
+        for bd in budget_defs:
+            if bd["cat"] in master_cats:
+                r = await c.post("/api/v1/budgets", headers=headers, json={
+                    "category_id": master_cats[bd["cat"]], "amount": bd["amount"],
+                })
+                if r.status_code == 201:
+                    print(f"   Budget: {bd['cat']} = {bd['amount']}")
+
+        print("\n=== Seed complete! ===")
+        print(f"Login: {USER['username']} / {USER['password']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -2,19 +2,21 @@
 
 Run with: docker compose exec backend python seed.py
 Or via: ./pfv seed
+
+Generates 3 past months + current month of data relative to today.
 """
 
 import asyncio
+import os
 import random
 from datetime import date, timedelta
 from decimal import Decimal
 
 import httpx
+from dateutil.relativedelta import relativedelta
 
 BASE = "http://localhost:8000"
 
-# Default user — override with env vars SEED_USERNAME / SEED_PASSWORD
-import os
 USER = {
     "username": os.getenv("SEED_USERNAME", "demo"),
     "email": os.getenv("SEED_EMAIL", "demo@example.com"),
@@ -24,10 +26,10 @@ USER = {
 
 
 async def main():
-    async with httpx.AsyncClient(base_url=BASE) as c:
+    async with httpx.AsyncClient(base_url=BASE, timeout=30) as c:
         print("=== PFV2 Seed Script ===\n")
 
-        # Register (skip if user exists)
+        # Auth
         print("1. Authenticating...")
         r = await c.post("/api/v1/auth/login", json={"username": USER["username"], "password": USER["password"]})
         if r.status_code != 200:
@@ -37,14 +39,14 @@ async def main():
                 print(f"   Registration failed: {r.text}")
                 return
             r = await c.post("/api/v1/auth/login", json={"username": USER["username"], "password": USER["password"]})
+
         token = r.json()["access_token"]
         headers = {"Authorization": f"Bearer {token}"}
         print(f"   Logged in as {USER['username']}")
 
-        # Get account types
+        # Account types
         r = await c.get("/api/v1/account-types", headers=headers)
         account_types = {at["slug"]: at["id"] for at in r.json() if at["slug"]}
-        print(f"   Account types: {list(account_types.keys())}")
 
         # Create accounts
         print("\n2. Creating accounts...")
@@ -58,36 +60,28 @@ async def main():
         ]
         for ad in acct_defs:
             r = await c.post("/api/v1/accounts", headers=headers, json={
-                "name": ad["name"],
-                "account_type_id": account_types[ad["type"]],
-                "balance": ad["balance"],
-                "currency": ad["currency"],
-                "close_day": ad.get("close_day"),
+                "name": ad["name"], "account_type_id": account_types[ad["type"]],
+                "balance": ad["balance"], "currency": ad["currency"], "close_day": ad.get("close_day"),
             })
             if r.status_code == 201:
-                acct = r.json()
-                accounts[ad["name"]] = acct["id"]
-                print(f"   Created: {ad['name']} ({ad['balance']} {ad['currency']})")
+                accounts[ad["name"]] = r.json()["id"]
+                print(f"   {ad['name']} ({ad['balance']} {ad['currency']})")
 
-        # Set default account
         if "ING Checking" in accounts:
-            await c.put(f"/api/v1/accounts/{accounts['ING Checking']}", headers=headers,
-                        json={"is_default": True})
-            print("   Set ING Checking as default")
+            await c.put(f"/api/v1/accounts/{accounts['ING Checking']}", headers=headers, json={"is_default": True})
 
-        # Get categories (subcategories for transactions)
+        # Categories
         r = await c.get("/api/v1/categories", headers=headers)
         cats = {cat["slug"]: cat["id"] for cat in r.json() if cat["slug"]}
         master_cats = {cat["slug"]: cat["id"] for cat in r.json() if cat["parent_id"] is None and cat["slug"]}
-        print(f"\n3. Categories loaded: {len(cats)} subcategories")
+        print(f"\n3. {len(cats)} categories loaded")
 
-        # Create transactions — 3 months of data
+        # --- Transactions: 3 past months + current month ---
         print("\n4. Creating transactions...")
         today = date.today()
         tx_count = 0
 
-        # Monthly recurring patterns
-        monthly_expenses = [
+        monthly_fixed = [
             {"acct": "ING Checking", "cat": "rent_mortgage", "desc": "Rent - Apartment", "amount": "1200.00", "day": 1},
             {"acct": "ING Checking", "cat": "electricity", "desc": "Vattenfall Electricity", "amount": "85.00", "day": 3},
             {"acct": "ING Checking", "cat": "water", "desc": "Water Board", "amount": "35.00", "day": 3},
@@ -100,8 +94,7 @@ async def main():
             {"acct": "ING Checking", "cat": "auto_insurance", "desc": "ANWB Car Insurance", "amount": "78.00", "day": 15},
         ]
 
-        # Variable expenses (credit card and checking)
-        variable_expenses = [
+        variable = [
             {"acct": "Amex Platinum", "cat": "groceries", "desc": "Albert Heijn", "min": 40, "max": 120},
             {"acct": "Amex Platinum", "cat": "groceries", "desc": "Jumbo Supermarket", "min": 30, "max": 80},
             {"acct": "Amex Platinum", "cat": "restaurants", "desc": "Restaurant dinner", "min": 35, "max": 90},
@@ -114,23 +107,37 @@ async def main():
             {"acct": "Revolut", "cat": "books_media", "desc": "Amazon Kindle", "min": 8, "max": 25},
         ]
 
-        for month_offset in range(3, 0, -1):
-            month_start = date(today.year, today.month - month_offset, 1) if today.month > month_offset else date(today.year - 1, 12 - (month_offset - today.month), 1)
+        # Generate for 3 past months + current month (4 total)
+        for offset in range(3, -1, -1):
+            m_start = today.replace(day=1) - relativedelta(months=offset)
+            m_end = m_start + relativedelta(months=1) - timedelta(days=1)
+            is_current = offset == 0
 
-            # Salary
+            # Salary (23rd-25th, only if date has passed)
             salary_day = random.choice([23, 24, 25])
-            tx_date = date(month_start.year, month_start.month, salary_day)
-            if tx_date <= today:
+            sal_date = m_start.replace(day=min(salary_day, 28))
+            if sal_date <= today and "paycheck" in cats:
                 await c.post("/api/v1/transactions", headers=headers, json={
                     "account_id": accounts["ING Checking"], "category_id": cats["paycheck"],
                     "description": "W&B Monthly Salary", "amount": "6500.00",
-                    "type": "income", "status": "settled", "date": tx_date.isoformat(),
+                    "type": "income", "status": "settled", "date": sal_date.isoformat(),
                 })
                 tx_count += 1
 
-            # Monthly fixed expenses
-            for exp in monthly_expenses:
-                tx_date = date(month_start.year, month_start.month, min(exp["day"], 28))
+            # Side income (occasional)
+            if random.random() > 0.5 and "side_hustles" in cats:
+                si_date = m_start.replace(day=random.randint(10, 20))
+                if si_date <= today:
+                    await c.post("/api/v1/transactions", headers=headers, json={
+                        "account_id": accounts["Revolut"], "category_id": cats["side_hustles"],
+                        "description": "Freelance consulting", "amount": str(random.randint(200, 800)),
+                        "type": "income", "status": "settled", "date": si_date.isoformat(),
+                    })
+                    tx_count += 1
+
+            # Fixed expenses
+            for exp in monthly_fixed:
+                tx_date = m_start.replace(day=min(exp["day"], 28))
                 if tx_date <= today and exp["cat"] in cats:
                     await c.post("/api/v1/transactions", headers=headers, json={
                         "account_id": accounts[exp["acct"]], "category_id": cats[exp["cat"]],
@@ -139,14 +146,16 @@ async def main():
                     })
                     tx_count += 1
 
-            # Variable expenses (8-15 per month)
-            for _ in range(random.randint(8, 15)):
-                exp = random.choice(variable_expenses)
-                day = random.randint(1, 28)
-                tx_date = date(month_start.year, month_start.month, day)
+            # Variable expenses (10-18 per month, spread across the month)
+            num_var = random.randint(10, 18)
+            for _ in range(num_var):
+                exp = random.choice(variable)
+                day = random.randint(1, min(today.day if is_current else 28, 28))
+                tx_date = m_start.replace(day=day)
                 if tx_date <= today and exp["cat"] in cats:
                     amount = round(random.uniform(exp["min"], exp["max"]), 2)
-                    status = "pending" if exp["acct"] == "Amex Platinum" and month_offset == 1 else "settled"
+                    # Current month credit card = pending
+                    status = "pending" if exp["acct"] == "Amex Platinum" and is_current else "settled"
                     await c.post("/api/v1/transactions", headers=headers, json={
                         "account_id": accounts[exp["acct"]], "category_id": cats[exp["cat"]],
                         "description": exp["desc"], "amount": str(amount),
@@ -154,43 +163,54 @@ async def main():
                     })
                     tx_count += 1
 
-        # Monthly savings transfer
-        for month_offset in range(3, 0, -1):
-            month_start = date(today.year, today.month - month_offset, 1) if today.month > month_offset else date(today.year - 1, 12 - (month_offset - today.month), 1)
-            tx_date = date(month_start.year, month_start.month, 26)
-            if tx_date <= today:
+            # Monthly savings transfer (26th)
+            xfer_date = m_start.replace(day=26)
+            if xfer_date <= today and "general_savings" in cats:
                 await c.post("/api/v1/transactions/transfer", headers=headers, json={
                     "from_account_id": accounts["ING Checking"],
                     "to_account_id": accounts["ING Savings"],
-                    "category_id": cats.get("general_savings", list(cats.values())[0]),
+                    "category_id": cats["general_savings"],
                     "description": "Monthly savings", "amount": "500.00",
-                    "status": "settled", "date": tx_date.isoformat(),
+                    "status": "settled", "date": xfer_date.isoformat(),
                 })
-                tx_count += 2  # two sides
+                tx_count += 2
+
+            # Investment contribution (15th, bi-monthly)
+            if offset % 2 == 0 and "investments" in cats:
+                inv_date = m_start.replace(day=15)
+                if inv_date <= today:
+                    await c.post("/api/v1/transactions/transfer", headers=headers, json={
+                        "from_account_id": accounts["ING Checking"],
+                        "to_account_id": accounts["Degiro"],
+                        "category_id": cats["investments"],
+                        "description": "ETF investment", "amount": "300.00",
+                        "status": "settled", "date": inv_date.isoformat(),
+                    })
+                    tx_count += 2
 
         print(f"   Created {tx_count} transactions")
 
-        # Create recurring transactions
+        # Recurring
         print("\n5. Creating recurring transactions...")
-        recurring_defs = [
-            {"acct": "ING Checking", "cat": "rent_mortgage", "desc": "Rent - Apartment", "amount": "1200.00", "freq": "monthly", "day": 1},
-            {"acct": "ING Checking", "cat": "gym", "desc": "BasicFit Membership", "amount": "29.99", "freq": "monthly", "day": 1},
-            {"acct": "ING Checking", "cat": "streaming", "desc": "Netflix", "amount": "17.99", "freq": "monthly", "day": 10},
-            {"acct": "ING Checking", "cat": "streaming", "desc": "Spotify Family", "amount": "16.99", "freq": "monthly", "day": 10},
+        rec_defs = [
+            {"acct": "ING Checking", "cat": "rent_mortgage", "desc": "Rent - Apartment", "amount": "1200.00", "freq": "monthly", "day": 1, "auto": True},
+            {"acct": "ING Checking", "cat": "gym", "desc": "BasicFit Membership", "amount": "29.99", "freq": "monthly", "day": 1, "auto": True},
+            {"acct": "ING Checking", "cat": "streaming", "desc": "Netflix", "amount": "17.99", "freq": "monthly", "day": 10, "auto": True},
+            {"acct": "ING Checking", "cat": "streaming", "desc": "Spotify Family", "amount": "16.99", "freq": "monthly", "day": 10, "auto": True},
+            {"acct": "ING Checking", "cat": "health_insurance", "desc": "Zilveren Kruis", "amount": "135.00", "freq": "monthly", "day": 1, "auto": True},
         ]
-        for rd in recurring_defs:
-            next_month = date(today.year, today.month + 1, 1) if today.month < 12 else date(today.year + 1, 1, 1)
-            next_due = date(next_month.year, next_month.month, min(rd["day"], 28))
+        next_month = today.replace(day=1) + relativedelta(months=1)
+        for rd in rec_defs:
             if rd["cat"] in cats:
                 await c.post("/api/v1/recurring", headers=headers, json={
                     "account_id": accounts[rd["acct"]], "category_id": cats[rd["cat"]],
-                    "description": rd["desc"], "amount": rd["amount"],
-                    "type": "expense", "frequency": rd["freq"],
-                    "next_due_date": next_due.isoformat(), "auto_settle": True,
+                    "description": rd["desc"], "amount": rd["amount"], "type": "expense",
+                    "frequency": rd["freq"], "next_due_date": next_month.replace(day=min(rd["day"], 28)).isoformat(),
+                    "auto_settle": rd["auto"],
                 })
-        print(f"   Created {len(recurring_defs)} recurring templates")
+        print(f"   Created {len(rec_defs)} recurring templates")
 
-        # Create budgets
+        # Budgets
         print("\n6. Creating budgets...")
         budget_defs = [
             {"cat": "housing", "amount": "1400.00"},
@@ -207,9 +227,9 @@ async def main():
                     "category_id": master_cats[bd["cat"]], "amount": bd["amount"],
                 })
                 if r.status_code == 201:
-                    print(f"   Budget: {bd['cat']} = {bd['amount']}")
+                    print(f"   {bd['cat']} = {bd['amount']}")
 
-        print("\n=== Seed complete! ===")
+        print(f"\n=== Seed complete! ===")
         print(f"Login: {USER['username']} / {USER['password']}")
 
 

--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -19,6 +19,11 @@ export default function AccountsPage() {
   const [editingTypeId, setEditingTypeId] = useState<number | null>(null);
   const [editingTypeName, setEditingTypeName] = useState("");
 
+  // Account edit
+  const [editAcctId, setEditAcctId] = useState<number | null>(null);
+  const [editAcctName, setEditAcctName] = useState("");
+  const [editAcctCloseDay, setEditAcctCloseDay] = useState("");
+
   const [showAccountForm, setShowAccountForm] = useState(false);
   const [acctName, setAcctName] = useState("");
   const [acctTypeId, setAcctTypeId] = useState<number | "">("");
@@ -93,6 +98,28 @@ export default function AccountsPage() {
     setError("");
     try {
       await apiFetch(`/api/v1/accounts/${id}`, { method: "DELETE" });
+      await reload();
+    } catch (err) { setError(extractErrorMessage(err)); }
+  }
+
+  function startEditAcct(a: Account) {
+    setEditAcctId(a.id);
+    setEditAcctName(a.name);
+    setEditAcctCloseDay(a.close_day ? String(a.close_day) : "");
+  }
+
+  async function handleSaveAcct() {
+    if (!editAcctId) return;
+    setError("");
+    try {
+      await apiFetch(`/api/v1/accounts/${editAcctId}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: editAcctName,
+          close_day: editAcctCloseDay ? Number(editAcctCloseDay) : null,
+        }),
+      });
+      setEditAcctId(null);
       await reload();
     } catch (err) { setError(extractErrorMessage(err)); }
   }
@@ -206,7 +233,17 @@ export default function AccountsPage() {
                 </form>
               )}
               <div className="space-y-1">
-                {accounts.map((a) => (
+                {accounts.map((a) => editAcctId === a.id ? (
+                  <div key={a.id} className="flex items-center gap-3 rounded-md bg-surface-raised px-3 py-2.5">
+                    <input aria-label="Account name" type="text" value={editAcctName} onChange={(e) => setEditAcctName(e.target.value)} className={`flex-1 text-sm ${input}`}
+                      onKeyDown={(e) => { if (e.key === "Enter") handleSaveAcct(); if (e.key === "Escape") setEditAcctId(null); }} autoFocus />
+                    {a.account_type_slug === "credit_card" && (
+                      <input aria-label="Close day" type="number" min={1} max={28} value={editAcctCloseDay} onChange={(e) => setEditAcctCloseDay(e.target.value)} placeholder="Close day" className={`w-24 text-sm ${input}`} />
+                    )}
+                    <button onClick={handleSaveAcct} className="text-xs text-accent hover:text-accent-hover">Save</button>
+                    <button onClick={() => setEditAcctId(null)} className="text-xs text-text-muted">Cancel</button>
+                  </div>
+                ) : (
                   <div key={a.id} className={`flex items-center justify-between rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised ${!a.is_active ? "opacity-40" : ""}`}>
                     <div>
                       <span className="text-sm font-medium text-text-primary">{a.name}</span>
@@ -221,9 +258,10 @@ export default function AccountsPage() {
                         <span className="text-text-muted">{a.currency}</span>
                       </span>
                       <div className="flex gap-3">
+                        <button onClick={() => startEditAcct(a)} aria-label={`Edit ${a.name}`} className="text-xs text-text-muted hover:text-accent">Edit</button>
                         {!a.is_default && a.is_active && (
                           <button onClick={async () => { try { await apiFetch(`/api/v1/accounts/${a.id}`, { method: "PUT", body: JSON.stringify({ is_default: true }) }); await reload(); } catch (err) { setError(extractErrorMessage(err)); } }} aria-label={`Set ${a.name} as default`} className="text-xs text-text-muted hover:text-accent">
-                            Set Default
+                            Default
                           </button>
                         )}
                         <button onClick={() => handleToggleActive(a)} aria-label={a.is_active ? `Deactivate ${a.name}` : `Activate ${a.name}`} className="text-xs text-text-muted hover:text-text-secondary">
@@ -233,6 +271,7 @@ export default function AccountsPage() {
                       </div>
                     </div>
                   </div>
+                ))
                 ))}
                 {accounts.length === 0 && (
                   <p className="py-4 text-center text-sm text-text-muted">

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -173,11 +173,11 @@ export default function SettingsPage() {
           </div>
         </div>
 
-        <div className={card}>
-          <div className={cardHeader}>
-            <h2 className={cardTitle}>Configuration</h2>
-            <p className="mt-1 text-xs text-text-muted">Runtime settings persisted in the database.</p>
-          </div>
+        <details className={card}>
+          <summary className={`cursor-pointer ${cardHeader}`}>
+            <h2 className={`inline ${cardTitle}`}>Advanced Configuration</h2>
+            <p className="mt-1 text-xs text-text-muted">Custom key-value settings for developers. Most users don't need this.</p>
+          </summary>
           <div className="p-6">
             {error && <div className={`mb-5 ${errorCls}`}>{error}</div>}
 
@@ -222,7 +222,7 @@ export default function SettingsPage() {
               {settings.length === 0 && <p className="py-4 text-center text-sm text-text-muted">No settings configured yet.</p>}
             </div>
           </div>
-        </div>
+        </details>
       </div>
     </AppShell>
   );

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -7,7 +7,7 @@ import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { isAdmin } from "@/lib/auth";
-import { input, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
+import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, success as successCls, pageTitle } from "@/lib/styles";
 import type { OrgSetting } from "@/lib/types";
 
 export default function SettingsPage() {
@@ -17,8 +17,13 @@ export default function SettingsPage() {
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
   const [error, setError] = useState("");
+  const [successMsg, setSuccessMsg] = useState("");
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
+
+  // Billing cycle
+  const [billingCycleDay, setBillingCycleDay] = useState(user?.billing_cycle_day ?? 1);
+  const [savingCycle, setSavingCycle] = useState(false);
 
   const admin = user ? isAdmin(user) : false;
 
@@ -36,6 +41,11 @@ export default function SettingsPage() {
   useEffect(() => {
     if (admin) reload();
   }, [admin, reload]);
+
+  // Sync billing cycle from user when available
+  useEffect(() => {
+    if (user?.billing_cycle_day) setBillingCycleDay(user.billing_cycle_day);
+  }, [user]);
 
   async function handleAdd(e: FormEvent) {
     e.preventDefault();
@@ -77,6 +87,47 @@ export default function SettingsPage() {
         <div className={`${card} p-6`}>
           <h2 className={`mb-2 ${cardTitle}`}>Organization</h2>
           <p className="text-sm text-text-primary">{user?.org_name}</p>
+        </div>
+
+        {/* Billing Cycle */}
+        <div className={`${card} p-6`}>
+          <h2 className={`mb-4 ${cardTitle}`}>Billing Cycle</h2>
+          <p className="mb-4 text-xs text-text-muted">
+            Set the day of the month when your billing cycle starts. This affects how the dashboard
+            and budgets define &quot;current month&quot; (e.g., day 15 means 15th to 14th).
+          </p>
+          {successMsg && <div className={`mb-4 ${successCls}`}>{successMsg}</div>}
+          <div className="flex items-end gap-3">
+            <div>
+              <label htmlFor="cycle-day" className={label}>Cycle Start Day (1-28)</label>
+              <input
+                id="cycle-day"
+                type="number"
+                min={1}
+                max={28}
+                value={billingCycleDay}
+                onChange={(e) => setBillingCycleDay(Number(e.target.value))}
+                className={`w-24 ${input}`}
+              />
+            </div>
+            <button
+              disabled={savingCycle}
+              onClick={async () => {
+                setSavingCycle(true); setError(""); setSuccessMsg("");
+                try {
+                  await apiFetch("/api/v1/settings/billing-cycle", {
+                    method: "PUT",
+                    body: JSON.stringify({ billing_cycle_day: billingCycleDay }),
+                  });
+                  setSuccessMsg("Billing cycle updated. Refresh to see changes on the dashboard.");
+                } catch (err) { setError(extractErrorMessage(err)); }
+                finally { setSavingCycle(false); }
+              }}
+              className={btnPrimary}
+            >
+              {savingCycle ? "Saving..." : "Save"}
+            </button>
+          </div>
         </div>
 
         <div className={card}>

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -140,7 +140,7 @@ export default function SettingsPage() {
             </button>
 
             <div className="border-l border-border pl-4">
-              <p className="text-xs text-text-muted mb-1">Default cycle hint day (for new periods)</p>
+              <label htmlFor="cycle-day" className="text-xs text-text-muted mb-1 block">Default cycle hint day (for new periods)</label>
               <div className="flex items-center gap-2">
                 <input
                   id="cycle-day"

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -21,9 +21,11 @@ export default function SettingsPage() {
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
 
-  // Billing cycle
+  // Billing
   const [billingCycleDay, setBillingCycleDay] = useState(user?.billing_cycle_day ?? 1);
   const [savingCycle, setSavingCycle] = useState(false);
+  const [currentPeriod, setCurrentPeriod] = useState<{ id: number; start_date: string; end_date: string | null } | null>(null);
+  const [closingPeriod, setClosingPeriod] = useState(false);
 
   const admin = user ? isAdmin(user) : false;
 
@@ -42,10 +44,18 @@ export default function SettingsPage() {
     if (admin) reload();
   }, [admin, reload]);
 
-  // Sync billing cycle from user when available
   useEffect(() => {
     if (user?.billing_cycle_day) setBillingCycleDay(user.billing_cycle_day);
   }, [user]);
+
+  // Load current billing period
+  useEffect(() => {
+    if (admin) {
+      apiFetch<{ id: number; start_date: string; end_date: string | null }>("/api/v1/settings/billing-period")
+        .then((p) => { if (p) setCurrentPeriod(p); })
+        .catch(() => {});
+    }
+  }, [admin]);
 
   async function handleAdd(e: FormEvent) {
     e.preventDefault();
@@ -89,44 +99,77 @@ export default function SettingsPage() {
           <p className="text-sm text-text-primary">{user?.org_name}</p>
         </div>
 
-        {/* Billing Cycle */}
+        {/* Billing Period */}
         <div className={`${card} p-6`}>
-          <h2 className={`mb-4 ${cardTitle}`}>Billing Cycle</h2>
-          <p className="mb-4 text-xs text-text-muted">
-            Set the day of the month when your billing cycle starts. This affects how the dashboard
-            and budgets define &quot;current month&quot; (e.g., day 15 means 15th to 14th).
-          </p>
+          <h2 className={`mb-4 ${cardTitle}`}>Billing Period</h2>
           {successMsg && <div className={`mb-4 ${successCls}`}>{successMsg}</div>}
-          <div className="flex items-end gap-3">
-            <div>
-              <label htmlFor="cycle-day" className={label}>Cycle Start Day (1-28)</label>
-              <input
-                id="cycle-day"
-                type="number"
-                min={1}
-                max={28}
-                value={billingCycleDay}
-                onChange={(e) => setBillingCycleDay(Number(e.target.value))}
-                className={`w-24 ${input}`}
-              />
+
+          {currentPeriod && (
+            <div className="mb-4 rounded-md bg-surface-raised px-4 py-3">
+              <p className="text-sm text-text-primary">
+                Current period: <span className="font-medium">{currentPeriod.start_date}</span>
+                {currentPeriod.end_date
+                  ? <> — <span className="font-medium">{currentPeriod.end_date}</span></>
+                  : <span className="ml-1 text-success text-xs font-medium">open</span>
+                }
+              </p>
             </div>
+          )}
+
+          <p className="mb-4 text-xs text-text-muted">
+            Close the current period when you receive your salary. The next period starts the following day.
+            Past settled transactions remain in their original period.
+          </p>
+
+          <div className="flex flex-wrap items-end gap-4">
             <button
-              disabled={savingCycle}
+              disabled={closingPeriod}
               onClick={async () => {
-                setSavingCycle(true); setError(""); setSuccessMsg("");
+                if (!confirm("Close the current billing period?\n\nA new period will start tomorrow. Budgets for the new period will need to be set.")) return;
+                setClosingPeriod(true); setError(""); setSuccessMsg("");
                 try {
-                  await apiFetch("/api/v1/settings/billing-cycle", {
-                    method: "PUT",
-                    body: JSON.stringify({ billing_cycle_day: billingCycleDay }),
-                  });
-                  setSuccessMsg("Billing cycle updated. Refresh to see changes on the dashboard.");
+                  const newP = await apiFetch<{ id: number; start_date: string; end_date: string | null }>("/api/v1/settings/billing-period/close", { method: "POST" });
+                  if (newP) setCurrentPeriod(newP);
+                  setSuccessMsg("Period closed. New period started.");
                 } catch (err) { setError(extractErrorMessage(err)); }
-                finally { setSavingCycle(false); }
+                finally { setClosingPeriod(false); }
               }}
               className={btnPrimary}
             >
-              {savingCycle ? "Saving..." : "Save"}
+              {closingPeriod ? "Closing..." : "Close Current Period"}
             </button>
+
+            <div className="border-l border-border pl-4">
+              <p className="text-xs text-text-muted mb-1">Default cycle hint day (for new periods)</p>
+              <div className="flex items-center gap-2">
+                <input
+                  id="cycle-day"
+                  type="number"
+                  min={1}
+                  max={28}
+                  value={billingCycleDay}
+                  onChange={(e) => setBillingCycleDay(Number(e.target.value))}
+                  className={`w-20 text-sm ${input}`}
+                />
+                <button
+                  disabled={savingCycle}
+                  onClick={async () => {
+                    setSavingCycle(true); setError(""); setSuccessMsg("");
+                    try {
+                      await apiFetch("/api/v1/settings/billing-cycle", {
+                        method: "PUT",
+                        body: JSON.stringify({ billing_cycle_day: billingCycleDay }),
+                      });
+                      setSuccessMsg("Default cycle day updated.");
+                    } catch (err) { setError(extractErrorMessage(err)); }
+                    finally { setSavingCycle(false); }
+                  }}
+                  className="rounded-md border border-border px-3 py-1.5 text-xs text-text-secondary hover:bg-surface-raised"
+                >
+                  {savingCycle ? "..." : "Save"}
+                </button>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { formatAmount } from "@/lib/format";
+import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
+import type { Budget, Category } from "@/lib/types";
+
+export default function BudgetsPage() {
+  const { user, loading } = useAuth();
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [fetching, setFetching] = useState(true);
+  const [error, setError] = useState("");
+  const [showForm, setShowForm] = useState(false);
+
+  const [formCategoryId, setFormCategoryId] = useState<number | "">("");
+  const [formAmount, setFormAmount] = useState("");
+
+  // Edit
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editAmount, setEditAmount] = useState("");
+
+  const reload = useCallback(async () => {
+    const [b, c] = await Promise.all([
+      apiFetch<Budget[]>("/api/v1/budgets"),
+      apiFetch<Category[]>("/api/v1/categories"),
+    ]);
+    setBudgets(b ?? []);
+    setCategories(c ?? []);
+    setFetching(false);
+  }, []);
+
+  useEffect(() => {
+    if (!loading && user) reload().catch(() => setFetching(false));
+  }, [loading, user, reload]);
+
+  // Master categories that don't have a budget yet
+  const masterCategories = categories.filter((c) => c.parent_id === null && c.type === "expense");
+  const budgetedCatIds = new Set(budgets.map((b) => b.category_id));
+  const availableCategories = masterCategories.filter((c) => !budgetedCatIds.has(c.id));
+
+  async function handleAdd(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    try {
+      await apiFetch("/api/v1/budgets", {
+        method: "POST",
+        body: JSON.stringify({ category_id: formCategoryId, amount: formAmount }),
+      });
+      setFormCategoryId(""); setFormAmount(""); setShowForm(false);
+      await reload();
+    } catch (err) { setError(extractErrorMessage(err)); }
+  }
+
+  async function handleUpdate(id: number) {
+    setError("");
+    try {
+      await apiFetch(`/api/v1/budgets/${id}`, {
+        method: "PUT",
+        body: JSON.stringify({ amount: editAmount }),
+      });
+      setEditingId(null);
+      await reload();
+    } catch (err) { setError(extractErrorMessage(err)); }
+  }
+
+  async function handleDelete(id: number) {
+    if (!confirm("Remove this budget?")) return;
+    try {
+      await apiFetch(`/api/v1/budgets/${id}`, { method: "DELETE" });
+      await reload();
+    } catch (err) { setError(extractErrorMessage(err)); }
+  }
+
+  const totalBudget = budgets.reduce((s, b) => s + Number(b.amount), 0);
+  const totalSpent = budgets.reduce((s, b) => s + Number(b.spent), 0);
+
+  return (
+    <AppShell>
+      <div className="mb-8 flex items-center justify-between">
+        <h1 className={`${pageTitle} mb-0`}>Budgets</h1>
+        {availableCategories.length > 0 && (
+          <button onClick={() => setShowForm(!showForm)} className={btnPrimary}>
+            {showForm ? "Cancel" : "+ Add Budget"}
+          </button>
+        )}
+      </div>
+
+      {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
+
+      {showForm && (
+        <div className={`mb-6 ${card} p-6`}>
+          <form onSubmit={handleAdd} className="flex flex-wrap gap-4 items-end">
+            <div className="flex-1 min-w-[200px]">
+              <label htmlFor="b-cat" className={label}>Category</label>
+              <select id="b-cat" required value={formCategoryId} onChange={(e) => setFormCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={input}>
+                <option value="">Select category</option>
+                {availableCategories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+              </select>
+            </div>
+            <div className="w-40">
+              <label htmlFor="b-amount" className={label}>Monthly limit</label>
+              <input id="b-amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value={formAmount} onChange={(e) => setFormAmount(e.target.value)} className={input} />
+            </div>
+            <button type="submit" className={btnPrimary}>Add</button>
+          </form>
+        </div>
+      )}
+
+      {fetching ? (
+        <Spinner />
+      ) : (
+        <div className="space-y-6">
+          {/* Summary */}
+          {budgets.length > 0 && (
+            <div className="flex gap-4">
+              <div className={`flex-1 ${card} p-5`}>
+                <p className={cardTitle}>Total Budget</p>
+                <p className="mt-1 text-2xl font-semibold tabular-nums text-text-primary">{formatAmount(totalBudget)}</p>
+              </div>
+              <div className={`flex-1 ${card} p-5`}>
+                <p className={cardTitle}>Total Spent</p>
+                <p className={`mt-1 text-2xl font-semibold tabular-nums ${totalSpent > totalBudget ? "text-danger" : "text-text-primary"}`}>{formatAmount(totalSpent)}</p>
+              </div>
+              <div className={`flex-1 ${card} p-5`}>
+                <p className={cardTitle}>Remaining</p>
+                <p className={`mt-1 text-2xl font-semibold tabular-nums ${totalBudget - totalSpent < 0 ? "text-danger" : "text-success"}`}>{formatAmount(totalBudget - totalSpent)}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Budget list */}
+          <div className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>
+                {budgets.length > 0 && budgets[0].period_start && (
+                  <span>Period: {budgets[0].period_start} — {budgets[0].period_end}</span>
+                )}
+                {budgets.length === 0 && "Current Period"}
+              </h2>
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {budgets.map((b) => {
+                const pct = Math.min(b.percent_used, 100);
+                const overBudget = b.percent_used > 100;
+                return (
+                  <div key={b.id} className="px-6 py-4">
+                    {editingId === b.id ? (
+                      <div className="flex items-center gap-3">
+                        <span className="text-sm font-medium text-text-primary flex-1">{b.category_name}</span>
+                        <input type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)}
+                          className={`w-32 ${input}`} autoFocus
+                          onKeyDown={(e) => { if (e.key === "Enter") handleUpdate(b.id); if (e.key === "Escape") setEditingId(null); }} />
+                        <button onClick={() => handleUpdate(b.id)} className="text-xs text-accent hover:text-accent-hover">Save</button>
+                        <button onClick={() => setEditingId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                      </div>
+                    ) : (
+                      <>
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="text-sm font-medium text-text-primary">{b.category_name}</span>
+                          <div className="flex items-center gap-4">
+                            <span className={`text-sm tabular-nums ${overBudget ? "text-danger font-medium" : "text-text-secondary"}`}>
+                              {formatAmount(b.spent)} / {formatAmount(b.amount)}
+                            </span>
+                            <div className="flex gap-2">
+                              <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
+                              <button onClick={() => handleDelete(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
+                            </div>
+                          </div>
+                        </div>
+                        {/* Progress bar */}
+                        <div className="h-2 rounded-full bg-surface-overlay">
+                          <div
+                            className={`h-2 rounded-full transition-all ${overBudget ? "bg-danger" : pct > 80 ? "bg-amber-500" : "bg-success"}`}
+                            style={{ width: `${Math.min(pct, 100)}%` }}
+                          />
+                        </div>
+                        <div className="mt-1 flex justify-between text-xs text-text-muted">
+                          <span>{b.percent_used}% used</span>
+                          <span>{formatAmount(b.remaining)} left</span>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                );
+              })}
+              {budgets.length === 0 && (
+                <div className="px-6 py-8 text-center text-sm text-text-muted">
+                  No budgets set. Click &quot;+ Add Budget&quot; to allocate spending limits for your categories.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -6,17 +6,10 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { formatAmount, todayISO } from "@/lib/format";
+import { formatAmount, formatLocalDate, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, pageTitle, error as errorCls } from "@/lib/styles";
 import CategorySelect from "@/components/ui/CategorySelect";
 import type { Account, Budget, Category, Transaction } from "@/lib/types";
-
-function formatLocalDate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
 
 interface BillingPeriod {
   id: number;

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -33,6 +33,8 @@ export default function DashboardPage() {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [budgets, setBudgets] = useState<Budget[]>([]);
   const [period, setPeriod] = useState<BillingPeriod | null>(null);
+  const [periods, setPeriods] = useState<BillingPeriod[]>([]);
+  const [periodIdx, setPeriodIdx] = useState(0);
   const [fetching, setFetching] = useState(true);
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -53,8 +55,10 @@ export default function DashboardPage() {
   const [formFrequency, setFormFrequency] = useState("monthly");
   const [formAutoSettle, setFormAutoSettle] = useState(false);
 
-  const monthFrom = period?.start_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
-  const monthTo = period?.end_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0));
+  // Selected period (navigate with arrows)
+  const selectedPeriod = periods.length > 0 ? periods[periodIdx] : period;
+  const monthFrom = selectedPeriod?.start_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
+  const monthTo = selectedPeriod?.end_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0));
 
   const loadRefs = useCallback(async () => {
     const [accts, cats] = await Promise.all([
@@ -62,11 +66,14 @@ export default function DashboardPage() {
       apiFetch<Category[]>("/api/v1/categories"),
       apiFetch<Budget[]>("/api/v1/budgets"),
       apiFetch<BillingPeriod>("/api/v1/settings/billing-period"),
+      apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),
     ]);
     setAccounts(accts ?? []);
     setCategories(cats ?? []);
     setBudgets(bds ?? []);
     if (per) setPeriod(per);
+    setPeriods(plist ?? []);
+    setPeriodIdx(0);
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {
@@ -189,6 +196,11 @@ export default function DashboardPage() {
 
   // Precompute tx map for O(1) linked lookups
   const txMap = new Map(transactions.map((tx) => [tx.id, tx]));
+
+  // Income vs expense totals for the period
+  const totalIncome = transactions.filter((tx) => tx.type === "income" && tx.status === "settled").reduce((s, tx) => s + Number(tx.amount), 0);
+  const totalExpense = transactions.filter((tx) => tx.type === "expense" && tx.status === "settled").reduce((s, tx) => s + Number(tx.amount), 0);
+  const maxBar = Math.max(totalIncome, totalExpense, 1);
 
   // Pending totals per account from current-month transactions
   const pendingByAccount = transactions
@@ -319,28 +331,21 @@ export default function DashboardPage() {
             </div>
           )}
 
-          {/* Per-account tiles */}
+          {/* Per-account tiles — compact */}
           {accountsWithBalance.length > 0 && (
-            <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <div className="grid grid-cols-3 gap-2 lg:grid-cols-5 xl:grid-cols-6">
               {accountsWithBalance.map((acct) => {
                 const pending = pendingByAccount[acct.id] || 0;
                 const isCreditCard = acct.account_type_slug === "credit_card";
                 return (
-                  <div key={acct.id} className={`${card} p-4`}>
-                    <p className="text-xs font-medium text-text-muted truncate">{acct.name}</p>
-                    <p className="text-[11px] text-text-muted">{acct.account_type_name}</p>
-                    <p className="mt-1.5 text-lg font-semibold tabular-nums text-text-primary">
-                      {formatAmount(acct.balance)} <span className="text-xs text-text-muted">{acct.currency}</span>
+                  <div key={acct.id} className={`${card} px-3 py-2.5`}>
+                    <p className="text-[11px] font-medium text-text-muted truncate">{acct.name}</p>
+                    <p className="mt-1 text-sm font-semibold tabular-nums text-text-primary">
+                      {formatAmount(acct.balance)} <span className="text-[10px] text-text-muted">{acct.currency}</span>
                     </p>
-                    {pending !== 0 && (
-                      <p className={`mt-0.5 text-xs tabular-nums ${isCreditCard ? "text-danger" : "text-text-muted"}`}>
-                        {isCreditCard ? "Pending charges: " : "Pending: "}
-                        {formatAmount(Math.abs(pending))}
-                      </p>
-                    )}
                     {isCreditCard && pending !== 0 && (
-                      <p className="mt-0.5 text-xs tabular-nums text-text-secondary">
-                        Net: {formatAmount(Number(acct.balance) + pending)}
+                      <p className="mt-0.5 text-[10px] tabular-nums text-danger">
+                        Pending: {formatAmount(Math.abs(pending))}
                       </p>
                     )}
                   </div>
@@ -381,10 +386,64 @@ export default function DashboardPage() {
             </div>
           )}
 
-          {/* Recent transactions (current month) */}
+          {/* Income vs Expense chart */}
+          {(totalIncome > 0 || totalExpense > 0) && (
+            <div className={`${card} p-5`}>
+              <h2 className={`mb-4 ${cardTitle}`}>Income vs Expense</h2>
+              <div className="space-y-3">
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs text-text-muted">Income</span>
+                    <span className="text-sm font-medium tabular-nums text-success">+{formatAmount(totalIncome)}</span>
+                  </div>
+                  <div className="h-3 rounded-full bg-surface-overlay">
+                    <div className="h-3 rounded-full bg-success transition-all" style={{ width: `${(totalIncome / maxBar) * 100}%` }} />
+                  </div>
+                </div>
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs text-text-muted">Expenses</span>
+                    <span className="text-sm font-medium tabular-nums text-danger">-{formatAmount(totalExpense)}</span>
+                  </div>
+                  <div className="h-3 rounded-full bg-surface-overlay">
+                    <div className="h-3 rounded-full bg-danger transition-all" style={{ width: `${(totalExpense / maxBar) * 100}%` }} />
+                  </div>
+                </div>
+                <div className="flex items-center justify-between pt-1 border-t border-border-subtle">
+                  <span className="text-xs text-text-muted">Net</span>
+                  <span className={`text-sm font-semibold tabular-nums ${totalIncome - totalExpense >= 0 ? "text-success" : "text-danger"}`}>
+                    {totalIncome - totalExpense >= 0 ? "+" : ""}{formatAmount(totalIncome - totalExpense)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Transactions with period navigation */}
           <div className={card}>
             <div className={`flex items-center justify-between ${cardHeader}`}>
-              <h2 className={cardTitle}>Transactions — This Month</h2>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1))}
+                  disabled={periodIdx >= periods.length - 1}
+                  className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30"
+                  aria-label="Previous period"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+                </button>
+                <h2 className={cardTitle}>
+                  {monthFrom}{monthTo !== monthFrom ? ` — ${monthTo}` : ""}
+                  {periodIdx === 0 && <span className="ml-2 text-success text-[10px]">current</span>}
+                </h2>
+                <button
+                  onClick={() => setPeriodIdx(Math.max(periodIdx - 1, 0))}
+                  disabled={periodIdx <= 0}
+                  className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30"
+                  aria-label="Next period"
+                >
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
+                </button>
+              </div>
               <Link href="/transactions" className="text-xs text-accent hover:text-accent-hover">
                 View All
               </Link>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { formatAmount, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, pageTitle, error as errorCls } from "@/lib/styles";
 import CategorySelect from "@/components/ui/CategorySelect";
-import type { Account, Category, Transaction } from "@/lib/types";
+import type { Account, Budget, Category, Transaction } from "@/lib/types";
 
 function formatLocalDate(d: Date): string {
   const y = d.getFullYear();
@@ -50,6 +50,7 @@ export default function DashboardPage() {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [budgets, setBudgets] = useState<Budget[]>([]);
   const [fetching, setFetching] = useState(true);
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -77,9 +78,11 @@ export default function DashboardPage() {
     const [accts, cats] = await Promise.all([
       apiFetch<Account[]>("/api/v1/accounts"),
       apiFetch<Category[]>("/api/v1/categories"),
+      apiFetch<Budget[]>("/api/v1/budgets"),
     ]);
     setAccounts(accts ?? []);
     setCategories(cats ?? []);
+    setBudgets(bds ?? []);
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {
@@ -359,6 +362,38 @@ export default function DashboardPage() {
                   </div>
                 );
               })}
+            </div>
+          )}
+
+          {/* Budget progress */}
+          {budgets.length > 0 && (
+            <div className={card}>
+              <div className={`flex items-center justify-between ${cardHeader}`}>
+                <h2 className={cardTitle}>Budget Progress</h2>
+                <a href="/budgets" className="text-xs text-accent hover:text-accent-hover">Manage</a>
+              </div>
+              <div className="divide-y divide-border-subtle">
+                {budgets.slice(0, 5).map((b) => {
+                  const pct = Math.min(b.percent_used, 100);
+                  const over = b.percent_used > 100;
+                  return (
+                    <div key={b.id} className="px-6 py-3">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-sm text-text-primary">{b.category_name}</span>
+                        <span className={`text-xs tabular-nums ${over ? "text-danger" : "text-text-muted"}`}>
+                          {formatAmount(b.spent)} / {formatAmount(b.amount)}
+                        </span>
+                      </div>
+                      <div className="h-1.5 rounded-full bg-surface-overlay">
+                        <div
+                          className={`h-1.5 rounded-full transition-all ${over ? "bg-danger" : pct > 80 ? "bg-amber-500" : "bg-success"}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           )}
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -18,29 +18,10 @@ function formatLocalDate(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
-function billingCycleRange(cycleDay: number): { from: string; to: string } {
-  const now = new Date();
-  const y = now.getFullYear();
-  const m = now.getMonth();
-  const d = now.getDate();
-
-  let fromDate: Date;
-  let toDate: Date;
-
-  if (d >= cycleDay) {
-    // We're in the current cycle: cycleDay this month → cycleDay next month - 1
-    fromDate = new Date(y, m, cycleDay);
-    toDate = new Date(y, m + 1, cycleDay - 1);
-  } else {
-    // We're before the cycle day: cycleDay last month → cycleDay this month - 1
-    fromDate = new Date(y, m - 1, cycleDay);
-    toDate = new Date(y, m, cycleDay - 1);
-  }
-
-  return {
-    from: formatLocalDate(fromDate),
-    to: formatLocalDate(toDate),
-  };
+interface BillingPeriod {
+  id: number;
+  start_date: string;
+  end_date: string | null;
 }
 
 const PAGE_SIZE = 10;
@@ -51,6 +32,7 @@ export default function DashboardPage() {
   const [categories, setCategories] = useState<Category[]>([]);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [budgets, setBudgets] = useState<Budget[]>([]);
+  const [period, setPeriod] = useState<BillingPeriod | null>(null);
   const [fetching, setFetching] = useState(true);
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -71,18 +53,20 @@ export default function DashboardPage() {
   const [formFrequency, setFormFrequency] = useState("monthly");
   const [formAutoSettle, setFormAutoSettle] = useState(false);
 
-  const cycleDay = user?.billing_cycle_day ?? 1;
-  const { from: monthFrom, to: monthTo } = billingCycleRange(cycleDay);
+  const monthFrom = period?.start_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
+  const monthTo = period?.end_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0));
 
   const loadRefs = useCallback(async () => {
     const [accts, cats] = await Promise.all([
       apiFetch<Account[]>("/api/v1/accounts"),
       apiFetch<Category[]>("/api/v1/categories"),
       apiFetch<Budget[]>("/api/v1/budgets"),
+      apiFetch<BillingPeriod>("/api/v1/settings/billing-period"),
     ]);
     setAccounts(accts ?? []);
     setCategories(cats ?? []);
     setBudgets(bds ?? []);
+    if (per) setPeriod(per);
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -54,7 +54,7 @@ export default function DashboardPage() {
   const monthTo = selectedPeriod?.end_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0));
 
   const loadRefs = useCallback(async () => {
-    const [accts, cats] = await Promise.all([
+    const [accts, cats, bds, per, plist] = await Promise.all([
       apiFetch<Account[]>("/api/v1/accounts"),
       apiFetch<Category[]>("/api/v1/categories"),
       apiFetch<Budget[]>("/api/v1/budgets"),

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -5,7 +5,7 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { formatAmount, todayISO } from "@/lib/format";
+import { formatAmount, formatLocalDate, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import CategorySelect from "@/components/ui/CategorySelect";
 import type { Account, Category, Transaction } from "@/lib/types";
@@ -40,6 +40,7 @@ export default function TransactionsPage() {
   const [filterStatus, setFilterStatus] = useState<string>("");
   const [filterDateFrom, setFilterDateFrom] = useState("");
   const [filterDateTo, setFilterDateTo] = useState("");
+  const [filterSearch, setFilterSearch] = useState("");
 
   // Form
   const [formMode, setFormMode] = useState<"transaction" | "transfer">("transaction");
@@ -72,11 +73,12 @@ export default function TransactionsPage() {
     if (filterStatus) url += `&status=${filterStatus}`;
     if (filterDateFrom) url += `&date_from=${filterDateFrom}`;
     if (filterDateTo) url += `&date_to=${filterDateTo}`;
+    if (filterSearch) url += `&search=${encodeURIComponent(filterSearch)}`;
     const data = (await apiFetch<Transaction[]>(url)) ?? [];
     setHasMore(data.length > PAGE_SIZE);
     setTransactions(data.slice(0, PAGE_SIZE));
     setFetching(false);
-  }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo]);
+  }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch]);
 
   useEffect(() => {
     if (!loading && user) loadRefs().catch(() => {});
@@ -89,7 +91,7 @@ export default function TransactionsPage() {
     }
   }, [loading, user, loadTransactions, page]);
 
-  useEffect(() => { setPage(0); }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo]);
+  useEffect(() => { setPage(0); }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch]);
 
   function handleTypeChange(t: "income" | "expense") {
     setFormType(t);
@@ -337,7 +339,25 @@ export default function TransactionsPage() {
         </div>
       )}
 
-      {/* Filters */}
+      {/* Search + Preset filters */}
+      <div className="mb-3 flex flex-wrap items-center gap-3">
+        <div className="flex-1 min-w-[200px]">
+          <label htmlFor="f-search" className="sr-only">Search transactions</label>
+          <input id="f-search" type="text" placeholder="Search descriptions..." value={filterSearch} onChange={(e) => setFilterSearch(e.target.value)} className={input} />
+        </div>
+        <div className="flex gap-1">
+          {[
+            { label: "Today", fn: () => { const d = todayISO(); setFilterDateFrom(d); setFilterDateTo(d); } },
+            { label: "This Week", fn: () => { const now = new Date(); const mon = new Date(now); mon.setDate(now.getDate() - now.getDay() + 1); setFilterDateFrom(formatLocalDate(mon)); setFilterDateTo(todayISO()); } },
+            { label: "This Month", fn: () => { const now = new Date(); setFilterDateFrom(formatLocalDate(new Date(now.getFullYear(), now.getMonth(), 1))); setFilterDateTo(todayISO()); } },
+            { label: "All", fn: () => { setFilterDateFrom(""); setFilterDateTo(""); } },
+          ].map((p) => (
+            <button key={p.label} type="button" onClick={p.fn} className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised">
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
       <div className="mb-4 flex flex-wrap gap-3">
         <div>
           <label htmlFor="f-account" className="sr-only">Filter by account</label>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -470,17 +470,23 @@ export default function TransactionsPage() {
                     </span>
                     <span className="col-span-2 text-sm text-text-secondary">{tx.category_name}</span>
                     <span className="col-span-1 text-center">
-                      <button
-                        onClick={() => handleToggleStatus(tx)}
-                        aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                          tx.status === "settled"
-                            ? "bg-success-dim text-success"
-                            : "bg-surface-overlay text-text-muted"
-                        }`}
-                      >
-                        {tx.status}
-                      </button>
+                      {isTransfer ? (
+                        <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                          {tx.status}
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => handleToggleStatus(tx)}
+                          aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                            tx.status === "settled"
+                              ? "bg-success-dim text-success"
+                              : "bg-surface-overlay text-text-muted"
+                          }`}
+                        >
+                          {tx.status}
+                        </button>
+                      )}
                     </span>
                     <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
                       {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -45,6 +45,16 @@ const navItems = [
     ),
   },
   {
+    href: "/budgets",
+    label: "Budgets",
+    icon: (
+      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
+      </svg>
+    ),
+  },
+  {
     href: "/categories",
     label: "Categories",
     icon: (

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -5,6 +5,13 @@ export function formatAmount(value: number | string): string {
   });
 }
 
+export function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
 export function todayISO(): string {
-  return new Date().toISOString().slice(0, 10);
+  return formatLocalDate(new Date());
 }

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -82,6 +82,18 @@ export interface RecurringTransaction {
   is_active: boolean;
 }
 
+export interface Budget {
+  id: number;
+  category_id: number;
+  category_name: string;
+  amount: number;
+  spent: number;
+  remaining: number;
+  percent_used: number;
+  period_start: string;
+  period_end: string;
+}
+
 export interface OrgSetting {
   key: string;
   value: string;

--- a/pfv
+++ b/pfv
@@ -87,7 +87,13 @@ cmd_shell() {
 
 cmd_seed() {
   echo "Seeding mock data..."
-  docker compose exec backend python seed.py
+  # Pass SEED_* env vars from .env or command line
+  docker compose exec \
+    ${SEED_USERNAME:+-e SEED_USERNAME="$SEED_USERNAME"} \
+    ${SEED_PASSWORD:+-e SEED_PASSWORD="$SEED_PASSWORD"} \
+    ${SEED_EMAIL:+-e SEED_EMAIL="$SEED_EMAIL"} \
+    ${SEED_ORG:+-e SEED_ORG="$SEED_ORG"} \
+    backend python seed.py
 }
 
 case "${1:-}" in

--- a/pfv
+++ b/pfv
@@ -23,6 +23,7 @@ Commands:
   logs [svc]   View logs (optional: backend, frontend, nginx, mysql)
   status       Show container status
   shell [svc]  Open a shell in a service (default: backend)
+  seed         Populate with mock data (demo user + 3 months of transactions)
 
 EOF
 }
@@ -84,6 +85,11 @@ cmd_shell() {
   docker compose exec "$svc" /bin/sh
 }
 
+cmd_seed() {
+  echo "Seeding mock data..."
+  docker compose exec backend python seed.py
+}
+
 case "${1:-}" in
   start)    cmd_start ;;
   stop)     cmd_stop ;;
@@ -94,5 +100,6 @@ case "${1:-}" in
   logs)     shift; cmd_logs "$@" ;;
   status)   cmd_status ;;
   shell)    shift; cmd_shell "$@" ;;
+  seed)     cmd_seed ;;
   *)        usage ;;
 esac

--- a/pfv
+++ b/pfv
@@ -58,6 +58,19 @@ cmd_rebuild() {
 cmd_reset() {
   echo "Destroying all data and starting fresh..."
   docker compose down -v
+
+  # Rotate JWT secret to invalidate all existing tokens
+  if [[ -f .env ]]; then
+    local new_secret
+    new_secret=$(openssl rand -hex 32)
+    if grep -q "^JWT_SECRET_KEY=" .env; then
+      sed -i.bak "s/^JWT_SECRET_KEY=.*/JWT_SECRET_KEY=${new_secret}/" .env && rm -f .env.bak
+    else
+      echo "JWT_SECRET_KEY=${new_secret}" >> .env
+    fi
+    echo "JWT secret rotated (all previous sessions invalidated)"
+  fi
+
   docker compose up --build -d
   echo "Ready: http://localhost"
 }


### PR DESCRIPTION
## Summary

Monthly budget allocations per master category with live spend tracking and progress visualization.

## Changes

### Backend
- Migration 013: `budgets` table with unique constraint per (org, category, period)
- Budget model: org-scoped, linked to master categories only, period dates
- Budget service: spend computed by summing settled expense transactions across all subcategories within the billing period
- Period auto-computed from org's `billing_cycle_day`
- CRUD at `/api/v1/budgets` — create validates master-category-only, blocks duplicates per period

### Frontend
- Budgets page: add/edit/remove budgets for expense master categories
- Progress bars: green (<80%), amber (80-100%), red (over budget)
- Summary tiles: total budget, total spent, remaining
- Dashboard: budget progress widget showing top 5 with compact progress bars
- Sidebar nav item added