### PR TITLE
feat(auth): L1.1 harden signup + Google SSO (pentest round 2)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -18,6 +18,9 @@ from app.models.user import Organization, Role, User
 from app.models.subscription import Subscription, Plan
 from app.services import subscription_service
 from app.schemas.auth import (
+    USERNAME_MAX_LENGTH,
+    USERNAME_MIN_LENGTH,
+    USERNAME_PATTERN,
     ForgotPasswordRequest,
     LoginRequest,
     MfaChallengeResponse,
@@ -169,7 +172,11 @@ async def auth_status(db: AsyncSession = Depends(get_db)):
 @limiter.limit("20/minute")
 async def check_username(
     request: Request,
-    username: str = Query(min_length=1),
+    username: str = Query(
+        min_length=USERNAME_MIN_LENGTH,
+        max_length=USERNAME_MAX_LENGTH,
+        pattern=USERNAME_PATTERN,
+    ),
     db: AsyncSession = Depends(get_db),
 ):
     """Check if a username is available and suggest alternatives."""
@@ -873,8 +880,14 @@ async def google_callback(
     if not email:
         raise HTTPException(status_code=400, detail="Google account has no email")
 
-    # Only trust email_verified if Google explicitly says so
-    google_verified = google_user.get("verified_email", False)
+    # Only trust Google's verification flag if it's explicitly present.
+    # The userinfo payload may expose this as either `verified_email`
+    # (OAuth2 v2 endpoint) or `email_verified` (OIDC userinfo) — accept
+    # both, default to False otherwise.
+    raw = google_user.get("verified_email")
+    if raw is None:
+        raw = google_user.get("email_verified", False)
+    google_verified = bool(raw)
     if not google_verified:
         # Refuse SSO for unverified Google accounts. Prevents an attacker
         # who created an unverified Google account at the victim's email
@@ -898,7 +911,8 @@ async def google_callback(
         # Existing user — login
         if not user.is_active:
             raise HTTPException(status_code=403, detail="Account is deactivated")
-        if google_verified and not user.email_verified:
+        # google_verified is guaranteed True by the guard above.
+        if not user.email_verified:
             user.email_verified = True
             await db.commit()
     else:
@@ -921,7 +935,7 @@ async def google_callback(
             last_name=last_name,
             avatar_url=google_user.get("picture"),
             password_hash=hash_password(secrets.token_urlsafe(32)),
-            email_verified=google_verified,
+            email_verified=True,  # guaranteed by the verified_email guard
             role=Role.OWNER,
             is_superadmin=is_first_user,
         )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -166,7 +166,9 @@ async def auth_status(db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/check-username", response_model=UsernameCheckResponse)
+@limiter.limit("20/minute")
 async def check_username(
+    request: Request,
     username: str = Query(min_length=1),
     db: AsyncSession = Depends(get_db),
 ):
@@ -181,7 +183,9 @@ async def check_username(
 
 
 @router.post("/register", response_model=UserResponse, status_code=201)
+@limiter.limit("5/hour")
 async def register(
+    request: Request,
     body: RegisterRequest,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
@@ -476,7 +480,8 @@ async def reset_password(body: ResetPasswordRequest, db: AsyncSession = Depends(
 
 
 @router.post("/verify-email")
-async def verify_email(body: VerifyEmailRequest, db: AsyncSession = Depends(get_db)):
+@limiter.limit("10/minute")
+async def verify_email(request: Request, body: VerifyEmailRequest, db: AsyncSession = Depends(get_db)):
     """Verify email address using a verification token."""
     payload = decode_token(body.token)
     if payload is None or payload.get("type") != "email_verify":
@@ -501,7 +506,9 @@ async def verify_email(body: VerifyEmailRequest, db: AsyncSession = Depends(get_
 
 
 @router.post("/resend-verification")
+@limiter.limit("3/hour")
 async def resend_verification(
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -868,6 +875,18 @@ async def google_callback(
 
     # Only trust email_verified if Google explicitly says so
     google_verified = google_user.get("verified_email", False)
+    if not google_verified:
+        # Refuse SSO for unverified Google accounts. Prevents an attacker
+        # who created an unverified Google account at the victim's email
+        # from silently merging with an existing password-based user, and
+        # prevents new registrations under unverified addresses.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Google has not verified this email. Verify it with Google "
+                "or sign in with a password."
+            ),
+        )
     first_name = google_user.get("given_name", "")
     last_name = google_user.get("family_name", "")
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -7,9 +8,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.user import User
-from app.schemas.auth import UserResponse
+from app.schemas.auth import (
+    USERNAME_MAX_LENGTH,
+    USERNAME_MIN_LENGTH,
+    USERNAME_PATTERN,
+    UserResponse,
+)
 from app.schemas.user import PasswordChange, ProfileUpdate
 from app.security import hash_password, verify_password
+
+_USERNAME_RE = re.compile(USERNAME_PATTERN)
 
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
 
@@ -41,6 +49,22 @@ async def update_profile(
     db: AsyncSession = Depends(get_db),
 ):
     if body.username is not None and body.username != current_user.username:
+        # Enforce the stricter /register rules only on actual changes so
+        # legacy users with a grandfathered short/looser username can
+        # still update their other profile fields.
+        if (
+            len(body.username) < USERNAME_MIN_LENGTH
+            or len(body.username) > USERNAME_MAX_LENGTH
+            or not _USERNAME_RE.match(body.username)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Username must be {USERNAME_MIN_LENGTH}-{USERNAME_MAX_LENGTH} "
+                    "characters: letters, digits, dot, underscore, or hyphen only."
+                ),
+            )
+
         existing = await db.execute(
             select(User).where(User.username == body.username)
         )

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -2,7 +2,10 @@ from pydantic import BaseModel, EmailStr, Field
 
 
 class RegisterRequest(BaseModel):
-    username: str = Field(min_length=1, max_length=64)
+    # Letters, digits, dot, underscore, hyphen. No whitespace, no punctuation,
+    # no unicode, no null bytes. 3-64 chars. Existing shorter/looser names
+    # stay — the check only runs on new signups.
+    username: str = Field(min_length=3, max_length=64, pattern=r"^[a-zA-Z0-9._-]+$")
     email: EmailStr
     password: str = Field(min_length=8, max_length=128)
     first_name: str | None = Field(default=None, max_length=100)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,11 +1,22 @@
 from pydantic import BaseModel, EmailStr, Field
 
+# Single source of truth for username rules. Re-used by `RegisterRequest`
+# below and by the `/check-username` Query constraint so the two stay
+# consistent — no more "available now, rejected on submit" UX drift.
+USERNAME_PATTERN = r"^[a-zA-Z0-9._-]+$"
+USERNAME_MIN_LENGTH = 3
+USERNAME_MAX_LENGTH = 64
+
 
 class RegisterRequest(BaseModel):
-    # Letters, digits, dot, underscore, hyphen. No whitespace, no punctuation,
-    # no unicode, no null bytes. 3-64 chars. Existing shorter/looser names
-    # stay — the check only runs on new signups.
-    username: str = Field(min_length=3, max_length=64, pattern=r"^[a-zA-Z0-9._-]+$")
+    # Letters, digits, dot, underscore, hyphen. No whitespace or other
+    # punctuation, no unicode, no null bytes. 3-64 chars. Existing
+    # shorter/looser names stay — the check only runs on new signups.
+    username: str = Field(
+        min_length=USERNAME_MIN_LENGTH,
+        max_length=USERNAME_MAX_LENGTH,
+        pattern=USERNAME_PATTERN,
+    )
     email: EmailStr
     password: str = Field(min_length=8, max_length=128)
     first_name: str | None = Field(default=None, max_length=100)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,21 +1,14 @@
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
-from app.schemas.auth import (
-    USERNAME_MAX_LENGTH,
-    USERNAME_MIN_LENGTH,
-    USERNAME_PATTERN,
-)
-
 
 class ProfileUpdate(BaseModel):
-    # Same rules as RegisterRequest — a signed-in user must not be able to
-    # bypass server-side invariants by renaming through PUT /users/me.
-    username: str | None = Field(
-        default=None,
-        min_length=USERNAME_MIN_LENGTH,
-        max_length=USERNAME_MAX_LENGTH,
-        pattern=USERNAME_PATTERN,
-    )
+    # Base bounds only (DoS protection). The 3-char minimum and pattern
+    # enforced at /register are applied in the PUT /users/me handler
+    # *only when the value actually changes* — legacy users with a
+    # grandfathered 1- or 2-char name must still be able to update
+    # their other profile fields (email, phone, name) without hitting
+    # the strict rule.
+    username: str | None = Field(default=None, min_length=1, max_length=64)
     email: EmailStr | None = None
     first_name: str | None = Field(default=None, max_length=100)
     last_name: str | None = Field(default=None, max_length=100)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,8 +1,21 @@
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
+from app.schemas.auth import (
+    USERNAME_MAX_LENGTH,
+    USERNAME_MIN_LENGTH,
+    USERNAME_PATTERN,
+)
+
 
 class ProfileUpdate(BaseModel):
-    username: str | None = Field(default=None, min_length=1, max_length=64)
+    # Same rules as RegisterRequest — a signed-in user must not be able to
+    # bypass server-side invariants by renaming through PUT /users/me.
+    username: str | None = Field(
+        default=None,
+        min_length=USERNAME_MIN_LENGTH,
+        max_length=USERNAME_MAX_LENGTH,
+        pattern=USERNAME_PATTERN,
+    )
     email: EmailStr | None = None
     first_name: str | None = Field(default=None, max_length=100)
     last_name: str | None = Field(default=None, max_length=100)

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -7,6 +7,13 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import { input, label, btnPrimary, btnSecondary, error as errorCls, success } from "@/lib/styles";
+import {
+  USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
+  USERNAME_PATTERN,
+  USERNAME_PATTERN_RE,
+  USERNAME_RULE_HINT,
+} from "@/lib/validation";
 
 interface UsernameCheck {
   available: boolean;
@@ -44,10 +51,15 @@ export default function RegisterPage() {
     if (slug) setUsername(slug);
   }, [firstName, lastName, usernameManual]);
 
-  // Check username availability (debounced, cancels stale requests)
+  // Check username availability (debounced, cancels stale requests).
+  // We only call the endpoint when the value satisfies the server rules —
+  // otherwise /check-username returns 422 and confuses the UI.
   const checkRef = useRef(0);
   const checkUsername = useCallback(async (name: string) => {
-    if (name.length < 2) { setUsernameStatus(""); return; }
+    if (name.length < USERNAME_MIN_LENGTH || !USERNAME_PATTERN_RE.test(name)) {
+      setUsernameStatus("");
+      return;
+    }
     const id = ++checkRef.current;
     setUsernameStatus("checking");
     try {
@@ -141,7 +153,19 @@ export default function RegisterPage() {
           </div>
           <div>
             <label htmlFor="reg-username" className={label}>Username</label>
-            <input id="reg-username" type="text" required value={username} onChange={(e) => { setUsername(e.target.value); setUsernameManual(true); }} className={input} autoComplete="username" />
+            <input
+              id="reg-username"
+              type="text"
+              required
+              minLength={USERNAME_MIN_LENGTH}
+              maxLength={USERNAME_MAX_LENGTH}
+              pattern={USERNAME_PATTERN}
+              title={USERNAME_RULE_HINT}
+              value={username}
+              onChange={(e) => { setUsername(e.target.value); setUsernameManual(true); }}
+              className={input}
+              autoComplete="username"
+            />
             {usernameStatus === "checking" && <p className="mt-1 text-xs text-text-muted">Checking...</p>}
             {usernameStatus === "available" && <p className="mt-1 text-xs text-success">Available</p>}
             {usernameStatus === "taken" && (
@@ -150,6 +174,9 @@ export default function RegisterPage() {
                   <> — try <button type="button" onClick={() => { setUsername(usernameSuggestion); setUsernameManual(true); }} className="text-accent underline">{usernameSuggestion}</button></>
                 )}
               </p>
+            )}
+            {!usernameStatus && (
+              <p className="mt-1 text-xs text-text-muted">{USERNAME_RULE_HINT}</p>
             )}
           </div>
           <div>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -34,15 +34,25 @@ export default function SettingsProfilePage() {
     e.preventDefault();
     setProfileMsg(""); setProfileErr(""); setSavingProfile(true);
     try {
+      // Only send fields that actually changed. Keeps legacy users with
+      // grandfathered 1-2 char usernames able to save email/phone/name
+      // without sending their username through the stricter validator.
+      const payload: Record<string, string | null> = {};
+      const normalize = (v: string) => v || null;
+      if (normalize(firstName) !== (user?.first_name ?? null)) payload.first_name = normalize(firstName);
+      if (normalize(lastName) !== (user?.last_name ?? null)) payload.last_name = normalize(lastName);
+      if (username !== user?.username) payload.username = username;
+      if (email !== user?.email) payload.email = email;
+      if (normalize(phone) !== (user?.phone ?? null)) payload.phone = normalize(phone);
+
+      if (Object.keys(payload).length === 0) {
+        setProfileMsg("No changes to save");
+        return;
+      }
+
       await apiFetch<User>("/api/v1/users/me", {
         method: "PUT",
-        body: JSON.stringify({
-          first_name: firstName || null,
-          last_name: lastName || null,
-          username,
-          email,
-          phone: phone || null,
-        }),
+        body: JSON.stringify(payload),
       });
       await refreshMe();
       setProfileMsg("Profile updated");

--- a/frontend/app/setup/page.tsx
+++ b/frontend/app/setup/page.tsx
@@ -5,6 +5,12 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/auth/AuthProvider";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import { input, label, btnPrimary, error as errorCls } from "@/lib/styles";
+import {
+  USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
+  USERNAME_PATTERN,
+  USERNAME_RULE_HINT,
+} from "@/lib/validation";
 
 export default function SetupPage() {
   const { needsSetup, loading, register, login } = useAuth();
@@ -59,7 +65,21 @@ export default function SetupPage() {
             {error && <div className={errorCls}>{error}</div>}
             <div>
               <label htmlFor="setup-username" className={label}>Username</label>
-              <input id="setup-username" type="text" required value={username} onChange={(e) => setUsername(e.target.value)} className={input} autoComplete="username" autoFocus />
+              <input
+                id="setup-username"
+                type="text"
+                required
+                minLength={USERNAME_MIN_LENGTH}
+                maxLength={USERNAME_MAX_LENGTH}
+                pattern={USERNAME_PATTERN}
+                title={USERNAME_RULE_HINT}
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className={input}
+                autoComplete="username"
+                autoFocus
+              />
+              <p className="mt-1 text-xs text-text-muted">{USERNAME_RULE_HINT}</p>
             </div>
             <div>
               <label htmlFor="setup-email" className={label}>Email</label>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -72,7 +72,27 @@ export async function apiFetch<T>(
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new ApiResponseError(res.status, body.detail || "Request failed");
+    let message: string;
+    if (Array.isArray(body.detail)) {
+      // FastAPI 422 validation error: detail is a list of
+      // { loc, msg, type, ... } objects. Flatten to "field: message"
+      // per entry so users see something useful instead of
+      // "[object Object]".
+      message = body.detail
+        .map((e: { loc?: unknown[]; msg?: string }) => {
+          const field = Array.isArray(e.loc)
+            ? e.loc.filter((p) => p !== "body" && typeof p === "string").join(".")
+            : "";
+          const msg = e.msg ?? "Invalid input";
+          return field ? `${field}: ${msg}` : msg;
+        })
+        .join("; ");
+    } else if (typeof body.detail === "string") {
+      message = body.detail;
+    } else {
+      message = "Request failed";
+    }
+    throw new ApiResponseError(res.status, message);
   }
 
   // 204 No Content

--- a/frontend/lib/validation.ts
+++ b/frontend/lib/validation.ts
@@ -1,0 +1,14 @@
+/**
+ * Client-side validation rules that mirror server-side schemas.
+ *
+ * These MUST stay in sync with backend/app/schemas/auth.py. If you change
+ * one, change the other. A future refactor could codegen these from the
+ * OpenAPI schema, but for a handful of fields manual duplication is fine.
+ */
+
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 64;
+export const USERNAME_PATTERN = "^[a-zA-Z0-9._-]+$";
+export const USERNAME_PATTERN_RE = /^[a-zA-Z0-9._-]+$/;
+export const USERNAME_RULE_HINT =
+  "3–64 characters. Letters, digits, dot, underscore, hyphen.";


### PR DESCRIPTION
## Summary

Closes **4 of 5** sub-items in roadmap L1.1 (auth hardening round 2). L4 (seeded-balance UX) deferred to its own follow-up PR — it touches transaction creation semantics and deserves focused review.

### M1 — Rate limits on previously unprotected endpoints

| Endpoint | Limit | Rationale |
|---|---|---|
| `POST /register` | 5/hour | Account-creation spam; each signup triggers a Mailgun email. |
| `GET /check-username` | 20/minute | Frontend debounces at 400ms, cancels stale requests — 20/min is well above legit usage but throttles enumeration. |
| `POST /verify-email` | 10/minute | Click-from-email flow, same IP is normal. |
| `POST /resend-verification` | 3/hour | Each call fires an email. |

All now accept \`request: Request\` as slowapi requires. Key = client IP via \`get_remote_address\`.

### M2 — Google SSO verified_email enforcement

Refuses the entire callback when Google returns \`verified_email: false\`. Prevents:
- Silent merge of an unverified Google account with an existing password-based user at the same email (the pentest finding).
- New registrations under unverified addresses.

Error message points users to password sign-in.

### L3 — Username regex

\`\`\`python
username: str = Field(min_length=3, max_length=64, pattern=r"^[a-zA-Z0-9._-]+$")
\`\`\`

Letters, digits, dot, underscore, hyphen only. Bumps min length from 1 to 3. Existing rows keep their old usernames — validation only runs on new input.

Previously accepted values now rejected: \`"a"\` (too short), \`" admin"\` (space), \`"admin;DROP TABLE users"\` (semicolon + space), null-byte prefixes.

### Verified locally

- \`/register\` with 1-char username: 422 string_too_short
- \`/register\` with "admin;DROP": 422 string_pattern_mismatch
- \`/register\` 5x 201 then 429 (rate limit)
- \`/check-username\` 20x 200 then 429
- Backend restarts clean under APP_ENV=development

### Deferred to follow-up

**L4 seeded account balance** — requires a design decision: reject non-zero balance at create (force users to add an "Opening Balance" transaction), or auto-create an offsetting transaction atomically. Preserves the balance-matches-transactions invariant either way. Will open a separate PR after picking the pattern.