### PR TITLE
feat: MFA/TOTP two-factor authentication

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -44,31 +44,18 @@ services:
       period_seconds: 15
       timeout_seconds: 5
       failure_threshold: 3
+    # Secrets (DATABASE_URL, REDIS_URL, JWT_SECRET_KEY, MFA_ENCRYPTION_KEY)
+    # are configured in DO console and inherited by preview apps.
+    # Only non-secret env vars are listed here.
     envs:
-      - key: DATABASE_URL
-        value: "placeholder-set-in-do-console"
-        type: SECRET
-      - key: REDIS_URL
-        value: "placeholder-set-in-do-console"
-        type: SECRET
-      - key: JWT_SECRET_KEY
-        value: "placeholder-set-in-do-console"
-        type: SECRET
-      - key: MFA_ENCRYPTION_KEY
-        value: "placeholder-set-in-do-console"
-        type: SECRET
       - key: APP_ENV
         value: "production"
       - key: APP_NAME
         value: "PFV2"
       - key: LOG_LEVEL
         value: "INFO"
-      - key: BACKEND_CORS_ORIGINS
-        value: "placeholder-update-after-deploy"
       - key: COOKIE_SECURE
         value: "true"
-      - key: APP_URL
-        value: "placeholder-update-after-deploy"
 
   - name: frontend
     github:

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -5,7 +5,7 @@ services:
     github:
       repo: flamarion/pfv
       branch: main
-      deploy_on_push: true
+      deploy_on_push: false
     source_dir: backend
     dockerfile_path: backend/Dockerfile
     http_port: 8000
@@ -17,19 +17,18 @@ services:
       period_seconds: 15
       timeout_seconds: 5
       failure_threshold: 3
-    routes:
-      - path: /api
-      - path: /health
-      - path: /ready
     envs:
       - key: DATABASE_URL
-        value: "placeholder-set-via-doctl"
+        value: "placeholder-set-in-do-console"
         type: SECRET
       - key: REDIS_URL
-        value: "placeholder-set-via-doctl"
+        value: "placeholder-set-in-do-console"
         type: SECRET
       - key: JWT_SECRET_KEY
-        value: "placeholder-set-via-doctl"
+        value: "placeholder-set-in-do-console"
+        type: SECRET
+      - key: MFA_ENCRYPTION_KEY
+        value: "placeholder-set-in-do-console"
         type: SECRET
       - key: APP_ENV
         value: "production"
@@ -41,19 +40,19 @@ services:
         value: "placeholder-update-after-deploy"
       - key: COOKIE_SECURE
         value: "true"
+      - key: APP_URL
+        value: "placeholder-update-after-deploy"
 
   - name: frontend
     github:
       repo: flamarion/pfv
       branch: main
-      deploy_on_push: true
+      deploy_on_push: false
     source_dir: frontend
     dockerfile_path: frontend/Dockerfile
     http_port: 3000
     instance_count: 1
     instance_size_slug: basic-xxs
-    routes:
-      - path: /
     envs:
       - key: NEXT_PUBLIC_API_URL
         value: ""

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,5 +1,32 @@
 name: pfv
 region: ams
+features:
+  - buildpack-stack=ubuntu-22
+ingress:
+  rules:
+    - match:
+        path:
+          prefix: /api
+      component:
+        name: backend
+        preserve_path_prefix: true
+    - match:
+        path:
+          prefix: /health
+      component:
+        name: backend
+        preserve_path_prefix: true
+    - match:
+        path:
+          prefix: /ready
+      component:
+        name: backend
+        preserve_path_prefix: true
+    - match:
+        path:
+          prefix: /
+      component:
+        name: frontend
 services:
   - name: backend
     github:

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ MAILGUN_DOMAIN=
 EMAIL_FROM=PFV2 <noreply@pfv.app>
 APP_URL=http://localhost
 
+# --- MFA ---
+# Fernet key for encrypting TOTP secrets at rest.
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+MFA_ENCRYPTION_KEY=
+
 # --- Google SSO ---
 # Create OAuth 2.0 credentials at https://console.cloud.google.com/apis/credentials
 # Set authorized redirect URI to: {APP_URL}/api/v1/auth/google/callback

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -14,3 +14,4 @@ jobs:
           from_pr_preview: "true"
           ignore_not_found: "true"
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          app_name: pfv

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -1,4 +1,6 @@
-name: Delete Preview
+# Delete Preview — DISABLED (preview deployments are disabled)
+
+name: Delete Preview (disabled)
 
 on:
   pull_request:
@@ -6,6 +8,7 @@ on:
 
 jobs:
   cleanup:
+    if: false  # Disabled — re-enable when preview deployments are active
     runs-on: ubuntu-latest
     steps:
       - name: Delete preview app

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -1,0 +1,16 @@
+name: Delete Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete preview app
+        uses: digitalocean/app_action/delete@v2
+        with:
+          from_pr_preview: "true"
+          ignore_not_found: "true"
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to DigitalOcean App Platform
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,3 +18,4 @@ jobs:
         uses: digitalocean/app_action/deploy@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          app_name: pfv

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,15 @@
-name: Preview Deployment
+# Preview Deployment — DISABLED
+#
+# DO App Platform requires plaintext secrets when creating new apps, but
+# the deploy action clones encrypted secrets from the production app.
+# To enable previews, store the following as GitHub Actions secrets:
+#   PREVIEW_DATABASE_URL, PREVIEW_REDIS_URL, PREVIEW_JWT_SECRET_KEY,
+#   PREVIEW_MFA_ENCRYPTION_KEY
+# Then uncomment the workflow below and template the secrets into the spec.
+#
+# For now, test feature branches locally or deploy to production after merge.
+
+name: Preview Deployment (disabled)
 
 on:
   pull_request:
@@ -11,66 +22,15 @@ permissions:
 
 jobs:
   preview:
+    if: false  # Disabled — see comment above
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Deploy preview app
-        id: deploy
         uses: digitalocean/app_action/deploy@v2
         with:
           deploy_pr_preview: "true"
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
           app_name: pfv
           project_id: 5c404689-358b-42c5-a8e2-f48a304d8298
-
-      - name: Comment with preview URL
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const app = JSON.parse('${{ steps.deploy.outputs.app }}');
-            const url = app.live_url;
-            const body = [
-              `**Preview deployed** to ${url}`,
-              '',
-              `Commit: \`${context.sha.slice(0, 7)}\``,
-              `This preview will be deleted when the PR is closed.`,
-            ].join('\n');
-
-            // Update existing comment or create new one
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const existing = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('Preview deployed')
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                comment_id: existing.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body,
-              });
-            }
-
-      - name: Comment on failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `**Preview deployment failed.** [View logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`,
-            });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,74 @@
+name: Preview Deployment
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy preview app
+        id: deploy
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          deploy_pr_preview: "true"
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Comment with preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const app = JSON.parse('${{ steps.deploy.outputs.app }}');
+            const url = app.live_url;
+            const body = [
+              `**Preview deployed** to ${url}`,
+              '',
+              `Commit: \`${context.sha.slice(0, 7)}\``,
+              `This preview will be deleted when the PR is closed.`,
+            ].join('\n');
+
+            // Update existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Preview deployed')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**Preview deployment failed.** [View logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`,
+            });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           deploy_pr_preview: "true"
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          app_name: pfv
+          project_id: 5c404689-358b-42c5-a8e2-f48a304d8298
 
       - name: Comment with preview URL
         uses: actions/github-script@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 
 - Docker & Docker Compose
 - Git
+- Node.js 18+ (only for local TypeScript checking — the app runs in containers)
 
 ## Quick Start
 
@@ -73,21 +74,218 @@ SEED_ORG="FJ Consulting" \
 | `./pfv shell [svc]` | Open a shell in a service (default: backend) |
 | `./pfv seed` | Populate with mock data |
 
+---
+
 ## Architecture
 
+### System Diagram
+
 ```
-Browser → nginx (:80) → /api/*  → backend (FastAPI :8000) → MySQL (:3306)
-                      → /*      → frontend (Next.js :3000)
-                                  backend → Redis (:6379)
+Browser --> nginx (:80) --> /api/*  --> backend (FastAPI :8000) --> MySQL (:3306)
+                        --> /*      --> frontend (Next.js :3000)
+                                        backend --> Redis (:6379)
 ```
 
