### PR TITLE
feat(legal): L1.2 + L1.3 Privacy Policy + Terms of Service

### DIFF
--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,0 +1,273 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — PFV2",
+  description: "How PFV2 collects, uses, and protects your personal data.",
+};
+
+const EFFECTIVE_DATE = "April 21, 2026";
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="relative min-h-screen px-4 py-12">
+      <ThemeToggle className="absolute right-6 top-6" />
+      <article className="mx-auto max-w-2xl">
+        <header className="mb-10">
+          <Link
+            href="/login"
+            className="text-sm text-text-muted hover:text-text-primary"
+          >
+            ← Back
+          </Link>
+          <h1 className="mt-6 font-display text-3xl font-semibold text-text-primary">
+            Privacy Policy
+          </h1>
+          <p className="mt-2 text-sm text-text-muted">
+            Effective {EFFECTIVE_DATE}
+          </p>
+        </header>
+
+        <div className="space-y-8 text-text-primary [&_h2]:font-display [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mb-3 [&_h2]:mt-8 [&_p]:text-sm [&_p]:leading-relaxed [&_p]:text-text-secondary [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-sm [&_ul]:leading-relaxed [&_ul]:text-text-secondary [&_li]:mt-1">
+          <section>
+            <p>
+              PFV2 (&ldquo;we&rdquo;, &ldquo;us&rdquo;) is a personal finance
+              application operated by Flamarion Jorge. We care about your
+              privacy and keep what we collect to the minimum needed to run
+              the service. This policy explains what we collect, why, how
+              long we keep it, and your rights.
+            </p>
+          </section>
+
+          <section>
+            <h2>1. What we collect</h2>
+            <p>When you create an account and use PFV2, we collect:</p>
+            <ul>
+              <li>
+                <strong>Identity:</strong> username, email, first/last name,
+                optional phone and avatar URL.
+              </li>
+              <li>
+                <strong>Credentials:</strong> a bcrypt hash of your password
+                (we never store the password itself). For Google sign-in, we
+                store the verified email address Google provides. If you
+                enable two-factor authentication, we store an encrypted TOTP
+                secret and hashed recovery codes.
+              </li>
+              <li>
+                <strong>Financial data you enter:</strong> accounts you
+                create, transactions you record or import, budgets, forecasts,
+                recurring items, and categories. This data stays scoped to
+                your organization and is never shared with other
+                organizations.
+              </li>
+              <li>
+                <strong>Operational telemetry:</strong> request logs
+                containing IP address, user agent, path, and timestamp for
+                up to 30 days, used for debugging and abuse prevention.
+              </li>
+              <li>
+                <strong>Cookies:</strong> an HTTP-only refresh-token cookie
+                to keep you logged in, a theme preference in local storage,
+                and a bot-management cookie set by Cloudflare. We do not use
+                analytics or advertising cookies.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>2. Why we collect it</h2>
+            <ul>
+              <li>
+                To authenticate you and protect your account.
+              </li>
+              <li>
+                To store and present the financial data you explicitly enter.
+              </li>
+              <li>
+                To send transactional emails: account verification, password
+                reset, MFA codes, and trial/billing notices.
+              </li>
+              <li>
+                To debug errors, prevent abuse, and secure the service.
+              </li>
+            </ul>
+            <p>
+              We do not sell your data. We do not train AI models on your
+              data. We do not use your data for advertising.
+            </p>
+          </section>
+
+          <section>
+            <h2>3. Third parties we share with</h2>
+            <p>
+              We share data only with service providers strictly necessary
+              to run PFV2:
+            </p>
+            <ul>
+              <li>
+                <strong>DigitalOcean</strong> (hosting) — stores your data at
+                rest in managed MySQL in the ams3 region (EU).
+              </li>
+              <li>
+                <strong>Cloudflare</strong> (CDN / edge) — handles TLS
+                termination, DDoS protection, and edge routing.
+              </li>
+              <li>
+                <strong>Mailgun</strong> (EU region) — sends transactional
+                emails. We send only what&rsquo;s needed (your email
+                address, the subject line, and the email body).
+              </li>
+              <li>
+                <strong>Google</strong> (optional, if you choose
+                &ldquo;Sign in with Google&rdquo;) — we receive your email,
+                name, and profile picture from Google after you authorize
+                the sign-in.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>4. How long we keep your data</h2>
+            <ul>
+              <li>
+                Account and financial data are kept for the lifetime of your
+                account.
+              </li>
+              <li>
+                If you close your account, we delete your data within 30
+                days. Backups are rotated within 90 days.
+              </li>
+              <li>
+                Request logs are kept for up to 30 days.
+              </li>
+              <li>
+                Email delivery records at Mailgun follow their retention
+                policy (typically 3 days for logs).
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>5. Your rights (GDPR)</h2>
+            <p>
+              If you are in the EU/EEA, you have the following rights under
+              the GDPR:
+            </p>
+            <ul>
+              <li>
+                <strong>Access</strong> — request a copy of your data.
+              </li>
+              <li>
+                <strong>Rectification</strong> — fix anything inaccurate.
+                Most of this is self-serve inside the app.
+              </li>
+              <li>
+                <strong>Erasure</strong> — delete your account and all data
+                associated with your organization.
+              </li>
+              <li>
+                <strong>Portability</strong> — export your data in a
+                machine-readable format.
+              </li>
+              <li>
+                <strong>Restriction / Objection</strong> — ask us to stop
+                or limit specific processing.
+              </li>
+              <li>
+                <strong>Complaint</strong> — lodge a complaint with your
+                national data-protection authority (in the Netherlands, the
+                Autoriteit Persoonsgegevens).
+              </li>
+            </ul>
+            <p>
+              To exercise any of these rights, email us at{" "}
+              <a
+                href="mailto:privacy@thebetterdecision.com"
+                className="underline hover:text-accent"
+              >
+                privacy@thebetterdecision.com
+              </a>
+              . We respond within 30 days.
+            </p>
+          </section>
+
+          <section>
+            <h2>6. Security</h2>
+            <p>
+              Passwords are stored as bcrypt hashes. TOTP secrets are
+              encrypted at rest. All traffic is served over HTTPS with HSTS.
+              Session refresh tokens are cookies scoped to the refresh
+              endpoint with the HttpOnly, Secure, and SameSite=Lax flags.
+              We review the application regularly with static analysis and
+              third-party security tools.
+            </p>
+            <p>
+              No system is perfectly secure. If you discover a vulnerability,
+              please report it to{" "}
+              <a
+                href="mailto:security@thebetterdecision.com"
+                className="underline hover:text-accent"
+              >
+                security@thebetterdecision.com
+              </a>
+              .
+            </p>
+          </section>
+
+          <section>
+            <h2>7. International transfers</h2>
+            <p>
+              Your data is stored in the EU (DigitalOcean ams3 region).
+              Cloudflare may process requests at edge nodes globally as part
+              of delivering the service. Mailgun operates in the EU region.
+            </p>
+          </section>
+
+          <section>
+            <h2>8. Children</h2>
+            <p>
+              PFV2 is not intended for children under 16. We do not knowingly
+              collect personal data from children.
+            </p>
+          </section>
+
+          <section>
+            <h2>9. Changes to this policy</h2>
+            <p>
+              When we make material changes we update the effective date and
+              notify you by email before the changes take effect. The
+              current version is always available at this page.
+            </p>
+          </section>
+
+          <section>
+            <h2>10. Contact</h2>
+            <p>
+              Privacy questions or requests:{" "}
+              <a
+                href="mailto:privacy@thebetterdecision.com"
+                className="underline hover:text-accent"
+              >
+                privacy@thebetterdecision.com
+              </a>
+              . General contact:{" "}
+              <a
+                href="mailto:hello@thebetterdecision.com"
+                className="underline hover:text-accent"
+              >
+                hello@thebetterdecision.com
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+
+        <footer className="mt-12 border-t border-border pt-6 text-xs text-text-muted">
+          See also: <Link href="/terms" className="underline hover:text-text-primary">Terms of Service</Link>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -168,6 +168,17 @@ export default function RegisterPage() {
             <label htmlFor="reg-password2" className={label}>Confirm Password</label>
             <input id="reg-password2" type="password" required value={password2} onChange={(e) => setPassword2(e.target.value)} className={input} autoComplete="new-password" />
           </div>
+          <p className="text-xs text-text-muted">
+            By creating an account you agree to our{" "}
+            <Link href="/terms" className="underline hover:text-text-primary">
+              Terms of Service
+            </Link>{" "}
+            and{" "}
+            <Link href="/privacy" className="underline hover:text-text-primary">
+              Privacy Policy
+            </Link>
+            .
+          </p>
           <button type="submit" disabled={submitting || usernameStatus === "taken"} className={`w-full ${btnPrimary}`}>
             {submitting ? "Creating account..." : "Create Account"}
           </button>

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,0 +1,258 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — PFV2",
+  description: "The agreement between you and PFV2 when you use the service.",
+};
+
+const EFFECTIVE_DATE = "April 21, 2026";
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="relative min-h-screen px-4 py-12">
+      <ThemeToggle className="absolute right-6 top-6" />
+      <article className="mx-auto max-w-2xl">
+        <header className="mb-10">
+          <Link
+            href="/login"
+            className="text-sm text-text-muted hover:text-text-primary"
+          >
+            ← Back
+          </Link>
+          <h1 className="mt-6 font-display text-3xl font-semibold text-text-primary">
+            Terms of Service
+          </h1>
+          <p className="mt-2 text-sm text-text-muted">
+            Effective {EFFECTIVE_DATE}
+          </p>
+        </header>
+
+        <div className="space-y-8 text-text-primary [&_h2]:font-display [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mb-3 [&_h2]:mt-8 [&_p]:text-sm [&_p]:leading-relaxed [&_p]:text-text-secondary [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-sm [&_ul]:leading-relaxed [&_ul]:text-text-secondary [&_li]:mt-1">
+          <section>
+            <p>
+              Welcome to PFV2. These Terms of Service (&ldquo;Terms&rdquo;)
+              govern your use of the PFV2 personal finance application
+              operated by Flamarion Jorge. By creating an account or using
+              the service you agree to these Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2>1. The service</h2>
+            <p>
+              PFV2 lets you track personal or small-organization finances:
+              accounts, transactions, budgets, forecasts, recurring items,
+              and related tooling. It&rsquo;s a bookkeeping and planning
+              tool, not a bank, broker, or financial advisor.
+            </p>
+            <p>
+              <strong>Beta notice.</strong> PFV2 is in an early stage.
+              Features may change, data models may evolve, and we may need
+              to reset or migrate parts of the service. We will give
+              reasonable notice and make best-effort data preservation
+              decisions, but we cannot offer a formal SLA during beta.
+            </p>
+          </section>
+
+          <section>
+            <h2>2. Your account</h2>
+            <ul>
+              <li>
+                Provide accurate information when you sign up and keep it
+                up to date.
+              </li>
+              <li>
+                Keep your password and MFA recovery codes safe. You are
+                responsible for activity on your account.
+              </li>
+              <li>
+                One account per individual. You may operate multiple
+                organizations from a single account.
+              </li>
+              <li>
+                You must be at least 16 years old to create an account.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2>3. Acceptable use</h2>
+            <p>You agree not to:</p>
+            <ul>
+              <li>
+                Attempt to access other users&rsquo; data or organizations.
+              </li>
+              <li>
+                Reverse-engineer, scrape, or automate the service beyond
+                reasonable personal use, or in a way that imposes
+                disproportionate load.
+              </li>
+              <li>
+                Upload or store unlawful content, or use the service for
+                money laundering, fraud, or evasion of tax or sanctions
+                obligations.
+              </li>
+              <li>
+                Probe, scan, or test the vulnerability of the service
+                without prior written permission from us.
+              </li>
+            </ul>
+            <p>
+              We may suspend or close accounts that violate these rules.
+            </p>
+          </section>
+
+          <section>
+            <h2>4. Your data and content</h2>
+            <p>
+              You own the financial data you enter. We process it on your
+              behalf as described in the{" "}
+              <Link href="/privacy" className="underline hover:text-accent">
+                Privacy Policy
+              </Link>
+              . You can export or delete your data at any time by closing
+              your account; within 30 days of closure we delete your data
+              from production systems.
+            </p>
+          </section>
+
+          <section>
+            <h2>5. Subscriptions and billing</h2>
+            <p>
+              Paid plans are billed in advance at the stated price. During
+              the current beta period, billing flows display a clear
+              &ldquo;mock / no charge&rdquo; notice and no money changes
+              hands; when we switch to real payments we will notify every
+              user by email before charging begins and honor any free-trial
+              periods already granted.
+            </p>
+            <p>
+              You can cancel at any time. Canceling stops future renewals;
+              the current period remains active until its end. We do not
+              prorate or refund partial periods unless required by law.
+            </p>
+          </section>
+
+          <section>
+            <h2>6. Not financial advice</h2>
+            <p>
+              PFV2 displays numbers, forecasts, and categorizations based on
+              the data you enter. Forecasts are estimates, not predictions.
+              Nothing in the app is investment advice, legal advice, tax
+              advice, or a substitute for a qualified professional.
+              Decisions you make based on the app are your own.
+            </p>
+          </section>
+
+          <section>
+            <h2>7. Third parties and integrations</h2>
+            <p>
+              PFV2 integrates with third-party services (Google for sign-in,
+              Mailgun for email, Cloudflare for edge, DigitalOcean for
+              hosting). Your use of those integrations is additionally
+              governed by the third party&rsquo;s terms. We are not
+              responsible for third-party outages or data handling beyond
+              what&rsquo;s described in our Privacy Policy.
+            </p>
+          </section>
+
+          <section>
+            <h2>8. Intellectual property</h2>
+            <p>
+              The PFV2 application, including its code, design, and
+              trademarks, belongs to us. These Terms do not grant you any
+              rights beyond the license to use the service for its intended
+              purpose.
+            </p>
+          </section>
+
+          <section>
+            <h2>9. Warranty disclaimer</h2>
+            <p>
+              The service is provided &ldquo;as is&rdquo; and &ldquo;as
+              available&rdquo;. We make no warranty of merchantability,
+              fitness for a particular purpose, uptime, data accuracy, or
+              non-infringement, except as required by mandatory applicable
+              law.
+            </p>
+          </section>
+
+          <section>
+            <h2>10. Limitation of liability</h2>
+            <p>
+              To the maximum extent permitted by law, we are not liable for
+              indirect, incidental, consequential, or special damages,
+              including lost profits or lost data. Our total liability for
+              any claim related to the service is limited to the greater of
+              (a) the amount you paid us in the 12 months before the claim
+              arose, or (b) &euro;100.
+            </p>
+            <p>
+              Nothing in these Terms limits liability that cannot be limited
+              under applicable law (for example, gross negligence,
+              intentional misconduct, or statutory consumer rights).
+            </p>
+          </section>
+
+          <section>
+            <h2>11. Termination</h2>
+            <p>
+              You may close your account at any time. We may suspend or
+              close accounts that violate these Terms, fail to pay, or pose
+              a security risk. We&rsquo;ll give you reasonable notice when
+              practical.
+            </p>
+          </section>
+
+          <section>
+            <h2>12. Changes to these Terms</h2>
+            <p>
+              When we make material changes we update the effective date and
+              notify you by email. Continued use after the effective date
+              means you accept the updated Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2>13. Governing law</h2>
+            <p>
+              These Terms are governed by the laws of the Netherlands,
+              without regard to conflict-of-law rules. Disputes are subject
+              to the exclusive jurisdiction of the competent courts in the
+              Netherlands, except where mandatory consumer-protection law
+              gives you rights to bring a claim in your country of
+              residence.
+            </p>
+          </section>
+
+          <section>
+            <h2>14. Contact</h2>
+            <p>
+              Questions about these Terms:{" "}
+              <a
+                href="mailto:legal@thebetterdecision.com"
+                className="underline hover:text-accent"
+              >
+                legal@thebetterdecision.com
+              </a>
+              . General contact:{" "}
+              <a
+                href="mailto:hello@thebetterdecision.com"
+                className="underline hover:text-accent"
+              >
+                hello@thebetterdecision.com
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+
+        <footer className="mt-12 border-t border-border pt-6 text-xs text-text-muted">
+          See also: <Link href="/privacy" className="underline hover:text-text-primary">Privacy Policy</Link>
+        </footer>
+      </article>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Two new public routes + a ToS acceptance line on the registration flow. Closes roadmap **L1.2** and **L1.3** in one PR since they share all the infrastructure.

