### PR TITLE
feat(transactions): multi-select + bulk delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ mysql_data/
 .claude/
 .superpowers/
 .playwright-mcp/
+docs/superpowers/
 
 # Local test fixtures and scratch
 mock/

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -8,6 +8,8 @@ from app.database import get_db
 from app.deps import get_current_user
 from app.models.user import User
 from app.schemas.transaction import (
+    BulkDeleteRequest,
+    BulkDeleteResponse,
     TransactionCreate,
     TransactionResponse,
     TransactionUpdate,
@@ -95,3 +97,24 @@ async def delete_transaction(
     db: AsyncSession = Depends(get_db),
 ):
     await svc.delete_transaction(db, current_user.org_id, transaction_id)
+
+
+@router.post("/bulk-delete", response_model=BulkDeleteResponse)
+async def bulk_delete_transactions(
+    body: BulkDeleteRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete multiple transactions atomically.
+
+    Cross-org IDs are silently skipped. Transfer-pair halves cascade.
+    Cap: 500 IDs per request (enforced by Pydantic).
+    """
+    deleted_count, skipped_ids = await svc.bulk_delete_transactions(
+        db, current_user.org_id, body.ids
+    )
+    return BulkDeleteResponse(
+        requested_count=len(body.ids),
+        deleted_count=deleted_count,
+        skipped_ids=skipped_ids,
+    )

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -110,11 +110,12 @@ async def bulk_delete_transactions(
     Cross-org IDs are silently skipped. Transfer-pair halves cascade.
     Cap: 500 IDs per request (enforced by Pydantic).
     """
+    unique_ids = list(dict.fromkeys(body.ids))
     deleted_count, skipped_ids = await svc.bulk_delete_transactions(
-        db, current_user.org_id, body.ids
+        db, current_user.org_id, unique_ids
     )
     return BulkDeleteResponse(
-        requested_count=len(body.ids),
+        requested_count=len(unique_ids),
         deleted_count=deleted_count,
         skipped_ids=skipped_ids,
     )

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -66,3 +66,22 @@ class TransactionResponse(BaseModel):
     is_imported: bool = False
 
     model_config = {"from_attributes": True}
+
+
+class BulkDeleteRequest(BaseModel):
+    """Body for POST /api/v1/transactions/bulk-delete."""
+
+    ids: list[int] = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Transaction IDs to delete. Cross-org IDs are silently ignored. Transfer-pair halves cascade.",
+    )
+
+
+class BulkDeleteResponse(BaseModel):
+    """Result of a bulk delete."""
+
+    requested_count: int
+    deleted_count: int
+    skipped_ids: list[int]  # IDs that were requested but not found in this org

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -279,7 +279,9 @@ async def bulk_delete_transactions(
 
     Returns (deleted_count, skipped_ids). Cross-org IDs are silently
     skipped. Transfer-pair halves cascade: deleting one half also deletes
-    the linked half. Balance reverts applied per transaction for settled rows.
+    the linked half. Balance reverts applied per transaction for settled rows
+    under SELECT FOR UPDATE locks acquired in sorted-ID order to prevent
+    lost updates and deadlocks.
     """
     if not ids:
         return (0, [])
@@ -314,45 +316,29 @@ async def bulk_delete_transactions(
         )
         found.extend(linked_result.scalars().all())
 
-    # Track accounts we've already loaded to avoid re-fetching in the loop
-    accounts_cache: dict[int, Account] = {}
+    # Collect distinct account IDs that will need a balance revert
+    account_ids_to_lock = sorted({
+        tx.account_id
+        for tx in found
+        if tx.status == TransactionStatus.SETTLED
+    })
 
-    async def _get_account(account_id: int) -> Account | None:
-        if account_id in accounts_cache:
-            return accounts_cache[account_id]
-        acct_result = await db.execute(
-            select(Account).where(
-                Account.id == account_id, Account.org_id == org_id
-            )
-        )
-        acct = acct_result.scalar_one_or_none()
-        if acct is not None:
-            accounts_cache[account_id] = acct
-        return acct
+    async with db.begin_nested():
+        # Lock each affected account in sorted order to prevent deadlocks
+        accounts: dict[int, Account] = {}
+        for aid in account_ids_to_lock:
+            accounts[aid] = await get_account_for_update(db, aid, org_id)
 
-    # Revert balances for settled rows, then delete
-    deleted_ids: set[int] = set()
-    for tx in found:
-        if tx.id in deleted_ids:
-            continue
-        if tx.status == TransactionStatus.SETTLED and tx.type != TransactionType.TRANSFER:
-            acct = await _get_account(tx.account_id)
-            if acct is not None:
-                revert_balance(acct, tx.amount, tx.type)
-        elif tx.status == TransactionStatus.SETTLED and tx.type == TransactionType.TRANSFER:
-            # Transfer pair: revert both halves independently. Each half is
-            # its own row with its own account + amount + type, so per-row
-            # revert is correct.
-            acct = await _get_account(tx.account_id)
-            if acct is not None:
-                # Transfer half stored as income on to-account or expense on
-                # from-account. revert_balance handles both via tx.type.
-                revert_balance(acct, tx.amount, tx.type)
-        await db.delete(tx)
-        deleted_ids.add(tx.id)
+        # Revert balances for settled rows, then delete every row
+        for tx in found:
+            if tx.status == TransactionStatus.SETTLED:
+                acct = accounts.get(tx.account_id)
+                if acct is not None:
+                    revert_balance(acct, tx.amount, tx.type)
+            await db.delete(tx)
 
     await db.commit()
-    return (len(deleted_ids), skipped_ids)
+    return (len(found), skipped_ids)
 
 
 async def create_transfer(

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -329,6 +329,13 @@ async def bulk_delete_transactions(
         for aid in account_ids_to_lock:
             accounts[aid] = await get_account_for_update(db, aid, org_id)
 
+        # Break linked-transfer FK cycles before deletion so SQLAlchemy can flush
+        # the deletes without hitting a circular dependency error
+        for tx in found:
+            if tx.linked_transaction_id is not None:
+                tx.linked_transaction_id = None
+        await db.flush()
+
         # Revert balances for settled rows, then delete every row
         for tx in found:
             if tx.status == TransactionStatus.SETTLED:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -272,6 +272,89 @@ async def delete_transaction(db: AsyncSession, org_id: int, transaction_id: int)
     await db.commit()
 
 
+async def bulk_delete_transactions(
+    db: AsyncSession, org_id: int, ids: list[int]
+) -> tuple[int, list[int]]:
+    """Delete multiple transactions in one atomic commit.
+
+    Returns (deleted_count, skipped_ids). Cross-org IDs are silently
+    skipped. Transfer-pair halves cascade: deleting one half also deletes
+    the linked half. Balance reverts applied per transaction for settled rows.
+    """
+    if not ids:
+        return (0, [])
+
+    # Dedupe input — caller may select both halves of a transfer
+    requested = list(dict.fromkeys(ids))
+
+    # Fetch all requested transactions scoped to this org
+    result = await db.execute(
+        select(Transaction).where(
+            Transaction.id.in_(requested),
+            Transaction.org_id == org_id,
+        )
+    )
+    found = list(result.scalars().all())
+    found_ids = {tx.id for tx in found}
+    skipped_ids = [i for i in requested if i not in found_ids]
+
+    # Expand transfer pairs — collect linked IDs not already in the list
+    linked_ids_to_fetch = {
+        tx.linked_transaction_id
+        for tx in found
+        if tx.linked_transaction_id is not None
+        and tx.linked_transaction_id not in found_ids
+    }
+    if linked_ids_to_fetch:
+        linked_result = await db.execute(
+            select(Transaction).where(
+                Transaction.id.in_(linked_ids_to_fetch),
+                Transaction.org_id == org_id,
+            )
+        )
+        found.extend(linked_result.scalars().all())
+
+    # Track accounts we've already loaded to avoid re-fetching in the loop
+    accounts_cache: dict[int, Account] = {}
+
+    async def _get_account(account_id: int) -> Account | None:
+        if account_id in accounts_cache:
+            return accounts_cache[account_id]
+        acct_result = await db.execute(
+            select(Account).where(
+                Account.id == account_id, Account.org_id == org_id
+            )
+        )
+        acct = acct_result.scalar_one_or_none()
+        if acct is not None:
+            accounts_cache[account_id] = acct
+        return acct
+
+    # Revert balances for settled rows, then delete
+    deleted_ids: set[int] = set()
+    for tx in found:
+        if tx.id in deleted_ids:
+            continue
+        if tx.status == TransactionStatus.SETTLED and tx.type != TransactionType.TRANSFER:
+            acct = await _get_account(tx.account_id)
+            if acct is not None:
+                revert_balance(acct, tx.amount, tx.type)
+        elif tx.status == TransactionStatus.SETTLED and tx.type == TransactionType.TRANSFER:
+            # Transfer pair: revert both halves independently. Each half is
+            # its own row with its own account + amount + type, so per-row
+            # revert is correct.
+            acct = await _get_account(tx.account_id)
+            if acct is not None:
+                # Transfer half stored as income on to-account or expense on
+                # from-account. revert_balance handles both via tx.type.
+                revert_balance(acct, tx.amount, tx.type)
+        await db.delete(tx)
+        deleted_ids.add(tx.id)
+
+    await db.commit()
+    return (len(deleted_ids), skipped_ids)
+
+
 async def create_transfer(
     db: AsyncSession, org_id: int, body: TransferCreate, *, is_imported: bool = False
 ) -> tuple[Transaction, Transaction]:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -289,12 +289,17 @@ async def bulk_delete_transactions(
     # Dedupe input — caller may select both halves of a transfer
     requested = list(dict.fromkeys(ids))
 
-    # Fetch all requested transactions scoped to this org
+    # Fetch all requested transactions scoped to this org. Lock the rows
+    # FOR UPDATE (ordered by id) so a concurrent delete of the same rows
+    # waits on us instead of producing stale-rowcount errors at flush time.
     result = await db.execute(
-        select(Transaction).where(
+        select(Transaction)
+        .where(
             Transaction.id.in_(requested),
             Transaction.org_id == org_id,
         )
+        .order_by(Transaction.id)
+        .with_for_update()
     )
     found = list(result.scalars().all())
     found_ids = {tx.id for tx in found}
@@ -309,10 +314,13 @@ async def bulk_delete_transactions(
     }
     if linked_ids_to_fetch:
         linked_result = await db.execute(
-            select(Transaction).where(
+            select(Transaction)
+            .where(
                 Transaction.id.in_(linked_ids_to_fetch),
                 Transaction.org_id == org_id,
             )
+            .order_by(Transaction.id)
+            .with_for_update()
         )
         found.extend(linked_result.scalars().all())
 

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -288,7 +288,7 @@ function TransactionsPageContent() {
       await loadTransactions(page);
       if (res.skipped_ids.length > 0) {
         setError(
-          `Deleted ${res.deleted_count} of ${res.requested_count} transactions. ${res.skipped_ids.length} were already gone.`,
+          `Deleted ${res.deleted_count} of ${res.requested_count} transactions. ${res.skipped_ids.length} ${res.skipped_ids.length === 1 ? "was" : "were"} already gone.`,
         );
       }
     } catch (err) {

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -81,6 +81,9 @@ function TransactionsPageContent() {
   const [formFrequency, setFormFrequency] = useState("monthly");
   const [formAutoSettle, setFormAutoSettle] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
 
   const loadRefs = useCallback(async () => {
     const [accts, cats, pers] = await Promise.all([
@@ -142,6 +145,11 @@ function TransactionsPageContent() {
   }, [loading, user, loadTransactions, page]);
 
   useEffect(() => { setPage(0); }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod]);
+
+  useEffect(() => {
+    clearSelection();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod, sortField, sortDir, page]);
 
   function handleTypeChange(t: "income" | "expense") {
     setFormType(t);
@@ -209,6 +217,36 @@ function TransactionsPageContent() {
     } catch (err) {
       setError(extractErrorMessage(err));
     }
+  }
+
+  const allPageSelected =
+    transactions.length > 0 && transactions.every((t) => selectedIds.has(t.id));
+  const somePageSelected =
+    transactions.some((t) => selectedIds.has(t.id)) && !allPageSelected;
+
+  function toggleOne(id: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function togglePage() {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allPageSelected) {
+        transactions.forEach((t) => next.delete(t.id));
+      } else {
+        transactions.forEach((t) => next.add(t.id));
+      }
+      return next;
+    });
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
   }
 
   async function handleDelete(id: number) {
@@ -501,9 +539,21 @@ function TransactionsPageContent() {
           <div className={`${card} md:overflow-x-auto`}>
             <div className="hidden md:block border-b border-border px-6 py-3">
               <div className="grid grid-cols-12 gap-4 text-xs font-medium uppercase tracking-wider text-text-muted">
+                <div className="col-span-1 flex items-center">
+                  <input
+                    type="checkbox"
+                    aria-label="Select all on page"
+                    checked={allPageSelected}
+                    ref={(el) => {
+                      if (el) el.indeterminate = somePageSelected;
+                    }}
+                    onChange={togglePage}
+                    className="h-4 w-4"
+                  />
+                </div>
                 {([
                   { field: "date" as const, label: "Date", span: "col-span-2", align: "" },
-                  { field: "description" as const, label: "Description", span: "col-span-3", align: "" },
+                  { field: "description" as const, label: "Description", span: "col-span-2", align: "" },
                   { field: "account_name" as const, label: "Account", span: "col-span-2", align: "" },
                   { field: "category_name" as const, label: "Category", span: "col-span-2", align: "" },
                   { field: "status" as const, label: "Status", span: "col-span-1", align: "text-center" },
@@ -536,6 +586,15 @@ function TransactionsPageContent() {
                       const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
                       return editingId === tx.id ? (
                         <div key={tx.id} className="grid grid-cols-12 items-center gap-2 px-6 py-2 bg-surface-raised">
+                          <span className="col-span-1 flex items-center">
+                            <input
+                              type="checkbox"
+                              aria-label={`Select transaction ${tx.id}`}
+                              checked={selectedIds.has(tx.id)}
+                              onChange={() => toggleOne(tx.id)}
+                              className="h-4 w-4"
+                            />
+                          </span>
                           <span className="col-span-2"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} /></span>
                           <span className="col-span-2"><input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
                           <span className="col-span-2">
@@ -559,15 +618,24 @@ function TransactionsPageContent() {
                             </select>
                             <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm w-20 ${input}`} />
                           </span>
-                          <span className="col-span-2 flex justify-end gap-2">
+                          <span className="col-span-1 flex justify-end gap-2">
                             <button onClick={handleSaveEdit} className="text-xs text-accent hover:text-accent-hover">Save</button>
                             <button onClick={() => setEditingId(null)} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
                           </span>
                         </div>
                       ) : (
                         <div key={tx.id} className={`grid grid-cols-12 items-center gap-4 px-6 py-3 transition-colors hover:bg-surface-raised ${tx.status === "pending" ? "opacity-60" : ""}`}>
+                          <span className="col-span-1 flex items-center">
+                            <input
+                              type="checkbox"
+                              aria-label={`Select transaction ${tx.id}`}
+                              checked={selectedIds.has(tx.id)}
+                              onChange={() => toggleOne(tx.id)}
+                              className="h-4 w-4"
+                            />
+                          </span>
                           <span className="col-span-2 text-sm tabular-nums text-text-secondary">{tx.date}</span>
-                          <span className="col-span-3 text-sm text-text-primary">{tx.description}</span>
+                          <span className="col-span-2 text-sm text-text-primary">{tx.description}</span>
                           <span className="col-span-2 text-sm text-text-secondary">
                             {isTransfer && linkedTx
                               ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -153,13 +153,18 @@ function TransactionsPageContent() {
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape" && selectedIds.size > 0 && !confirmBulkDelete) {
+      if (
+        e.key === "Escape" &&
+        selectedIds.size > 0 &&
+        !confirmBulkDelete &&
+        !bulkDeleting
+      ) {
         clearSelection();
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [selectedIds.size, confirmBulkDelete]);
+  }, [selectedIds.size, confirmBulkDelete, bulkDeleting]);
 
   function handleTypeChange(t: "income" | "expense") {
     setFormType(t);
@@ -229,10 +234,22 @@ function TransactionsPageContent() {
     }
   }
 
+  // Selection state operates on the VISIBLE rows only (transfer pairs are
+  // rendered as a single row — the hidden half cascades server-side). Using
+  // visibleTxs here keeps allPageSelected / togglePage consistent with what
+  // the user actually sees.
+  const selectionHiddenIds = new Set<number>();
+  for (const t of transactions) {
+    if (t.linked_transaction_id && t.id > t.linked_transaction_id) {
+      selectionHiddenIds.add(t.id);
+    }
+  }
+  const selectableTxs = transactions.filter((t) => !selectionHiddenIds.has(t.id));
+
   const allPageSelected =
-    transactions.length > 0 && transactions.every((t) => selectedIds.has(t.id));
+    selectableTxs.length > 0 && selectableTxs.every((t) => selectedIds.has(t.id));
   const somePageSelected =
-    transactions.some((t) => selectedIds.has(t.id)) && !allPageSelected;
+    selectableTxs.some((t) => selectedIds.has(t.id)) && !allPageSelected;
 
   function toggleOne(id: number) {
     setSelectedIds((prev) => {
@@ -247,9 +264,9 @@ function TransactionsPageContent() {
     setSelectedIds((prev) => {
       const next = new Set(prev);
       if (allPageSelected) {
-        transactions.forEach((t) => next.delete(t.id));
+        selectableTxs.forEach((t) => next.delete(t.id));
       } else {
-        transactions.forEach((t) => next.add(t.id));
+        selectableTxs.forEach((t) => next.add(t.id));
       }
       return next;
     });
@@ -630,16 +647,11 @@ function TransactionsPageContent() {
               </div>
             </div>
             {(() => {
-              // Precompute tx map for O(1) lookups
+              // Precompute tx map for O(1) lookups. The dedupe set is hoisted
+              // above (selectionHiddenIds) so the selection helpers see the
+              // same hidden-half rule as the render.
               const txMap = new Map(transactions.map((t) => [t.id, t]));
-              // Deduplicate transfers: keep the lower id (expense side)
-              const hiddenIds = new Set<number>();
-              for (const t of transactions) {
-                if (t.linked_transaction_id && t.id > t.linked_transaction_id) {
-                  hiddenIds.add(t.id);
-                }
-              }
-              const visibleTxs = sortedTransactions.filter((t) => !hiddenIds.has(t.id));
+              const visibleTxs = sortedTransactions.filter((t) => !selectionHiddenIds.has(t.id));
               return (
                 <>
                   {/* Desktop/tablet grid rows (md+) */}
@@ -887,11 +899,11 @@ function TransactionsPageContent() {
 
           {(page > 0 || hasMore) && (
             <div className="mt-4 flex items-center justify-between">
-              <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0} className="rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-raised disabled:opacity-40">
+              <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0 || bulkDeleting} className="rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-raised disabled:opacity-40">
                 Previous
               </button>
               <span className="text-xs text-text-muted">Page {page + 1}</span>
-              <button onClick={() => setPage(page + 1)} disabled={!hasMore} className="rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-raised disabled:opacity-40">
+              <button onClick={() => setPage(page + 1)} disabled={!hasMore || bulkDeleting} className="rounded-md border border-border px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-raised disabled:opacity-40">
                 Next
               </button>
             </div>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -741,6 +741,13 @@ function TransactionsPageContent() {
                           className={`flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 shadow-sm ${tx.status === "pending" ? "opacity-60" : ""}`}
                         >
                           <div className="flex items-start justify-between gap-2">
+                            <input
+                              type="checkbox"
+                              aria-label={`Select transaction ${tx.id}`}
+                              checked={selectedIds.has(tx.id)}
+                              onChange={() => toggleOne(tx.id)}
+                              className="mt-0.5 h-5 w-5 shrink-0"
+                            />
                             <div className="min-w-0 flex-1">
                               <div className="truncate text-sm font-medium text-text-primary">
                                 {tx.description}

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -151,6 +151,16 @@ function TransactionsPageContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterAccount, filterCategory, filterType, filterStatus, filterDateFrom, filterDateTo, filterSearch, filterPeriod, sortField, sortDir, page]);
 
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && selectedIds.size > 0 && !confirmBulkDelete) {
+        clearSelection();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedIds.size, confirmBulkDelete]);
+
   function handleTypeChange(t: "income" | "expense") {
     setFormType(t);
     setFormCategoryId("");
@@ -718,8 +728,8 @@ function TransactionsPageContent() {
                             {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                           </span>
                           <span className="col-span-1 flex justify-end gap-2">
-                            {!isTransfer && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} className="text-xs text-text-muted hover:text-accent">Edit</button>}
-                            <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} className="text-xs text-text-muted hover:text-danger">Delete</button>
+                            {!isTransfer && <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} disabled={bulkDeleting} className="text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Edit</button>}
+                            <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} disabled={bulkDeleting} className="text-xs text-text-muted hover:text-danger disabled:opacity-40 disabled:cursor-not-allowed">Delete</button>
                           </span>
                         </div>
                       );
@@ -842,7 +852,8 @@ function TransactionsPageContent() {
                               <button
                                 onClick={() => startEdit(tx)}
                                 aria-label={`Edit: ${tx.description}`}
-                                className="min-h-[44px] px-3 rounded-md border border-border text-sm text-text-secondary"
+                                disabled={bulkDeleting}
+                                className="min-h-[44px] px-3 rounded-md border border-border text-sm text-text-secondary disabled:opacity-40 disabled:cursor-not-allowed"
                               >
                                 Edit
                               </button>
@@ -850,7 +861,8 @@ function TransactionsPageContent() {
                             <button
                               onClick={() => setConfirmDeleteId(tx.id)}
                               aria-label={`Delete: ${tx.description}`}
-                              className="min-h-[44px] px-3 rounded-md border border-border text-sm text-danger"
+                              disabled={bulkDeleting}
+                              className="min-h-[44px] px-3 rounded-md border border-border text-sm text-danger disabled:opacity-40 disabled:cursor-not-allowed"
                             >
                               Delete
                             </button>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -260,6 +260,34 @@ function TransactionsPageContent() {
     }
   }
 
+  async function handleBulkDelete() {
+    setConfirmBulkDelete(false);
+    setError("");
+    setBulkDeleting(true);
+    try {
+      const body = { ids: Array.from(selectedIds) };
+      const res = await apiFetch<{
+        requested_count: number;
+        deleted_count: number;
+        skipped_ids: number[];
+      }>("/api/v1/transactions/bulk-delete", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      clearSelection();
+      await loadTransactions(page);
+      if (res.skipped_ids.length > 0) {
+        setError(
+          `Deleted ${res.deleted_count} of ${res.requested_count} transactions. ${res.skipped_ids.length} were already gone.`,
+        );
+      }
+    } catch (err) {
+      setError(extractErrorMessage(err));
+    } finally {
+      setBulkDeleting(false);
+    }
+  }
+
   function startEdit(tx: Transaction) {
     setEditingId(tx.id);
     setEditDesc(tx.description);
@@ -344,6 +372,31 @@ function TransactionsPageContent() {
 
   return (
     <AppShell>
+      {selectedIds.size > 0 && (
+        <div className="sticky top-0 z-20 -mx-4 sm:-mx-8 mb-4 flex items-center justify-between gap-3 border-b border-border bg-surface-raised/95 px-4 sm:px-8 py-3 backdrop-blur">
+          <span className="text-sm font-medium" aria-live="polite">
+            {selectedIds.size} selected
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className={btnSecondary}
+              onClick={clearSelection}
+              disabled={bulkDeleting}
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              className="inline-flex min-h-[44px] items-center rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500 disabled:opacity-50"
+              onClick={() => setConfirmBulkDelete(true)}
+              disabled={bulkDeleting}
+            >
+              {bulkDeleting ? "Deleting…" : "Delete selected"}
+            </button>
+          </div>
+        </div>
+      )}
       <div className="mb-8 flex items-center justify-between">
         <h1 className={`${pageTitle} mb-0`}>Transactions</h1>
         <div className="flex items-center gap-2">
@@ -841,6 +894,15 @@ function TransactionsPageContent() {
         variant="danger"
         onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
         onCancel={() => setConfirmDeleteId(null)}
+      />
+      <ConfirmModal
+        open={confirmBulkDelete}
+        title="Delete transactions"
+        message={`Delete ${selectedIds.size} selected transaction${selectedIds.size === 1 ? "" : "s"}? This cannot be undone. Balances will be adjusted for settled transactions.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={handleBulkDelete}
+        onCancel={() => setConfirmBulkDelete(false)}
       />
     </AppShell>
   );

--- a/frontend/components/ui/ConfirmModal.tsx
+++ b/frontend/components/ui/ConfirmModal.tsx
@@ -48,7 +48,7 @@ export default function ConfirmModal({
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { onCancel(); return; }
+      if (e.key === "Escape") { e.stopPropagation(); onCancel(); return; }
       if (e.key === "Tab") {
         const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'


### PR DESCRIPTION
## Summary
- New checkbox column on the Transactions page (desktop table + mobile card) with header select-all + indeterminate state.
- Sticky bulk action bar shows "N selected" with Clear and Delete actions. Escape clears selection.
- New `POST /api/v1/transactions/bulk-delete` endpoint — atomic, transfer-pair cascade, `SELECT FOR UPDATE` with sorted-ID lock ordering, 500-ID cap enforced via Pydantic.
- Transfer-pair FK cycle fix: null out `linked_transaction_id` before delete to avoid SQLAlchemy `CircularDependencyError` when both halves are in the same flush.
- `ConfirmModal` gained `e.stopPropagation()` on Escape to prevent the new page-level Escape handler from double-firing after the modal closes.

## Out of scope (tracked follow-ups)
- "Select all matching filters" (server-side bulk-select-by-filter)
- Bulk settle/unsettle, bulk categorize
- Notice/amber banner channel for partial-success `skipped_ids` message
- Reset to previous page when bulk delete empties the current page
- Export `BulkDeleteResponse` to `lib/types.ts` when a second caller appears