### PR TITLE
feat: editable forecast plans

### DIFF
--- a/backend/alembic/versions/016_forecast_plans.py
+++ b/backend/alembic/versions/016_forecast_plans.py
@@ -1,0 +1,73 @@
+"""Add forecast_plans and forecast_plan_items tables
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-04-04
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "016"
+down_revision: Union[str, None] = "015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "forecast_plans",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("org_id", sa.Integer(), nullable=False),
+        sa.Column("billing_period_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("draft", "active", name="planstatus"),
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"]),
+        sa.ForeignKeyConstraint(["billing_period_id"], ["billing_periods.id"]),
+        sa.UniqueConstraint("org_id", "billing_period_id", name="uq_forecast_plan_org_period"),
+    )
+    op.create_index("ix_forecast_plans_org_period", "forecast_plans", ["org_id", "billing_period_id"])
+
+    op.create_table(
+        "forecast_plan_items",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("plan_id", sa.Integer(), nullable=False),
+        sa.Column("org_id", sa.Integer(), nullable=False),
+        sa.Column("category_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum("income", "expense", name="forecastitemtype"),
+            nullable=False,
+        ),
+        sa.Column("planned_amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column(
+            "source",
+            sa.Enum("manual", "recurring", "history", name="itemsource"),
+            nullable=False,
+            server_default="manual",
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["plan_id"], ["forecast_plans.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"]),
+        sa.ForeignKeyConstraint(["category_id"], ["categories.id"]),
+        sa.UniqueConstraint("plan_id", "category_id", "type", name="uq_forecast_item_plan_cat_type"),
+    )
+    op.create_index("ix_forecast_plan_items_plan", "forecast_plan_items", ["plan_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_forecast_plan_items_plan", table_name="forecast_plan_items")
+    op.drop_table("forecast_plan_items")
+    op.drop_index("ix_forecast_plans_org_period", table_name="forecast_plans")
+    op.drop_table("forecast_plans")

--- a/backend/alembic/versions/017_billing_period_unique_constraint.py
+++ b/backend/alembic/versions/017_billing_period_unique_constraint.py
@@ -1,0 +1,28 @@
+"""Add unique constraint on billing_periods(org_id, start_date)
+
+Revision ID: 017
+Revises: 016
+"""
+
+from alembic import op
+
+revision = "017"
+down_revision = "016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Remove any existing duplicates first (keep the one with lowest id)
+    op.execute("""
+        DELETE bp1 FROM billing_periods bp1
+        INNER JOIN billing_periods bp2
+        ON bp1.org_id = bp2.org_id
+           AND bp1.start_date = bp2.start_date
+           AND bp1.id > bp2.id
+    """)
+    op.create_unique_constraint("uq_billing_period_org_start", "billing_periods", ["org_id", "start_date"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_billing_period_org_start", "billing_periods", type_="unique")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from app.config import settings as app_settings
 from app.database import engine
 from app.logging import setup_logging
-from app.routers import account_types, accounts, auth, budgets, categories, forecast, recurring, settings, transactions, users
+from app.routers import account_types, accounts, auth, budgets, categories, forecast, forecast_plans, recurring, settings, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -79,6 +79,7 @@ app.include_router(transactions.router)
 app.include_router(recurring.router)
 app.include_router(budgets.router)
 app.include_router(forecast.router)
+app.include_router(forecast_plans.router)
 app.include_router(settings.router)
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.recurring import RecurringTransaction, Frequency
 from app.models.budget import Budget
 from app.models.billing import BillingPeriod
 from app.models.settings import OrgSetting
+from app.models.forecast_plan import ForecastPlan, ForecastPlanItem, PlanStatus, ForecastItemType, ItemSource
 
 __all__ = [
     "Base",
@@ -24,4 +25,9 @@ __all__ = [
     "Budget",
     "BillingPeriod",
     "OrgSetting",
+    "ForecastPlan",
+    "ForecastPlanItem",
+    "PlanStatus",
+    "ForecastItemType",
+    "ItemSource",
 ]

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import Optional
 
-from sqlalchemy import Date, DateTime, ForeignKey, Integer, func
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -9,6 +9,9 @@ from app.models.base import Base
 
 class BillingPeriod(Base):
     __tablename__ = "billing_periods"
+    __table_args__ = (
+        UniqueConstraint("org_id", "start_date", name="uq_billing_period_org_start"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     org_id: Mapped[int] = mapped_column(

--- a/backend/app/models/forecast_plan.py
+++ b/backend/app/models/forecast_plan.py
@@ -1,0 +1,82 @@
+import enum
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    Numeric,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class PlanStatus(str, enum.Enum):
+    DRAFT = "draft"
+    ACTIVE = "active"
+
+
+class ForecastItemType(str, enum.Enum):
+    INCOME = "income"
+    EXPENSE = "expense"
+
+
+class ItemSource(str, enum.Enum):
+    MANUAL = "manual"
+    RECURRING = "recurring"
+    HISTORY = "history"
+
+
+class ForecastPlan(Base):
+    __tablename__ = "forecast_plans"
+    __table_args__ = (
+        UniqueConstraint("org_id", "billing_period_id", name="uq_forecast_plan_org_period"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
+    billing_period_id: Mapped[int] = mapped_column(Integer, ForeignKey("billing_periods.id"), nullable=False)
+    status: Mapped[PlanStatus] = mapped_column(
+        Enum(PlanStatus, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        server_default="draft",
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    billing_period = relationship("BillingPeriod", lazy="selectin")
+    items: Mapped[list["ForecastPlanItem"]] = relationship(
+        back_populates="plan", cascade="all, delete-orphan", lazy="selectin",
+    )
+
+
+class ForecastPlanItem(Base):
+    __tablename__ = "forecast_plan_items"
+    __table_args__ = (
+        UniqueConstraint("plan_id", "category_id", "type", name="uq_forecast_item_plan_cat_type"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    plan_id: Mapped[int] = mapped_column(Integer, ForeignKey("forecast_plans.id", ondelete="CASCADE"), nullable=False)
+    org_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False)
+    category_id: Mapped[int] = mapped_column(Integer, ForeignKey("categories.id"), nullable=False)
+    type: Mapped[ForecastItemType] = mapped_column(
+        Enum(ForecastItemType, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+    )
+    planned_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    source: Mapped[ItemSource] = mapped_column(
+        Enum(ItemSource, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        server_default="manual",
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    plan: Mapped["ForecastPlan"] = relationship(back_populates="items")
+    category = relationship("Category", lazy="selectin")

--- a/backend/app/models/forecast_plan.py
+++ b/backend/app/models/forecast_plan.py
@@ -79,4 +79,4 @@ class ForecastPlanItem(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
 
     plan: Mapped["ForecastPlan"] = relationship(back_populates="items")
-    category = relationship("Category", lazy="selectin")
+    category = relationship("Category", lazy="raise")

--- a/backend/app/routers/forecast_plans.py
+++ b/backend/app/routers/forecast_plans.py
@@ -1,0 +1,99 @@
+import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.user import User
+from app.schemas.forecast_plan import (
+    BulkUpsertRequest,
+    ForecastPlanItemCreate,
+    ForecastPlanItemUpdate,
+    ForecastPlanResponse,
+)
+from app.services import forecast_plan_service as svc
+
+router = APIRouter(prefix="/api/v1/forecast-plans", tags=["forecast-plans"])
+
+
+@router.get("", response_model=ForecastPlanResponse)
+async def get_plan(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    period_start: datetime.date | None = Query(default=None),
+):
+    return await svc.get_or_create_plan(db, current_user.org_id, period_start=period_start)
+
+
+@router.post("/populate", response_model=ForecastPlanResponse)
+async def populate_plan(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    period_start: datetime.date | None = Query(default=None),
+):
+    return await svc.populate_from_sources(db, current_user.org_id, period_start=period_start)
+
+
+@router.post("/{plan_id}/items", response_model=ForecastPlanResponse, status_code=201)
+async def add_item(
+    plan_id: int,
+    body: ForecastPlanItemCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.upsert_item(db, current_user.org_id, plan_id, body)
+
+
+@router.post("/{plan_id}/items/bulk", response_model=ForecastPlanResponse)
+async def bulk_upsert_items(
+    plan_id: int,
+    body: BulkUpsertRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.bulk_upsert(db, current_user.org_id, plan_id, body)
+
+
+@router.put("/{plan_id}/items/{item_id}", response_model=ForecastPlanResponse)
+async def update_item(
+    plan_id: int,
+    item_id: int,
+    body: ForecastPlanItemUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.update_item(db, current_user.org_id, plan_id, item_id, body)
+
+
+@router.delete("/{plan_id}/items/{item_id}", response_model=ForecastPlanResponse)
+async def delete_item(
+    plan_id: int,
+    item_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.delete_item(db, current_user.org_id, plan_id, item_id)
+
+
+@router.post("/{plan_id}/activate", response_model=ForecastPlanResponse)
+async def activate_plan(
+    plan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.activate_plan(db, current_user.org_id, plan_id)
+
+
+@router.post("/copy", response_model=ForecastPlanResponse)
+async def copy_plan(
+    source_period_start: datetime.date = Query(),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    period_start: datetime.date | None = Query(default=None),
+):
+    return await svc.copy_from_period(
+        db, current_user.org_id,
+        target_period_start=period_start,
+        source_period_start=source_period_start,
+    )

--- a/backend/app/routers/forecast_plans.py
+++ b/backend/app/routers/forecast_plans.py
@@ -8,6 +8,7 @@ from app.deps import get_current_user
 from app.models.user import User
 from app.schemas.forecast_plan import (
     BulkUpsertRequest,
+    CopyPlanRequest,
     ForecastPlanItemCreate,
     ForecastPlanItemUpdate,
     ForecastPlanResponse,
@@ -105,13 +106,12 @@ async def discard_plan(
 
 @router.post("/copy", response_model=ForecastPlanResponse)
 async def copy_plan(
-    source_period_start: datetime.date = Query(),
+    body: CopyPlanRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-    period_start: datetime.date | None = Query(default=None),
 ):
     return await svc.copy_from_period(
         db, current_user.org_id,
-        target_period_start=period_start,
-        source_period_start=source_period_start,
+        target_period_start=body.target_period_start,
+        source_period_start=body.source_period_start,
     )

--- a/backend/app/routers/forecast_plans.py
+++ b/backend/app/routers/forecast_plans.py
@@ -85,6 +85,24 @@ async def activate_plan(
     return await svc.activate_plan(db, current_user.org_id, plan_id)
 
 
+@router.post("/{plan_id}/revert", response_model=ForecastPlanResponse)
+async def revert_to_draft(
+    plan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.revert_to_draft(db, current_user.org_id, plan_id)
+
+
+@router.post("/{plan_id}/discard", response_model=ForecastPlanResponse)
+async def discard_plan(
+    plan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.discard_plan(db, current_user.org_id, plan_id)
+
+
 @router.post("/copy", response_model=ForecastPlanResponse)
 async def copy_plan(
     source_period_start: datetime.date = Query(),

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -197,6 +197,24 @@ async def create_period(
     }
 
 
+@router.post("/billing-periods/ensure-future")
+async def ensure_future_periods(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    count: int = 3,
+):
+    """Create stub periods for upcoming months so the user can plan ahead."""
+    created = await billing_service.ensure_future_periods(db, current_user.org_id, count=count)
+    return [
+        {
+            "id": p.id,
+            "start_date": p.start_date.isoformat(),
+            "end_date": p.end_date.isoformat() if p.end_date else None,
+        }
+        for p in created
+    ]
+
+
 @router.post("/billing-period/close")
 async def close_period(
     current_user: User = Depends(get_current_user),

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -204,6 +204,7 @@ async def ensure_future_periods(
     count: int = 3,
 ):
     """Create stub periods for upcoming months so the user can plan ahead."""
+    count = min(max(count, 1), 6)  # Cap between 1 and 6 months
     created = await billing_service.ensure_future_periods(db, current_user.org_id, count=count)
     return [
         {

--- a/backend/app/schemas/forecast_plan.py
+++ b/backend/app/schemas/forecast_plan.py
@@ -55,3 +55,8 @@ class BulkUpsertItem(BaseModel):
 
 class BulkUpsertRequest(BaseModel):
     items: list[BulkUpsertItem]
+
+
+class CopyPlanRequest(BaseModel):
+    source_period_start: datetime.date
+    target_period_start: Optional[datetime.date] = None

--- a/backend/app/schemas/forecast_plan.py
+++ b/backend/app/schemas/forecast_plan.py
@@ -1,0 +1,57 @@
+import datetime
+from decimal import Decimal
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ForecastPlanItemCreate(BaseModel):
+    category_id: int
+    type: Literal["income", "expense"]
+    planned_amount: Decimal = Field(gt=0)
+    source: Literal["manual", "recurring", "history"] = "manual"
+
+
+class ForecastPlanItemUpdate(BaseModel):
+    planned_amount: Decimal = Field(gt=0)
+
+
+class ForecastPlanItemResponse(BaseModel):
+    id: int
+    plan_id: int
+    category_id: int
+    category_name: str = ""
+    parent_id: Optional[int] = None
+    type: Literal["income", "expense"]
+    planned_amount: Decimal
+    source: Literal["manual", "recurring", "history"]
+    actual_amount: Decimal = Decimal("0.00")
+    variance: Decimal = Decimal("0.00")
+
+    model_config = {"from_attributes": True}
+
+
+class ForecastPlanResponse(BaseModel):
+    id: int
+    billing_period_id: int
+    period_start: datetime.date
+    period_end: Optional[datetime.date] = None
+    status: Literal["draft", "active"]
+    total_planned_income: Decimal = Decimal("0.00")
+    total_planned_expense: Decimal = Decimal("0.00")
+    total_actual_income: Decimal = Decimal("0.00")
+    total_actual_expense: Decimal = Decimal("0.00")
+    items: list[ForecastPlanItemResponse] = []
+
+    model_config = {"from_attributes": True}
+
+
+class BulkUpsertItem(BaseModel):
+    category_id: int
+    type: Literal["income", "expense"]
+    planned_amount: Decimal = Field(gt=0)
+    source: Literal["manual", "recurring", "history"] = "manual"
+
+
+class BulkUpsertRequest(BaseModel):
+    items: list[BulkUpsertItem]

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -106,9 +106,15 @@ async def ensure_future_periods(
         created.append(stub)
 
     if created:
-        await db.commit()
-        for s in created:
-            await db.refresh(s)
+        from sqlalchemy.exc import IntegrityError
+        try:
+            await db.commit()
+            for s in created:
+                await db.refresh(s)
+        except IntegrityError:
+            # Concurrent request already created the stubs — safe to ignore
+            await db.rollback()
+            created = []
 
     return created
 

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -55,9 +55,80 @@ async def list_periods(db: AsyncSession, org_id: int) -> list[BillingPeriod]:
         select(BillingPeriod)
         .where(BillingPeriod.org_id == org_id)
         .order_by(BillingPeriod.start_date.desc())
-        .limit(12)
+        .limit(24)
     )
     return list(result.scalars().all())
+
+
+async def ensure_future_periods(
+    db: AsyncSession, org_id: int, count: int = 3,
+) -> list[BillingPeriod]:
+    """Create stub periods for upcoming months so the user can plan ahead.
+
+    Stubs have a start_date and end_date derived from the org's billing cycle day.
+    They are distinguishable from real (closed) periods only by being in the future.
+    Returns the newly created stubs (if any).
+    """
+    from dateutil.relativedelta import relativedelta
+
+    current = await get_current_period(db, org_id)
+    org = await db.scalar(select(Organization).where(Organization.id == org_id))
+    cycle_day = org.billing_cycle_day if org else 1
+
+    # Find the latest period start_date
+    result = await db.execute(
+        select(BillingPeriod.start_date)
+        .where(BillingPeriod.org_id == org_id)
+        .order_by(BillingPeriod.start_date.desc())
+        .limit(1)
+    )
+    latest_start = result.scalar_one()
+
+    created = []
+    for i in range(count):
+        # Next period starts ~1 month after the latest
+        next_start = latest_start + relativedelta(months=1)
+        # Snap to cycle_day
+        try:
+            next_start = next_start.replace(day=cycle_day)
+        except ValueError:
+            # e.g. cycle_day=31 in a 30-day month — use last day
+            import calendar
+            last_day = calendar.monthrange(next_start.year, next_start.month)[1]
+            next_start = next_start.replace(day=min(cycle_day, last_day))
+
+        # Check if it already exists
+        existing = await db.scalar(
+            select(BillingPeriod.id).where(
+                BillingPeriod.org_id == org_id,
+                BillingPeriod.start_date == next_start,
+            )
+        )
+        if existing:
+            latest_start = next_start
+            continue
+
+        # Compute end_date (day before the next cycle start)
+        end_date = next_start + relativedelta(months=1)
+        try:
+            end_date = end_date.replace(day=cycle_day)
+        except ValueError:
+            import calendar
+            last_day = calendar.monthrange(end_date.year, end_date.month)[1]
+            end_date = end_date.replace(day=min(cycle_day, last_day))
+        end_date = end_date - datetime.timedelta(days=1)
+
+        stub = BillingPeriod(org_id=org_id, start_date=next_start, end_date=end_date)
+        db.add(stub)
+        created.append(stub)
+        latest_start = next_start
+
+    if created:
+        await db.commit()
+        for s in created:
+            await db.refresh(s)
+
+    return created
 
 
 async def close_period(db: AsyncSession, org_id: int, close_date: datetime.date | None = None) -> BillingPeriod:

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -63,41 +63,33 @@ async def list_periods(db: AsyncSession, org_id: int) -> list[BillingPeriod]:
 async def ensure_future_periods(
     db: AsyncSession, org_id: int, count: int = 3,
 ) -> list[BillingPeriod]:
-    """Create stub periods for upcoming months so the user can plan ahead.
+    """Create stub periods for the next `count` months from today.
 
-    Stubs have a start_date and end_date derived from the org's billing cycle day.
-    They are distinguishable from real (closed) periods only by being in the future.
-    Returns the newly created stubs (if any).
+    Always anchored to today — calling this multiple times is idempotent
+    and will never create stubs beyond `count` months in the future.
     """
