### PR TITLE
feat: P1 auth — email service, password reset, email verification, Google SSO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ MAILGUN_DOMAIN=
 EMAIL_FROM=PFV2 <noreply@pfv.app>
 APP_URL=http://localhost
 
+# --- Google SSO ---
+# Create OAuth 2.0 credentials at https://console.cloud.google.com/apis/credentials
+# Set authorized redirect URI to: {APP_URL}/api/v1/auth/google/callback
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
 # --- Frontend ---
 # When using nginx (default), leave empty — API calls are same-origin via /api/
 # Only set this if running frontend standalone without nginx

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,14 @@ COOKIE_SECURE=false
 # Included in both dev and prod compose stacks
 REDIS_URL=redis://redis:6379/0
 
+# --- Email (Mailgun) ---
+# Leave empty for development (emails logged to console)
+# Set for production to send real emails via Mailgun
+MAILGUN_API_KEY=
+MAILGUN_DOMAIN=
+EMAIL_FROM=PFV2 <noreply@pfv.app>
+APP_URL=http://localhost
+
 # --- Frontend ---
 # When using nginx (default), leave empty — API calls are same-origin via /api/
 # Only set this if running frontend standalone without nginx

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,6 +22,12 @@ class Settings(BaseSettings):
     # Redis (optional — used for sessions/cache in production)
     redis_url: str = ""
 
+    # Email (Mailgun)
+    mailgun_api_key: str = ""
+    mailgun_domain: str = ""
+    email_from: str = "PFV2 <noreply@pfv.app>"
+    app_url: str = "http://localhost"  # used for email links
+
     # CORS
     backend_cors_origins: str = "http://localhost:3000"
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,10 @@ class Settings(BaseSettings):
     email_from: str = "PFV2 <noreply@pfv.app>"
     app_url: str = "http://localhost"  # used for email links
 
+    # Google SSO
+    google_client_id: str = ""
+    google_client_secret: str = ""
+
     # CORS
     backend_cors_origins: str = "http://localhost:3000"
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,5 +1,6 @@
 import re
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, Cookie, status
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -359,3 +360,167 @@ async def resend_verification(
     token = create_email_verification_token(current_user.id)
     await send_verification_email(current_user.email, token)
     return {"detail": "Verification email sent"}
+
+
+# ── Google SSO ───────────────────────────────────────────────────────────────
+
+
+@router.get("/google")
+async def google_login():
+    """Redirect to Google OAuth consent screen."""
+    if not app_settings.google_client_id:
+        raise HTTPException(status_code=501, detail="Google SSO not configured")
+
+    params = {
+        "client_id": app_settings.google_client_id,
+        "redirect_uri": f"{app_settings.app_url}/api/v1/auth/google/callback",
+        "response_type": "code",
+        "scope": "openid email profile",
+        "access_type": "offline",
+        "prompt": "select_account",
+    }
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    return {"redirect_url": f"https://accounts.google.com/o/oauth2/v2/auth?{query}"}
+
+
+@router.get("/google/callback")
+async def google_callback(
+    code: str,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
+    """Handle Google OAuth callback — exchange code for tokens, create or login user."""
+    if not app_settings.google_client_id:
+        raise HTTPException(status_code=501, detail="Google SSO not configured")
+
+    # Exchange authorization code for tokens
+    async with httpx.AsyncClient() as client:
+        token_resp = await client.post(
+            "https://oauth2.googleapis.com/token",
+            data={
+                "code": code,
+                "client_id": app_settings.google_client_id,
+                "client_secret": app_settings.google_client_secret,
+                "redirect_uri": f"{app_settings.app_url}/api/v1/auth/google/callback",
+                "grant_type": "authorization_code",
+            },
+        )
+        if token_resp.status_code != 200:
+            raise HTTPException(status_code=400, detail="Failed to exchange Google auth code")
+        tokens = token_resp.json()
+
+        # Get user info from Google
+        userinfo_resp = await client.get(
+            "https://www.googleapis.com/oauth2/v2/userinfo",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"},
+        )
+        if userinfo_resp.status_code != 200:
+            raise HTTPException(status_code=400, detail="Failed to get Google user info")
+        google_user = userinfo_resp.json()
+
+    email = google_user.get("email", "")
+    first_name = google_user.get("given_name", "")
+    last_name = google_user.get("family_name", "")
+
+    # Check if user already exists by email
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+
+    if user:
+        # Existing user — login
+        if not user.is_active:
+            raise HTTPException(status_code=403, detail="Account is deactivated")
+        # Update email_verified since Google verified it
+        if not user.email_verified:
+            user.email_verified = True
+            await db.commit()
+    else:
+        # New user — register with Google profile
+        # Check for existing superadmin
+        existing_superadmin = await db.scalar(
+            select(func.count()).select_from(User).where(User.is_superadmin == True)
+        )
+        is_first_user = existing_superadmin == 0
+
+        # Generate a username from Google name
+        base_username = _suggest_username(first_name, last_name, email)
+        username = await _find_available_username(db, base_username)
+
+        # Create org + user + system data (same as register)
+        org = Organization(name=f"{username}'s Organization")
+        db.add(org)
+        await db.flush()
+
+        for sat in SYSTEM_ACCOUNT_TYPES:
+            db.add(AccountType(org_id=org.id, name=sat["name"], slug=sat["slug"], is_system=True))
+
+        for master_def in SYSTEM_CATEGORIES:
+            master = Category(
+                org_id=org.id,
+                name=master_def["name"],
+                slug=master_def["slug"],
+                description=master_def["description"],
+                type=CategoryType(master_def["type"]),
+                is_system=True,
+            )
+            db.add(master)
+            await db.flush()
+            for child_def in master_def.get("children", []):
+                db.add(Category(
+                    org_id=org.id,
+                    parent_id=master.id,
+                    name=child_def["name"],
+                    slug=child_def["slug"],
+                    description=child_def["description"],
+                    type=CategoryType(master_def["type"]),
+                    is_system=True,
+                ))
+
+        db.add(Category(
+            org_id=org.id, name="Transfer", slug="transfer",
+            description="Internal transfers between accounts",
+            type=CategoryType.BOTH, is_system=True,
+        ))
+
+        # Google users get a random password (they login via Google)
+        import secrets
+        random_password = secrets.token_urlsafe(32)
+
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            avatar_url=google_user.get("picture"),
+            password_hash=hash_password(random_password),
+            email_verified=True,  # Google verified the email
+            role=Role.OWNER,
+            is_superadmin=is_first_user,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+
+    # Issue tokens
+    await db.refresh(user, ["organization"])
+    access_token = create_access_token(user.id, user.org_id, user.role.value)
+    refresh_token = create_refresh_token(user.id)
+
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        httponly=True,
+        secure=app_settings.cookie_secure,
+        samesite="lax",
+        max_age=7 * 24 * 60 * 60,
+        path="/api/v1/auth/refresh",
+    )
+
+    # Redirect to frontend with access token
+    from urllib.parse import urlencode
+    redirect_params = urlencode({"token": access_token})
+    return Response(
+        status_code=302,
+        headers={"Location": f"{app_settings.app_url}/auth/google/callback?{redirect_params}"},
+    )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -10,20 +10,26 @@ from app.models.account import AccountType, SYSTEM_ACCOUNT_TYPES
 from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
 from app.models.user import Organization, Role, User
 from app.schemas.auth import (
+    ForgotPasswordRequest,
     LoginRequest,
     RegisterRequest,
+    ResetPasswordRequest,
     TokenResponse,
     UsernameCheckResponse,
     UserResponse,
+    VerifyEmailRequest,
 )
 from app.config import settings as app_settings
 from app.security import (
     create_access_token,
+    create_email_verification_token,
+    create_password_reset_token,
     create_refresh_token,
     decode_token,
     hash_password,
     verify_password,
 )
+from app.services.email_service import send_password_reset_email, send_verification_email
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
@@ -165,6 +171,10 @@ async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)):
     await db.refresh(user)
     await db.refresh(org)
 
