### PR TITLE
fix(frontend): add security response headers

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,11 +1,56 @@
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV !== "production";
+
+// CSP. Tailwind + styled-jsx + Next's hydration inline scripts force
+// 'unsafe-inline' on both script-src and style-src; dev also needs
+// 'unsafe-eval' and WebSocket connections for Fast Refresh.
+const cspDirectives = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  `connect-src 'self'${isDev ? " ws: wss:" : ""}`,
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: cspDirectives },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
+];
+
 const nextConfig: NextConfig = {
   output: "standalone",
+  poweredByHeader: false,
   logging: {
     fetches: {
       fullUrl: false,
     },
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,16 +2,33 @@ import type { NextConfig } from "next";
 
 const isDev = process.env.NODE_ENV !== "production";
 
+// If the frontend is deployed with a cross-origin API URL (e.g., separate
+// DO App Platform components), allow that origin in connect-src so
+// api.ts fetch() calls aren't blocked. Empty string → same-origin via
+// nginx, nothing extra to allow.
+function apiOrigin(): string {
+  const raw = process.env.NEXT_PUBLIC_API_URL;
+  if (!raw) return "";
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return "";
+  }
+}
+const extraConnectSrc = apiOrigin();
+
 // CSP. Tailwind + styled-jsx + Next's hydration inline scripts force
 // 'unsafe-inline' on both script-src and style-src; dev also needs
-// 'unsafe-eval' and WebSocket connections for Fast Refresh.
+// 'unsafe-eval' and WebSocket connections for Fast Refresh. Google Fonts
+// (Fraunces + Outfit, loaded from app/layout.tsx) need their two origins
+// allowlisted on style-src and font-src.
 const cspDirectives = [
   "default-src 'self'",
   `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
-  "style-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "img-src 'self' data: blob:",
-  "font-src 'self' data:",
-  `connect-src 'self'${isDev ? " ws: wss:" : ""}`,
+  "font-src 'self' data: https://fonts.gstatic.com",
+  `connect-src 'self'${extraConnectSrc ? " " + extraConnectSrc : ""}${isDev ? " ws: wss:" : ""}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",


### PR DESCRIPTION
## Summary

Addresses the missing-response-header findings from the external ZAP scan run against production earlier today. All fixes live in `frontend/next.config.ts`; no backend or nginx changes needed.

### Headers added (applied to every route)

| Header | Value |
|---|---|
| Content-Security-Policy | see below |
| X-Frame-Options | DENY |
| X-Content-Type-Options | nosniff |
| Referrer-Policy | strict-origin-when-cross-origin |
| Permissions-Policy | camera=(), microphone=(), geolocation=(), interest-cohort=() |
| Strict-Transport-Security | max-age=63072000; includeSubDomains; preload |
| Cross-Origin-Opener-Policy | same-origin |
| Cross-Origin-Resource-Policy | same-origin |

### Removed

- `X-Powered-By: Next.js` via `poweredByHeader: false`.

### CSP choices

- `'unsafe-inline'` stays on `script-src` and `style-src` — Next.js App Router emits inline hydration scripts, and Tailwind / styled-jsx emit inline styles. Nonce-based SSR rewrites are a larger change and can come later if needed.
- `'unsafe-eval'` and `ws:/wss:` are added **only in dev** for Fast Refresh. Production CSP is strict on those.
- `frame-ancestors 'none'` pairs with `X-Frame-Options: DENY` as belt-and-suspenders.

### Not included (separate follow-ups)

- **Cloudflare HSTS toggle** — needs to also be enabled in the Cloudflare dashboard (SSL/TLS → Edge Certificates → HSTS) for the `preload` directive to be honored at the edge.
- **Sub-Resource Integrity** on external script tags — we don't currently load any third-party JS on HTML pages, so no action needed; revisit if we add Mailgun / analytics widgets.
- **Authenticated ZAP re-scan** — today's scan was unauthenticated. A logged-in scan would actually exercise the app surface.

### Verified locally

- All 8 headers present on `/`, `/login`, `/register`.
- `X-Powered-By` absent.
- App loads and renders normally — no CSP console errors on the core pages.