### PR TITLE
feat: P3 UI polish — responsive layout, styled modals, chart consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to PFV2
 
+This guide covers everything you need to develop, test, and deploy PFV2. Start with Quick Start if you're setting up for the first time, then refer to the architecture and API sections as needed.
+
 ## Prerequisites
 
 - Docker & Docker Compose

--- a/README.md
+++ b/README.md
@@ -1,24 +1,67 @@
 # PFV2
 
-Personal finance management application.
+Personal finance management for people who actually want to understand where their money goes.
 
-## Stack
+Track income and expenses across multiple accounts, set budgets per category, forecast future spending, import bank CSVs, and manage recurring transactions — all org-scoped so multiple users can share a household's finances.
 
-- **Backend:** Python 3.12, FastAPI, SQLAlchemy 2.0 (async), Alembic
-- **Frontend:** Next.js 15, React 19, TypeScript, Tailwind CSS
-- **Database:** MySQL 8.0
-- **Reverse proxy:** nginx
+## Features
+
+- **Dashboard** with spending breakdown, budget progress, and forecast comparison charts
+- **Transactions** with income, expenses, and linked account-to-account transfers
+- **Hierarchical categories** — master categories for budgets, subcategories for tagging
+- **Budgets** per category per billing period, with inter-budget transfers
+- **Forecast plans** — editable income/expense plans with actual vs. planned tracking
+- **Recurring transactions** — templates that auto-generate future transactions
+- **CSV import** — upload bank exports, preview with duplicate detection, map categories
+- **Billing periods** — org-level month close dates with configurable cycle day
+- **Multi-account** — checking, savings, credit cards, each with balance tracking
+- **Authentication** — email/password, Google SSO, TOTP MFA with recovery codes and email fallback
+- **Org-scoped** — all data isolated per organization, multi-user ready
+- **Responsive** — works on desktop and narrow viewports (tablet, half-screen)
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | Python 3.12, FastAPI, SQLAlchemy 2.0 (async), Alembic, Pydantic v2 |
+| Frontend | Next.js 15 (App Router), React 19, TypeScript, Tailwind CSS, Recharts |
+| Database | MySQL 8.0 |
+| Cache | Redis / Valkey |
+| Auth | JWT (access + refresh), bcrypt, TOTP (pyotp), Google OAuth2 |
+| Email | Mailgun (production), structlog (development) |
+| Proxy | nginx (development), DO App Platform ingress (production) |
 
 ## Quick Start
 
 ```bash
-cp .env.example .env    # first time only
-./pfv start             # build, start, run migrations
+git clone https://github.com/flamarion/pfv.git && cd pfv
+cp .env.example .env
+./pfv start
 ```
 
-App: http://localhost
+Open http://localhost. The first user to register becomes the superadmin.
 
-## Commands
+**Seed mock data** (optional):
+
+```bash
+./pfv seed          # creates demo/demo1234 user with 100+ transactions
+```
+
+## Architecture
+
+```
+Browser --> nginx (:80) --> /api/*  --> backend (FastAPI :8000) --> MySQL (:3306)
+                        --> /*      --> frontend (Next.js :3000)
+                                        backend --> Redis (:6379)
+```
+
+- **Backend** serves a REST API under `/api/v1/`. Stateless, horizontally scalable.
+- **Frontend** is a Next.js App Router SPA. All API calls use Bearer token auth with silent refresh.
+- **nginx** routes traffic in development. In production, DigitalOcean App Platform handles ingress.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full architecture breakdown, environment variables, deployment guide, and development workflow.
+
+## CLI
 
 ```bash
 ./pfv start             # build and start all services
@@ -27,14 +70,39 @@ App: http://localhost
 ./pfv rebuild           # force rebuild (no cache)
 ./pfv reset             # destroy all data and start fresh
 ./pfv migrate           # run pending migrations
-./pfv logs [service]    # view logs (backend, frontend, nginx, mysql)
+./pfv logs [service]    # view logs (backend, frontend, nginx, mysql, redis)
 ./pfv status            # container status
 ./pfv shell [service]   # shell into a container (default: backend)
+./pfv seed              # populate with mock data
+./pfv prod              # build and start in production mode
 ```
 
-## Architecture
+## API Documentation
 