+    import calendar
+
     from dateutil.relativedelta import relativedelta
 
     current = await get_current_period(db, org_id)
     org = await db.scalar(select(Organization).where(Organization.id == org_id))
     cycle_day = org.billing_cycle_day if org else 1
 
-    # Find the latest period start_date
-    result = await db.execute(
-        select(BillingPeriod.start_date)
-        .where(BillingPeriod.org_id == org_id)
-        .order_by(BillingPeriod.start_date.desc())
-        .limit(1)
-    )
-    latest_start = result.scalar_one()
-
-    created = []
-    for i in range(count):
-        # Next period starts ~1 month after the latest
-        next_start = latest_start + relativedelta(months=1)
-        # Snap to cycle_day
+    def _snap_to_cycle(d: datetime.date) -> datetime.date:
         try:
-            next_start = next_start.replace(day=cycle_day)
+            return d.replace(day=cycle_day)
         except ValueError:
-            # e.g. cycle_day=31 in a 30-day month — use last day
-            import calendar
-            last_day = calendar.monthrange(next_start.year, next_start.month)[1]
-            next_start = next_start.replace(day=min(cycle_day, last_day))
+            last = calendar.monthrange(d.year, d.month)[1]
+            return d.replace(day=min(cycle_day, last))
 
-        # Check if it already exists
+    # Build the target months: 1, 2, ... count months from current period
+    base = current.start_date
+    created = []
+    for i in range(1, count + 1):
+        next_start = _snap_to_cycle(base + relativedelta(months=i))
+
+        # Skip if already exists
         existing = await db.scalar(
             select(BillingPeriod.id).where(
                 BillingPeriod.org_id == org_id,
@@ -105,23 +97,13 @@ async def ensure_future_periods(
             )
         )
         if existing:
-            latest_start = next_start
             continue
 
-        # Compute end_date (day before the next cycle start)
-        end_date = next_start + relativedelta(months=1)
-        try:
-            end_date = end_date.replace(day=cycle_day)
-        except ValueError:
-            import calendar
-            last_day = calendar.monthrange(end_date.year, end_date.month)[1]
-            end_date = end_date.replace(day=min(cycle_day, last_day))
-        end_date = end_date - datetime.timedelta(days=1)
+        end_date = _snap_to_cycle(next_start + relativedelta(months=1)) - datetime.timedelta(days=1)
 
         stub = BillingPeriod(org_id=org_id, start_date=next_start, end_date=end_date)
         db.add(stub)
         created.append(stub)
-        latest_start = next_start
 
     if created:
         await db.commit()

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -259,6 +259,7 @@ async def populate_from_sources(
     """
     period = await _resolve_period(db, org_id, period_start)
     plan = await _get_or_create_plan_row(db, org_id, period.id)
+    _require_draft(plan)
     await db.refresh(plan, ["billing_period", "items"])
 
     # Existing (category_id, type_str) combos — always use strings for consistency

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -76,9 +76,9 @@ async def _get_or_create_plan_row(
     )
     db.add(plan)
     try:
-        await db.flush()
+        async with db.begin_nested():
+            await db.flush()
     except IntegrityError:
-        await db.rollback()
         result = await db.execute(
             select(ForecastPlan).where(
                 ForecastPlan.org_id == org_id,
@@ -238,13 +238,18 @@ async def populate_from_sources(
         if key in existing_keys:
             continue
 
-        # Count occurrences within the period
+        # Count occurrences within the period — advance to period start first
         total = Decimal("0")
         d = r.next_due_date
-        while d <= p_end:
-            if d >= p_start:
-                total += r.amount
+        # Fast-forward past dates before the period to avoid unnecessary iterations
+        while d < p_start and d <= p_end:
             d = _advance_date(d, r.frequency)
+        while d <= p_end:
+            total += r.amount
+            prev = d
+            d = _advance_date(d, r.frequency)
+            if d <= prev:
+                break  # safety: prevent infinite loop on bad frequency
 
         if total > 0:
             item = ForecastPlanItem(
@@ -490,8 +495,9 @@ async def revert_to_draft(
 async def discard_plan(
     db: AsyncSession, org_id: int, plan_id: int,
 ) -> ForecastPlanResponse:
-    """Remove all items from a plan and reset to draft."""
+    """Remove all items from a draft plan."""
     plan = await _get_plan(db, org_id, plan_id)
+    _require_draft(plan)
 
     for item in list(plan.items):
         await db.delete(item)
@@ -525,6 +531,7 @@ async def copy_from_period(
     # Get or create target plan (race-safe)
     target_plan = await _get_or_create_plan_row(db, org_id, target_period.id)
     await db.refresh(target_plan, ["billing_period", "items"])
+    _require_draft(target_plan)
 
     existing_keys: set[tuple[int, str]] = set()
     if target_plan.items:

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -111,34 +111,64 @@ async def _validate_master_category(
         raise ValidationError("Forecast plan items must use master categories, not subcategories")
 
 
-async def _compute_actual(
-    db: AsyncSession, org_id: int, category_id: int,
-    item_type: ForecastItemType,
+async def _compute_actuals_batch(
+    db: AsyncSession, org_id: int,
+    items: list[ForecastPlanItem],
     period_start: datetime.date, period_end: datetime.date | None,
-) -> Decimal:
-    """Sum settled transactions for a category within the period."""
-    tx_type = TransactionType.INCOME if item_type == ForecastItemType.INCOME else TransactionType.EXPENSE
+) -> dict[tuple[int, str], Decimal]:
+    """Compute actual amounts for all plan items in two queries (income + expense).
 
-    # Include subcategories
+    Returns a dict keyed by (category_id, type_value) → actual amount.
+    Each category includes its subcategories in the sum.
+    """
+    if not items:
+        return {}
+
+    # Collect all master category IDs from plan items
+    master_ids = {item.category_id for item in items}
+
+    # Build mapping: master_id → [master_id, sub1, sub2, ...]
     sub_result = await db.execute(
-        select(Category.id).where(
-            Category.parent_id == category_id, Category.org_id == org_id
+        select(Category.id, Category.parent_id).where(
+            Category.parent_id.in_(master_ids), Category.org_id == org_id
         )
     )
-    all_ids = [category_id] + [r[0] for r in sub_result.all()]
+    cat_to_master: dict[int, int] = {}
+    for cat_id, parent_id in sub_result.all():
+        cat_to_master[cat_id] = parent_id
+    # Masters map to themselves
+    for mid in master_ids:
+        cat_to_master[mid] = mid
 
-    q = select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+    all_cat_ids = list(cat_to_master.keys())
+
+    # Single query: sum by (category_id, type) for all relevant categories
+    q = select(
+        Transaction.category_id,
+        Transaction.type,
+        func.coalesce(func.sum(Transaction.amount), 0),
+    ).where(
         Transaction.org_id == org_id,
-        Transaction.category_id.in_(all_ids),
-        Transaction.type == tx_type,
+        Transaction.category_id.in_(all_cat_ids),
         Transaction.status == TransactionStatus.SETTLED,
         Transaction.date >= period_start,
+        Transaction.type.in_(["income", "expense"]),
     )
     if period_end is not None:
         q = q.where(Transaction.date <= period_end)
+    q = q.group_by(Transaction.category_id, Transaction.type)
 
-    val = await db.scalar(q)
-    return Decimal(str(val))
+    result = await db.execute(q)
+
+    # Aggregate to master category level
+    actuals: dict[tuple[int, str], Decimal] = {}
+    for cat_id, tx_type_raw, amount in result.all():
+        tx_type = tx_type_raw.value if hasattr(tx_type_raw, "value") else str(tx_type_raw)
+        master_id = cat_to_master.get(cat_id, cat_id)
+        key = (master_id, tx_type)
+        actuals[key] = actuals.get(key, Decimal("0")) + Decimal(str(amount))
+
+    return actuals
 
 
 def _item_response(item: ForecastPlanItem, actual: Decimal) -> ForecastPlanItemResponse:
@@ -163,6 +193,9 @@ async def _build_response(
     p_start = period.start_date
     p_end = period.end_date
 
+    # Batch compute actuals for all items (2 queries instead of 2*N)
+    actuals = await _compute_actuals_batch(db, org_id, plan.items, p_start, p_end)
+
     item_responses = []
     total_planned_income = Decimal("0")
     total_planned_expense = Decimal("0")
@@ -170,7 +203,7 @@ async def _build_response(
     total_actual_expense = Decimal("0")
 
     for item in plan.items:
-        actual = await _compute_actual(db, org_id, item.category_id, item.type, p_start, p_end)
+        actual = actuals.get((item.category_id, item.type.value), Decimal("0"))
         resp = _item_response(item, actual)
         item_responses.append(resp)
 

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -171,21 +171,6 @@ async def _compute_actuals_batch(
     return actuals
 
 
-def _item_response(item: ForecastPlanItem, actual: Decimal) -> ForecastPlanItemResponse:
-    return ForecastPlanItemResponse(
-        id=item.id,
-        plan_id=item.plan_id,
-        category_id=item.category_id,
-        category_name=item.category.name if item.category else "",
-        parent_id=item.category.parent_id if item.category else None,
-        type=item.type.value,
-        planned_amount=item.planned_amount,
-        source=item.source.value,
-        actual_amount=actual,
-        variance=actual - item.planned_amount,
-    )
-
-
 async def _build_response(
     db: AsyncSession, org_id: int, plan: ForecastPlan,
 ) -> ForecastPlanResponse:
@@ -196,6 +181,18 @@ async def _build_response(
     # Batch compute actuals for all items (2 queries instead of 2*N)
     actuals = await _compute_actuals_batch(db, org_id, plan.items, p_start, p_end)
 
+    # Batch fetch category names (avoids lazy-load MissingGreenlet in async)
+    cat_ids = {item.category_id for item in plan.items}
+    cat_info: dict[int, tuple[str, int | None]] = {}
+    if cat_ids:
+        cat_result = await db.execute(
+            select(Category.id, Category.name, Category.parent_id).where(
+                Category.id.in_(cat_ids), Category.org_id == org_id
+            )
+        )
+        for cid, cname, pid in cat_result.all():
+            cat_info[cid] = (cname, pid)
+
     item_responses = []
     total_planned_income = Decimal("0")
     total_planned_expense = Decimal("0")
@@ -204,7 +201,19 @@ async def _build_response(
 
     for item in plan.items:
         actual = actuals.get((item.category_id, item.type.value), Decimal("0"))
-        resp = _item_response(item, actual)
+        cname, pid = cat_info.get(item.category_id, ("Unknown", None))
+        resp = ForecastPlanItemResponse(
+            id=item.id,
+            plan_id=item.plan_id,
+            category_id=item.category_id,
+            category_name=cname,
+            parent_id=pid,
+            type=item.type.value,
+            planned_amount=item.planned_amount,
+            source=item.source.value,
+            actual_amount=actual,
+            variance=actual - item.planned_amount,
+        )
         item_responses.append(resp)
 
         if item.type == ForecastItemType.INCOME:

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -522,6 +522,7 @@ async def activate_plan(
 ) -> ForecastPlanResponse:
     """Mark plan as active (finalized). Active plans are read-only."""
     plan = await _get_plan(db, org_id, plan_id)
+    _require_draft(plan)
 
     if not plan.items:
         raise ValidationError("Cannot activate an empty plan")

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -91,6 +91,12 @@ async def _get_or_create_plan_row(
     return plan
 
 
+def _require_draft(plan: ForecastPlan) -> None:
+    """Raise if the plan is active (read-only)."""
+    if plan.status == PlanStatus.ACTIVE:
+        raise ValidationError("Cannot modify an active plan. Revert to draft first.")
+
+
 async def _validate_master_category(
     db: AsyncSession, org_id: int, category_id: int,
 ) -> None:
@@ -328,6 +334,7 @@ async def upsert_item(
 ) -> ForecastPlanResponse:
     """Add or update a single plan item."""
     plan = await _get_plan(db, org_id, plan_id)
+    _require_draft(plan)
 
     await _validate_master_category(db, org_id, body.category_id)
 
@@ -362,6 +369,7 @@ async def bulk_upsert(
 ) -> ForecastPlanResponse:
     """Bulk add/update multiple plan items at once."""
     plan = await _get_plan(db, org_id, plan_id)
+    _require_draft(plan)
 
     # Validate all category IDs belong to the org and are master categories
     requested_ids = {item.category_id for item in body.items}
@@ -408,6 +416,7 @@ async def update_item(
 ) -> ForecastPlanResponse:
     """Update a single plan item amount."""
     plan = await _get_plan(db, org_id, plan_id)
+    _require_draft(plan)
 
     item = None
     for i in plan.items:
@@ -431,6 +440,7 @@ async def delete_item(
 ) -> ForecastPlanResponse:
     """Remove a single plan item."""
     plan = await _get_plan(db, org_id, plan_id)
+    _require_draft(plan)
 
     item = None
     for i in plan.items:
@@ -450,13 +460,43 @@ async def delete_item(
 async def activate_plan(
     db: AsyncSession, org_id: int, plan_id: int,
 ) -> ForecastPlanResponse:
-    """Mark plan as active (finalized)."""
+    """Mark plan as active (finalized). Active plans are read-only."""
     plan = await _get_plan(db, org_id, plan_id)
 
     if not plan.items:
         raise ValidationError("Cannot activate an empty plan")
 
     plan.status = PlanStatus.ACTIVE
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def revert_to_draft(
+    db: AsyncSession, org_id: int, plan_id: int,
+) -> ForecastPlanResponse:
+    """Revert an active plan back to draft for editing."""
+    plan = await _get_plan(db, org_id, plan_id)
+
+    if plan.status != PlanStatus.ACTIVE:
+        raise ValidationError("Plan is already a draft")
+
+    plan.status = PlanStatus.DRAFT
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def discard_plan(
+    db: AsyncSession, org_id: int, plan_id: int,
+) -> ForecastPlanResponse:
+    """Remove all items from a plan and reset to draft."""
+    plan = await _get_plan(db, org_id, plan_id)
+
+    for item in list(plan.items):
+        await db.delete(item)
+
+    plan.status = PlanStatus.DRAFT
     await db.commit()
     await db.refresh(plan, ["billing_period", "items"])
     return await _build_response(db, org_id, plan)

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -268,7 +268,16 @@ async def populate_from_sources(
     p_start = period.start_date
     p_end = period.end_date or (p_start + relativedelta(months=1) - datetime.timedelta(days=1))
 
+    # ── Pre-fetch category → master mapping ──
+    cat_result = await db.execute(
+        select(Category.id, Category.parent_id).where(Category.org_id == org_id)
+    )
+    cat_to_master: dict[int, int] = {}
+    for cid, pid in cat_result.all():
+        cat_to_master[cid] = pid if pid else cid
+
     # ── From active recurring templates (with date filter) ──
+    # Aggregate by master category before inserting
     rec_result = await db.execute(
         select(RecurringTransaction).where(
             RecurringTransaction.org_id == org_id,
@@ -276,15 +285,15 @@ async def populate_from_sources(
             RecurringTransaction.next_due_date <= p_end,
         )
     )
+    recurring_totals: dict[tuple[int, str], Decimal] = {}
     for r in rec_result.scalars().all():
-        key = (r.category_id, r.type)  # r.type is str on RecurringTransaction
+        master_id = cat_to_master.get(r.category_id, r.category_id)
+        key = (master_id, r.type)
         if key in existing_keys:
             continue
 
-        # Count occurrences within the period — advance to period start first
         total = Decimal("0")
         d = r.next_due_date
-        # Fast-forward past dates before the period to avoid unnecessary iterations
         while d < p_start and d <= p_end:
             d = _advance_date(d, r.frequency)
         while d <= p_end:
@@ -292,21 +301,28 @@ async def populate_from_sources(
             prev = d
             d = _advance_date(d, r.frequency)
             if d <= prev:
-                break  # safety: prevent infinite loop on bad frequency
+                break
 
         if total > 0:
-            item = ForecastPlanItem(
-                plan_id=plan.id,
-                org_id=org_id,
-                category_id=r.category_id,
-                type=ForecastItemType(r.type),
-                planned_amount=total,
-                source=ItemSource.RECURRING,
-            )
-            db.add(item)
-            existing_keys.add(key)
+            recurring_totals[key] = recurring_totals.get(key, Decimal("0")) + total
+
+    for key, total in recurring_totals.items():
+        if key in existing_keys:
+            continue
+        master_id, r_type = key
+        item = ForecastPlanItem(
+            plan_id=plan.id,
+            org_id=org_id,
+            category_id=master_id,
+            type=ForecastItemType(r_type),
+            planned_amount=total,
+            source=ItemSource.RECURRING,
+        )
+        db.add(item)
+        existing_keys.add(key)
 
     # ── From 3-month historical monthly averages ──
+    # Aggregate subcategories into master before averaging
     three_months_ago = p_start - relativedelta(months=3)
 
     # Subquery: sum per category per type per month
@@ -328,49 +344,44 @@ async def populate_from_sources(
         .subquery()
     )
 
-    # Average the monthly totals
     hist_result = await db.execute(
         select(
             monthly_sub.c.category_id,
             monthly_sub.c.type,
-            func.avg(monthly_sub.c.monthly_total),
-            func.count(literal_column("*")),
-        ).group_by(monthly_sub.c.category_id, monthly_sub.c.type)
+            monthly_sub.c.month,
+            monthly_sub.c.monthly_total,
+        )
     )
 
-    for cat_id, tx_type_raw, avg_monthly, month_count in hist_result.all():
-        # Normalize tx_type to string (may come back as enum or str depending on driver)
+    # Roll up to master category, then compute monthly averages
+    # Structure: {(master_id, type): {month: total}}
+    master_monthly: dict[tuple[int, str], dict[str, Decimal]] = {}
+    for cat_id, tx_type_raw, month, monthly_total in hist_result.all():
         tx_type = tx_type_raw.value if hasattr(tx_type_raw, "value") else str(tx_type_raw)
+        master_id = cat_to_master.get(cat_id, cat_id)
+        key = (master_id, tx_type)
+        if key not in master_monthly:
+            master_monthly[key] = {}
+        master_monthly[key][month] = master_monthly[key].get(month, Decimal("0")) + Decimal(str(monthly_total))
 
-        key = (cat_id, tx_type)
+    for key, months in master_monthly.items():
         if key in existing_keys:
             continue
-        if month_count < 2:  # Need at least 2 months to suggest
+        if len(months) < 2:  # Need at least 2 months to suggest
             continue
-
-        # Resolve to master category for the plan item
-        cat_result = await db.execute(
-            select(Category).where(Category.id == cat_id, Category.org_id == org_id)
-        )
-        cat = cat_result.scalar_one_or_none()
-        if cat is None:
-            continue
-
-        master_id = cat.parent_id if cat.parent_id else cat.id
-        master_key = (master_id, tx_type)
-        if master_key in existing_keys:
-            continue
+        master_id, tx_type = key
+        avg_amount = sum(months.values()) / len(months)
 
         item = ForecastPlanItem(
             plan_id=plan.id,
             org_id=org_id,
             category_id=master_id,
             type=ForecastItemType(tx_type),
-            planned_amount=Decimal(str(round(float(avg_monthly), 2))),
+            planned_amount=Decimal(str(round(float(avg_amount), 2))),
             source=ItemSource.HISTORY,
         )
         db.add(item)
-        existing_keys.add(master_key)
+        existing_keys.add(key)
 
     await db.commit()
     await db.refresh(plan, ["billing_period", "items"])
@@ -453,6 +464,7 @@ async def bulk_upsert(
                 source=ItemSource(item_data.source),
             )
             db.add(new_item)
+            existing_map[key] = new_item  # track to handle duplicates in same request
 
     await db.commit()
     await db.refresh(plan, ["billing_period", "items"])

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -1,0 +1,524 @@
+"""Forecast plan service — editable plans for income/expense per billing period.
+
+Users can create a plan for a billing period, auto-populate from recurring
+templates and historical averages, then manually adjust. The plan tracks
+actual vs planned for each line item.
+"""
+
+import datetime
+from decimal import Decimal
+
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import func, literal_column, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.billing import BillingPeriod
+from app.models.category import Category
+from app.models.forecast_plan import (
+    ForecastItemType,
+    ForecastPlan,
+    ForecastPlanItem,
+    ItemSource,
+    PlanStatus,
+)
+from app.models.recurring import RecurringTransaction
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.schemas.forecast_plan import (
+    BulkUpsertRequest,
+    ForecastPlanItemCreate,
+    ForecastPlanItemResponse,
+    ForecastPlanItemUpdate,
+    ForecastPlanResponse,
+)
+from app.services.billing_service import get_current_period
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.forecast_service import _advance_date
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+async def _resolve_period(
+    db: AsyncSession, org_id: int, period_start: datetime.date | None
+) -> BillingPeriod:
+    if period_start:
+        result = await db.execute(
+            select(BillingPeriod).where(
+                BillingPeriod.org_id == org_id,
+                BillingPeriod.start_date == period_start,
+            )
+        )
+        period = result.scalar_one_or_none()
+        if period is None:
+            raise ValidationError("Billing period not found")
+        return period
+    return await get_current_period(db, org_id)
+
+
+async def _get_or_create_plan_row(
+    db: AsyncSession, org_id: int, period_id: int,
+) -> ForecastPlan:
+    """Get or create a plan row, handling concurrent insert races."""
+    result = await db.execute(
+        select(ForecastPlan).where(
+            ForecastPlan.org_id == org_id,
+            ForecastPlan.billing_period_id == period_id,
+        )
+    )
+    plan = result.scalar_one_or_none()
+    if plan is not None:
+        return plan
+
+    plan = ForecastPlan(
+        org_id=org_id,
+        billing_period_id=period_id,
+        status=PlanStatus.DRAFT,
+    )
+    db.add(plan)
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        result = await db.execute(
+            select(ForecastPlan).where(
+                ForecastPlan.org_id == org_id,
+                ForecastPlan.billing_period_id == period_id,
+            )
+        )
+        plan = result.scalar_one_or_none()
+        if plan is None:
+            raise ValidationError("Failed to create forecast plan")
+    return plan
+
+
+async def _validate_master_category(
+    db: AsyncSession, org_id: int, category_id: int,
+) -> None:
+    """Validate that the category exists, belongs to the org, and is a master category."""
+    result = await db.execute(
+        select(Category).where(Category.id == category_id, Category.org_id == org_id)
+    )
+    cat = result.scalar_one_or_none()
+    if cat is None:
+        raise ValidationError("Invalid category")
+    if cat.parent_id is not None:
+        raise ValidationError("Forecast plan items must use master categories, not subcategories")
+
+
+async def _compute_actual(
+    db: AsyncSession, org_id: int, category_id: int,
+    item_type: ForecastItemType,
+    period_start: datetime.date, period_end: datetime.date | None,
+) -> Decimal:
+    """Sum settled transactions for a category within the period."""
+    tx_type = TransactionType.INCOME if item_type == ForecastItemType.INCOME else TransactionType.EXPENSE
+
+    # Include subcategories
+    sub_result = await db.execute(
+        select(Category.id).where(
+            Category.parent_id == category_id, Category.org_id == org_id
+        )
+    )
+    all_ids = [category_id] + [r[0] for r in sub_result.all()]
+
+    q = select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+        Transaction.org_id == org_id,
+        Transaction.category_id.in_(all_ids),
+        Transaction.type == tx_type,
+        Transaction.status == TransactionStatus.SETTLED,
+        Transaction.date >= period_start,
+    )
+    if period_end is not None:
+        q = q.where(Transaction.date <= period_end)
+
+    val = await db.scalar(q)
+    return Decimal(str(val))
+
+
+def _item_response(item: ForecastPlanItem, actual: Decimal) -> ForecastPlanItemResponse:
+    return ForecastPlanItemResponse(
+        id=item.id,
+        plan_id=item.plan_id,
+        category_id=item.category_id,
+        category_name=item.category.name if item.category else "",
+        parent_id=item.category.parent_id if item.category else None,
+        type=item.type.value,
+        planned_amount=item.planned_amount,
+        source=item.source.value,
+        actual_amount=actual,
+        variance=actual - item.planned_amount,
+    )
+
+
+async def _build_response(
+    db: AsyncSession, org_id: int, plan: ForecastPlan,
+) -> ForecastPlanResponse:
+    period = plan.billing_period
+    p_start = period.start_date
+    p_end = period.end_date
+
+    item_responses = []
+    total_planned_income = Decimal("0")
+    total_planned_expense = Decimal("0")
+    total_actual_income = Decimal("0")
+    total_actual_expense = Decimal("0")
+
+    for item in plan.items:
+        actual = await _compute_actual(db, org_id, item.category_id, item.type, p_start, p_end)
+        resp = _item_response(item, actual)
+        item_responses.append(resp)
+
+        if item.type == ForecastItemType.INCOME:
+            total_planned_income += item.planned_amount
+            total_actual_income += actual
+        else:
+            total_planned_expense += item.planned_amount
+            total_actual_expense += actual
+
+    return ForecastPlanResponse(
+        id=plan.id,
+        billing_period_id=plan.billing_period_id,
+        period_start=p_start,
+        period_end=p_end,
+        status=plan.status.value,
+        total_planned_income=total_planned_income,
+        total_planned_expense=total_planned_expense,
+        total_actual_income=total_actual_income,
+        total_actual_expense=total_actual_expense,
+        items=item_responses,
+    )
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────────────
+
+async def get_or_create_plan(
+    db: AsyncSession, org_id: int, period_start: datetime.date | None = None,
+) -> ForecastPlanResponse:
+    """Get existing plan for a period, or create a new draft."""
+    period = await _resolve_period(db, org_id, period_start)
+    plan = await _get_or_create_plan_row(db, org_id, period.id)
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def populate_from_sources(
+    db: AsyncSession, org_id: int, period_start: datetime.date | None = None,
+) -> ForecastPlanResponse:
+    """Auto-populate plan items from recurring templates and 3-month history averages.
+
+    Only adds items for categories not already in the plan.
+    """
+    period = await _resolve_period(db, org_id, period_start)
+    plan = await _get_or_create_plan_row(db, org_id, period.id)
+    await db.refresh(plan, ["billing_period", "items"])
+
+    # Existing (category_id, type_str) combos — always use strings for consistency
+    existing_keys: set[tuple[int, str]] = {(i.category_id, i.type.value) for i in plan.items}
+
+    p_start = period.start_date
+    p_end = period.end_date or (p_start + relativedelta(months=1) - datetime.timedelta(days=1))
+
+    # ── From active recurring templates (with date filter) ──
+    rec_result = await db.execute(
+        select(RecurringTransaction).where(
+            RecurringTransaction.org_id == org_id,
+            RecurringTransaction.is_active == True,
+            RecurringTransaction.next_due_date <= p_end,
+        )
+    )
+    for r in rec_result.scalars().all():
+        key = (r.category_id, r.type)  # r.type is str on RecurringTransaction
+        if key in existing_keys:
+            continue
+
+        # Count occurrences within the period
+        total = Decimal("0")
+        d = r.next_due_date
+        while d <= p_end:
+            if d >= p_start:
+                total += r.amount
+            d = _advance_date(d, r.frequency)
+
+        if total > 0:
+            item = ForecastPlanItem(
+                plan_id=plan.id,
+                org_id=org_id,
+                category_id=r.category_id,
+                type=ForecastItemType(r.type),
+                planned_amount=total,
+                source=ItemSource.RECURRING,
+            )
+            db.add(item)
+            existing_keys.add(key)
+
+    # ── From 3-month historical monthly averages ──
+    three_months_ago = p_start - relativedelta(months=3)
+
+    # Subquery: sum per category per type per month
+    monthly_sub = (
+        select(
+            Transaction.category_id,
+            Transaction.type,
+            func.date_format(Transaction.date, "%Y-%m").label("month"),
+            func.sum(Transaction.amount).label("monthly_total"),
+        )
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.date >= three_months_ago,
+            Transaction.date < p_start,
+            Transaction.type.in_(["income", "expense"]),
+        )
+        .group_by(Transaction.category_id, Transaction.type, text("month"))
+        .subquery()
+    )
+
+    # Average the monthly totals
+    hist_result = await db.execute(
+        select(
+            monthly_sub.c.category_id,
+            monthly_sub.c.type,
+            func.avg(monthly_sub.c.monthly_total),
+            func.count(literal_column("*")),
+        ).group_by(monthly_sub.c.category_id, monthly_sub.c.type)
+    )
+
+    for cat_id, tx_type_raw, avg_monthly, month_count in hist_result.all():
+        # Normalize tx_type to string (may come back as enum or str depending on driver)
+        tx_type = tx_type_raw.value if hasattr(tx_type_raw, "value") else str(tx_type_raw)
+
+        key = (cat_id, tx_type)
+        if key in existing_keys:
+            continue
+        if month_count < 2:  # Need at least 2 months to suggest
+            continue
+
+        # Resolve to master category for the plan item
+        cat_result = await db.execute(
+            select(Category).where(Category.id == cat_id, Category.org_id == org_id)
+        )
+        cat = cat_result.scalar_one_or_none()
+        if cat is None:
+            continue
+
+        master_id = cat.parent_id if cat.parent_id else cat.id
+        master_key = (master_id, tx_type)
+        if master_key in existing_keys:
+            continue
+
+        item = ForecastPlanItem(
+            plan_id=plan.id,
+            org_id=org_id,
+            category_id=master_id,
+            type=ForecastItemType(tx_type),
+            planned_amount=Decimal(str(round(float(avg_monthly), 2))),
+            source=ItemSource.HISTORY,
+        )
+        db.add(item)
+        existing_keys.add(master_key)
+
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def upsert_item(
+    db: AsyncSession, org_id: int, plan_id: int, body: ForecastPlanItemCreate,
+) -> ForecastPlanResponse:
+    """Add or update a single plan item."""
+    plan = await _get_plan(db, org_id, plan_id)
+
+    await _validate_master_category(db, org_id, body.category_id)
+
+    # Find existing item
+    existing = None
+    for item in plan.items:
+        if item.category_id == body.category_id and item.type.value == body.type:
+            existing = item
+            break
+
+    if existing:
+        existing.planned_amount = body.planned_amount
+        existing.source = ItemSource(body.source)
+    else:
+        new_item = ForecastPlanItem(
+            plan_id=plan.id,
+            org_id=org_id,
+            category_id=body.category_id,
+            type=ForecastItemType(body.type),
+            planned_amount=body.planned_amount,
+            source=ItemSource(body.source),
+        )
+        db.add(new_item)
+
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def bulk_upsert(
+    db: AsyncSession, org_id: int, plan_id: int, body: BulkUpsertRequest,
+) -> ForecastPlanResponse:
+    """Bulk add/update multiple plan items at once."""
+    plan = await _get_plan(db, org_id, plan_id)
+
+    # Validate all category IDs belong to the org and are master categories
+    requested_ids = {item.category_id for item in body.items}
+    if requested_ids:
+        valid_result = await db.execute(
+            select(Category.id).where(
+                Category.id.in_(requested_ids),
+                Category.org_id == org_id,
+                Category.parent_id.is_(None),
+            )
+        )
+        valid_ids = {r[0] for r in valid_result.all()}
+        invalid = requested_ids - valid_ids
+        if invalid:
+            raise ValidationError(f"Invalid or non-master category IDs: {sorted(invalid)}")
+
+    existing_map = {
+        (i.category_id, i.type.value): i for i in plan.items
+    }
+
+    for item_data in body.items:
+        key = (item_data.category_id, item_data.type)
+        if key in existing_map:
+            existing_map[key].planned_amount = item_data.planned_amount
+            existing_map[key].source = ItemSource(item_data.source)
+        else:
+            new_item = ForecastPlanItem(
+                plan_id=plan.id,
+                org_id=org_id,
+                category_id=item_data.category_id,
+                type=ForecastItemType(item_data.type),
+                planned_amount=item_data.planned_amount,
+                source=ItemSource(item_data.source),
+            )
+            db.add(new_item)
+
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def update_item(
+    db: AsyncSession, org_id: int, plan_id: int, item_id: int, body: ForecastPlanItemUpdate,
+) -> ForecastPlanResponse:
+    """Update a single plan item amount."""
+    plan = await _get_plan(db, org_id, plan_id)
+
+    item = None
+    for i in plan.items:
+        if i.id == item_id:
+            item = i
+            break
+
+    if item is None:
+        raise NotFoundError("Forecast plan item")
+
+    item.planned_amount = body.planned_amount
+    item.source = ItemSource.MANUAL
+
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def delete_item(
+    db: AsyncSession, org_id: int, plan_id: int, item_id: int,
+) -> ForecastPlanResponse:
+    """Remove a single plan item."""
+    plan = await _get_plan(db, org_id, plan_id)
+
+    item = None
+    for i in plan.items:
+        if i.id == item_id:
+            item = i
+            break
+
+    if item is None:
+        raise NotFoundError("Forecast plan item")
+
+    await db.delete(item)
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def activate_plan(
+    db: AsyncSession, org_id: int, plan_id: int,
+) -> ForecastPlanResponse:
+    """Mark plan as active (finalized)."""
+    plan = await _get_plan(db, org_id, plan_id)
+
+    if not plan.items:
+        raise ValidationError("Cannot activate an empty plan")
+
+    plan.status = PlanStatus.ACTIVE
+    await db.commit()
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
+async def copy_from_period(
+    db: AsyncSession, org_id: int,
+    target_period_start: datetime.date | None,
+    source_period_start: datetime.date,
+) -> ForecastPlanResponse:
+    """Copy plan items from a previous period to the target period."""
+    target_period = await _resolve_period(db, org_id, target_period_start)
+    source_period = await _resolve_period(db, org_id, source_period_start)
+
+    # Get source plan
+    source_result = await db.execute(
+        select(ForecastPlan).where(
+            ForecastPlan.org_id == org_id,
+            ForecastPlan.billing_period_id == source_period.id,
+        )
+    )
+    source_plan = source_result.scalar_one_or_none()
+    if source_plan is None or not source_plan.items:
+        raise ValidationError("Source period has no plan to copy")
+
+    # Get or create target plan (race-safe)
+    target_plan = await _get_or_create_plan_row(db, org_id, target_period.id)
+    await db.refresh(target_plan, ["billing_period", "items"])
+
+    existing_keys: set[tuple[int, str]] = set()
+    if target_plan.items:
+        existing_keys = {(i.category_id, i.type.value) for i in target_plan.items}
+
+    for src_item in source_plan.items:
+        key = (src_item.category_id, src_item.type.value)
+        if key in existing_keys:
+            continue
+        new_item = ForecastPlanItem(
+            plan_id=target_plan.id,
+            org_id=org_id,
+            category_id=src_item.category_id,
+            type=src_item.type,
+            planned_amount=src_item.planned_amount,
+            source=src_item.source,
+        )
+        db.add(new_item)
+
+    await db.commit()
+    await db.refresh(target_plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, target_plan)
+
+
+# ── Internal ─────────────────────────────────────────────────────────────────
+
+async def _get_plan(db: AsyncSession, org_id: int, plan_id: int) -> ForecastPlan:
+    result = await db.execute(
+        select(ForecastPlan).where(
+            ForecastPlan.id == plan_id,
+            ForecastPlan.org_id == org_id,
+        )
+    )
+    plan = result.scalar_one_or_none()
+    if plan is None:
+        raise NotFoundError("Forecast plan")
+    return plan

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -35,7 +35,7 @@ export default function BudgetsPage() {
 
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
-  const isCurrentPeriod = periodIdx === 0;
+  const isCurrentPeriod = selectedPeriod?.end_date === null;
 
   const loadRefs = useCallback(async () => {
     const [c, p] = await Promise.all([
@@ -134,6 +134,9 @@ export default function BudgetsPage() {
           <button onClick={() => setPeriodIdx(Math.max(periodIdx - 1, 0))} disabled={periodIdx <= 0} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
           </button>
+          {!isCurrentPeriod && (
+            <button onClick={() => { const idx = periods.findIndex((p) => p.end_date === null); if (idx >= 0) setPeriodIdx(idx); }} className="ml-1 rounded-md px-2 py-1 text-[11px] font-medium text-text-muted hover:bg-surface-raised">Today</button>
+          )}
         </div>
       )}
 

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -43,7 +43,11 @@ export default function BudgetsPage() {
       apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),
     ]);
     setCategories(c ?? []);
-    setPeriods(p ?? []);
+    const pl = p ?? [];
+    setPeriods(pl);
+    // Default to current period (open = no end_date), not index 0
+    const currentIdx = pl.findIndex((bp) => bp.end_date === null);
+    if (currentIdx >= 0) setPeriodIdx(currentIdx);
   }, []);
 
   const loadBudgets = useCallback(async () => {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -88,7 +88,11 @@ export default function DashboardPage() {
     setCategories(cats ?? []);
     setBudgets(bds ?? []);
     if (per) setPeriod(per);
-    setPeriods(plist ?? []);
+    const pl = plist ?? [];
+    setPeriods(pl);
+    // Default to current period (open = no end_date), not index 0
+    const currentIdx = pl.findIndex((p) => p.end_date === null);
+    if (currentIdx >= 0) setPeriodIdx(currentIdx);
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -396,7 +396,10 @@ export default function DashboardPage() {
               <button onClick={() => { setPeriodIdx(Math.max(periodIdx - 1, 0)); setChartFilter(null); }} disabled={periodIdx <= 0} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
               </button>
-              {periodIdx === 0 && <span className="ml-1 rounded bg-success-dim px-2 py-0.5 text-[10px] font-semibold text-success">CURRENT</span>}
+              {selectedPeriod?.end_date === null && <span className="ml-1 rounded bg-success-dim px-2 py-0.5 text-[10px] font-semibold text-success">CURRENT</span>}
+              {selectedPeriod?.end_date !== null && (
+                <button onClick={() => { const idx = periods.findIndex((p) => p.end_date === null); if (idx >= 0) { setPeriodIdx(idx); setChartFilter(null); } }} className="ml-1 rounded-md px-2 py-1 text-[11px] font-medium text-text-muted hover:bg-surface-raised">Today</button>
+              )}
             </div>
             <Link href="/transactions" className="text-xs text-accent hover:text-accent-hover">View All Transactions</Link>
           </div>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -1,0 +1,705 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { formatAmount } from "@/lib/format";
+import {
+  input,
+  label,
+  btnPrimary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  pageTitle,
+  btnLink,
+  btnDanger,
+} from "@/lib/styles";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  Legend,
+} from "recharts";
+import type { Category, ForecastPlan, ForecastPlanItem } from "@/lib/types";
+
+interface BillingPeriod {
+  id: number;
+  start_date: string;
+  end_date: string | null;
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  manual: "Manual",
+  recurring: "Recurring",
+  history: "Avg (3mo)",
+};
+
+export default function ForecastPlansPage() {
+  const { user, loading } = useAuth();
+  const [plan, setPlan] = useState<ForecastPlan | null>(null);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [periods, setPeriods] = useState<BillingPeriod[]>([]);
+  const [periodIdx, setPeriodIdx] = useState(0);
+  const [fetching, setFetching] = useState(true);
+  const [error, setError] = useState("");
+  const [showForm, setShowForm] = useState(false);
+
+  // Add form
+  const [formCategoryId, setFormCategoryId] = useState<number | "">("");
+  const [formType, setFormType] = useState<"income" | "expense">("expense");
+  const [formAmount, setFormAmount] = useState("");
+
+  // Edit
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editAmount, setEditAmount] = useState("");
+
+  // View filter
+  const [viewFilter, setViewFilter] = useState<"all" | "income" | "expense">("all");
+
+  const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
+  const periodStart = selectedPeriod?.start_date ?? "";
+  const isCurrentPeriod = periodIdx === 0;
+
+  const loadRefs = useCallback(async () => {
+    const [c, p] = await Promise.all([
+      apiFetch<Category[]>("/api/v1/categories"),
+      apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),
+    ]);
+    setCategories(c ?? []);
+    setPeriods(p ?? []);
+  }, []);
+
+  const loadPlan = useCallback(async () => {
+    const url = periodStart
+      ? `/api/v1/forecast-plans?period_start=${periodStart}`
+      : "/api/v1/forecast-plans";
+    const p = await apiFetch<ForecastPlan>(url);
+    setPlan(p);
+    setFetching(false);
+  }, [periodStart]);
+
+  useEffect(() => {
+    if (!loading && user) loadRefs().catch(() => {});
+  }, [loading, user, loadRefs]);
+
+  useEffect(() => {
+    if (!loading && user) {
+      setFetching(true);
+      loadPlan().catch(() => setFetching(false));
+    }
+  }, [loading, user, loadPlan]);
+
+  // Available categories for add form
+  const masterCategories = categories.filter((c) => c.parent_id === null);
+  const existingKeys = new Set(
+    (plan?.items ?? []).map((i) => `${i.category_id}-${i.type}`)
+  );
+  const availableForType = masterCategories.filter(
+    (c) =>
+      !existingKeys.has(`${c.id}-${formType}`) &&
+      (formType === "expense"
+        ? c.type === "expense" || c.type === "both"
+        : c.type === "income" || c.type === "both")
+  );
+
+  // Filtered items
+  const items = (plan?.items ?? []).filter(
+    (i) => viewFilter === "all" || i.type === viewFilter
+  );
+
+  // Grouped by type for display
+  const incomeItems = items.filter((i) => i.type === "income");
+  const expenseItems = items.filter((i) => i.type === "expense");
+
+  async function handlePopulate() {
+    setError("");
+    try {
+      const url = periodStart
+        ? `/api/v1/forecast-plans/populate?period_start=${periodStart}`
+        : "/api/v1/forecast-plans/populate";
+      const p = await apiFetch<ForecastPlan>(url, { method: "POST" });
+      setPlan(p);
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleAddItem(e: FormEvent) {
+    e.preventDefault();
+    if (!plan) return;
+    setError("");
+    try {
+      const p = await apiFetch<ForecastPlan>(
+        `/api/v1/forecast-plans/${plan.id}/items`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            category_id: formCategoryId,
+            type: formType,
+            planned_amount: parseFloat(formAmount),
+          }),
+        }
+      );
+      setPlan(p);
+      setFormCategoryId("");
+      setFormAmount("");
+      setShowForm(false);
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleUpdateItem(itemId: number) {
+    if (!plan) return;
+    setError("");
+    try {
+      const p = await apiFetch<ForecastPlan>(
+        `/api/v1/forecast-plans/${plan.id}/items/${itemId}`,
+        {
+          method: "PUT",
+          body: JSON.stringify({ planned_amount: parseFloat(editAmount) }),
+        }
+      );
+      setPlan(p);
+      setEditingId(null);
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleDeleteItem(itemId: number) {
+    if (!plan || !confirm("Remove this plan item?")) return;
+    try {
+      const p = await apiFetch<ForecastPlan>(
+        `/api/v1/forecast-plans/${plan.id}/items/${itemId}`,
+        { method: "DELETE" }
+      );
+      setPlan(p);
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleActivate() {
+    if (!plan || !confirm("Mark this plan as active? You can still edit items."))
+      return;
+    setError("");
+    try {
+      const p = await apiFetch<ForecastPlan>(
+        `/api/v1/forecast-plans/${plan.id}/activate`,
+        { method: "POST" }
+      );
+      setPlan(p);
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    }
+  }
+
+  // Chart data — expense items only
+  const chartData = expenseItems.map((i) => ({
+    name: i.category_name,
+    planned: Number(i.planned_amount),
+    actual: Number(i.actual_amount),
+  }));
+
+  const plannedNet =
+    Number(plan?.total_planned_income ?? 0) -
+    Number(plan?.total_planned_expense ?? 0);
+  const actualNet =
+    Number(plan?.total_actual_income ?? 0) -
+    Number(plan?.total_actual_expense ?? 0);
+
+  return (
+    <AppShell>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className={`${pageTitle} mb-0`}>Forecast Plans</h1>
+        <div className="flex gap-2">
+          <button onClick={handlePopulate} className={btnPrimary}>
+            Auto-populate
+          </button>
+          <button
+            onClick={() => setShowForm(!showForm)}
+            className={btnPrimary}
+          >
+            {showForm ? "Cancel" : "+ Add Item"}
+          </button>
+        </div>
+      </div>
+
+      {/* Period navigation */}
+      {periods.length > 0 && (
+        <div className="mb-5 flex items-center gap-3">
+          <button
+            onClick={() =>
+              setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1))
+            }
+            disabled={periodIdx >= periods.length - 1}
+            className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30"
+            aria-label="Older period"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15.75 19.5 8.25 12l7.5-7.5"
+              />
+            </svg>
+          </button>
+          <span className="text-sm text-text-secondary">
+            {selectedPeriod?.start_date}
+            {selectedPeriod?.end_date
+              ? ` — ${selectedPeriod.end_date}`
+              : ""}
+            {isCurrentPeriod && (
+              <span className="ml-2 text-xs font-medium text-success">
+                current
+              </span>
+            )}
+          </span>
+          <button
+            onClick={() => setPeriodIdx(Math.max(periodIdx - 1, 0))}
+            disabled={periodIdx <= 0}
+            className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30"
+            aria-label="Newer period"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="m8.25 4.5 7.5 7.5-7.5 7.5"
+              />
+            </svg>
+          </button>
+          {plan && (
+            <span
+              className={`ml-3 rounded-full px-2.5 py-0.5 text-[11px] font-medium ${
+                plan.status === "active"
+                  ? "bg-success/15 text-success"
+                  : "bg-accent/15 text-accent"
+              }`}
+            >
+              {plan.status}
+            </span>
+          )}
+        </div>
+      )}
+
+      {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
+
+      {/* Add item form */}
+      {showForm && (
+        <div className={`mb-6 ${card} p-6`}>
+          <form
+            onSubmit={handleAddItem}
+            className="flex flex-wrap items-end gap-4"
+          >
+            <div className="w-32">
+              <label htmlFor="fp-type" className={label}>
+                Type
+              </label>
+              <select
+                id="fp-type"
+                value={formType}
+                onChange={(e) =>
+                  setFormType(e.target.value as "income" | "expense")
+                }
+                className={input}
+              >
+                <option value="expense">Expense</option>
+                <option value="income">Income</option>
+              </select>
+            </div>
+            <div className="min-w-[200px] flex-1">
+              <label htmlFor="fp-cat" className={label}>
+                Category
+              </label>
+              <select
+                id="fp-cat"
+                required
+                value={formCategoryId}
+                onChange={(e) =>
+                  setFormCategoryId(
+                    e.target.value === "" ? "" : Number(e.target.value)
+                  )
+                }
+                className={input}
+              >
+                <option value="">Select category</option>
+                {availableForType.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="w-40">
+              <label htmlFor="fp-amount" className={label}>
+                Planned Amount
+              </label>
+              <input
+                id="fp-amount"
+                type="number"
+                step="0.01"
+                min="0.01"
+                required
+                placeholder="0.00"
+                value={formAmount}
+                onChange={(e) => setFormAmount(e.target.value)}
+                className={input}
+              />
+            </div>
+            <button type="submit" className={btnPrimary}>
+              Add
+            </button>
+          </form>
+        </div>
+      )}
+
+      {fetching ? (
+        <Spinner />
+      ) : (
+        <div className="space-y-6">
+          {/* Summary cards */}
+          {plan && plan.items.length > 0 && (
+            <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+              <div className={`${card} p-5`}>
+                <p className={cardTitle}>Planned Income</p>
+                <p className="mt-1 text-xl font-semibold tabular-nums text-success">
+                  {formatAmount(plan.total_planned_income)}
+                </p>
+                <p className="mt-0.5 text-xs text-text-muted">
+                  Actual: {formatAmount(plan.total_actual_income)}
+                </p>
+              </div>
+              <div className={`${card} p-5`}>
+                <p className={cardTitle}>Planned Expenses</p>
+                <p className="mt-1 text-xl font-semibold tabular-nums text-danger">
+                  {formatAmount(plan.total_planned_expense)}
+                </p>
+                <p className="mt-0.5 text-xs text-text-muted">
+                  Actual: {formatAmount(plan.total_actual_expense)}
+                </p>
+              </div>
+              <div className={`${card} p-5`}>
+                <p className={cardTitle}>Planned Net</p>
+                <p
+                  className={`mt-1 text-xl font-semibold tabular-nums ${plannedNet >= 0 ? "text-success" : "text-danger"}`}
+                >
+                  {formatAmount(plannedNet)}
+                </p>
+              </div>
+              <div className={`${card} p-5`}>
+                <p className={cardTitle}>Actual Net</p>
+                <p
+                  className={`mt-1 text-xl font-semibold tabular-nums ${actualNet >= 0 ? "text-success" : "text-danger"}`}
+                >
+                  {formatAmount(actualNet)}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Planned vs Actual chart */}
+          {chartData.length > 0 && (
+            <div className={`${card} p-5`}>
+              <h2 className={`${cardTitle} mb-4`}>
+                Planned vs Actual (Expenses)
+              </h2>
+              <div style={{ height: Math.max(chartData.length * 52, 120) }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={chartData}
+                    layout="vertical"
+                    margin={{ left: 10, right: 10, top: 0, bottom: 0 }}
+                  >
+                    <XAxis type="number" hide />
+                    <YAxis
+                      type="category"
+                      dataKey="name"
+                      width={130}
+                      tick={{
+                        fill: "var(--color-text-secondary)",
+                        fontSize: 12,
+                      }}
+                    />
+                    <Tooltip
+                      formatter={(v: number, name: string) => [
+                        formatAmount(v),
+                        name === "planned" ? "Planned" : "Actual",
+                      ]}
+                      contentStyle={{
+                        background: "var(--color-surface)",
+                        border: "1px solid var(--color-border)",
+                        borderRadius: "6px",
+                        fontSize: "12px",
+                      }}
+                    />
+                    <Legend
+                      formatter={(v) =>
+                        v === "planned" ? "Planned" : "Actual"
+                      }
+                      wrapperStyle={{ fontSize: "12px" }}
+                    />
+                    <Bar
+                      dataKey="planned"
+                      fill="var(--color-accent)"
+                      radius={[4, 4, 4, 4]}
+                      barSize={14}
+                      animationDuration={800}
+                    />
+                    <Bar
+                      dataKey="actual"
+                      radius={[4, 4, 4, 4]}
+                      barSize={14}
+                      animationDuration={800}
+                    >
+                      {chartData.map((d, i) => (
+                        <Cell
+                          key={i}
+                          fill={
+                            d.actual > d.planned ? "#f87171" : "#4ade80"
+                          }
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          )}
+
+          {/* Filter tabs */}
+          {plan && plan.items.length > 0 && (
+            <div className="flex gap-1">
+              {(["all", "expense", "income"] as const).map((f) => (
+                <button
+                  key={f}
+                  onClick={() => setViewFilter(f)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                    viewFilter === f
+                      ? "bg-accent text-accent-text"
+                      : "text-text-muted hover:bg-surface-raised"
+                  }`}
+                >
+                  {f === "all"
+                    ? "All"
+                    : f === "income"
+                      ? "Income"
+                      : "Expenses"}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Item list */}
+          {(viewFilter === "all" || viewFilter === "income") &&
+            incomeItems.length > 0 && (
+              <ItemSection
+                title="Income"
+                items={incomeItems}
+                editingId={editingId}
+                editAmount={editAmount}
+                onStartEdit={(item) => {
+                  setEditingId(item.id);
+                  setEditAmount(String(item.planned_amount));
+                }}
+                onCancelEdit={() => setEditingId(null)}
+                onSaveEdit={handleUpdateItem}
+                onDelete={handleDeleteItem}
+                setEditAmount={setEditAmount}
+              />
+            )}
+
+          {(viewFilter === "all" || viewFilter === "expense") &&
+            expenseItems.length > 0 && (
+              <ItemSection
+                title="Expenses"
+                items={expenseItems}
+                editingId={editingId}
+                editAmount={editAmount}
+                onStartEdit={(item) => {
+                  setEditingId(item.id);
+                  setEditAmount(String(item.planned_amount));
+                }}
+                onCancelEdit={() => setEditingId(null)}
+                onSaveEdit={handleUpdateItem}
+                onDelete={handleDeleteItem}
+                setEditAmount={setEditAmount}
+              />
+            )}
+
+          {plan && plan.items.length === 0 && (
+            <div className={`${card} px-6 py-12 text-center`}>
+              <p className="text-sm text-text-muted">
+                No plan items yet. Click{" "}
+                <strong>&quot;Auto-populate&quot;</strong> to import from
+                recurring templates and history, or{" "}
+                <strong>&quot;+ Add Item&quot;</strong> manually.
+              </p>
+            </div>
+          )}
+
+          {/* Actions */}
+          {plan && plan.items.length > 0 && plan.status === "draft" && (
+            <div className="flex justify-end">
+              <button onClick={handleActivate} className={btnPrimary}>
+                Activate Plan
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </AppShell>
+  );
+}
+
+/* ── Item section component ──────────────────────────────────────────────── */
+
+function ItemSection({
+  title,
+  items,
+  editingId,
+  editAmount,
+  onStartEdit,
+  onCancelEdit,
+  onSaveEdit,
+  onDelete,
+  setEditAmount,
+}: {
+  title: string;
+  items: ForecastPlanItem[];
+  editingId: number | null;
+  editAmount: string;
+  onStartEdit: (item: ForecastPlanItem) => void;
+  onCancelEdit: () => void;
+  onSaveEdit: (id: number) => void;
+  onDelete: (id: number) => void;
+  setEditAmount: (v: string) => void;
+}) {
+  return (
+    <div className={card}>
+      <div className={cardHeader}>
+        <h2 className={cardTitle}>{title}</h2>
+      </div>
+      {/* Header row */}
+      <div className="grid grid-cols-[1fr_100px_100px_100px_80px_100px] gap-2 px-6 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+        <span>Category</span>
+        <span className="text-right">Planned</span>
+        <span className="text-right">Actual</span>
+        <span className="text-right">Variance</span>
+        <span className="text-center">Source</span>
+        <span className="text-right">Actions</span>
+      </div>
+      <div className="divide-y divide-border-subtle">
+        {items.map((item) => {
+          const variance = Number(item.variance);
+          const isOver =
+            item.type === "expense" ? variance > 0 : variance < 0;
+          return (
+            <div
+              key={item.id}
+              className="grid grid-cols-[1fr_100px_100px_100px_80px_100px] items-center gap-2 px-6 py-2.5"
+            >
+              {editingId === item.id ? (
+                <>
+                  <span className="text-sm text-text-primary">
+                    {item.category_name}
+                  </span>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0.01"
+                    value={editAmount}
+                    onChange={(e) => setEditAmount(e.target.value)}
+                    className={`text-right ${input}`}
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") onSaveEdit(item.id);
+                      if (e.key === "Escape") onCancelEdit();
+                    }}
+                  />
+                  <span className="text-right text-sm tabular-nums text-text-secondary">
+                    {formatAmount(item.actual_amount)}
+                  </span>
+                  <span />
+                  <span />
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => onSaveEdit(item.id)}
+                      className="text-xs text-accent hover:text-accent-hover"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={onCancelEdit}
+                      className="text-xs text-text-muted hover:text-text-secondary"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <span className="text-sm text-text-primary">
+                    {item.category_name}
+                  </span>
+                  <span className="text-right text-sm tabular-nums text-text-primary">
+                    {formatAmount(item.planned_amount)}
+                  </span>
+                  <span className="text-right text-sm tabular-nums text-text-secondary">
+                    {formatAmount(item.actual_amount)}
+                  </span>
+                  <span
+                    className={`text-right text-sm tabular-nums font-medium ${
+                      isOver ? "text-danger" : "text-success"
+                    }`}
+                  >
+                    {variance > 0 ? "+" : ""}
+                    {formatAmount(variance)}
+                  </span>
+                  <span className="text-center text-[11px] text-text-muted">
+                    {SOURCE_LABELS[item.source] ?? item.source}
+                  </span>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => onStartEdit(item)}
+                      className={btnLink}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => onDelete(item.id)}
+                      className={btnDanger}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -172,7 +172,7 @@ export default function ForecastPlansPage() {
           body: JSON.stringify({
             category_id: formCategoryId,
             type: formType,
-            planned_amount: parseFloat(formAmount),
+            planned_amount: formAmount,
           }),
         }
       );
@@ -193,7 +193,7 @@ export default function ForecastPlansPage() {
         `/api/v1/forecast-plans/${plan.id}/items/${itemId}`,
         {
           method: "PUT",
-          body: JSON.stringify({ planned_amount: parseFloat(editAmount) }),
+          body: JSON.stringify({ planned_amount: editAmount }),
         }
       );
       setPlan(p);

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -88,19 +88,28 @@ export default function ForecastPlansPage() {
   const futureEnsured = useRef(false);
 
   const loadRefs = useCallback(async () => {
-    // Ensure future period stubs exist (once per session)
+    // Ensure future period stubs exist (fire-and-forget, once per session)
     if (!futureEnsured.current) {
-      await apiFetch("/api/v1/settings/billing-periods/ensure-future", {
-        method: "POST",
-      });
       futureEnsured.current = true;
+      apiFetch("/api/v1/settings/billing-periods/ensure-future", {
+        method: "POST",
+      }).then(() => {
+        // Reload periods after stubs are created
+        apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods").then((pl2) => {
+          if (pl2) setPeriods(pl2);
+        });
+      }).catch(() => {});
     }
     const [c, p] = await Promise.all([
       apiFetch<Category[]>("/api/v1/categories"),
       apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),
     ]);
     setCategories(c ?? []);
-    setPeriods(p ?? []);
+    const pl = p ?? [];
+    setPeriods(pl);
+    // Default to current period (open = no end_date), not index 0
+    const currentIdx = pl.findIndex((bp) => bp.end_date === null);
+    if (currentIdx >= 0) setPeriodIdx(currentIdx);
   }, []);
 
   const loadPlan = useCallback(async () => {

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -407,6 +407,17 @@ export default function ForecastPlansPage() {
               />
             </svg>
           </button>
+          {!isCurrentPeriod && (
+            <button
+              onClick={() => {
+                const idx = periods.findIndex((p) => p.end_date === null);
+                if (idx >= 0) setPeriodIdx(idx);
+              }}
+              className="ml-1 rounded-md px-2 py-1 text-[11px] font-medium text-text-muted hover:bg-surface-raised"
+            >
+              Today
+            </button>
+          )}
           {plan && (
             <span
               className={`rounded-full px-2.5 py-0.5 text-[11px] font-medium ${

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -297,7 +297,15 @@ export default function ForecastPlansPage() {
       <div className="mb-2 flex items-center justify-between">
         <h1 className={`${pageTitle} mb-0`}>Forecast Plans</h1>
         {isDraft && (
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
+            {hasItems && (
+              <button
+                onClick={handleDiscard}
+                className="rounded-md px-3 py-2 text-xs text-text-muted hover:text-danger"
+              >
+                Discard
+              </button>
+            )}
             <button onClick={handlePopulate} className={btnPrimary}>
               Auto-populate
             </button>
@@ -682,25 +690,11 @@ export default function ForecastPlansPage() {
           )}
 
           {/* Bottom actions */}
-          {plan && hasItems && (
-            <div className="flex items-center justify-between">
-              <div>
-                {isDraft && hasItems && (
-                  <button
-                    onClick={handleDiscard}
-                    className="text-xs text-text-muted hover:text-danger"
-                  >
-                    Discard Draft
-                  </button>
-                )}
-              </div>
-              <div className="flex gap-3">
-                {isDraft && (
-                  <button onClick={handleActivate} className={btnPrimary}>
-                    Finalize Plan
-                  </button>
-                )}
-              </div>
+          {plan && hasItems && isDraft && (
+            <div className="flex justify-end">
+              <button onClick={handleActivate} className={btnPrimary}>
+                Finalize Plan
+              </button>
             </div>
           )}
         </div>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -88,20 +88,11 @@ export default function ForecastPlansPage() {
   const futureEnsured = useRef(false);
 
   const loadRefs = useCallback(async () => {
-    // Ensure future period stubs exist (fire-and-forget, once per session)
+    // Ensure future period stubs exist (once per session, before loading periods)
     if (!futureEnsured.current) {
       futureEnsured.current = true;
-      apiFetch("/api/v1/settings/billing-periods/ensure-future", {
+      await apiFetch("/api/v1/settings/billing-periods/ensure-future", {
         method: "POST",
-      }).then(() => {
-        // Reload periods after stubs are created
-        apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods").then((pl2) => {
-          if (pl2) {
-            setPeriods(pl2);
-            const idx = pl2.findIndex((bp) => bp.end_date === null);
-            if (idx >= 0) setPeriodIdx(idx);
-          }
-        });
       }).catch(() => {});
     }
     const [c, p] = await Promise.all([

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -96,7 +96,11 @@ export default function ForecastPlansPage() {
       }).then(() => {
         // Reload periods after stubs are created
         apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods").then((pl2) => {
-          if (pl2) setPeriods(pl2);
+          if (pl2) {
+            setPeriods(pl2);
+            const idx = pl2.findIndex((bp) => bp.end_date === null);
+            if (idx >= 0) setPeriodIdx(idx);
+          }
         });
       }).catch(() => {});
     }
@@ -214,6 +218,7 @@ export default function ForecastPlansPage() {
 
   async function handleDeleteItem(itemId: number) {
     if (!plan || !confirm("Remove this plan item?")) return;
+    setError("");
     try {
       const p = await apiFetch<ForecastPlan>(
         `/api/v1/forecast-plans/${plan.id}/items/${itemId}`,

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -62,13 +62,34 @@ export default function ForecastPlansPage() {
   const [editAmount, setEditAmount] = useState("");
 
   // View filter
-  const [viewFilter, setViewFilter] = useState<"all" | "income" | "expense">("all");
+  const [viewFilter, setViewFilter] = useState<"all" | "income" | "expense">(
+    "all"
+  );
 
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
-  const isCurrentPeriod = periodIdx === 0;
+  const isActive = plan?.status === "active";
+  const isDraft = plan?.status === "draft";
+  const hasItems = (plan?.items?.length ?? 0) > 0;
+
+  // Determine period context label
+  const today = new Date().toISOString().slice(0, 10);
+  const isFuturePeriod = selectedPeriod
+    ? selectedPeriod.start_date > today
+    : false;
+  const isCurrentPeriod = selectedPeriod
+    ? selectedPeriod.start_date <= today &&
+      (!selectedPeriod.end_date || selectedPeriod.end_date >= today)
+    : false;
+  const isPastPeriod = selectedPeriod
+    ? selectedPeriod.end_date !== null && selectedPeriod.end_date < today
+    : false;
 
   const loadRefs = useCallback(async () => {
+    // Ensure future period stubs exist before loading the list
+    await apiFetch("/api/v1/settings/billing-periods/ensure-future", {
+      method: "POST",
+    });
     const [c, p] = await Promise.all([
       apiFetch<Category[]>("/api/v1/categories"),
       apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),
@@ -78,10 +99,10 @@ export default function ForecastPlansPage() {
   }, []);
 
   const loadPlan = useCallback(async () => {
-    const url = periodStart
-      ? `/api/v1/forecast-plans?period_start=${periodStart}`
-      : "/api/v1/forecast-plans";
-    const p = await apiFetch<ForecastPlan>(url);
+    if (!periodStart) return;
+    const p = await apiFetch<ForecastPlan>(
+      `/api/v1/forecast-plans?period_start=${periodStart}`
+    );
     setPlan(p);
     setFetching(false);
   }, [periodStart]);
@@ -91,11 +112,13 @@ export default function ForecastPlansPage() {
   }, [loading, user, loadRefs]);
 
   useEffect(() => {
-    if (!loading && user) {
+    if (!loading && user && periodStart) {
       setFetching(true);
+      setShowForm(false);
+      setEditingId(null);
       loadPlan().catch(() => setFetching(false));
     }
-  }, [loading, user, loadPlan]);
+  }, [loading, user, loadPlan, periodStart]);
 
   // Available categories for add form
   const masterCategories = categories.filter((c) => c.parent_id === null);
@@ -114,18 +137,18 @@ export default function ForecastPlansPage() {
   const items = (plan?.items ?? []).filter(
     (i) => viewFilter === "all" || i.type === viewFilter
   );
-
-  // Grouped by type for display
   const incomeItems = items.filter((i) => i.type === "income");
   const expenseItems = items.filter((i) => i.type === "expense");
+
+  // ── Actions ──────────────────────────────────────────────────────────────
 
   async function handlePopulate() {
     setError("");
     try {
-      const url = periodStart
-        ? `/api/v1/forecast-plans/populate?period_start=${periodStart}`
-        : "/api/v1/forecast-plans/populate";
-      const p = await apiFetch<ForecastPlan>(url, { method: "POST" });
+      const p = await apiFetch<ForecastPlan>(
+        `/api/v1/forecast-plans/populate?period_start=${periodStart}`,
+        { method: "POST" }
+      );
       setPlan(p);
     } catch (err) {
       setError(extractErrorMessage(err));
@@ -189,7 +212,12 @@ export default function ForecastPlansPage() {
   }
 
   async function handleActivate() {
-    if (!plan || !confirm("Mark this plan as active? You can still edit items."))
+    if (
+      !plan ||
+      !confirm(
+        "Finalize this plan? It will become read-only. You can revert to draft later if needed."
+      )
+    )
       return;
     setError("");
     try {
@@ -203,7 +231,43 @@ export default function ForecastPlansPage() {
     }
   }
 
-  // Chart data — expense items only
+  async function handleRevertToDraft() {
+    if (!plan || !confirm("Revert to draft? This will unlock the plan for editing."))
+      return;
+    setError("");
+    try {
+      const p = await apiFetch<ForecastPlan>(
+        `/api/v1/forecast-plans/${plan.id}/revert`,
+        { method: "POST" }
+      );
+      setPlan(p);
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleDiscard() {
+    if (
+      !plan ||
+      !confirm(
+        "Discard this plan? All items will be removed and the plan will reset to an empty draft."
+      )
+    )
+      return;
+    setError("");
+    try {
+      const p = await apiFetch<ForecastPlan>(
+        `/api/v1/forecast-plans/${plan.id}/discard`,
+        { method: "POST" }
+      );
+      setPlan(p);
+      setShowForm(false);
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    }
+  }
+
+  // Chart data
   const chartData = expenseItems.map((i) => ({
     name: i.category_name,
     planned: Number(i.planned_amount),
@@ -219,20 +283,49 @@ export default function ForecastPlansPage() {
 
   return (
     <AppShell>
-      <div className="mb-6 flex items-center justify-between">
+      {/* Header */}
+      <div className="mb-2 flex items-center justify-between">
         <h1 className={`${pageTitle} mb-0`}>Forecast Plans</h1>
-        <div className="flex gap-2">
-          <button onClick={handlePopulate} className={btnPrimary}>
-            Auto-populate
+        {isDraft && (
+          <div className="flex gap-2">
+            <button onClick={handlePopulate} className={btnPrimary}>
+              Auto-populate
+            </button>
+            <button
+              onClick={() => setShowForm(!showForm)}
+              className={btnPrimary}
+            >
+              {showForm ? "Cancel" : "+ Add Item"}
+            </button>
+          </div>
+        )}
+        {isActive && (
+          <button onClick={handleRevertToDraft} className={btnPrimary}>
+            Edit Plan
           </button>
-          <button
-            onClick={() => setShowForm(!showForm)}
-            className={btnPrimary}
-          >
-            {showForm ? "Cancel" : "+ Add Item"}
-          </button>
-        </div>
+        )}
       </div>
+
+      {/* Contextual guidance */}
+      <p className="mb-5 text-xs text-text-muted leading-relaxed">
+        {isFuturePeriod
+          ? "Plan your expected income and expenses for this future period. Use Auto-populate to import from recurring templates and historical averages, then adjust manually."
+          : isCurrentPeriod
+            ? "Track your planned vs actual income and expenses for the current period. Actuals update automatically from settled transactions."
+            : isPastPeriod
+              ? "Review how your plan compared to actual results for this closed period."
+              : "Set up your financial plan for this billing period."}
+        {isDraft && hasItems && (
+          <span className="ml-1">
+            This plan is a <strong>draft</strong> — finalize it when you&apos;re done editing.
+          </span>
+        )}
+        {isActive && (
+          <span className="ml-1">
+            This plan is <strong>finalized</strong>. Click <strong>Edit Plan</strong> to make changes.
+          </span>
+        )}
+      </p>
 
       {/* Period navigation */}
       {periods.length > 0 && (
@@ -269,6 +362,11 @@ export default function ForecastPlansPage() {
                 current
               </span>
             )}
+            {isFuturePeriod && (
+              <span className="ml-2 text-xs font-medium text-accent">
+                future
+              </span>
+            )}
           </span>
           <button
             onClick={() => setPeriodIdx(Math.max(periodIdx - 1, 0))}
@@ -292,13 +390,13 @@ export default function ForecastPlansPage() {
           </button>
           {plan && (
             <span
-              className={`ml-3 rounded-full px-2.5 py-0.5 text-[11px] font-medium ${
-                plan.status === "active"
+              className={`rounded-full px-2.5 py-0.5 text-[11px] font-medium ${
+                isActive
                   ? "bg-success/15 text-success"
                   : "bg-accent/15 text-accent"
               }`}
             >
-              {plan.status}
+              {isActive ? "Finalized" : "Draft"}
             </span>
           )}
         </div>
@@ -306,8 +404,8 @@ export default function ForecastPlansPage() {
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
 
-      {/* Add item form */}
-      {showForm && (
+      {/* Add item form (draft only) */}
+      {showForm && isDraft && (
         <div className={`mb-6 ${card} p-6`}>
           <form
             onSubmit={handleAddItem}
@@ -380,7 +478,7 @@ export default function ForecastPlansPage() {
       ) : (
         <div className="space-y-6">
           {/* Summary cards */}
-          {plan && plan.items.length > 0 && (
+          {plan && hasItems && (
             <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
               <div className={`${card} p-5`}>
                 <p className={cardTitle}>Planned Income</p>
@@ -489,7 +587,7 @@ export default function ForecastPlansPage() {
           )}
 
           {/* Filter tabs */}
-          {plan && plan.items.length > 0 && (
+          {plan && hasItems && (
             <div className="flex gap-1">
               {(["all", "expense", "income"] as const).map((f) => (
                 <button
@@ -511,12 +609,13 @@ export default function ForecastPlansPage() {
             </div>
           )}
 
-          {/* Item list */}
+          {/* Item lists */}
           {(viewFilter === "all" || viewFilter === "income") &&
             incomeItems.length > 0 && (
               <ItemSection
                 title="Income"
                 items={incomeItems}
+                readOnly={isActive}
                 editingId={editingId}
                 editAmount={editAmount}
                 onStartEdit={(item) => {
@@ -535,6 +634,7 @@ export default function ForecastPlansPage() {
               <ItemSection
                 title="Expenses"
                 items={expenseItems}
+                readOnly={isActive}
                 editingId={editingId}
                 editAmount={editAmount}
                 onStartEdit={(item) => {
@@ -548,23 +648,38 @@ export default function ForecastPlansPage() {
               />
             )}
 
-          {plan && plan.items.length === 0 && (
+          {/* Empty state */}
+          {plan && !hasItems && (
             <div className={`${card} px-6 py-12 text-center`}>
               <p className="text-sm text-text-muted">
                 No plan items yet. Click{" "}
                 <strong>&quot;Auto-populate&quot;</strong> to import from
-                recurring templates and history, or{" "}
-                <strong>&quot;+ Add Item&quot;</strong> manually.
+                recurring templates and historical averages, or{" "}
+                <strong>&quot;+ Add Item&quot;</strong> to add manually.
               </p>
             </div>
           )}
 
-          {/* Actions */}
-          {plan && plan.items.length > 0 && plan.status === "draft" && (
-            <div className="flex justify-end">
-              <button onClick={handleActivate} className={btnPrimary}>
-                Activate Plan
-              </button>
+          {/* Bottom actions */}
+          {plan && hasItems && (
+            <div className="flex items-center justify-between">
+              <div>
+                {isDraft && hasItems && (
+                  <button
+                    onClick={handleDiscard}
+                    className="text-xs text-text-muted hover:text-danger"
+                  >
+                    Discard Draft
+                  </button>
+                )}
+              </div>
+              <div className="flex gap-3">
+                {isDraft && (
+                  <button onClick={handleActivate} className={btnPrimary}>
+                    Finalize Plan
+                  </button>
+                )}
+              </div>
             </div>
           )}
         </div>
@@ -578,6 +693,7 @@ export default function ForecastPlansPage() {
 function ItemSection({
   title,
   items,
+  readOnly,
   editingId,
   editAmount,
   onStartEdit,
@@ -588,6 +704,7 @@ function ItemSection({
 }: {
   title: string;
   items: ForecastPlanItem[];
+  readOnly: boolean;
   editingId: number | null;
   editAmount: string;
   onStartEdit: (item: ForecastPlanItem) => void;
@@ -596,19 +713,25 @@ function ItemSection({
   onDelete: (id: number) => void;
   setEditAmount: (v: string) => void;
 }) {
+  const colTemplate = readOnly
+    ? "grid-cols-[1fr_100px_100px_100px_80px]"
+    : "grid-cols-[1fr_100px_100px_100px_80px_100px]";
+
   return (
     <div className={card}>
       <div className={cardHeader}>
         <h2 className={cardTitle}>{title}</h2>
       </div>
       {/* Header row */}
-      <div className="grid grid-cols-[1fr_100px_100px_100px_80px_100px] gap-2 px-6 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+      <div
+        className={`grid ${colTemplate} gap-2 px-6 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-muted`}
+      >
         <span>Category</span>
         <span className="text-right">Planned</span>
         <span className="text-right">Actual</span>
         <span className="text-right">Variance</span>
         <span className="text-center">Source</span>
-        <span className="text-right">Actions</span>
+        {!readOnly && <span className="text-right">Actions</span>}
       </div>
       <div className="divide-y divide-border-subtle">
         {items.map((item) => {
@@ -618,9 +741,9 @@ function ItemSection({
           return (
             <div
               key={item.id}
-              className="grid grid-cols-[1fr_100px_100px_100px_80px_100px] items-center gap-2 px-6 py-2.5"
+              className={`grid ${colTemplate} items-center gap-2 px-6 py-2.5`}
             >
-              {editingId === item.id ? (
+              {!readOnly && editingId === item.id ? (
                 <>
                   <span className="text-sm text-text-primary">
                     {item.category_name}
@@ -680,20 +803,22 @@ function ItemSection({
                   <span className="text-center text-[11px] text-text-muted">
                     {SOURCE_LABELS[item.source] ?? item.source}
                   </span>
-                  <div className="flex justify-end gap-2">
-                    <button
-                      onClick={() => onStartEdit(item)}
-                      className={btnLink}
-                    >
-                      Edit
-                    </button>
-                    <button
-                      onClick={() => onDelete(item.id)}
-                      className={btnDanger}
-                    >
-                      Remove
-                    </button>
-                  </div>
+                  {!readOnly && (
+                    <div className="flex justify-end gap-2">
+                      <button
+                        onClick={() => onStartEdit(item)}
+                        className={btnLink}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => onDelete(item.id)}
+                        className={btnDanger}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -604,7 +604,9 @@ export default function ForecastPlansPage() {
                         <Cell
                           key={i}
                           fill={
-                            d.actual > d.planned ? "#f87171" : "#4ade80"
+                            d.actual > d.planned
+                              ? "var(--color-danger)"
+                              : "var(--color-success)"
                           }
                         />
                       ))}

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -85,11 +85,16 @@ export default function ForecastPlansPage() {
     ? selectedPeriod.end_date !== null && selectedPeriod.end_date < today
     : false;
 
+  const futureEnsured = useRef(false);
+
   const loadRefs = useCallback(async () => {
-    // Ensure future period stubs exist before loading the list
-    await apiFetch("/api/v1/settings/billing-periods/ensure-future", {
-      method: "POST",
-    });
+    // Ensure future period stubs exist (once per session)
+    if (!futureEnsured.current) {
+      await apiFetch("/api/v1/settings/billing-periods/ensure-future", {
+        method: "POST",
+      });
+      futureEnsured.current = true;
+    }
     const [c, p] = await Promise.all([
       apiFetch<Category[]>("/api/v1/categories"),
       apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -55,6 +55,15 @@ const navItems = [
     ),
   },
   {
+    href: "/forecast-plans",
+    label: "Forecast Plans",
+    icon: (
+      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+      </svg>
+    ),
+  },
+  {
     href: "/categories",
     label: "Categories",
     icon: (

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -98,3 +98,29 @@ export interface OrgSetting {
   key: string;
   value: string;
 }
+
+export interface ForecastPlanItem {
+  id: number;
+  plan_id: number;
+  category_id: number;
+  category_name: string;
+  parent_id: number | null;
+  type: "income" | "expense";
+  planned_amount: number;
+  source: "manual" | "recurring" | "history";
+  actual_amount: number;
+  variance: number;
+}
+
+export interface ForecastPlan {
+  id: number;
+  billing_period_id: number;
+  period_start: string;
+  period_end: string | null;
+  status: "draft" | "active";
+  total_planned_income: number;
+  total_planned_expense: number;
+  total_actual_income: number;
+  total_actual_expense: number;
+  items: ForecastPlanItem[];
+}


### PR DESCRIPTION
## Summary

- Add `forecast_plans` and `forecast_plan_items` tables (migration 016) with draft/active status, per-category planned amounts, and source tracking (manual/recurring/history)
- Full backend: model, schemas, service layer (8 functions), router (8 endpoints at `/api/v1/forecast-plans`)
- Auto-populate from active recurring templates and 3-month historical monthly averages
- Single-item and bulk upsert, inline edit, delete, activate, and copy-from-period
- Actual vs planned computation with variance per line item
- Frontend plan editor page with period navigation, planned-vs-actual bar chart, income/expense filter tabs, and inline editing
- Master-category-only validation, org-scoped security, race-safe plan creation