### PR TITLE
fix: responsive sweep — data tables (Transactions, Forecast Plans, Budgets)

### DIFF
--- a/docs/superpowers/audits/2026-04-19-responsive-findings.md
+++ b/docs/superpowers/audits/2026-04-19-responsive-findings.md
@@ -1,0 +1,95 @@
+# Responsive Audit Findings — 2026-04-19
+
+Source: spec `docs/superpowers/specs/2026-04-19-responsive-sweep-design.md`.
+
+## Method
+Code scan followed by visual verification (pending per-page). Viewport targets: 375px, 768px, 1280px.
+
+## Findings table
+
+| Page | Current state | Symptom < md | Chosen pattern | PR |
+|---|---|---|---|---|
+| transactions | 12-col CSS grid "table" (`grid grid-cols-12`) for rows + a wrap-capable filter bar (`flex flex-wrap` with `min-w-[200px]` search field). Quick-add form is already `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`. Row container wrapped in `overflow-x-auto`. | 12-col grid squeezes every cell (date/description/category/amount) into unreadable widths; tiny action icons drop below the 44px tap target. Filter bar wraps but each 200px-min field still forces horizontal scroll on 375px. | Card (A) | PR1 |
+| forecast-plans | Plain table built as a custom grid via `grid-cols-[1fr_100px_100px_100px_80px(_100px)]` template. No `overflow-x-auto`, no `sm:/md:` on the row template. Inline bar-chart section uses fixed `style={{ height }}`. Filters row is `flex flex-wrap` with `min-w-[200px]`. | Fixed px column template plus chart row blow past 375px viewport → horizontal page scroll. Numeric columns still render but category names truncate hard. | Hybrid (B) | PR1 |
+| budgets | Summary tiles in a `flex gap-4` row of three cards (no breakpoint), category list built from raw `flex` rows with per-row progress bars and transfer form (`flex flex-wrap` + `basis-40`). Chart section uses `style={{ height }}`. Add form is `flex flex-wrap`. No `sm:/md:/lg:` anywhere in the file. | Three summary cards stay side-by-side on 375px and shrink to ~100px each, truncating amounts. Inline progress bars + action buttons on the same row push off-screen; the transfer sub-form overlaps. | Hybrid (B) | PR1 |
+| recurring | Two `grid grid-cols-12` "tables" (active / inactive) wrapped in `overflow-x-auto`. No headers, no breakpoint prefixes. Actions live in `col-span-2 flex justify-end gap-2`. | 12-col grid collapses every cell on 375px; action buttons undersized; horizontal scroll is required just to see the amount. | Card (A) | PR2 |
+| accounts | Two-column `grid grid-cols-1 gap-6 lg:grid-cols-2` outer layout, then each column renders a list of `flex items-center justify-between` rows with inline delete/edit/form controls. | Outer layout already stacks below `lg`, but inner rows squeeze name + balance + actions into one flex row; on 375px the action icons wrap under the balance. Add-account form (`flex gap-2`) overflows. | Card (A) | PR2 |
+| categories | Master/sub category list with nested forms (`flex flex-wrap gap-3`) and per-row flex controls including color swatches, rename input, delete. Two `min-w-[200px]` inputs in the master-add form. | Add form's two 200px-min fields force overflow at 375px; sub-category rows with color swatch + name + two buttons push actions offscreen. | Card (A) | PR2 |
+| import | Wizard with file-upload step, preview table (7 columns: Skip/Date/Description/Amount/Type/Category/Transfer) wrapped in `overflow-x-auto`, and summary footer (`flex items-center gap-4`). Description cell uses `max-w-[300px] truncate`. Action bar is `flex gap-4 border-t`. No `sm:/md:` prefixes. | 7-col table needs the outer `overflow-x-auto` (already present) but wizard chrome/step indicators sit in unqualified `flex` rows that wrap awkwardly. Action bar's side-by-side buttons still fit, but upload + account picker row collapses. | Form-stack adapted | PR2 |
+| login / register / forgot / reset / verify / mfa / setup | Centered card (`max-w-sm` or `max-w-md`) with `space-y-5` form stack. Register uses `flex gap-3` first-name/last-name pair. Setup is `max-w-md` stack. None have responsive prefixes, but the centered card sits on `px-4` so it doesn't overflow. | Auth forms are already stack-shaped and narrow; the only sub-md break is the register first/last-name `flex gap-3` which squeezes both inputs to ~140px on 375px. Nothing goes offscreen but submit buttons can be pushed under soft keyboards (not in scope here, but pattern still applies). | Form-stack (C) | PR2 |
+| settings/* | Settings hub (`/settings`) renders inline profile card + `flex gap-3` first/last-name pair. `settings/security` has 2FA blocks using `grid grid-cols-2 gap-2` for recovery codes and `flex gap-3` rows; uses `max-w-[200px]` on session-duration input. `settings/organization` has billing-cycle form (`flex items-end gap-3`) and a raw `<table>` (no `overflow-x-auto`) for key/value settings. `settings/billing` has `mt-6 grid grid-cols-3 gap-4` usage summary + a `grid gap-4 sm:grid-cols-2` plans grid. | Unqualified 2-col grids (recovery-code blocks, billing summary 3-col) squeeze to unreadable widths at 375px. Org settings `<table>` is the only table in the app without `overflow-x-auto` — it will cause page-level horizontal scroll. First/last-name `flex gap-3` on the hub shrinks inputs. | Form-stack (C) | PR2 |
+| admin/settings | 12-line file: `useEffect` redirect to `/settings/organization`. Nothing to render. | N/A — no UI. Still listed because it appears on route inventory. | Form-stack (C) | PR2 |
+| system/plans | Plan-create/edit form is `p-6 grid grid-cols-2 gap-4` (unqualified). Plans list is a `<table>` wrapped in `overflow-x-auto`. Actions bar is `col-span-2 flex gap-3`. | 2-col form cuts every label/input to ~160px on 375px; numeric pricing inputs get crammed. Table is already scroll-wrapped. | Form-stack (C) | PR2 |
+| dashboard | Already heavily breakpoint-prefixed: `grid-cols-1 lg:grid-cols-2`, `grid-cols-1 lg:grid-cols-3`, summary uses `grid-cols-2 gap-4` inside a card (small tiles, ok), `flex gap-3 overflow-x-auto` for chip strip, `flex-col sm:flex-row` for charts. Two inner `grid grid-cols-2 gap-4` blocks (summary tiles inside cards) and a Quick-Add form at `grid-cols-2 gap-3 lg:grid-cols-4` remain unqualified at `sm:`. | Quick-Add form crams four fields into 2 cols on 375px → inputs narrow but readable; summary tile `grid-cols-2` stays OK because tiles are small. No full-page horizontal scroll observed in code. | — (regression only) | PR2 |
+
+## Raw scan output
+
+### Step 1 — Fixed pixel widths / inline width-height styles
+
+```
+frontend/app/settings/security/page.tsx:452:                  className={`${input} max-w-[200px]`}
+frontend/app/forecast-plans/page.tsx:471:            <div className="min-w-[200px] flex-1">
+frontend/app/forecast-plans/page.tsx:567:              <div style={{ height: Math.max(chartData.length * 40, 100) }}>
+frontend/app/dashboard/page.tsx:589:                <div className="p-4" style={{ height: Math.max(budgets.slice(0, 6).length * 40, 100) }}>
+frontend/app/dashboard/page.tsx:639:                <div style={{ height: Math.max(Math.min(forecast.categories.length, 8) * 32, 100) }}>
+frontend/app/transactions/page.tsx:426:        <div className="flex-1 min-w-[200px]">
+frontend/app/budgets/page.tsx:169:            <div className="flex-1 min-w-[200px]">
+frontend/app/budgets/page.tsx:216:              <div className="p-4" style={{ height: Math.max(budgets.length * 36, 100) }}>
+frontend/app/import/page.tsx:284:                      <td className="max-w-[300px] truncate px-4 py-2 text-text-primary" title={previewRow.description}>
+frontend/app/categories/page.tsx:173:            <div className="flex-1 min-w-[200px]">
+frontend/app/categories/page.tsx:185:            <div className="flex-1 min-w-[200px]">
+```
+
+(AppShell.tsx hits for `h-[18px] w-[18px]` on SVG icon sizes are intentional and omitted — those are 18px nav glyphs, not layout widths.)
+
+### Step 2 — Unqualified multi-column grids (no `sm:`/`md:`/`lg:` prefix)
+
+```
+frontend/app/settings/security/page.tsx:323:              <div className="grid grid-cols-2 gap-2 rounded-lg bg-surface-raised p-4">
+frontend/app/settings/security/page.tsx:379:                  <div className="grid grid-cols-2 gap-2 rounded-lg bg-surface-raised p-4">
+frontend/app/settings/billing/page.tsx:181:              <div className="mt-6 grid grid-cols-3 gap-4 border-t border-border pt-4">
+frontend/app/dashboard/page.tsx:441:              <div className="grid grid-cols-2 gap-4">
+frontend/app/dashboard/page.tsx:464:                  <div className="grid grid-cols-2 gap-4">
+frontend/app/system/plans/page.tsx:176:          <form onSubmit={handleSubmit} className="p-6 grid grid-cols-2 gap-4">
+```
+
+### Step 3 — `<table>` without `overflow-x-auto` wrapper in same file
+
+```
+NEEDS-WRAP: frontend/app/settings/organization/page.tsx
+```
+
+(`frontend/app/system/plans/page.tsx` and `frontend/app/import/page.tsx` contain both `<table` and `overflow-x-auto` — they passed the check.)
+
+### Step 4 — Pages with zero `sm:`/`md:`/`lg:`/`xl:` classes
+
+```
+NO-RESPONSIVE: frontend/app/mfa-verify/page.tsx
+NO-RESPONSIVE: frontend/app/settings/organization/page.tsx
+NO-RESPONSIVE: frontend/app/settings/security/page.tsx
+NO-RESPONSIVE: frontend/app/settings/page.tsx
+NO-RESPONSIVE: frontend/app/auth/google/callback/page.tsx
+NO-RESPONSIVE: frontend/app/setup/page.tsx
+NO-RESPONSIVE: frontend/app/admin/settings/page.tsx
+NO-RESPONSIVE: frontend/app/system/plans/page.tsx
+NO-RESPONSIVE: frontend/app/verify-email/page.tsx
+NO-RESPONSIVE: frontend/app/register/page.tsx
+NO-RESPONSIVE: frontend/app/profile/page.tsx
+NO-RESPONSIVE: frontend/app/forgot-password/page.tsx
+NO-RESPONSIVE: frontend/app/budgets/page.tsx
+NO-RESPONSIVE: frontend/app/reset-password/page.tsx
+NO-RESPONSIVE: frontend/app/import/page.tsx
+NO-RESPONSIVE: frontend/app/page.tsx
+NO-RESPONSIVE: frontend/app/categories/page.tsx
+NO-RESPONSIVE: frontend/app/login/page.tsx
+NO-RESPONSIVE: frontend/app/recurring/page.tsx
+```
+
+`frontend/app/page.tsx`, `frontend/app/profile/page.tsx`, `frontend/app/admin/settings/page.tsx`, and `frontend/app/auth/google/callback/page.tsx` are all router redirects / stubs with no UI — they're listed by the scan but don't need remediation.
+
+## Open questions
+
+- **Budgets inline charts (Pattern B risk).** Spec already calls this out: inline bar charts use `style={{ height }}` and won't comfortably survive hide-and-scroll. If the hybrid feels cramped in PR1 visual verification, Budgets falls back to Pattern A (card) and we document the exception. Likely needs a decision during PR1 implementation, not now.
+- **Transactions "table" is actually a CSS grid**, not a `<table>`. Pattern A still applies (stack rows as cards below `md`), but the column-header row at line 503 and every row at 534/564 all use `grid grid-cols-12`. The fix is the same shape as if it were a real table but won't rely on `hidden md:table-cell`. Worth confirming during PR1 that card rendering doesn't require re-parenting the grid wrapper.
+- **`settings/organization` has a bare `<table>`** (line 256) with no `overflow-x-auto`. This is the only such case in the app and is the most likely cause of page-level horizontal scroll on `/settings/organization` at 375px. Fix is trivial (wrap in `overflow-x-auto`) but noting it here so PR2 doesn't miss it.
+- **Recurring page has no column headers** — the 12-col grid only renders data rows. When we transform to cards below `md`, the primary field choice is the description; confirm during PR2 that's the right "card title" field (vs. next-due-date).

--- a/docs/superpowers/audits/2026-04-19-responsive-findings.md
+++ b/docs/superpowers/audits/2026-04-19-responsive-findings.md
@@ -3,15 +3,19 @@
 Source: spec `docs/superpowers/specs/2026-04-19-responsive-sweep-design.md`.
 
 ## Method
-Code scan followed by visual verification (pending per-page). Viewport targets: 375px, 768px, 1280px.
+Code scan followed by visual verification. Viewport targets: 375px, 768px, 1280px.
+
+## Status
+- **PR1 implementation:** complete (Transactions, Forecast Plans, Budgets). Visual verification pending merge.
+- **PR2 implementation:** not started.
 
 ## Findings table
 
 | Page | Current state | Symptom < md | Chosen pattern | PR |
 |---|---|---|---|---|
-| transactions | 12-col CSS grid "table" (`grid grid-cols-12`) for rows + a wrap-capable filter bar (`flex flex-wrap` with `min-w-[200px]` search field). Quick-add form is already `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`. Row container wrapped in `overflow-x-auto`. | 12-col grid squeezes every cell (date/description/category/amount) into unreadable widths; tiny action icons drop below the 44px tap target. Filter bar wraps but each 200px-min field still forces horizontal scroll on 375px. | Card (A) | PR1 |
-| forecast-plans | Plain table built as a custom grid via `grid-cols-[1fr_100px_100px_100px_80px(_100px)]` template. No `overflow-x-auto`, no `sm:/md:` on the row template. Inline bar-chart section uses fixed `style={{ height }}`. Filters row is `flex flex-wrap` with `min-w-[200px]`. | Fixed px column template plus chart row blow past 375px viewport → horizontal page scroll. Numeric columns still render but category names truncate hard. | Hybrid (B) | PR1 |
-| budgets | Summary tiles in a `flex gap-4` row of three cards (no breakpoint), category list built from raw `flex` rows with per-row progress bars and transfer form (`flex flex-wrap` + `basis-40`). Chart section uses `style={{ height }}`. Add form is `flex flex-wrap`. No `sm:/md:/lg:` anywhere in the file. | Three summary cards stay side-by-side on 375px and shrink to ~100px each, truncating amounts. Inline progress bars + action buttons on the same row push off-screen; the transfer sub-form overlaps. | Hybrid (B) | PR1 |
+| transactions | 12-col CSS grid "table" (`grid grid-cols-12`) for rows + a wrap-capable filter bar. **PR1 fix:** header row + grid rows gated `hidden md:block`; new `md:hidden` card sibling renders the same transactions with amount, date/account subline, category, and Edit/Settle/Delete buttons at `min-h-[44px]`. Filter bar stacks `flex-col sm:flex-row`. Inline edit form stacks at `grid-cols-1 sm:grid-cols-2`. | Original: 12-col grid squeezed fields to unreadable widths below `md`. Resolved by card layout. | Card (A) | PR1 ✅ |
+| forecast-plans | Custom CSS-grid "table" (`grid-cols-[...]`). **PR1 fix:** grid template becomes `grid-cols-[1fr_100px]` below `md`, restores full template at `md+`. Actual/Variance/Source cells gated `hidden md:block`. Inline summary line inside Category cell shows Actual/Variance/Source below `md`. Wrapper uses `overflow-x-auto` with `min-w-[320px]` fallback (not 640 — the mobile column set fits 320 naturally, per implementer). Add-item form stacks `flex-col sm:flex-row`. | Original: fixed px template overflowed at 375px; category names truncated. Resolved by hide-and-scroll with inline summary. | Hybrid (B) | PR1 ✅ |
+| budgets | Flex-row per budget with inline progress bar, amount, and actions. **PR1 fix:** each row reflows to `flex-col md:flex-row md:items-center md:justify-between`; amount duplicated with `ml-auto md:hidden` (mobile position) and `hidden md:inline` (desktop position) so only one shows per viewport. Actions get `flex flex-wrap`, `min-h-[44px] md:min-h-0`. Summary tiles: `grid-cols-1 sm:grid-cols-3`. Add-budget + transfer inline forms: `flex-col sm:flex-row`. Header action row: `flex-col sm:flex-row sm:items-center`. No per-row expansion chart — page has a single aggregate bar chart, no change. | Original: amounts overlapped category names; Transfer/Edit/Remove too small to tap; summary cards shrank to unreadable widths on 375px. All three resolved. | Reflow (A-adapted) | PR1 ✅ |
 | recurring | Two `grid grid-cols-12` "tables" (active / inactive) wrapped in `overflow-x-auto`. No headers, no breakpoint prefixes. Actions live in `col-span-2 flex justify-end gap-2`. | 12-col grid collapses every cell on 375px; action buttons undersized; horizontal scroll is required just to see the amount. | Card (A) | PR2 |
 | accounts | Two-column `grid grid-cols-1 gap-6 lg:grid-cols-2` outer layout, then each column renders a list of `flex items-center justify-between` rows with inline delete/edit/form controls. | Outer layout already stacks below `lg`, but inner rows squeeze name + balance + actions into one flex row; on 375px the action icons wrap under the balance. Add-account form (`flex gap-2`) overflows. | Card (A) | PR2 |
 | categories | Master/sub category list with nested forms (`flex flex-wrap gap-3`) and per-row flex controls including color swatches, rename input, delete. Two `min-w-[200px]` inputs in the master-add form. | Add form's two 200px-min fields force overflow at 375px; sub-category rows with color swatch + name + two buttons push actions offscreen. | Card (A) | PR2 |
@@ -89,7 +93,8 @@ NO-RESPONSIVE: frontend/app/recurring/page.tsx
 
 ## Open questions
 
-- **Budgets inline charts (Pattern B risk).** Spec already calls this out: inline bar charts use `style={{ height }}` and won't comfortably survive hide-and-scroll. If the hybrid feels cramped in PR1 visual verification, Budgets falls back to Pattern A (card) and we document the exception. Likely needs a decision during PR1 implementation, not now.
-- **Transactions "table" is actually a CSS grid**, not a `<table>`. Pattern A still applies (stack rows as cards below `md`), but the column-header row at line 503 and every row at 534/564 all use `grid grid-cols-12`. The fix is the same shape as if it were a real table but won't rely on `hidden md:table-cell`. Worth confirming during PR1 that card rendering doesn't require re-parenting the grid wrapper.
-- **`settings/organization` has a bare `<table>`** (line 256) with no `overflow-x-auto`. This is the only such case in the app and is the most likely cause of page-level horizontal scroll on `/settings/organization` at 375px. Fix is trivial (wrap in `overflow-x-auto`) but noting it here so PR2 doesn't miss it.
-- **Recurring page has no column headers** — the 12-col grid only renders data rows. When we transform to cards below `md`, the primary field choice is the description; confirm during PR2 that's the right "card title" field (vs. next-due-date).
+- **Budgets: page has no per-row chart** — just a single aggregate bar chart above the list. Plan's Step 3 about per-row expansion grids did not apply; handled gracefully during PR1.
+- **Transactions "table" is a CSS grid, not a `<table>`** — confirmed during PR1. Used `hidden md:block` + `md:hidden` card sibling instead of `hidden md:table-cell`. Pattern A still applied successfully.
+- **`settings/organization` has a bare `<table>`** (line 256) with no `overflow-x-auto` — carried into PR2.
+- **Recurring page has no column headers** — primary card-title field decision (description vs next-due-date) carried into PR2.
+- **Period nav icon buttons on Budgets** deliberately not bumped to 44px during PR1 (they are tight icon-only affordances flanking date text). Revisit if touch tests show they're hard to tap.

--- a/docs/superpowers/plans/2026-04-19-responsive-sweep.md
+++ b/docs/superpowers/plans/2026-04-19-responsive-sweep.md
@@ -1,0 +1,988 @@
+# Responsive Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every authenticated page in PFV2 render correctly from 320px through 1024px+, shipping as two reviewable PRs.
+
+**Architecture:** Audit-then-fix using Tailwind's `sm`/`md`/`lg` breakpoints. Four reusable fix patterns (Cards, Hybrid hide-and-scroll, Form-stack, Modal containment) applied per-page based on the spec. Acceptance per page is visual verification at 375px and 768px plus a `lg+` regression check — no new test infrastructure, since the frontend has none today.
+
+**Tech Stack:** Next.js 15 App Router, React 19, Tailwind CSS, TypeScript. Chrome DevTools MCP for viewport verification.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-responsive-sweep-design.md`
+
+---
+
+## File-by-File Impact
+
+### PR1 (branch: `fix/responsive-sweep-data-tables`)
+
+| Path | Scope | Pattern |
+|---|---|---|
+| `frontend/app/transactions/page.tsx` | Full responsive pass | Card (A) |
+| `frontend/app/forecast-plans/page.tsx` | Full responsive pass | Hybrid (B) |
+| `frontend/app/budgets/page.tsx` | Full responsive pass | Hybrid (B) |
+| `frontend/components/ui/DataCard.tsx` | **New** — extracted only if the second page clearly needs the same shape | — |
+| `docs/superpowers/audits/2026-04-19-responsive-findings.md` | **New** — audit report committed with PR1 | — |
+
+### PR2 (branch: `fix/responsive-sweep-remaining`, off main after PR1 merges)
+
+| Path | Scope | Pattern |
+|---|---|---|
+| `frontend/app/recurring/page.tsx` | Full responsive pass | Card (A) |
+| `frontend/app/accounts/page.tsx` | Full responsive pass | Card (A) |
+| `frontend/app/categories/page.tsx` | Full responsive pass | Card (A) or tighter table |
+| `frontend/app/import/page.tsx` | Stack the wizard steps on phones | Form-stack (C) adapted |
+| `frontend/app/login/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/register/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/forgot-password/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/reset-password/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/verify-email/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/mfa-verify/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/setup/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/settings/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/settings/billing/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/settings/organization/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/settings/security/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/app/system/plans/page.tsx` | Breakpoint sweep | Form-stack (C) |
+| `frontend/components/SettingsLayout.tsx` | Tabs must wrap/scroll on phones | — |
+| `frontend/components/ui/ConfirmModal.tsx` | Max-viewport containment | Modal (D) |
+| Inline modals across pages | Same containment rules | Modal (D) |
+| `frontend/app/dashboard/page.tsx` | Regression check only — no code changes unless broken | — |
+
+---
+
+## Conventions Used Across All Tasks
+
+- **Commit cadence:** one commit per task's "Step N: Commit" moment. Use the exact commit message supplied. Don't bundle pages into a single commit.
+- **Visual verification:** use Chrome DevTools MCP (`mcp__chrome-devtools__*` tools) to navigate to `http://localhost/<path>`, resize to 375×812, screenshot, then resize to 768×1024, screenshot, then resize to 1280×800, screenshot. Save screenshots under `/tmp/responsive-sweep/<page>-<viewport>.png` — do NOT commit them to the repo (they go into PR descriptions only).
+- **Logged-in state:** before verification, make sure the dev stack is up (`./pfv status` → running; `./pfv start` if not), then log in as the superadmin account at `http://localhost/login`. Reuse the same session across all verifications.
+- **Safe classes recap:**
+  - `<table>` containers get `overflow-x-auto` + `min-w-*` when Pattern B is used.
+  - Cards use `flex flex-col gap-3 rounded-lg border p-4` as a baseline; amounts right-aligned via `ml-auto`.
+  - Tap targets get `min-h-[44px]` (or `h-11`) on action buttons below `md`.
+  - Forms below `sm` use `grid-cols-1` instead of `grid-cols-2`; above `sm` they restore their original columns.
+- **DRY trigger:** extract a component only after the third repetition of the same shape. Two repetitions = inline. Three = extract to `frontend/components/ui/`.
+- **No Tailwind config changes.** If you feel you need a custom breakpoint, stop and flag it in the PR description instead.
+
+---
+
+## Phase 0 — Preflight
+
+### Task 0: Confirm branch and environment
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm branch**
+
+Run:
+```bash
+git branch --show-current
+```
+Expected: `fix/responsive-sweep-data-tables`
+
+- [ ] **Step 2: Confirm dev stack is up**
+
+Run:
+```bash
+./pfv status
+```
+Expected: backend, frontend, nginx, mysql all running. If not, run `./pfv start` and wait for "Migrations complete" in the backend logs.
+
+- [ ] **Step 3: Sanity-open the app**
+
+Run:
+```bash
+curl -fsS http://localhost/api/health
+```
+Expected: HTTP 200 and a JSON body with `"status":"ok"`.
+
+Do not commit anything in this task.
+
+---
+
+## Phase 1 — Audit
+
+### Task 1: Produce the code-scan audit report
+
+**Files:**
+- Create: `docs/superpowers/audits/2026-04-19-responsive-findings.md`
+
+- [ ] **Step 1: Scan for fixed pixel widths**
+
+Run:
+```bash
+grep -rnE 'w-\[[0-9]+px\]|h-\[[0-9]+px\]|style=\{\{.*(width|height):' frontend/app frontend/components | grep -v node_modules
+```
+Capture the output for the report.
+
+- [ ] **Step 2: Scan for unqualified grids and flex rows**
+
+Run:
+```bash
+grep -rnE 'grid-cols-[2-9]( |")' frontend/app frontend/components | grep -v node_modules | grep -vE '(sm|md|lg|xl):grid-cols'
+```
+Any match is a page that uses a multi-column grid with no breakpoint qualifier — likely breaks below `sm`.
+
+- [ ] **Step 3: Scan for `<table>` without `overflow-x-auto`**
+
+Run:
+```bash
+grep -rln '<table' frontend/app | xargs -I{} sh -c 'grep -L "overflow-x-auto" {} && echo "NEEDS-WRAP: {}"'
+```
+
+- [ ] **Step 4: Scan for pages with no responsive classes at all**
+
+Run:
+```bash
+for f in $(find frontend/app -name 'page.tsx'); do
+  if ! grep -qE '(sm|md|lg|xl):' "$f"; then
+    echo "NO-RESPONSIVE: $f"
+  fi
+done
+```
+
+- [ ] **Step 5: Write the audit report**
+
+Write `docs/superpowers/audits/2026-04-19-responsive-findings.md` with this exact structure:
+
+```markdown
+# Responsive Audit Findings — 2026-04-19
+
+Source: spec `docs/superpowers/specs/2026-04-19-responsive-sweep-design.md`.
+
+## Method
+Code scan followed by visual verification (pending per-page). Viewport targets: 375px, 768px, 1280px.
+
+## Findings table
+
+| Page | Current state | Symptom < md | Chosen pattern | PR |
+|---|---|---|---|---|
+| transactions | <summary of table + filters> | <describe> | Card (A) | PR1 |
+| forecast-plans | <summary> | <describe> | Hybrid (B) | PR1 |
+| budgets | <summary> | <describe> | Hybrid (B) | PR1 |
+| recurring | <summary> | <describe> | Card (A) | PR2 |
+| accounts | <summary> | <describe> | Card (A) | PR2 |
+| categories | <summary> | <describe> | Card (A) | PR2 |
+| import | <summary> | <describe> | Form-stack adapted | PR2 |
+| login / register / forgot / reset / verify / mfa / setup | <summary> | <describe> | Form-stack (C) | PR2 |
+| settings/* | <summary> | <describe> | Form-stack (C) | PR2 |
+| admin/settings | <summary> | <describe> | Form-stack (C) | PR2 |
+| system/plans | <summary> | <describe> | Form-stack (C) | PR2 |
+| dashboard | already responsive | regression only | — | PR2 |
+
+## Raw scan output
+(paste the outputs from steps 1–4 here, trimmed to relevant hits)
+
+## Open questions
+(any page where the chosen pattern needs reconsideration — leave blank if none)
+```
+
+Fill in the `<summary>` and `<describe>` cells by briefly reading each page file (you don't need to parse every line — just enough to say "8-column table, filters in a flex row, no breakpoint qualifiers" or similar).
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add docs/superpowers/audits/2026-04-19-responsive-findings.md
+git commit -m "docs: responsive audit findings"
+```
+
+---
+
+## Phase 2 — PR1: Data-Table Pages
+
+### Task 2: Transactions page responsive fix
+
+**Files:**
+- Modify: `frontend/app/transactions/page.tsx`
+
+- [ ] **Step 1: Read the current page**
+
+Run:
+```bash
+wc -l frontend/app/transactions/page.tsx
+```
+Expected: ~639 lines.
+
+Read the full file. Identify:
+- The filters/actions bar (usually at the top, multi-column flex or grid)
+- The main table (or grid-cols-12 row pattern)
+- Any pagination bar at the bottom
+- Action buttons per row (edit, delete, settle/unsettle)
+
+- [ ] **Step 2: Apply filter-bar stacking**
+
+Replace the filter bar's wrapper so it is a single column below `sm` and restores its original layout from `sm+`. Example transformation — match the actual markup, don't copy blindly:
+
+```tsx
+// Before:
+<div className="flex items-center gap-2">
+  <input className="w-64 ..." />
+  <select className="..." />
+  <button className="...">Filter</button>
+</div>
+
+// After:
+<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
+  <input className="w-full sm:w-64 ..." />
+  <select className="w-full sm:w-auto ..." />
+  <button className="w-full sm:w-auto min-h-[44px] sm:min-h-0 ...">Filter</button>
+</div>
+```
+
+- [ ] **Step 3: Apply card layout to transactions below `md`**
+
+If the page uses a `<table>`: add `hidden md:table` to the table, and insert a sibling `<div className="md:hidden flex flex-col gap-3">` that maps over the same `transactions` array and renders:
+
+```tsx
+<article
+  key={tx.id}
+  className="flex flex-col gap-2 rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+>
+  <div className="flex items-start justify-between gap-2">
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+        {tx.description}
+      </div>
+      <div className="mt-0.5 text-xs text-slate-500">
+        {formatDate(tx.date)} · {tx.account_name}
+      </div>
+    </div>
+    <div className={`shrink-0 text-right text-sm font-semibold ${tx.amount < 0 ? "text-rose-600" : "text-emerald-600"}`}>
+      {formatAmount(tx.amount)}
+    </div>
+  </div>
+  {tx.category_name && (
+    <div className="text-xs text-slate-600 dark:text-slate-400">
+      {tx.category_name}
+    </div>
+  )}
+  <div className="flex flex-wrap gap-2 pt-2 border-t border-slate-100 dark:border-slate-800">
+    <button className="min-h-[44px] px-3 rounded ..." onClick={() => startEdit(tx)}>Edit</button>
+    <button className="min-h-[44px] px-3 rounded ..." onClick={() => toggleSettled(tx)}>
+      {tx.settled ? "Unsettle" : "Settle"}
+    </button>
+    <button className="min-h-[44px] px-3 rounded text-rose-600 ..." onClick={() => askDelete(tx)}>Delete</button>
+  </div>
+</article>
+```
+
+If the page uses `grid-cols-12` row divs instead of a `<table>`: keep the grid for `md+` by adding `hidden md:grid` to the row container, and render the same card markup above in a `md:hidden` sibling.
+
+- [ ] **Step 4: Fix any inline-edit form to stack on phones**
+
+The edit form (if inline) likely uses `grid-cols-*` with multiple fields per row. Add `grid-cols-1 sm:grid-cols-2` (or the original count) so inputs stack below `sm`. Ensure action buttons are `min-h-[44px]` below `sm`.
+
+- [ ] **Step 5: Start dev server (if not already) and visually verify at 375px**
+
+Navigate via chrome-devtools MCP to `http://localhost/transactions` after logging in. Resize to 375×812. Check:
+- No horizontal page scroll.
+- Cards render cleanly with amount visible on the right.
+- Filter inputs stack full-width.
+- All buttons are tappable (≥44px).
+
+Screenshot to `/tmp/responsive-sweep/transactions-375.png`.
+
+- [ ] **Step 6: Visually verify at 768px**
+
+Resize to 768×1024. Confirm the table is visible (cards hidden) and the filter bar is restored to its desktop row layout. Screenshot to `/tmp/responsive-sweep/transactions-768.png`.
+
+- [ ] **Step 7: Regression check at 1280px**
+
+Resize to 1280×800. Confirm no visual regression vs. main. Screenshot to `/tmp/responsive-sweep/transactions-1280.png`.
+
+- [ ] **Step 8: Commit**
+
+Run:
+```bash
+git add frontend/app/transactions/page.tsx
+git commit -m "fix(responsive): transactions card layout below md"
+```
+
+---
+
+### Task 3: Forecast Plans page responsive fix (hybrid)
+
+**Files:**
+- Modify: `frontend/app/forecast-plans/page.tsx`
+
+- [ ] **Step 1: Read the current page**
+
+Read `frontend/app/forecast-plans/page.tsx`. Identify the main table's columns in order. Typical shape: Category, Planned, Actual, Variance, Source, Actions.
+
+- [ ] **Step 2: Classify columns by priority**
+
+Mark columns as:
+- **Always visible:** Category (name), Planned (primary amount), Actions trigger.
+- **Visible from `md+`:** Actual, Variance, Source.
+
+- [ ] **Step 3: Apply hide-and-scroll**
+
+On each `<th>` and matching `<td>` for the non-essential columns, add `hidden md:table-cell`:
+
+```tsx
+<th className="... hidden md:table-cell">Actual</th>
+<th className="... hidden md:table-cell">Variance</th>
+<th className="... hidden md:table-cell">Source</th>
+
+{rows.map(r => (
+  <tr key={r.id}>
+    <td>{r.category}</td>
+    <td className="text-right">{fmt(r.planned)}</td>
+    <td className="hidden md:table-cell text-right">{fmt(r.actual)}</td>
+    <td className="hidden md:table-cell text-right">{fmt(r.variance)}</td>
+    <td className="hidden md:table-cell">{r.source}</td>
+    <td>{actions}</td>
+  </tr>
+))}
+```
+
+- [ ] **Step 4: Wrap the table in a scroller**
+
+Wrap the `<table>` in `<div className="overflow-x-auto">` and set the table to `min-w-[640px]` so the visible columns never squish under their content.
+
+- [ ] **Step 5: Summary card — show hidden fields inline below `md`**
+
+For each row on phones, show the hidden fields as a secondary line underneath the row so the user still sees Actual/Variance. The simplest implementation: after the Category cell, add a `<div className="md:hidden mt-1 text-xs text-slate-500">` containing the Actual and Variance values. Place this inside the first `<td>`, not a new row.
+
+Example:
+```tsx
+<td>
+  <div>{r.category}</div>
+  <div className="md:hidden mt-1 text-xs text-slate-500">
+    Actual {fmt(r.actual)} · Variance {fmt(r.variance)}
+  </div>
+</td>
+```
+
+- [ ] **Step 6: Stack filters / headers**
+
+Apply the same filter-bar stacking treatment as Task 2 Step 2 to any header controls on this page.
+
+- [ ] **Step 7: Visually verify at 375px**
+
+Navigate to `http://localhost/forecast-plans`. Resize to 375×812. Check:
+- No horizontal page scroll (inside-table horizontal scroll is fine).
+- Category and Planned are visible; Actual/Variance appear as the secondary line inline.
+- Actions trigger (button or kebab) is tappable.
+
+Screenshot `/tmp/responsive-sweep/forecast-plans-375.png`.
+
+- [ ] **Step 8: Verify at 768 and 1280**
+
+Confirm table fills normally. Screenshot to `/tmp/responsive-sweep/forecast-plans-768.png` and `/tmp/responsive-sweep/forecast-plans-1280.png`.
+
+- [ ] **Step 9: Commit**
+
+Run:
+```bash
+git add frontend/app/forecast-plans/page.tsx
+git commit -m "fix(responsive): forecast plans hybrid table below md"
+```
+
+---
+
+### Task 4: Budgets page responsive fix (hybrid)
+
+**Files:**
+- Modify: `frontend/app/budgets/page.tsx`
+
+- [ ] **Step 1: Read the current page**
+
+Read `frontend/app/budgets/page.tsx` (~336 lines). Budgets uses expandable rows with inline bar charts and a Transfer action. Identify:
+- The outer row layout (grid vs. table vs. stacked divs)
+- The expansion area with the bar chart
+- Action buttons (Transfer, Edit, Remove)
+
+- [ ] **Step 2: Keep the row structure but reflow internals**
+
+For each budget row below `md`:
+- Category name and amount on the first line (flex row, amount right-aligned).
+- Bar chart on the second line (full width).
+- Action buttons on the third line (wrap with `flex-wrap gap-2`, each button `min-h-[44px]`).
+
+Use `md:flex-row md:items-center` on the outer row container to restore the desktop single-line layout.
+
+- [ ] **Step 3: Expansion area**
+
+If the expansion area has its own grid (e.g. planned vs spent split), add `grid-cols-1 sm:grid-cols-2` to stack on phones.
+
+- [ ] **Step 4: Transfer form fix (if present inline)**
+
+If an inline transfer form exists on this page, apply form-stack rules: single column below `sm`, buttons at least `min-h-[44px]` below `sm`.
+
+- [ ] **Step 5: Visually verify at 375/768/1280**
+
+Navigate to `http://localhost/budgets`. Screenshot at each viewport. Specifically confirm:
+- Amounts never overlap category names (a known bug from backlog #29c).
+- Transfer/Edit/Remove buttons are all tappable (known bug: "too small to tap").
+- Bar charts render at full width below `md`.
+
+Save screenshots under `/tmp/responsive-sweep/budgets-{375,768,1280}.png`.
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add frontend/app/budgets/page.tsx
+git commit -m "fix(responsive): budgets row reflow and tap targets below md"
+```
+
+---
+
+### Task 5: Card component extraction decision
+
+**Files:**
+- Maybe create: `frontend/components/ui/DataCard.tsx`
+
+- [ ] **Step 1: Evaluate**
+
+Task 2 produced one card shape (Transactions). Tasks 3 and 4 produced hybrid rows, not cards. So as of PR1, cards exist in ONE place. Per the DRY trigger (extract at third repetition), **do nothing in this task and leave Transactions inline.** This task exists purely to document that the evaluation was performed.
+
+If, unexpectedly, you found yourself re-implementing the same card shape in both Task 2 and a second PR1 page, extract it now with the props shape:
+```ts
+type DataCardProps = {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  amount?: React.ReactNode;
+  amountTone?: "positive" | "negative" | "neutral";
+  meta?: React.ReactNode;
+  actions?: React.ReactNode;
+};
+```
+
+- [ ] **Step 2: If no extraction, commit nothing and move on**
+
+No commit.
+
+---
+
+### Task 6: Fill in the audit report with PR1 visual findings
+
+**Files:**
+- Modify: `docs/superpowers/audits/2026-04-19-responsive-findings.md`
+
+- [ ] **Step 1: Update each PR1 row**
+
+For transactions, forecast-plans, budgets: update the `Symptom < md` and any newly-observed issues captured during visual verification. Keep the tone terse.
+
+- [ ] **Step 2: Commit**
+
+Run:
+```bash
+git add docs/superpowers/audits/2026-04-19-responsive-findings.md
+git commit -m "docs: update audit findings with PR1 verification results"
+```
+
+---
+
+### Task 7: Open PR1
+
+**Files:** none (GitHub operations only).
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin fix/responsive-sweep-data-tables
+```
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+```bash
+gh pr create --title "fix: responsive sweep — data tables (Transactions, Forecast Plans, Budgets)" --body "$(cat <<'EOF'
+## Summary
+Part 1 of the responsive sweep (see spec `docs/superpowers/specs/2026-04-19-responsive-sweep-design.md`).
+
+- Transactions: card layout below `md`, table restored from `md+`.
+- Forecast Plans: hybrid hide-and-scroll, secondary line shows Actual/Variance inline below `md`.
+- Budgets: row reflow (name, chart, actions stacked) below `md`; tap targets bumped to 44px.
+
+## Audit report
+See `docs/superpowers/audits/2026-04-19-responsive-findings.md`.
+
+## Screenshots
+<attach 375px and 768px screenshots from /tmp/responsive-sweep/>
+
+## Follow-up
+PR2 will cover Recurring, Accounts, Categories, Import, all auth/settings/admin forms, the modal sweep, and a dashboard regression check.
+EOF
+)"
+```
+
+- [ ] **Step 3: Attach screenshots**
+
+Upload the six screenshots from `/tmp/responsive-sweep/` into the PR description using the GitHub web UI or `gh pr edit --body-file`. Screenshots do not go into the repo.
+
+---
+
+### Task 8: Wait for PR1 merge
+
+- [ ] **Step 1: Stop here until PR1 is merged**
+
+Do not start Phase 3 until the user confirms PR1 is merged into main. The PR2 branch must be cut from main-post-PR1.
+
+---
+
+## Phase 3 — PR2: Remaining Pages
+
+### Task 9: Cut PR2 branch
+
+**Files:** none.
+
+- [ ] **Step 1: Sync main**
+
+Run:
+```bash
+git checkout main
+git pull --ff-only
+```
+
+- [ ] **Step 2: Create PR2 branch**
+
+Run:
+```bash
+git checkout -b fix/responsive-sweep-remaining
+```
+
+---
+
+### Task 10: Recurring page
+
+**Files:**
+- Modify: `frontend/app/recurring/page.tsx`
+
+- [ ] **Step 1: Apply the same card pattern used in Transactions (Task 2 Step 3)**
+
+Fields in each card: description, next occurrence date, cadence, amount (right-aligned, colored), account, category, action buttons (Edit, Delete, Skip-next if applicable). Table retained for `md+`.
+
+- [ ] **Step 2: Stack filter/create controls below `sm`**
+
+Same treatment as Task 2 Step 2.
+
+- [ ] **Step 3: Visual verify at 375/768/1280**
+
+Screenshots to `/tmp/responsive-sweep/recurring-{375,768,1280}.png`.
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+git add frontend/app/recurring/page.tsx
+git commit -m "fix(responsive): recurring card layout below md"
+```
+
+---
+
+### Task 11: Accounts page
+
+**Files:**
+- Modify: `frontend/app/accounts/page.tsx`
+
+- [ ] **Step 1: Apply card pattern**
+
+Fields per card: account name, type, currency, balance (right-aligned, colored on negative), default badge, action row (Edit, Default, Deactivate, Delete) — known bug: these overlap on mobile, so wrap `flex-wrap gap-2` with 44px tap heights.
+
+- [ ] **Step 2: Evaluate extraction**
+
+This is the second page using the exact transactions-style card. Still below the three-repetition threshold — keep inline.
+
+- [ ] **Step 3: Visual verify at 375/768/1280**
+
+Screenshots to `/tmp/responsive-sweep/accounts-{375,768,1280}.png`.
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+git add frontend/app/accounts/page.tsx
+git commit -m "fix(responsive): accounts card layout below md"
+```
+
+---
+
+### Task 12: Categories page & extraction check
+
+**Files:**
+- Modify: `frontend/app/categories/page.tsx`
+- Maybe create: `frontend/components/ui/DataCard.tsx`
+
+- [ ] **Step 1: Read the page**
+
+Categories is a two-level tree (masters and subcategories). A full card may be overkill. Try the simpler approach first:
+- Below `md`, ensure the tree rows use `flex flex-wrap gap-2` with the label taking priority and buttons wrapping to a second line.
+- Tap targets ≥44px.
+- Add horizontal padding so touch targets don't hug the edge.
+
+- [ ] **Step 2: Extraction decision**
+
+If Tasks 2, 10, and 11 all ended up building the same inline card shape, extract now:
+
+Create `frontend/components/ui/DataCard.tsx`:
+
+```tsx
+import type { ReactNode } from "react";
+
+export type DataCardProps = {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  amount?: ReactNode;
+  amountTone?: "positive" | "negative" | "neutral";
+  meta?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+};
+
+const toneClass: Record<NonNullable<DataCardProps["amountTone"]>, string> = {
+  positive: "text-emerald-600",
+  negative: "text-rose-600",
+  neutral: "text-slate-900 dark:text-slate-100",
+};
+
+export function DataCard({
+  title,
+  subtitle,
+  amount,
+  amountTone = "neutral",
+  meta,
+  actions,
+  className = "",
+}: DataCardProps) {
+  return (
+    <article
+      className={`flex flex-col gap-2 rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+            {title}
+          </div>
+          {subtitle && (
+            <div className="mt-0.5 text-xs text-slate-500">{subtitle}</div>
+          )}
+        </div>
+        {amount !== undefined && (
+          <div className={`shrink-0 text-right text-sm font-semibold ${toneClass[amountTone]}`}>
+            {amount}
+          </div>
+        )}
+      </div>
+      {meta && <div className="text-xs text-slate-600 dark:text-slate-400">{meta}</div>}
+      {actions && (
+        <div className="flex flex-wrap gap-2 pt-2 border-t border-slate-100 dark:border-slate-800">
+          {actions}
+        </div>
+      )}
+    </article>
+  );
+}
+```
+
+Then refactor Transactions (Task 2), Recurring (Task 10), and Accounts (Task 11) to use `<DataCard>` in their `md:hidden` sections. Each refactor is a small drop-in: replace the inline `<article>` with `<DataCard ... />`.
+
+- [ ] **Step 3: If extracted, re-verify each affected page visually at 375px**
+
+One screenshot per page is enough; compare against the pre-extraction screenshots from Tasks 2/10/11.
+
+- [ ] **Step 4: Visual verify Categories at 375/768/1280**
+
+Screenshots to `/tmp/responsive-sweep/categories-{375,768,1280}.png`.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add frontend/app/categories/page.tsx
+# if extraction happened, also:
+# git add frontend/components/ui/DataCard.tsx frontend/app/transactions/page.tsx frontend/app/recurring/page.tsx frontend/app/accounts/page.tsx
+git commit -m "fix(responsive): categories reflow and DataCard extraction"
+```
+
+If no extraction, use `"fix(responsive): categories reflow below md"` instead.
+
+---
+
+### Task 13: Import wizard
+
+**Files:**
+- Modify: `frontend/app/import/page.tsx`
+
+- [ ] **Step 1: Read the page and identify wizard steps**
+
+Import is a multi-step flow (upload → map columns → preview → confirm). Identify each step container.
+
+- [ ] **Step 2: Stack step indicators below `sm`**
+
+If there's a horizontal step indicator using `flex`, add `flex-col sm:flex-row` so steps stack on phones. If the indicator has connectors (lines between steps), switch them to vertical on phones or hide them.
+
+- [ ] **Step 3: Map/preview table**
+
+The column-mapping step likely has a table of CSV columns → target fields. Apply Pattern B (hide-and-scroll) — keep the table, make it `overflow-x-auto` with `min-w-[640px]`.
+
+The preview step (showing rows that will be imported) also uses Pattern B.
+
+- [ ] **Step 4: Action buttons**
+
+Back / Continue / Cancel buttons should be `min-h-[44px]` below `sm` and arranged in a `flex flex-col-reverse sm:flex-row sm:justify-end gap-2` (primary action on top in mobile stack).
+
+- [ ] **Step 5: Visual verify at 375/768/1280**
+
+Screenshots to `/tmp/responsive-sweep/import-{375,768,1280}.png`.
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add frontend/app/import/page.tsx
+git commit -m "fix(responsive): import wizard stacking below sm"
+```
+
+---
+
+### Task 14: Auth pages sweep
+
+**Files:**
+- Modify: `frontend/app/login/page.tsx`
+- Modify: `frontend/app/register/page.tsx`
+- Modify: `frontend/app/forgot-password/page.tsx`
+- Modify: `frontend/app/reset-password/page.tsx`
+- Modify: `frontend/app/verify-email/page.tsx`
+- Modify: `frontend/app/mfa-verify/page.tsx`
+- Modify: `frontend/app/setup/page.tsx`
+
+- [ ] **Step 1: For each page, apply form-stack**
+
+These pages are already mostly responsive (centered auth card), but check and apply:
+- Outer container: `min-h-screen flex items-center justify-center px-4 py-8`.
+- Card: `w-full max-w-md` (unchanged on desktop, full width with 1rem padding on phones).
+- Any multi-column forms (e.g., register's first-name/last-name pair): `grid grid-cols-1 sm:grid-cols-2 gap-3`.
+- Submit buttons: `w-full min-h-[44px]`.
+
+Apply to each of the seven pages. Most will need only 1–3 small class tweaks; a few may already be correct.
+
+- [ ] **Step 2: Visual verify at 375px only**
+
+One screenshot per page at 375px is enough — auth pages are narrow by design, so 768 and 1280 don't vary meaningfully. Save to `/tmp/responsive-sweep/auth-<page>-375.png`.
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git add frontend/app/login/page.tsx frontend/app/register/page.tsx frontend/app/forgot-password/page.tsx frontend/app/reset-password/page.tsx frontend/app/verify-email/page.tsx frontend/app/mfa-verify/page.tsx frontend/app/setup/page.tsx
+git commit -m "fix(responsive): auth pages form-stack below sm"
+```
+
+---
+
+### Task 15: Settings pages sweep
+
+**Files:**
+- Modify: `frontend/app/settings/page.tsx`
+- Modify: `frontend/app/settings/billing/page.tsx`
+- Modify: `frontend/app/settings/organization/page.tsx`
+- Modify: `frontend/app/settings/security/page.tsx`
+- Modify: `frontend/components/SettingsLayout.tsx`
+
+- [ ] **Step 1: Fix SettingsLayout tabs for phones**
+
+Read `frontend/components/SettingsLayout.tsx`. The tab bar likely uses a horizontal `flex` with pills/underlines. On phones it can overflow invisibly. Apply:
+```tsx
+<nav className="flex gap-1 overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+  {/* tabs */}
+</nav>
+```
+The negative margin + padding trick lets the tabs extend to the viewport edge on phones while preserving visual padding.
+
+- [ ] **Step 2: For each settings page, apply form-stack**
+
+- Any `grid-cols-2`/`grid-cols-3` inside a settings card → add `grid-cols-1 sm:grid-cols-2` (or similar) so fields stack below `sm`.
+- Submit/action buttons: `w-full min-h-[44px] sm:w-auto`.
+- Card header rows (title + action button): `flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between`.
+
+- [ ] **Step 3: Billing page specifically**
+
+The billing page shows plan comparison cards. Make sure they're `grid-cols-1 md:grid-cols-2 lg:grid-cols-3` (or appropriate) so they stack on phones.
+
+- [ ] **Step 4: Security page specifically**
+
+The security page has password change + MFA setup sections. The MFA QR code area must stay centered and within viewport on phones.
+
+- [ ] **Step 5: Visual verify at 375 and 768 for each page**
+
+Five pages × two viewports = 10 screenshots. Name them `/tmp/responsive-sweep/settings-<page>-<viewport>.png`.
+
+- [ ] **Step 6: Commit**
+
+Run:
+```bash
+git add frontend/app/settings/page.tsx frontend/app/settings/billing/page.tsx frontend/app/settings/organization/page.tsx frontend/app/settings/security/page.tsx frontend/components/SettingsLayout.tsx
+git commit -m "fix(responsive): settings pages and tab bar below sm"
+```
+
+---
+
+### Task 16: Admin & system pages
+
+**Files:**
+- Modify: `frontend/app/admin/settings/page.tsx`
+- Modify: `frontend/app/system/plans/page.tsx`
+- Modify: `frontend/app/profile/page.tsx`
+
+- [ ] **Step 1: admin/settings and profile are 12-line stubs**
+
+Read both files. They are likely just redirects or thin pages. If they render nothing meaningful, no change needed — skip.
+
+- [ ] **Step 2: system/plans is a CRUD page**
+
+Apply Pattern B (hide-and-scroll) to the plans table. Stack the "Create plan" form section using form-stack rules.
+
+- [ ] **Step 3: Visual verify system/plans at 375/768/1280**
+
+Screenshots to `/tmp/responsive-sweep/system-plans-{375,768,1280}.png`.
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+git add frontend/app/system/plans/page.tsx
+# only add admin/profile if actually modified
+git commit -m "fix(responsive): system plans hybrid table below md"
+```
+
+---
+
+### Task 17: Modal sweep
+
+**Files:**
+- Modify: `frontend/components/ui/ConfirmModal.tsx`
+- Modify: any inline modals found across pages
+
+- [ ] **Step 1: Harden ConfirmModal**
+
+Read `frontend/components/ui/ConfirmModal.tsx`. Ensure the shell:
+- Outer overlay: `fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50`.
+- Inner panel: `w-full max-w-md max-h-[90vh] overflow-y-auto max-w-[calc(100vw-2rem)]`.
+- Footer buttons: `flex flex-col-reverse sm:flex-row sm:justify-end gap-2`, each button `w-full sm:w-auto min-h-[44px]`.
+
+Apply whatever subset is missing.
+
+- [ ] **Step 2: Find other modals**
+
+Run:
+```bash
+grep -rln 'role="dialog"\|aria-modal\|fixed inset-0' frontend/app frontend/components
+```
+
+For each match that isn't `ConfirmModal`, open the file and apply the same containment rules.
+
+- [ ] **Step 3: Visual verify a representative modal on a phone viewport**
+
+Open the app at 375px, trigger a confirm dialog (e.g., delete a transaction). Confirm:
+- Modal is centered, has 1rem breathing room on each side.
+- Body scrolls if content exceeds `90vh`.
+- Both buttons are visible without scrolling the modal itself.
+
+Screenshot to `/tmp/responsive-sweep/modal-confirm-375.png`.
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+git add frontend/components/ui/ConfirmModal.tsx
+# add any inline-modal files you modified
+git commit -m "fix(responsive): modal containment at small viewports"
+```
+
+---
+
+### Task 18: Dashboard regression check
+
+**Files:**
+- Possibly modify: `frontend/app/dashboard/page.tsx`
+
+- [ ] **Step 1: Visual check at 375/768/1280**
+
+Navigate to `http://localhost/dashboard` after login. Resize through the three viewports. Confirm:
+- No horizontal scroll at 375.
+- Chart cards wrap cleanly.
+- Tap targets on the account balance list are ≥44px.
+
+Screenshots to `/tmp/responsive-sweep/dashboard-{375,768,1280}.png`.
+
+- [ ] **Step 2: Fix only if regression is found**
+
+If any regression appears (e.g., PR1's changes affected a shared component that dashboard also uses), fix the specific broken element. If everything is clean, skip to Step 3.
+
+- [ ] **Step 3: Commit (if there were fixes)**
+
+Run:
+```bash
+git add frontend/app/dashboard/page.tsx
+git commit -m "fix(responsive): dashboard regression cleanup"
+```
+
+If no fixes, no commit.
+
+---
+
+### Task 19: Open PR2
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u origin fix/responsive-sweep-remaining
+```
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+```bash
+gh pr create --title "fix: responsive sweep — remaining pages, forms, modals" --body "$(cat <<'EOF'
+## Summary
+Part 2 of the responsive sweep. Completes the app-wide pass started in PR1.
+
+- Card pattern: Recurring, Accounts, Categories (+ optional `DataCard` extraction).
+- Hybrid hide-and-scroll: Import wizard table, System Plans.
+- Form-stack: all auth pages, all settings pages, SettingsLayout tab bar.
+- Modal containment: ConfirmModal and any inline modals.
+- Dashboard regression check passed.
+
+## Audit report
+See `docs/superpowers/audits/2026-04-19-responsive-findings.md` (committed in PR1).
+
+## Screenshots
+<attach screenshots from /tmp/responsive-sweep/>
+EOF
+)"
+```
+
+- [ ] **Step 3: Attach screenshots via PR description**
+
+Use the GitHub web UI to drop the screenshots into the PR body.
+
+---
+
+## Phase 4 — Close out
+
+### Task 20: Update roadmap memory after PR2 merges
+
+**Files:** memory system (no repo files).
+
+- [ ] **Step 1: Once PR2 is merged, update memory**
+
+Update `project_ui_improvements.md` to mark item #29 (mobile responsive for data-heavy pages) as DONE with reference to both PRs. Confirm there are no remaining open mobile-specific items.
+
+No repo commit — this is memory-only.
+
+---
+
+## Self-Review Checklist (run before handing off)
+
+1. **Spec coverage:** every success criterion in the spec is verified in at least one task step? ✔
+2. **Placeholders:** no TBDs, TODOs, "add appropriate X"? ✔
+3. **Type consistency:** `DataCard` props referenced identically in Tasks 12 and any card refactors? ✔
+4. **PR boundary clarity:** Task 8 pauses until PR1 merges; Task 9 is the single place where PR2's branch is cut? ✔

--- a/docs/superpowers/specs/2026-04-19-responsive-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-19-responsive-sweep-design.md
@@ -1,0 +1,115 @@
+# Responsive Sweep — Full App Mobile Audit & Fix
+
+**Status:** Design approved, pending implementation plan
+**Date:** 2026-04-19
+**Owner:** fjorge
+**Scope:** Single milestone across two PRs
+
+## Goal
+
+Every authenticated page in PFV2 renders correctly from 320px through 1024px+. No horizontal page scroll, no truncated numeric columns, no offscreen submit buttons, no untappable controls.
+
+## Non-goals
+
+- No new features. No design overhaul. No component library migration.
+- No custom breakpoints. Only Tailwind's built-in `sm=640`, `md=768`, `lg=1024`.
+- No tablet-specific (landscape) layouts beyond what `md` naturally provides.
+
+## Audit method (hybrid)
+
+1. **Code scan** across `frontend/app/` and `frontend/components/`:
+   - Fixed pixel widths (`w-[Npx]`, inline styles)
+   - `<table>` elements without responsive treatment
+   - `grid-cols-*` and `flex-*` without breakpoint variants
+   - Pages with zero `sm:`/`md:`/`lg:` classes
+   - Missing `overflow-x-auto` on wide content containers
+2. **Findings table** produced in PR description: page → viewport where it breaks → symptom → chosen pattern.
+3. **Visual verification** via chrome-devtools at **375px** (iPhone SE baseline) and **768px** (portrait tablet edge). Logged-in state with seeded data. Screenshots attached to PR.
+
+## Fix pattern library
+
+Each page picks exactly one primary pattern. Patterns are shared, not one-offs.
+
+### Pattern A — Card layout (default for row-based data)
+
+Applies to: Transactions, Recurring, Accounts, Categories.
+
+- `<table>` stays on `md+`.
+- Below `md`, rows render as stacked `<article>` cards:
+  - Primary field (description / name) as card header
+  - Secondary fields as label/value rows
+  - Amounts always visible and right-aligned within the card
+  - Actions (edit / delete / etc.) collected into a single row at the bottom of the card, ≥44px tap height
+- If a shared `<DataCard>` component emerges naturally across 2+ pages, extract it into `components/ui/DataCard.tsx`. Do not premature-extract.
+
+### Pattern B — Hybrid hide-and-scroll
+
+Applies to: Budgets, Forecast Plans.
+
+- Keep the table on all breakpoints (expansion rows and inline charts don't transplant well to cards).
+- Below `md`: hide low-priority columns using `hidden md:table-cell`.
+- Remaining table wrapped in `overflow-x-auto` with a sensible `min-w-*` so the preserved columns stay legible.
+- Priority columns (always visible): category name, primary amount, action trigger.
+
+### Pattern C — Form stack
+
+Applies to: login, register, forgot-password, reset-password, verify-email, mfa-verify, setup, profile, settings/*, admin/*, system/plans forms, any modal form bodies.
+
+- Multi-column forms (`grid-cols-2`, side-by-side `flex`) collapse to single column below `sm`.
+- Sticky or footer action bars become fixed-bottom on phones to prevent submit buttons being pushed offscreen by soft keyboards.
+- Label/input pairs stack; labels never truncate.
+
+### Pattern D — Modal containment
+
+Applies to: every modal (`ConfirmModal`, form modals).
+
+- Shell: `max-w-[calc(100vw-2rem)]` so there's always a margin.
+- Body: `max-h-[90vh]` with `overflow-y-auto`.
+- Action buttons never hidden below the fold.
+
+## PR decomposition
+
+### PR1 — `fix/responsive-sweep-data-tables`
+
+**Pages:** Transactions, Forecast Plans, Budgets.
+
+**Why these first:** They set the pattern precedents. Transactions establishes the card shape. Forecast Plans and Budgets prove the hybrid approach. If cards feel wrong we iterate here before replicating across PR2.
+
+**Deliverables:**
+- Full code-scan audit report in the PR description.
+- Responsive classes on the three pages.
+- Card component extraction if pattern repetition justifies it.
+- Visual-verification screenshots at 375px and 768px for each page.
+
+### PR2 — `fix/responsive-sweep-remaining`
+
+**Pages:**
+- Card pattern: Recurring, Accounts, Categories.
+- Hybrid / misc: Import wizard (step stacking below `sm`).
+- Form-stack: login, register, forgot-password, reset-password, verify-email, mfa-verify, setup, profile, settings (billing, organization, security), admin/settings, system/plans.
+- Modal sweep across all variants.
+- Dashboard regression check (already considered responsive — confirm no breakage after PR1).
+
+**Deliverables:** same structure as PR1.
+
+## Success criteria
+
+1. No horizontal page-level scroll at 375px on any authenticated page. Intentional inside-container scroll (e.g. a hide-and-scroll table) is OK.
+2. All tap targets ≥44px on touch viewports.
+3. Numeric columns (amounts, balances, budgets) never truncate below `md`.
+4. Form submit buttons always reachable without horizontal or awkward vertical scrolling.
+5. Modals never render with their actions offscreen at 375px.
+6. No regressions on `md+` — desktop layouts unchanged.
+
+## Out of scope (may surface as follow-ups)
+
+- Genuine visual-design changes (e.g. replacing bar charts with donut charts, #16 in the backlog).
+- Tablet-landscape-specific layouts.
+- Touch-gesture enhancements (swipe to delete, pull to refresh).
+- Backend data shape changes to support different mobile views.
+
+## Risks & mitigations
+
+- **Risk:** Card extraction bikeshed. **Mitigation:** Don't pre-extract; let the second page inform the shape, extract on the third if still useful.
+- **Risk:** Hybrid tables still feel cramped on Budgets specifically because of inline bar charts. **Mitigation:** Charts may need their own `sm:`/`md:` size steps; if hybrid doesn't work we fall back to Pattern A for Budgets in PR1 and document the exception.
+- **Risk:** Visual regressions on desktop from aggressive mobile-first classes. **Mitigation:** Every responsive class is breakpoint-prefixed; no unqualified overrides. Verify `lg+` layouts visually after PR1.

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -133,10 +133,10 @@ export default function BudgetsPage() {
 
   return (
     <AppShell>
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h1 className={`${pageTitle} mb-0`}>Budgets</h1>
         {availableCategories.length > 0 && (
-          <button onClick={() => setShowForm(!showForm)} className={btnPrimary}>
+          <button onClick={() => setShowForm(!showForm)} className={`${btnPrimary} min-h-[44px] sm:min-h-0`}>
             {showForm ? "Cancel" : "+ Add Budget"}
           </button>
         )}
@@ -144,7 +144,7 @@ export default function BudgetsPage() {
 
       {/* Period navigation */}
       {periods.length > 0 && (
-        <div className="mb-5 flex items-center gap-3">
+        <div className="mb-5 flex flex-wrap items-center gap-3">
           <button onClick={() => setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1))} disabled={periodIdx >= periods.length - 1} className="rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Previous period">
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
           </button>
@@ -165,19 +165,19 @@ export default function BudgetsPage() {
 
       {showForm && (
         <div className={`mb-6 ${card} p-6`}>
-          <form onSubmit={handleAdd} className="flex flex-wrap gap-4 items-end">
-            <div className="flex-1 min-w-[200px]">
+          <form onSubmit={handleAdd} className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end">
+            <div className="w-full sm:flex-1 sm:min-w-[200px]">
               <label htmlFor="b-cat" className={label}>Category</label>
               <select id="b-cat" required value={formCategoryId} onChange={(e) => setFormCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={input}>
                 <option value="">Select category</option>
                 {availableCategories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
               </select>
             </div>
-            <div className="w-40">
+            <div className="w-full sm:w-40">
               <label htmlFor="b-amount" className={label}>Monthly limit</label>
               <input id="b-amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value={formAmount} onChange={(e) => setFormAmount(e.target.value)} className={input} />
             </div>
-            <button type="submit" className={btnPrimary}>Add</button>
+            <button type="submit" className={`${btnPrimary} min-h-[44px] sm:min-h-0`}>Add</button>
           </form>
         </div>
       )}
@@ -188,7 +188,7 @@ export default function BudgetsPage() {
         <div className="space-y-6">
           {/* Summary */}
           {budgets.length > 0 && (
-            <div className="flex gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               <div className={`flex-1 ${card} p-5`}>
                 <p className={cardTitle}>Total Budget</p>
                 <p className="mt-1 text-2xl font-semibold tabular-nums text-text-primary">{formatAmount(totalBudget)}</p>
@@ -269,43 +269,52 @@ export default function BudgetsPage() {
                 return (
                   <div key={b.id} className="px-6 py-3">
                     {editingId === b.id ? (
-                      <div className="flex items-center gap-3">
-                        <span className="text-sm font-medium text-text-primary flex-1">{b.category_name}</span>
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                        <span className="text-sm font-medium text-text-primary sm:flex-1">{b.category_name}</span>
                         <input type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)}
-                          className={`w-32 ${input}`} autoFocus
+                          className={`w-full sm:w-32 ${input}`} autoFocus
                           onKeyDown={(e) => { if (e.key === "Enter") handleUpdate(b.id); if (e.key === "Escape") setEditingId(null); }} />
-                        <button onClick={() => handleUpdate(b.id)} className="text-xs text-accent hover:text-accent-hover">Save</button>
-                        <button onClick={() => setEditingId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                        <div className="flex flex-wrap gap-2">
+                          <button onClick={() => handleUpdate(b.id)} className="min-h-[44px] text-xs text-accent hover:text-accent-hover sm:min-h-0">Save</button>
+                          <button onClick={() => setEditingId(null)} className="min-h-[44px] text-xs text-text-muted hover:text-text-secondary sm:min-h-0">Cancel</button>
+                        </div>
                       </div>
                     ) : (
                       <>
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm text-text-primary">{b.category_name}</span>
-                          <div className="flex items-center gap-4">
-                            <span className={`text-sm tabular-nums ${overBudget ? "text-danger font-medium" : "text-text-secondary"}`}>
+                        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                          <div className="flex items-center">
+                            <span className="text-sm text-text-primary">{b.category_name}</span>
+                            <span className={`ml-auto text-sm tabular-nums md:hidden ${overBudget ? "text-danger font-medium" : "text-text-secondary"}`}>
+                              {formatAmount(b.spent)} / {formatAmount(b.amount)}
+                            </span>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 md:gap-4">
+                            <span className={`hidden text-sm tabular-nums md:inline ${overBudget ? "text-danger font-medium" : "text-text-secondary"}`}>
                               {formatAmount(b.spent)} / {formatAmount(b.amount)}
                             </span>
                             <span className={`text-xs tabular-nums ${overBudget ? "text-danger" : "text-text-muted"}`}>
                               {b.percent_used}%
                             </span>
-                            <div className="flex gap-2">
-                              <button onClick={() => { setTransferringId(transferringId === b.id ? null : b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="text-xs text-text-muted hover:text-accent">Transfer</button>
-                              <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="text-xs text-text-muted hover:text-accent">Edit</button>
-                              <button onClick={() => setConfirmDeleteId(b.id)} className="text-xs text-text-muted hover:text-danger">Remove</button>
+                            <div className="flex flex-wrap gap-2 ml-auto md:ml-0">
+                              <button onClick={() => { setTransferringId(transferringId === b.id ? null : b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Transfer</button>
+                              <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Edit</button>
+                              <button onClick={() => setConfirmDeleteId(b.id)} className="min-h-[44px] text-xs text-text-muted hover:text-danger md:min-h-0">Remove</button>
                             </div>
                           </div>
                         </div>
                         {transferringId === b.id && (
-                          <div className="mt-2 flex flex-wrap items-center gap-2">
-                            <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`min-w-0 flex-1 basis-40 ${input}`}>
+                          <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+                            <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`w-full min-w-0 sm:flex-1 sm:basis-40 ${input}`}>
                               <option value="">Select target category</option>
                               {transferTargets.map((c) => <option key={c.id} value={c.id}>{c.name}{budgetedCatIds.has(c.id) ? " (has budget)" : ""}</option>)}
                             </select>
                             <input type="number" step="0.01" min="0.01" max={Number(b.amount)} placeholder="Amount" value={transferAmount} onChange={(e) => setTransferAmount(e.target.value)}
-                              className={`w-28 ${input}`}
+                              className={`w-full sm:w-28 ${input}`}
                               onKeyDown={(e) => { if (e.key === "Enter" && transferCategoryId && transferAmount) handleTransfer(b.id); if (e.key === "Escape") setTransferringId(null); }} />
-                            <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="text-xs text-accent hover:text-accent-hover disabled:opacity-50">Transfer</button>
-                            <button onClick={() => setTransferringId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                            <div className="flex flex-wrap gap-2">
+                              <button onClick={() => handleTransfer(b.id)} disabled={!transferCategoryId || !transferAmount} className="min-h-[44px] text-xs text-accent hover:text-accent-hover disabled:opacity-50 sm:min-h-0">Transfer</button>
+                              <button onClick={() => setTransferringId(null)} className="min-h-[44px] text-xs text-text-muted hover:text-text-secondary sm:min-h-0">Cancel</button>
+                            </div>
                           </div>
                         )}
                       </>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -450,9 +450,9 @@ export default function ForecastPlansPage() {
         <div className={`mb-6 ${card} p-6`}>
           <form
             onSubmit={handleAddItem}
-            className="flex flex-wrap items-end gap-4"
+            className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-end sm:gap-4"
           >
-            <div className="w-32">
+            <div className="w-full sm:w-32">
               <label htmlFor="fp-type" className={label}>
                 Type
               </label>
@@ -468,7 +468,7 @@ export default function ForecastPlansPage() {
                 <option value="income">Income</option>
               </select>
             </div>
-            <div className="min-w-[200px] flex-1">
+            <div className="w-full sm:min-w-[200px] sm:flex-1">
               <label htmlFor="fp-cat" className={label}>
                 Category
               </label>
@@ -491,7 +491,7 @@ export default function ForecastPlansPage() {
                 ))}
               </select>
             </div>
-            <div className="w-40">
+            <div className="w-full sm:w-40">
               <label htmlFor="fp-amount" className={label}>
                 Planned Amount
               </label>
@@ -507,7 +507,10 @@ export default function ForecastPlansPage() {
                 className={input}
               />
             </div>
-            <button type="submit" className={btnPrimary}>
+            <button
+              type="submit"
+              className={`${btnPrimary} w-full min-h-[44px] sm:w-auto sm:min-h-0`}
+            >
               Add
             </button>
           </form>
@@ -743,116 +746,136 @@ function ItemSection({
   setEditAmount: (v: string) => void;
 }) {
   const colTemplate = readOnly
-    ? "grid-cols-[1fr_100px_100px_100px_80px]"
-    : "grid-cols-[1fr_100px_100px_100px_80px_100px]";
+    ? "grid-cols-[1fr_100px] md:grid-cols-[1fr_100px_100px_100px_80px]"
+    : "grid-cols-[1fr_100px_100px] md:grid-cols-[1fr_100px_100px_100px_80px_100px]";
 
   return (
     <div className={card}>
       <div className={cardHeader}>
         <h2 className={cardTitle}>{title}</h2>
       </div>
-      {/* Header row */}
-      <div
-        className={`grid ${colTemplate} gap-2 px-6 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-muted`}
-      >
-        <span>Category</span>
-        <span className="text-right">Planned</span>
-        <span className="text-right">Actual</span>
-        <span className="text-right">Variance</span>
-        <span className="text-center">Source</span>
-        {!readOnly && <span className="text-right">Actions</span>}
-      </div>
-      <div className="divide-y divide-border-subtle">
-        {items.map((item) => {
-          const variance = Number(item.variance);
-          const isOver =
-            item.type === "expense" ? variance > 0 : variance < 0;
-          return (
-            <div
-              key={item.id}
-              className={`grid ${colTemplate} items-center gap-2 px-6 py-2.5`}
-            >
-              {!readOnly && editingId === item.id ? (
-                <>
-                  <span className="text-sm text-text-primary">
-                    {item.category_name}
-                  </span>
-                  <input
-                    type="number"
-                    step="0.01"
-                    min="0.01"
-                    value={editAmount}
-                    onChange={(e) => setEditAmount(e.target.value)}
-                    className={`text-right ${input}`}
-                    autoFocus
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") onSaveEdit(item.id);
-                      if (e.key === "Escape") onCancelEdit();
-                    }}
-                  />
-                  <span className="text-right text-sm tabular-nums text-text-secondary">
-                    {formatAmount(item.actual_amount)}
-                  </span>
-                  <span />
-                  <span />
-                  <div className="flex justify-end gap-2">
-                    <button
-                      onClick={() => onSaveEdit(item.id)}
-                      className="text-xs text-accent hover:text-accent-hover"
-                    >
-                      Save
-                    </button>
-                    <button
-                      onClick={onCancelEdit}
-                      className="text-xs text-text-muted hover:text-text-secondary"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </>
-              ) : (
-                <>
-                  <span className="text-sm text-text-primary">
-                    {item.category_name}
-                  </span>
-                  <span className="text-right text-sm tabular-nums text-text-primary">
-                    {formatAmount(item.planned_amount)}
-                  </span>
-                  <span className="text-right text-sm tabular-nums text-text-secondary">
-                    {formatAmount(item.actual_amount)}
-                  </span>
-                  <span
-                    className={`text-right text-sm tabular-nums font-medium ${
-                      isOver ? "text-danger" : "text-success"
-                    }`}
-                  >
-                    {variance > 0 ? "+" : ""}
-                    {formatAmount(variance)}
-                  </span>
-                  <span className="text-center text-[11px] text-text-muted">
-                    {SOURCE_LABELS[item.source] ?? item.source}
-                  </span>
-                  {!readOnly && (
-                    <div className="flex justify-end gap-2">
-                      <button
-                        onClick={() => onStartEdit(item)}
-                        className={btnLink}
+      <div className="overflow-x-auto">
+        <div className="min-w-[320px]">
+          {/* Header row */}
+          <div
+            className={`grid ${colTemplate} gap-2 px-6 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-muted`}
+          >
+            <span>Category</span>
+            <span className="text-right">Planned</span>
+            <span className="hidden text-right md:block">Actual</span>
+            <span className="hidden text-right md:block">Variance</span>
+            <span className="hidden text-center md:block">Source</span>
+            {!readOnly && <span className="text-right">Actions</span>}
+          </div>
+          <div className="divide-y divide-border-subtle">
+            {items.map((item) => {
+              const variance = Number(item.variance);
+              const isOver =
+                item.type === "expense" ? variance > 0 : variance < 0;
+              return (
+                <div
+                  key={item.id}
+                  className={`grid ${colTemplate} items-center gap-2 px-6 py-2.5`}
+                >
+                  {!readOnly && editingId === item.id ? (
+                    <>
+                      <div className="text-sm text-text-primary">
+                        {item.category_name}
+                        <div className="md:hidden mt-1 text-xs text-text-muted">
+                          Actual {formatAmount(item.actual_amount)}
+                        </div>
+                      </div>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0.01"
+                        value={editAmount}
+                        onChange={(e) => setEditAmount(e.target.value)}
+                        className={`text-right ${input}`}
+                        autoFocus
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") onSaveEdit(item.id);
+                          if (e.key === "Escape") onCancelEdit();
+                        }}
+                      />
+                      <span className="hidden text-right text-sm tabular-nums text-text-secondary md:block">
+                        {formatAmount(item.actual_amount)}
+                      </span>
+                      <span className="hidden md:block" />
+                      <span className="hidden md:block" />
+                      <div className="flex justify-end gap-2">
+                        <button
+                          onClick={() => onSaveEdit(item.id)}
+                          className="text-xs text-accent hover:text-accent-hover"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={onCancelEdit}
+                          className="text-xs text-text-muted hover:text-text-secondary"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="text-sm text-text-primary">
+                        {item.category_name}
+                        <div className="md:hidden mt-1 text-xs text-text-muted">
+                          Actual {formatAmount(item.actual_amount)} · Variance{" "}
+                          <span
+                            className={`font-medium ${
+                              isOver ? "text-danger" : "text-success"
+                            }`}
+                          >
+                            {variance > 0 ? "+" : ""}
+                            {formatAmount(variance)}
+                          </span>
+                          {" · "}
+                          {SOURCE_LABELS[item.source] ?? item.source}
+                        </div>
+                      </div>
+                      <span className="text-right text-sm tabular-nums text-text-primary">
+                        {formatAmount(item.planned_amount)}
+                      </span>
+                      <span className="hidden text-right text-sm tabular-nums text-text-secondary md:block">
+                        {formatAmount(item.actual_amount)}
+                      </span>
+                      <span
+                        className={`hidden text-right text-sm tabular-nums font-medium md:block ${
+                          isOver ? "text-danger" : "text-success"
+                        }`}
                       >
-                        Edit
-                      </button>
-                      <button
-                        onClick={() => onDelete(item.id)}
-                        className={btnDanger}
-                      >
-                        Remove
-                      </button>
-                    </div>
+                        {variance > 0 ? "+" : ""}
+                        {formatAmount(variance)}
+                      </span>
+                      <span className="hidden text-center text-[11px] text-text-muted md:block">
+                        {SOURCE_LABELS[item.source] ?? item.source}
+                      </span>
+                      {!readOnly && (
+                        <div className="flex justify-end gap-2">
+                          <button
+                            onClick={() => onStartEdit(item)}
+                            className={btnLink}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => onDelete(item.id)}
+                            className={btnDanger}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      )}
+                    </>
                   )}
-                </>
-              )}
-            </div>
-          );
-        })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -422,67 +422,67 @@ function TransactionsPageContent() {
       )}
 
       {/* Search + Preset filters */}
-      <div className="mb-3 flex flex-wrap items-center gap-3">
-        <div className="flex-1 min-w-[200px]">
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
+        <div className="w-full sm:flex-1 sm:min-w-[200px]">
           <label htmlFor="f-search" className="sr-only">Search transactions</label>
           <input id="f-search" type="text" placeholder="Search descriptions..." value={filterSearch} onChange={(e) => setFilterSearch(e.target.value)} className={input} />
         </div>
-        <div className="flex gap-1">
+        <div className="flex flex-wrap gap-1">
           {[
             { label: "Today", fn: () => { const d = todayISO(); setFilterDateFrom(d); setFilterDateTo(d); } },
             { label: "This Week", fn: () => { const now = new Date(); const day = now.getDay(); const diff = day === 0 ? 6 : day - 1; const mon = new Date(now); mon.setDate(now.getDate() - diff); setFilterDateFrom(formatLocalDate(mon)); setFilterDateTo(todayISO()); } },
             { label: "This Month", fn: () => { const now = new Date(); setFilterDateFrom(formatLocalDate(new Date(now.getFullYear(), now.getMonth(), 1))); setFilterDateTo(todayISO()); } },
             { label: "All", fn: () => { setFilterDateFrom(""); setFilterDateTo(""); } },
           ].map((p) => (
-            <button key={p.label} type="button" onClick={p.fn} className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised">
+            <button key={p.label} type="button" onClick={p.fn} className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised min-h-[44px] sm:min-h-0">
               {p.label}
             </button>
           ))}
         </div>
       </div>
-      <div className="mb-4 flex flex-wrap gap-3">
-        <div>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-3">
+        <div className="w-full sm:w-auto">
           <label htmlFor="f-account" className="sr-only">Filter by account</label>
-          <select id="f-account" value={filterAccount} onChange={(e) => setFilterAccount(e.target.value === "" ? "" : Number(e.target.value))} className={`w-40 ${input}`}>
+          <select id="f-account" value={filterAccount} onChange={(e) => setFilterAccount(e.target.value === "" ? "" : Number(e.target.value))} className={`w-full sm:w-40 ${input}`}>
             <option value="">All accounts</option>
             {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
           </select>
         </div>
-        <div>
+        <div className="w-full sm:w-auto">
           <label htmlFor="f-category" className="sr-only">Filter by category</label>
-          <select id="f-category" value={filterCategory} onChange={(e) => setFilterCategory(e.target.value === "" ? "" : Number(e.target.value))} className={`w-40 ${input}`}>
+          <select id="f-category" value={filterCategory} onChange={(e) => setFilterCategory(e.target.value === "" ? "" : Number(e.target.value))} className={`w-full sm:w-40 ${input}`}>
             <option value="">All categories</option>
             {categories.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
           </select>
         </div>
-        <div>
+        <div className="w-full sm:w-auto">
           <label htmlFor="f-type" className="sr-only">Filter by type</label>
-          <select id="f-type" value={filterType} onChange={(e) => setFilterType(e.target.value)} className={`w-32 ${input}`}>
+          <select id="f-type" value={filterType} onChange={(e) => setFilterType(e.target.value)} className={`w-full sm:w-32 ${input}`}>
             <option value="">All types</option>
             <option value="income">Income</option>
             <option value="expense">Expense</option>
           </select>
         </div>
-        <div>
+        <div className="w-full sm:w-auto">
           <label htmlFor="f-status" className="sr-only">Filter by status</label>
-          <select id="f-status" value={filterStatus} onChange={(e) => setFilterStatus(e.target.value)} className={`w-32 ${input}`}>
+          <select id="f-status" value={filterStatus} onChange={(e) => setFilterStatus(e.target.value)} className={`w-full sm:w-32 ${input}`}>
             <option value="">All statuses</option>
             <option value="settled">Settled</option>
             <option value="pending">Pending</option>
           </select>
         </div>
-        <div>
+        <div className="w-full sm:w-auto">
           <label htmlFor="f-from" className="sr-only">From date</label>
-          <input id="f-from" type="date" value={filterDateFrom} onChange={(e) => setFilterDateFrom(e.target.value)} className={`w-32 ${input}`} placeholder="From" />
+          <input id="f-from" type="date" value={filterDateFrom} onChange={(e) => setFilterDateFrom(e.target.value)} className={`w-full sm:w-32 ${input}`} placeholder="From" />
         </div>
-        <div>
+        <div className="w-full sm:w-auto">
           <label htmlFor="f-to" className="sr-only">To date</label>
-          <input id="f-to" type="date" value={filterDateTo} onChange={(e) => setFilterDateTo(e.target.value)} className={`w-32 ${input}`} placeholder="To" />
+          <input id="f-to" type="date" value={filterDateTo} onChange={(e) => setFilterDateTo(e.target.value)} className={`w-full sm:w-32 ${input}`} placeholder="To" />
         </div>
         {periods.length > 0 && (
-          <div>
+          <div className="w-full sm:w-auto">
             <label htmlFor="f-period" className="sr-only">Billing period</label>
-            <select id="f-period" value={filterPeriod} onChange={(e) => { setFilterPeriod(e.target.value); if (e.target.value) { setFilterDateFrom(""); setFilterDateTo(""); } }} className={`w-40 ${input}`}>
+            <select id="f-period" value={filterPeriod} onChange={(e) => { setFilterPeriod(e.target.value); if (e.target.value) { setFilterDateFrom(""); setFilterDateTo(""); } }} className={`w-full sm:w-40 ${input}`}>
               <option value="">All periods</option>
               {periods.map((p) => (
                 <option key={p.id} value={String(p.id)}>
@@ -498,8 +498,8 @@ function TransactionsPageContent() {
         <Spinner />
       ) : (
         <>
-          <div className={`${card} overflow-x-auto`}>
-            <div className="border-b border-border px-6 py-3">
+          <div className={`${card} md:overflow-x-auto`}>
+            <div className="hidden md:block border-b border-border px-6 py-3">
               <div className="grid grid-cols-12 gap-4 text-xs font-medium uppercase tracking-wider text-text-muted">
                 {([
                   { field: "date" as const, label: "Date", span: "col-span-2", align: "" },
@@ -516,100 +516,233 @@ function TransactionsPageContent() {
                 <span className="col-span-1" />
               </div>
             </div>
-            <div className="divide-y divide-border-subtle">
-              {(() => {
-                // Precompute tx map for O(1) lookups
-                const txMap = new Map(transactions.map((t) => [t.id, t]));
-                // Deduplicate transfers: keep the lower id (expense side)
-                const hiddenIds = new Set<number>();
-                for (const t of transactions) {
-                  if (t.linked_transaction_id && t.id > t.linked_transaction_id) {
-                    hiddenIds.add(t.id);
-                  }
+            {(() => {
+              // Precompute tx map for O(1) lookups
+              const txMap = new Map(transactions.map((t) => [t.id, t]));
+              // Deduplicate transfers: keep the lower id (expense side)
+              const hiddenIds = new Set<number>();
+              for (const t of transactions) {
+                if (t.linked_transaction_id && t.id > t.linked_transaction_id) {
+                  hiddenIds.add(t.id);
                 }
-                return sortedTransactions.filter((t) => !hiddenIds.has(t.id)).map((tx) => {
-                const isTransfer = tx.linked_transaction_id !== null;
-                const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
-                return editingId === tx.id ? (
-                  <div key={tx.id} className="grid grid-cols-12 items-center gap-2 px-6 py-2 bg-surface-raised">
-                    <span className="col-span-2"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} /></span>
-                    <span className="col-span-2"><input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
-                    <span className="col-span-2">
-                      <select aria-label="Account" value={editAccountId} onChange={(e) => setEditAccountId(e.target.value === "" ? "" : Number(e.target.value))} className={`text-sm ${input}`}>
-                        {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}{!a.is_active ? " (inactive)" : ""}</option>)}
-                      </select>
-                    </span>
-                    <span className="col-span-2">
-                      <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} />
-                    </span>
-                    <span className="col-span-1">
-                      <select aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-[11px] ${input}`}>
-                        <option value="settled">Settled</option>
-                        <option value="pending">Pending</option>
-                      </select>
-                    </span>
-                    <span className="col-span-1 flex gap-1">
-                      <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-[11px] w-14 ${input}`}>
-                        <option value="expense">-</option>
-                        <option value="income">+</option>
-                      </select>
-                      <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm w-20 ${input}`} />
-                    </span>
-                    <span className="col-span-2 flex justify-end gap-2">
-                      <button onClick={handleSaveEdit} className="text-xs text-accent hover:text-accent-hover">Save</button>
-                      <button onClick={() => setEditingId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
-                    </span>
-                  </div>
-                ) : (
-                  <div key={tx.id} className={`grid grid-cols-12 items-center gap-4 px-6 py-3 transition-colors hover:bg-surface-raised ${tx.status === "pending" ? "opacity-60" : ""}`}>
-                    <span className="col-span-2 text-sm tabular-nums text-text-secondary">{tx.date}</span>
-                    <span className="col-span-3 text-sm text-text-primary">{tx.description}</span>
-                    <span className="col-span-2 text-sm text-text-secondary">
-                      {isTransfer && linkedTx
-                        ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
-                        : tx.account_name}
-                    </span>
-                    <span className="col-span-2 text-sm text-text-secondary">{tx.category_name}</span>
-                    <span className="col-span-1 text-center">
-                      {isTransfer ? (
-                        <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
-                          {tx.status}
-                        </span>
+              }
+              const visibleTxs = sortedTransactions.filter((t) => !hiddenIds.has(t.id));
+              return (
+                <>
+                  {/* Desktop/tablet grid rows (md+) */}
+                  <div className="hidden md:block divide-y divide-border-subtle">
+                    {visibleTxs.map((tx) => {
+                      const isTransfer = tx.linked_transaction_id !== null;
+                      const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
+                      return editingId === tx.id ? (
+                        <div key={tx.id} className="grid grid-cols-12 items-center gap-2 px-6 py-2 bg-surface-raised">
+                          <span className="col-span-2"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} /></span>
+                          <span className="col-span-2"><input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
+                          <span className="col-span-2">
+                            <select aria-label="Account" value={editAccountId} onChange={(e) => setEditAccountId(e.target.value === "" ? "" : Number(e.target.value))} className={`text-sm ${input}`}>
+                              {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}{!a.is_active ? " (inactive)" : ""}</option>)}
+                            </select>
+                          </span>
+                          <span className="col-span-2">
+                            <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} />
+                          </span>
+                          <span className="col-span-1">
+                            <select aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-[11px] ${input}`}>
+                              <option value="settled">Settled</option>
+                              <option value="pending">Pending</option>
+                            </select>
+                          </span>
+                          <span className="col-span-1 flex gap-1">
+                            <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-[11px] w-14 ${input}`}>
+                              <option value="expense">-</option>
+                              <option value="income">+</option>
+                            </select>
+                            <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm w-20 ${input}`} />
+                          </span>
+                          <span className="col-span-2 flex justify-end gap-2">
+                            <button onClick={handleSaveEdit} className="text-xs text-accent hover:text-accent-hover">Save</button>
+                            <button onClick={() => setEditingId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                          </span>
+                        </div>
                       ) : (
-                        <button
-                          onClick={() => handleToggleStatus(tx)}
-                          aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
-                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                            tx.status === "settled"
-                              ? "bg-success-dim text-success"
-                              : "bg-surface-overlay text-text-muted"
-                          }`}
-                        >
-                          {tx.status}
-                        </button>
-                      )}
-                    </span>
-                    <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
-                      {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
-                    </span>
-                    <span className="col-span-1 flex justify-end gap-2">
-                      {!isTransfer && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>}
-                      <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
-                    </span>
+                        <div key={tx.id} className={`grid grid-cols-12 items-center gap-4 px-6 py-3 transition-colors hover:bg-surface-raised ${tx.status === "pending" ? "opacity-60" : ""}`}>
+                          <span className="col-span-2 text-sm tabular-nums text-text-secondary">{tx.date}</span>
+                          <span className="col-span-3 text-sm text-text-primary">{tx.description}</span>
+                          <span className="col-span-2 text-sm text-text-secondary">
+                            {isTransfer && linkedTx
+                              ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
+                              : tx.account_name}
+                          </span>
+                          <span className="col-span-2 text-sm text-text-secondary">{tx.category_name}</span>
+                          <span className="col-span-1 text-center">
+                            {isTransfer ? (
+                              <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                                {tx.status}
+                              </span>
+                            ) : (
+                              <button
+                                onClick={() => handleToggleStatus(tx)}
+                                aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
+                                className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                                  tx.status === "settled"
+                                    ? "bg-success-dim text-success"
+                                    : "bg-surface-overlay text-text-muted"
+                                }`}
+                              >
+                                {tx.status}
+                              </button>
+                            )}
+                          </span>
+                          <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
+                            {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
+                          </span>
+                          <span className="col-span-1 flex justify-end gap-2">
+                            {!isTransfer && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>}
+                            <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                          </span>
+                        </div>
+                      );
+                    })}
+                    {transactions.length === 0 && (
+                      <div className="px-6 py-8 text-center text-sm text-text-muted">
+                        {activeAccounts.length === 0
+                          ? "Create an account first."
+                          : categories.length === 0
+                            ? "Create a category first."
+                            : "No transactions match your filters."}
+                      </div>
+                    )}
                   </div>
-                );
-                });
-              })()}
-              {transactions.length === 0 && (
-                <div className="px-6 py-8 text-center text-sm text-text-muted">
-                  {activeAccounts.length === 0
-                    ? "Create an account first."
-                    : categories.length === 0
-                      ? "Create a category first."
-                      : "No transactions match your filters."}
-                </div>
-              )}
-            </div>
+
+                  {/* Mobile card layout (below md) */}
+                  <div className="md:hidden flex flex-col gap-3 p-3">
+                    {visibleTxs.map((tx) => {
+                      const isTransfer = tx.linked_transaction_id !== null;
+                      const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
+                      if (editingId === tx.id) {
+                        return (
+                          <article key={tx.id} className="flex flex-col gap-3 rounded-lg border border-border bg-surface-raised p-4 shadow-sm">
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              <div>
+                                <label className={label}>Date</label>
+                                <input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} />
+                              </div>
+                              <div>
+                                <label className={label}>Description</label>
+                                <input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} />
+                              </div>
+                              <div>
+                                <label className={label}>Account</label>
+                                <select aria-label="Account" value={editAccountId} onChange={(e) => setEditAccountId(e.target.value === "" ? "" : Number(e.target.value))} className={`text-sm ${input}`}>
+                                  {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}{!a.is_active ? " (inactive)" : ""}</option>)}
+                                </select>
+                              </div>
+                              <div>
+                                <label className={label}>Category</label>
+                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} />
+                              </div>
+                              <div>
+                                <label className={label}>Status</label>
+                                <select aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-sm ${input}`}>
+                                  <option value="settled">Settled</option>
+                                  <option value="pending">Pending</option>
+                                </select>
+                              </div>
+                              <div>
+                                <label className={label}>Type</label>
+                                <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-sm ${input}`}>
+                                  <option value="expense">Expense</option>
+                                  <option value="income">Income</option>
+                                </select>
+                              </div>
+                              <div className="sm:col-span-2">
+                                <label className={label}>Amount</label>
+                                <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm ${input}`} />
+                              </div>
+                            </div>
+                            <div className="flex flex-wrap gap-2 pt-2 border-t border-border-subtle">
+                              <button onClick={handleSaveEdit} className="min-h-[44px] px-4 rounded-md bg-accent text-accent-text text-sm font-medium">Save</button>
+                              <button onClick={() => setEditingId(null)} className="min-h-[44px] px-4 rounded-md border border-border text-sm text-text-secondary">Cancel</button>
+                            </div>
+                          </article>
+                        );
+                      }
+                      return (
+                        <article
+                          key={tx.id}
+                          className={`flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 shadow-sm ${tx.status === "pending" ? "opacity-60" : ""}`}
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-sm font-medium text-text-primary">
+                                {tx.description}
+                              </div>
+                              <div className="mt-0.5 text-xs text-text-muted tabular-nums">
+                                {tx.date} · {isTransfer && linkedTx ? <>{tx.account_name} &rarr; {linkedTx.account_name}</> : tx.account_name}
+                              </div>
+                            </div>
+                            <div className={`shrink-0 text-right text-sm font-semibold tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
+                              {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
+                            </div>
+                          </div>
+                          <div className="flex items-center justify-between gap-2">
+                            {tx.category_name && (
+                              <div className="text-xs text-text-secondary truncate">
+                                {tx.category_name}
+                              </div>
+                            )}
+                            {isTransfer ? (
+                              <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                                {tx.status}
+                              </span>
+                            ) : (
+                              <button
+                                onClick={() => handleToggleStatus(tx)}
+                                aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
+                                className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                                  tx.status === "settled"
+                                    ? "bg-success-dim text-success"
+                                    : "bg-surface-overlay text-text-muted"
+                                }`}
+                              >
+                                {tx.status}
+                              </button>
+                            )}
+                          </div>
+                          <div className="flex flex-wrap gap-2 pt-2 border-t border-border-subtle">
+                            {!isTransfer && (
+                              <button
+                                onClick={() => startEdit(tx)}
+                                aria-label={`Edit: ${tx.description}`}
+                                className="min-h-[44px] px-3 rounded-md border border-border text-sm text-text-secondary"
+                              >
+                                Edit
+                              </button>
+                            )}
+                            <button
+                              onClick={() => setConfirmDeleteId(tx.id)}
+                              aria-label={`Delete: ${tx.description}`}
+                              className="min-h-[44px] px-3 rounded-md border border-border text-sm text-danger"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </article>
+                      );
+                    })}
+                    {transactions.length === 0 && (
+                      <div className="px-4 py-8 text-center text-sm text-text-muted">
+                        {activeAccounts.length === 0
+                          ? "Create an account first."
+                          : categories.length === 0
+                            ? "Create a category first."
+                            : "No transactions match your filters."}
+                      </div>
+                    )}
+                  </div>
+                </>
+              );
+            })()}
           </div>
 
           {(page > 0 || hasMore) && (

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -603,7 +603,7 @@ function TransactionsPageContent() {
                         </div>
                       );
                     })}