-## Creating Migrations
+In production (DigitalOcean App Platform), nginx is replaced by DO's built-in ingress routing.
+
+### Backend (Python / FastAPI)
+
+```
+backend/app/
+├── main.py                  # App factory, lifespan, CORS, router registration
+├── config.py                # pydantic-settings — all config from env vars
+├── database.py              # Async SQLAlchemy engine + session factory
+├── security.py              # JWT creation/decode, bcrypt, MFA token helpers
+├── deps.py                  # FastAPI dependencies: get_db, get_current_user
+├── logging.py               # structlog JSON logging + health check filter
+├── rate_limit.py            # slowapi rate limiter (shared instance)
+├── models/                  # SQLAlchemy ORM models
+│   ├── user.py              #   User, Organization, Role enum
+│   ├── account.py           #   Account, AccountType
+│   ├── category.py          #   Category (hierarchical), CategoryType
+│   ├── transaction.py       #   Transaction (income/expense/transfer)
+│   ├── recurring.py         #   RecurringTransaction templates
+│   ├── billing.py           #   BillingPeriod (org-scoped)
+│   ├── budget.py            #   Budget (per category per period)
+│   ├── forecast_plan.py     #   ForecastPlan + ForecastPlanItem
+│   └── settings.py          #   OrgSetting (key-value per org)
+├── schemas/                 # Pydantic request/response models (mirrors models/)
+├── routers/                 # API route handlers
+│   ├── auth.py              #   Login, register, MFA, Google SSO, password reset
+│   ├── users.py             #   Profile update, password change
+│   ├── accounts.py          #   CRUD accounts
+│   ├── account_types.py     #   CRUD account types
+│   ├── categories.py        #   CRUD categories (hierarchical)
+│   ├── transactions.py      #   CRUD transactions + transfers
+│   ├── recurring.py         #   CRUD recurring templates + generation
+│   ├── budgets.py           #   CRUD budgets + transfers between budgets
+│   ├── forecast.py          #   Read-only computed forecast
+│   ├── forecast_plans.py    #   CRUD editable forecast plans
+│   ├── import_router.py     #   CSV import: preview + confirm
+│   └── settings.py          #   Org settings, billing periods, billing cycle
+└── services/                # Business logic (called by routers)
+    ├── billing_service.py   #   Period management, resolve_period()
+    ├── budget_service.py    #   Budget queries with spending calculations
+    ├── transaction_service.py # Shared validation helpers
+    ├── recurring_service.py #   Generate transactions from templates
+    ├── forecast_service.py  #   Compute forecast from transactions + recurring
+    ├── forecast_plan_service.py # Forecast plan CRUD with actual tracking
+    ├── import_parser.py     #   CSV parsing (delimiter, date, amount detection)
+    ├── import_service.py    #   Import preview + commit logic
+    ├── email_service.py     #   Mailgun (prod) / structlog (dev) email sender
+    ├── mfa_service.py       #   TOTP, QR codes, recovery codes, encryption
+    └── date_utils.py        #   Shared advance_date() for billing calculations
+```
+
+### Frontend (Next.js / TypeScript)
+
+```
+frontend/
+├── app/                     # Next.js App Router pages
+│   ├── dashboard/           #   Main dashboard with charts + summary
+│   ├── transactions/        #   Transaction list with filters
+│   ├── accounts/            #   Account management
+│   ├── recurring/           #   Recurring transaction templates
+│   ├── budgets/             #   Budget management + transfers
+│   ├── forecast-plans/      #   Editable forecast plans
+│   ├── categories/          #   Category hierarchy management
+│   ├── import/              #   CSV import wizard
+│   ├── profile/             #   User profile editing
+│   ├── settings/security/   #   Password, MFA, session lifetime
+│   ├── admin/settings/      #   Org settings, billing periods
+│   ├── login/               #   Login page
+│   ├── register/            #   Registration page
+│   ├── mfa-verify/          #   MFA challenge during login
+│   ├── forgot-password/     #   Request password reset
+│   ├── reset-password/      #   Complete password reset
+│   ├── verify-email/        #   Email verification
+│   └── auth/google/callback/ # Google SSO callback
+├── components/
+│   ├── AppShell.tsx         #   Sidebar + header + footer layout
+│   ├── auth/AuthProvider.tsx #  Auth context, login/logout/refresh
+│   └── ui/                  #   Shared UI components
+└── lib/
+    ├── api.ts               #   Typed fetch wrapper with silent token refresh
+    ├── types.ts             #   Shared TypeScript interfaces
+    ├── styles.ts            #   Tailwind class constants
+    └── auth.ts              #   isAdmin() helper
+```
+
+### Key Design Decisions
+
+- **All config via env vars** — pydantic-settings in backend, `NEXT_PUBLIC_` prefix in frontend
+- **Stateless backend** — no in-memory state. JWT for auth, ready for horizontal scaling.
+- **Migrations auto-run on startup** in dev. In production, they run before the app starts.
+- **First user is superadmin** — no seed data needed for bootstrapping.
+- **Org-scoped data** — every query filters by `org_id`. Users only see their org's data.
+- **Hierarchical categories** — master categories for budgets, subcategories as transaction tags.
+- **Billing periods** — org-level month close date. `settled_date` determines which period a transaction counts against.
+
+---
+
+## Authentication & Security
+
+### Auth Flow
+
+1. **Login** — `POST /api/v1/auth/login` with username/email + password
+2. **MFA challenge** (if enabled) — returns `mfa_token`, user completes TOTP/recovery/email verification
+3. **Tokens issued** — access token (15 min, in response body) + refresh token (7 day, httpOnly cookie)
+4. **Silent refresh** — frontend auto-refreshes via `POST /api/v1/auth/refresh` on 401
+5. **Absolute session lifetime** — sessions expire after a configurable max duration (default 30 days)
+
+### MFA (Two-Factor Authentication)
+
+- TOTP via authenticator app (Google Authenticator, Authy, 1Password, etc.)
+- 8 single-use recovery codes (HMAC-SHA256 hashed, downloadable)
+- Email fallback with 6-digit code (10-minute expiry)
+- TOTP secrets encrypted at rest via Fernet (`MFA_ENCRYPTION_KEY` env var)
+- Setup/disable via `/settings/security` page
+
+### Rate Limiting
+
+| Endpoint | Limit |
+|----------|-------|
+| `POST /api/v1/auth/login` | 10/minute |
+| `POST /api/v1/auth/forgot-password` | 5/minute |
+| `POST /api/v1/auth/mfa/verify` | 10/minute |
+| `POST /api/v1/auth/mfa/email-code` | 3/minute |
+| `POST /api/v1/auth/mfa/email-verify` | 10/minute |
+
+### Public Endpoints (no auth required)
+
+`/health`, `/ready`, `/api/v1/auth/status`, `/api/v1/auth/login`, `/api/v1/auth/register`, `/api/v1/auth/refresh`, `/api/v1/auth/forgot-password`, `/api/v1/auth/reset-password`, `/api/v1/auth/verify-email`, `/api/v1/auth/google`, `/api/v1/auth/google/callback`, `/api/v1/auth/mfa/verify`, `/api/v1/auth/mfa/recovery`, `/api/v1/auth/mfa/email-code`, `/api/v1/auth/mfa/email-verify`
+
+All other endpoints require a Bearer access token via `get_current_user` dependency.
+
+---
+
+## Environment Variables
+
+### Required (Backend)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DATABASE_URL` | MySQL connection string | `mysql+aiomysql://user:pass@host:3306/db` |
+| `JWT_SECRET_KEY` | HS256 signing key | `openssl rand -hex 32` |
+
+### Optional (Backend)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `APP_ENV` | `development` | `development` or `production` |
+| `APP_NAME` | `PFV2` | App name (used in TOTP issuer, emails) |
+| `LOG_LEVEL` | `INFO` | Python log level |
+| `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | Access token lifetime |
+| `JWT_REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token (idle timeout) |
+| `SESSION_LIFETIME_DAYS` | `30` | Absolute max session duration |
+| `COOKIE_SECURE` | `true` | Set `false` for local dev (HTTP) |
+| `REDIS_URL` | _(empty)_ | Redis/Valkey connection |
+| `MFA_ENCRYPTION_KEY` | _(empty)_ | Fernet key for TOTP secret encryption |
+| `MAILGUN_API_KEY` | _(empty)_ | Mailgun API key (emails logged if empty) |
+| `MAILGUN_DOMAIN` | _(empty)_ | Mailgun sending domain |
+| `EMAIL_FROM` | `PFV2 <noreply@pfv.app>` | From address for emails |
+| `APP_URL` | `http://localhost` | Public URL (used in email links) |
+| `GOOGLE_CLIENT_ID` | _(empty)_ | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | _(empty)_ | Google OAuth client secret |
+| `BACKEND_CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins |
+
+### Frontend
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_API_URL` | _(empty)_ | API base URL (empty = same-origin via nginx) |
+| `HOSTNAME` | `0.0.0.0` | Next.js bind address |
+
+### Generating Keys
 
 ```bash
-docker compose exec backend alembic revision -m "description"
+# JWT secret
+openssl rand -hex 32
+
+# MFA encryption key (Fernet)
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ```
 
-Then edit the generated file in `backend/alembic/versions/`.
+---
+
+## Database Migrations
+
+Migrations auto-run on backend startup in development. In production, they run as part of the container entrypoint before the app starts.
+
+```bash
+# Create a new migration
+docker compose exec backend alembic revision -m "description"
+
+# Run pending migrations manually
+./pfv migrate
+
+# Check current migration state
+docker compose exec backend alembic current
+```
+
+Migration files are in `backend/alembic/versions/` and follow sequential numbering (001, 002, ...).
+
+---
 
 ## Development vs Production
 
@@ -97,10 +295,149 @@ Then edit the generated file in `backend/alembic/versions/`.
 | Backend | uvicorn with `--reload` | uvicorn with 2 workers |
 | Migrations | Auto-run on backend startup | Separate init service (runs first) |
 | Volumes | Source code mounted | Immutable containers |
-| Redis | Included | Included |
+| Emails | Logged to console (structlog) | Sent via Mailgun |
+| Entry point | nginx on port 80 | DO App Platform ingress |
 
-## Branching
+---
 
-- Never push directly to `main` — always branch + PR
+## Branching & Pull Requests
+
+- **Never push directly to `main`** — always branch + PR
 - Feature branches: `feat/<name>`
 - Fix branches: `fix/<name>`
+- Merge to `main` triggers production deployment via GitHub Actions
+
+---
+
+## Deployment
+
+### DigitalOcean App Platform
+
+The app is deployed on DO App Platform (Amsterdam region) with managed MySQL and Valkey (Redis-compatible).
+
+**GitHub Actions workflows (`.github/workflows/`):**
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `deploy.yml` | Push to `main` | Deploys to production via `digitalocean/app_action/deploy@v2` |
+| `preview.yml` | PR opened/updated | Creates ephemeral preview app, posts URL as PR comment |
+| `delete-preview.yml` | PR closed | Cleans up preview app |
+
+**Required GitHub repository secret:**
+
+| Secret | Description |
+|--------|-------------|
+| `DIGITALOCEAN_ACCESS_TOKEN` | DO API token with read/write access to App Platform |
+
+**App spec:** `.do/app.yaml` defines the app structure. Secrets use placeholder values — real secrets are configured in DO console and preserved across deployments.
+
+### Manual Deployment
+
+If you need to deploy without GitHub Actions:
+
+```bash
+# Install doctl
+brew install doctl
+doctl auth init
+
+# Deploy current branch to the app
+doctl apps create-deployment <app-id>
+```
+
+### Infrastructure
+
+| Component | Service | Details |
+|-----------|---------|---------|
+| Backend | DO App Service | FastAPI, basic-xxs, port 8000 |
+| Frontend | DO App Service | Next.js standalone, basic-xxs, port 3000 |
+| Database | DO Managed MySQL 8 | Single node, ams3 |
+| Cache | DO Managed Valkey 8 | Single node, ams3 |
+
+---
+
+## API Documentation
+
+- **Swagger UI:** http://localhost/docs (development)
+- **OpenAPI spec:** http://localhost/openapi.json
+
+All API routes are prefixed with `/api/v1/`. The API is organized by resource:
+
+| Resource | Prefix | Description |
+|----------|--------|-------------|
+| Auth | `/api/v1/auth` | Login, register, MFA, SSO, password reset |
+| Users | `/api/v1/users` | Profile, password change |
+| Accounts | `/api/v1/accounts` | Bank accounts and balances |
+| Account Types | `/api/v1/account-types` | Checking, savings, credit card, etc. |
+| Categories | `/api/v1/categories` | Hierarchical income/expense categories |
+| Transactions | `/api/v1/transactions` | Income, expenses, transfers |
+| Recurring | `/api/v1/recurring` | Recurring transaction templates |
+| Budgets | `/api/v1/budgets` | Per-category per-period budgets |
+| Forecast | `/api/v1/forecast` | Computed forecast (read-only) |
+| Forecast Plans | `/api/v1/forecast-plans` | Editable forecast plans |
+| Import | `/api/v1/import` | CSV file import (preview + confirm) |
+| Settings | `/api/v1/settings` | Org settings, billing periods |
+
+---
+
+## Testing
+
+### TypeScript Type Checking
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+### Backend (manual)
+
+No automated test suite yet. Test via:
+- Swagger UI at http://localhost/docs
+- Browser testing of full flows
+- API calls via `curl` or httpie
+
+Adding pytest infrastructure is on the technical debt backlog.
+
+---
+
+## Troubleshooting
+
+### Backend won't start
+
+```bash
+# Check logs
+./pfv logs backend
+
+# Common issues:
+# - MySQL not ready: wait for health check, try ./pfv restart
+# - Missing env var: check .env against .env.example
+# - Migration error: ./pfv migrate
+```
+
+### Frontend build fails
+
+```bash
+# Check for TypeScript errors
+cd frontend && npx tsc --noEmit
+
+# Rebuild from scratch
+./pfv rebuild
+```
+
+### Database issues
+
+```bash
+# Connect to MySQL
+docker compose exec mysql mysql -upfv2 -ppfv2_secret pfv2
+
+# Reset everything (destroys all data)
+./pfv reset
+```
+
+### MFA locked out
+
+If you lose access to your authenticator and recovery codes:
+
+```bash
+# Disable MFA directly in the database
+docker compose exec mysql mysql -upfv2 -ppfv2_secret pfv2 \
+  -e "UPDATE users SET mfa_enabled=0, totp_secret=NULL, recovery_codes=NULL WHERE username='youruser';"
+```

