### PR TITLE
feat: budget transfers between categories

### DIFF
--- a/backend/app/routers/budgets.py
+++ b/backend/app/routers/budgets.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.user import User
-from app.schemas.budget import BudgetCreate, BudgetResponse, BudgetUpdate
+from app.schemas.budget import BudgetCreate, BudgetResponse, BudgetTransfer, BudgetUpdate
 from app.services import budget_service as svc
 
 router = APIRouter(prefix="/api/v1/budgets", tags=["budgets"])
@@ -39,6 +39,20 @@ async def update_budget(
     db: AsyncSession = Depends(get_db),
 ):
     return await svc.update_budget(db, current_user.org_id, budget_id, body)
+
+
+@router.post("/transfer", response_model=list[BudgetResponse])
+async def transfer_budget(
+    body: BudgetTransfer,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await svc.transfer_budget(
+        db, current_user.org_id,
+        from_budget_id=body.from_budget_id,
+        to_category_id=body.to_category_id,
+        amount=body.amount,
+    )
 
 
 @router.delete("/{budget_id}", status_code=204)

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -204,6 +204,7 @@ async def ensure_future_periods(
     count: int = 3,
 ):
     """Create stub periods for upcoming months so the user can plan ahead."""
+    _require_admin(current_user)
     count = min(max(count, 1), 6)  # Cap between 1 and 6 months
     created = await billing_service.ensure_future_periods(db, current_user.org_id, count=count)
     return [

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -133,6 +133,10 @@ async def update_billing_cycle(
     current_period = await billing_service.get_current_period(db, current_user.org_id)
     if current_period.end_date is None:
         import datetime
+        from sqlalchemy import update
+        from app.models.budget import Budget
+
+        old_start = current_period.start_date
         today = datetime.date.today()
         new_day = body.billing_cycle_day
         y, m, d = today.year, today.month, today.day
@@ -142,6 +146,14 @@ async def update_billing_cycle(
             prev = datetime.date(y, m, 1) - datetime.timedelta(days=1)
             new_start = datetime.date(prev.year, prev.month, new_day)
         current_period.start_date = new_start
+
+        # Update budgets tied to the old period start date
+        if old_start != new_start:
+            await db.execute(
+                update(Budget)
+                .where(Budget.org_id == current_user.org_id, Budget.period_start == old_start)
+                .values(period_start=new_start)
+            )
 
     await db.commit()
     return {"billing_cycle_day": org.billing_cycle_day}

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,12 +1,13 @@
 import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.deps import get_current_user
+from app.models.budget import Budget
 from app.models.settings import OrgSetting
 from app.models.user import Organization, Role, User
 from app.schemas.settings import BillingCycleUpdate, OrgSettingResponse, OrgSettingUpdate
@@ -132,10 +133,6 @@ async def update_billing_cycle(
     # Recalculate the current open period to match the new cycle day
     current_period = await billing_service.get_current_period(db, current_user.org_id)
     if current_period.end_date is None:
-        import datetime
-        from sqlalchemy import update
-        from app.models.budget import Budget
-
         old_start = current_period.start_date
         today = datetime.date.today()
         new_day = body.billing_cycle_day

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -14,6 +14,12 @@ class BudgetUpdate(BaseModel):
     amount: Optional[Decimal] = Field(default=None, gt=0)
 
 
+class BudgetTransfer(BaseModel):
+    from_budget_id: int
+    to_category_id: int
+    amount: Decimal = Field(gt=0)
+
+
 class BudgetResponse(BaseModel):
     id: int
     category_id: int

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -190,9 +190,13 @@ async def transfer_budget(
     If the target category has no budget yet, one is created.
     Returns both the source and target budgets.
     """
-    # Load source budget
+    from sqlalchemy.exc import IntegrityError
+
+    # Lock source budget for update to prevent concurrent over-allocation
     result = await db.execute(
-        select(Budget).where(Budget.id == from_budget_id, Budget.org_id == org_id)
+        select(Budget)
+        .where(Budget.id == from_budget_id, Budget.org_id == org_id)
+        .with_for_update()
     )
     source = result.scalar_one_or_none()
     if source is None:
@@ -232,6 +236,26 @@ async def transfer_budget(
             period_end=source.period_end,
         )
         db.add(target)
+        try:
+            await db.flush()
+        except IntegrityError:
+            await db.rollback()
+            # Re-lock source and re-fetch target after race
+            result = await db.execute(
+                select(Budget).where(Budget.id == from_budget_id, Budget.org_id == org_id).with_for_update()
+            )
+            source = result.scalar_one()
+            if amount > source.amount:
+                raise ValidationError("Transfer amount exceeds source budget")
+            target_result = await db.execute(
+                select(Budget).where(
+                    Budget.org_id == org_id,
+                    Budget.category_id == to_category_id,
+                    Budget.period_start == source.period_start,
+                )
+            )
+            target = target_result.scalar_one()
+            target.amount += amount
     else:
         target.amount += amount
 

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -181,6 +181,75 @@ async def update_budget(
     return _to_response(budget, spent)
 
 
+async def transfer_budget(
+    db: AsyncSession, org_id: int,
+    from_budget_id: int, to_category_id: int, amount: Decimal,
+) -> list[BudgetResponse]:
+    """Transfer allocation from one budget to another within the same period.
+
+    If the target category has no budget yet, one is created.
+    Returns both the source and target budgets.
+    """
+    # Load source budget
+    result = await db.execute(
+        select(Budget).where(Budget.id == from_budget_id, Budget.org_id == org_id)
+    )
+    source = result.scalar_one_or_none()
+    if source is None:
+        raise NotFoundError("Source budget")
+
+    if amount > source.amount:
+        raise ValidationError("Transfer amount exceeds source budget")
+
+    # Validate target is a master category
+    cat_result = await db.execute(
+        select(Category).where(Category.id == to_category_id, Category.org_id == org_id)
+    )
+    target_cat = cat_result.scalar_one_or_none()
+    if target_cat is None:
+        raise ValidationError("Invalid target category")
+    if target_cat.parent_id is not None:
+        raise ValidationError("Target must be a master category")
+    if target_cat.id == source.category_id:
+        raise ValidationError("Cannot transfer to the same category")
+
+    # Find or create target budget in same period
+    target_result = await db.execute(
+        select(Budget).where(
+            Budget.org_id == org_id,
+            Budget.category_id == to_category_id,
+            Budget.period_start == source.period_start,
+        )
+    )
+    target = target_result.scalar_one_or_none()
+
+    if target is None:
+        target = Budget(
+            org_id=org_id,
+            category_id=to_category_id,
+            amount=amount,
+            period_start=source.period_start,
+            period_end=source.period_end,
+        )
+        db.add(target)
+    else:
+        target.amount += amount
+
+    source.amount -= amount
+
+    await db.commit()
+    await db.refresh(source, ["category"])
+    await db.refresh(target, ["category"])
+
+    period = await get_current_period(db, org_id)
+    end = period.end_date if period.start_date == source.period_start else source.period_end
+
+    source_spent = await _compute_spent(db, org_id, source.category_id, source.period_start, end)
+    target_spent = await _compute_spent(db, org_id, target.category_id, target.period_start, end)
+
+    return [_to_response(source, source_spent), _to_response(target, target_spent)]
+
+
 async def delete_budget(db: AsyncSession, org_id: int, budget_id: int) -> None:
     result = await db.execute(
         select(Budget).where(Budget.id == budget_id, Budget.org_id == org_id)

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -272,12 +272,12 @@ export default function BudgetsPage() {
                           <span className="text-xs text-text-muted">— transfer to:</span>
                         </div>
                         <div className="flex items-center gap-3">
-                          <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`flex-1 ${input}`}>
+                          <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-[200px] flex-[3] ${input}`}>
                             <option value="">Select target category</option>
                             {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{otherBudgetedCats.has(c.id) ? " (has budget)" : ""}</option>)}
                           </select>
                           <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
-                            className={`w-32 ${input}`}
+                            className={`w-36 shrink-0 ${input}`}
                             onKeyDown={(e) => { if (e.key === "Enter" && transferCategoryId && transferAmount) handleTransfer(b.id); if (e.key === "Escape") setTransferringId(null); }} />
                           <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="text-xs text-accent hover:text-accent-hover disabled:opacity-50">Transfer</button>
                           <button onClick={() => setTransferringId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -215,15 +215,13 @@ export default function BudgetsPage() {
                   {selectedPeriod && <>{selectedPeriod.start_date}{selectedPeriod.end_date ? ` — ${selectedPeriod.end_date}` : " (open)"}</>}
                 </span>
               </div>
-              <div style={{ height: Math.max(budgets.length * 44, 120) }}>
+              <div style={{ height: Math.max(budgets.length * 40, 100) }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={budgets.map((b) => ({
                     name: b.category_name,
                     spent: Number(b.spent),
                     remaining: Math.max(Number(b.amount) - Number(b.spent), 0),
                     over: Math.max(Number(b.spent) - Number(b.amount), 0),
-                    budget: Number(b.amount),
-                    pct: b.percent_used,
                   }))} layout="vertical" margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
                     <XAxis type="number" hide />
                     <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
@@ -233,13 +231,19 @@ export default function BudgetsPage() {
                     />
                     <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
                       {budgets.map((b, i) => (
-                        <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#4ade80"} />
+                        <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#D4A64A"} />
                       ))}
                     </Bar>
-                    <Bar dataKey="remaining" stackId="a" fill="#163157" radius={[0, 4, 4, 0]} animationDuration={600} />
+                    <Bar dataKey="remaining" stackId="a" fill="#e8ebf0" radius={[0, 4, 4, 0]} animationDuration={600} />
                     <Bar dataKey="over" stackId="a" fill="#f87171" radius={[0, 4, 4, 0]} animationDuration={600} />
                   </BarChart>
                 </ResponsiveContainer>
+              </div>
+              <div className="mt-3 flex gap-4 px-4 pb-2 text-[10px] text-text-muted">
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Spent</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f59e0b" }} /> &gt;80%</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over budget</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#e8ebf0" }} /> Remaining</span>
               </div>
             </div>
           )}

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -215,7 +215,7 @@ export default function BudgetsPage() {
                   {selectedPeriod && <>{selectedPeriod.start_date}{selectedPeriod.end_date ? ` — ${selectedPeriod.end_date}` : " (open)"}</>}
                 </span>
               </div>
-              <div style={{ height: Math.max(budgets.length * 40, 100) }}>
+              <div className="p-4" style={{ height: Math.max(budgets.length * 36, 100) }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={budgets.map((b) => ({
                     name: b.category_name,

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -252,7 +252,7 @@ export default function BudgetsPage() {
             <div className="divide-y divide-border-subtle">
               {budgets.map((b) => {
                 const overBudget = b.percent_used > 100;
-                const otherBudgetedCats = new Set(budgets.filter((x) => x.id !== b.id).map((x) => x.category_id));
+                const budgetedCatIds = new Set(budgets.map((x) => x.category_id));
                 const transferTargets = masterCategories.filter((c) => c.id !== b.category_id);
                 return (
                   <div key={b.id} className="px-6 py-3">
@@ -274,7 +274,7 @@ export default function BudgetsPage() {
                         <div className="flex flex-wrap items-center gap-2">
                           <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-0 flex-1 basis-40 ${input}`}>
                             <option value="">Select target category</option>
-                            {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{otherBudgetedCats.has(c.id) ? " (has budget)" : ""}</option>)}
+                            {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{budgetedCatIds.has(c.id) ? " (has budget)" : ""}</option>)}
                           </select>
                           <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
                             className={`w-28 ${input}`}

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -33,6 +33,11 @@ export default function BudgetsPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editAmount, setEditAmount] = useState("");
 
+  // Transfer
+  const [transferringId, setTransferringId] = useState<number | null>(null);
+  const [transferCategoryId, setTransferCategoryId] = useState<number | "">("");
+  const [transferAmount, setTransferAmount] = useState("");
+
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
   const isCurrentPeriod = selectedPeriod?.end_date === null;
@@ -103,6 +108,24 @@ export default function BudgetsPage() {
     if (!confirm("Remove this budget?")) return;
     try {
       await apiFetch(`/api/v1/budgets/${id}`, { method: "DELETE" });
+      await loadBudgets();
+    } catch (err) { setError(extractErrorMessage(err)); }
+  }
+
+  async function handleTransfer(fromId: number) {
+    setError("");
+    try {
+      await apiFetch("/api/v1/budgets/transfer", {
+        method: "POST",
+        body: JSON.stringify({
+          from_budget_id: fromId,
+          to_category_id: transferCategoryId,
+          amount: transferAmount,
+        }),
+      });
+      setTransferringId(null);
+      setTransferCategoryId("");
+      setTransferAmount("");
       await loadBudgets();
     } catch (err) { setError(extractErrorMessage(err)); }
   }
@@ -229,6 +252,8 @@ export default function BudgetsPage() {
             <div className="divide-y divide-border-subtle">
               {budgets.map((b) => {
                 const overBudget = b.percent_used > 100;
+                const otherBudgetedCats = new Set(budgets.filter((x) => x.id !== b.id).map((x) => x.category_id));
+                const transferTargets = masterCategories.filter((c) => c.id !== b.category_id);
                 return (
                   <div key={b.id} className="px-6 py-3">
                     {editingId === b.id ? (
@@ -239,6 +264,24 @@ export default function BudgetsPage() {
                           onKeyDown={(e) => { if (e.key === "Enter") handleUpdate(b.id); if (e.key === "Escape") setEditingId(null); }} />
                         <button onClick={() => handleUpdate(b.id)} className="text-xs text-accent hover:text-accent-hover">Save</button>
                         <button onClick={() => setEditingId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                      </div>
+                    ) : transferringId === b.id ? (
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-text-primary">{b.category_name}</span>
+                          <span className="text-xs text-text-muted">— transfer to:</span>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`flex-1 ${input}`}>
+                            <option value="">Select target category</option>
+                            {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{otherBudgetedCats.has(c.id) ? " (has budget)" : ""}</option>)}
+                          </select>
+                          <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
+                            className={`w-32 ${input}`}
+                            onKeyDown={(e) => { if (e.key === "Enter" && transferCategoryId && transferAmount) handleTransfer(b.id); if (e.key === "Escape") setTransferringId(null); }} />
+                          <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="text-xs text-accent hover:text-accent-hover disabled:opacity-50">Transfer</button>
+                          <button onClick={() => setTransferringId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                        </div>
                       </div>
                     ) : (
                       <div className="flex items-center justify-between">
@@ -251,6 +294,7 @@ export default function BudgetsPage() {
                             {b.percent_used}%
                           </span>
                           <div className="flex gap-2">
+                            <button onClick={() => { setTransferringId(b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="text-xs text-text-muted hover:text-accent">Transfer</button>
                             <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
                             <button onClick={() => handleDelete(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
                           </div>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -226,18 +226,18 @@ export default function BudgetsPage() {
                     pct: b.percent_used,
                   }))} layout="vertical" margin={{ left: 10, right: 10, top: 0, bottom: 0 }}>
                     <XAxis type="number" hide />
-                    <YAxis type="category" dataKey="name" width={120} tick={{ fill: "var(--color-text-secondary)", fontSize: 12 }} />
+                    <YAxis type="category" dataKey="name" width={120} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
                     <Tooltip
                       formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : name === "remaining" ? "Remaining" : "Over budget"]}
-                      contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "12px" }}
+                      contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px" }}
                     />
-                    <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={800}>
+                    <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
                       {budgets.map((b, i) => (
                         <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#4ade80"} />
                       ))}
                     </Bar>
-                    <Bar dataKey="remaining" stackId="a" fill="var(--color-surface-overlay)" radius={[0, 4, 4, 0]} animationDuration={800} />
-                    <Bar dataKey="over" stackId="a" fill="#f87171" radius={[0, 4, 4, 0]} animationDuration={800} />
+                    <Bar dataKey="remaining" stackId="a" fill="var(--color-surface-overlay)" radius={[0, 4, 4, 0]} animationDuration={600} />
+                    <Bar dataKey="over" stackId="a" fill="#f87171" radius={[0, 4, 4, 0]} animationDuration={600} />
                   </BarChart>
                 </ResponsiveContainer>
               </div>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -271,13 +271,13 @@ export default function BudgetsPage() {
                           <span className="text-sm font-medium text-text-primary">{b.category_name}</span>
                           <span className="text-xs text-text-muted">— transfer to:</span>
                         </div>
-                        <div className="flex items-center gap-3">
-                          <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-[200px] flex-[3] ${input}`}>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-0 flex-1 basis-40 ${input}`}>
                             <option value="">Select target category</option>
                             {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{otherBudgetedCats.has(c.id) ? " (has budget)" : ""}</option>)}
                           </select>
                           <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
-                            className={`w-36 shrink-0 ${input}`}
+                            className={`w-28 ${input}`}
                             onKeyDown={(e) => { if (e.key === "Enter" && transferCategoryId && transferAmount) handleTransfer(b.id); if (e.key === "Escape") setTransferringId(null); }} />
                           <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="text-xs text-accent hover:text-accent-hover disabled:opacity-50">Transfer</button>
                           <button onClick={() => setTransferringId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -215,7 +215,7 @@ export default function BudgetsPage() {
                   {selectedPeriod && <>{selectedPeriod.start_date}{selectedPeriod.end_date ? ` — ${selectedPeriod.end_date}` : " (open)"}</>}
                 </span>
               </div>
-              <div style={{ height: Math.max(budgets.length * 48, 120) }}>
+              <div style={{ height: Math.max(budgets.length * 44, 120) }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={budgets.map((b) => ({
                     name: b.category_name,
@@ -224,19 +224,19 @@ export default function BudgetsPage() {
                     over: Math.max(Number(b.spent) - Number(b.amount), 0),
                     budget: Number(b.amount),
                     pct: b.percent_used,
-                  }))} layout="vertical" margin={{ left: 10, right: 10, top: 0, bottom: 0 }}>
+                  }))} layout="vertical" margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
                     <XAxis type="number" hide />
-                    <YAxis type="category" dataKey="name" width={120} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
+                    <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
                     <Tooltip
                       formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : name === "remaining" ? "Remaining" : "Over budget"]}
-                      contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px", color: "var(--color-text-primary)" }}
+                      contentStyle={{ fontSize: "11px" }}
                     />
                     <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
                       {budgets.map((b, i) => (
                         <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#4ade80"} />
                       ))}
                     </Bar>
-                    <Bar dataKey="remaining" stackId="a" fill="var(--color-surface-overlay)" radius={[0, 4, 4, 0]} animationDuration={600} />
+                    <Bar dataKey="remaining" stackId="a" fill="#163157" radius={[0, 4, 4, 0]} animationDuration={600} />
                     <Bar dataKey="over" stackId="a" fill="#f87171" radius={[0, 4, 4, 0]} animationDuration={600} />
                   </BarChart>
                 </ResponsiveContainer>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -229,7 +229,7 @@ export default function BudgetsPage() {
                     <YAxis type="category" dataKey="name" width={120} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
                     <Tooltip
                       formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : name === "remaining" ? "Remaining" : "Over budget"]}
-                      contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px" }}
+                      contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px", color: "var(--color-text-primary)" }}
                     />
                     <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
                       {budgets.map((b, i) => (

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -74,7 +74,15 @@ export default function DashboardPage() {
   // Selected period (navigate with arrows)
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : period;
   const monthFrom = selectedPeriod?.start_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
-  const monthTo = selectedPeriod?.end_date ?? "";
+  // For open periods, compute expected end from billing cycle day
+  const cycleDay = user?.billing_cycle_day ?? 1;
+  let monthTo = selectedPeriod?.end_date ?? "";
+  if (!monthTo && monthFrom) {
+    const start = new Date(monthFrom + "T00:00:00");
+    const nextMonth = new Date(start.getFullYear(), start.getMonth() + 1, cycleDay);
+    nextMonth.setDate(nextMonth.getDate() - 1);
+    monthTo = formatLocalDate(nextMonth);
+  }
 
   const loadRefs = useCallback(async () => {
     const [accts, cats, bds, per, plist] = await Promise.all([

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -536,7 +536,7 @@ export default function DashboardPage() {
                               opacity={chartFilter && chartFilter !== d.name ? 0.3 : 1} />
                           ))}
                         </Pie>
-                        <Tooltip formatter={(v) => formatAmount(Number(v))} contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "12px" }} />
+                        <Tooltip formatter={(v) => formatAmount(Number(v))} contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "12px", color: "var(--color-text-primary)" }} />
                       </PieChart>
                     </ResponsiveContainer>
                   </div>
@@ -577,7 +577,7 @@ export default function DashboardPage() {
                       <YAxis type="category" dataKey="name" width={100} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
                       <Tooltip
                         formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : "Remaining"]}
-                        contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px" }}
+                        contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px", color: "var(--color-text-primary)" }}
                       />
                       <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
                         {budgets.slice(0, 6).map((b, i) => (
@@ -615,7 +615,7 @@ export default function DashboardPage() {
                       <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
                       <Tooltip
                         formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? "Executed" : name === "pending" ? "Pending" : "Recurring"]}
-                        contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px" }}
+                        contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px", color: "var(--color-text-primary)" }}
                       />
                       <Bar dataKey="executed" stackId="a" fill="#4ade80" radius={[3, 0, 0, 3]} animationDuration={600} />
                       <Bar dataKey="pending" stackId="a" fill="#D4A64A" animationDuration={600} />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -536,7 +536,7 @@ export default function DashboardPage() {
                               opacity={chartFilter && chartFilter !== d.name ? 0.3 : 1} />
                           ))}
                         </Pie>
-                        <Tooltip formatter={(v) => formatAmount(Number(v))} contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "12px", color: "var(--color-text-primary)" }} />
+                        <Tooltip formatter={(v) => formatAmount(Number(v))} contentStyle={{ fontSize: "12px" }} />
                       </PieChart>
                     </ResponsiveContainer>
                   </div>
@@ -577,7 +577,7 @@ export default function DashboardPage() {
                       <YAxis type="category" dataKey="name" width={100} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
                       <Tooltip
                         formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : "Remaining"]}
-                        contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px", color: "var(--color-text-primary)" }}
+                        contentStyle={{ fontSize: "11px" }}
                       />
                       <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
                         {budgets.slice(0, 6).map((b, i) => (
@@ -615,7 +615,7 @@ export default function DashboardPage() {
                       <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
                       <Tooltip
                         formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? "Executed" : name === "pending" ? "Pending" : "Recurring"]}
-                        contentStyle={{ background: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "6px", fontSize: "11px", color: "var(--color-text-primary)" }}
+                        contentStyle={{ fontSize: "11px" }}
                       />
                       <Bar dataKey="executed" stackId="a" fill="#4ade80" radius={[3, 0, 0, 3]} animationDuration={600} />
                       <Bar dataKey="pending" stackId="a" fill="#D4A64A" animationDuration={600} />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -45,6 +45,7 @@ export default function DashboardPage() {
   const [budgets, setBudgets] = useState<Budget[]>([]);
   const [period, setPeriod] = useState<BillingPeriod | null>(null);
   const [periods, setPeriods] = useState<BillingPeriod[]>([]);
+  const [billingCycleDay, setBillingCycleDay] = useState(user?.billing_cycle_day ?? 1);
   const [periodIdx, setPeriodIdx] = useState(0);
   const [forecast, setForecast] = useState<Forecast | null>(null);
   const [fetching, setFetching] = useState(true);
@@ -75,7 +76,7 @@ export default function DashboardPage() {
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : period;
   const monthFrom = selectedPeriod?.start_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
   // For open periods, compute expected end from billing cycle day
-  const cycleDay = user?.billing_cycle_day ?? 1;
+  const cycleDay = billingCycleDay;
   let monthTo = selectedPeriod?.end_date ?? "";
   if (!monthTo && monthFrom) {
     const start = new Date(monthFrom + "T00:00:00");
@@ -85,16 +86,18 @@ export default function DashboardPage() {
   }
 
   const loadRefs = useCallback(async () => {
-    const [accts, cats, bds, per, plist] = await Promise.all([
+    const [accts, cats, bds, per, plist, bc] = await Promise.all([
       apiFetch<Account[]>("/api/v1/accounts"),
       apiFetch<Category[]>("/api/v1/categories"),
       apiFetch<Budget[]>("/api/v1/budgets"),
       apiFetch<BillingPeriod>("/api/v1/settings/billing-period"),
       apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),
+      apiFetch<{ billing_cycle_day: number }>("/api/v1/settings/billing-cycle"),
     ]);
     setAccounts(accts ?? []);
     setCategories(cats ?? []);
     setBudgets(bds ?? []);
+    if (bc) setBillingCycleDay(bc.billing_cycle_day);
     if (per) setPeriod(per);
     const pl = plist ?? [];
     setPeriods(pl);

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -74,7 +74,7 @@ export default function DashboardPage() {
   // Selected period (navigate with arrows)
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : period;
   const monthFrom = selectedPeriod?.start_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
-  const monthTo = selectedPeriod?.end_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0));
+  const monthTo = selectedPeriod?.end_date ?? "";
 
   const loadRefs = useCallback(async () => {
     const [accts, cats, bds, per, plist] = await Promise.all([
@@ -98,9 +98,10 @@ export default function DashboardPage() {
   const loadTransactions = useCallback(async (p: number) => {
     const budgetUrl = monthFrom ? `/api/v1/budgets?period_start=${monthFrom}` : "/api/v1/budgets";
     const forecastUrl = monthFrom ? `/api/v1/forecast?period_start=${monthFrom}` : "/api/v1/forecast";
+    const dateFilter = `date_from=${monthFrom}${monthTo ? `&date_to=${monthTo}` : ""}`;
     const [pageData, allData, bds, fc] = await Promise.all([
-      apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&date_from=${monthFrom}&date_to=${monthTo}`),
-      p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?limit=200&date_from=${monthFrom}&date_to=${monthTo}`) : null,
+      apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
+      p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?limit=200&${dateFilter}`) : null,
       p === 0 ? apiFetch<Budget[]>(budgetUrl) : null,
       p === 0 ? apiFetch<Forecast>(forecastUrl) : null,
     ]);
@@ -391,7 +392,7 @@ export default function DashboardPage() {
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
               </button>
               <span className="text-sm font-medium text-text-primary">
-                {monthFrom}{monthTo !== monthFrom ? ` — ${monthTo}` : ""}
+                {monthFrom}{monthTo ? ` — ${monthTo}` : ""}
               </span>
               <button onClick={() => { setPeriodIdx(Math.max(periodIdx - 1, 0)); setChartFilter(null); }} disabled={periodIdx <= 0} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -565,6 +565,7 @@ export default function DashboardPage() {
                 <Link href="/budgets" className="text-xs text-accent hover:text-accent-hover">Manage</Link>
               </div>
               {budgets.length > 0 ? (
+                <>
                 <div className="p-4" style={{ height: Math.max(budgets.slice(0, 6).length * 40, 100) }}>
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart data={budgets.slice(0, 6).map((b) => ({
@@ -574,20 +575,25 @@ export default function DashboardPage() {
                       pct: b.percent_used,
                     }))} layout="vertical" margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
                       <XAxis type="number" hide />
-                      <YAxis type="category" dataKey="name" width={100} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
+                      <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
                       <Tooltip
                         formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : "Remaining"]}
                         contentStyle={{ fontSize: "11px" }}
                       />
                       <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
                         {budgets.slice(0, 6).map((b, i) => (
-                          <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#4ade80"} />
+                          <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#D4A64A"} />
                         ))}
                       </Bar>
-                      <Bar dataKey="remaining" stackId="a" fill="var(--color-surface-overlay)" radius={[0, 4, 4, 0]} animationDuration={600} />
+                      <Bar dataKey="remaining" stackId="a" fill="#e8ebf0" radius={[0, 4, 4, 0]} animationDuration={600} />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
+                <div className="flex gap-3 px-4 pb-3 text-[10px] text-text-muted">
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Spent</span>
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#e8ebf0" }} /> Remaining</span>
+                </div>
+                </>
               ) : (
                 <div className="px-5 py-6 text-center text-sm text-text-muted">
                   No budgets set. <Link href="/budgets" className="text-accent">Add one</Link>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -566,7 +566,7 @@ export default function ForecastPlansPage() {
                       width={130}
                       tick={{
                         fill: "var(--color-text-secondary)",
-                        fontSize: 12,
+                        fontSize: 11,
                       }}
                     />
                     <Tooltip
@@ -578,28 +578,26 @@ export default function ForecastPlansPage() {
                         background: "var(--color-surface)",
                         border: "1px solid var(--color-border)",
                         borderRadius: "6px",
-                        fontSize: "12px",
+                        fontSize: "11px",
                       }}
                     />
                     <Legend
                       formatter={(v) =>
                         v === "planned" ? "Planned" : "Actual"
                       }
-                      wrapperStyle={{ fontSize: "12px" }}
+                      wrapperStyle={{ fontSize: "11px" }}
                     />
                     <Bar
                       dataKey="planned"
                       fill="var(--color-accent)"
-                      radius={[4, 4, 4, 4]}
-                      barSize={14}
-                      animationDuration={800}
+                      radius={[4, 0, 0, 4]}
+                      animationDuration={600}
                     />
                     <Bar
                       dataKey="actual"
                       fill="var(--color-success)"
-                      radius={[4, 4, 4, 4]}
-                      barSize={14}
-                      animationDuration={800}
+                      radius={[0, 4, 4, 0]}
+                      animationDuration={600}
                     >
                       {chartData.map((d, i) => (
                         <Cell

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -596,6 +596,7 @@ export default function ForecastPlansPage() {
                     />
                     <Bar
                       dataKey="actual"
+                      fill="var(--color-success)"
                       radius={[4, 4, 4, 4]}
                       barSize={14}
                       animationDuration={800}

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -552,35 +552,26 @@ export default function ForecastPlansPage() {
               <h2 className={`${cardTitle} mb-4`}>
                 Planned vs Actual (Expenses)
               </h2>
-              <div style={{ height: Math.max(chartData.length * 52, 120) }}>
+              <div style={{ height: Math.max(chartData.length * 44, 120) }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart
                     data={chartData}
                     layout="vertical"
-                    margin={{ left: 10, right: 10, top: 0, bottom: 0 }}
+                    margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
                   >
                     <XAxis type="number" hide />
                     <YAxis
                       type="category"
                       dataKey="name"
-                      width={130}
-                      tick={{
-                        fill: "var(--color-text-secondary)",
-                        fontSize: 11,
-                      }}
+                      width={100}
+                      tick={{ fill: "#9ba8bd", fontSize: 11 }}
                     />
                     <Tooltip
                       formatter={(v: number, name: string) => [
                         formatAmount(v),
                         name === "planned" ? "Planned" : "Actual",
                       ]}
-                      contentStyle={{
-                        background: "var(--color-surface)",
-                        border: "1px solid var(--color-border)",
-                        borderRadius: "6px",
-                        fontSize: "11px",
-                        color: "var(--color-text-primary)",
-                      }}
+                      contentStyle={{ fontSize: "11px" }}
                     />
                     <Legend
                       formatter={(v) =>
@@ -590,24 +581,20 @@ export default function ForecastPlansPage() {
                     />
                     <Bar
                       dataKey="planned"
-                      fill="var(--color-accent)"
+                      fill="#D4A64A"
                       radius={[4, 0, 0, 4]}
                       animationDuration={600}
                     />
                     <Bar
                       dataKey="actual"
-                      fill="var(--color-success)"
+                      fill="#4ade80"
                       radius={[0, 4, 4, 0]}
                       animationDuration={600}
                     >
                       {chartData.map((d, i) => (
                         <Cell
                           key={i}
-                          fill={
-                            d.actual > d.planned
-                              ? "var(--color-danger)"
-                              : "var(--color-success)"
-                          }
+                          fill={d.actual > d.planned ? "#f87171" : "#4ade80"}
                         />
                       ))}
                     </Bar>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -26,7 +26,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Cell,
-  Legend,
+
 } from "recharts";
 import type { Category, ForecastPlan, ForecastPlanItem } from "@/lib/types";
 
@@ -552,7 +552,7 @@ export default function ForecastPlansPage() {
               <h2 className={`${cardTitle} mb-4`}>
                 Planned vs Actual (Expenses)
               </h2>
-              <div style={{ height: Math.max(chartData.length * 44, 120) }}>
+              <div style={{ height: Math.max(chartData.length * 40, 100) }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart
                     data={chartData}
@@ -573,22 +573,16 @@ export default function ForecastPlansPage() {
                       ]}
                       contentStyle={{ fontSize: "11px" }}
                     />
-                    <Legend
-                      formatter={(v) =>
-                        v === "planned" ? "Planned" : "Actual"
-                      }
-                      wrapperStyle={{ fontSize: "11px" }}
-                    />
                     <Bar
                       dataKey="planned"
                       fill="#D4A64A"
-                      radius={[4, 0, 0, 4]}
+                      radius={[4, 4, 4, 4]}
                       animationDuration={600}
                     />
                     <Bar
                       dataKey="actual"
                       fill="#4ade80"
-                      radius={[0, 4, 4, 0]}
+                      radius={[4, 4, 4, 4]}
                       animationDuration={600}
                     >
                       {chartData.map((d, i) => (
@@ -600,6 +594,11 @@ export default function ForecastPlansPage() {
                     </Bar>
                   </BarChart>
                 </ResponsiveContainer>
+              </div>
+              <div className="mt-3 flex gap-4 px-4 pb-2 text-[10px] text-text-muted">
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Planned</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#4ade80" }} /> Under plan</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over plan</span>
               </div>
             </div>
           )}

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -579,6 +579,7 @@ export default function ForecastPlansPage() {
                         border: "1px solid var(--color-border)",
                         borderRadius: "6px",
                         fontSize: "11px",
+                        color: "var(--color-text-primary)",
                       }}
                     />
                     <Legend

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -148,3 +148,16 @@ input:-webkit-autofill:focus {
 }
 
 a, button { transition: all 0.15s ease; }
+
+/* ─── Recharts tooltip override (inline styles don't resolve CSS vars in portals) ─── */
+.recharts-tooltip-wrapper .recharts-default-tooltip {
+  background: var(--theme-surface) !important;
+  border-color: var(--theme-border) !important;
+  border-radius: 6px !important;
+}
+.recharts-tooltip-wrapper .recharts-default-tooltip .recharts-tooltip-label {
+  color: var(--theme-text-secondary) !important;
+}
+.recharts-tooltip-wrapper .recharts-default-tooltip .recharts-tooltip-item {
+  color: var(--theme-text-primary) !important;
+}

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -427,16 +427,16 @@ export default function TransactionsPage() {
         </div>
         <div>
           <label htmlFor="f-from" className="sr-only">From date</label>
-          <input id="f-from" type="date" value={filterDateFrom} onChange={(e) => setFilterDateFrom(e.target.value)} className={`w-36 ${input}`} placeholder="From" />
+          <input id="f-from" type="date" value={filterDateFrom} onChange={(e) => setFilterDateFrom(e.target.value)} className={`w-32 ${input}`} placeholder="From" />
         </div>
         <div>
           <label htmlFor="f-to" className="sr-only">To date</label>
-          <input id="f-to" type="date" value={filterDateTo} onChange={(e) => setFilterDateTo(e.target.value)} className={`w-36 ${input}`} placeholder="To" />
+          <input id="f-to" type="date" value={filterDateTo} onChange={(e) => setFilterDateTo(e.target.value)} className={`w-32 ${input}`} placeholder="To" />
         </div>
         {periods.length > 0 && (
           <div>
             <label htmlFor="f-period" className="sr-only">Billing period</label>
-            <select id="f-period" value={filterPeriod} onChange={(e) => { setFilterPeriod(e.target.value); if (e.target.value) { setFilterDateFrom(""); setFilterDateTo(""); } }} className={`w-52 ${input}`}>
+            <select id="f-period" value={filterPeriod} onChange={(e) => { setFilterPeriod(e.target.value); if (e.target.value) { setFilterDateFrom(""); setFilterDateTo(""); } }} className={`w-40 ${input}`}>
               <option value="">All periods</option>
               {periods.map((p) => (
                 <option key={p.id} value={String(p.id)}>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -224,7 +224,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         <header className="flex h-14 shrink-0 items-center justify-end border-b border-border bg-surface px-8">
           <ThemeToggle />
         </header>
-        <main className="flex-1 overflow-auto p-8"><div className="mx-auto max-w-6xl">{children}</div></main>
+        <main className="flex-1 overflow-auto p-8"><div className="mx-auto max-w-screen-xl">{children}</div></main>
         <footer className="border-t border-border bg-surface px-8 py-4">
           <div className="flex items-center justify-between text-xs text-text-muted">
             <span>PFV2 — Personal Finance</span>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -224,7 +224,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         <header className="flex h-14 shrink-0 items-center justify-end border-b border-border bg-surface px-8">
           <ThemeToggle />
         </header>
-        <main className="flex-1 p-8">{children}</main>
+        <main className="flex-1 overflow-auto p-8"><div className="mx-auto max-w-6xl">{children}</div></main>
         <footer className="border-t border-border bg-surface px-8 py-4">
           <div className="flex items-center justify-between text-xs text-text-muted">
             <span>PFV2 — Personal Finance</span>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -120,16 +120,16 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="flex min-h-screen">
-      {/* Dark sidebar */}
-      <aside className="flex w-56 flex-col bg-sidebar-bg">
+    <div className="flex h-screen overflow-hidden">
+      {/* Dark sidebar — fixed height, never scrolls */}
+      <aside className="flex h-screen w-56 flex-col bg-sidebar-bg shrink-0">
         <div className="px-5 pt-5 pb-6">
           <Link href="/dashboard" className="font-display text-lg font-semibold text-sidebar-text-bright">
             PFV2
           </Link>
         </div>
 
-        <nav className="flex-1 space-y-0.5 px-3">
+        <nav className="flex-1 overflow-y-auto space-y-0.5 px-3">
           {navItems.map((item) => (
             <Link
               key={item.href}
@@ -220,7 +220,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </div>
       </aside>
 
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col overflow-hidden">
         <header className="flex h-14 shrink-0 items-center justify-end border-b border-border bg-surface px-8">
           <ThemeToggle />
         </header>


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/budgets/transfer` — atomic transfer of budget allocation from one category to another within the same billing period
- Creates target budget automatically if it doesn't exist
- Validates: master-category only, same-category rejection, amount bounds
- Inline transfer UI on budgets page with category picker and amount input