### PR TITLE
feat: settled_date — transactions count against the period they settle in

### DIFF
--- a/backend/alembic/versions/020_add_settled_date_to_transactions.py
+++ b/backend/alembic/versions/020_add_settled_date_to_transactions.py
@@ -20,9 +20,16 @@ def upgrade() -> None:
     )
     # Backfill: existing settled transactions get their date as settled_date
     op.execute(
-        "UPDATE transactions SET settled_date = date WHERE status = 'settled'"
+        "UPDATE transactions SET settled_date = `date` WHERE status = 'settled'"
+    )
+    # Index for budget/forecast queries that filter by org + status + settled_date
+    op.create_index(
+        "ix_transactions_org_settled_date",
+        "transactions",
+        ["org_id", "status", "settled_date"],
     )
 
 
 def downgrade() -> None:
+    op.drop_index("ix_transactions_org_settled_date", table_name="transactions")
     op.drop_column("transactions", "settled_date")

--- a/backend/alembic/versions/020_add_settled_date_to_transactions.py
+++ b/backend/alembic/versions/020_add_settled_date_to_transactions.py
@@ -1,0 +1,28 @@
+"""add settled_date to transactions
+
+Revision ID: 020
+Revises: 019
+
+Adds a nullable settled_date column. For existing settled transactions,
+backfills settled_date from the transaction date.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "020"
+down_revision = "019"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transactions",
+        sa.Column("settled_date", sa.Date(), nullable=True),
+    )
+    # Backfill: existing settled transactions get their date as settled_date
+    op.execute(
+        "UPDATE transactions SET settled_date = date WHERE status = 'settled'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("transactions", "settled_date")

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -61,6 +61,7 @@ class Transaction(Base):
         Integer, ForeignKey("recurring_transactions.id", ondelete="SET NULL"), nullable=True
     )
     date: Mapped[date] = mapped_column(Date, nullable=False)
+    settled_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
     is_imported: Mapped[bool] = mapped_column(Boolean, default=False, server_default="0", nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -62,6 +62,7 @@ class TransactionResponse(BaseModel):
     linked_transaction_id: Optional[int] = None
     recurring_id: Optional[int] = None
     date: datetime.date
+    settled_date: datetime.date | None = None
     is_imported: bool = False
 
     model_config = {"from_attributes": True}

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -32,16 +32,18 @@ async def _compute_spent(
     sub_ids = [r[0] for r in sub_ids_result.all()]
     all_cat_ids = [master_category_id] + sub_ids
 
+    # Use settled_date for budget computation — transactions count against
+    # the billing period in which they settled, not when the purchase happened.
     q = select(func.coalesce(func.sum(Transaction.amount), 0)).where(
         Transaction.org_id == org_id,
         Transaction.category_id.in_(all_cat_ids),
         Transaction.type == TransactionType.EXPENSE,
         Transaction.status == TransactionStatus.SETTLED,
-        Transaction.date >= period_start,
+        Transaction.settled_date >= period_start,
     )
     # If period is still open (no end_date), include all from start_date onward
     if period_end is not None:
-        q = q.where(Transaction.date <= period_end)
+        q = q.where(Transaction.settled_date <= period_end)
 
     spent = await db.scalar(q)
     return Decimal(str(spent))

--- a/backend/app/services/forecast_service.py
+++ b/backend/app/services/forecast_service.py
@@ -68,14 +68,16 @@ async def compute_forecast(
     # For open periods, project to ~30 days from start
     p_end = period.end_date or (p_start + relativedelta(months=1) - datetime.timedelta(days=1))
 
-    # ── Executed (settled) ────────────────────────────────────────────────
+    # ── Executed (settled) — uses settled_date for period assignment ─────
+    # Transactions count against the period in which they settled,
+    # not when the purchase happened (important for CC late settlements).
     executed_income = await db.scalar(
         select(func.coalesce(func.sum(Transaction.amount), 0)).where(
             Transaction.org_id == org_id,
             Transaction.type == TransactionType.INCOME,
             Transaction.status == TransactionStatus.SETTLED,
-            Transaction.date >= p_start,
-            Transaction.date <= p_end,
+            Transaction.settled_date >= p_start,
+            Transaction.settled_date <= p_end,
         )
     ) or Decimal("0")
 
@@ -84,12 +86,12 @@ async def compute_forecast(
             Transaction.org_id == org_id,
             Transaction.type == TransactionType.EXPENSE,
             Transaction.status == TransactionStatus.SETTLED,
-            Transaction.date >= p_start,
-            Transaction.date <= p_end,
+            Transaction.settled_date >= p_start,
+            Transaction.settled_date <= p_end,
         )
     ) or Decimal("0")
 
-    # ── Pending ───────────────────────────────────────────────────────────
+    # ── Pending — uses transaction date (when purchase happened) ──────────
     pending_income = await db.scalar(
         select(func.coalesce(func.sum(Transaction.amount), 0)).where(
             Transaction.org_id == org_id,
@@ -135,7 +137,7 @@ async def compute_forecast(
             d = _advance_date(d, r.frequency)
 
     # ── Per-category breakdown ────────────────────────────────────────────
-    # Executed by category
+    # Executed by category (uses settled_date for period assignment)
     cat_exec_result = await db.execute(
         select(
             Transaction.category_id,
@@ -144,8 +146,8 @@ async def compute_forecast(
             Transaction.org_id == org_id,
             Transaction.type == TransactionType.EXPENSE,
             Transaction.status == TransactionStatus.SETTLED,
-            Transaction.date >= p_start,
-            Transaction.date <= p_end,
+            Transaction.settled_date >= p_start,
+            Transaction.settled_date <= p_end,
         ).group_by(Transaction.category_id)
     )
     cat_executed = {row[0]: Decimal(str(row[1])) for row in cat_exec_result.all()}

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -241,6 +241,7 @@ async def generate_due_transactions(db: AsyncSession, org_id: int) -> int:
                     type=TransactionType(r.type),
                     status=tx_status,
                     date=r.next_due_date,
+                    settled_date=r.next_due_date if tx_status == TransactionStatus.SETTLED else None,
                     recurring_id=r.id,
                 )
                 db.add(tx)

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -44,6 +44,7 @@ def to_response(tx: Transaction) -> TransactionResponse:
         linked_transaction_id=tx.linked_transaction_id,
         recurring_id=tx.recurring_id,
         date=tx.date,
+        settled_date=tx.settled_date,
         is_imported=tx.is_imported,
     )
 
@@ -138,6 +139,7 @@ async def create_transaction(
             type=tx_type,
             status=tx_status,
             date=body.date,
+            settled_date=body.date if tx_status == TransactionStatus.SETTLED else None,
             is_imported=is_imported,
         )
         db.add(tx)
@@ -200,6 +202,10 @@ async def update_transaction(
             tx.account_id = body.account_id
         if body.status is not None:
             tx.status = new_status
+            if new_status == TransactionStatus.SETTLED and old_status != TransactionStatus.SETTLED:
+                tx.settled_date = datetime.date.today()
+            elif new_status == TransactionStatus.PENDING and old_status == TransactionStatus.SETTLED:
+                tx.settled_date = None
 
         # Apply new balance if now settled
         if new_status == TransactionStatus.SETTLED:
@@ -313,6 +319,7 @@ async def create_transfer(
     async with db.begin_nested():
         # Expense side (source account) — uses EXPENSE type so existing
         # balance logic (apply/revert) works unchanged
+        settled = body.date if tx_status == TransactionStatus.SETTLED else None
         expense_tx = Transaction(
             org_id=org_id,
             account_id=body.from_account_id,
@@ -322,6 +329,7 @@ async def create_transfer(
             type=TransactionType.EXPENSE,
             status=tx_status,
             date=body.date,
+            settled_date=settled,
             is_imported=is_imported,
         )
         # Income side (destination account)
@@ -334,6 +342,7 @@ async def create_transfer(
             type=TransactionType.INCOME,
             status=tx_status,
             date=body.date,
+            settled_date=settled,
             is_imported=is_imported,
         )
         db.add(expense_tx)

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -70,6 +70,7 @@ export interface Transaction {
   linked_transaction_id: number | null;
   recurring_id: number | null;
   date: string;
+  settled_date: string | null;
   is_imported: boolean;
 }
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -23,10 +23,14 @@ function sanitizeQuery(search: string): string | undefined {
   return result || undefined;
 }
 
+function clientIp(request: NextRequest): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+  return request.headers.get("x-real-ip") || "unknown";
+}
+
 export function middleware(request: NextRequest) {
-  const start = Date.now();
   const response = NextResponse.next();
-  const duration = Date.now() - start;
 
   const entry = {
     timestamp: new Date().toISOString(),
@@ -35,9 +39,7 @@ export function middleware(request: NextRequest) {
     method: request.method,
     path: request.nextUrl.pathname,
     query: sanitizeQuery(request.nextUrl.search),
-    status: response.status,
-    duration_ms: duration,
-    remote_addr: request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || "unknown",
+    remote_addr: clientIp(request),
     user_agent: request.headers.get("user-agent") || undefined,
     referer: request.headers.get("referer") || undefined,
   };

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -24,7 +24,9 @@ function sanitizeQuery(search: string): string | undefined {
 }
 
 export function middleware(request: NextRequest) {
+  const start = Date.now();
   const response = NextResponse.next();
+  const duration = Date.now() - start;
 
   const entry = {
     timestamp: new Date().toISOString(),
@@ -33,9 +35,19 @@ export function middleware(request: NextRequest) {
     method: request.method,
     path: request.nextUrl.pathname,
     query: sanitizeQuery(request.nextUrl.search),
+    status: response.status,
+    duration_ms: duration,
+    remote_addr: request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || "unknown",
+    user_agent: request.headers.get("user-agent") || undefined,
+    referer: request.headers.get("referer") || undefined,
   };
 
-  console.log(JSON.stringify(entry));
+  // Remove undefined values for cleaner JSON
+  const clean = Object.fromEntries(
+    Object.entries(entry).filter(([, v]) => v !== undefined)
+  );
+
+  console.log(JSON.stringify(clean));
 
   return response;
 }


### PR DESCRIPTION
## Summary

- Add `settled_date` column to transactions (migration 020, backfills existing settled records)
- Budgets compute spend using `settled_date` instead of `date`
- Forecasts use `settled_date` for executed totals, `date` for pending visibility
- CC transactions that settle after a billing period closes now correctly count against the next period