--- a/backend/alembic/versions/022_add_mfa_fields.py
+++ b/backend/alembic/versions/022_add_mfa_fields.py
@@ -1,0 +1,23 @@
+"""Add MFA fields to users table
+
+Revision ID: 022
+Revises: 021
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "022"
+down_revision = "021"
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("mfa_enabled", sa.Boolean(), nullable=False, server_default="0"))
+    op.add_column("users", sa.Column("totp_secret", sa.String(256), nullable=True))
+    op.add_column("users", sa.Column("recovery_codes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "recovery_codes")
+    op.drop_column("users", "totp_secret")
+    op.drop_column("users", "mfa_enabled")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     jwt_access_token_expire_minutes: int = 15
     jwt_refresh_token_expire_days: int = 7
     jwt_algorithm: str = "HS256"
+    session_lifetime_days: int = 30  # absolute max session duration
 
     # Cookies — True in production (HTTPS), False in dev (HTTP)
     cookie_secure: bool = True

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,9 @@ class Settings(BaseSettings):
     email_from: str = "PFV2 <noreply@pfv.app>"
     app_url: str = "http://localhost"  # used for email links
 
+    # MFA
+    mfa_encryption_key: str = ""  # Fernet key for encrypting TOTP secrets
+
     # Google SSO
     google_client_id: str = ""
     google_client_secret: str = ""

--- a/backend/app/logging.py
+++ b/backend/app/logging.py
@@ -17,26 +17,34 @@ _ACCESS_RE = re.compile(
 _SILENT_PATHS = {"/health", "/ready"}
 
 
-def _parse_uvicorn_access(logger: object, method_name: str, event_dict: dict) -> dict:
-    """Parse uvicorn access log into structured fields.
+class _DropHealthCheck(logging.Filter):
+    """Logging filter that silently drops health check access log records.
 
-    Suppresses health check requests to keep logs readable in production
-    where DO pings /health every 15 seconds.
+    Applied directly to the uvicorn.access logger so the record never
+    reaches the formatter — avoids structlog.DropEvent issues in the
+    ProcessorFormatter chain.
     """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        match = _ACCESS_RE.match(msg)
+        if match and match.group("path") in _SILENT_PATHS:
+            return False
+        return True
+
+
+def _parse_uvicorn_access(logger: object, method_name: str, event_dict: dict) -> dict:
+    """Parse uvicorn access log into structured fields."""
     if event_dict.get("logger") != "uvicorn.access":
         return event_dict
 
     msg = event_dict.get("event", "")
     match = _ACCESS_RE.match(str(msg))
     if match:
-        path = match.group("path")
-        if path in _SILENT_PATHS:
-            raise structlog.DropEvent
-
         event_dict["event"] = "request"
         event_dict["remote_addr"] = match.group("remote")
         event_dict["method"] = match.group("method")
-        event_dict["path"] = path
+        event_dict["path"] = match.group("path")
         event_dict["status"] = int(match.group("status"))
 
     return event_dict
@@ -91,3 +99,6 @@ def setup_logging() -> None:
         uv_logger.handlers.clear()
         uv_logger.addHandler(handler)
         uv_logger.propagate = False
