### PR TITLE
feat: forecasting — executed vs forecast comparison

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from app.config import settings as app_settings
 from app.database import engine
 from app.logging import setup_logging
-from app.routers import account_types, accounts, auth, budgets, categories, recurring, settings, transactions, users
+from app.routers import account_types, accounts, auth, budgets, categories, forecast, recurring, settings, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -78,6 +78,7 @@ app.include_router(categories.router)
 app.include_router(transactions.router)
 app.include_router(recurring.router)
 app.include_router(budgets.router)
+app.include_router(forecast.router)
 app.include_router(settings.router)
 
 

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -123,6 +123,11 @@ async def update_account(
             raise HTTPException(status_code=400, detail="Invalid account type")
         account.account_type_id = body.account_type_id
     if body.is_active is not None:
+        if body.is_active is False and account.balance != 0:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Cannot deactivate account with balance {account.balance}. Transfer the balance first.",
+            )
         account.is_active = body.is_active
     if "close_day" in body.model_fields_set:
         account.close_day = body.close_day
@@ -185,6 +190,12 @@ async def delete_account(
     account = result.scalar_one_or_none()
     if account is None:
         raise HTTPException(status_code=404, detail="Account not found")
+
+    if account.balance != 0:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Cannot delete account with balance {account.balance}. Transfer the balance first.",
+        )
 
     await assert_no_dependents(
         db, Transaction,

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -81,6 +81,13 @@ async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)):
                 is_system=True,
             ))
 
+    # Transfer category (used automatically for transfers, no parent)
+    db.add(Category(
+        org_id=org.id, name="Transfer", slug="transfer",
+        description="Internal transfers between accounts",
+        type=CategoryType.BOTH, is_system=True,
+    ))
+
     user = User(
         org_id=org.id,
         username=body.username,

--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -113,12 +113,6 @@ async def update_category(
     if cat is None:
         raise HTTPException(status_code=404, detail="Category not found")
 
-    if cat.is_system:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot modify system category",
-        )
-
     if body.name is not None:
         cat.name = body.name
     if body.type is not None:
@@ -161,12 +155,6 @@ async def delete_category(
     cat = result.scalar_one_or_none()
     if cat is None:
         raise HTTPException(status_code=404, detail="Category not found")
-
-    if cat.is_system:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot delete system category",
-        )
 
     # Check for child categories
     await assert_no_dependents(

--- a/backend/app/routers/forecast.py
+++ b/backend/app/routers/forecast.py
@@ -1,0 +1,20 @@
+import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.user import User
+from app.services import forecast_service as svc
+
+router = APIRouter(prefix="/api/v1/forecast", tags=["forecast"])
+
+
+@router.get("")
+async def get_forecast(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    period_start: datetime.date | None = Query(default=None),
+):
+    return await svc.compute_forecast(db, current_user.org_id, period_start=period_start)

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -18,7 +18,7 @@ class TransactionCreate(BaseModel):
 class TransferCreate(BaseModel):
     from_account_id: int
     to_account_id: int
-    category_id: int
+    category_id: Optional[int] = None
     description: str
     amount: Decimal = Field(gt=0)
     status: Literal["settled", "pending"] = "settled"

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -19,7 +19,7 @@ class TransferCreate(BaseModel):
     from_account_id: int
     to_account_id: int
     category_id: Optional[int] = None
-    description: str
+    description: str = "Transfer"
     amount: Decimal = Field(gt=0)
     status: Literal["settled", "pending"] = "settled"
     date: datetime.date

--- a/backend/app/services/forecast_service.py
+++ b/backend/app/services/forecast_service.py
@@ -1,0 +1,224 @@
+"""Forecast service — compute projected month-end from executed + pending + recurring.
+
+Forecast = Settled (what happened) + Pending (committed but not settled) + Upcoming Recurring (will be generated)
+
+This gives the user a complete picture of where the month is heading.
+"""
+
+import datetime
+from decimal import Decimal
+
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing import BillingPeriod
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services.billing_service import get_current_period
+
+
+def _advance_date(current: datetime.date, freq: Frequency) -> datetime.date:
+    if freq == Frequency.WEEKLY:
+        return current + datetime.timedelta(weeks=1)
+    elif freq == Frequency.BIWEEKLY:
+        return current + datetime.timedelta(weeks=2)
+    elif freq == Frequency.MONTHLY:
+        return current + relativedelta(months=1)
+    elif freq == Frequency.QUARTERLY:
+        return current + relativedelta(months=3)
+    elif freq == Frequency.YEARLY:
+        return current + relativedelta(years=1)
+    return current + relativedelta(months=1)
+
+
+async def compute_forecast(
+    db: AsyncSession, org_id: int, period_start: datetime.date | None = None
+) -> dict:
+    """Compute the full forecast for a billing period.
+
+    Returns:
+        executed_income: sum of settled income
+        executed_expense: sum of settled expenses
+        pending_income: sum of pending income
+        pending_expense: sum of pending expenses
+        recurring_income: projected income from recurring templates
+        recurring_expense: projected expenses from recurring templates
+        forecast_income: executed + pending + recurring income
+        forecast_expense: executed + pending + recurring expense
+        forecast_net: forecast_income - forecast_expense
+        executed_net: executed_income - executed_expense
+        categories: per-category breakdown with executed + forecast
+    """
+    # Get the period
+    if period_start:
+        result = await db.execute(
+            select(BillingPeriod).where(
+                BillingPeriod.org_id == org_id,
+                BillingPeriod.start_date == period_start,
+            )
+        )
+        period = result.scalar_one_or_none()
+        if period is None:
+            period = await get_current_period(db, org_id)
+    else:
+        period = await get_current_period(db, org_id)
+
+    p_start = period.start_date
+    # For open periods, project to ~30 days from start
+    p_end = period.end_date or (p_start + relativedelta(months=1) - datetime.timedelta(days=1))
+
+    # ── Executed (settled) ────────────────────────────────────────────────
+    executed_income = await db.scalar(
+        select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+            Transaction.org_id == org_id,
+            Transaction.type == TransactionType.INCOME,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.date >= p_start,
+            Transaction.date <= p_end,
+        )
+    ) or Decimal("0")
+
+    executed_expense = await db.scalar(
+        select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+            Transaction.org_id == org_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.date >= p_start,
+            Transaction.date <= p_end,
+        )
+    ) or Decimal("0")
+
+    # ── Pending ───────────────────────────────────────────────────────────
+    pending_income = await db.scalar(
+        select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+            Transaction.org_id == org_id,
+            Transaction.type == TransactionType.INCOME,
+            Transaction.status == TransactionStatus.PENDING,
+            Transaction.date >= p_start,
+            Transaction.date <= p_end,
+        )
+    ) or Decimal("0")
+
+    pending_expense = await db.scalar(
+        select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+            Transaction.org_id == org_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.status == TransactionStatus.PENDING,
+            Transaction.date >= p_start,
+            Transaction.date <= p_end,
+        )
+    ) or Decimal("0")
+
+    # ── Upcoming recurring (not yet generated for this period) ────────────
+    today = datetime.date.today()
+    result = await db.execute(
+        select(RecurringTransaction).where(
+            RecurringTransaction.org_id == org_id,
+            RecurringTransaction.is_active == True,
+            RecurringTransaction.next_due_date <= p_end,
+            RecurringTransaction.next_due_date > today,
+        )
+    )
+    recurring_items = list(result.scalars().all())
+
+    recurring_income = Decimal("0")
+    recurring_expense = Decimal("0")
+
+    for r in recurring_items:
+        d = r.next_due_date
+        while d <= p_end:
+            if r.type == "income":
+                recurring_income += r.amount
+            else:
+                recurring_expense += r.amount
+            d = _advance_date(d, r.frequency)
+
+    # ── Per-category breakdown ────────────────────────────────────────────
+    # Executed by category
+    cat_exec_result = await db.execute(
+        select(
+            Transaction.category_id,
+            func.sum(Transaction.amount),
+        ).where(
+            Transaction.org_id == org_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.date >= p_start,
+            Transaction.date <= p_end,
+        ).group_by(Transaction.category_id)
+    )
+    cat_executed = {row[0]: Decimal(str(row[1])) for row in cat_exec_result.all()}
+
+    # Pending by category
+    cat_pend_result = await db.execute(
+        select(
+            Transaction.category_id,
+            func.sum(Transaction.amount),
+        ).where(
+            Transaction.org_id == org_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.status == TransactionStatus.PENDING,
+            Transaction.date >= p_start,
+            Transaction.date <= p_end,
+        ).group_by(Transaction.category_id)
+    )
+    cat_pending = {row[0]: Decimal(str(row[1])) for row in cat_pend_result.all()}
+
+    # Recurring by category
+    cat_recurring: dict[int, Decimal] = {}
+    for r in recurring_items:
+        if r.type == "expense":
+            d = r.next_due_date
+            while d <= p_end:
+                cat_recurring[r.category_id] = cat_recurring.get(r.category_id, Decimal("0")) + r.amount
+                d = _advance_date(d, r.frequency)
+
+    # Merge all category IDs
+    all_cat_ids = set(cat_executed.keys()) | set(cat_pending.keys()) | set(cat_recurring.keys())
+
+    # Get category names
+    from app.models.category import Category
+    cat_names = {}
+    if all_cat_ids:
+        name_result = await db.execute(
+            select(Category.id, Category.name, Category.parent_id).where(Category.id.in_(all_cat_ids))
+        )
+        for row in name_result.all():
+            cat_names[row[0]] = {"name": row[1], "parent_id": row[2]}
+
+    categories = []
+    for cid in sorted(all_cat_ids):
+        ex = cat_executed.get(cid, Decimal("0"))
+        pe = cat_pending.get(cid, Decimal("0"))
+        rc = cat_recurring.get(cid, Decimal("0"))
+        info = cat_names.get(cid, {"name": "Unknown", "parent_id": None})
+        categories.append({
+            "category_id": cid,
+            "category_name": info["name"],
+            "parent_id": info["parent_id"],
+            "executed": str(ex),
+            "pending": str(pe),
+            "recurring": str(rc),
+            "forecast": str(ex + pe + rc),
+        })
+
+    # ── Totals ────────────────────────────────────────────────────────────
+    forecast_income = executed_income + pending_income + recurring_income
+    forecast_expense = executed_expense + pending_expense + recurring_expense
+
+    return {
+        "period_start": p_start.isoformat(),
+        "period_end": p_end.isoformat(),
+        "executed_income": str(executed_income),
+        "executed_expense": str(executed_expense),
+        "executed_net": str(executed_income - executed_expense),
+        "pending_income": str(pending_income),
+        "pending_expense": str(pending_expense),
+        "recurring_income": str(recurring_income),
+        "recurring_expense": str(recurring_expense),
+        "forecast_income": str(forecast_income),
+        "forecast_expense": str(forecast_expense),
+        "forecast_net": str(forecast_income - forecast_expense),
+        "categories": categories,
+    }

