### PR TITLE
chore: ignore local scratch dirs and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ mysql_data/
 
 # Claude stuff
 .claude/
+.superpowers/
+.playwright-mcp/
+
+# Local test fixtures and scratch
+mock/
+*.png
+!frontend/public/**/*.png
+frontend/tsconfig.tsbuildinfo


### PR DESCRIPTION
## Summary
- Ignore `.superpowers/` and `.playwright-mcp/` (tool-generated output)
- Ignore `mock/` for local CSV import fixtures
- Ignore stray `*.png` debug screenshots at repo root (with allowlist for `frontend/public/**/*.png`)
- Ignore `frontend/tsconfig.tsbuildinfo` (TS incremental build cache)