+
+    # Drop health check records before they reach the formatter chain
+    logging.getLogger("uvicorn.access").addFilter(_DropHealthCheck())

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -2,7 +2,7 @@ import enum
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, func
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -53,6 +53,9 @@ class User(Base):
     is_superadmin: Mapped[bool] = mapped_column(default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(default=True, nullable=False)
     password_changed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    mfa_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    totp_secret: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    recovery_codes: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,4 +1,3 @@
-import hashlib
 import re
 import secrets
 from datetime import datetime, timezone
@@ -441,6 +440,9 @@ async def _resolve_mfa_user(mfa_token: str, db: AsyncSession) -> User:
     user = result.scalar_one_or_none()
     if user is None or not user.is_active:
         raise HTTPException(status_code=401, detail="Invalid or expired MFA token")
+    # Reject if MFA was disabled after the challenge token was issued
+    if not user.mfa_enabled:
+        raise HTTPException(status_code=401, detail="MFA is no longer enabled for this account")
     return user
 
 
@@ -474,7 +476,10 @@ async def mfa_setup(
     qr_code = generate_qr_base64(uri)
 
     # Store encrypted secret (not yet enabled)
-    current_user.totp_secret = encrypt_secret(secret)
+    try:
+        current_user.totp_secret = encrypt_secret(secret)
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="MFA is not available — encryption not configured")
     await db.commit()
 
     return MfaSetupResponse(qr_code=qr_code, secret=secret, uri=uri)
@@ -492,7 +497,10 @@ async def mfa_enable(
     if not current_user.totp_secret:
         raise HTTPException(status_code=400, detail="Call /mfa/setup first")
 
-    secret = decrypt_secret(current_user.totp_secret)
+    try:
+        secret = decrypt_secret(current_user.totp_secret)
+    except (ValueError, RuntimeError):
+        raise HTTPException(status_code=503, detail="MFA configuration error — contact support")
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=400, detail="Invalid TOTP code")
 
@@ -557,7 +565,10 @@ async def mfa_verify(
     if not user.totp_secret:
         raise HTTPException(status_code=400, detail="MFA not configured")
 
-    secret = decrypt_secret(user.totp_secret)
+    try:
+        secret = decrypt_secret(user.totp_secret)
+    except (ValueError, RuntimeError):
+        raise HTTPException(status_code=503, detail="MFA configuration error — contact support")
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=401, detail="Invalid TOTP code")
 
@@ -623,9 +634,11 @@ async def mfa_email_verify(
     db: AsyncSession = Depends(get_db),
 ):
     """Verify an email-based MFA code to complete authentication."""
+    import hmac as _hmac
+
     user = await _resolve_mfa_user(body.mfa_token, db)
 
-    # Validate the email_token and extract the code hash
+    # Validate the email_token and extract the code HMAC
     email_payload = decode_token(body.email_token)
     if email_payload is None or email_payload.get("type") != "mfa_email":
         raise HTTPException(status_code=401, detail="Invalid or expired email code")
@@ -634,9 +647,11 @@ async def mfa_email_verify(
     if int(email_payload["sub"]) != user.id:
         raise HTTPException(status_code=401, detail="Invalid or expired email code")
 
-    # Verify the code matches
-    code_hash = hashlib.sha256(body.code.encode()).hexdigest()
-    if code_hash != email_payload.get("code_hash"):
+    # Verify the code matches using HMAC (keyed hash, not brute-forceable)
+    expected_hmac = _hmac.new(
+        app_settings.jwt_secret_key.encode(), body.code.encode(), "sha256"
+    ).hexdigest()
+    if not _hmac.compare_digest(expected_hmac, email_payload.get("code_hmac", "")):
         raise HTTPException(status_code=401, detail="Invalid code")
 
     return _issue_tokens(user, response)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.account import AccountType, SYSTEM_ACCOUNT_TYPES
+from app.models.settings import OrgSetting
 from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
 from app.models.user import Organization, Role, User
 from app.schemas.auth import (
@@ -298,8 +299,41 @@ async def refresh(
             detail="User not found or inactive",
         )
 
+    # Enforce absolute session lifetime
+    session_created_at = payload.get("session_created_at")
+    if session_created_at:
+        session_start = datetime.fromtimestamp(session_created_at, tz=timezone.utc)
+
+        # Check org-level override first, fall back to system default
+        max_days = app_settings.session_lifetime_days
+        org_setting = await db.scalar(
+            select(OrgSetting.value).where(
+                OrgSetting.org_id == user.org_id,
+                OrgSetting.key == "session_lifetime_days",
+            )
+        )
+        if org_setting:
+            try:
+                max_days = int(org_setting)
+            except ValueError:
+                pass
+
+        if datetime.now(timezone.utc) - session_start > timedelta(days=max_days):
+            response.delete_cookie("refresh_token", path="/api/v1/auth/refresh")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Session expired — please sign in again",
+            )
+
+    # Carry forward session_created_at from the original login
+    original_session = (
+        datetime.fromtimestamp(session_created_at, tz=timezone.utc)
+        if session_created_at
+        else None
+    )
+
     access_token = create_access_token(user.id, user.org_id, user.role.value)
-    new_refresh_token = create_refresh_token(user.id)
+    new_refresh_token = create_refresh_token(user.id, session_created_at=original_session)
 
     response.set_cookie(
         key="refresh_token",

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,6 +1,7 @@
 import re
 import secrets
-from datetime import datetime, timezone
+import hmac as _hmac
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import httpx
@@ -669,8 +670,6 @@ async def mfa_email_verify(
     db: AsyncSession = Depends(get_db),
 ):
     """Verify an email-based MFA code to complete authentication."""
-    import hmac as _hmac
-
     user = await _resolve_mfa_user(body.mfa_token, db)
 
     # Validate the email_token and extract the code HMAC
@@ -824,8 +823,16 @@ async def google_callback(
         await db.commit()
         await db.refresh(user)
 
-    # Issue tokens
+    # Issue tokens (or MFA challenge if enabled)
     await db.refresh(user, ["organization"])
+
+    if user.mfa_enabled:
+        mfa_token = create_mfa_challenge_token(user.id)
+        return Response(
+            status_code=302,
+            headers={"Location": f"{app_settings.app_url}/mfa-verify?mfa_token={mfa_token}"},
+        )
+
     access_token = create_access_token(user.id, user.org_id, user.role.value)
     refresh_token = create_refresh_token(user.id)
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -48,6 +48,7 @@ from app.security import (
 from app.rate_limit import limiter
 from app.services.email_service import send_mfa_email_code, send_password_reset_email, send_verification_email
 from app.services.mfa_service import (
+    MfaConfigError,
     decrypt_secret,
     encrypt_secret,
     generate_qr_base64,
@@ -478,7 +479,7 @@ async def mfa_setup(
     # Store encrypted secret (not yet enabled)
     try:
         current_user.totp_secret = encrypt_secret(secret)
-    except RuntimeError:
+    except MfaConfigError:
         raise HTTPException(status_code=503, detail="MFA is not available — encryption not configured")
     await db.commit()
 
@@ -499,7 +500,7 @@ async def mfa_enable(
 
     try:
         secret = decrypt_secret(current_user.totp_secret)
-    except (ValueError, RuntimeError):
+    except (ValueError, MfaConfigError):
         raise HTTPException(status_code=503, detail="MFA configuration error — contact support")
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=400, detail="Invalid TOTP code")
@@ -567,7 +568,7 @@ async def mfa_verify(
 
     try:
         secret = decrypt_secret(user.totp_secret)
-    except (ValueError, RuntimeError):
+    except (ValueError, MfaConfigError):
         raise HTTPException(status_code=503, detail="MFA configuration error — contact support")
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=401, detail="Invalid TOTP code")

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 import secrets
 from datetime import datetime, timezone
@@ -16,6 +17,16 @@ from app.models.user import Organization, Role, User
 from app.schemas.auth import (
     ForgotPasswordRequest,
     LoginRequest,
+    MfaChallengeResponse,
+    MfaDisableRequest,
+    MfaEmailCodeRequest,
+    MfaEmailVerifyRequest,
+    MfaEnableRequest,
+    MfaEnableResponse,
+    MfaRecoveryRequest,
+    MfaRegenerateRequest,
+    MfaSetupResponse,
+    MfaVerifyRequest,
     RegisterRequest,
     ResetPasswordRequest,
     TokenResponse,
@@ -27,6 +38,8 @@ from app.config import settings as app_settings
 from app.security import (
     create_access_token,
     create_email_verification_token,
+    create_mfa_challenge_token,
+    create_mfa_email_token,
     create_password_reset_token,
     create_refresh_token,
     decode_token,
@@ -34,7 +47,18 @@ from app.security import (
     verify_password,
 )
 from app.rate_limit import limiter
-from app.services.email_service import send_password_reset_email, send_verification_email
+from app.services.email_service import send_mfa_email_code, send_password_reset_email, send_verification_email
+from app.services.mfa_service import (
+    decrypt_secret,
+    encrypt_secret,
+    generate_qr_base64,
+    generate_recovery_codes,
+    generate_totp_secret,
+    get_totp_uri,
+    hash_recovery_code,
+    verify_recovery_code,
+    verify_totp,
+)
 
 GOOGLE_OAUTH_TIMEOUT = httpx.Timeout(10.0)
 
@@ -57,6 +81,7 @@ def _user_response(user: User, org: Organization) -> UserResponse:
         billing_cycle_day=org.billing_cycle_day,
         is_superadmin=user.is_superadmin,
         is_active=user.is_active,
+        mfa_enabled=user.mfa_enabled,
     )
 
 
@@ -198,7 +223,7 @@ async def register(
     return _user_response(user, org)
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post("/login")
 @limiter.limit("10/minute")
 async def login(
     request: Request, body: LoginRequest, response: Response, db: AsyncSession = Depends(get_db)
@@ -222,6 +247,11 @@ async def login(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Account is deactivated",
         )
+
+    # If MFA is enabled, return a challenge token instead of access tokens
+    if user.mfa_enabled:
+        mfa_token = create_mfa_challenge_token(user.id)
+        return MfaChallengeResponse(mfa_token=mfa_token)
 
     access_token = create_access_token(user.id, user.org_id, user.role.value)
     refresh_token = create_refresh_token(user.id)
@@ -396,6 +426,220 @@ async def resend_verification(
     token = create_email_verification_token(current_user.id)
     await send_verification_email(current_user.email, token)
     return {"detail": "Verification email sent"}
+
+
+# ── MFA ─────────────────────────────────────────────────────────────────────
+
+
+async def _resolve_mfa_user(mfa_token: str, db: AsyncSession) -> User:
+    """Validate an MFA challenge token and return the associated user."""
+    payload = decode_token(mfa_token)
+    if payload is None or payload.get("type") != "mfa_challenge":
+        raise HTTPException(status_code=401, detail="Invalid or expired MFA token")
+    user_id = int(payload["sub"])
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=401, detail="Invalid or expired MFA token")
+    return user
+
+
+def _issue_tokens(user: User, response: Response) -> TokenResponse:
+    """Issue access + refresh tokens and set the refresh cookie."""
+    access_token = create_access_token(user.id, user.org_id, user.role.value)
+    refresh_token = create_refresh_token(user.id)
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        httponly=True,
+        secure=app_settings.cookie_secure,
+        samesite="lax",
+        max_age=7 * 24 * 60 * 60,
+        path="/api/v1/auth/refresh",
+    )
+    return TokenResponse(access_token=access_token)
+
+
+@router.post("/mfa/setup", response_model=MfaSetupResponse)
+async def mfa_setup(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Start MFA enrollment — generate TOTP secret and QR code."""
+    if current_user.mfa_enabled:
+        raise HTTPException(status_code=400, detail="MFA is already enabled")
+
+    secret = generate_totp_secret()
+    uri = get_totp_uri(secret, current_user.email)
+    qr_code = generate_qr_base64(uri)
+
+    # Store encrypted secret (not yet enabled)
+    current_user.totp_secret = encrypt_secret(secret)
+    await db.commit()
+
+    return MfaSetupResponse(qr_code=qr_code, secret=secret, uri=uri)
+
+
+@router.post("/mfa/enable", response_model=MfaEnableResponse)
+async def mfa_enable(
+    body: MfaEnableRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Confirm MFA setup with a TOTP code, activate MFA, return recovery codes."""
+    if current_user.mfa_enabled:
+        raise HTTPException(status_code=400, detail="MFA is already enabled")
+    if not current_user.totp_secret:
+        raise HTTPException(status_code=400, detail="Call /mfa/setup first")
+
+    secret = decrypt_secret(current_user.totp_secret)
+    if not verify_totp(secret, body.code):
+        raise HTTPException(status_code=400, detail="Invalid TOTP code")
+
+    codes = generate_recovery_codes()
+    current_user.mfa_enabled = True
+    current_user.recovery_codes = ",".join(hash_recovery_code(c) for c in codes)
+    await db.commit()
+
+    return MfaEnableResponse(recovery_codes=codes)
+
+
+@router.post("/mfa/disable")
+async def mfa_disable(
+    body: MfaDisableRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Disable MFA. Requires password confirmation."""
+    if not current_user.mfa_enabled:
+        raise HTTPException(status_code=400, detail="MFA is not enabled")
+    if not verify_password(body.password, current_user.password_hash):
+        raise HTTPException(status_code=403, detail="Invalid password")
+
+    current_user.mfa_enabled = False
+    current_user.totp_secret = None
+    current_user.recovery_codes = None
+    await db.commit()
+
+    return {"detail": "MFA disabled"}
+
+
+@router.post("/mfa/recovery-codes", response_model=MfaEnableResponse)
+async def mfa_regenerate_codes(
+    body: MfaRegenerateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Regenerate recovery codes. Requires password confirmation."""
+    if not current_user.mfa_enabled:
+        raise HTTPException(status_code=400, detail="MFA is not enabled")
+    if not verify_password(body.password, current_user.password_hash):
+        raise HTTPException(status_code=403, detail="Invalid password")
+
+    codes = generate_recovery_codes()
+    current_user.recovery_codes = ",".join(hash_recovery_code(c) for c in codes)
+    await db.commit()
+
+    return MfaEnableResponse(recovery_codes=codes)
+
+
+@router.post("/mfa/verify", response_model=TokenResponse)
+@limiter.limit("10/minute")
+async def mfa_verify(
+    request: Request,
+    body: MfaVerifyRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
+    """Verify TOTP code during login to complete authentication."""
+    user = await _resolve_mfa_user(body.mfa_token, db)
+
+    if not user.totp_secret:
+        raise HTTPException(status_code=400, detail="MFA not configured")
+
+    secret = decrypt_secret(user.totp_secret)
+    if not verify_totp(secret, body.code):
+        raise HTTPException(status_code=401, detail="Invalid TOTP code")
+
+    return _issue_tokens(user, response)
+
+
+@router.post("/mfa/recovery", response_model=TokenResponse)
+@limiter.limit("10/minute")
+async def mfa_recovery(
+    request: Request,
+    body: MfaRecoveryRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
+    """Use a recovery code during login to complete authentication."""
+    user = await _resolve_mfa_user(body.mfa_token, db)
+
+    if not user.recovery_codes:
+        raise HTTPException(status_code=400, detail="No recovery codes available")
+
+    hashed_codes = user.recovery_codes.split(",")
+    idx = verify_recovery_code(body.code, hashed_codes)
+    if idx is None:
+        raise HTTPException(status_code=401, detail="Invalid recovery code")
+
+    # Remove the used code
+    hashed_codes.pop(idx)
+    user.recovery_codes = ",".join(hashed_codes) if hashed_codes else None
+    await db.commit()
+
+    return _issue_tokens(user, response)
+
+
+@router.post("/mfa/email-code")
+@limiter.limit("3/minute")
+async def mfa_email_code(
+    request: Request,
+    body: MfaEmailCodeRequest,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+):
+    """Send a one-time code to the user's email as MFA fallback."""
+    user = await _resolve_mfa_user(body.mfa_token, db)
+
+    # Generate 6-digit numeric code
+    code = f"{secrets.randbelow(1000000):06d}"
+
+    # Store as a JWT so we don't need DB state
+    email_token = create_mfa_email_token(user.id, code)
+
+    background_tasks.add_task(send_mfa_email_code, user.email, code)
+
+    # Return the email token — frontend stores it to verify later
+    return {"detail": "Code sent", "email_token": email_token}
+
+
+@router.post("/mfa/email-verify", response_model=TokenResponse)
+@limiter.limit("10/minute")
+async def mfa_email_verify(
+    request: Request,
+    body: MfaEmailVerifyRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
+    """Verify an email-based MFA code to complete authentication."""
+    user = await _resolve_mfa_user(body.mfa_token, db)
+
+    # Validate the email_token and extract the code hash
+    email_payload = decode_token(body.email_token)
+    if email_payload is None or email_payload.get("type") != "mfa_email":
+        raise HTTPException(status_code=401, detail="Invalid or expired email code")
+
+    # Ensure the email token belongs to the same user
+    if int(email_payload["sub"]) != user.id:
+        raise HTTPException(status_code=401, detail="Invalid or expired email code")
+
+    # Verify the code matches
+    code_hash = hashlib.sha256(body.code.encode()).hexdigest()
+    if code_hash != email_payload.get("code_hash"):
+        raise HTTPException(status_code=401, detail="Invalid code")
+
+    return _issue_tokens(user, response)
 
 
 # ── Google SSO ───────────────────────────────────────────────────────────────

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -28,6 +28,7 @@ def _user_response(user: User) -> UserResponse:
         billing_cycle_day=user.organization.billing_cycle_day,
         is_superadmin=user.is_superadmin,
         is_active=user.is_active,
+        mfa_enabled=user.mfa_enabled,
     )
 
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -91,7 +91,7 @@ class MfaVerifyRequest(BaseModel):
 
 class MfaRecoveryRequest(BaseModel):
     mfa_token: str = Field(max_length=2048)
-    code: str = Field(max_length=20)
+    code: str = Field(min_length=1, max_length=20)
 
 
 class MfaEmailCodeRequest(BaseModel):

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -20,6 +20,11 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
+class MfaChallengeResponse(BaseModel):
+    mfa_required: bool = True
+    mfa_token: str
+
+
 class UserResponse(BaseModel):
     id: int
     username: str
@@ -35,6 +40,7 @@ class UserResponse(BaseModel):
     billing_cycle_day: int = 1
     is_superadmin: bool
     is_active: bool
+    mfa_enabled: bool = False
 
     model_config = {"from_attributes": True}
 
@@ -55,3 +61,48 @@ class ResetPasswordRequest(BaseModel):
 
 class VerifyEmailRequest(BaseModel):
     token: str
+
+
+# ── MFA ─────────────────────────────────────────────────────────────────────
+
+
+class MfaSetupResponse(BaseModel):
+    qr_code: str  # base64 PNG
+    secret: str  # for manual entry
+    uri: str  # otpauth:// URI
+
+
+class MfaEnableRequest(BaseModel):
+    code: str = Field(min_length=6, max_length=6)
+
+
+class MfaEnableResponse(BaseModel):
+    recovery_codes: list[str]
+
+
+class MfaDisableRequest(BaseModel):
+    password: str = Field(max_length=128)
+
+
+class MfaVerifyRequest(BaseModel):
+    mfa_token: str = Field(max_length=2048)
+    code: str = Field(min_length=6, max_length=6)
+
+
+class MfaRecoveryRequest(BaseModel):
+    mfa_token: str = Field(max_length=2048)
+    code: str = Field(max_length=20)
+
+
+class MfaEmailCodeRequest(BaseModel):
+    mfa_token: str = Field(max_length=2048)
+
+
+class MfaEmailVerifyRequest(BaseModel):
+    mfa_token: str = Field(max_length=2048)
+    email_token: str = Field(max_length=2048)
+    code: str = Field(min_length=6, max_length=6)
+
+
+class MfaRegenerateRequest(BaseModel):
+    password: str = Field(max_length=128)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -53,6 +53,30 @@ def create_password_reset_token(user_id: int) -> str:
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
 
 
+def create_mfa_challenge_token(user_id: int) -> str:
+    """Create a short-lived token for MFA challenge (5 minutes)."""
+    expire = datetime.now(timezone.utc) + timedelta(minutes=5)
+    payload = {
+        "sub": str(user_id),
+        "type": "mfa_challenge",
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def create_mfa_email_token(user_id: int, code: str) -> str:
+    """Create a short-lived token containing an MFA email code (10 minutes)."""
+    expire = datetime.now(timezone.utc) + timedelta(minutes=10)
+    code_hash = __import__("hashlib").sha256(code.encode()).hexdigest()
+    payload = {
+        "sub": str(user_id),
+        "type": "mfa_email",
+        "code_hash": code_hash,
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
 def create_email_verification_token(user_id: int) -> str:
     """Create a token for email verification (24 hours)."""
     expire = datetime.now(timezone.utc) + timedelta(hours=24)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -65,13 +65,20 @@ def create_mfa_challenge_token(user_id: int) -> str:
 
 
 def create_mfa_email_token(user_id: int, code: str) -> str:
-    """Create a short-lived token containing an MFA email code (10 minutes)."""
+    """Create a short-lived token containing an MFA email code (10 minutes).
+
+    Uses HMAC-SHA256 keyed with jwt_secret_key so the code hash cannot be
+    brute-forced offline even though JWT payloads are readable.
+    """
+    import hmac as _hmac
     expire = datetime.now(timezone.utc) + timedelta(minutes=10)
-    code_hash = __import__("hashlib").sha256(code.encode()).hexdigest()
+    code_hmac = _hmac.new(
+        settings.jwt_secret_key.encode(), code.encode(), "sha256"
+    ).hexdigest()
     payload = {
         "sub": str(user_id),
         "type": "mfa_email",
-        "code_hash": code_hash,
+        "code_hmac": code_hmac,
         "exp": expire,
     }
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,3 +1,4 @@
+import hmac as _hmac
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
@@ -79,7 +80,6 @@ def create_mfa_email_token(user_id: int, code: str) -> str:
     Uses HMAC-SHA256 keyed with jwt_secret_key so the code hash cannot be
     brute-forced offline even though JWT payloads are readable.
     """
-    import hmac as _hmac
     expire = datetime.now(timezone.utc) + timedelta(minutes=10)
     code_hmac = _hmac.new(
         settings.jwt_secret_key.encode(), code.encode(), "sha256"

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -28,13 +28,22 @@ def create_access_token(subject: int, org_id: int, role: str) -> str:
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
 
 
-def create_refresh_token(subject: int) -> str:
-    expire = datetime.now(timezone.utc) + timedelta(
-        days=settings.jwt_refresh_token_expire_days
-    )
+def create_refresh_token(
+    subject: int,
+    session_created_at: datetime | None = None,
+) -> str:
+    """Create a refresh token.
+
+    session_created_at tracks when the original login happened. It is set
+    on first login and carried forward on every refresh so the backend can
+    enforce an absolute session lifetime regardless of activity.
+    """
+    now = datetime.now(timezone.utc)
+    expire = now + timedelta(days=settings.jwt_refresh_token_expire_days)
     payload = {
         "sub": str(subject),
         "type": "refresh",
+        "session_created_at": (session_created_at or now).timestamp(),
         "exp": expire,
     }
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -68,6 +68,19 @@ async def send_password_reset_email(to: str, token: str) -> bool:
     return await send_email(to, subject, body_html, body_text)
 
 
+async def send_mfa_email_code(to: str, code: str) -> bool:
+    """Send a one-time MFA verification code via email."""
+    subject = "PFV2 — Your Login Verification Code"
+    body_html = f"""
+    <h2>Your Verification Code</h2>
+    <p>Use this code to complete your sign-in:</p>
+    <p style="font-size:32px;font-weight:bold;letter-spacing:8px;color:#c8a951;font-family:monospace;">{code}</p>
+    <p>This code expires in 10 minutes. If you didn't try to sign in, you can ignore this email.</p>
+    """
+    body_text = f"Your PFV2 verification code: {code}\n\nThis code expires in 10 minutes."
+    return await send_email(to, subject, body_html, body_text)
+
+
 async def send_verification_email(to: str, token: str) -> bool:
     """Send an email verification link."""
     verify_url = f"{settings.app_url}/verify-email?token={token}"

--- a/backend/app/services/mfa_service.py
+++ b/backend/app/services/mfa_service.py
@@ -1,0 +1,96 @@
+"""MFA service — TOTP setup, verification, recovery codes, and encryption."""
+
+import hashlib
+import io
+import secrets
+from base64 import b64encode
+
+import pyotp
+import qrcode
+import qrcode.constants
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.config import settings
+
+
+# ── Encryption ──────────────────────────────────────────────────────────────
+
+
+def _get_fernet() -> Fernet:
+    key = settings.mfa_encryption_key
+    if not key:
+        raise RuntimeError("MFA_ENCRYPTION_KEY is not configured")
+    return Fernet(key.encode())
+
+
+def encrypt_secret(plain: str) -> str:
+    return _get_fernet().encrypt(plain.encode()).decode()
+
+
+def decrypt_secret(cipher: str) -> str:
+    try:
+        return _get_fernet().decrypt(cipher.encode()).decode()
+    except InvalidToken:
+        raise ValueError("Failed to decrypt TOTP secret")
+
+
+# ── TOTP ────────────────────────────────────────────────────────────────────
+
+
+def generate_totp_secret() -> str:
+    return pyotp.random_base32()
+
+
+def get_totp_uri(secret: str, email: str) -> str:
+    return pyotp.totp.TOTP(secret).provisioning_uri(
+        name=email, issuer_name=settings.app_name
+    )
+
+
+def verify_totp(secret: str, code: str) -> bool:
+    """Verify a TOTP code with +/- 1 window for clock drift."""
+    totp = pyotp.TOTP(secret)
+    return totp.verify(code, valid_window=1)
+
+
+def generate_qr_base64(uri: str) -> str:
+    """Generate a QR code PNG as a base64-encoded string."""
+    qr = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=8,
+        border=4,
+    )
+    qr.add_data(uri)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return b64encode(buf.getvalue()).decode()
+
+
+# ── Recovery Codes ──────────────────────────────────────────────────────────
+
+
+def generate_recovery_codes(count: int = 8) -> list[str]:
+    """Generate high-entropy recovery codes (xxxx-xxxx format)."""
+    codes = []
+    for _ in range(count):
+        raw = secrets.token_hex(4)  # 8 hex chars
+        codes.append(f"{raw[:4]}-{raw[4:]}")
+    return codes
+
+
+def hash_recovery_code(code: str) -> str:
+    """SHA-256 hash a recovery code for storage."""
+    normalized = code.strip().lower().replace("-", "")
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def verify_recovery_code(code: str, hashed_codes: list[str]) -> int | None:
+    """Check if a code matches any stored hash. Returns index if found."""
+    h = hash_recovery_code(code)
+    for i, stored in enumerate(hashed_codes):
+        if h == stored:
+            return i
+    return None

--- a/backend/app/services/mfa_service.py
+++ b/backend/app/services/mfa_service.py
@@ -1,6 +1,6 @@
 """MFA service — TOTP setup, verification, recovery codes, and encryption."""
 
-import hashlib
+import hmac
 import io
 import secrets
 from base64 import b64encode
@@ -73,24 +73,30 @@ def generate_qr_base64(uri: str) -> str:
 
 
 def generate_recovery_codes(count: int = 8) -> list[str]:
-    """Generate high-entropy recovery codes (xxxx-xxxx format)."""
+    """Generate high-entropy recovery codes (xxxx-xxxx-xxxx-xxxx format, 64-bit)."""
     codes = []
     for _ in range(count):
-        raw = secrets.token_hex(4)  # 8 hex chars
-        codes.append(f"{raw[:4]}-{raw[4:]}")
+        raw = secrets.token_hex(8)  # 16 hex chars = 64 bits
+        codes.append(f"{raw[:4]}-{raw[4:8]}-{raw[8:12]}-{raw[12:]}")
     return codes
 
 
+def _hmac_key() -> bytes:
+    """Return the HMAC key for recovery code hashing (derived from JWT secret)."""
+    return settings.jwt_secret_key.encode()
+
+
 def hash_recovery_code(code: str) -> str:
-    """SHA-256 hash a recovery code for storage."""
+    """HMAC-SHA256 a recovery code for storage (keyed, not brute-forceable)."""
     normalized = code.strip().lower().replace("-", "")
-    return hashlib.sha256(normalized.encode()).hexdigest()
+    return hmac.new(_hmac_key(), normalized.encode(), "sha256").hexdigest()
 
 
 def verify_recovery_code(code: str, hashed_codes: list[str]) -> int | None:
-    """Check if a code matches any stored hash. Returns index if found."""
-    h = hash_recovery_code(code)
+    """Check if a code matches any stored HMAC. Constant-time, no early exit."""
+    candidate = hash_recovery_code(code)
+    match_idx: int | None = None
     for i, stored in enumerate(hashed_codes):
-        if h == stored:
-            return i
-    return None
+        if hmac.compare_digest(candidate, stored):
+            match_idx = i
+    return match_idx

--- a/backend/app/services/mfa_service.py
+++ b/backend/app/services/mfa_service.py
@@ -16,11 +16,18 @@ from app.config import settings
 # ── Encryption ──────────────────────────────────────────────────────────────
 
 
+class MfaConfigError(RuntimeError):
+    """Raised when MFA encryption is misconfigured or unavailable."""
+
+
 def _get_fernet() -> Fernet:
     key = settings.mfa_encryption_key
     if not key:
-        raise RuntimeError("MFA_ENCRYPTION_KEY is not configured")
-    return Fernet(key.encode())
+        raise MfaConfigError("MFA_ENCRYPTION_KEY is not configured")
+    try:
+        return Fernet(key.encode())
+    except (ValueError, Exception) as exc:
+        raise MfaConfigError(f"MFA_ENCRYPTION_KEY is malformed: {exc}") from exc
 
 
 def encrypt_secret(plain: str) -> str:

--- a/backend/app/services/mfa_service.py
+++ b/backend/app/services/mfa_service.py
@@ -26,7 +26,7 @@ def _get_fernet() -> Fernet:
         raise MfaConfigError("MFA_ENCRYPTION_KEY is not configured")
     try:
         return Fernet(key.encode())
-    except (ValueError, Exception) as exc:
+    except (ValueError, TypeError) as exc:
         raise MfaConfigError(f"MFA_ENCRYPTION_KEY is malformed: {exc}") from exc
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ structlog==25.1.0
 python-dateutil==2.9.0
 httpx==0.28.1
 slowapi==0.1.9
+pyotp==2.9.0
+qrcode[pil]==8.0
+cryptography==44.0.3

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAuth } from "@/components/auth/AuthProvider";
+import { useAuth, MfaRequiredError } from "@/components/auth/AuthProvider";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import { apiFetch } from "@/lib/api";
 import { input, label, btnPrimary, btnSecondary, error as errorCls } from "@/lib/styles";
@@ -29,6 +29,11 @@ export default function LoginPage() {
       await login(loginId, password);
       router.push("/dashboard");
     } catch (err) {
+      if (err instanceof MfaRequiredError) {
+        sessionStorage.setItem("mfa_token", err.mfaToken);
+        router.push("/mfa-verify");
+        return;
+      }
       setError(err instanceof Error ? err.message : "Login failed");
     } finally {
       setSubmitting(false);

--- a/frontend/app/mfa-verify/page.tsx
+++ b/frontend/app/mfa-verify/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormEvent, useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiFetch, setAccessToken } from "@/lib/api";
 import { useAuth } from "@/components/auth/AuthProvider";
 import ThemeToggle from "@/components/ui/ThemeToggle";
@@ -21,8 +21,12 @@ export default function MfaVerifyPage() {
   const [emailToken, setEmailToken] = useState<string | null>(null);
   const [emailSending, setEmailSending] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const searchParams = useSearchParams();
 
-  const mfaToken = typeof window !== "undefined" ? sessionStorage.getItem("mfa_token") : null;
+  // Support mfa_token from sessionStorage (password login) or query param (Google SSO redirect)
+  const mfaToken = typeof window !== "undefined"
+    ? (sessionStorage.getItem("mfa_token") || searchParams.get("mfa_token"))
+    : null;
 
   useEffect(() => {
     if (!loading && user) { router.replace("/dashboard"); return; }
@@ -39,8 +43,7 @@ export default function MfaVerifyPage() {
   async function completeLogin(data: TokenResponse) {
     setAccessToken(data.access_token);
     sessionStorage.removeItem("mfa_token");
-    router.push("/dashboard");
-    // Force a full page load so AuthProvider picks up the new token
+    // Full page load so AuthProvider picks up the new token via refresh
     window.location.href = "/dashboard";
   }
 

--- a/frontend/app/mfa-verify/page.tsx
+++ b/frontend/app/mfa-verify/page.tsx
@@ -160,7 +160,7 @@ export default function MfaVerifyPage() {
                 value={code}
                 onChange={(e) => setCode(e.target.value)}
                 className={`${input} text-center tracking-wider`}
-                placeholder="xxxx-xxxx"
+                placeholder="xxxx-xxxx-xxxx-xxxx"
               />
             </div>
             <button type="submit" disabled={submitting || !code.trim()} className={`w-full ${btnPrimary}`}>

--- a/frontend/app/mfa-verify/page.tsx
+++ b/frontend/app/mfa-verify/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiFetch, setAccessToken } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import { input, label, btnPrimary, error as errorCls, success as successCls } from "@/lib/styles";
+import type { TokenResponse } from "@/lib/types";
+
+type Mode = "totp" | "recovery" | "email";
+
+export default function MfaVerifyPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [mode, setMode] = useState<Mode>("totp");
+  const [code, setCode] = useState("");
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [emailToken, setEmailToken] = useState<string | null>(null);
+  const [emailSending, setEmailSending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const mfaToken = typeof window !== "undefined" ? sessionStorage.getItem("mfa_token") : null;
+
+  useEffect(() => {
+    if (!loading && user) { router.replace("/dashboard"); return; }
+    if (!mfaToken) { router.replace("/login"); }
+  }, [loading, user, mfaToken, router]);
+
+  useEffect(() => {
+    setCode("");
+    setError("");
+    setMessage("");
+    inputRef.current?.focus();
+  }, [mode]);
+
+  async function completeLogin(data: TokenResponse) {
+    setAccessToken(data.access_token);
+    sessionStorage.removeItem("mfa_token");
+    router.push("/dashboard");
+    // Force a full page load so AuthProvider picks up the new token
+    window.location.href = "/dashboard";
+  }
+
+  async function handleTotpSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!mfaToken) return;
+    setError(""); setSubmitting(true);
+    try {
+      const data = await apiFetch<TokenResponse>("/api/v1/auth/mfa/verify", {
+        method: "POST",
+        body: JSON.stringify({ mfa_token: mfaToken, code }),
+      });
+      await completeLogin(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Verification failed");
+    } finally { setSubmitting(false); }
+  }
+
+  async function handleRecoverySubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!mfaToken) return;
+    setError(""); setSubmitting(true);
+    try {
+      const data = await apiFetch<TokenResponse>("/api/v1/auth/mfa/recovery", {
+        method: "POST",
+        body: JSON.stringify({ mfa_token: mfaToken, code }),
+      });
+      await completeLogin(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid recovery code");
+    } finally { setSubmitting(false); }
+  }
+
+  async function handleSendEmail() {
+    if (!mfaToken) return;
+    setEmailSending(true); setError(""); setMessage("");
+    try {
+      const data = await apiFetch<{ detail: string; email_token: string }>("/api/v1/auth/mfa/email-code", {
+        method: "POST",
+        body: JSON.stringify({ mfa_token: mfaToken }),
+      });
+      setEmailToken(data.email_token);
+      setMode("email");
+      setMessage("Code sent to your email");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send code");
+    } finally { setEmailSending(false); }
+  }
+
+  async function handleEmailSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!mfaToken || !emailToken) return;
+    setError(""); setSubmitting(true);
+    try {
+      const data = await apiFetch<TokenResponse>("/api/v1/auth/mfa/email-verify", {
+        method: "POST",
+        body: JSON.stringify({ mfa_token: mfaToken, email_token: emailToken, code }),
+      });
+      await completeLogin(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid code");
+    } finally { setSubmitting(false); }
+  }
+
+  if (!mfaToken) return null;
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center px-4">
+      <ThemeToggle className="absolute right-6 top-6" />
+
+      <div className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <h1 className="font-display text-2xl font-semibold text-text-primary">Two-Factor Authentication</h1>
+          <p className="mt-1.5 text-sm text-text-muted">
+            {mode === "totp" && "Enter the code from your authenticator app"}
+            {mode === "recovery" && "Enter one of your recovery codes"}
+            {mode === "email" && "Enter the code sent to your email"}
+          </p>
+        </div>
+
+        {error && <div className={`mb-4 ${errorCls}`}>{error}</div>}
+        {message && <div className={`mb-4 ${successCls}`}>{message}</div>}
+
+        {mode === "totp" && (
+          <form onSubmit={handleTotpSubmit} className="space-y-5">
+            <div>
+              <label htmlFor="totp-code" className={label}>Verification Code</label>
+              <input
+                ref={inputRef}
+                id="totp-code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                required
+                maxLength={6}
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                className={`${input} text-center text-lg tracking-[0.3em]`}
+                placeholder="000000"
+              />
+            </div>
+            <button type="submit" disabled={submitting || code.length !== 6} className={`w-full ${btnPrimary}`}>
+              {submitting ? "Verifying..." : "Verify"}
+            </button>
+          </form>
+        )}
+
+        {mode === "recovery" && (
+          <form onSubmit={handleRecoverySubmit} className="space-y-5">
+            <div>
+              <label htmlFor="recovery-code" className={label}>Recovery Code</label>
+              <input
+                ref={inputRef}
+                id="recovery-code"
+                type="text"
+                required
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                className={`${input} text-center tracking-wider`}
+                placeholder="xxxx-xxxx"
+              />
+            </div>
+            <button type="submit" disabled={submitting || !code.trim()} className={`w-full ${btnPrimary}`}>
+              {submitting ? "Verifying..." : "Verify"}
+            </button>
+          </form>
+        )}
+
+        {mode === "email" && (
+          <form onSubmit={handleEmailSubmit} className="space-y-5">
+            <div>
+              <label htmlFor="email-code" className={label}>Email Code</label>
+              <input
+                ref={inputRef}
+                id="email-code"
+                type="text"
+                inputMode="numeric"
+                required
+                maxLength={6}
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                className={`${input} text-center text-lg tracking-[0.3em]`}
+                placeholder="000000"
+              />
+            </div>
+            <button type="submit" disabled={submitting || code.length !== 6} className={`w-full ${btnPrimary}`}>
+              {submitting ? "Verifying..." : "Verify"}
+            </button>
+          </form>
+        )}
+
+        <div className="mt-6 space-y-2 text-center text-sm">
+          {mode !== "totp" && (
+            <button onClick={() => setMode("totp")} className="block w-full text-accent hover:text-accent-hover">
+              Use authenticator app
+            </button>
+          )}
+          {mode !== "recovery" && (
+            <button onClick={() => setMode("recovery")} className="block w-full text-text-muted hover:text-accent">
+              Use a recovery code
+            </button>
+          )}
+          {mode !== "email" && (
+            <button onClick={handleSendEmail} disabled={emailSending} className="block w-full text-text-muted hover:text-accent">
+              {emailSending ? "Sending..." : "Send a code to my email"}
+            </button>
+          )}
+          <button onClick={() => { sessionStorage.removeItem("mfa_token"); router.push("/login"); }} className="block w-full text-xs text-text-muted hover:text-text-primary mt-4">
+            Back to login
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
+import Link from "next/link";
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -8,7 +9,7 @@ import { input, label, btnPrimary, card, cardTitle, error as errorCls, success a
 import type { User } from "@/lib/types";
 
 export default function ProfilePage() {
-  const { user, login, refreshMe } = useAuth();
+  const { user, refreshMe } = useAuth();
 
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -30,13 +31,6 @@ export default function ProfilePage() {
   const [profileErr, setProfileErr] = useState("");
   const [savingProfile, setSavingProfile] = useState(false);
 
-  const [currentPassword, setCurrentPassword] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [pwdMsg, setPwdMsg] = useState("");
-  const [pwdErr, setPwdErr] = useState("");
-  const [savingPwd, setSavingPwd] = useState(false);
-
   async function handleProfileSubmit(e: FormEvent) {
     e.preventDefault();
     setProfileMsg(""); setProfileErr(""); setSavingProfile(true);
@@ -55,24 +49,6 @@ export default function ProfilePage() {
       setProfileMsg("Profile updated");
     } catch (err) { setProfileErr(extractErrorMessage(err)); }
     finally { setSavingProfile(false); }
-  }
-
-  async function handlePasswordSubmit(e: FormEvent) {
-    e.preventDefault();
-    setPwdMsg(""); setPwdErr("");
-    if (newPassword !== confirmPassword) { setPwdErr("New passwords do not match"); return; }
-    setSavingPwd(true);
-    try {
-      await apiFetch("/api/v1/users/me/password", {
-        method: "POST",
-        body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
-      });
-      setPwdMsg("Password changed. Signing in with new credentials...");
-      await login(user!.username, newPassword);
-      setCurrentPassword(""); setNewPassword(""); setConfirmPassword("");
-      setPwdMsg("Password changed successfully");
-    } catch (err) { setPwdErr(extractErrorMessage(err)); }
-    finally { setSavingPwd(false); }
   }
 
   const displayName = [user?.first_name, user?.last_name].filter(Boolean).join(" ") || user?.username || "";
@@ -135,26 +111,11 @@ export default function ProfilePage() {
         </div>
 
         <div className={`${card} p-6`}>
-          <h2 className={`mb-5 ${cardTitle}`}>Change Password</h2>
-          <form onSubmit={handlePasswordSubmit} className="space-y-4">
-            {pwdMsg && <div className={successCls}>{pwdMsg}</div>}
-            {pwdErr && <div className={errorCls}>{pwdErr}</div>}
-            <div>
-              <label htmlFor="pwd-current" className={label}>Current Password</label>
-              <input id="pwd-current" type="password" required value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className={input} autoComplete="current-password" />
-            </div>
-            <div>
-              <label htmlFor="pwd-new" className={label}>New Password</label>
-              <input id="pwd-new" type="password" required minLength={8} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className={input} autoComplete="new-password" />
-            </div>
-            <div>
-              <label htmlFor="pwd-confirm" className={label}>Confirm New Password</label>
-              <input id="pwd-confirm" type="password" required value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className={input} autoComplete="new-password" />
-            </div>
-            <button type="submit" disabled={savingPwd} className={btnPrimary}>
-              {savingPwd ? "Changing..." : "Change Password"}
-            </button>
-          </form>
+          <h2 className={`mb-3 ${cardTitle}`}>Security</h2>
+          <p className="mb-3 text-sm text-text-muted">Manage your password, two-factor authentication, and recovery codes.</p>
+          <Link href="/settings/security" className="text-sm font-medium text-accent hover:text-accent-hover">
+            Manage security settings &rarr;
+          </Link>
         </div>
       </div>
     </AppShell>

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  input,
+  label,
+  btnPrimary,
+  btnSecondary,
+  btnDanger,
+  card,
+  cardTitle,
+  error as errorCls,
+  success as successCls,
+  pageTitle,
+} from "@/lib/styles";
+import type { MfaSetupResponse, MfaEnableResponse } from "@/lib/types";
+
+type MfaStep = "idle" | "qr" | "verify" | "codes";
+
+export default function SecurityPage() {
+  const { user, login, refreshMe } = useAuth();
+
+  // ── Change Password ──────────────────────────────────────────────────────
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [pwdMsg, setPwdMsg] = useState("");
+  const [pwdErr, setPwdErr] = useState("");
+  const [savingPwd, setSavingPwd] = useState(false);
+
+  async function handlePasswordSubmit(e: FormEvent) {
+    e.preventDefault();
+    setPwdMsg(""); setPwdErr("");
+    if (newPassword !== confirmPassword) { setPwdErr("New passwords do not match"); return; }
+    setSavingPwd(true);
+    try {
+      await apiFetch("/api/v1/users/me/password", {
+        method: "POST",
+        body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+      });
+      setPwdMsg("Password changed. Signing in with new credentials...");
+      await login(user!.username, newPassword);
+      setCurrentPassword(""); setNewPassword(""); setConfirmPassword("");
+      setPwdMsg("Password changed successfully");
+    } catch (err) { setPwdErr(extractErrorMessage(err)); }
+    finally { setSavingPwd(false); }
+  }
+
+  // ── MFA Setup ────────────────────────────────────────────────────────────
+  const [mfaStep, setMfaStep] = useState<MfaStep>("idle");
+  const [setupData, setSetupData] = useState<MfaSetupResponse | null>(null);
+  const [totpCode, setTotpCode] = useState("");
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [codesSaved, setCodesSaved] = useState(false);
+  const [mfaMsg, setMfaMsg] = useState("");
+  const [mfaErr, setMfaErr] = useState("");
+  const [mfaLoading, setMfaLoading] = useState(false);
+
+  // ── MFA Disable ──────────────────────────────────────────────────────────
+  const [disablePassword, setDisablePassword] = useState("");
+  const [disableErr, setDisableErr] = useState("");
+  const [disabling, setDisabling] = useState(false);
+  const [showDisable, setShowDisable] = useState(false);
+
+  // ── Regenerate Codes ─────────────────────────────────────────────────────
+  const [regenPassword, setRegenPassword] = useState("");
+  const [regenErr, setRegenErr] = useState("");
+  const [regenerating, setRegenerating] = useState(false);
+  const [showRegen, setShowRegen] = useState(false);
+  const [regenCodes, setRegenCodes] = useState<string[]>([]);
+
+  async function handleSetup() {
+    setMfaErr(""); setMfaLoading(true);
+    try {
+      const data = await apiFetch<MfaSetupResponse>("/api/v1/auth/mfa/setup", {
+        method: "POST",
+      });
+      setSetupData(data);
+      setMfaStep("qr");
+    } catch (err) { setMfaErr(extractErrorMessage(err)); }
+    finally { setMfaLoading(false); }
+  }
+
+  async function handleVerifyCode(e: FormEvent) {
+    e.preventDefault();
+    setMfaErr(""); setMfaLoading(true);
+    try {
+      const data = await apiFetch<MfaEnableResponse>("/api/v1/auth/mfa/enable", {
+        method: "POST",
+        body: JSON.stringify({ code: totpCode }),
+      });
+      setRecoveryCodes(data.recovery_codes);
+      setMfaStep("codes");
+    } catch (err) { setMfaErr(extractErrorMessage(err)); }
+    finally { setMfaLoading(false); }
+  }
+
+  function handleFinishSetup() {
+    setMfaStep("idle");
+    setSetupData(null);
+    setTotpCode("");
+    setRecoveryCodes([]);
+    setCodesSaved(false);
+    setMfaMsg("Two-factor authentication enabled");
+    refreshMe();
+  }
+
+  function downloadCodes(codes: string[]) {
+    const text = "PFV2 Recovery Codes\n" +
+      "===================\n\n" +
+      "Store these codes in a safe place.\n" +
+      "Each code can only be used once.\n\n" +
+      codes.map((c, i) => `${i + 1}. ${c}`).join("\n") + "\n";
+    const blob = new Blob([text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "pfv2-recovery-codes.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function handleDisable(e: FormEvent) {
+    e.preventDefault();
+    setDisableErr(""); setDisabling(true);
+    try {
+      await apiFetch("/api/v1/auth/mfa/disable", {
+        method: "POST",
+        body: JSON.stringify({ password: disablePassword }),
+      });
+      setShowDisable(false);
+      setDisablePassword("");
+      setMfaMsg("Two-factor authentication disabled");
+      refreshMe();
+    } catch (err) { setDisableErr(extractErrorMessage(err)); }
+    finally { setDisabling(false); }
+  }
+
+  async function handleRegenerate(e: FormEvent) {
+    e.preventDefault();
+    setRegenErr(""); setRegenerating(true);
+    try {
+      const data = await apiFetch<MfaEnableResponse>("/api/v1/auth/mfa/recovery-codes", {
+        method: "POST",
+        body: JSON.stringify({ password: regenPassword }),
+      });
+      setRegenCodes(data.recovery_codes);
+      setRegenPassword("");
+    } catch (err) { setRegenErr(extractErrorMessage(err)); }
+    finally { setRegenerating(false); }
+  }
+
+  const mfaEnabled = user?.mfa_enabled ?? false;
+
+  return (
+    <AppShell>
+      <h1 className={pageTitle}>Security</h1>
+
+      <div className="max-w-lg space-y-6">
+        {/* ── Change Password ──────────────────────────────────────────── */}
+        <div className={`${card} p-6`}>
+          <h2 className={`mb-5 ${cardTitle}`}>Change Password</h2>
+          <form onSubmit={handlePasswordSubmit} className="space-y-4">
+            {pwdMsg && <div className={successCls}>{pwdMsg}</div>}
+            {pwdErr && <div className={errorCls}>{pwdErr}</div>}
+            <div>
+              <label htmlFor="pwd-current" className={label}>Current Password</label>
+              <input id="pwd-current" type="password" required value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className={input} autoComplete="current-password" />
+            </div>
+            <div>
+              <label htmlFor="pwd-new" className={label}>New Password</label>
+              <input id="pwd-new" type="password" required minLength={8} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className={input} autoComplete="new-password" />
+            </div>
+            <div>
+              <label htmlFor="pwd-confirm" className={label}>Confirm New Password</label>
+              <input id="pwd-confirm" type="password" required value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className={input} autoComplete="new-password" />
+            </div>
+            <button type="submit" disabled={savingPwd} className={btnPrimary}>
+              {savingPwd ? "Changing..." : "Change Password"}
+            </button>
+          </form>
+        </div>
+
+        {/* ── Two-Factor Authentication ────────────────────────────────── */}
+        <div className={`${card} p-6`}>
+          <h2 className={`mb-5 ${cardTitle}`}>Two-Factor Authentication</h2>
+
+          {mfaMsg && <div className={`mb-4 ${successCls}`}>{mfaMsg}</div>}
+          {mfaErr && <div className={`mb-4 ${errorCls}`}>{mfaErr}</div>}
+
+          {/* ── Idle: Not enabled ─────────────────────────────────── */}
+          {!mfaEnabled && mfaStep === "idle" && (
+            <div>
+              <p className="mb-4 text-sm text-text-muted">
+                Add an extra layer of security to your account by requiring a verification code when you sign in.
+              </p>
+              <button onClick={handleSetup} disabled={mfaLoading} className={btnPrimary}>
+                {mfaLoading ? "Setting up..." : "Set Up Two-Factor Authentication"}
+              </button>
+            </div>
+          )}
+
+          {/* ── Step 1: QR Code ───────────────────────────────────── */}
+          {mfaStep === "qr" && setupData && (
+            <div className="space-y-4">
+              <p className="text-sm text-text-muted">
+                Scan this QR code with your authenticator app (Google Authenticator, Authy, 1Password, etc.)
+              </p>
+              <div className="flex justify-center rounded-lg bg-white p-4">
+                <img
+                  src={`data:image/png;base64,${setupData.qr_code}`}
+                  alt="TOTP QR Code"
+                  className="h-48 w-48"
+                />
+              </div>
+              <details className="text-sm">
+                <summary className="cursor-pointer text-text-muted hover:text-text-primary">
+                  Can&apos;t scan? Enter this key manually
+                </summary>
+                <code className="mt-2 block rounded bg-surface-raised px-3 py-2 text-xs text-text-primary break-all select-all">
+                  {setupData.secret}
+                </code>
+              </details>
+              <div className="flex gap-3">
+                <button onClick={() => { setMfaStep("idle"); setSetupData(null); }} className={btnSecondary}>
+                  Cancel
+                </button>
+                <button onClick={() => setMfaStep("verify")} className={btnPrimary}>
+                  Continue
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* ── Step 2: Verify code ───────────────────────────────── */}
+          {mfaStep === "verify" && (
+            <form onSubmit={handleVerifyCode} className="space-y-4">
+              <p className="text-sm text-text-muted">
+                Enter the 6-digit code from your authenticator app to confirm it&apos;s working.
+              </p>
+              <div>
+                <label htmlFor="mfa-setup-code" className={label}>Verification Code</label>
+                <input
+                  id="mfa-setup-code"
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  required
+                  maxLength={6}
+                  value={totpCode}
+                  onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, ""))}
+                  className={`${input} text-center text-lg tracking-[0.3em]`}
+                  placeholder="000000"
+                  autoFocus
+                />
+              </div>
+              <div className="flex gap-3">
+                <button type="button" onClick={() => setMfaStep("qr")} className={btnSecondary}>
+                  Back
+                </button>
+                <button type="submit" disabled={mfaLoading || totpCode.length !== 6} className={btnPrimary}>
+                  {mfaLoading ? "Verifying..." : "Verify & Enable"}
+                </button>
+              </div>
+            </form>
+          )}
+
+          {/* ── Step 3: Recovery codes ────────────────────────────── */}
+          {mfaStep === "codes" && recoveryCodes.length > 0 && (
+            <div className="space-y-4">
+              <p className="text-sm text-text-primary font-medium">
+                Save your recovery codes
+              </p>
+              <p className="text-sm text-text-muted">
+                If you lose access to your authenticator app, you can use these codes to sign in. Each code can only be used once.
+              </p>
+              <div className="grid grid-cols-2 gap-2 rounded-lg bg-surface-raised p-4">
+                {recoveryCodes.map((code, i) => (
+                  <code key={i} className="text-sm text-text-primary font-mono">
+                    {i + 1}. {code}
+                  </code>
+                ))}
+              </div>
+              <button onClick={() => downloadCodes(recoveryCodes)} className={`w-full ${btnSecondary}`}>
+                Download Codes
+              </button>
+              <label className="flex items-center gap-2 text-sm text-text-muted">
+                <input type="checkbox" checked={codesSaved} onChange={(e) => setCodesSaved(e.target.checked)} className="rounded border-border" />
+                I&apos;ve saved these recovery codes
+              </label>
+              <button onClick={handleFinishSetup} disabled={!codesSaved} className={`w-full ${btnPrimary}`}>
+                Done
+              </button>
+            </div>
+          )}
+
+          {/* ── Enabled state ─────────────────────────────────────── */}
+          {mfaEnabled && mfaStep === "idle" && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <div className="h-2 w-2 rounded-full bg-success" />
+                <span className="text-sm font-medium text-text-primary">Enabled</span>
+              </div>
+              <p className="text-sm text-text-muted">
+                Your account is protected with two-factor authentication via an authenticator app.
+              </p>
+
+              {/* Regenerate recovery codes */}
+              {!showRegen && regenCodes.length === 0 && (
+                <button onClick={() => setShowRegen(true)} className={btnSecondary}>
+                  Regenerate Recovery Codes
+                </button>
+              )}
+              {showRegen && regenCodes.length === 0 && (
+                <form onSubmit={handleRegenerate} className="space-y-3 rounded-lg border border-border p-4">
+                  <p className="text-xs text-text-muted">This will invalidate your existing recovery codes.</p>
+                  {regenErr && <div className={errorCls}>{regenErr}</div>}
+                  <div>
+                    <label htmlFor="regen-pwd" className={label}>Confirm Password</label>
+                    <input id="regen-pwd" type="password" required value={regenPassword} onChange={(e) => setRegenPassword(e.target.value)} className={input} />
+                  </div>
+                  <div className="flex gap-2">
+                    <button type="button" onClick={() => { setShowRegen(false); setRegenPassword(""); }} className={btnSecondary}>Cancel</button>
+                    <button type="submit" disabled={regenerating} className={btnPrimary}>
+                      {regenerating ? "Generating..." : "Regenerate"}
+                    </button>
+                  </div>
+                </form>
+              )}
+              {regenCodes.length > 0 && (
+                <div className="space-y-3">
+                  <p className="text-sm font-medium text-text-primary">New Recovery Codes</p>
+                  <div className="grid grid-cols-2 gap-2 rounded-lg bg-surface-raised p-4">
+                    {regenCodes.map((code, i) => (
+                      <code key={i} className="text-sm text-text-primary font-mono">
+                        {i + 1}. {code}
+                      </code>
+                    ))}
+                  </div>
+                  <button onClick={() => downloadCodes(regenCodes)} className={`w-full ${btnSecondary}`}>
+                    Download Codes
+                  </button>
+                  <button onClick={() => { setRegenCodes([]); setShowRegen(false); }} className={`w-full ${btnPrimary}`}>
+                    Done
+                  </button>
+                </div>
+              )}
+
+              {/* Disable MFA */}
+              <div className="border-t border-border pt-4">
+                {!showDisable ? (
+                  <button onClick={() => setShowDisable(true)} className={btnDanger}>
+                    Disable Two-Factor Authentication
+                  </button>
+                ) : (
+                  <form onSubmit={handleDisable} className="space-y-3">
+                    <p className="text-xs text-text-muted">Enter your password to disable two-factor authentication.</p>
+                    {disableErr && <div className={errorCls}>{disableErr}</div>}
+                    <div>
+                      <label htmlFor="disable-pwd" className={label}>Password</label>
+                      <input id="disable-pwd" type="password" required value={disablePassword} onChange={(e) => setDisablePassword(e.target.value)} className={input} />
+                    </div>
+                    <div className="flex gap-2">
+                      <button type="button" onClick={() => { setShowDisable(false); setDisablePassword(""); }} className={btnSecondary}>Cancel</button>
+                      <button type="submit" disabled={disabling} className={`${btnPrimary} !bg-danger hover:!bg-danger/80`}>
+                        {disabling ? "Disabling..." : "Disable MFA"}
+                      </button>
+                    </div>
+                  </form>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* ── Email Fallback Info ──────────────────────────────────────── */}
+        {mfaEnabled && mfaStep === "idle" && (
+          <div className={`${card} p-6`}>
+            <h2 className={`mb-3 ${cardTitle}`}>Email Fallback</h2>
+            <p className="text-sm text-text-muted">
+              If you can&apos;t access your authenticator app or recovery codes, a verification code can be sent to <span className="font-medium text-text-primary">{user?.email}</span>.
+            </p>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { isAdmin } from "@/lib/auth";
 import {
   input,
   label,
@@ -71,6 +72,40 @@ export default function SecurityPage() {
   const [regenerating, setRegenerating] = useState(false);
   const [showRegen, setShowRegen] = useState(false);
   const [regenCodes, setRegenCodes] = useState<string[]>([]);
+
+  // ── Session Lifetime ──────────────────────────────────────────────────
+  const [sessionDays, setSessionDays] = useState("30");
+  const [sessionMsg, setSessionMsg] = useState("");
+  const [sessionErr, setSessionErr] = useState("");
+  const [savingSession, setSavingSession] = useState(false);
+  const admin = user ? isAdmin(user) : false;
+
+  useEffect(() => {
+    if (!admin) return;
+    apiFetch<{ key: string; value: string }[]>("/api/v1/settings")
+      .then((settings) => {
+        const s = settings.find((s) => s.key === "session_lifetime_days");
+        if (s) setSessionDays(s.value);
+      })
+      .catch(() => {});
+  }, [admin]);
+
+  async function handleSessionSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSessionMsg(""); setSessionErr(""); setSavingSession(true);
+    const days = parseInt(sessionDays, 10);
+    if (isNaN(days) || days < 1 || days > 365) {
+      setSessionErr("Must be between 1 and 365 days"); setSavingSession(false); return;
+    }
+    try {
+      await apiFetch("/api/v1/settings", {
+        method: "PUT",
+        body: JSON.stringify({ key: "session_lifetime_days", value: String(days) }),
+      });
+      setSessionMsg("Session lifetime updated");
+    } catch (err) { setSessionErr(extractErrorMessage(err)); }
+    finally { setSavingSession(false); }
+  }
 
   async function handleSetup() {
     setMfaErr(""); setMfaLoading(true);
@@ -383,6 +418,36 @@ export default function SecurityPage() {
             <p className="text-sm text-text-muted">
               If you can&apos;t access your authenticator app or recovery codes, a verification code can be sent to <span className="font-medium text-text-primary">{user?.email}</span>.
             </p>
+          </div>
+        )}
+
+        {/* ── Session Lifetime (admin only) ────────────────────────────── */}
+        {admin && (
+          <div className={`${card} p-6`}>
+            <h2 className={`mb-5 ${cardTitle}`}>Session Lifetime</h2>
+            <p className="mb-4 text-sm text-text-muted">
+              Maximum number of days a user can stay signed in before being required to re-authenticate. Applies to all users in your organization.
+            </p>
+            <form onSubmit={handleSessionSubmit} className="space-y-4">
+              {sessionMsg && <div className={successCls}>{sessionMsg}</div>}
+              {sessionErr && <div className={errorCls}>{sessionErr}</div>}
+              <div>
+                <label htmlFor="session-days" className={label}>Maximum Session Duration (days)</label>
+                <input
+                  id="session-days"
+                  type="number"
+                  min={1}
+                  max={365}
+                  required
+                  value={sessionDays}
+                  onChange={(e) => setSessionDays(e.target.value)}
+                  className={`${input} max-w-[200px]`}
+                />
+              </div>
+              <button type="submit" disabled={savingSession} className={btnPrimary}>
+                {savingSession ? "Saving..." : "Save"}
+              </button>
+            </form>
           </div>
         )}
       </div>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -205,6 +205,15 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 </svg>
                 Profile
               </Link>
+              <Link
+                href="/settings/security"
+                className="flex items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+                </svg>
+                Security
+              </Link>
               <div className="my-1 border-t border-sidebar-border" />
               <button
                 onClick={logout}

--- a/frontend/components/auth/AuthProvider.tsx
+++ b/frontend/components/auth/AuthProvider.tsx
@@ -8,7 +8,14 @@ import {
   useState,
 } from "react";
 import { apiFetch, setAccessToken } from "@/lib/api";
-import type { User, TokenResponse } from "@/lib/types";
+import type { User, TokenResponse, MfaChallengeResponse } from "@/lib/types";
+
+export class MfaRequiredError extends Error {
+  constructor(public mfaToken: string) {
+    super("MFA required");
+    this.name = "MfaRequiredError";
+  }
+}
 
 interface AuthContextValue {
   user: User | null;
@@ -73,11 +80,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [fetchMe]);
 
   const login = async (loginId: string, password: string) => {
-    const data = await apiFetch<TokenResponse>("/api/v1/auth/login", {
+    const data = await apiFetch<TokenResponse | MfaChallengeResponse>("/api/v1/auth/login", {
       method: "POST",
       body: JSON.stringify({ login: loginId, password }),
     });
-    setAccessToken(data.access_token);
+
+    // MFA challenge — throw so the login page can redirect
+    if ("mfa_required" in data && data.mfa_required) {
+      throw new MfaRequiredError((data as MfaChallengeResponse).mfa_token);
+    }
+
+    const tokenData = data as TokenResponse;
+    setAccessToken(tokenData.access_token);
     await fetchMe();
     setNeedsSetup(false);
   };

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -13,11 +13,27 @@ export interface User {
   billing_cycle_day: number;
   is_superadmin: boolean;
   is_active: boolean;
+  mfa_enabled: boolean;
 }
 
 export interface TokenResponse {
   access_token: string;
   token_type: string;
+}
+
+export interface MfaChallengeResponse {
+  mfa_required: boolean;
+  mfa_token: string;
+}
+
+export interface MfaSetupResponse {
+  qr_code: string;
+  secret: string;
+  uri: string;
+}
+
+export interface MfaEnableResponse {
+  recovery_codes: string[];
 }
 
 export interface ApiError {


### PR DESCRIPTION
## Summary
- TOTP-based two-factor authentication with QR code setup and manual key entry
- Dedicated `/settings/security` page (password management moved from profile, MFA setup/disable, recovery codes)
- Two-step login flow: password auth -> MFA challenge page with TOTP, recovery code, and email fallback options
- 8 single-use recovery codes (SHA-256 hashed), downloadable as `.txt`
- Email fallback: 6-digit code with 10-minute expiry for users who lose their authenticator
- TOTP secrets encrypted at rest via Fernet (`MFA_ENCRYPTION_KEY` env var)
- Rate limiting on MFA verify (10/min) and email code requests (3/min)
- Migration 022: `mfa_enabled`, `totp_secret`, `recovery_codes` columns on users table