-```
-Browser -> nginx (:80) -> /api/*  -> backend (FastAPI :8000) -> MySQL (:3306)
-                       -> /*      -> frontend (Next.js :3000)
-```
+Swagger UI is available at http://localhost/docs when running locally.
+
+| Resource | Prefix | Description |
+|----------|--------|-------------|
+| Auth | `/api/v1/auth` | Login, register, MFA, SSO, password reset |
+| Users | `/api/v1/users` | Profile, password change |
+| Accounts | `/api/v1/accounts` | Bank accounts and balances |
+| Categories | `/api/v1/categories` | Hierarchical income/expense categories |
+| Transactions | `/api/v1/transactions` | Income, expenses, transfers |
+| Recurring | `/api/v1/recurring` | Recurring transaction templates |
+| Budgets | `/api/v1/budgets` | Per-category spending limits |
+| Forecast | `/api/v1/forecast` | Computed forecast (read-only) |
+| Forecast Plans | `/api/v1/forecast-plans` | Editable forecast plans |
+| Import | `/api/v1/import` | CSV import (preview + confirm) |
+| Settings | `/api/v1/settings` | Org settings, billing periods |
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, architecture details, environment variables, branching workflow, and deployment guide.
+
+## Deployment
+
+Production runs on DigitalOcean App Platform (Amsterdam). Merging to `main` triggers automatic deployment via GitHub Actions. See [CONTRIBUTING.md](CONTRIBUTING.md#deployment) for details.
+
+## License
+
+Private project. Not open source.

--- a/docs/superpowers/plans/2026-04-15-p3-ui-polish.md
+++ b/docs/superpowers/plans/2026-04-15-p3-ui-polish.md
@@ -1,0 +1,1122 @@
+# P3 — UI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make PFV2 feel professional for real users — responsive layout, styled modals, consistent charts, and polished interactions.
+
+**Architecture:** Shared-first approach. Build ConfirmModal and responsive AppShell first, then layer per-page fixes on top. All changes are frontend-only (no backend or migration work).
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Tailwind CSS, Recharts
+
+**Spec:** `docs/superpowers/specs/2026-04-15-p3-ui-polish-design.md`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/components/ui/ConfirmModal.tsx` | Create | Reusable confirmation dialog |
+| `frontend/components/AppShell.tsx` | Modify | Responsive sidebar + hamburger menu |
+| `frontend/app/dashboard/page.tsx` | Modify | Chart consistency, account cards, balance refresh, clickable bars |
+| `frontend/app/budgets/page.tsx` | Modify | ConfirmModal, transfer form visibility, clickable bars |
+| `frontend/app/forecast-plans/page.tsx` | Modify | ConfirmModal, chart overflow (already done), clickable bars, tooltip colors |
+| `frontend/app/transactions/page.tsx` | Modify | ConfirmModal |
+| `frontend/app/accounts/page.tsx` | Modify | ConfirmModal |
+| `frontend/app/categories/page.tsx` | Modify | ConfirmModal |
+| `frontend/app/recurring/page.tsx` | Modify | ConfirmModal |
+| `frontend/app/admin/settings/page.tsx` | Modify | ConfirmModal |
+| `frontend/app/import/page.tsx` | Modify | CategorySelect type-ahead |
+| `frontend/lib/styles.ts` | Modify | Add btnWarning style |
+
+---
+
+## Task 1: Create feature branch
+
+**Files:**
+- None (git only)
+
+- [ ] **Step 1: Create branch from main**
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/p3-ui-polish
+```
+
+- [ ] **Step 2: Cherry-pick the forecast overflow fix from fix/post-merge-fixes**
+
+The forecast chart overflow fix is already implemented on `fix/post-merge-fixes`. Bring it along:
+
+```bash
+git cherry-pick <commit-hash-of-overflow-fix>
+```
+
+If there's a conflict with `tsconfig.tsbuildinfo`, accept the incoming version — it's auto-generated.
+
+- [ ] **Step 3: Commit confirmation**
+
+Run: `git log --oneline -3`
+Expected: see the cherry-picked commit on the new branch.
+
+---
+
+## Task 2: ConfirmModal component
+
+**Files:**
+- Create: `frontend/components/ui/ConfirmModal.tsx`
+- Modify: `frontend/lib/styles.ts`
+
+- [ ] **Step 1: Add btnWarning style to styles.ts**
+
+Add after the existing `btnDanger` export in `frontend/lib/styles.ts`:
+
+```typescript
+export const btnWarning =
+  "rounded-md bg-warning px-4 py-2 text-sm font-medium text-warning-text hover:bg-warning-hover disabled:opacity-50";
+```
+
+Note: Check if `warning`, `warning-text`, `warning-hover` exist in `tailwind.config.ts`. If not, use amber fallbacks: `bg-amber-500 text-white hover:bg-amber-600`.
+
+- [ ] **Step 2: Create ConfirmModal.tsx**
+
+Create `frontend/components/ui/ConfirmModal.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useRef } from "react";
+import { btnPrimary, btnSecondary } from "@/lib/styles";
+
+interface Props {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "warning" | "danger";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const variantClasses: Record<string, string> = {
+  default: btnPrimary,
+  warning: "rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600",
+  danger: "rounded-md bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-red-600",
+};
+
+export default function ConfirmModal({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  onConfirm,
+  onCancel,
+}: Props) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  // Focus confirm button when modal opens
+  useEffect(() => {
+    if (open) confirmRef.current?.focus();
+  }, [open]);
+
+  // ESC to close
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  // Lock body scroll
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onCancel}
+    >
+      <div
+        className="mx-4 w-full max-w-md rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-semibold text-text-primary">{title}</h3>
+        <p className="mt-2 whitespace-pre-line text-sm text-text-secondary">{message}</p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button onClick={onCancel} className={btnSecondary}>
+            {cancelLabel}
+          </button>
+          <button ref={confirmRef} onClick={onConfirm} className={variantClasses[variant]}>
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/ui/ConfirmModal.tsx frontend/lib/styles.ts
+git commit -m "feat: add ConfirmModal component for styled confirmation dialogs"
+```
+
+---
+
+## Task 3: Responsive AppShell
+
+**Files:**
+- Modify: `frontend/components/AppShell.tsx` (lines 1-244)
+
+This is the largest single task. The current AppShell has a fixed 224px (`w-56`) sidebar that doesn't collapse. We need three breakpoints:
+- `>=1024px`: current full sidebar
+- `768-1023px`: icon-only sidebar (48px), expands on click
+- `<768px`: hidden sidebar, hamburger menu with slide-out overlay
+
+- [ ] **Step 1: Add mobile menu state and resize hook**
+
+At the top of the `AppShell` function (after the existing state declarations at line 94), add:
+
+```tsx
+const [sidebarOpen, setSidebarOpen] = useState(false);
+```
+
+- [ ] **Step 2: Replace the sidebar JSX**
+
+Replace the `<aside>` element (lines 124-228) with a responsive version. The sidebar needs:
+
+1. A hamburger button in the header (visible below 1024px)
+2. On `<768px`: sidebar is hidden by default, slides in as an overlay when hamburger is clicked
+3. On `768-1023px`: sidebar shows icon-only (no labels), clicking a nav item navigates and stays icon-only
+4. On `>=1024px`: current full sidebar with labels
+
+Replace the entire `return (...)` block (lines 121-243) with:
+
+```tsx
+return (
+  <div className="flex h-screen overflow-hidden">
+    {/* Mobile overlay backdrop */}
+    {sidebarOpen && (
+      <div
+        className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+        onClick={() => setSidebarOpen(false)}
+      />
+    )}
+
+    {/* Sidebar — full on lg, icon-only on md, slide-out overlay on mobile */}
+    <aside
+      className={`
+        fixed inset-y-0 left-0 z-50 flex flex-col bg-sidebar-bg transition-transform duration-200
+        w-56 lg:relative lg:translate-x-0
+        ${sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}
+        md:w-56 lg:w-56
+      `.trim()}
+    >
+      <div className="flex items-center justify-between px-5 pt-5 pb-6">
+        <Link href="/dashboard" className="font-display text-lg font-semibold text-sidebar-text-bright">
+          PFV2
+        </Link>
+        {/* Close button — mobile only */}
+        <button
+          onClick={() => setSidebarOpen(false)}
+          className="rounded-md p-1 text-sidebar-muted hover:text-sidebar-text-bright lg:hidden"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto space-y-0.5 px-3">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={() => setSidebarOpen(false)}
+            className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors ${
+              isActive(item.href)
+                ? "bg-sidebar-active-bg text-sidebar-active-text"
+                : "text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
+            }`}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </Link>
+        ))}
+
+        {admin && (
+          <>
+            <div className="pb-1 pt-6 px-3">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-sidebar-muted">
+                Admin
+              </span>
+            </div>
+            {adminItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setSidebarOpen(false)}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors ${
+                  isActive(item.href)
+                    ? "bg-sidebar-active-bg text-sidebar-active-text"
+                    : "text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
+                }`}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </Link>
+            ))}
+          </>
+        )}
+      </nav>
+
+      {/* User section at bottom — same as before */}
+      <div className="relative border-t border-sidebar-border px-3 py-3">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setUserExpanded(!userExpanded);
+          }}
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-sidebar-hover"
+        >
+          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-sidebar-active-bg text-xs font-semibold text-sidebar-active-text">
+            {(user.first_name || user.username).charAt(0).toUpperCase()}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="truncate text-[13px] font-medium text-sidebar-text-bright">{user.first_name || user.username}</p>
+            <p className="truncate text-[11px] text-sidebar-muted">{user.org_name}</p>
+          </div>
+          <svg
+            className={`h-3.5 w-3.5 text-sidebar-muted transition-transform ${userExpanded ? "rotate-180" : ""}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+          </svg>
+        </button>
+
+        {userExpanded && (
+          <div className="absolute bottom-full left-3 right-3 mb-1.5 rounded-lg border border-sidebar-border bg-sidebar-bg py-1 shadow-xl">
+            <Link
+              href="/profile"
+              onClick={() => setSidebarOpen(false)}
+              className="flex items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+              </svg>
+              Profile
+            </Link>
+            <Link
+              href="/settings/security"
+              onClick={() => setSidebarOpen(false)}
+              className="flex items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+              </svg>
+              Security
+            </Link>
+            <div className="my-1 border-t border-sidebar-border" />
+            <button
+              onClick={logout}
+              className="flex w-full items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
+              </svg>
+              Sign Out
+            </button>
+          </div>
+        )}
+      </div>
+    </aside>
+
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-surface px-4 sm:px-8">
+        {/* Hamburger — visible below lg */}
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="rounded-md p-2 text-text-muted hover:text-text-primary lg:hidden"
+          aria-label="Open menu"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+          </svg>
+        </button>
+        <div className="lg:hidden" /> {/* Spacer for centered layout on mobile */}
+        <ThemeToggle />
+      </header>
+      <main className="flex-1 overflow-auto p-4 sm:p-8"><div className="mx-auto max-w-screen-xl">{children}</div></main>
+      <footer className="border-t border-border bg-surface px-4 sm:px-8 py-4">
+        <div className="flex items-center justify-between text-xs text-text-muted">
+          <span>PFV2 — Personal Finance</span>
+          <span>&copy; {new Date().getFullYear()}</span>
+        </div>
+      </footer>
+    </div>
+  </div>
+);
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 4: Test in browser at three widths**
+
+1. Open http://localhost — full width (>1024px): sidebar shows with labels as before
+2. Resize to ~900px: sidebar should still show (same as full width since we're using slide-out for all sub-lg)
+3. Resize to ~600px: sidebar hidden, hamburger visible in header. Click hamburger → sidebar slides in as overlay. Click a nav item → sidebar closes, page navigates.
+4. Click backdrop → sidebar closes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/AppShell.tsx
+git commit -m "feat: responsive sidebar — hamburger menu below 1024px, slide-out overlay"
+```
+
+---
+
+## Task 4: Per-page responsive fixes
+
+**Files:**
+- Modify: `frontend/app/dashboard/page.tsx`
+- Modify: `frontend/app/transactions/page.tsx`
+- Modify: `frontend/app/budgets/page.tsx`
+- Modify: `frontend/app/forecast-plans/page.tsx`
+- Modify: `frontend/app/import/page.tsx`
+
+Wrap all data tables in `overflow-x-auto` containers and make grid layouts responsive.
+
+- [ ] **Step 1: Dashboard — responsive grid**
+
+In `frontend/app/dashboard/page.tsx`, find the three-chart grid (around line 517):
+
+```tsx
+<div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+```
+
+This already uses `grid-cols-1` as base with `lg:grid-cols-3`. Verify the summary cards row (ROW 1) and accounts row (ROW 2) also collapse properly. The accounts row uses `flex ... overflow-x-auto` which is already responsive. The summary cards at the top likely need `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4` if they use a fixed grid.
+
+Check the quick-add form — ensure side-by-side fields stack on small screens. Find the form grid and add responsive classes:
+
+Replace any `grid-cols-2` in the quick-add form with `grid-cols-1 sm:grid-cols-2`.
+
+- [ ] **Step 2: Transactions page — table scroll wrapper**
+
+In `frontend/app/transactions/page.tsx`, find the `<table>` element and wrap it:
+
+```tsx
+<div className="overflow-x-auto">
+  <table className="...">
+    {/* existing table content */}
+  </table>
+</div>
+```
+
+- [ ] **Step 3: Import page — table scroll wrapper**
+
+In `frontend/app/import/page.tsx`, find the preview `<table>` and wrap it:
+
+```tsx
+<div className="overflow-x-auto">
+  <table className="...">
+    {/* existing table content */}
+  </table>
+</div>
+```
+
+- [ ] **Step 4: Verify at narrow width**
+
+Open each page at ~600px width. Tables should scroll horizontally. Cards should stack vertically. Nothing should overflow the viewport.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/app/dashboard/page.tsx frontend/app/transactions/page.tsx frontend/app/import/page.tsx
+git commit -m "feat: responsive tables and grids — overflow-x-auto wrappers, stacking layouts"
+```
+
+---
+
+## Task 5: Replace window.confirm() — budgets, transactions, accounts, categories
+
+**Files:**
+- Modify: `frontend/app/budgets/page.tsx` (line 102)
+- Modify: `frontend/app/transactions/page.tsx` (line 185)
+- Modify: `frontend/app/accounts/page.tsx` (lines 71, 97)
+- Modify: `frontend/app/categories/page.tsx` (line 148)
+
+All four follow the same pattern: `if (!confirm("message")) return;` inside an async function. Replace with ConfirmModal state.
+
+- [ ] **Step 1: Budgets page**
+
+In `frontend/app/budgets/page.tsx`:
+
+1. Add import at top:
+```tsx
+import ConfirmModal from "@/components/ui/ConfirmModal";
+```
+
+2. Add state (near existing state declarations):
+```tsx
+const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+```
+
+3. Replace `handleDelete`:
+```tsx
+async function handleDelete(id: number) {
+  try {
+    await apiFetch(`/api/v1/budgets/${id}`, { method: "DELETE" });
+    setConfirmDeleteId(null);
+    await loadBudgets();
+  } catch (err) { setError(extractErrorMessage(err)); }
+}
+```
+
+4. Change the "Remove" button click from `onClick={() => handleDelete(b.id)}` to `onClick={() => setConfirmDeleteId(b.id)}`.
+
+5. Add ConfirmModal before the closing `</AppShell>`:
+```tsx
+<ConfirmModal
+  open={confirmDeleteId !== null}
+  title="Remove Budget"
+  message="Remove this budget? This cannot be undone."
+  confirmLabel="Remove"
+  variant="danger"
+  onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
+  onCancel={() => setConfirmDeleteId(null)}
+/>
+```
+
+- [ ] **Step 2: Transactions page**
+
+Same pattern in `frontend/app/transactions/page.tsx`:
+
+1. Import `ConfirmModal`.
+2. Add state: `const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);`
+3. Replace `handleDelete` — remove the `confirm()` call, add `setConfirmDeleteId(null)` before the API call.
+4. Change delete button click to `setConfirmDeleteId(tx.id)`.
+5. Add `<ConfirmModal>` with title="Delete Transaction", message="Delete this transaction?", variant="danger".
+
+- [ ] **Step 3: Accounts page**
+
+In `frontend/app/accounts/page.tsx`, there are two `confirm()` calls:
+
+1. Line 71: delete account type — add `confirmDeleteTypeId` state
+2. Line 97: delete account — add `confirmDeleteAcctId` state
+
+Import `ConfirmModal`, add two separate modal instances:
+
+```tsx
+<ConfirmModal
+  open={confirmDeleteTypeId !== null}
+  title="Delete Account Type"
+  message="Delete this account type?"
+  confirmLabel="Delete"
+  variant="danger"
+  onConfirm={() => confirmDeleteTypeId !== null && handleDeleteType(confirmDeleteTypeId)}
+  onCancel={() => setConfirmDeleteTypeId(null)}
+/>
+<ConfirmModal
+  open={confirmDeleteAcctId !== null}
+  title="Delete Account"
+  message="Delete this account? All associated transactions will be affected."
+  confirmLabel="Delete"
+  variant="danger"
+  onConfirm={() => confirmDeleteAcctId !== null && handleDeleteAccount(confirmDeleteAcctId)}
+  onCancel={() => setConfirmDeleteAcctId(null)}
+/>
+```
+
+- [ ] **Step 4: Categories page**
+
+Same pattern in `frontend/app/categories/page.tsx` (line 148):
+
+1. Import `ConfirmModal`.
+2. Add `confirmDeleteId` state.
+3. Replace `confirm()` → set state, add modal with title="Delete Category", variant="danger".
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/app/budgets/page.tsx frontend/app/transactions/page.tsx frontend/app/accounts/page.tsx frontend/app/categories/page.tsx
+git commit -m "feat: replace window.confirm with ConfirmModal — budgets, transactions, accounts, categories"
+```
+
+---
+
+## Task 6: Replace window.confirm() — recurring, forecast-plans, admin/settings
+
+**Files:**
+- Modify: `frontend/app/recurring/page.tsx` (lines 39, 61)
+- Modify: `frontend/app/forecast-plans/page.tsx` (lines 205, 221, 239, 256)
+- Modify: `frontend/app/admin/settings/page.tsx` (lines 80, 128)
+
+- [ ] **Step 1: Recurring page**
+
+Two `confirm()` calls:
+1. Line 39: stop recurring — `variant="warning"`, message includes the consequence about deleting pending transactions
+2. Line 61: delete template — `variant="danger"`
+
+Add two state variables: `confirmStopId` and `confirmDeleteId`. The stop action needs the item description for the message, so store the full item or the description.
+
+```tsx
+const [confirmStop, setConfirmStop] = useState<{ id: number; description: string } | null>(null);
+const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+```
+
+Two modals:
+```tsx
+<ConfirmModal
+  open={confirmStop !== null}
+  title="Stop Recurring Transaction"
+  message={`Stop "${confirmStop?.description}"?\n\nThis will deactivate the recurring schedule and delete any pending future transactions.\n\nSettled (past) transactions will NOT be affected.`}
+  confirmLabel="Stop"
+  variant="warning"
+  onConfirm={() => { if (confirmStop) { handleStop(confirmStop.id); setConfirmStop(null); } }}
+  onCancel={() => setConfirmStop(null)}
+/>
+<ConfirmModal
+  open={confirmDeleteId !== null}
+  title="Delete Recurring Template"
+  message="Permanently delete this recurring template?\n\nAny remaining pending future transactions will also be removed.\nSettled transactions are preserved."
+  confirmLabel="Delete"
+  variant="danger"
+  onConfirm={() => { if (confirmDeleteId !== null) { handleDelete(confirmDeleteId); setConfirmDeleteId(null); } }}
+  onCancel={() => setConfirmDeleteId(null)}
+/>
+```
+
+- [ ] **Step 2: Forecast plans page**
+
+Four `confirm()` calls:
+1. Line 205: remove plan item — `variant="danger"`
+2. Line 221: finalize/activate plan — `variant="warning"`
+3. Line 239: revert to draft — `variant="warning"`
+4. Line 256: discard plan — `variant="danger"`
+
+Add state:
+```tsx
+const [confirmAction, setConfirmAction] = useState<{
+  title: string; message: string; variant: "warning" | "danger"; action: () => void;
+} | null>(null);
+```
+
+Use a single generic modal:
+```tsx
+<ConfirmModal
+  open={confirmAction !== null}
+  title={confirmAction?.title ?? ""}
+  message={confirmAction?.message ?? ""}
+  confirmLabel="Confirm"
+  variant={confirmAction?.variant ?? "default"}
+  onConfirm={() => { confirmAction?.action(); setConfirmAction(null); }}
+  onCancel={() => setConfirmAction(null)}
+/>
+```
+
+Then replace each `confirm()` call with a `setConfirmAction(...)` call. For example, replace `handleRemoveItem`:
+
+```tsx
+async function handleRemoveItem(itemId: number) {
+  if (!plan) return;
+  setConfirmAction({
+    title: "Remove Plan Item",
+    message: "Remove this plan item?",
+    variant: "danger",
+    action: async () => {
+      try {
+        const p = await apiFetch<ForecastPlan>(
+          `/api/v1/forecast-plans/${plan.id}/items/${itemId}`,
+          { method: "DELETE" }
+        );
+        setPlan(p);
+      } catch (err) { setError(extractErrorMessage(err)); }
+    },
+  });
+}
+```
+
+Apply the same pattern for `handleActivate`, `handleRevertToDraft`, and `handleDiscard`.
+
+- [ ] **Step 3: Admin settings page**
+
+Two `confirm()` calls:
+1. Line 80: delete setting — `variant="danger"`, message includes the setting key
+2. Line 128: close billing period — `variant="warning"`
+
+Use `confirmAction` pattern (same as forecast page) since the messages are dynamic.
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 5: Test one modal in browser**
+
+Navigate to Budgets page, click "Remove" on a budget. Should see styled modal with red "Remove" button. Click "Cancel" — should dismiss. ESC — should dismiss. Click backdrop — should dismiss.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/app/recurring/page.tsx frontend/app/forecast-plans/page.tsx frontend/app/admin/settings/page.tsx
+git commit -m "feat: replace window.confirm with ConfirmModal — recurring, forecast, admin"
+```
+
+---
+
+## Task 7: Dashboard chart consistency
+
+**Files:**
+- Modify: `frontend/app/dashboard/page.tsx`
+
+- [ ] **Step 1: Update Budget Progress chart colors and legend**
+
+Find the Budget Progress chart section (around line 570). The `<Bar dataKey="spent">` uses `<Cell>` with conditional colors — this is already correct:
+- `>100%`: red (`#f87171`)
+- `>80%`: amber (`#f59e0b`)
+- Normal: `#D4A64A`
+
+But the legend (around line 600) only shows "Spent" and "Remaining". Update it to match the Budgets page:
+
+```tsx
+<div className="flex flex-wrap gap-3 px-4 pb-3 text-[10px] text-text-muted">
+  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Spent</span>
+  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f59e0b" }} /> &gt;80%</span>
+  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over budget</span>
+  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#e8ebf0" }} /> Remaining</span>
+</div>
+```
+
+- [ ] **Step 2: Update Forecast chart to match forecast page**
+
+Find the Forecast by Category chart (around line 610). Currently it shows executed/pending/recurring stacked bars with green/amber/blue colors. The forecast page uses a different scheme: planned (amber) vs actual (green/red for under/over plan).
+
+Change the forecast dashboard chart to use the same planned vs actual comparison:
+
+Replace the chart data mapping:
+```tsx
+data={forecast.categories.slice(0, 8).map((c) => ({
+  name: c.category_name.length > 12 ? c.category_name.slice(0, 12) + "…" : c.category_name,
+  planned: Number(c.forecast),
+  actual: Number(c.executed),
+}))}
+```
+
+Replace the `<Bar>` elements:
+```tsx
+<Bar dataKey="planned" fill="#D4A64A" radius={[4, 4, 4, 4]} animationDuration={600} />
+<Bar dataKey="actual" fill="#4ade80" radius={[4, 4, 4, 4]} animationDuration={600}>
+  {forecast.categories.slice(0, 8).map((c, i) => (
+    <Cell key={i} fill={Number(c.executed) > Number(c.forecast) ? "#f87171" : "#4ade80"} />
+  ))}
+</Bar>
+```
+
+Update the legend:
+```tsx
+<div className="mt-2 flex gap-3 text-[10px] text-text-muted">
+  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Planned</span>
+  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#4ade80" }} /> Under plan</span>
+  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over plan</span>
+</div>
+```
+
+Update the Tooltip formatter to match:
+```tsx
+<Tooltip
+  formatter={(v, name) => [
+    formatAmount(Number(v)),
+    name === "planned" ? <span style={{ color: "#D4A64A" }}>Planned</span> : <span style={{ color: "#4ade80" }}>Actual</span>,
+  ]}
+  contentStyle={{ fontSize: "11px" }}
+/>
+```
+
+- [ ] **Step 3: Update Tooltip colors on Budget chart**
+
+Update the Budget chart tooltip formatter to use semantic colors:
+```tsx
+<Tooltip
+  formatter={(v, name) => [
+    formatAmount(Number(v)),
+    name === "spent" ? <span style={{ color: "#f87171" }}>Spent</span> : <span style={{ color: "#4ade80" }}>Remaining</span>,
+  ]}
+  contentStyle={{ fontSize: "11px" }}
+/>
+```
+
+- [ ] **Step 4: Add overflow-hidden and right margin to dashboard charts**
+
+Add `overflow-hidden` to both chart card containers and `right: 20` to BarChart margins (same fix as the forecast page overflow bug).
+
+- [ ] **Step 5: Verify in browser**
+
+Open dashboard. Budget chart should show 4-color legend (Spent, >80%, Over budget, Remaining). Forecast chart should show Planned/Under plan/Over plan matching the Forecast Plans page.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/app/dashboard/page.tsx
+git commit -m "feat: dashboard chart consistency — match budget/forecast page colors and legends"
+```
+
+---
+
+## Task 8: Tooltip colors on dedicated pages
+
+**Files:**
+- Modify: `frontend/app/budgets/page.tsx`
+- Modify: `frontend/app/forecast-plans/page.tsx`
+
+- [ ] **Step 1: Budgets page tooltip**
+
+Find the `<Tooltip>` in the Budgets page bar chart. Update the formatter to color values semantically — red for spent, green for remaining.
+
+- [ ] **Step 2: Forecast page tooltip**
+
+Already has colors via `<span style>` in the formatter. Verify the colors match the plan: amber for planned, green for under-plan, red for over-plan.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/app/budgets/page.tsx frontend/app/forecast-plans/page.tsx
+git commit -m "feat: semantic tooltip colors on budgets and forecast charts"
+```
+
+---
+
+## Task 9: Clickable bar charts
+
+**Files:**
+- Modify: `frontend/app/dashboard/page.tsx`
+- Modify: `frontend/app/budgets/page.tsx`
+- Modify: `frontend/app/forecast-plans/page.tsx`
+
+- [ ] **Step 1: Dashboard budget bars — click to filter**
+
+The dashboard already has `chartFilter` state and uses it with the spending donut. Add `onClick` to the Budget Progress `<Bar>`:
+
+```tsx
+<Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}
+  cursor="pointer"
+  onClick={(_, idx) => {
+    const name = budgets[idx]?.category_name;
+    if (name) setChartFilter(chartFilter === name ? null : name);
+  }}
+>
+```
+
+Also add `cursor="pointer"` to the remaining bar.
+
+- [ ] **Step 2: Dashboard forecast bars — click to filter**
+
+Same pattern on the Forecast chart:
+
+```tsx
+<Bar dataKey="planned" fill="#D4A64A" radius={[4, 4, 4, 4]} animationDuration={600}
+  cursor="pointer"
+  onClick={(_, idx) => {
+    const name = forecast.categories[idx]?.category_name;
+    if (name) setChartFilter(chartFilter === name ? null : name);
+  }}
+/>
+```
+
+- [ ] **Step 3: Budgets page — click to navigate**
+
+On the Budgets page bar chart, add onClick that navigates to transactions filtered by category:
+
+```tsx
+import { useRouter } from "next/navigation";
+// ... in the component:
+const router = useRouter();
+// ... on the Bar:
+<Bar ... cursor="pointer"
+  onClick={(data) => {
+    if (data?.name) router.push(`/transactions?category=${encodeURIComponent(data.name)}`);
+  }}
+/>
+```
+
+Note: The transactions page must read `category` from URL search params to pre-filter. Check if this is already supported — if not, add it.
+
+- [ ] **Step 4: Forecast page — click to navigate**
+
+Same pattern as budgets page.
+
+- [ ] **Step 5: Verify in browser**
+
+On dashboard: click a budget bar → transaction list below filters. Click again → clears. On budgets page: click a bar → navigates to `/transactions?category=Food+%26+Dining`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/app/dashboard/page.tsx frontend/app/budgets/page.tsx frontend/app/forecast-plans/page.tsx
+git commit -m "feat: clickable bar charts — click to filter transactions by category"
+```
+
+---
+
+## Task 10: Quick wins bundle
+
+**Files:**
+- Modify: `frontend/app/dashboard/page.tsx` (balance refresh, show all accounts)
+- Modify: `frontend/app/budgets/page.tsx` (transfer form visibility)
+- Modify: `frontend/app/import/page.tsx` (CategorySelect)
+- Modify: `frontend/app/dashboard/page.tsx` (transfer category picker)
+- Modify: `frontend/app/transactions/page.tsx` (transfer category picker)
+
+- [ ] **Step 1: Dashboard balance refresh after settle/unsettle**
+
+In `frontend/app/dashboard/page.tsx`, find the inline settle/unsettle button (around line 678):
+
+```tsx
+onClick={async () => { try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "PUT", body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }) }); await loadTransactions(page); } catch (err) { setError(extractErrorMessage(err)); } }}
+```
+
+After `await loadTransactions(page)`, also reload accounts so balances update:
+
+```tsx
+await loadTransactions(page); await loadRefs();
+```
+
+`loadRefs` already fetches accounts and sets state. This ensures account cards reflect the new balances immediately.
+
+- [ ] **Step 2: Show all active accounts on dashboard**
+
+In `frontend/app/dashboard/page.tsx`, find line 232:
+
+```tsx
+const accountsWithBalance = activeAccounts.filter((a) => Number(a.balance) !== 0);
+```
+
+Replace with:
+
+```tsx
+const accountsWithBalance = activeAccounts;
+```
+
+The variable name is now misleading — rename it to `displayAccounts` or just use `activeAccounts` directly in the JSX (at lines 476-478). The simplest change is to remove the filter:
+
+```tsx
+const displayAccounts = activeAccounts;
+```
+
+And update the three references from `accountsWithBalance` to `displayAccounts`.
+
+- [ ] **Step 3: Budget transfer form visibility fix**
+
+In `frontend/app/budgets/page.tsx`, find the budget row rendering (around line 265). Currently the row has three states in a ternary: editing, transferring, or default. When `transferringId === b.id`, the entire row is replaced with the transfer form and the spent/amount/percentage disappears.
+
+Fix: always show the data line, and render the transfer form below it:
+
+```tsx
+<div key={b.id} className="px-6 py-3">
+  {editingId === b.id ? (
+    {/* ... existing edit form unchanged ... */}
+  ) : (
+    <>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-text-primary">{b.category_name}</span>
+        <div className="flex items-center gap-4">
+          <span className={`text-sm tabular-nums ${overBudget ? "text-danger font-medium" : "text-text-secondary"}`}>
+            {formatAmount(b.spent)} / {formatAmount(b.amount)}
+          </span>
+          <span className={`text-xs tabular-nums ${overBudget ? "text-danger" : "text-text-muted"}`}>
+            {b.percent_used}%
+          </span>
+          <div className="flex gap-2">
+            <button onClick={() => { setTransferringId(transferringId === b.id ? null : b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="text-xs text-text-muted hover:text-accent">Transfer</button>
+            <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
+            <button onClick={() => setConfirmDeleteId(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
+          </div>
+        </div>
+      </div>
+      {transferringId === b.id && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <span className="text-xs text-text-muted">Transfer to:</span>
+          <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-0 flex-1 basis-40 ${input}`}>
+            <option value="">Select target category</option>
+            {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{budgetedCatIds.has(c.id) ? " (has budget)" : ""}</option>)}
+          </select>
+          <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
+            className={`w-28 ${input}`}
+            onKeyDown={(e) => { if (e.key === "Enter" && transferCategoryId && transferAmount) handleTransfer(b.id); if (e.key === "Escape") setTransferringId(null); }} />
+          <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="text-xs text-accent hover:text-accent-hover disabled:opacity-50">Transfer</button>
+          <button onClick={() => setTransferringId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+        </div>
+      )}
+    </>
+  )}
+</div>
+```
+
+Key change: the data row (category name, spent/amount, %) is always visible. The transfer form appears below when expanded.
+
+- [ ] **Step 4: CategorySelect on import page**
+
+In `frontend/app/import/page.tsx`, find the category `<select>` (around line 298):
+
+```tsx
+<select
+  value={rowState.category_id ?? ""}
+  onChange={(e) =>
+    updateRow(previewRow.row_number, {
+      category_id: e.target.value === "" ? null : Number(e.target.value),
+    })
+  }
+  className={input + " !w-40"}
+>
+  <option value="">Default</option>
+  {catOptions.map((c) => (
+    <option key={c.id} value={c.id}>{c.name}</option>
+  ))}
+</select>
+```
+
+Replace with:
+
+```tsx
+<CategorySelect
+  id={`cat-${previewRow.row_number}`}
+  categories={catOptions}
+  value={rowState.category_id ?? ""}
+  onChange={(id) =>
+    updateRow(previewRow.row_number, {
+      category_id: id === "" ? null : id,
+    })
+  }
+  filterType={previewRow.type === "income" ? "income" : "expense"}
+  className={input + " !w-48"}
+/>
+```
+
+Add the import at the top:
+```tsx
+import CategorySelect from "@/components/ui/CategorySelect";
+```
+
+- [ ] **Step 5: Transfer category picker on dashboard**
+
+In `frontend/app/dashboard/page.tsx`, find the quick-transfer form (around line 330 where `formMode === "transfer"`). Add a `formCategoryId` state and a CategorySelect below the "To" account selector:
+
+After the "To" account select, add:
+```tsx
+<div>
+  <label className={label}>Category (optional)</label>
+  <CategorySelect
+    id="da-transfer-cat"
+    categories={categories}
+    value={formTransferCatId}
+    onChange={setFormTransferCatId}
+    className={input}
+  />
+  <p className="mt-1 text-[10px] text-text-muted">Defaults to Transfer. Override to track in budgets.</p>
+</div>
+```
+
+Add state: `const [formTransferCatId, setFormTransferCatId] = useState<number | "">("");`
+
+Include `category_id` in the transfer API call body (only if set):
+```tsx
+const body: Record<string, unknown> = {
+  from_account_id: formAccountId,
+  to_account_id: formToAccountId,
+  amount: Number(formAmount),
+  description: formDescription,
+  date: formDate,
+  status: formStatus,
+};
+if (formTransferCatId !== "") body.category_id = formTransferCatId;
+```
+
+Reset `formTransferCatId` after submission.
+
+- [ ] **Step 6: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 7: Test in browser**
+
+1. Dashboard: settle a transaction → account balance cards update immediately
+2. Dashboard: zero-balance accounts appear in the row
+3. Budgets: click Transfer on a budget → form expands below while spent/amount stay visible
+4. Import: category dropdown is now a type-ahead search
+5. Dashboard: quick-transfer form shows optional category picker
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/app/dashboard/page.tsx frontend/app/budgets/page.tsx frontend/app/import/page.tsx frontend/app/transactions/page.tsx
+git commit -m "feat: quick wins — balance refresh, all accounts shown, transfer form fix, CategorySelect on import, transfer category picker"
+```
+
+---
+
+## Task 11: Final verification and cleanup
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Full TypeScript check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 2: Backend syntax check**
+
+Run: `docker compose exec backend python -m compileall app/ -q`
+Expected: no errors (no backend changes, but verify)
+
+- [ ] **Step 3: Visual regression check**
+
+Open each page at full width and ~600px width:
+1. Dashboard — charts, accounts, transactions, quick-add form
+2. Transactions — table, forms
+3. Budgets — chart, details with transfer
+4. Forecast Plans — chart, plan items
+5. Accounts — account type and account lists
+6. Categories — category list
+7. Recurring — schedule list
+8. Import — file upload, preview table with CategorySelect
+9. Admin Settings — settings table, billing period actions
+
+Verify: no overflow, no broken layouts, modals work, charts are consistent.
+
+- [ ] **Step 4: Commit any final tweaks**
+
+If any visual issues found, fix and commit.
+
+- [ ] **Step 5: Create PR**
+
+```bash
+git push -u origin feat/p3-ui-polish
+gh pr create --title "feat: P3 UI polish — responsive layout, styled modals, chart consistency" --body "..."
+```

--- a/docs/superpowers/specs/2026-04-15-p3-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-04-15-p3-ui-polish-design.md
@@ -1,0 +1,194 @@
+# P3 — UI Polish for Production
+
+**Date:** 2026-04-15
+**Branch:** TBD (created at implementation time)
+**Status:** Approved, pending implementation
+
+## Goal
+
+Make PFV2 feel professional for real users. Friends are actively testing — first impressions matter. The app works functionally but has visual inconsistencies, broken responsive behavior, and raw browser dialogs that undermine trust in a finance product.
+
+## Scope
+
+12 items grouped into shared infrastructure + per-item changes. Responsive layout is the highest priority — half-screen browser use is currently broken.
+
+---
+
+## Shared Infrastructure
+
+### 1. ConfirmModal Component
+
+**File:** `frontend/components/ui/ConfirmModal.tsx`
+
+Reusable confirmation dialog replacing all `window.confirm()` calls.
+
+**Props:**
+- `open: boolean` — controls visibility
+- `title: string` — dialog heading
+- `message: string | ReactNode` — body content
+- `confirmLabel?: string` — default "Confirm"
+- `cancelLabel?: string` — default "Cancel"
+- `variant?: "default" | "warning" | "danger"` — controls confirm button color
+- `onConfirm: () => void`
+- `onCancel: () => void`
+
+**Behavior:**
+- Backdrop overlay (semi-transparent dark), click-outside dismisses
+- Centered card with focus trap (trap focus within modal while open)
+- ESC key dismisses
+- Confirm button gets variant-appropriate color: default=accent, warning=amber, danger=red
+- Body scroll locked while open
+
+### 2. Responsive Layout System
+
+**File:** `frontend/components/AppShell.tsx` (modify existing)
+
+Three breakpoints using Tailwind responsive prefixes:
+
+| Breakpoint | Sidebar | Content | Nav |
+|-----------|---------|---------|-----|
+| `>=1024px` | Full sidebar (current) | Side-by-side with sidebar | Sidebar links |
+| `768-1023px` | Icon-only, expand on click | Full width minus icon bar | Icon sidebar |
+| `<768px` | Hidden | Full width | Hamburger menu with slide-out overlay |
+
+**Per-page responsive rules:**
+- **Tables:** Wrap in `overflow-x-auto` container. No layout changes — horizontal scroll on narrow screens.
+- **Dashboard cards:** CSS grid that collapses from multi-column to single-column below 768px.
+- **Forms:** Inputs go full-width below 768px. Side-by-side form groups stack vertically.
+- **Charts:** Reduce YAxis `width` prop on narrow screens. Allow parent container to scroll if chart exceeds viewport.
+
+### 3. Chart Click-to-Filter Pattern
+
+Extend the existing `chartFilter` pattern (already used by dashboard spending donut) to budget and forecast bar charts.
+
+**Mechanism:**
+- `onClick` handler on `<Bar>` components reads the clicked category from the chart data
+- Sets `chartFilter` state to the clicked category name
+- Transaction list below filters to show only that category
+- Clicking again (or clicking a "clear filter" chip) resets
+
+On dedicated pages (Budgets, Forecast), clicking a bar navigates to `/transactions?category=<name>` since those pages don't have inline transaction lists.
+
+---
+
+## Per-Item Changes
+
+### A. Tooltip Text Colors
+
+**Files:** Dashboard, Budgets page, Forecast page — wherever `<Tooltip>` formatters exist.
+
+Color the numeric values in chart tooltips to match semantic meaning:
+- Green: remaining, under-plan, income
+- Red: over-budget, over-plan
+- Amber: spent, planned
+
+Apply via inline `style` on the `<span>` returned by the Recharts `formatter` prop.
+
+### B. Dashboard Balance Refresh After Settle/Unsettle
+
+**File:** `frontend/app/dashboard/page.tsx`
+
+After a transaction is settled/unsettled via the inline transaction list, call `mutate("/api/v1/accounts")` (or the appropriate SWR key for the accounts fetch) so the account balance cards re-render without a full page reload.
+
+### C. Forecast Chart Overflow Fix
+
+**Already implemented** on the current branch. The `Planned vs Actual (Expenses)` card on the forecast-plans page gets `overflow-hidden` and `margin.right: 20` on the `<BarChart>` to prevent bars from bleeding past the card edge.
+
+### D. CategorySelect on Import Page
+
+**File:** `frontend/app/import/page.tsx`
+
+Replace the plain `<select>` dropdown (around line 298) with the existing `CategorySelect` component. This gives type-ahead search, recent categories, and grouped master/sub display — critical with the current number of pre-seeded categories.
+
+**Props mapping:**
+- `value` = `rowState.category_id`
+- `onChange` = calls `updateRow(previewRow.row_number, { category_id })`
+- `categories` = existing `catOptions` array
+- `filterType` = based on transaction type (expense/income)
+
+### E. Transfer Category Picker
+
+**Files:** `frontend/app/dashboard/page.tsx` (quick-transfer form), `frontend/app/transactions/page.tsx` (transfer form)
+
+Add an optional `CategorySelect` to both transfer forms. Defaults to empty (which means backend auto-assigns "Transfer" category), but user can override to e.g. "General Savings" for savings transfers that should count in budgets.
+
+Label: "Category (optional)" with helper text: "Defaults to Transfer. Override to track in budgets."
+
+### F. Budget Transfer Form Visibility Fix
+
+**File:** `frontend/app/budgets/page.tsx`
+
+When the budget transfer row expands to show the transfer form, the source row's spent/budget/percentage figures currently disappear. Fix: keep those figures visible while the form is expanded. This is likely a conditional CSS class that hides the row content — change it to only hide the action buttons, not the data cells.
+
+### G. Replace window.confirm() with ConfirmModal
+
+**Audit scope:** Search all `window.confirm(` calls in frontend/ and replace each with the shared ConfirmModal.
+
+Expected locations (verify during implementation):
+- Delete transaction
+- Delete budget
+- Delete account
+- Close billing period
+- Disable MFA
+- Delete forecast plan
+- Any other destructive actions
+
+Each gets an appropriate variant:
+- `danger` for deletes (red confirm button)
+- `warning` for close-period, disable-MFA (amber confirm button)
+- `default` for non-destructive confirmations
+
+### H. Dashboard Chart Consistency
+
+**File:** `frontend/app/dashboard/page.tsx`
+
+**Budget bar chart:** Match the Budgets page color scheme:
+- Normal spend: accent/default
+- `>80%` of budget: amber/warning
+- Over budget: red/danger
+- Show "Remaining" as a stacked lighter segment
+
+**Forecast bar chart:** Match the Forecast page color scheme:
+- Planned: amber (`#D4A64A`)
+- Under plan (actual < planned): green (`#4ade80`)
+- Over plan (actual > planned): red (`#f87171`)
+
+Legends on both charts must match their dedicated page counterparts exactly.
+
+### I. Clickable Bar Charts
+
+**Files:** Dashboard page, Budgets page, Forecast page
+
+**Dashboard:** Clicking a budget or forecast bar sets `chartFilter` to that category, filtering the transaction list below (same pattern as spending donut).
+
+**Budgets/Forecast pages:** Clicking a bar navigates to `/transactions?category=<slug>` to show filtered transactions for that category.
+
+Add `cursor: pointer` style on bars and a subtle hover highlight.
+
+### J. Show All Active Accounts on Dashboard
+
+**File:** `frontend/app/dashboard/page.tsx`
+
+Remove the filter that hides zero-balance accounts. All active (non-archived) accounts should appear in the account cards section. Users need to see their credit card account even after paying the bill (balance = 0).
+
+---
+
+## Implementation Order
+
+Shared infrastructure first, then layer changes on top:
+
+1. **Responsive layout** (highest priority — currently broken for half-screen use)
+2. **ConfirmModal component**
+3. **Replace window.confirm()** (uses ConfirmModal)
+4. **Dashboard chart consistency** (colors + legends)
+5. **Clickable bar charts** (uses chart click pattern)
+6. **Quick wins** (tooltip colors, balance refresh, forecast overflow, CategorySelect on import, transfer category picker, budget transfer visibility, show all accounts)
+
+## Out of Scope
+
+- Mobile native app / PWA
+- Budget rebalancing suggestions (P3 roadmap, deferred to next round)
+- Transfer exclusion from spending chart (complex logic change, deferred)
+- "Add category" inline creation (needs new backend endpoint, deferred)
+- Onboarding wizard / demo seed / user manual (deferred)
+- Notification preferences (deferred)

--- a/docs/superpowers/specs/2026-04-15-p3-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-04-15-p3-ui-polish-design.md
@@ -1,8 +1,8 @@
 # P3 — UI Polish for Production
 
 **Date:** 2026-04-15
-**Branch:** TBD (created at implementation time)
-**Status:** Approved, pending implementation
+**Branch:** feat/p3-ui-polish
+**Status:** Implemented (PR #55)
 
 ## Goal
 

--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -8,6 +8,7 @@ import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { formatAmount } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import type { Account, AccountType } from "@/lib/types";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 
 export default function AccountsPage() {
   const { user, loading } = useAuth();
@@ -33,6 +34,8 @@ export default function AccountsPage() {
   const selectedType = accountTypes.find((t) => t.id === acctTypeId) ?? null;
 
   const [error, setError] = useState("");
+  const [confirmDeleteTypeId, setConfirmDeleteTypeId] = useState<number | null>(null);
+  const [confirmDeleteAcctId, setConfirmDeleteAcctId] = useState<number | null>(null);
 
   const reload = useCallback(async () => {
     const [types, accts] = await Promise.all([
@@ -68,7 +71,7 @@ export default function AccountsPage() {
   }
 
   async function handleDeleteType(id: number) {
-    if (!confirm("Delete this account type?")) return;
+    setConfirmDeleteTypeId(null);
     setError("");
     try {
       await apiFetch(`/api/v1/account-types/${id}`, { method: "DELETE" });
@@ -94,7 +97,7 @@ export default function AccountsPage() {
   }
 
   async function handleDeleteAccount(id: number) {
-    if (!confirm("Delete this account?")) return;
+    setConfirmDeleteAcctId(null);
     setError("");
     try {
       await apiFetch(`/api/v1/accounts/${id}`, { method: "DELETE" });
@@ -176,7 +179,7 @@ export default function AccountsPage() {
                           {!at.is_system && (
                             <>
                               <button onClick={() => { setEditingTypeId(at.id); setEditingTypeName(at.name); }} aria-label={`Edit ${at.name}`} className="text-xs text-text-muted hover:text-accent">Edit</button>
-                              <button onClick={() => handleDeleteType(at.id)} aria-label={`Delete ${at.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                              <button onClick={() => setConfirmDeleteTypeId(at.id)} aria-label={`Delete ${at.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                             </>
                           )}
                         </div>
@@ -267,7 +270,7 @@ export default function AccountsPage() {
                         <button onClick={() => handleToggleActive(a)} aria-label={a.is_active ? `Deactivate ${a.name}` : `Activate ${a.name}`} className="text-xs text-text-muted hover:text-text-secondary">
                           {a.is_active ? "Deactivate" : "Activate"}
                         </button>
-                        <button onClick={() => handleDeleteAccount(a.id)} aria-label={`Delete ${a.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                        <button onClick={() => setConfirmDeleteAcctId(a.id)} aria-label={`Delete ${a.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                       </div>
                     </div>
                   </div>
@@ -282,6 +285,24 @@ export default function AccountsPage() {
           </div>
         </div>
       )}
+      <ConfirmModal
+        open={confirmDeleteTypeId !== null}
+        title="Delete Account Type"
+        message="Delete this account type?"
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => { if (confirmDeleteTypeId !== null) handleDeleteType(confirmDeleteTypeId); }}
+        onCancel={() => setConfirmDeleteTypeId(null)}
+      />
+      <ConfirmModal
+        open={confirmDeleteAcctId !== null}
+        title="Delete Account"
+        message="Delete this account?"
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => { if (confirmDeleteAcctId !== null) handleDeleteAccount(confirmDeleteAcctId); }}
+        onCancel={() => setConfirmDeleteAcctId(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/admin/settings/page.tsx
+++ b/frontend/app/admin/settings/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { isAdmin } from "@/lib/auth";
@@ -20,6 +21,14 @@ export default function SettingsPage() {
   const [successMsg, setSuccessMsg] = useState("");
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
+
+  // Confirm modal
+  const [confirmAction, setConfirmAction] = useState<{
+    title: string;
+    message: string;
+    variant: "warning" | "danger";
+    action: () => void;
+  } | null>(null);
 
   // Billing
   const [billingCycleDay, setBillingCycleDay] = useState(user?.billing_cycle_day ?? 1);
@@ -77,12 +86,18 @@ export default function SettingsPage() {
   }
 
   async function handleDelete(settingKey: string) {
-    if (!confirm(`Delete setting "${settingKey}"?`)) return;
-    setError("");
-    try {
-      await apiFetch(`/api/v1/settings/${encodeURIComponent(settingKey)}`, { method: "DELETE" });
-      await reload();
-    } catch (err) { setError(extractErrorMessage(err)); }
+    setConfirmAction({
+      title: "Delete Setting",
+      message: `Delete setting "${settingKey}"?`,
+      variant: "danger",
+      action: async () => {
+        setError("");
+        try {
+          await apiFetch(`/api/v1/settings/${encodeURIComponent(settingKey)}`, { method: "DELETE" });
+          await reload();
+        } catch (err) { setError(extractErrorMessage(err)); }
+      },
+    });
   }
 
   if (loading || !admin) {
@@ -124,15 +139,21 @@ export default function SettingsPage() {
           <div className="flex flex-wrap items-end gap-4">
             <button
               disabled={closingPeriod}
-              onClick={async () => {
-                if (!confirm("Close the current billing period?\n\nA new period will start tomorrow. Budgets for the new period will need to be set.")) return;
-                setClosingPeriod(true); setError(""); setSuccessMsg("");
-                try {
-                  const newP = await apiFetch<{ id: number; start_date: string; end_date: string | null }>("/api/v1/settings/billing-period/close", { method: "POST" });
-                  if (newP) setCurrentPeriod(newP);
-                  setSuccessMsg("Period closed. New period started.");
-                } catch (err) { setError(extractErrorMessage(err)); }
-                finally { setClosingPeriod(false); }
+              onClick={() => {
+                setConfirmAction({
+                  title: "Close Billing Period",
+                  message: "Close the current billing period?\n\nA new period will start tomorrow. Budgets for the new period will need to be set.",
+                  variant: "warning",
+                  action: async () => {
+                    setClosingPeriod(true); setError(""); setSuccessMsg("");
+                    try {
+                      const newP = await apiFetch<{ id: number; start_date: string; end_date: string | null }>("/api/v1/settings/billing-period/close", { method: "POST" });
+                      if (newP) setCurrentPeriod(newP);
+                      setSuccessMsg("Period closed. New period started.");
+                    } catch (err) { setError(extractErrorMessage(err)); }
+                    finally { setClosingPeriod(false); }
+                  },
+                });
               }}
               className={btnPrimary}
             >
@@ -224,6 +245,15 @@ export default function SettingsPage() {
           </div>
         </details>
       </div>
+      <ConfirmModal
+        open={confirmAction !== null}
+        title={confirmAction?.title ?? ""}
+        message={confirmAction?.message ?? ""}
+        confirmLabel="Confirm"
+        variant={confirmAction?.variant ?? "default"}
+        onConfirm={() => { confirmAction?.action(); setConfirmAction(null); }}
+        onCancel={() => setConfirmAction(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -222,7 +222,10 @@ export default function BudgetsPage() {
                     <XAxis type="number" hide />
                     <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
                     <Tooltip
-                      formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? <span style={{ color: "#ef4444" }}>Spent</span> : name === "remaining" ? <span style={{ color: "#4ade80" }}>Remaining</span> : <span style={{ color: "#ef4444" }}>Over budget</span>]}
+                      formatter={(v, name) => [
+                        formatAmount(Number(v)),
+                        name === "spent" ? <span style={{ color: "#f87171" }}>Spent</span> : <span style={{ color: "#4ade80" }}>Remaining</span>,
+                      ]}
                       contentStyle={{ fontSize: "11px" }}
                     />
                     <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -9,6 +9,7 @@ import { formatAmount } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import type { BillingPeriod, Budget, Category } from "@/lib/types";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 
 export default function BudgetsPage() {
   const { user, loading } = useAuth();
@@ -31,6 +32,7 @@ export default function BudgetsPage() {
   const [transferringId, setTransferringId] = useState<number | null>(null);
   const [transferCategoryId, setTransferCategoryId] = useState<number | "">("");
   const [transferAmount, setTransferAmount] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
@@ -99,7 +101,7 @@ export default function BudgetsPage() {
   }
 
   async function handleDelete(id: number) {
-    if (!confirm("Remove this budget?")) return;
+    setConfirmDeleteId(null);
     try {
       await apiFetch(`/api/v1/budgets/${id}`, { method: "DELETE" });
       await loadBudgets();
@@ -293,7 +295,7 @@ export default function BudgetsPage() {
                           <div className="flex gap-2">
                             <button onClick={() => { setTransferringId(b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="text-xs text-text-muted hover:text-accent">Transfer</button>
                             <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
-                            <button onClick={() => handleDelete(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
+                            <button onClick={() => setConfirmDeleteId(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
                           </div>
                         </div>
                       </div>
@@ -310,6 +312,15 @@ export default function BudgetsPage() {
           </div>
         </div>
       )}
+      <ConfirmModal
+        open={confirmDeleteId !== null}
+        title="Remove Budget"
+        message="Remove this budget? This cannot be undone."
+        confirmLabel="Remove"
+        variant="danger"
+        onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -13,6 +14,7 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 
 export default function BudgetsPage() {
   const { user, loading } = useAuth();
+  const router = useRouter();
   const [budgets, setBudgets] = useState<Budget[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [periods, setPeriods] = useState<BillingPeriod[]>([]);
@@ -228,7 +230,13 @@ export default function BudgetsPage() {
                       ]}
                       contentStyle={{ fontSize: "11px" }}
                     />
-                    <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
+                    <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}
+                      cursor="pointer"
+                      onClick={(data) => {
+                        const name = data?.name || data?.payload?.name;
+                        if (name) router.push(`/transactions?category=${encodeURIComponent(name)}`);
+                      }}
+                    >
                       {budgets.map((b, i) => (
                         <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#D4A64A"} />
                       ))}

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -226,7 +226,9 @@ export default function BudgetsPage() {
                     <Tooltip
                       formatter={(v, name) => [
                         formatAmount(Number(v)),
-                        name === "spent" ? <span style={{ color: "#f87171" }}>Spent</span> : <span style={{ color: "#4ade80" }}>Remaining</span>,
+                        name === "spent" ? <span style={{ color: "#f87171" }}>Spent</span>
+                          : name === "over" ? <span style={{ color: "#f87171" }}>Over budget</span>
+                          : <span style={{ color: "#4ade80" }}>Remaining</span>,
                       ]}
                       contentStyle={{ fontSize: "11px" }}
                     />

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -275,41 +275,38 @@ export default function BudgetsPage() {
                         <button onClick={() => handleUpdate(b.id)} className="text-xs text-accent hover:text-accent-hover">Save</button>
                         <button onClick={() => setEditingId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
                       </div>
-                    ) : transferringId === b.id ? (
-                      <div className="space-y-2">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-medium text-text-primary">{b.category_name}</span>
-                          <span className="text-xs text-text-muted">— transfer to:</span>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-0 flex-1 basis-40 ${input}`}>
-                            <option value="">Select target category</option>
-                            {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{budgetedCatIds.has(c.id) ? " (has budget)" : ""}</option>)}
-                          </select>
-                          <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
-                            className={`w-28 ${input}`}
-                            onKeyDown={(e) => { if (e.key === "Enter" && transferCategoryId && transferAmount) handleTransfer(b.id); if (e.key === "Escape") setTransferringId(null); }} />
-                          <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="text-xs text-accent hover:text-accent-hover disabled:opacity-50">Transfer</button>
-                          <button onClick={() => setTransferringId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
-                        </div>
-                      </div>
                     ) : (
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm text-text-primary">{b.category_name}</span>
-                        <div className="flex items-center gap-4">
-                          <span className={`text-sm tabular-nums ${overBudget ? "text-danger font-medium" : "text-text-secondary"}`}>
-                            {formatAmount(b.spent)} / {formatAmount(b.amount)}
-                          </span>
-                          <span className={`text-xs tabular-nums ${overBudget ? "text-danger" : "text-text-muted"}`}>
-                            {b.percent_used}%
-                          </span>
-                          <div className="flex gap-2">
-                            <button onClick={() => { setTransferringId(b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="text-xs text-text-muted hover:text-accent">Transfer</button>
-                            <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
-                            <button onClick={() => setConfirmDeleteId(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
+                      <>
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm text-text-primary">{b.category_name}</span>
+                          <div className="flex items-center gap-4">
+                            <span className={`text-sm tabular-nums ${overBudget ? "text-danger font-medium" : "text-text-secondary"}`}>
+                              {formatAmount(b.spent)} / {formatAmount(b.amount)}
+                            </span>
+                            <span className={`text-xs tabular-nums ${overBudget ? "text-danger" : "text-text-muted"}`}>
+                              {b.percent_used}%
+                            </span>
+                            <div className="flex gap-2">
+                              <button onClick={() => { setTransferringId(transferringId === b.id ? null : b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="text-xs text-text-muted hover:text-accent">Transfer</button>
+                              <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
+                              <button onClick={() => setConfirmDeleteId(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
+                            </div>
                           </div>
                         </div>
-                      </div>
+                        {transferringId === b.id && (
+                          <div className="mt-2 flex flex-wrap items-center gap-2">
+                            <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-0 flex-1 basis-40 ${input}`}>
+                              <option value="">Select target category</option>
+                              {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{budgetedCatIds.has(c.id) ? " (has budget)" : ""}</option>)}
+                            </select>
+                            <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
+                              className={`w-28 ${input}`}
+                              onKeyDown={(e) => { if (e.key === "Enter" && transferCategoryId && transferAmount) handleTransfer(b.id); if (e.key === "Escape") setTransferringId(null); }} />
+                            <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="text-xs text-accent hover:text-accent-hover disabled:opacity-50">Transfer</button>
+                            <button onClick={() => setTransferringId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                          </div>
+                        )}
+                      </>
                     )}
                   </div>
                 );

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { input, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import type { Category } from "@/lib/types";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import {
   Wallet, Home, Zap, UtensilsCrossed, Car, HeartPulse,
   Scissors, Gamepad2, Target, CreditCard, Gift, HelpCircle, Tag,
@@ -57,6 +58,7 @@ export default function CategoriesPage() {
   const [newMasterName, setNewMasterName] = useState("");
   const [newMasterType, setNewMasterType] = useState<"income" | "expense" | "both">("expense");
   const [newMasterDesc, setNewMasterDesc] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
   const reload = useCallback(async () => {
     const data = await apiFetch<Category[]>("/api/v1/categories");
@@ -145,7 +147,7 @@ export default function CategoriesPage() {
   }
 
   async function handleDelete(id: number) {
-    if (!confirm("Delete this category?")) return;
+    setConfirmDeleteId(null);
     setError("");
     try {
       await apiFetch(`/api/v1/categories/${id}`, { method: "DELETE" });
@@ -231,7 +233,7 @@ export default function CategoriesPage() {
                       {addingToMaster === master.id ? "Cancel" : "+ Add Sub"}
                     </button>
                     <button onClick={() => { setEditingCatId(master.id); setEditCatName(master.name); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
-                    <button onClick={() => handleDelete(master.id)} aria-label={`Delete ${master.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                    <button onClick={() => setConfirmDeleteId(master.id)} aria-label={`Delete ${master.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                   </div>
                 </div>
 
@@ -274,7 +276,7 @@ export default function CategoriesPage() {
                               </div>
                               <div className="flex gap-2">
                                 <button onClick={() => { setEditingCatId(sub.id); setEditCatName(sub.name); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
-                                <button onClick={() => handleDelete(sub.id)} aria-label={`Delete ${sub.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                                <button onClick={() => setConfirmDeleteId(sub.id)} aria-label={`Delete ${sub.name}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                               </div>
                             </>
                           )}
@@ -296,6 +298,15 @@ export default function CategoriesPage() {
           )}
         </div>
       )}
+      <ConfirmModal
+        open={confirmDeleteId !== null}
+        title="Delete Category"
+        message="Delete this category?"
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -558,7 +558,7 @@ export default function DashboardPage() {
                     </ResponsiveContainer>
                   </div>
                   <div className="flex-1 space-y-1.5">
-                    {donutData.map((d, i) => (
+                    {donutData.slice(0, 10).map((d, i) => (
                       <button key={d.name} onClick={() => setChartFilter(chartFilter === d.name ? null : d.name)}
                         className={`flex w-full items-center justify-between rounded px-1.5 py-0.5 transition-colors hover:bg-surface-raised ${chartFilter === d.name ? "bg-accent-dim" : ""}`}>
                         <div className="flex items-center gap-2">
@@ -568,6 +568,9 @@ export default function DashboardPage() {
                         <span className="text-xs tabular-nums text-text-muted">{formatAmount(d.value)}</span>
                       </button>
                     ))}
+                    {donutData.length > 10 && (
+                      <p className="px-1.5 text-[10px] text-text-muted">+{donutData.length - 10} more — click chart to filter</p>
+                    )}
                   </div>
                 </div>
               ) : (

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -63,6 +63,7 @@ export default function DashboardPage() {
   const [formRecurring, setFormRecurring] = useState(false);
   const [formFrequency, setFormFrequency] = useState("monthly");
   const [formAutoSettle, setFormAutoSettle] = useState(false);
+  const [formTransferCatId, setFormTransferCatId] = useState<number | "">("");
 
   const [chartFilter, setChartFilter] = useState<string | null>(null);
   const [dashSortField, setDashSortField] = useState<"date" | "description" | "amount">("date");
@@ -151,6 +152,7 @@ export default function DashboardPage() {
             amount: formAmount,
             status: formStatus,
             date: formDate,
+            ...(formTransferCatId !== "" && { category_id: formTransferCatId }),
           }),
         });
       } else {
@@ -187,6 +189,7 @@ export default function DashboardPage() {
       setFormType("expense");
       setFormStatus("settled");
       setFormToAccountId("");
+      setFormTransferCatId("");
       setFormRecurring(false);
       setFormAutoSettle(false);
       setFormDate(todayISO());
@@ -228,8 +231,8 @@ export default function DashboardPage() {
   );
   const currencies = Object.entries(balanceByCurrency);
 
-  // Accounts with balance != 0 for individual tiles
-  const accountsWithBalance = activeAccounts.filter((a) => Number(a.balance) !== 0);
+  // All active accounts for individual tiles
+  const accountsWithBalance = activeAccounts;
 
   // Precompute tx map for O(1) linked lookups
   const txMap = new Map(allTransactions.map((tx) => [tx.id, tx]));
@@ -348,6 +351,19 @@ export default function DashboardPage() {
                   <div>
                     <label htmlFor="da-category" className={label}>Category</label>
                     <CategorySelect id="da-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+                  </div>
+                )}
+                {formMode === "transfer" && (
+                  <div>
+                    <label className={label}>Category (optional)</label>
+                    <CategorySelect
+                      id="da-transfer-cat"
+                      categories={categories}
+                      value={formTransferCatId}
+                      onChange={setFormTransferCatId}
+                      className={input}
+                    />
+                    <p className="mt-1 text-[10px] text-text-muted">Defaults to Transfer. Override to track in budgets.</p>
                   </div>
                 )}
                 <div>
@@ -697,7 +713,7 @@ export default function DashboardPage() {
                         {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                       </span>
                       {!isTransfer && (
-                        <button onClick={async () => { try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "PUT", body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }) }); await loadTransactions(page); } catch (err) { setError(extractErrorMessage(err)); } }} aria-label={`Toggle status`} className={`rounded px-1 py-0.5 text-[9px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                        <button onClick={async () => { try { await apiFetch(`/api/v1/transactions/${tx.id}`, { method: "PUT", body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }) }); await loadTransactions(page); await loadRefs(); } catch (err) { setError(extractErrorMessage(err)); } }} aria-label={`Toggle status`} className={`rounded px-1 py-0.5 text-[9px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
                           {tx.status}
                         </button>
                       )}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -584,7 +584,13 @@ export default function DashboardPage() {
                         ]}
                         contentStyle={{ fontSize: "11px" }}
                       />
-                      <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
+                      <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}
+                        cursor="pointer"
+                        onClick={(_, idx) => {
+                          const name = budgets.slice(0, 6)[idx]?.category_name;
+                          if (name) setChartFilter(chartFilter === name ? null : name);
+                        }}
+                      >
                         {budgets.slice(0, 6).map((b, i) => (
                           <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#D4A64A"} />
                         ))}
@@ -631,7 +637,13 @@ export default function DashboardPage() {
                         ]}
                         contentStyle={{ fontSize: "11px" }}
                       />
-                      <Bar dataKey="planned" fill="#D4A64A" radius={[4, 4, 4, 4]} animationDuration={600} />
+                      <Bar dataKey="planned" fill="#D4A64A" radius={[4, 4, 4, 4]} animationDuration={600}
+                        cursor="pointer"
+                        onClick={(_, idx) => {
+                          const name = forecast?.categories[idx]?.category_name;
+                          if (name) setChartFilter(chartFilter === name ? null : name);
+                        }}
+                      />
                       <Bar dataKey="actual" fill="#4ade80" radius={[4, 4, 4, 4]} animationDuration={600}>
                         {forecast.categories.slice(0, 8).map((c, i) => (
                           <Cell key={i} fill={Number(c.executed) > Number(c.forecast) ? "#f87171" : "#4ade80"} />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -152,7 +152,7 @@ export default function DashboardPage() {
             amount: formAmount,
             status: formStatus,
             date: formDate,
-            ...(formTransferCatId !== "" && { category_id: formTransferCatId }),
+            ...(formTransferCatId !== "" ? { category_id: formTransferCatId } : {}),
           }),
         });
       } else {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -560,7 +560,7 @@ export default function DashboardPage() {
             </div>
 
             {/* Budget progress */}
-            <div className={card}>
+            <div className={`${card} overflow-hidden`}>
               <div className={`flex items-center justify-between ${cardHeader}`}>
                 <h2 className={cardTitle}>Budget Progress</h2>
                 <Link href="/budgets" className="text-xs text-accent hover:text-accent-hover">Manage</Link>
@@ -574,11 +574,14 @@ export default function DashboardPage() {
                       spent: Number(b.spent),
                       remaining: Math.max(Number(b.amount) - Number(b.spent), 0),
                       pct: b.percent_used,
-                    }))} layout="vertical" margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
+                    }))} layout="vertical" margin={{ left: 0, right: 20, top: 0, bottom: 0 }}>
                       <XAxis type="number" hide />
                       <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
                       <Tooltip
-                        formatter={(v, name) => [formatAmount(Number(v)), name === "spent" ? <span style={{ color: "#ef4444" }}>Spent</span> : <span style={{ color: "#4ade80" }}>Remaining</span>]}
+                        formatter={(v, name) => [
+                          formatAmount(Number(v)),
+                          name === "spent" ? <span style={{ color: "#f87171" }}>Spent</span> : <span style={{ color: "#4ade80" }}>Remaining</span>,
+                        ]}
                         contentStyle={{ fontSize: "11px" }}
                       />
                       <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}>
@@ -590,8 +593,10 @@ export default function DashboardPage() {
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
-                <div className="flex gap-3 px-4 pb-3 text-[10px] text-text-muted">
+                <div className="flex flex-wrap gap-3 px-4 pb-3 text-[10px] text-text-muted">
                   <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Spent</span>
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f59e0b" }} /> &gt;80%</span>
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over budget</span>
                   <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#e8ebf0" }} /> Remaining</span>
                 </div>
                 </>
@@ -602,8 +607,8 @@ export default function DashboardPage() {
               )}
             </div>
 
-            {/* Forecast comparison — executed vs forecast per category */}
-            <div className={`${card} p-5`}>
+            {/* Forecast comparison — planned vs actual per category */}
+            <div className={`${card} overflow-hidden p-5`}>
               <h2 className={`mb-3 ${cardTitle}`}>Forecast by Category</h2>
               {forecast && forecast.categories.length > 0 ? (
                 <div style={{ height: Math.max(Math.min(forecast.categories.length, 8) * 32, 100) }}>
@@ -611,22 +616,27 @@ export default function DashboardPage() {
                     <BarChart
                       data={forecast.categories.slice(0, 8).map((c) => ({
                         name: c.category_name.length > 12 ? c.category_name.slice(0, 12) + "…" : c.category_name,
-                        executed: Number(c.executed),
-                        pending: Number(c.pending),
-                        recurring: Number(c.recurring),
+                        planned: Number(c.forecast),
+                        actual: Number(c.executed),
                       }))}
                       layout="vertical"
-                      margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+                      margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
                     >
                       <XAxis type="number" hide />
                       <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
                       <Tooltip
-                        formatter={(v, name) => [formatAmount(Number(v)), name === "executed" ? <span style={{ color: "#4ade80" }}>Executed</span> : name === "pending" ? <span style={{ color: "#D4A64A" }}>Pending</span> : <span style={{ color: "#5FA8D3" }}>Recurring</span>]}
+                        formatter={(v, name) => [
+                          formatAmount(Number(v)),
+                          name === "planned" ? <span style={{ color: "#D4A64A" }}>Planned</span> : <span style={{ color: "#4ade80" }}>Actual</span>,
+                        ]}
                         contentStyle={{ fontSize: "11px" }}
                       />
-                      <Bar dataKey="executed" stackId="a" fill="#4ade80" radius={[3, 0, 0, 3]} animationDuration={600} />
-                      <Bar dataKey="pending" stackId="a" fill="#D4A64A" animationDuration={600} />
-                      <Bar dataKey="recurring" stackId="a" fill="#5FA8D3" radius={[0, 3, 3, 0]} animationDuration={600} />
+                      <Bar dataKey="planned" fill="#D4A64A" radius={[4, 4, 4, 4]} animationDuration={600} />
+                      <Bar dataKey="actual" fill="#4ade80" radius={[4, 4, 4, 4]} animationDuration={600}>
+                        {forecast.categories.slice(0, 8).map((c, i) => (
+                          <Cell key={i} fill={Number(c.executed) > Number(c.forecast) ? "#f87171" : "#4ade80"} />
+                        ))}
+                      </Bar>
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
@@ -634,9 +644,9 @@ export default function DashboardPage() {
                 <p className="text-sm text-text-muted py-6 text-center">No forecast data</p>
               )}
               <div className="mt-2 flex gap-3 text-[10px] text-text-muted">
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full bg-success" /> Executed</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Pending</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#5FA8D3" }} /> Recurring</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Planned</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#4ade80" }} /> Under plan</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over plan</span>
               </div>
             </div>
           </div>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { formatAmount } from "@/lib/format";
@@ -59,6 +60,14 @@ export default function ForecastPlansPage() {
   const [viewFilter, setViewFilter] = useState<"all" | "income" | "expense">(
     "all"
   );
+
+  // Confirm modal
+  const [confirmAction, setConfirmAction] = useState<{
+    title: string;
+    message: string;
+    variant: "warning" | "danger";
+    action: () => void;
+  } | null>(null);
 
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
@@ -202,73 +211,80 @@ export default function ForecastPlansPage() {
   }
 
   async function handleDeleteItem(itemId: number) {
-    if (!plan || !confirm("Remove this plan item?")) return;
-    setError("");
-    try {
-      const p = await apiFetch<ForecastPlan>(
-        `/api/v1/forecast-plans/${plan.id}/items/${itemId}`,
-        { method: "DELETE" }
-      );
-      setPlan(p);
-    } catch (err) {
-      setError(extractErrorMessage(err));
-    }
+    if (!plan) return;
+    setConfirmAction({
+      title: "Remove Plan Item",
+      message: "Remove this plan item?",
+      variant: "danger",
+      action: async () => {
+        setError("");
+        try {
+          const p = await apiFetch<ForecastPlan>(
+            `/api/v1/forecast-plans/${plan.id}/items/${itemId}`,
+            { method: "DELETE" }
+          );
+          setPlan(p);
+        } catch (err) { setError(extractErrorMessage(err)); }
+      },
+    });
   }
 
   async function handleActivate() {
-    if (
-      !plan ||
-      !confirm(
-        "Finalize this plan? It will become read-only. You can revert to draft later if needed."
-      )
-    )
-      return;
-    setError("");
-    try {
-      const p = await apiFetch<ForecastPlan>(
-        `/api/v1/forecast-plans/${plan.id}/activate`,
-        { method: "POST" }
-      );
-      setPlan(p);
-    } catch (err) {
-      setError(extractErrorMessage(err));
-    }
+    if (!plan) return;
+    setConfirmAction({
+      title: "Finalize Plan",
+      message: "Finalize this plan? It will become read-only. You can revert to draft later if needed.",
+      variant: "warning",
+      action: async () => {
+        setError("");
+        try {
+          const p = await apiFetch<ForecastPlan>(
+            `/api/v1/forecast-plans/${plan.id}/activate`,
+            { method: "POST" }
+          );
+          setPlan(p);
+        } catch (err) { setError(extractErrorMessage(err)); }
+      },
+    });
   }
 
   async function handleRevertToDraft() {
-    if (!plan || !confirm("Revert to draft? This will unlock the plan for editing."))
-      return;
-    setError("");
-    try {
-      const p = await apiFetch<ForecastPlan>(
-        `/api/v1/forecast-plans/${plan.id}/revert`,
-        { method: "POST" }
-      );
-      setPlan(p);
-    } catch (err) {
-      setError(extractErrorMessage(err));
-    }
+    if (!plan) return;
+    setConfirmAction({
+      title: "Revert to Draft",
+      message: "Revert to draft? This will unlock the plan for editing.",
+      variant: "warning",
+      action: async () => {
+        setError("");
+        try {
+          const p = await apiFetch<ForecastPlan>(
+            `/api/v1/forecast-plans/${plan.id}/revert`,
+            { method: "POST" }
+          );
+          setPlan(p);
+        } catch (err) { setError(extractErrorMessage(err)); }
+      },
+    });
   }
 
   async function handleDiscard() {
-    if (
-      !plan ||
-      !confirm(
-        "Discard this plan? All items will be removed and the plan will reset to an empty draft."
-      )
-    )
-      return;
-    setError("");
-    try {
-      const p = await apiFetch<ForecastPlan>(
-        `/api/v1/forecast-plans/${plan.id}/discard`,
-        { method: "POST" }
-      );
-      setPlan(p);
-      setShowForm(false);
-    } catch (err) {
-      setError(extractErrorMessage(err));
-    }
+    if (!plan) return;
+    setConfirmAction({
+      title: "Discard Plan",
+      message: "Discard this plan? All items will be removed and the plan will reset to an empty draft.",
+      variant: "danger",
+      action: async () => {
+        setError("");
+        try {
+          const p = await apiFetch<ForecastPlan>(
+            `/api/v1/forecast-plans/${plan.id}/discard`,
+            { method: "POST" }
+          );
+          setPlan(p);
+          setShowForm(false);
+        } catch (err) { setError(extractErrorMessage(err)); }
+      },
+    });
   }
 
   // Chart data
@@ -681,6 +697,15 @@ export default function ForecastPlansPage() {
           )}
         </div>
       )}
+      <ConfirmModal
+        open={confirmAction !== null}
+        title={confirmAction?.title ?? ""}
+        message={confirmAction?.message ?? ""}
+        confirmLabel="Confirm"
+        variant={confirmAction?.variant ?? "default"}
+        onConfirm={() => { confirmAction?.action(); setConfirmAction(null); }}
+        onCancel={() => setConfirmAction(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
@@ -39,6 +40,7 @@ const SOURCE_LABELS: Record<string, string> = {
 
 export default function ForecastPlansPage() {
   const { user, loading } = useAuth();
+  const router = useRouter();
   const [plan, setPlan] = useState<ForecastPlan | null>(null);
   const [categories, setCategories] = useState<Category[]>([]);
   const [periods, setPeriods] = useState<BillingPeriod[]>([]);
@@ -588,6 +590,11 @@ export default function ForecastPlansPage() {
                       fill="#D4A64A"
                       radius={[4, 4, 4, 4]}
                       animationDuration={600}
+                      cursor="pointer"
+                      onClick={(data) => {
+                        const name = data?.name || data?.payload?.name;
+                        if (name) router.push(`/transactions?category=${encodeURIComponent(name)}`);
+                      }}
                     />
                     <Bar
                       dataKey="actual"

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -542,7 +542,7 @@ export default function ForecastPlansPage() {
 
           {/* Planned vs Actual chart */}
           {chartData.length > 0 && (
-            <div className={`${card} p-5`}>
+            <div className={`${card} p-5 overflow-hidden`}>
               <h2 className={`${cardTitle} mb-4`}>
                 Planned vs Actual (Expenses)
               </h2>
@@ -551,7 +551,7 @@ export default function ForecastPlansPage() {
                   <BarChart
                     data={chartData}
                     layout="vertical"
-                    margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+                    margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
                   >
                     <XAxis type="number" hide />
                     <YAxis

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -5,6 +5,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import AppShell from "@/components/AppShell";
+import CategorySelect from "@/components/ui/CategorySelect";
 import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import type {
   Account,
@@ -294,20 +295,18 @@ function ImportPageContent() {
                       <td className="px-4 py-2 capitalize text-text-secondary">{previewRow.type}</td>
                       <td className="px-4 py-2">
                         {!rowState.skip && !rowState.is_transfer && (
-                          <select
+                          <CategorySelect
+                            id={`cat-${previewRow.row_number}`}
+                            categories={catOptions}
                             value={rowState.category_id ?? ""}
-                            onChange={(e) =>
+                            onChange={(id) =>
                               updateRow(previewRow.row_number, {
-                                category_id: e.target.value === "" ? null : Number(e.target.value),
+                                category_id: id === "" ? null : id,
                               })
                             }
-                            className={input + " !w-40"}
-                          >
-                            <option value="">Default</option>
-                            {catOptions.map((c) => (
-                              <option key={c.id} value={c.id}>{c.name}</option>
-                            ))}
-                          </select>
+                            filterType={previewRow.type === "income" ? "income" : "expense"}
+                            className={input + " !w-48"}
+                          />
                         )}
                       </td>
                       <td className="px-4 py-2">

--- a/frontend/app/recurring/page.tsx
+++ b/frontend/app/recurring/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { formatAmount } from "@/lib/format";
@@ -24,6 +25,8 @@ export default function RecurringPage() {
   const [fetching, setFetching] = useState(true);
   const [error, setError] = useState("");
   const [successMsg, setSuccessMsg] = useState("");
+  const [confirmStop, setConfirmStop] = useState<{ id: number; description: string } | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
   const reload = useCallback(async () => {
     const data = await apiFetch<RecurringTransaction[]>("/api/v1/recurring");
@@ -36,13 +39,14 @@ export default function RecurringPage() {
   }, [loading, user, reload]);
 
   async function handleStop(item: RecurringTransaction) {
-    if (!confirm(
-      `Stop "${item.description}"?\n\nThis will deactivate the recurring schedule and delete any pending future transactions.\n\nSettled (past) transactions will NOT be affected.`
-    )) return;
+    setConfirmStop({ id: item.id, description: item.description });
+  }
+
+  async function doStop(id: number, description: string) {
     setError(""); setSuccessMsg("");
     try {
-      const res = await apiFetch<{ pending_removed: number }>(`/api/v1/recurring/${item.id}/stop`, { method: "POST" });
-      setSuccessMsg(`Stopped "${item.description}". ${res?.pending_removed ?? 0} pending transaction(s) removed.`);
+      const res = await apiFetch<{ pending_removed: number }>(`/api/v1/recurring/${id}/stop`, { method: "POST" });
+      setSuccessMsg(`Stopped "${description}". ${res?.pending_removed ?? 0} pending transaction(s) removed.`);
       await reload();
     } catch (err) { setError(extractErrorMessage(err)); }
   }
@@ -58,7 +62,10 @@ export default function RecurringPage() {
   }
 
   async function handleDelete(id: number) {
-    if (!confirm("Permanently delete this recurring template?\n\nAny remaining pending future transactions will also be removed.\nSettled transactions are preserved.")) return;
+    setConfirmDeleteId(id);
+  }
+
+  async function doDelete(id: number) {
     setError(""); setSuccessMsg("");
     try {
       const res = await apiFetch<{ pending_removed: number }>(`/api/v1/recurring/${id}`, { method: "DELETE" });
@@ -162,6 +169,24 @@ export default function RecurringPage() {
           )}
         </div>
       )}
+      <ConfirmModal
+        open={confirmStop !== null}
+        title="Stop Recurring Transaction"
+        message={confirmStop ? `Stop "${confirmStop.description}"?\n\nThis will deactivate the recurring schedule and delete any pending future transactions.\n\nSettled (past) transactions will NOT be affected.` : ""}
+        confirmLabel="Stop"
+        variant="warning"
+        onConfirm={() => { if (confirmStop) { doStop(confirmStop.id, confirmStop.description); } setConfirmStop(null); }}
+        onCancel={() => setConfirmStop(null)}
+      />
+      <ConfirmModal
+        open={confirmDeleteId !== null}
+        title="Delete Recurring Template"
+        message="Permanently delete this recurring template?\n\nAny remaining pending future transactions will also be removed.\nSettled transactions are preserved."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => { if (confirmDeleteId !== null) { doDelete(confirmDeleteId); } setConfirmDeleteId(null); }}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/recurring/page.tsx
+++ b/frontend/app/recurring/page.tsx
@@ -102,7 +102,7 @@ export default function RecurringPage() {
       ) : (
         <div className="space-y-6">
           {/* Active */}
-          <div className={card}>
+          <div className={`${card} overflow-x-auto`}>
             <div className={cardHeader}>
               <h2 className={cardTitle}>Active ({activeItems.length})</h2>
             </div>
@@ -136,7 +136,7 @@ export default function RecurringPage() {
 
           {/* Paused */}
           {pausedItems.length > 0 && (
-            <div className={card}>
+            <div className={`${card} overflow-x-auto`}>
               <div className={cardHeader}>
                 <h2 className={cardTitle}>Paused ({pausedItems.length})</h2>
               </div>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -10,6 +10,7 @@ import { formatAmount, formatLocalDate, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import CategorySelect from "@/components/ui/CategorySelect";
 import type { Account, Category, Transaction } from "@/lib/types";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 
 
 
@@ -64,6 +65,7 @@ export default function TransactionsPage() {
   const [formRecurring, setFormRecurring] = useState(false);
   const [formFrequency, setFormFrequency] = useState("monthly");
   const [formAutoSettle, setFormAutoSettle] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
   const loadRefs = useCallback(async () => {
     const [accts, cats, pers] = await Promise.all([
@@ -182,7 +184,7 @@ export default function TransactionsPage() {
   }
 
   async function handleDelete(id: number) {
-    if (!confirm("Delete this transaction?")) return;
+    setConfirmDeleteId(null);
     setError("");
     try {
       await apiFetch(`/api/v1/transactions/${id}`, { method: "DELETE" });
@@ -557,7 +559,7 @@ export default function TransactionsPage() {
                     </span>
                     <span className="col-span-1 flex justify-end gap-2">
                       {!isTransfer && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>}
-                      <button onClick={() => handleDelete(tx.id)} aria-label={`Delete: ${tx.description}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                      <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
                     </span>
                   </div>
                 );
@@ -588,6 +590,15 @@ export default function TransactionsPage() {
           )}
         </>
       )}
+      <ConfirmModal
+        open={confirmDeleteId !== null}
+        title="Delete Transaction"
+        message="Delete this transaction?"
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import { FormEvent, Suspense, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -17,7 +18,20 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 const PAGE_SIZE = 20;
 
 export default function TransactionsPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent" />
+      </div>
+    }>
+      <TransactionsPageContent />
+    </Suspense>
+  );
+}
+
+function TransactionsPageContent() {
   const { user, loading } = useAuth();
+  const searchParams = useSearchParams();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -107,6 +121,17 @@ export default function TransactionsPage() {
   useEffect(() => {
     if (!loading && user) loadRefs().catch(() => {});
   }, [loading, user, loadRefs]);
+
+  // Apply ?category= URL param once categories are loaded
+  useEffect(() => {
+    const categoryName = searchParams.get("category");
+    if (categoryName && categories.length > 0) {
+      const match = categories.find(
+        (c) => c.name.toLowerCase() === categoryName.toLowerCase()
+      );
+      if (match) setFilterCategory(match.id);
+    }
+  }, [categories, searchParams]);
 
   useEffect(() => {
     if (!loading && user) {

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -461,7 +461,7 @@ export default function TransactionsPage() {
         <Spinner />
       ) : (
         <>
-          <div className={card}>
+          <div className={`${card} overflow-x-auto`}>
             <div className="border-b border-border px-6 py-3">
               <div className="grid grid-cols-12 gap-4 text-xs font-medium uppercase tracking-wider text-text-muted">
                 {([

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -21,7 +21,7 @@ export default function TransactionsPage() {
   return (
     <Suspense fallback={
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent" />
+        <Spinner />
       </div>
     }>
       <TransactionsPageContent />
@@ -70,6 +70,7 @@ function TransactionsPageContent() {
   const [formMode, setFormMode] = useState<"transaction" | "transfer">("transaction");
   const [formAccountId, setFormAccountId] = useState<number | "">("");
   const [formToAccountId, setFormToAccountId] = useState<number | "">("");
+  const [formTransferCatId, setFormTransferCatId] = useState<number | "">("");
   const [formCategoryId, setFormCategoryId] = useState<number | "">("");
   const [formDescription, setFormDescription] = useState("");
   const [formAmount, setFormAmount] = useState("");
@@ -161,6 +162,7 @@ function TransactionsPageContent() {
             amount: formAmount,
             status: formStatus,
             date: formDate,
+            ...(formTransferCatId !== "" ? { category_id: formTransferCatId } : {}),
           }),
         });
       } else {
@@ -198,6 +200,7 @@ function TransactionsPageContent() {
       setFormType("expense");
       setFormStatus("settled");
       setFormToAccountId("");
+      setFormTransferCatId("");
       setFormRecurring(false);
       setFormAutoSettle(false);
       setFormDate(todayISO());
@@ -357,6 +360,13 @@ function TransactionsPageContent() {
               <div>
                 <label htmlFor="tx-category" className={label}>Category</label>
                 <CategorySelect id="tx-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+              </div>
+            )}
+            {formMode === "transfer" && (
+              <div>
+                <label className={label}>Category (optional)</label>
+                <CategorySelect id="tx-transfer-cat" categories={categories} value={formTransferCatId} onChange={setFormTransferCatId} className={input} />
+                <p className="mt-1 text-[10px] text-text-muted">Defaults to Transfer. Override to track in budgets.</p>
               </div>
             )}
             <div>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -133,7 +133,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <Link href="/dashboard" className="font-display text-lg font-semibold text-sidebar-text-bright">
             PFV2
           </Link>
-          <button onClick={() => setSidebarOpen(false)} className="rounded-md p-1 text-sidebar-muted hover:text-sidebar-text-bright lg:hidden">
+          <button onClick={() => setSidebarOpen(false)} aria-label="Close menu" className="rounded-md p-1 text-sidebar-muted hover:text-sidebar-text-bright lg:hidden">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
             </svg>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -93,6 +93,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const [userExpanded, setUserExpanded] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     if (!loading && !user) router.replace("/login");
@@ -121,12 +122,22 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex h-screen overflow-hidden">
+      {/* Mobile overlay backdrop */}
+      {sidebarOpen && (
+        <div className="fixed inset-0 z-40 bg-black/50 lg:hidden" onClick={() => setSidebarOpen(false)} />
+      )}
+
       {/* Dark sidebar — fixed height, never scrolls */}
-      <aside className="flex h-screen w-56 flex-col bg-sidebar-bg shrink-0">
-        <div className="px-5 pt-5 pb-6">
+      <aside className={`fixed inset-y-0 left-0 z-50 flex w-56 flex-col bg-sidebar-bg transition-transform duration-200 lg:relative lg:translate-x-0 ${sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}`}>
+        <div className="flex items-center justify-between px-5 pt-5 pb-6">
           <Link href="/dashboard" className="font-display text-lg font-semibold text-sidebar-text-bright">
             PFV2
           </Link>
+          <button onClick={() => setSidebarOpen(false)} className="rounded-md p-1 text-sidebar-muted hover:text-sidebar-text-bright lg:hidden">
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
         </div>
 
         <nav className="flex-1 overflow-y-auto space-y-0.5 px-3">
@@ -134,6 +145,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             <Link
               key={item.href}
               href={item.href}
+              onClick={() => setSidebarOpen(false)}
               className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors ${
                 isActive(item.href)
                   ? "bg-sidebar-active-bg text-sidebar-active-text"
@@ -156,6 +168,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 <Link
                   key={item.href}
                   href={item.href}
+                  onClick={() => setSidebarOpen(false)}
                   className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors ${
                     isActive(item.href)
                       ? "bg-sidebar-active-bg text-sidebar-active-text"
@@ -198,6 +211,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             <div className="absolute bottom-full left-3 right-3 mb-1.5 rounded-lg border border-sidebar-border bg-sidebar-bg py-1 shadow-xl">
               <Link
                 href="/profile"
+                onClick={() => setSidebarOpen(false)}
                 className="flex items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
               >
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -207,6 +221,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               </Link>
               <Link
                 href="/settings/security"
+                onClick={() => setSidebarOpen(false)}
                 className="flex items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
               >
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -230,11 +245,17 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       </aside>
 
       <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="flex h-14 shrink-0 items-center justify-end border-b border-border bg-surface px-8">
+        <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-surface px-4 sm:px-8">
+          <button onClick={() => setSidebarOpen(true)} className="rounded-md p-2 text-text-muted hover:text-text-primary lg:hidden" aria-label="Open menu">
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          </button>
+          <div className="lg:hidden" />
           <ThemeToggle />
         </header>
-        <main className="flex-1 overflow-auto p-8"><div className="mx-auto max-w-screen-xl">{children}</div></main>
-        <footer className="border-t border-border bg-surface px-8 py-4">
+        <main className="flex-1 overflow-auto p-4 sm:p-8"><div className="mx-auto max-w-screen-xl">{children}</div></main>
+        <footer className="border-t border-border bg-surface px-4 sm:px-8 py-4">
           <div className="flex items-center justify-between text-xs text-text-muted">
             <span>PFV2 — Personal Finance</span>
             <span>&copy; {new Date().getFullYear()}</span>

--- a/frontend/components/ui/ConfirmModal.tsx
+++ b/frontend/components/ui/ConfirmModal.tsx
@@ -30,16 +30,38 @@ export default function ConfirmModal({
   onConfirm,
   onCancel,
 }: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
   const confirmRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
-    if (open) confirmRef.current?.focus();
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      confirmRef.current?.focus();
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
   }, [open]);
 
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
+      if (e.key === "Escape") { onCancel(); return; }
+      if (e.key === "Tab") {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault(); last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault(); first.focus();
+        }
+      }
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
@@ -59,13 +81,17 @@ export default function ConfirmModal({
       onClick={onCancel}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
         className="mx-4 w-full max-w-md rounded-lg border border-border bg-surface p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="text-lg font-semibold text-text-primary">{title}</h3>
+        <h3 id="confirm-modal-title" className="text-lg font-semibold text-text-primary">{title}</h3>
         <p className="mt-2 whitespace-pre-line text-sm text-text-secondary">{message}</p>
         <div className="mt-6 flex justify-end gap-3">
-          <button onClick={onCancel} className={btnSecondary}>
+          <button ref={cancelRef} onClick={onCancel} className={btnSecondary}>
             {cancelLabel}
           </button>
           <button ref={confirmRef} onClick={onConfirm} className={variantClasses[variant]}>

--- a/frontend/components/ui/ConfirmModal.tsx
+++ b/frontend/components/ui/ConfirmModal.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { btnPrimary, btnSecondary } from "@/lib/styles";
+
+interface Props {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "warning" | "danger";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const variantClasses: Record<string, string> = {
+  default: btnPrimary,
+  warning: "rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600",
+  danger: "rounded-md bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-red-600",
+};
+
+export default function ConfirmModal({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  onConfirm,
+  onCancel,
+}: Props) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) confirmRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onCancel}
+    >
+      <div
+        className="mx-4 w-full max-w-md rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-semibold text-text-primary">{title}</h3>
+        <p className="mt-2 whitespace-pre-line text-sm text-text-secondary">{message}</p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button onClick={onCancel} className={btnSecondary}>
+            {cancelLabel}
+          </button>
+          <button ref={confirmRef} onClick={onConfirm} className={variantClasses[variant]}>
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/styles.ts
+++ b/frontend/lib/styles.ts
@@ -13,6 +13,9 @@ export const btnSecondary =
 export const btnDanger =
   "text-xs text-text-muted hover:text-danger";
 
+export const btnWarning =
+  "rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50";
+
 export const btnLink =
   "text-xs text-text-muted hover:text-accent";
 


### PR DESCRIPTION
## Summary
- Responsive sidebar with hamburger menu below 1024px (slide-out overlay)
- Tables scroll horizontally on narrow viewports
- Replaced all 12 `window.confirm()` calls with styled `ConfirmModal` component (danger/warning variants)
- Dashboard Budget and Forecast charts now match dedicated page color schemes and legends
- Semantic tooltip colors across all chart tooltips
- Clickable bar charts — click budget/forecast bars to filter transactions
- Spending category legend capped at top 10 to prevent card height blow-up
- All active accounts shown on dashboard (including zero-balance)
- Account balances refresh after settle/unsettle without page reload
- Budget transfer form keeps spent/amount visible while expanded
- CategorySelect type-ahead on import page (replaces plain dropdown)
- Optional category picker on transfer form (e.g. "General Savings" for budgetable transfers)
- Forecast chart overflow fix