+    # Send verification email (non-blocking — don't fail registration if email fails)
+    token = create_email_verification_token(user.id)
+    await send_verification_email(user.email, token)
+
     return _user_response(user, org)
 
 
@@ -266,3 +276,86 @@ async def me(
 async def logout(response: Response):
     response.delete_cookie("refresh_token", path="/api/v1/auth/refresh")
     return {"detail": "Logged out"}
+
+
+# ── Password Reset ───────────────────────────────────────────────────────────
+
+
+@router.post("/forgot-password")
+async def forgot_password(body: ForgotPasswordRequest, db: AsyncSession = Depends(get_db)):
+    """Send a password reset email. Always returns 200 to prevent email enumeration."""
+    result = await db.execute(select(User).where(User.email == body.email))
+    user = result.scalar_one_or_none()
+
+    if user and user.is_active:
+        token = create_password_reset_token(user.id)
+        await send_password_reset_email(user.email, token)
+
+    return {"detail": "If that email exists, a reset link has been sent"}
+
+
+@router.post("/reset-password")
+async def reset_password(body: ResetPasswordRequest, db: AsyncSession = Depends(get_db)):
+    """Reset password using a valid reset token."""
+    payload = decode_token(body.token)
+    if payload is None or payload.get("type") != "password_reset":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired reset token",
+        )
+
+    user_id = int(payload["sub"])
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired reset token",
+        )
+
+    user.password_hash = hash_password(body.new_password)
+    await db.commit()
+    return {"detail": "Password has been reset"}
+
+
+# ── Email Verification ───────────────────────────────────────────────────────
+
+
+@router.post("/verify-email")
+async def verify_email(body: VerifyEmailRequest, db: AsyncSession = Depends(get_db)):
+    """Verify email address using a verification token."""
+    payload = decode_token(body.token)
+    if payload is None or payload.get("type") != "email_verify":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired verification token",
+        )
+
+    user_id = int(payload["sub"])
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired verification token",
+        )
+
+    user.email_verified = True
+    await db.commit()
+    return {"detail": "Email verified"}
+
+
+@router.post("/resend-verification")
+async def resend_verification(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Resend verification email for the current user."""
+    if current_user.email_verified:
+        return {"detail": "Email already verified"}
+
+    token = create_email_verification_token(current_user.id)
+    await send_verification_email(current_user.email, token)
+    return {"detail": "Verification email sent"}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,7 +1,9 @@
 import re
+import secrets
+from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, Cookie, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Response, Cookie, status
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,6 +33,8 @@ from app.security import (
     verify_password,
 )
 from app.services.email_service import send_password_reset_email, send_verification_email
+
+GOOGLE_OAUTH_TIMEOUT = httpx.Timeout(10.0)
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
@@ -77,45 +81,9 @@ async def _find_available_username(db: AsyncSession, base: str) -> str:
     return f"{base}{hash(base) % 10000}"
 
 
-@router.get("/status")
-async def auth_status(db: AsyncSession = Depends(get_db)):
-    """Check if the system needs initial setup (no users exist)."""
-    user_count = await db.scalar(select(func.count()).select_from(User))
-    return {"needs_setup": user_count == 0}
-
-
-@router.get("/check-username", response_model=UsernameCheckResponse)
-async def check_username(
-    username: str = Query(min_length=1),
-    db: AsyncSession = Depends(get_db),
-):
-    """Check if a username is available and suggest alternatives."""
-    exists = await db.scalar(
-        select(User.id).where(User.username == username)
-    )
-    if not exists:
-        return UsernameCheckResponse(available=True)
-    suggestion = await _find_available_username(db, username)
-    return UsernameCheckResponse(available=False, suggestion=suggestion)
-
-
-@router.post("/register", response_model=UserResponse, status_code=201)
-async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)):
-    existing = await db.execute(
-        select(User).where(or_(User.username == body.username, User.email == body.email))
-    )
-    if existing.scalar_one_or_none():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Username or email already taken",
-        )
-
-    existing_superadmin = await db.scalar(
-        select(func.count()).select_from(User).where(User.is_superadmin == True)
-    )
-    is_first_user = existing_superadmin == 0
-
-    org = Organization(name=body.org_name or f"{body.username}'s Organization")
+async def _create_org_with_defaults(db: AsyncSession, org_name: str) -> Organization:
+    """Create an organization with system account types and categories."""
+    org = Organization(name=org_name)
     db.add(org)
     await db.flush()
 
@@ -150,6 +118,55 @@ async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)):
         type=CategoryType.BOTH, is_system=True,
     ))
 
+    return org
+
+
+@router.get("/status")
+async def auth_status(db: AsyncSession = Depends(get_db)):
+    """Check if the system needs initial setup (no users exist)."""
+    user_count = await db.scalar(select(func.count()).select_from(User))
+    return {"needs_setup": user_count == 0}
+
+
+@router.get("/check-username", response_model=UsernameCheckResponse)
+async def check_username(
+    username: str = Query(min_length=1),
+    db: AsyncSession = Depends(get_db),
+):
+    """Check if a username is available and suggest alternatives."""
+    exists = await db.scalar(
+        select(User.id).where(User.username == username)
+    )
+    if not exists:
+        return UsernameCheckResponse(available=True)
+    suggestion = await _find_available_username(db, username)
+    return UsernameCheckResponse(available=False, suggestion=suggestion)
+
+
+@router.post("/register", response_model=UserResponse, status_code=201)
+async def register(
+    body: RegisterRequest,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+):
+    existing = await db.execute(
+        select(User).where(or_(User.username == body.username, User.email == body.email))
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username or email already taken",
+        )
+
+    existing_superadmin = await db.scalar(
+        select(func.count()).select_from(User).where(User.is_superadmin == True)
+    )
+    is_first_user = existing_superadmin == 0
+
+    org = await _create_org_with_defaults(
+        db, body.org_name or f"{body.username}'s Organization"
+    )
+
     user = User(
         org_id=org.id,
         username=body.username,
@@ -172,9 +189,9 @@ async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)):
     await db.refresh(user)
     await db.refresh(org)
 
-    # Send verification email (non-blocking — don't fail registration if email fails)
+    # Send verification email in background — don't block registration
     token = create_email_verification_token(user.id)
-    await send_verification_email(user.email, token)
+    background_tasks.add_task(send_verification_email, user.email, token)
 
     return _user_response(user, org)
 
@@ -365,11 +382,28 @@ async def resend_verification(
 # ── Google SSO ───────────────────────────────────────────────────────────────
 
 
-@router.get("/google")
-async def google_login():
-    """Redirect to Google OAuth consent screen."""
-    if not app_settings.google_client_id:
+def _validate_google_config() -> None:
+    """Raise 501 if Google SSO is not fully configured."""
+    if not app_settings.google_client_id or not app_settings.google_client_secret:
         raise HTTPException(status_code=501, detail="Google SSO not configured")
+
+
+@router.get("/google")
+async def google_login(response: Response):
+    """Redirect to Google OAuth consent screen."""
+    _validate_google_config()
+
+    # Generate CSRF state token and store in a signed cookie
+    state = secrets.token_urlsafe(32)
+    response.set_cookie(
+        key="oauth_state",
+        value=state,
+        httponly=True,
+        secure=app_settings.cookie_secure,
+        samesite="lax",
+        max_age=600,  # 10 minutes
+        path="/api/v1/auth/google",
+    )
 
     params = {
         "client_id": app_settings.google_client_id,
@@ -378,47 +412,63 @@ async def google_login():
         "scope": "openid email profile",
         "access_type": "offline",
         "prompt": "select_account",
+        "state": state,
     }
-    query = "&".join(f"{k}={v}" for k, v in params.items())
-    return {"redirect_url": f"https://accounts.google.com/o/oauth2/v2/auth?{query}"}
+    return {"redirect_url": f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}"}
 
 
 @router.get("/google/callback")
 async def google_callback(
     code: str,
+    state: str,
     response: Response,
     db: AsyncSession = Depends(get_db),
+    oauth_state: str | None = Cookie(default=None),
 ):
     """Handle Google OAuth callback — exchange code for tokens, create or login user."""
-    if not app_settings.google_client_id:
-        raise HTTPException(status_code=501, detail="Google SSO not configured")
+    _validate_google_config()
+
+    # Validate CSRF state
+    if not oauth_state or oauth_state != state:
+        raise HTTPException(status_code=400, detail="Invalid OAuth state — possible CSRF")
+
+    # Clear the state cookie
+    response.delete_cookie("oauth_state", path="/api/v1/auth/google")
 
     # Exchange authorization code for tokens
-    async with httpx.AsyncClient() as client:
-        token_resp = await client.post(
-            "https://oauth2.googleapis.com/token",
-            data={
-                "code": code,
-                "client_id": app_settings.google_client_id,
-                "client_secret": app_settings.google_client_secret,
-                "redirect_uri": f"{app_settings.app_url}/api/v1/auth/google/callback",
-                "grant_type": "authorization_code",
-            },
-        )
-        if token_resp.status_code != 200:
-            raise HTTPException(status_code=400, detail="Failed to exchange Google auth code")
-        tokens = token_resp.json()
+    try:
+        async with httpx.AsyncClient(timeout=GOOGLE_OAUTH_TIMEOUT) as client:
+            token_resp = await client.post(
+                "https://oauth2.googleapis.com/token",
+                data={
+                    "code": code,
+                    "client_id": app_settings.google_client_id,
+                    "client_secret": app_settings.google_client_secret,
+                    "redirect_uri": f"{app_settings.app_url}/api/v1/auth/google/callback",
+                    "grant_type": "authorization_code",
+                },
+            )
+            if token_resp.status_code != 200:
+                raise HTTPException(status_code=400, detail="Failed to exchange Google auth code")
+            tokens = token_resp.json()
 
-        # Get user info from Google
-        userinfo_resp = await client.get(
-            "https://www.googleapis.com/oauth2/v2/userinfo",
-            headers={"Authorization": f"Bearer {tokens['access_token']}"},
-        )
-        if userinfo_resp.status_code != 200:
-            raise HTTPException(status_code=400, detail="Failed to get Google user info")
-        google_user = userinfo_resp.json()
+            # Get user info from Google
+            userinfo_resp = await client.get(
+                "https://www.googleapis.com/oauth2/v2/userinfo",
+                headers={"Authorization": f"Bearer {tokens['access_token']}"},
+            )
+            if userinfo_resp.status_code != 200:
+                raise HTTPException(status_code=400, detail="Failed to get Google user info")
+            google_user = userinfo_resp.json()
+    except httpx.HTTPError:
+        raise HTTPException(status_code=502, detail="Failed to communicate with Google")
 
     email = google_user.get("email", "")
+    if not email:
+        raise HTTPException(status_code=400, detail="Google account has no email")
+
+    # Only trust email_verified if Google explicitly says so
+    google_verified = google_user.get("verified_email", False)
     first_name = google_user.get("given_name", "")
     last_name = google_user.get("family_name", "")
 
@@ -430,61 +480,20 @@ async def google_callback(
         # Existing user — login
         if not user.is_active:
             raise HTTPException(status_code=403, detail="Account is deactivated")
-        # Update email_verified since Google verified it
-        if not user.email_verified:
+        if google_verified and not user.email_verified:
             user.email_verified = True
             await db.commit()
     else:
         # New user — register with Google profile
-        # Check for existing superadmin
         existing_superadmin = await db.scalar(
             select(func.count()).select_from(User).where(User.is_superadmin == True)
         )
         is_first_user = existing_superadmin == 0
 
-        # Generate a username from Google name
         base_username = _suggest_username(first_name, last_name, email)
         username = await _find_available_username(db, base_username)
 
-        # Create org + user + system data (same as register)
-        org = Organization(name=f"{username}'s Organization")
-        db.add(org)
-        await db.flush()
-
-        for sat in SYSTEM_ACCOUNT_TYPES:
-            db.add(AccountType(org_id=org.id, name=sat["name"], slug=sat["slug"], is_system=True))
-
-        for master_def in SYSTEM_CATEGORIES:
-            master = Category(
-                org_id=org.id,
-                name=master_def["name"],
-                slug=master_def["slug"],
-                description=master_def["description"],
-                type=CategoryType(master_def["type"]),
-                is_system=True,
-            )
-            db.add(master)
-            await db.flush()
-            for child_def in master_def.get("children", []):
-                db.add(Category(
-                    org_id=org.id,
-                    parent_id=master.id,
-                    name=child_def["name"],
-                    slug=child_def["slug"],
-                    description=child_def["description"],
-                    type=CategoryType(master_def["type"]),
-                    is_system=True,
-                ))
-
-        db.add(Category(
-            org_id=org.id, name="Transfer", slug="transfer",
-            description="Internal transfers between accounts",
-            type=CategoryType.BOTH, is_system=True,
-        ))
-
-        # Google users get a random password (they login via Google)
-        import secrets
-        random_password = secrets.token_urlsafe(32)
+        org = await _create_org_with_defaults(db, f"{username}'s Organization")
 
         user = User(
             org_id=org.id,
@@ -493,8 +502,8 @@ async def google_callback(
             first_name=first_name,
             last_name=last_name,
             avatar_url=google_user.get("picture"),
-            password_hash=hash_password(random_password),
-            email_verified=True,  # Google verified the email
+            password_hash=hash_password(secrets.token_urlsafe(32)),
+            email_verified=google_verified,
             role=Role.OWNER,
             is_superadmin=is_first_user,
         )
@@ -517,10 +526,9 @@ async def google_callback(
         path="/api/v1/auth/refresh",
     )
 
-    # Redirect to frontend with access token
-    from urllib.parse import urlencode
-    redirect_params = urlencode({"token": access_token})
+    # Redirect to frontend with token in URL fragment (not query string)
+    # Fragments are not sent to the server, preventing leaks in logs/Referer headers
     return Response(
         status_code=302,
-        headers={"Location": f"{app_settings.app_url}/auth/google/callback?{redirect_params}"},
+        headers={"Location": f"{app_settings.app_url}/auth/google/callback#token={access_token}"},
     )

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -42,3 +42,16 @@ class UserResponse(BaseModel):
 class UsernameCheckResponse(BaseModel):
     available: bool
     suggestion: str | None = None
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str = Field(min_length=8)
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -40,6 +40,28 @@ def create_refresh_token(subject: int) -> str:
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
 
 
+def create_password_reset_token(user_id: int) -> str:
+    """Create a short-lived token for password reset (1 hour)."""
+    expire = datetime.now(timezone.utc) + timedelta(hours=1)
+    payload = {
+        "sub": str(user_id),
+        "type": "password_reset",
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def create_email_verification_token(user_id: int) -> str:
+    """Create a token for email verification (24 hours)."""
+    expire = datetime.now(timezone.utc) + timedelta(hours=24)
+    payload = {
+        "sub": str(user_id),
+        "type": "email_verify",
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
 def decode_token(token: str) -> dict | None:
     try:
         return jwt.decode(

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,82 @@
+"""Email service — sends emails via Mailgun in production, logs in development.
+
+In development (no MAILGUN_API_KEY set), emails are logged to structlog
+with full content including any links. This lets developers see verification
+and password reset URLs without needing a real email provider.
+"""
+
+import structlog
+import httpx
+
+from app.config import settings
+
+logger = structlog.get_logger()
+
+
+async def send_email(
+    to: str,
+    subject: str,
+    body_html: str,
+    body_text: str | None = None,
+) -> bool:
+    """Send an email. Returns True if sent/logged successfully."""
+    if not settings.mailgun_api_key:
+        # Development: log the email content
+        await logger.ainfo(
+            "email_sent_dev",
+            to=to,
+            subject=subject,
+            body_text=body_text or "(html only)",
+            body_html=body_html,
+        )
+        return True
+
+    # Production: send via Mailgun HTTP API
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"https://api.mailgun.net/v3/{settings.mailgun_domain}/messages",
+                auth=("api", settings.mailgun_api_key),
+                data={
+                    "from": settings.email_from,
+                    "to": [to],
+                    "subject": subject,
+                    "html": body_html,
+                    **({"text": body_text} if body_text else {}),
+                },
+            )
+            response.raise_for_status()
+            await logger.ainfo("email_sent", to=to, subject=subject, status=response.status_code)
+            return True
+    except Exception as exc:
+        await logger.aerror("email_send_failed", to=to, subject=subject, error=str(exc))
+        return False
+
+
+async def send_password_reset_email(to: str, token: str) -> bool:
+    """Send a password reset email with a link containing the reset token."""
+    reset_url = f"{settings.app_url}/reset-password?token={token}"
+    subject = "PFV2 — Reset Your Password"
+    body_html = f"""
+    <h2>Reset Your Password</h2>
+    <p>You requested a password reset for your PFV2 account.</p>
+    <p><a href="{reset_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Reset Password</a></p>
+    <p>Or copy this link: <code>{reset_url}</code></p>
+    <p>This link expires in 1 hour. If you didn't request this, ignore this email.</p>
+    """
+    body_text = f"Reset your password: {reset_url}\n\nThis link expires in 1 hour."
+    return await send_email(to, subject, body_html, body_text)
+
+
+async def send_verification_email(to: str, token: str) -> bool:
+    """Send an email verification link."""
+    verify_url = f"{settings.app_url}/verify-email?token={token}"
+    subject = "PFV2 — Verify Your Email"
+    body_html = f"""
+    <h2>Verify Your Email</h2>
+    <p>Welcome to PFV2! Please verify your email address.</p>
+    <p><a href="{verify_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Verify Email</a></p>
+    <p>Or copy this link: <code>{verify_url}</code></p>
+    """
+    body_text = f"Verify your email: {verify_url}"
+    return await send_email(to, subject, body_html, body_text)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -33,7 +33,7 @@ async def send_email(
 
     # Production: send via Mailgun HTTP API
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
             response = await client.post(
                 f"https://api.mailgun.net/v3/{settings.mailgun_domain}/messages",
                 auth=("api", settings.mailgun_api_key),

--- a/frontend/app/auth/google/callback/page.tsx
+++ b/frontend/app/auth/google/callback/page.tsx
@@ -1,25 +1,32 @@
 "use client";
 
-import { Suspense, useEffect, useRef } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { setAccessToken } from "@/lib/api";
 import { useAuth } from "@/components/auth/AuthProvider";
 
-function GoogleCallbackHandler() {
-  const searchParams = useSearchParams();
+export default function GoogleCallbackPage() {
   const router = useRouter();
   const { refreshMe } = useAuth();
-  const token = searchParams.get("token");
   const calledRef = useRef(false);
 
   useEffect(() => {
     if (calledRef.current) return;
     calledRef.current = true;
 
+    // Token is in the URL fragment (#token=xxx) to prevent leaks in
+    // server logs, Referer headers, and browser history
+    const hash = window.location.hash.substring(1); // remove #
+    const params = new URLSearchParams(hash);
+    const token = params.get("token");
+
     if (!token) {
       router.replace("/login");
       return;
     }
+
+    // Clear the fragment from the URL immediately
+    window.history.replaceState(null, "", window.location.pathname);
 
     setAccessToken(token);
     refreshMe().then(() => {
@@ -27,25 +34,11 @@ function GoogleCallbackHandler() {
     }).catch(() => {
       router.replace("/login");
     });
-  }, [token, router, refreshMe]);
+  }, [router, refreshMe]);
 
   return (
     <div className="flex min-h-screen items-center justify-center">
       <p className="text-sm text-text-muted">Signing you in...</p>
     </div>
-  );
-}
-
-export default function GoogleCallbackPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-screen items-center justify-center">
-          <p className="text-sm text-text-muted">Loading...</p>
-        </div>
-      }
-    >
-      <GoogleCallbackHandler />
-    </Suspense>
   );
 }

--- a/frontend/app/auth/google/callback/page.tsx
+++ b/frontend/app/auth/google/callback/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { setAccessToken } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+function GoogleCallbackHandler() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { refreshMe } = useAuth();
+  const token = searchParams.get("token");
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    if (calledRef.current) return;
+    calledRef.current = true;
+
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+
+    setAccessToken(token);
+    refreshMe().then(() => {
+      router.replace("/dashboard");
+    }).catch(() => {
+      router.replace("/login");
+    });
+  }, [token, router, refreshMe]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-sm text-text-muted">Signing you in...</p>
+    </div>
+  );
+}
+
+export default function GoogleCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-sm text-text-muted">Loading...</p>
+        </div>
+      }
+    >
+      <GoogleCallbackHandler />
+    </Suspense>
+  );
+}

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { input, label, btnPrimary, error as errorCls, success } from "@/lib/styles";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [sent, setSent] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      await apiFetch("/api/v1/auth/forgot-password", {
+        method: "POST",
+        body: JSON.stringify({ email }),
+      });
+      setSent(true);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Something went wrong. Please try again."));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center px-4">
+      <ThemeToggle className="absolute right-6 top-6" />
+
+      <div className="w-full max-w-sm">
+        <div className="mb-10 text-center">
+          <h1 className="font-display text-3xl font-semibold text-text-primary">Reset Password</h1>
+          <p className="mt-1.5 text-sm text-text-muted">
+            Enter your email and we&apos;ll send you a reset link
+          </p>
+        </div>
+
+        {sent ? (
+          <div className="space-y-5">
+            <div className={success}>
+              If that email exists, a reset link has been sent.
+            </div>
+            <p className="text-center text-sm text-text-muted">
+              <Link href="/login" className="text-accent hover:text-accent-hover">
+                Back to login
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <>
+            <form onSubmit={handleSubmit} className="space-y-5">
+              {error && <div className={errorCls}>{error}</div>}
+              <div>
+                <label htmlFor="forgot-email" className={label}>Email</label>
+                <input
+                  id="forgot-email"
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className={input}
+                  autoComplete="email"
+                  placeholder="you@example.com"
+                />
+              </div>
+              <button type="submit" disabled={submitting} className={`w-full ${btnPrimary}`}>
+                {submitting ? "Sending..." : "Send Reset Link"}
+              </button>
+            </form>
+            <p className="mt-6 text-center text-sm text-text-muted">
+              <Link href="/login" className="text-accent hover:text-accent-hover">
+                Back to login
+              </Link>
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -5,7 +5,8 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/components/auth/AuthProvider";
 import ThemeToggle from "@/components/ui/ThemeToggle";
-import { input, label, btnPrimary, error as errorCls } from "@/lib/styles";
+import { apiFetch } from "@/lib/api";
+import { input, label, btnPrimary, btnSecondary, error as errorCls } from "@/lib/styles";
 
 export default function LoginPage() {
   const { user, login, loading, needsSetup } = useAuth();
@@ -34,6 +35,15 @@ export default function LoginPage() {
     }
   }
 
+  async function handleGoogleLogin() {
+    try {
+      const data = await apiFetch<{ redirect_url: string }>("/api/v1/auth/google");
+      window.location.href = data.redirect_url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Google sign-in is not available");
+    }
+  }
+
   return (
     <div className="relative flex min-h-screen items-center justify-center px-4">
       <ThemeToggle className="absolute right-6 top-6" />
@@ -53,8 +63,19 @@ export default function LoginPage() {
             <label htmlFor="login-password" className={label}>Password</label>
             <input id="login-password" type="password" required value={password} onChange={(e) => setPassword(e.target.value)} className={input} autoComplete="current-password" />
           </div>
+          <div className="text-right">
+            <a href="/forgot-password" className="text-xs text-accent hover:text-accent-hover">Forgot your password?</a>
+          </div>
           <button type="submit" disabled={submitting} className={`w-full ${btnPrimary}`}>
             {submitting ? "Signing in..." : "Sign In"}
+          </button>
+          <div className="flex items-center gap-3 my-4">
+            <div className="flex-1 border-t border-border" />
+            <span className="text-xs text-text-muted">or</span>
+            <div className="flex-1 border-t border-border" />
+          </div>
+          <button onClick={handleGoogleLogin} className={btnSecondary + " w-full"} type="button">
+            Sign in with Google
           </button>
         </form>
         <p className="mt-6 text-center text-sm text-text-muted">

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -64,7 +64,7 @@ export default function LoginPage() {
             <input id="login-password" type="password" required value={password} onChange={(e) => setPassword(e.target.value)} className={input} autoComplete="current-password" />
           </div>
           <div className="text-right">
-            <a href="/forgot-password" className="text-xs text-accent hover:text-accent-hover">Forgot your password?</a>
+            <Link href="/forgot-password" className="text-xs text-accent hover:text-accent-hover">Forgot your password?</Link>
           </div>
           <button type="submit" disabled={submitting} className={`w-full ${btnPrimary}`}>
             {submitting ? "Signing in..." : "Sign In"}

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
 import ThemeToggle from "@/components/ui/ThemeToggle";
-import { input, label, btnPrimary, error as errorCls } from "@/lib/styles";
+import { input, label, btnPrimary, btnSecondary, error as errorCls, success } from "@/lib/styles";
 
 interface UsernameCheck {
   available: boolean;
@@ -33,6 +33,7 @@ export default function RegisterPage() {
   const [orgName, setOrgName] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [registered, setRegistered] = useState(false);
 
   // Auto-suggest username from name
   useEffect(() => {
@@ -77,12 +78,44 @@ export default function RegisterPage() {
     setSubmitting(true);
     try {
       await register(username, email, password, orgName || undefined, firstName || undefined, lastName || undefined);
-      router.push("/login");
+      setRegistered(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Registration failed");
     } finally {
       setSubmitting(false);
     }
+  }
+
+  async function handleGoogleLogin() {
+    try {
+      const data = await apiFetch<{ redirect_url: string }>("/api/v1/auth/google");
+      window.location.href = data.redirect_url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Google sign-in is not available");
+    }
+  }
+
+  if (registered) {
+    return (
+      <div className="relative flex min-h-screen items-center justify-center px-4">
+        <ThemeToggle className="absolute right-6 top-6" />
+        <div className="w-full max-w-sm">
+          <div className="mb-10 text-center">
+            <h1 className="font-display text-3xl font-semibold text-text-primary">Check Your Email</h1>
+          </div>
+          <div className="space-y-5">
+            <div className={success}>
+              Account created! Check your email to verify your account.
+            </div>
+            <p className="text-center text-sm text-text-muted">
+              <Link href="/login" className="text-accent hover:text-accent-hover">
+                Go to login
+              </Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -137,6 +170,14 @@ export default function RegisterPage() {
           </div>
           <button type="submit" disabled={submitting || usernameStatus === "taken"} className={`w-full ${btnPrimary}`}>
             {submitting ? "Creating account..." : "Create Account"}
+          </button>
+          <div className="flex items-center gap-3 my-4">
+            <div className="flex-1 border-t border-border" />
+            <span className="text-xs text-text-muted">or</span>
+            <div className="flex-1 border-t border-border" />
+          </div>
+          <button onClick={handleGoogleLogin} className={btnSecondary + " w-full"} type="button">
+            Sign up with Google
           </button>
         </form>
         <p className="mt-6 text-center text-sm text-text-muted">

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { FormEvent, Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { input, label, btnPrimary, error as errorCls, success } from "@/lib/styles";
+
+function ResetPasswordForm() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [password2, setPassword2] = useState("");
+  const [error, setError] = useState("");
+  const [done, setDone] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!token) {
+    return (
+      <div className="space-y-5">
+        <div className={errorCls}>Invalid reset link.</div>
+        <p className="text-center text-sm text-text-muted">
+          <Link href="/forgot-password" className="text-accent hover:text-accent-hover">
+            Request a new link
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+    if (password !== password2) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await apiFetch("/api/v1/auth/reset-password", {
+        method: "POST",
+        body: JSON.stringify({ token, new_password: password }),
+      });
+      setDone(true);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Reset failed. The link may have expired."));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="space-y-5">
+        <div className={success}>Password reset successfully!</div>
+        <p className="text-center text-sm text-text-muted">
+          <Link href="/login" className="text-accent hover:text-accent-hover">
+            Sign in with your new password
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {error && <div className={errorCls}>{error}</div>}
+        <div>
+          <label htmlFor="reset-password" className={label}>New Password</label>
+          <input
+            id="reset-password"
+            type="password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={input}
+            autoComplete="new-password"
+          />
+        </div>
+        <div>
+          <label htmlFor="reset-password2" className={label}>Confirm Password</label>
+          <input
+            id="reset-password2"
+            type="password"
+            required
+            value={password2}
+            onChange={(e) => setPassword2(e.target.value)}
+            className={input}
+            autoComplete="new-password"
+          />
+        </div>
+        <button type="submit" disabled={submitting} className={`w-full ${btnPrimary}`}>
+          {submitting ? "Resetting..." : "Reset Password"}
+        </button>
+      </form>
+      <p className="mt-6 text-center text-sm text-text-muted">
+        <Link href="/login" className="text-accent hover:text-accent-hover">
+          Back to login
+        </Link>
+      </p>
+    </>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center px-4">
+      <ThemeToggle className="absolute right-6 top-6" />
+
+      <div className="w-full max-w-sm">
+        <div className="mb-10 text-center">
+          <h1 className="font-display text-3xl font-semibold text-text-primary">New Password</h1>
+          <p className="mt-1.5 text-sm text-text-muted">Choose a new password for your account</p>
+        </div>
+        <Suspense fallback={<p className="text-center text-sm text-text-muted">Loading...</p>}>
+          <ResetPasswordForm />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/verify-email/page.tsx
+++ b/frontend/app/verify-email/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { error as errorCls, success } from "@/lib/styles";
+
+function VerifyEmailHandler() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const { user } = useAuth();
+
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [errorMsg, setErrorMsg] = useState("");
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    if (!token || calledRef.current) return;
+    calledRef.current = true;
+
+    apiFetch("/api/v1/auth/verify-email", {
+      method: "POST",
+      body: JSON.stringify({ token }),
+    })
+      .then(() => setStatus("success"))
+      .catch((err) => {
+        setStatus("error");
+        setErrorMsg(err instanceof Error ? err.message : "Verification failed");
+      });
+  }, [token]);
+
+  if (!token) {
+    return (
+      <div className="space-y-5">
+        <div className={errorCls}>Invalid verification link.</div>
+        <p className="text-center text-sm text-text-muted">
+          <Link href="/login" className="text-accent hover:text-accent-hover">
+            Go to login
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  if (status === "loading") {
+    return <p className="text-center text-sm text-text-muted">Verifying your email...</p>;
+  }
+
+  if (status === "error") {
+    return (
+      <div className="space-y-5">
+        <div className={errorCls}>
+          {errorMsg || "Invalid or expired verification link."}
+        </div>
+        <p className="text-center text-sm text-text-muted">
+          <Link href="/login" className="text-accent hover:text-accent-hover">
+            Go to login
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className={success}>Email verified!</div>
+      <p className="text-center text-sm text-text-muted">
+        <Link
+          href={user ? "/dashboard" : "/login"}
+          className="text-accent hover:text-accent-hover"
+        >
+          {user ? "Go to dashboard" : "Sign in"}
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <div className="relative flex min-h-screen items-center justify-center px-4">
+      <ThemeToggle className="absolute right-6 top-6" />
+
+      <div className="w-full max-w-sm">
+        <div className="mb-10 text-center">
+          <h1 className="font-display text-3xl font-semibold text-text-primary">Email Verification</h1>
+        </div>
+        <Suspense fallback={<p className="text-center text-sm text-text-muted">Loading...</p>}>
+          <VerifyEmailHandler />
+        </Suspense>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Email service with Mailgun support (dev mode logs emails to console)
- Password reset flow: forgot-password → email with token → reset-password page
- Email verification: sent on register, verify-email page, resend-verification endpoint
- Google SSO: OAuth2 flow with auto-registration, callback page
- Login page: "Forgot your password?" link + "Sign in with Google" button
- Register page: post-registration "check your email" prompt + Google SSO button
- 13 auth endpoints total (6 new: forgot-password, reset-password, verify-email, resend-verification, google, google/callback)