### PR TITLE
feat: P3 UI polish — tooltip colors, transfer auto-desc, mandatory descriptions

### DIFF
--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class TransactionCreate(BaseModel):
@@ -14,12 +14,19 @@ class TransactionCreate(BaseModel):
     status: Literal["settled", "pending"] = "settled"
     date: datetime.date
 
+    @field_validator("description")
+    @classmethod
+    def description_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Description is required")
+        return v.strip()
+
 
 class TransferCreate(BaseModel):
     from_account_id: int
     to_account_id: int
     category_id: Optional[int] = None
-    description: str = "Transfer"
+    description: str = ""
     amount: Decimal = Field(gt=0)
     status: Literal["settled", "pending"] = "settled"
     date: datetime.date
@@ -33,6 +40,13 @@ class TransactionUpdate(BaseModel):
     type: Optional[Literal["income", "expense"]] = None
     status: Optional[Literal["settled", "pending"]] = None
     date: Optional[datetime.date] = None
+
+    @field_validator("description")
+    @classmethod
+    def description_not_empty(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("Description is required")
+        return v.strip() if v is not None else v
 
 
 class TransactionResponse(BaseModel):

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -274,6 +274,17 @@ async def create_transfer(
     await validate_account(db, body.from_account_id, org_id)
     await validate_account(db, body.to_account_id, org_id)
 
+    # Auto-generate description if not provided
+    description = body.description
+    if not description.strip():
+        from_name = await db.scalar(
+            select(Account.name).where(Account.id == body.from_account_id, Account.org_id == org_id)
+        )
+        to_name = await db.scalar(
+            select(Account.name).where(Account.id == body.to_account_id, Account.org_id == org_id)
+        )
+        description = f"Transfer from {from_name} to {to_name}"
+
     # Auto-assign Transfer category if not provided
     category_id = body.category_id
     if category_id is None:
@@ -304,7 +315,7 @@ async def create_transfer(
             org_id=org_id,
             account_id=body.from_account_id,
             category_id=category_id,
-            description=body.description,
+            description=description,
             amount=body.amount,
             type=TransactionType.EXPENSE,
             status=tx_status,
@@ -315,7 +326,7 @@ async def create_transfer(
             org_id=org_id,
             account_id=body.to_account_id,
             category_id=category_id,
-            description=body.description,
+            description=description,
             amount=body.amount,
             type=TransactionType.INCOME,
             status=tx_status,

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -275,8 +275,8 @@ async def create_transfer(
     await validate_account(db, body.to_account_id, org_id)
 
     # Auto-generate description if not provided
-    description = body.description
-    if not description.strip():
+    description = body.description.strip()
+    if not description:
         from_name = await db.scalar(
             select(Account.name).where(Account.id == body.from_account_id, Account.org_id == org_id)
         )

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -226,7 +226,7 @@ export default function BudgetsPage() {
                     <XAxis type="number" hide />
                     <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
                     <Tooltip
-                      formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : name === "remaining" ? "Remaining" : "Over budget"]}
+                      formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? <span style={{ color: "#ef4444" }}>Spent</span> : name === "remaining" ? <span style={{ color: "#4ade80" }}>Remaining</span> : <span style={{ color: "#ef4444" }}>Over budget</span>]}
                       contentStyle={{ fontSize: "11px" }}
                     />
                     <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -351,7 +351,7 @@ export default function DashboardPage() {
                 )}
                 <div>
                   <label htmlFor="da-desc" className={label}>Description</label>
-                  <input id="da-desc" type="text" required={formMode === "transaction"} placeholder={formMode === "transfer" ? "Transfer (optional)" : "What was it for?"} value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
+                  <input id="da-desc" type="text" required={formMode === "transaction"} placeholder={formMode === "transfer" ? "Auto: Transfer from X to Y" : "What was it for?"} value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
                 </div>
                 <div>
                   <label htmlFor="da-amount" className={label}>Amount</label>
@@ -577,7 +577,7 @@ export default function DashboardPage() {
                       <XAxis type="number" hide />
                       <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
                       <Tooltip
-                        formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? "Spent" : "Remaining"]}
+                        formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? <span style={{ color: "#ef4444" }}>Spent</span> : <span style={{ color: "#4ade80" }}>Remaining</span>]}
                         contentStyle={{ fontSize: "11px" }}
                       />
                       <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
@@ -620,7 +620,7 @@ export default function DashboardPage() {
                       <XAxis type="number" hide />
                       <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
                       <Tooltip
-                        formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? "Executed" : name === "pending" ? "Pending" : "Recurring"]}
+                        formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? <span style={{ color: "#4ade80" }}>Executed</span> : name === "pending" ? <span style={{ color: "#D4A64A" }}>Pending</span> : <span style={{ color: "#5FA8D3" }}>Recurring</span>]}
                         contentStyle={{ fontSize: "11px" }}
                       />
                       <Bar dataKey="executed" stackId="a" fill="#4ade80" radius={[3, 0, 0, 3]} animationDuration={600} />

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -569,7 +569,7 @@ export default function ForecastPlansPage() {
                     <Tooltip
                       formatter={(v, name) => [
                         formatAmount(Number(v)),
-                        name === "planned" ? "Planned" : "Actual",
+                        name === "planned" ? <span style={{ color: "#D4A64A" }}>Planned</span> : <span style={{ color: "#4ade80" }}>Actual</span>,
                       ]}
                       contentStyle={{ fontSize: "11px" }}
                     />

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -202,6 +202,7 @@ export default function TransactionsPage() {
 
   async function handleSaveEdit() {
     if (editingId === null) return;
+    if (!editDesc.trim()) { setError("Description is required"); return; }
     setError("");
     try {
       await apiFetch(`/api/v1/transactions/${editingId}`, {

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -325,7 +325,7 @@ export default function TransactionsPage() {
             )}
             <div>
               <label htmlFor="tx-desc" className={label}>Description</label>
-              <input id="tx-desc" type="text" required={formMode === "transaction"} placeholder={formMode === "transfer" ? "Transfer (optional)" : "What was it for?"} value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
+              <input id="tx-desc" type="text" required={formMode === "transaction"} placeholder={formMode === "transfer" ? "Auto: Transfer from X to Y" : "What was it for?"} value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
             </div>
             <div>
               <label htmlFor="tx-amount" className={label}>Amount</label>
@@ -487,7 +487,7 @@ export default function TransactionsPage() {
                 return editingId === tx.id ? (
                   <div key={tx.id} className="grid grid-cols-12 items-center gap-2 px-6 py-2 bg-surface-raised">
                     <span className="col-span-2"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} /></span>
-                    <span className="col-span-2"><input aria-label="Description" type="text" value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
+                    <span className="col-span-2"><input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
                     <span className="col-span-2">
                       <select aria-label="Account" value={editAccountId} onChange={(e) => setEditAccountId(e.target.value === "" ? "" : Number(e.target.value))} className={`text-sm ${input}`}>
                         {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}{!a.is_active ? " (inactive)" : ""}</option>)}


### PR DESCRIPTION
## Summary
- Semantic tooltip text colors across all charts: Spent/Over=red, Remaining=green, Executed=green, Pending=gold, Recurring=blue, Planned=gold, Actual=green
- Auto-generate "Transfer from {source} to {destination}" when no description is provided on transfers
- Reject empty/whitespace-only descriptions on transaction create and update (backend Pydantic validators + frontend `required` on edit form)