--- a/backend/app/services/forecast_service.py
+++ b/backend/app/services/forecast_service.py
@@ -182,7 +182,9 @@ async def compute_forecast(
     cat_names = {}
     if all_cat_ids:
         name_result = await db.execute(
-            select(Category.id, Category.name, Category.parent_id).where(Category.id.in_(all_cat_ids))
+            select(Category.id, Category.name, Category.parent_id).where(
+                Category.id.in_(all_cat_ids), Category.org_id == org_id
+            )
         )
         for row in name_result.all():
             cat_names[row[0]] = {"name": row[1], "parent_id": row[2]}

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -273,7 +273,18 @@ async def create_transfer(
 
     await validate_account(db, body.from_account_id, org_id)
     await validate_account(db, body.to_account_id, org_id)
-    await validate_category(db, body.category_id, org_id)
+
+    # Auto-assign Transfer category if not provided
+    category_id = body.category_id
+    if category_id is None:
+        transfer_cat = await db.scalar(
+            select(Category.id).where(Category.slug == "transfer", Category.org_id == org_id)
+        )
+        if transfer_cat is None:
+            raise ValidationError("Transfer category not found. Please re-register or create one manually.")
+        category_id = transfer_cat
+    else:
+        await validate_category(db, category_id, org_id)
 
     tx_status = TransactionStatus(body.status)
 
@@ -283,7 +294,7 @@ async def create_transfer(
         expense_tx = Transaction(
             org_id=org_id,
             account_id=body.from_account_id,
-            category_id=body.category_id,
+            category_id=category_id,
             description=body.description,
             amount=body.amount,
             type=TransactionType.EXPENSE,
@@ -294,7 +305,7 @@ async def create_transfer(
         income_tx = Transaction(
             org_id=org_id,
             account_id=body.to_account_id,
-            category_id=body.category_id,
+            category_id=category_id,
             description=body.description,
             amount=body.amount,
             type=TransactionType.INCOME,

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -281,7 +281,16 @@ async def create_transfer(
             select(Category.id).where(Category.slug == "transfer", Category.org_id == org_id)
         )
         if transfer_cat is None:
-            raise ValidationError("Transfer category not found. Please re-register or create one manually.")
+            # Auto-create the Transfer category if missing (legacy data)
+            from app.models.category import CategoryType
+            new_cat = Category(
+                org_id=org_id, name="Transfer", slug="transfer",
+                description="Internal transfers between accounts",
+                type=CategoryType.BOTH, is_system=True,
+            )
+            db.add(new_cat)
+            await db.flush()
+            transfer_cat = new_cat.id
         category_id = transfer_cat
     else:
         await validate_category(db, category_id, org_id)

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -132,6 +132,7 @@ export default function CategoriesPage() {
   }
 
   async function handleEditCat(id: number) {
+    if (!editCatName.trim()) return;
     setError("");
     try {
       await apiFetch(`/api/v1/categories/${id}`, {

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -40,6 +40,10 @@ export default function CategoriesPage() {
   const [fetching, setFetching] = useState(true);
   const [error, setError] = useState("");
 
+  // Edit
+  const [editingCatId, setEditingCatId] = useState<number | null>(null);
+  const [editCatName, setEditCatName] = useState("");
+
   // Add subcategory form
   const [addingToMaster, setAddingToMaster] = useState<number | null>(null);
   const [newSubName, setNewSubName] = useState("");
@@ -127,6 +131,18 @@ export default function CategoriesPage() {
     } catch (err) { setError(extractErrorMessage(err)); }
   }
 
+  async function handleEditCat(id: number) {
+    setError("");
+    try {
+      await apiFetch(`/api/v1/categories/${id}`, {
+        method: "PUT",
+        body: JSON.stringify({ name: editCatName }),
+      });
+      setEditingCatId(null);
+      await reload();
+    } catch (err) { setError(extractErrorMessage(err)); }
+  }
+
   async function handleDelete(id: number) {
     if (!confirm("Delete this category?")) return;
     setError("");
@@ -191,11 +207,20 @@ export default function CategoriesPage() {
                 <div className={`flex items-center justify-between ${cardHeader}`}>
                   <div className="flex items-center gap-2.5">
                     <Icon className="h-4 w-4 text-text-muted" />
-                    <h2 className="text-sm font-medium text-text-primary">{master.name}</h2>
-                    <span className={`text-[11px] font-medium ${TYPE_COLORS[master.type]}`}>
-                      {master.type}
-                    </span>
-                    {master.is_system && <span className="rounded bg-surface-overlay px-1.5 py-0.5 text-[10px] font-medium text-text-muted">system</span>}
+                    {editingCatId === master.id ? (
+                      <div className="flex items-center gap-2">
+                        <input type="text" value={editCatName} onChange={(e) => setEditCatName(e.target.value)} className={`text-sm ${input}`} autoFocus
+                          onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(master.id); if (e.key === "Escape") setEditingCatId(null); }} />
+                        <button onClick={() => handleEditCat(master.id)} className="text-xs text-accent">Save</button>
+                        <button onClick={() => setEditingCatId(null)} className="text-xs text-text-muted">Cancel</button>
+                      </div>
+                    ) : (
+                      <>
+                        <h2 className="text-sm font-medium text-text-primary">{master.name}</h2>
+                        <span className={`text-[11px] font-medium ${TYPE_COLORS[master.type]}`}>{master.type}</span>
+                        {master.is_system && <span className="rounded bg-surface-overlay px-1.5 py-0.5 text-[10px] font-medium text-text-muted">system</span>}
+                      </>
+                    )}
                   </div>
                   <div className="flex items-center gap-3">
                     <button
@@ -204,6 +229,7 @@ export default function CategoriesPage() {
                     >
                       {addingToMaster === master.id ? "Cancel" : "+ Add Sub"}
                     </button>
+                    <button onClick={() => { setEditingCatId(master.id); setEditCatName(master.name); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
                     <button onClick={() => handleDelete(master.id)} aria-label={`Delete ${master.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                   </div>
                 </div>
@@ -231,12 +257,26 @@ export default function CategoriesPage() {
                     <div className="space-y-0.5">
                       {subs.map((sub) => (
                         <div key={sub.id} className="flex items-center justify-between rounded-md px-3 py-2 transition-colors hover:bg-surface-raised">
-                          <div>
-                            <span className="text-sm text-text-primary">{sub.name}</span>
-                            {sub.description && <span className="ml-2 text-xs text-text-muted">{sub.description}</span>}
-                            <span className="ml-2 text-xs text-text-muted" title={`${sub.transaction_count} transaction(s)`}>{sub.transaction_count}</span>
-                          </div>
-                          <button onClick={() => handleDelete(sub.id)} aria-label={`Delete ${sub.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                          {editingCatId === sub.id ? (
+                            <div className="flex flex-1 items-center gap-2">
+                              <input type="text" value={editCatName} onChange={(e) => setEditCatName(e.target.value)} className={`flex-1 text-sm ${input}`} autoFocus
+                                onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(sub.id); if (e.key === "Escape") setEditingCatId(null); }} />
+                              <button onClick={() => handleEditCat(sub.id)} className="text-xs text-accent">Save</button>
+                              <button onClick={() => setEditingCatId(null)} className="text-xs text-text-muted">Cancel</button>
+                            </div>
+                          ) : (
+                            <>
+                              <div>
+                                <span className="text-sm text-text-primary">{sub.name}</span>
+                                {sub.description && <span className="ml-2 text-xs text-text-muted">{sub.description}</span>}
+                                <span className="ml-2 text-xs text-text-muted" title={`${sub.transaction_count} transaction(s)`}>{sub.transaction_count}</span>
+                              </div>
+                              <div className="flex gap-2">
+                                <button onClick={() => { setEditingCatId(sub.id); setEditCatName(sub.name); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
+                                <button onClick={() => handleDelete(sub.id)} aria-label={`Delete ${sub.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                              </div>
+                            </>
+                          )}
                         </div>
                       ))}
                     </div>

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -204,9 +204,7 @@ export default function CategoriesPage() {
                     >
                       {addingToMaster === master.id ? "Cancel" : "+ Add Sub"}
                     </button>
-                    {!master.is_system && (
-                      <button onClick={() => handleDelete(master.id)} aria-label={`Delete ${master.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
-                    )}
+                    <button onClick={() => handleDelete(master.id)} aria-label={`Delete ${master.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                   </div>
                 </div>
 
@@ -238,9 +236,7 @@ export default function CategoriesPage() {
                             {sub.description && <span className="ml-2 text-xs text-text-muted">{sub.description}</span>}
                             <span className="ml-2 text-xs text-text-muted" title={`${sub.transaction_count} transaction(s)`}>{sub.transaction_count}</span>
                           </div>
-                          {!sub.is_system && (
-                            <button onClick={() => handleDelete(sub.id)} aria-label={`Delete ${sub.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
-                          )}
+                          <button onClick={() => handleDelete(sub.id)} aria-label={`Delete ${sub.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                         </div>
                       ))}
                     </div>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -12,6 +12,22 @@ import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveCo
 import CategorySelect from "@/components/ui/CategorySelect";
 import type { Account, Budget, Category, Transaction } from "@/lib/types";
 
+interface Forecast {
+  period_start: string;
+  period_end: string;
+  executed_income: string;
+  executed_expense: string;
+  executed_net: string;
+  pending_income: string;
+  pending_expense: string;
+  recurring_income: string;
+  recurring_expense: string;
+  forecast_income: string;
+  forecast_expense: string;
+  forecast_net: string;
+  categories: { category_id: number; category_name: string; executed: string; pending: string; recurring: string; forecast: string }[];
+}
+
 interface BillingPeriod {
   id: number;
   start_date: string;
@@ -30,6 +46,7 @@ export default function DashboardPage() {
   const [period, setPeriod] = useState<BillingPeriod | null>(null);
   const [periods, setPeriods] = useState<BillingPeriod[]>([]);
   const [periodIdx, setPeriodIdx] = useState(0);
+  const [forecast, setForecast] = useState<Forecast | null>(null);
   const [fetching, setFetching] = useState(true);
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -76,16 +93,19 @@ export default function DashboardPage() {
 
   const loadTransactions = useCallback(async (p: number) => {
     const budgetUrl = monthFrom ? `/api/v1/budgets?period_start=${monthFrom}` : "/api/v1/budgets";
-    const [pageData, allData, bds] = await Promise.all([
+    const forecastUrl = monthFrom ? `/api/v1/forecast?period_start=${monthFrom}` : "/api/v1/forecast";
+    const [pageData, allData, bds, fc] = await Promise.all([
       apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&date_from=${monthFrom}&date_to=${monthTo}`),
       p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?limit=200&date_from=${monthFrom}&date_to=${monthTo}`) : null,
       p === 0 ? apiFetch<Budget[]>(budgetUrl) : null,
+      p === 0 ? apiFetch<Forecast>(forecastUrl) : null,
     ]);
     const page_txs = pageData ?? [];
     setHasMore(page_txs.length > PAGE_SIZE);
     setTransactions(page_txs.slice(0, PAGE_SIZE));
     if (allData) setAllTransactions(allData);
     if (bds) setBudgets(bds);
+    if (fc) setForecast(fc);
     setFetching(false);
   }, [monthFrom, monthTo]);
 
@@ -390,6 +410,84 @@ export default function DashboardPage() {
               );
             })}
           </div>
+
+          {/* Forecast: Executed vs Forecast comparison */}
+          {forecast && (Number(forecast.forecast_expense) > 0 || Number(forecast.forecast_income) > 0) && (
+            <div className={`${card} p-5`}>
+              <h2 className={`mb-4 ${cardTitle}`}>Executed vs Forecast</h2>
+              <div className="grid grid-cols-2 gap-6 lg:grid-cols-4">
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Executed Income</p>
+                  <p className="mt-1 text-lg font-semibold tabular-nums text-success">+{formatAmount(forecast.executed_income)}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Forecast Income</p>
+                  <p className="mt-1 text-lg font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_income)}</p>
+                  {Number(forecast.pending_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_income)} pending</p>}
+                  {Number(forecast.recurring_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_income)} recurring</p>}
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Executed Expenses</p>
+                  <p className="mt-1 text-lg font-semibold tabular-nums text-danger">-{formatAmount(forecast.executed_expense)}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Forecast Expenses</p>
+                  <p className="mt-1 text-lg font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_expense)}</p>
+                  {Number(forecast.pending_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_expense)} pending</p>}
+                  {Number(forecast.recurring_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_expense)} recurring</p>}
+                </div>
+              </div>
+              <div className="mt-4 flex items-center justify-between border-t border-border-subtle pt-3">
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Executed Net</p>
+                  <p className={`text-lg font-semibold tabular-nums ${Number(forecast.executed_net) >= 0 ? "text-success" : "text-danger"}`}>
+                    {Number(forecast.executed_net) >= 0 ? "+" : ""}{formatAmount(forecast.executed_net)}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Forecast Net</p>
+                  <p className={`text-lg font-semibold tabular-nums ${Number(forecast.forecast_net) >= 0 ? "text-success" : "text-danger"}`}>
+                    {Number(forecast.forecast_net) >= 0 ? "+" : ""}{formatAmount(forecast.forecast_net)}
+                  </p>
+                </div>
+              </div>
+              {/* Category forecast bars */}
+              {forecast.categories.length > 0 && (
+                <div className="mt-4 border-t border-border-subtle pt-4">
+                  <p className={`mb-3 ${cardTitle}`}>Expense Forecast by Category</p>
+                  <div style={{ height: Math.max(forecast.categories.length * 36, 80) }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                      <BarChart
+                        data={forecast.categories.map((c) => ({
+                          name: c.category_name,
+                          executed: Number(c.executed),
+                          pending: Number(c.pending),
+                          recurring: Number(c.recurring),
+                        }))}
+                        layout="vertical"
+                        margin={{ left: 10, right: 10, top: 0, bottom: 0 }}
+                      >
+                        <XAxis type="number" hide />
+                        <YAxis type="category" dataKey="name" width={110} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
+                        <Tooltip
+                          formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? "Executed" : name === "pending" ? "Pending" : "Recurring"]}
+                          contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px" }}
+                        />
+                        <Bar dataKey="executed" stackId="a" fill="#4ade80" radius={[4, 0, 0, 4]} animationDuration={600} />
+                        <Bar dataKey="pending" stackId="a" fill="#D4A64A" animationDuration={600} />
+                        <Bar dataKey="recurring" stackId="a" fill="#5FA8D3" radius={[0, 4, 4, 0]} animationDuration={600} />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <div className="mt-2 flex gap-4 text-[10px] text-text-muted">
+                    <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full bg-success" /> Executed</span>
+                    <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Pending</span>
+                    <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#5FA8D3" }} /> Recurring</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Row 3: Two-column — Chart + Budget */}
           <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -378,114 +378,101 @@ export default function DashboardPage() {
             </div>
           )}
 
-          {/* Summary + Account tiles — unified grid */}
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-            {/* KPI tiles */}
-            <div className={`${card} p-4`}>
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Income</p>
-              <p className="mt-1.5 text-lg font-semibold tabular-nums text-success">+{formatAmount(totalIncome)}</p>
+          {/* ═══ HERO: Period + Net Position + Forecast Gauge ═══ */}
+          <div className={`${card} overflow-hidden`}>
+            {/* Period nav bar */}
+            <div className="flex items-center justify-between px-6 py-3 border-b border-border-subtle">
+              <div className="flex items-center gap-2">
+                <button onClick={() => { setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1)); setChartFilter(null); }} disabled={periodIdx >= periods.length - 1} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Previous period">
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+                </button>
+                <span className="text-xs font-medium text-text-secondary">
+                  {monthFrom}{monthTo !== monthFrom ? ` — ${monthTo}` : ""}
+                  {periodIdx === 0 && <span className="ml-1.5 text-success">current</span>}
+                </span>
+                <button onClick={() => { setPeriodIdx(Math.max(periodIdx - 1, 0)); setChartFilter(null); }} disabled={periodIdx <= 0} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
+                </button>
+              </div>
+              <Link href="/transactions" className="text-xs text-accent hover:text-accent-hover">View All Transactions</Link>
             </div>
-            <div className={`${card} p-4`}>
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Expenses</p>
-              <p className="mt-1.5 text-lg font-semibold tabular-nums text-danger">-{formatAmount(totalExpense)}</p>
-            </div>
-            <div className={`${card} p-4`}>
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Net</p>
-              <p className={`mt-1.5 text-lg font-semibold tabular-nums ${totalIncome - totalExpense >= 0 ? "text-success" : "text-danger"}`}>
-                {totalIncome - totalExpense >= 0 ? "+" : ""}{formatAmount(totalIncome - totalExpense)}
-              </p>
-            </div>
-            {/* Account tiles — same size as KPIs */}
-            {accountsWithBalance.map((acct) => {
-              const pending = pendingByAccount[acct.id] || 0;
-              const isCreditCard = acct.account_type_slug === "credit_card";
-              return (
-                <div key={acct.id} className={`${card} p-4`}>
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted truncate">{acct.name}</p>
-                  <p className="mt-1.5 text-lg font-semibold tabular-nums text-text-primary">{formatAmount(acct.balance)}</p>
-                  {isCreditCard && pending !== 0 && (
-                    <p className="mt-0.5 text-[10px] tabular-nums text-danger">Pending: {formatAmount(Math.abs(pending))}</p>
+
+            {/* Hero content: 3-column */}
+            <div className="grid grid-cols-1 lg:grid-cols-3 divide-y lg:divide-y-0 lg:divide-x divide-border-subtle">
+              {/* Left: Income flow */}
+              <div className="p-6">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-3">Income</p>
+                <div className="flex items-baseline gap-3">
+                  <p className="text-2xl font-semibold tabular-nums text-success">+{formatAmount(totalIncome)}</p>
+                  {forecast && Number(forecast.forecast_income) !== totalIncome && (
+                    <p className="text-xs text-text-muted tabular-nums">forecast {formatAmount(forecast.forecast_income)}</p>
                   )}
                 </div>
-              );
-            })}
+                {forecast && Number(forecast.pending_income) > 0 && (
+                  <p className="mt-1 text-[11px] text-text-muted">+{formatAmount(forecast.pending_income)} pending</p>
+                )}
+              </div>
+
+              {/* Center: Net position — the HERO number */}
+              <div className="p-6 flex flex-col items-center justify-center text-center">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-2">Net This Period</p>
+                <p className={`font-display text-4xl tabular-nums ${totalIncome - totalExpense >= 0 ? "text-accent" : "text-danger"}`}>
+                  {totalIncome - totalExpense >= 0 ? "+" : ""}{formatAmount(totalIncome - totalExpense)}
+                </p>
+                {forecast && (
+                  <div className="mt-3 w-full max-w-[200px]">
+                    <div className="flex justify-between text-[10px] text-text-muted mb-1">
+                      <span>Executed</span>
+                      <span>Forecast</span>
+                    </div>
+                    <div className="h-2 rounded-full bg-surface-overlay overflow-hidden">
+                      <div
+                        className="h-2 rounded-full bg-accent transition-all duration-700"
+                        style={{ width: `${Math.min((totalExpense / Math.max(Number(forecast.forecast_expense), 1)) * 100, 100)}%` }}
+                      />
+                    </div>
+                    <p className="mt-1 text-center text-[10px] text-text-muted tabular-nums">
+                      {formatAmount(forecast.forecast_net)} projected
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {/* Right: Expense flow */}
+              <div className="p-6">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-3">Expenses</p>
+                <div className="flex items-baseline gap-3">
+                  <p className="text-2xl font-semibold tabular-nums text-danger">-{formatAmount(totalExpense)}</p>
+                  {forecast && Number(forecast.forecast_expense) !== totalExpense && (
+                    <p className="text-xs text-text-muted tabular-nums">forecast {formatAmount(forecast.forecast_expense)}</p>
+                  )}
+                </div>
+                {forecast && Number(forecast.pending_expense) > 0 && (
+                  <p className="mt-1 text-[11px] text-text-muted">+{formatAmount(forecast.pending_expense)} pending</p>
+                )}
+                {forecast && Number(forecast.recurring_expense) > 0 && (
+                  <p className="text-[11px] text-text-muted">+{formatAmount(forecast.recurring_expense)} upcoming</p>
+                )}
+              </div>
+            </div>
           </div>
 
-          {/* Forecast: Executed vs Forecast comparison */}
-          {forecast && (Number(forecast.forecast_expense) > 0 || Number(forecast.forecast_income) > 0) && (
-            <div className={`${card} p-5`}>
-              <h2 className={`mb-4 ${cardTitle}`}>Executed vs Forecast</h2>
-              <div className="grid grid-cols-2 gap-6 lg:grid-cols-4">
-                <div>
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Executed Income</p>
-                  <p className="mt-1 text-lg font-semibold tabular-nums text-success">+{formatAmount(forecast.executed_income)}</p>
-                </div>
-                <div>
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Forecast Income</p>
-                  <p className="mt-1 text-lg font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_income)}</p>
-                  {Number(forecast.pending_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_income)} pending</p>}
-                  {Number(forecast.recurring_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_income)} recurring</p>}
-                </div>
-                <div>
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Executed Expenses</p>
-                  <p className="mt-1 text-lg font-semibold tabular-nums text-danger">-{formatAmount(forecast.executed_expense)}</p>
-                </div>
-                <div>
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Forecast Expenses</p>
-                  <p className="mt-1 text-lg font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_expense)}</p>
-                  {Number(forecast.pending_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_expense)} pending</p>}
-                  {Number(forecast.recurring_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_expense)} recurring</p>}
-                </div>
-              </div>
-              <div className="mt-4 flex items-center justify-between border-t border-border-subtle pt-3">
-                <div>
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Executed Net</p>
-                  <p className={`text-lg font-semibold tabular-nums ${Number(forecast.executed_net) >= 0 ? "text-success" : "text-danger"}`}>
-                    {Number(forecast.executed_net) >= 0 ? "+" : ""}{formatAmount(forecast.executed_net)}
-                  </p>
-                </div>
-                <div className="text-right">
-                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Forecast Net</p>
-                  <p className={`text-lg font-semibold tabular-nums ${Number(forecast.forecast_net) >= 0 ? "text-success" : "text-danger"}`}>
-                    {Number(forecast.forecast_net) >= 0 ? "+" : ""}{formatAmount(forecast.forecast_net)}
-                  </p>
-                </div>
-              </div>
-              {/* Category forecast bars */}
-              {forecast.categories.length > 0 && (
-                <div className="mt-4 border-t border-border-subtle pt-4">
-                  <p className={`mb-3 ${cardTitle}`}>Expense Forecast by Category</p>
-                  <div style={{ height: Math.max(forecast.categories.length * 36, 80) }}>
-                    <ResponsiveContainer width="100%" height="100%">
-                      <BarChart
-                        data={forecast.categories.map((c) => ({
-                          name: c.category_name,
-                          executed: Number(c.executed),
-                          pending: Number(c.pending),
-                          recurring: Number(c.recurring),
-                        }))}
-                        layout="vertical"
-                        margin={{ left: 10, right: 10, top: 0, bottom: 0 }}
-                      >
-                        <XAxis type="number" hide />
-                        <YAxis type="category" dataKey="name" width={110} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
-                        <Tooltip
-                          formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? "Executed" : name === "pending" ? "Pending" : "Recurring"]}
-                          contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px" }}
-                        />
-                        <Bar dataKey="executed" stackId="a" fill="#4ade80" radius={[4, 0, 0, 4]} animationDuration={600} />
-                        <Bar dataKey="pending" stackId="a" fill="#D4A64A" animationDuration={600} />
-                        <Bar dataKey="recurring" stackId="a" fill="#5FA8D3" radius={[0, 4, 4, 0]} animationDuration={600} />
-                      </BarChart>
-                    </ResponsiveContainer>
+          {/* ═══ ACCOUNTS — horizontal strip ═══ */}
+          {accountsWithBalance.length > 0 && (
+            <div className="flex gap-3 overflow-x-auto pb-1">
+              {accountsWithBalance.map((acct) => {
+                const pending = pendingByAccount[acct.id] || 0;
+                const isCreditCard = acct.account_type_slug === "credit_card";
+                return (
+                  <div key={acct.id} className={`${card} px-4 py-3 shrink-0 min-w-[150px]`}>
+                    <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted truncate">{acct.name}</p>
+                    <p className="mt-1 text-base font-semibold tabular-nums text-text-primary">{formatAmount(acct.balance)}</p>
+                    {isCreditCard && pending !== 0 && (
+                      <p className="text-[10px] tabular-nums text-danger">Pending: {formatAmount(Math.abs(pending))}</p>
+                    )}
                   </div>
-                  <div className="mt-2 flex gap-4 text-[10px] text-text-muted">
-                    <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full bg-success" /> Executed</span>
-                    <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Pending</span>
-                    <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#5FA8D3" }} /> Recurring</span>
-                  </div>
-                </div>
-              )}
+                );
+              })}
             </div>
           )}
 
@@ -577,22 +564,10 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          {/* Row 4: Recent transactions with period nav */}
+          {/* Recent transactions */}
           <div className={card}>
             <div className={`flex items-center justify-between ${cardHeader}`}>
-              <div className="flex items-center gap-2">
-                <button onClick={() => { setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1)); setChartFilter(null); }} disabled={periodIdx >= periods.length - 1} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Previous period">
-                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
-                </button>
-                <h2 className={`${cardTitle} text-[11px]`}>
-                  {monthFrom}{monthTo !== monthFrom ? ` — ${monthTo}` : ""}
-                  {periodIdx === 0 && <span className="ml-1.5 text-success">current</span>}
-                </h2>
-                <button onClick={() => { setPeriodIdx(Math.max(periodIdx - 1, 0)); setChartFilter(null); }} disabled={periodIdx <= 0} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
-                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
-                </button>
-              </div>
-              <Link href="/transactions" className="text-xs text-accent hover:text-accent-hover">View All</Link>
+              <h2 className={cardTitle}>Recent Transactions</h2>
             </div>
             {/* Sortable mini-header */}
             <div className="flex items-center justify-between px-5 py-1.5 border-b border-border-subtle text-[10px] font-semibold uppercase tracking-wider text-text-muted">

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -378,106 +378,117 @@ export default function DashboardPage() {
             </div>
           )}
 
-          {/* ═══ HERO: Period + Net Position + Forecast Gauge ═══ */}
-          <div className={`${card} overflow-hidden`}>
-            {/* Period nav bar */}
-            <div className="flex items-center justify-between px-6 py-3 border-b border-border-subtle">
-              <div className="flex items-center gap-2">
-                <button onClick={() => { setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1)); setChartFilter(null); }} disabled={periodIdx >= periods.length - 1} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Previous period">
-                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
-                </button>
-                <span className="text-xs font-medium text-text-secondary">
-                  {monthFrom}{monthTo !== monthFrom ? ` — ${monthTo}` : ""}
-                  {periodIdx === 0 && <span className="ml-1.5 text-success">current</span>}
-                </span>
-                <button onClick={() => { setPeriodIdx(Math.max(periodIdx - 1, 0)); setChartFilter(null); }} disabled={periodIdx <= 0} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
-                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
-                </button>
-              </div>
-              <Link href="/transactions" className="text-xs text-accent hover:text-accent-hover">View All Transactions</Link>
+          {/* ═══ BILLING PERIOD — standalone nav bar ═══ */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <button onClick={() => { setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1)); setChartFilter(null); }} disabled={periodIdx >= periods.length - 1} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Previous period">
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+              </button>
+              <span className="text-sm font-medium text-text-primary">
+                {monthFrom}{monthTo !== monthFrom ? ` — ${monthTo}` : ""}
+              </span>
+              <button onClick={() => { setPeriodIdx(Math.max(periodIdx - 1, 0)); setChartFilter(null); }} disabled={periodIdx <= 0} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
+              </button>
+              {periodIdx === 0 && <span className="ml-1 rounded bg-success-dim px-2 py-0.5 text-[10px] font-semibold text-success">CURRENT</span>}
             </div>
+            <Link href="/transactions" className="text-xs text-accent hover:text-accent-hover">View All Transactions</Link>
+          </div>
 
-            {/* Hero content: 3-column */}
-            <div className="grid grid-cols-1 lg:grid-cols-3 divide-y lg:divide-y-0 lg:divide-x divide-border-subtle">
-              {/* Left: Income flow */}
-              <div className="p-6">
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-3">Income</p>
-                <div className="flex items-baseline gap-3">
-                  <p className="text-2xl font-semibold tabular-nums text-success">+{formatAmount(totalIncome)}</p>
-                  {forecast && Number(forecast.forecast_income) !== totalIncome && (
-                    <p className="text-xs text-text-muted tabular-nums">forecast {formatAmount(forecast.forecast_income)}</p>
-                  )}
+          {/* ═══ ROW 1: Executed | Forecast — two symmetric columns ═══ */}
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {/* Executed */}
+            <div className={`${card} p-5`}>
+              <h2 className={`mb-4 ${cardTitle}`}>Executed</h2>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Income</p>
+                  <p className="mt-1 text-xl font-semibold tabular-nums text-success">+{formatAmount(totalIncome)}</p>
                 </div>
-                {forecast && Number(forecast.pending_income) > 0 && (
-                  <p className="mt-1 text-[11px] text-text-muted">+{formatAmount(forecast.pending_income)} pending</p>
-                )}
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Expenses</p>
+                  <p className="mt-1 text-xl font-semibold tabular-nums text-danger">-{formatAmount(totalExpense)}</p>
+                </div>
               </div>
-
-              {/* Center: Net position — the HERO number */}
-              <div className="p-6 flex flex-col items-center justify-center text-center">
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-2">Net This Period</p>
-                <p className={`font-display text-4xl tabular-nums ${totalIncome - totalExpense >= 0 ? "text-accent" : "text-danger"}`}>
+              <div className="mt-4 pt-3 border-t border-border-subtle">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Net</p>
+                <p className={`mt-1 font-display text-2xl tabular-nums ${totalIncome - totalExpense >= 0 ? "text-accent" : "text-danger"}`}>
                   {totalIncome - totalExpense >= 0 ? "+" : ""}{formatAmount(totalIncome - totalExpense)}
                 </p>
-                {forecast && (
-                  <div className="mt-3 w-full max-w-[200px]">
-                    <div className="flex justify-between text-[10px] text-text-muted mb-1">
-                      <span>Executed</span>
-                      <span>Forecast</span>
+              </div>
+            </div>
+
+            {/* Forecast */}
+            <div className={`${card} p-5`}>
+              <h2 className={`mb-4 ${cardTitle}`}>Forecast</h2>
+              {forecast ? (
+                <>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Income</p>
+                      <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_income)}</p>
+                      {Number(forecast.pending_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_income)} pending</p>}
+                      {Number(forecast.recurring_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_income)} recurring</p>}
                     </div>
-                    <div className="h-2 rounded-full bg-surface-overlay overflow-hidden">
-                      <div
-                        className="h-2 rounded-full bg-accent transition-all duration-700"
-                        style={{ width: `${Math.min((totalExpense / Math.max(Number(forecast.forecast_expense), 1)) * 100, 100)}%` }}
-                      />
+                    <div>
+                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Expenses</p>
+                      <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_expense)}</p>
+                      {Number(forecast.pending_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_expense)} pending</p>}
+                      {Number(forecast.recurring_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_expense)} recurring</p>}
                     </div>
-                    <p className="mt-1 text-center text-[10px] text-text-muted tabular-nums">
-                      {formatAmount(forecast.forecast_net)} projected
+                  </div>
+                  <div className="mt-4 pt-3 border-t border-border-subtle">
+                    <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Projected Net</p>
+                    <p className={`mt-1 font-display text-2xl tabular-nums ${Number(forecast.forecast_net) >= 0 ? "text-accent" : "text-danger"}`}>
+                      {Number(forecast.forecast_net) >= 0 ? "+" : ""}{formatAmount(forecast.forecast_net)}
                     </p>
                   </div>
-                )}
-              </div>
-
-              {/* Right: Expense flow */}
-              <div className="p-6">
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-3">Expenses</p>
-                <div className="flex items-baseline gap-3">
-                  <p className="text-2xl font-semibold tabular-nums text-danger">-{formatAmount(totalExpense)}</p>
-                  {forecast && Number(forecast.forecast_expense) !== totalExpense && (
-                    <p className="text-xs text-text-muted tabular-nums">forecast {formatAmount(forecast.forecast_expense)}</p>
-                  )}
-                </div>
-                {forecast && Number(forecast.pending_expense) > 0 && (
-                  <p className="mt-1 text-[11px] text-text-muted">+{formatAmount(forecast.pending_expense)} pending</p>
-                )}
-                {forecast && Number(forecast.recurring_expense) > 0 && (
-                  <p className="text-[11px] text-text-muted">+{formatAmount(forecast.recurring_expense)} upcoming</p>
-                )}
-              </div>
+                </>
+              ) : (
+                <p className="text-sm text-text-muted py-4">No forecast data</p>
+              )}
             </div>
           </div>
 
-          {/* ═══ ACCOUNTS — horizontal strip ═══ */}
-          {accountsWithBalance.length > 0 && (
-            <div className="flex gap-3 overflow-x-auto pb-1">
-              {accountsWithBalance.map((acct) => {
-                const pending = pendingByAccount[acct.id] || 0;
-                const isCreditCard = acct.account_type_slug === "credit_card";
-                return (
-                  <div key={acct.id} className={`${card} px-4 py-3 shrink-0 min-w-[150px]`}>
-                    <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted truncate">{acct.name}</p>
-                    <p className="mt-1 text-base font-semibold tabular-nums text-text-primary">{formatAmount(acct.balance)}</p>
-                    {isCreditCard && pending !== 0 && (
-                      <p className="text-[10px] tabular-nums text-danger">Pending: {formatAmount(Math.abs(pending))}</p>
+          {/* ═══ ROW 2: Accounts — default first (larger), others sorted ═══ */}
+          {accountsWithBalance.length > 0 && (() => {
+            const defaultAcct = accountsWithBalance.find((a) => a.is_default);
+            const others = accountsWithBalance.filter((a) => !a.is_default);
+            return (
+              <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                {/* Default/main account — spans 2 cols */}
+                {defaultAcct && (
+                  <div className={`${card} p-5 col-span-2`}>
+                    <div className="flex items-center gap-2 mb-2">
+                      <p className="text-[10px] font-semibold uppercase tracking-wider text-accent">{defaultAcct.name}</p>
+                      <span className="rounded bg-accent-dim px-1.5 py-0.5 text-[9px] font-semibold text-accent">PRIMARY</span>
+                    </div>
+                    <p className="font-display text-3xl tabular-nums text-text-primary">{formatAmount(defaultAcct.balance)} <span className="text-base text-text-muted">{defaultAcct.currency}</span></p>
+                    {pendingByAccount[defaultAcct.id] !== undefined && pendingByAccount[defaultAcct.id] !== 0 && (
+                      <p className="mt-1 text-xs tabular-nums text-text-muted">Pending: {formatAmount(Math.abs(pendingByAccount[defaultAcct.id]))}</p>
                     )}
                   </div>
-                );
-              })}
-            </div>
-          )}
+                )}
+                {/* Other accounts */}
+                {others.map((acct) => {
+                  const pending = pendingByAccount[acct.id] || 0;
+                  const isCreditCard = acct.account_type_slug === "credit_card";
+                  return (
+                    <div key={acct.id} className={`${card} p-4`}>
+                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted truncate">{acct.name}</p>
+                      <p className="mt-1.5 text-lg font-semibold tabular-nums text-text-primary">{formatAmount(acct.balance)}</p>
+                      {isCreditCard && pending !== 0 && (
+                        <p className="mt-0.5 text-[10px] tabular-nums text-danger">Pending: {formatAmount(Math.abs(pending))}</p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })()}
 
-          {/* Row 3: Two-column — Chart + Budget */}
-          <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+          {/* ═══ ROW 3: Three equal charts ═══ */}
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
             {/* Spending by category (donut) */}
             <div className={`${card} p-5`}>
               <h2 className={`mb-3 ${cardTitle}`}>Spending by Category</h2>
@@ -561,6 +572,44 @@ export default function DashboardPage() {
                   No budgets set. <Link href="/budgets" className="text-accent">Add one</Link>
                 </div>
               )}
+            </div>
+
+            {/* Forecast comparison — executed vs forecast per category */}
+            <div className={`${card} p-5`}>
+              <h2 className={`mb-3 ${cardTitle}`}>Forecast by Category</h2>
+              {forecast && forecast.categories.length > 0 ? (
+                <div style={{ height: Math.max(Math.min(forecast.categories.length, 8) * 32, 100) }}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart
+                      data={forecast.categories.slice(0, 8).map((c) => ({
+                        name: c.category_name.length > 12 ? c.category_name.slice(0, 12) + "…" : c.category_name,
+                        executed: Number(c.executed),
+                        pending: Number(c.pending),
+                        recurring: Number(c.recurring),
+                      }))}
+                      layout="vertical"
+                      margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+                    >
+                      <XAxis type="number" hide />
+                      <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
+                      <Tooltip
+                        formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? "Executed" : name === "pending" ? "Pending" : "Recurring"]}
+                        contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px" }}
+                      />
+                      <Bar dataKey="executed" stackId="a" fill="#4ade80" radius={[3, 0, 0, 3]} animationDuration={600} />
+                      <Bar dataKey="pending" stackId="a" fill="#D4A64A" animationDuration={600} />
+                      <Bar dataKey="recurring" stackId="a" fill="#5FA8D3" radius={[0, 3, 3, 0]} animationDuration={600} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <p className="text-sm text-text-muted py-6 text-center">No forecast data</p>
+              )}
+              <div className="mt-2 flex gap-3 text-[10px] text-text-muted">
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full bg-success" /> Executed</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Pending</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#5FA8D3" }} /> Recurring</span>
+              </div>
             </div>
           </div>
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -135,7 +135,6 @@ export default function DashboardPage() {
           body: JSON.stringify({
             from_account_id: formAccountId,
             to_account_id: formToAccountId,
-            category_id: formCategoryId,
             description: formDescription,
             amount: formAmount,
             status: formStatus,
@@ -327,10 +326,12 @@ export default function DashboardPage() {
                     </select>
                   </div>
                 )}
-                <div>
-                  <label htmlFor="da-category" className={label}>Category</label>
-                  <CategorySelect id="da-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formMode === "transfer" ? "expense" : formType} className={input} />
-                </div>
+                {formMode === "transaction" && (
+                  <div>
+                    <label htmlFor="da-category" className={label}>Category</label>
+                    <CategorySelect id="da-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+                  </div>
+                )}
                 <div>
                   <label htmlFor="da-desc" className={label}>Description</label>
                   <input id="da-desc" type="text" required placeholder="What was it for?" value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -180,6 +180,7 @@ export default function DashboardPage() {
       setFormDate(todayISO());
       setShowForm(false);
       await loadRefs();
+      await loadTransactions(0);
     } catch (err) {
       setError(extractErrorMessage(err));
     }
@@ -219,7 +220,7 @@ export default function DashboardPage() {
   const accountsWithBalance = activeAccounts.filter((a) => Number(a.balance) !== 0);
 
   // Precompute tx map for O(1) linked lookups
-  const txMap = new Map(transactions.map((tx) => [tx.id, tx]));
+  const txMap = new Map(allTransactions.map((tx) => [tx.id, tx]));
 
   // Totals from ALL period transactions (not just the paginated page)
   const totalIncome = allTransactions.filter((tx) => tx.type === "income" && tx.status === "settled").reduce((s, tx) => s + Number(tx.amount), 0);

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -334,7 +334,7 @@ export default function DashboardPage() {
                 )}
                 <div>
                   <label htmlFor="da-desc" className={label}>Description</label>
-                  <input id="da-desc" type="text" required placeholder="What was it for?" value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
+                  <input id="da-desc" type="text" required={formMode === "transaction"} placeholder={formMode === "transfer" ? "Transfer (optional)" : "What was it for?"} value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
                 </div>
                 <div>
                   <label htmlFor="da-amount" className={label}>Amount</label>
@@ -451,22 +451,22 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          {/* ═══ ROW 2: Accounts — default first (larger), others sorted ═══ */}
+          {/* ═══ ROW 2: Accounts — single row, primary slightly bigger ═══ */}
           {accountsWithBalance.length > 0 && (() => {
             const defaultAcct = accountsWithBalance.find((a) => a.is_default);
             const others = accountsWithBalance.filter((a) => !a.is_default);
             return (
-              <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-                {/* Default/main account — spans 2 cols */}
+              <div className="flex gap-3 overflow-x-auto pb-1">
+                {/* Primary account — wider */}
                 {defaultAcct && (
-                  <div className={`${card} p-5 col-span-2`}>
-                    <div className="flex items-center gap-2 mb-2">
+                  <div className={`${card} px-5 py-3 shrink-0`} style={{ minWidth: "220px" }}>
+                    <div className="flex items-center gap-2">
                       <p className="text-[10px] font-semibold uppercase tracking-wider text-accent">{defaultAcct.name}</p>
                       <span className="rounded bg-accent-dim px-1.5 py-0.5 text-[9px] font-semibold text-accent">PRIMARY</span>
                     </div>
-                    <p className="font-display text-3xl tabular-nums text-text-primary">{formatAmount(defaultAcct.balance)} <span className="text-base text-text-muted">{defaultAcct.currency}</span></p>
+                    <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(defaultAcct.balance)} <span className="text-xs text-text-muted">{defaultAcct.currency}</span></p>
                     {pendingByAccount[defaultAcct.id] !== undefined && pendingByAccount[defaultAcct.id] !== 0 && (
-                      <p className="mt-1 text-xs tabular-nums text-text-muted">Pending: {formatAmount(Math.abs(pendingByAccount[defaultAcct.id]))}</p>
+                      <p className="text-[10px] tabular-nums text-text-muted">Pending: {formatAmount(Math.abs(pendingByAccount[defaultAcct.id]))}</p>
                     )}
                   </div>
                 )}
@@ -475,11 +475,11 @@ export default function DashboardPage() {
                   const pending = pendingByAccount[acct.id] || 0;
                   const isCreditCard = acct.account_type_slug === "credit_card";
                   return (
-                    <div key={acct.id} className={`${card} p-4`}>
+                    <div key={acct.id} className={`${card} px-4 py-3 shrink-0`} style={{ minWidth: "150px" }}>
                       <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted truncate">{acct.name}</p>
-                      <p className="mt-1.5 text-lg font-semibold tabular-nums text-text-primary">{formatAmount(acct.balance)}</p>
+                      <p className="mt-1 text-base font-semibold tabular-nums text-text-primary">{formatAmount(acct.balance)}</p>
                       {isCreditCard && pending !== 0 && (
-                        <p className="mt-0.5 text-[10px] tabular-nums text-danger">Pending: {formatAmount(Math.abs(pending))}</p>
+                        <p className="text-[10px] tabular-nums text-danger">Pending: {formatAmount(Math.abs(pending))}</p>
                       )}
                     </div>
                   );

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -325,7 +325,7 @@ export default function TransactionsPage() {
             )}
             <div>
               <label htmlFor="tx-desc" className={label}>Description</label>
-              <input id="tx-desc" type="text" required placeholder="What was it for?" value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
+              <input id="tx-desc" type="text" required={formMode === "transaction"} placeholder={formMode === "transfer" ? "Transfer (optional)" : "What was it for?"} value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
             </div>
             <div>
               <label htmlFor="tx-amount" className={label}>Amount</label>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -127,7 +127,6 @@ export default function TransactionsPage() {
           body: JSON.stringify({
             from_account_id: formAccountId,
             to_account_id: formToAccountId,
-            category_id: formCategoryId,
             description: formDescription,
             amount: formAmount,
             status: formStatus,
@@ -318,10 +317,12 @@ export default function TransactionsPage() {
                 </select>
               </div>
             )}
-            <div>
-              <label htmlFor="tx-category" className={label}>Category</label>
-              <CategorySelect id="tx-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formMode === "transfer" ? "expense" : formType} className={input} />
-            </div>
+            {formMode === "transaction" && (
+              <div>
+                <label htmlFor="tx-category" className={label}>Category</label>
+                <CategorySelect id="tx-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+              </div>
+            )}
             <div>
               <label htmlFor="tx-desc" className={label}>Description</label>
               <input id="tx-desc" type="text" required placeholder="What was it for?" value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />


### PR DESCRIPTION
## Summary

Forecasting: see what happened vs what's coming. The key feature that replicates the spreadsheet's most valuable view.

## Changes

### Backend
- `forecast_service.py`: computes the full forecast for any billing period
  - Executed: sum of settled transactions (what happened)
  - Pending: committed but unsettled (what's in the pipeline)
  - Recurring: upcoming recurring items that will generate in the period
  - Per-category breakdown with all three components
- `GET /api/v1/forecast` with optional `period_start` param

### Dashboard
- "Executed vs Forecast" card with 4-column layout:
  - Executed Income / Forecast Income
  - Executed Expenses / Forecast Expenses
  - Pending and recurring shown as sub-labels
- Net comparison: executed net vs forecast net
- Category forecast stacked bar chart (executed=green, pending=gold, recurring=blue)
- Follows billing period navigation