### PR TITLE
chore: scope deploy and release workflows to relevant file changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,13 @@ name: Deploy to Production
 on:
   push:
     branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "nginx/**"
+      - ".do/**"
+      - "docker-compose*.yml"
+      - "Dockerfile*"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
     paths-ignore:
       - "docs/**"
-      - "**.md"
+      - "*.md"
+      - "**/*.md"
       - ".github/workflows/**"
       - ".superpowers/**"
       - "LICENSE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/**"
+      - ".superpowers/**"
+      - "LICENSE"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Deploy workflow now only triggers on backend, frontend, nginx, .do, or Docker config changes
- Release workflow skips docs-only, markdown-only, workflow-only, and license-only changes
- Prevents unnecessary deployments and releases from non-app changes