### PR TITLE
fix(auth): harden auth + config + input validation (pentest findings)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,10 @@ MYSQL_DATABASE=pfv2
 MYSQL_USER=pfv2
 MYSQL_PASSWORD=pfv2_secret
 
-# --- Auth (required — generate with: openssl rand -hex 32) ---
+# --- Auth (REQUIRED — the placeholder will be refused at startup) ---
+# Generate a real secret (>= 32 chars) with ONE of:
+#   openssl rand -hex 32
+#   python -c "import secrets; print(secrets.token_urlsafe(64))"
 JWT_SECRET_KEY=change-me-generate-a-real-secret
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15
 JWT_REFRESH_TOKEN_EXPIRE_DAYS=7

--- a/backend/alembic/versions/024_add_sessions_invalidated_at.py
+++ b/backend/alembic/versions/024_add_sessions_invalidated_at.py
@@ -1,0 +1,29 @@
+"""add sessions_invalidated_at to users
+
+Revision ID: f19715b7e00c
+Revises: 023
+Create Date: 2026-04-20 14:12:28.664801
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f19715b7e00c'
+down_revision: Union[str, None] = '023'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("sessions_invalidated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "sessions_invalidated_at")

--- a/backend/alembic/versions/024_add_sessions_invalidated_at.py
+++ b/backend/alembic/versions/024_add_sessions_invalidated_at.py
@@ -1,6 +1,6 @@
 """add sessions_invalidated_at to users
 
-Revision ID: f19715b7e00c
+Revision ID: 024
 Revises: 023
 Create Date: 2026-04-20 14:12:28.664801
 

--- a/backend/alembic/versions/024_add_sessions_invalidated_at.py
+++ b/backend/alembic/versions/024_add_sessions_invalidated_at.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'f19715b7e00c'
+revision: str = '024'
 down_revision: Union[str, None] = '023'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -43,6 +44,18 @@ class Settings(BaseSettings):
     # Billing
     default_plan_slug: str = "pro"  # "pro" during beta, "free" when billing goes live
     trial_duration_days: int = 14
+
+    @field_validator("jwt_secret_key")
+    @classmethod
+    def _validate_jwt_secret(cls, v: str) -> str:
+        if v == "change-me-generate-a-real-secret":
+            raise ValueError(
+                "JWT_SECRET_KEY must be set to a real secret, not the placeholder. "
+                "Generate one via: python -c 'import secrets; print(secrets.token_urlsafe(64))'"
+            )
+        if len(v) < 32:
+            raise ValueError("JWT_SECRET_KEY must be at least 32 characters")
+        return v
 
     @property
     def cors_origins(self) -> list[str]:

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
@@ -5,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.models.user import User
-from app.security import decode_token
+from app.security import decode_token, token_cutoff
 
 bearer_scheme = HTTPBearer()
 
@@ -30,5 +32,15 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found or inactive",
         )
+
+    # Reject tokens issued before the session cutoff (logout / password change)
+    iat = payload.get("iat")
+    if iat is not None:
+        token_issued_at = datetime.fromtimestamp(iat, tz=timezone.utc)
+        if token_issued_at < token_cutoff(user):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Session has been invalidated",
+            )
 
     return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,10 +63,13 @@ async def lifespan(app: FastAPI):
     await logger.ainfo("shutdown complete")
 
 
