### PR TITLE
fix: password reset fails with naive/aware datetime comparison

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -408,7 +408,7 @@ async def reset_password(body: ResetPasswordRequest, db: AsyncSession = Depends(
 
     # Reject tokens issued before the last password change
     if user.password_changed_at:
-        token_iat = datetime.fromtimestamp(payload.get("iat", 0), tz=timezone.utc)
+        token_iat = datetime.fromtimestamp(payload.get("iat", 0), tz=timezone.utc).replace(tzinfo=None)
         if token_iat < user.password_changed_at:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## Summary

- Fix `TypeError: can't compare offset-naive and offset-aware datetimes` in password reset flow
- `token_iat` from JWT is timezone-aware (UTC), but `user.password_changed_at` from MySQL is naive
- Strip tzinfo from `token_iat` before comparison since both values are UTC

Root cause: `datetime.fromtimestamp(..., tz=timezone.utc)` produces an aware datetime, MySQL `DateTime` columns produce naive datetimes. Python refuses to compare them.