-                    {transactions.length === 0 && (
+                    {visibleTxs.length === 0 && (
                       <div className="px-6 py-8 text-center text-sm text-text-muted">
                         {activeAccounts.length === 0
                           ? "Create an account first."
@@ -685,21 +685,21 @@ function TransactionsPageContent() {
                               {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                             </div>
                           </div>
-                          <div className="flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2">
                             {tx.category_name && (
                               <div className="text-xs text-text-secondary truncate">
                                 {tx.category_name}
                               </div>
                             )}
                             {isTransfer ? (
-                              <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                              <span className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
                                 {tx.status}
                               </span>
                             ) : (
                               <button
                                 onClick={() => handleToggleStatus(tx)}
                                 aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
-                                className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                                className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-medium ${
                                   tx.status === "settled"
                                     ? "bg-success-dim text-success"
                                     : "bg-surface-overlay text-text-muted"
@@ -730,7 +730,7 @@ function TransactionsPageContent() {
                         </article>
                       );
                     })}
-                    {transactions.length === 0 && (
+                    {visibleTxs.length === 0 && (
                       <div className="px-4 py-8 text-center text-sm text-text-muted">
                         {activeAccounts.length === 0
                           ? "Create an account first."


### PR DESCRIPTION
## Summary
Part 1 of the responsive sweep (see spec \`docs/superpowers/specs/2026-04-19-responsive-sweep-design.md\`).

- **Transactions**: header row + 12-col grid rows gated \`hidden md:block\`; new \`md:hidden\` card sibling renders each transaction as a stacked card with amount, date/account subline, category, and Edit/Settle/Delete buttons at \`min-h-[44px]\`. Filter bar stacks below \`sm\`.
- **Forecast Plans**: hybrid hide-and-scroll. Column template collapses to \`[1fr_100px]\` below \`md\`, restoring full template at \`md+\`. Actual/Variance/Source hidden below \`md\` and surfaced inline under the category name. Add-item form stacks below \`sm\`.
- **Budgets**: each budget row reflows to name+amount / progress bar / actions stack below \`md\`, restoring the single-line layout at \`md+\`. Action buttons get 44px tap height. Summary tiles go \`grid-cols-1 sm:grid-cols-3\`. Inline add-budget and transfer forms stack below \`sm\`.

## Audit report
\`docs/superpowers/audits/2026-04-19-responsive-findings.md\` — details the code-scan findings, PR1 implementation notes, and PR2 carryovers (bare \`<table>\` on settings/organization, recurring-page header absence).

## Design + plan
- Design spec: \`docs/superpowers/specs/2026-04-19-responsive-sweep-design.md\`
- Implementation plan: \`docs/superpowers/plans/2026-04-19-responsive-sweep.md\`

## Verification checklist (reviewer)
Please verify visually at these viewports — no automated UI tests exist for this:

- [ ] **375×812 (iPhone SE / small phone)**
  - \`/transactions\` — cards stack cleanly, amounts right-aligned, no horizontal page scroll
  - \`/forecast-plans\` — categories visible, Actual/Variance shown inline, inner table may scroll horizontally but page does not
  - \`/budgets\` — name+amount on one line, progress bar full-width, Transfer/Edit/Remove all tappable
- [ ] **768×1024 (portrait tablet)**
  - All three pages restore their original table/grid layout
- [ ] **1280×800 (desktop)** — no regressions vs main

## Follow-up (PR2)
Recurring, Accounts, Categories, Import wizard, auth/settings/admin forms, modals sweep, dashboard regression check.