+_is_dev = app_settings.app_env == "development"
+
 app = FastAPI(
     title=app_settings.app_name,
     lifespan=lifespan,
-    docs_url="/docs" if app_settings.app_env == "development" else None,
+    docs_url="/docs" if _is_dev else None,
+    openapi_url="/openapi.json" if _is_dev else None,
     redoc_url=None,
 )
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -53,6 +53,9 @@ class User(Base):
     is_superadmin: Mapped[bool] = mapped_column(default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(default=True, nullable=False)
     password_changed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    sessions_invalidated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     mfa_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     totp_secret: Mapped[str | None] = mapped_column(String(256), nullable=True)
     recovery_codes: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -384,12 +384,29 @@ async def me(
 
 @router.post("/logout")
 async def logout(
+    request: Request,
     response: Response,
-    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    current_user.sessions_invalidated_at = datetime.now(timezone.utc)
-    await db.commit()
+    # Best-effort server-side invalidation: if the caller still has a valid
+    # access token, mark their sessions invalidated so the refresh token and
+    # any sibling access tokens are killed. Regardless of auth state, always
+    # clear the refresh cookie so the browser stops sending it.
+    authorization = request.headers.get("Authorization", "")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() == "bearer" and token:
+        try:
+            payload = decode_token(token)
+            user_id = payload.get("sub")
+            if user_id is not None:
+                result = await db.execute(select(User).where(User.id == int(user_id)))
+                user = result.scalar_one_or_none()
+                if user is not None:
+                    user.sessions_invalidated_at = datetime.now(timezone.utc)
+                    await db.commit()
+        except Exception:
+            # Missing/expired/malformed token: still clear the cookie below.
+            pass
     response.delete_cookie("refresh_token", path="/api/v1/auth/refresh")
     return {"detail": "Logged out"}
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -47,6 +47,7 @@ from app.security import (
     create_refresh_token,
     decode_token,
     hash_password,
+    token_cutoff,
     verify_password,
 )
 from app.rate_limit import limiter
@@ -309,6 +310,16 @@ async def refresh(
             detail="User not found or inactive",
         )
 
+    # Reject refresh tokens issued before the session cutoff (logout / password change)
+    iat = payload.get("iat")
+    if iat is not None:
+        token_issued_at = datetime.fromtimestamp(iat, tz=timezone.utc)
+        if token_issued_at < token_cutoff(user):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Session has been invalidated",
+            )
+
     # Enforce absolute session lifetime
     session_created_at = payload.get("session_created_at")
     if session_created_at:
@@ -372,7 +383,13 @@ async def me(
 
 
 @router.post("/logout")
-async def logout(response: Response):
+async def logout(
+    response: Response,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    current_user.sessions_invalidated_at = datetime.now(timezone.utc)
+    await db.commit()
     response.delete_cookie("refresh_token", path="/api/v1/auth/refresh")
     return {"detail": "Logged out"}
 
@@ -428,8 +445,10 @@ async def reset_password(body: ResetPasswordRequest, db: AsyncSession = Depends(
                 detail="Invalid or expired reset token",
             )
 
+    now = datetime.now(timezone.utc)
     user.password_hash = hash_password(body.new_password)
-    user.password_changed_at = datetime.now(timezone.utc)
+    user.password_changed_at = now
+    user.sessions_invalidated_at = now
     await db.commit()
     return {"detail": "Password has been reset"}
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -90,6 +90,8 @@ async def change_password(
             detail="Current password is incorrect",
         )
 
+    now = datetime.now(timezone.utc)
     current_user.password_hash = hash_password(body.new_password)
-    current_user.password_changed_at = datetime.now(timezone.utc)
+    current_user.password_changed_at = now
+    current_user.sessions_invalidated_at = now
     await db.commit()

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -9,7 +9,7 @@ class TransactionCreate(BaseModel):
     account_id: int
     category_id: int
     description: str = Field(max_length=255)
-    amount: Decimal = Field(gt=0)
+    amount: Decimal = Field(gt=0, max_digits=12, decimal_places=2)
     type: Literal["income", "expense"]
     status: Literal["settled", "pending"] = "settled"
     date: datetime.date
@@ -27,7 +27,7 @@ class TransferCreate(BaseModel):
     to_account_id: int
     category_id: Optional[int] = None
     description: str = Field(default="", max_length=255)
-    amount: Decimal = Field(gt=0)
+    amount: Decimal = Field(gt=0, max_digits=12, decimal_places=2)
     status: Literal["settled", "pending"] = "settled"
     date: datetime.date
 
@@ -36,7 +36,7 @@ class TransactionUpdate(BaseModel):
     account_id: Optional[int] = None
     category_id: Optional[int] = None
     description: Optional[str] = None
-    amount: Optional[Decimal] = Field(default=None, gt=0)
+    amount: Optional[Decimal] = Field(default=None, gt=0, max_digits=12, decimal_places=2)
     type: Optional[Literal["income", "expense"]] = None
     status: Optional[Literal["settled", "pending"]] = None
     date: Optional[datetime.date] = None

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -5,6 +5,7 @@ import bcrypt
 import jwt
 
 from app.config import settings
+from app.models.user import User
 
 
 def hash_password(password: str) -> str:
@@ -114,7 +115,7 @@ def decode_token(token: str) -> dict | None:
         return None
 
 
-def token_cutoff(user) -> datetime:
+def token_cutoff(user: User) -> datetime:
     """Earliest iat that is still valid for this user.
 
     Tokens issued before this timestamp are rejected. Updated on logout,

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -16,14 +16,14 @@ def verify_password(plain: str, hashed: str) -> bool:
 
 
 def create_access_token(subject: int, org_id: int, role: str) -> str:
-    expire = datetime.now(timezone.utc) + timedelta(
-        minutes=settings.jwt_access_token_expire_minutes
-    )
+    now = datetime.now(timezone.utc)
+    expire = now + timedelta(minutes=settings.jwt_access_token_expire_minutes)
     payload = {
         "sub": str(subject),
         "org_id": org_id,
         "role": role,
         "type": "access",
+        "iat": int(now.timestamp()),
         "exp": expire,
     }
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
@@ -45,6 +45,7 @@ def create_refresh_token(
         "sub": str(subject),
         "type": "refresh",
         "session_created_at": (session_created_at or now).timestamp(),
+        "iat": int(now.timestamp()),
         "exp": expire,
     }
     return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
@@ -111,3 +112,24 @@ def decode_token(token: str) -> dict | None:
         )
     except jwt.PyJWTError:
         return None
+
+
+def token_cutoff(user) -> datetime:
+    """Earliest iat that is still valid for this user.
+
+    Tokens issued before this timestamp are rejected. Updated on logout,
+    password reset, and password change.
+    """
+    ts = []
+    if user.password_changed_at is not None:
+        # password_changed_at is stored as a naive datetime (no tz) in MySQL
+        if user.password_changed_at.tzinfo is None:
+            ts.append(user.password_changed_at.replace(tzinfo=timezone.utc))
+        else:
+            ts.append(user.password_changed_at)
+    if user.sessions_invalidated_at is not None:
+        if user.sessions_invalidated_at.tzinfo is None:
+            ts.append(user.sessions_invalidated_at.replace(tzinfo=timezone.utc))
+        else:
+            ts.append(user.sessions_invalidated_at)
+    return max(ts) if ts else datetime.min.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

Addresses 4 findings from today's authorized local pentest:

- **H1 — Session invalidation on logout / password change / reset** (`c40ac88`)
  Adds `users.sessions_invalidated_at`; `/logout`, `/reset-password`, `/users/me/password` set it to now. Access-token and refresh-token validation reject anything whose `iat` is earlier than `max(password_changed_at, sessions_invalidated_at)`. Closes the window where a stolen refresh token stayed usable up to the 30-day absolute session limit after logout or password change. Migration 024.

- **H2 — Refuse to start with default/weak JWT secret** (`44c6152`)
  pydantic-settings validator on `Settings.jwt_secret_key` rejects the public placeholder and any secret shorter than 32 chars. Fails closed at startup so a forgotten env var can't silently run with a forgeable secret.

- **M3 — Gate `/openapi.json` behind dev env** (`8bcee31`)
  Matches the existing `/docs` pattern. No change in dev; prod no longer exposes the full API schema publicly.

- **M4 — Bound transaction amounts to `Numeric(12, 2)`** (`2a064e3`)
  Pydantic `max_digits=12, decimal_places=2` on create/update/transfer schemas. Over-range amounts now 422 at the schema layer instead of 500 + stack trace in logs.

Polish commit (`29eb04f`): `.env.example` gets explicit generation guidance for `JWT_SECRET_KEY`, and migration 024's revision id renamed to `"024"` to match the project's sequential-integer convention.

## Migration

`024_add_sessions_invalidated_at` adds one nullable `DateTime(timezone=True)` column. Safe to run without downtime; backfill is not needed (NULL means "no cutoff applied yet").

## Pre-fix token grace window

Tokens issued **before** this deploy don't have an `iat` claim (PyJWT, not python-jose — doesn't auto-add iat). The cutoff check skips them, so existing tokens keep working until their natural expiry: access ≤ 15 min, refresh ≤ 7 days. After that all tokens carry `iat` and the invalidation gate is active.

Operators who want to force-rotate every session on deploy can run:
```sql
UPDATE users SET sessions_invalidated_at = NOW() WHERE sessions_invalidated_at IS NULL;
```

## Verified

- H2 validator rejects default + <32-char secrets; accepts real secrets.
- M3 routes present in dev, gated in prod.
- M4 over-range amount → 422 `decimal_whole_digits` instead of DB 500.
- H1: access token + refresh cookie both 401 with "Session has been invalidated" after logout, password change, and password reset.

No frontend changes — the existing logout flow handles the new 401-possibility gracefully (`try/catch` in AuthProvider, silent refresh in apiFetch).