### New routes

- \`/privacy\` — full GDPR-compliant privacy policy
- \`/terms\` — Terms of Service with a clear beta notice

Both rendered as static server components with page-level \`<Metadata>\` (good for SEO later), a back-to-login link, theme toggle in the corner, and mutual cross-linking.

### Register page

Above the submit button:

> By creating an account you agree to our **Terms of Service** and **Privacy Policy**.

### Content structure

**Privacy Policy (10 sections):** what we collect · why · third parties (DigitalOcean, Cloudflare, Mailgun, Google) · retention (30-day purge on closure) · GDPR rights · security · international transfers · children · changes · contact.

**Terms of Service (14 sections):** service description + beta notice · account rules · acceptable use · data ownership · billing (explicit mock-phase disclosure) · not-financial-advice disclaimer · third parties · IP · warranty disclaimer · liability cap (greater of €100 or 12 months fees) · termination · changes · governing law (Netherlands) · contact.

### Contact email addresses referenced

The copy consistently references four aliases at \`thebetterdecision.com\`:

- \`privacy@\` — privacy requests
- \`legal@\` — ToS questions
- \`security@\` — vulnerability reports
- \`hello@\` — general

These need mailbox setup or alias routing before launch. Flagged in the commit message too.

### Not in this PR (scoped out on purpose)

- Global footer with privacy/terms links (L5.4 — header & footer pass)
- i18n / pt-BR translations (Post-Launch P2)
- A checkbox requiring explicit ToS acceptance before submit (conservative-enough: the inline disclaimer is "click-wrap" which is standard for beta SaaS — promote to a checkbox if a lawyer recommends it at real launch)

### Verified

- \`/privacy\` and \`/terms\` both return 200 locally under the dev build
- \`/register\` markup contains href=\"/privacy\" and href=\"/terms\"
- \`tsc --noEmit\` clean
- Both pages use existing style tokens (\`text-text-primary\`, \`font-display\`, \`border-border\`, \`accent\` hover) — no new CSS