### PR TITLE
feat: L5.1 public landing page + rebrand to The Better Decision

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -51,7 +51,7 @@ services:
       - key: APP_ENV
         value: "production"
       - key: APP_NAME
-        value: "PFV2"
+        value: "The Better Decision"
       - key: LOG_LEVEL
         value: "INFO"
       - key: COOKIE_SECURE

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # =============================================================================
-# PFV2 — Environment Configuration
+# The Better Decision — Environment Configuration
 # Copy to .env and fill in values: cp .env.example .env
 # =============================================================================
 
@@ -19,7 +19,7 @@ JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15
 JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # --- App ---
-APP_NAME=PFV2
+APP_NAME="The Better Decision"
 APP_ENV=development
 LOG_LEVEL=INFO
 BACKEND_CORS_ORIGINS=http://localhost
@@ -39,7 +39,7 @@ MAILGUN_API_KEY=
 MAILGUN_DOMAIN=
 MAILGUN_REGION=
 # Set to "eu" for EU Mailgun endpoint (api.eu.mailgun.net), leave empty for US
-EMAIL_FROM=PFV2 <noreply@pfv.app>
+EMAIL_FROM=The Better Decision <noreply@thebetterdecision.com>
 APP_URL=http://localhost
 
 # --- MFA ---

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ MAILGUN_API_KEY=
 MAILGUN_DOMAIN=
 MAILGUN_REGION=
 # Set to "eu" for EU Mailgun endpoint (api.eu.mailgun.net), leave empty for US
-EMAIL_FROM=The Better Decision <noreply@thebetterdecision.com>
+EMAIL_FROM="The Better Decision <noreply@thebetterdecision.com>"
 APP_URL=http://localhost
 
 # --- MFA ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PFV2 is a personal finance management application. FastAPI backend, Next.js + TypeScript frontend, MySQL database. Designed as a 12-factor app targeting Kubernetes for production.
+The Better Decision is a personal finance management application. FastAPI backend, Next.js + TypeScript frontend, MySQL database. Designed as a 12-factor app targeting Kubernetes for production.
 
 ## Stack
 
@@ -45,6 +45,16 @@ docker compose up --build -d backend
 docker compose up --build -d frontend
 ```
 
+## Local Operation Info
+
+During the local development, if it's necessary to reset the system to test a new feature or re-seed the system, the following data must be used
+
+- username: flamarion
+- email: flamarion@example.com
+- organization name: Home Sweet Home
+- password: abcd1234
+
+
 ## Architecture
 
 ```
@@ -80,6 +90,11 @@ frontend/
     └── types.ts     # Shared TypeScript types
 ```
 
+## Working with Next.js
+**When starting work on a Next.js project, ALWAYS call the `init` tool from
+next-devtools-mcp FIRST to set up proper context and establish documentation
+requirements. Do this automatically without being asked.**
+
 ## Key Conventions
 
 - **All config via env vars** — pydantic-settings in backend, NEXT_PUBLIC_ prefix in frontend
@@ -92,3 +107,5 @@ frontend/
 - **Enum values** — SQLAlchemy enums use `values_callable=lambda x: [e.value for e in x]` to store lowercase values in MySQL
 - **Frontend has two Dockerfiles** — `Dockerfile.dev` for local dev (hot reload with volume mounts), `Dockerfile` for production (multi-stage standalone build, ~slim image)
 - **nginx is the single entry point** — backend and frontend only expose ports internally. `/api/*` routes to FastAPI, everything else to Next.js. `/docs` and `/openapi.json` are proxied directly.
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,15 +45,9 @@ docker compose up --build -d backend
 docker compose up --build -d frontend
 ```
 
-## Local Operation Info
+## Seeding
 
-During the local development, if it's necessary to reset the system to test a new feature or re-seed the system, the following data must be used
-
-- username: flamarion
-- email: flamarion@example.com
-- organization name: Home Sweet Home
-- password: abcd1234
-
+For a repeatable local dataset (accounts, transactions, budgets, recurring templates), run `./pfv seed`. See the Seeding Mock Data section of CONTRIBUTING.md for the full workflow and the `SEED_*` environment variables that let you customize the seeded user.
 
 ## Architecture
 
@@ -89,11 +83,6 @@ frontend/
     ├── api.ts       # Typed fetch wrapper with Bearer token + silent refresh
     └── types.ts     # Shared TypeScript types
 ```
-
-## Working with Next.js
-**When starting work on a Next.js project, ALWAYS call the `init` tool from
-next-devtools-mcp FIRST to set up proper context and establish documentation
-requirements. Do this automatically without being asked.**
 
 ## Key Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ All other endpoints require a Bearer access token via `get_current_user` depende
 | `MFA_ENCRYPTION_KEY` | _(empty)_ | Fernet key for TOTP secret encryption |
 | `MAILGUN_API_KEY` | _(empty)_ | Mailgun API key (emails logged if empty) |
 | `MAILGUN_DOMAIN` | _(empty)_ | Mailgun sending domain |
-| `EMAIL_FROM` | `The Better Decision <noreply@pfv.app>` | From address for emails |
+| `EMAIL_FROM` | `The Better Decision <noreply@thebetterdecision.com>` | From address for emails |
 | `APP_URL` | `http://localhost` | Public URL (used in email links) |
 | `GOOGLE_CLIENT_ID` | _(empty)_ | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | _(empty)_ | Google OAuth client secret |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to PFV2
+# Contributing to The Better Decision
 
-This guide covers everything you need to develop, test, and deploy PFV2. Start with Quick Start if you're setting up for the first time, then refer to the architecture and API sections as needed.
+This guide covers everything you need to develop, test, and deploy The Better Decision. Start with Quick Start if you're setting up for the first time, then refer to the architecture and API sections as needed.
 
 ## Prerequisites
 
@@ -247,7 +247,7 @@ All other endpoints require a Bearer access token via `get_current_user` depende
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `APP_ENV` | `development` | `development` or `production` |
-| `APP_NAME` | `PFV2` | App name (used in TOTP issuer, emails) |
+| `APP_NAME` | `The Better Decision` | App name (used in TOTP issuer, emails) |
 | `LOG_LEVEL` | `INFO` | Python log level |
 | `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | Access token lifetime |
 | `JWT_REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token (idle timeout) |
@@ -257,7 +257,7 @@ All other endpoints require a Bearer access token via `get_current_user` depende
 | `MFA_ENCRYPTION_KEY` | _(empty)_ | Fernet key for TOTP secret encryption |
 | `MAILGUN_API_KEY` | _(empty)_ | Mailgun API key (emails logged if empty) |
 | `MAILGUN_DOMAIN` | _(empty)_ | Mailgun sending domain |
-| `EMAIL_FROM` | `PFV2 <noreply@pfv.app>` | From address for emails |
+| `EMAIL_FROM` | `The Better Decision <noreply@pfv.app>` | From address for emails |
 | `APP_URL` | `http://localhost` | Public URL (used in email links) |
 | `GOOGLE_CLIENT_ID` | _(empty)_ | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | _(empty)_ | Google OAuth client secret |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PFV2
+# The Better Decision
 
 Personal finance management for people who actually want to understand where their money goes.
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     # App
-    app_name: str = "PFV2"
+    app_name: str = "The Better Decision"
     app_env: str = "development"
     log_level: str = "INFO"
 
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     mailgun_api_key: str = ""
     mailgun_domain: str = ""
     mailgun_region: str = ""  # "eu" for EU endpoint, empty for US
-    email_from: str = "PFV2 <noreply@pfv.app>"
+    email_from: str = "The Better Decision <noreply@thebetterdecision.com>"
     app_url: str = "http://localhost"  # used for email links
 
     # MFA

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -60,7 +60,7 @@ async def send_password_reset_email(to: str, token: str) -> bool:
     subject = "The Better Decision — reset your password"
     body_html = f"""
     <h2>Reset Your Password</h2>
-    <p>You requested a password reset for your The Better Decision account.</p>
+    <p>You requested a password reset for your account.</p>
     <p><a href="{reset_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Reset Password</a></p>
     <p>Or copy this link: <code>{reset_url}</code></p>
     <p>This link expires in 1 hour. If you didn't request this, ignore this email.</p>

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -57,7 +57,7 @@ async def send_email(
 async def send_password_reset_email(to: str, token: str) -> bool:
     """Send a password reset email with a link containing the reset token."""
     reset_url = f"{settings.app_url}/reset-password?token={token}"
-    subject = "The Better Decision — reset your password"
+    subject = "The Better Decision: reset your password"
     body_html = f"""
     <h2>Reset Your Password</h2>
     <p>You requested a password reset for your account.</p>
@@ -71,7 +71,7 @@ async def send_password_reset_email(to: str, token: str) -> bool:
 
 async def send_mfa_email_code(to: str, code: str) -> bool:
     """Send a one-time MFA verification code via email."""
-    subject = "The Better Decision — your login code"
+    subject = "The Better Decision: your login code"
     body_html = f"""
     <h2>Your Verification Code</h2>
     <p>Use this code to complete your sign-in:</p>
@@ -85,7 +85,7 @@ async def send_mfa_email_code(to: str, code: str) -> bool:
 async def send_verification_email(to: str, token: str) -> bool:
     """Send an email verification link."""
     verify_url = f"{settings.app_url}/verify-email?token={token}"
-    subject = "The Better Decision — verify your email"
+    subject = "The Better Decision: verify your email"
     body_html = f"""
     <h2>Verify Your Email</h2>
     <p>Welcome to The Better Decision! Please verify your email address.</p>
@@ -99,13 +99,13 @@ async def send_verification_email(to: str, token: str) -> bool:
 async def send_trial_expiring_email(to: str, days_left: int, org_name: str) -> bool:
     """Send a trial expiring notification."""
     upgrade_url = f"{settings.app_url}/settings/billing"
-    subject = f"The Better Decision — your trial ends in {days_left} day{'s' if days_left != 1 else ''}"
+    subject = f"The Better Decision: your trial ends in {days_left} day{'s' if days_left != 1 else ''}"
     body_html = f"""
     <h2>Your Trial Is Ending Soon</h2>
     <p>Hi! Your <strong>{org_name}</strong> trial ends in <strong>{days_left} day{'s' if days_left != 1 else ''}</strong>.</p>
     <p>After the trial, your account will switch to the Free plan with limited features.</p>
     <p><a href="{upgrade_url}">Upgrade to Pro</a> to keep all your features.</p>
-    <p style="color: #666; font-size: 12px;">No charge will be applied during beta — upgrading simply reserves your spot.</p>
+    <p style="color: #666; font-size: 12px;">No charge will be applied during beta. Upgrading simply reserves your spot.</p>
     """
     body_text = (
         f"Your {org_name} trial ends in {days_left} day{'s' if days_left != 1 else ''}.\n"

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -57,10 +57,10 @@ async def send_email(
 async def send_password_reset_email(to: str, token: str) -> bool:
     """Send a password reset email with a link containing the reset token."""
     reset_url = f"{settings.app_url}/reset-password?token={token}"
-    subject = "PFV2 — Reset Your Password"
+    subject = "The Better Decision — reset your password"
     body_html = f"""
     <h2>Reset Your Password</h2>
-    <p>You requested a password reset for your PFV2 account.</p>
+    <p>You requested a password reset for your The Better Decision account.</p>
     <p><a href="{reset_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Reset Password</a></p>
     <p>Or copy this link: <code>{reset_url}</code></p>
     <p>This link expires in 1 hour. If you didn't request this, ignore this email.</p>
@@ -71,24 +71,24 @@ async def send_password_reset_email(to: str, token: str) -> bool:
 
 async def send_mfa_email_code(to: str, code: str) -> bool:
     """Send a one-time MFA verification code via email."""
-    subject = "PFV2 — Your Login Verification Code"
+    subject = "The Better Decision — your login code"
     body_html = f"""
     <h2>Your Verification Code</h2>
     <p>Use this code to complete your sign-in:</p>
     <p style="font-size:32px;font-weight:bold;letter-spacing:8px;color:#c8a951;font-family:monospace;">{code}</p>
     <p>This code expires in 10 minutes. If you didn't try to sign in, you can ignore this email.</p>
     """
-    body_text = f"Your PFV2 verification code: {code}\n\nThis code expires in 10 minutes."
+    body_text = f"Your verification code: {code}\n\nThis code expires in 10 minutes."
     return await send_email(to, subject, body_html, body_text)
 
 
 async def send_verification_email(to: str, token: str) -> bool:
     """Send an email verification link."""
     verify_url = f"{settings.app_url}/verify-email?token={token}"
-    subject = "PFV2 — Verify Your Email"
+    subject = "The Better Decision — verify your email"
     body_html = f"""
     <h2>Verify Your Email</h2>
-    <p>Welcome to PFV2! Please verify your email address.</p>
+    <p>Welcome to The Better Decision! Please verify your email address.</p>
     <p><a href="{verify_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Verify Email</a></p>
     <p>Or copy this link: <code>{verify_url}</code></p>
     """
@@ -99,7 +99,7 @@ async def send_verification_email(to: str, token: str) -> bool:
 async def send_trial_expiring_email(to: str, days_left: int, org_name: str) -> bool:
     """Send a trial expiring notification."""
     upgrade_url = f"{settings.app_url}/settings/billing"
-    subject = f"PFV2 — Your trial ends in {days_left} day{'s' if days_left != 1 else ''}"
+    subject = f"The Better Decision — your trial ends in {days_left} day{'s' if days_left != 1 else ''}"
     body_html = f"""
     <h2>Your Trial Is Ending Soon</h2>
     <p>Hi! Your <strong>{org_name}</strong> trial ends in <strong>{days_left} day{'s' if days_left != 1 else ''}</strong>.</p>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "@/components/ThemeProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "PFV2 — Personal Finance",
+  title: "The Better Decision",
   description: "Personal finance management",
 };
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -55,8 +55,8 @@ export default function LoginPage() {
 
       <div className="w-full max-w-sm">
         <div className="mb-10 text-center">
-          <h1 className="font-display text-3xl font-semibold text-text-primary">PFV2</h1>
-          <p className="mt-1.5 text-sm text-text-muted">Personal Finance</p>
+          <h1 className="font-display text-3xl font-semibold text-text-primary">The Better Decision</h1>
+          <p className="mt-1.5 text-sm text-text-muted">Sign in</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-5">
           {error && <div className={errorCls}>{error}</div>}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import LandingPageBody from "@/components/landing/LandingPageBody";
 
 export const metadata: Metadata = {
-  title: "The Better Decision — know your money, plan what's next",
+  title: "The Better Decision: know your money, plan what's next",
   description:
-    "A finance app for normal people. Know what you have, what's coming, and where it goes — without the spreadsheet fatigue.",
+    "A finance app for normal people. Know what you have, what's coming, and where it goes. No spreadsheet fatigue.",
   openGraph: {
-    title: "The Better Decision — know your money, plan what's next",
+    title: "The Better Decision: know your money, plan what's next",
     description:
       "A finance app for normal people. Know what you have, what's coming, and where it goes.",
     type: "website",

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,28 +1,19 @@
-"use client";
+import type { Metadata } from "next";
+import LandingPageBody from "@/components/landing/LandingPageBody";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useAuth } from "@/components/auth/AuthProvider";
+export const metadata: Metadata = {
+  title: "The Better Decision — know your money, plan what's next",
+  description:
+    "A finance app for normal people. Know what you have, what's coming, and where it goes — without the spreadsheet fatigue.",
+  openGraph: {
+    title: "The Better Decision — know your money, plan what's next",
+    description:
+      "A finance app for normal people. Know what you have, what's coming, and where it goes.",
+    type: "website",
+    siteName: "The Better Decision",
+  },
+};
 
-export default function RootPage() {
-  const { user, loading, needsSetup } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!loading) {
-      if (needsSetup) {
-        router.replace("/setup");
-      } else if (user) {
-        router.replace("/dashboard");
-      } else {
-        router.replace("/login");
-      }
-    }
-  }, [user, loading, needsSetup, router]);
-
-  return (
-    <div className="flex h-screen items-center justify-center bg-bg">
-      <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent" />
-    </div>
-  );
+export default function LandingPage() {
+  return <LandingPageBody />;
 }

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy — The Better Decision",
+  title: "The Better Decision: Privacy Policy",
   description: "How The Better Decision collects, uses, and protects your personal data.",
 };
 
@@ -107,21 +107,21 @@ export default function PrivacyPolicyPage() {
             </p>
             <ul>
               <li>
-                <strong>DigitalOcean</strong> (hosting) — stores your data at
+                <strong>DigitalOcean</strong> (hosting): stores your data at
                 rest in managed MySQL in the ams3 region (EU).
               </li>
               <li>
-                <strong>Cloudflare</strong> (CDN / edge) — handles TLS
+                <strong>Cloudflare</strong> (CDN / edge): handles TLS
                 termination, DDoS protection, and edge routing.
               </li>
               <li>
-                <strong>Mailgun</strong> (EU region) — sends transactional
+                <strong>Mailgun</strong> (EU region): sends transactional
                 emails. We send only what&rsquo;s needed (your email
                 address, the subject line, and the email body).
               </li>
               <li>
                 <strong>Google</strong> (optional, if you choose
-                &ldquo;Sign in with Google&rdquo;) — we receive your email,
+                &ldquo;Sign in with Google&rdquo;): we receive your email,
                 name, and profile picture from Google after you authorize
                 the sign-in.
               </li>
@@ -157,26 +157,26 @@ export default function PrivacyPolicyPage() {
             </p>
             <ul>
               <li>
-                <strong>Access</strong> — request a copy of your data.
+                <strong>Access</strong>: request a copy of your data.
               </li>
               <li>
-                <strong>Rectification</strong> — fix anything inaccurate.
+                <strong>Rectification</strong>: fix anything inaccurate.
                 Most of this is self-serve inside the app.
               </li>
               <li>
-                <strong>Erasure</strong> — delete your account and all data
+                <strong>Erasure</strong>: delete your account and all data
                 associated with your organization.
               </li>
               <li>
-                <strong>Portability</strong> — export your data in a
+                <strong>Portability</strong>: export your data in a
                 machine-readable format.
               </li>
               <li>
-                <strong>Restriction / Objection</strong> — ask us to stop
+                <strong>Restriction / Objection</strong>: ask us to stop
                 or limit specific processing.
               </li>
               <li>
-                <strong>Complaint</strong> — lodge a complaint with your
+                <strong>Complaint</strong>: lodge a complaint with your
                 national data-protection authority (in the Netherlands, the
                 Autoriteit Persoonsgegevens).
               </li>

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy — PFV2",
-  description: "How PFV2 collects, uses, and protects your personal data.",
+  title: "Privacy Policy — The Better Decision",
+  description: "How The Better Decision collects, uses, and protects your personal data.",
 };
 
 const EFFECTIVE_DATE = "April 21, 2026";
@@ -32,7 +32,7 @@ export default function PrivacyPolicyPage() {
         <div className="space-y-8 text-text-primary [&_h2]:font-display [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mb-3 [&_h2]:mt-8 [&_p]:text-sm [&_p]:leading-relaxed [&_p]:text-text-secondary [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-sm [&_ul]:leading-relaxed [&_ul]:text-text-secondary [&_li]:mt-1">
           <section>
             <p>
-              PFV2 (&ldquo;we&rdquo;, &ldquo;us&rdquo;) is a personal finance
+              The Better Decision (&ldquo;we&rdquo;, &ldquo;us&rdquo;) is a personal finance
               application operated by Flamarion Jorge. We care about your
               privacy and keep what we collect to the minimum needed to run
               the service. This policy explains what we collect, why, how
@@ -42,7 +42,7 @@ export default function PrivacyPolicyPage() {
 
           <section>
             <h2>1. What we collect</h2>
-            <p>When you create an account and use PFV2, we collect:</p>
+            <p>When you create an account and use The Better Decision, we collect:</p>
             <ul>
               <li>
                 <strong>Identity:</strong> username, email, first/last name,
@@ -103,7 +103,7 @@ export default function PrivacyPolicyPage() {
             <h2>3. Third parties we share with</h2>
             <p>
               We share data only with service providers strictly necessary
-              to run PFV2:
+              to run The Better Decision:
             </p>
             <ul>
               <li>
@@ -228,7 +228,7 @@ export default function PrivacyPolicyPage() {
           <section>
             <h2>8. Children</h2>
             <p>
-              PFV2 is not intended for children under 16. We do not knowingly
+              The Better Decision is not intended for children under 16. We do not knowingly
               collect personal data from children.
             </p>
           </section>

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
+import BackLink from "@/components/ui/BackLink";
 
 export const metadata: Metadata = {
   title: "The Better Decision: Privacy Policy",
@@ -15,12 +16,7 @@ export default function PrivacyPolicyPage() {
       <ThemeToggle className="absolute right-6 top-6" />
       <article className="mx-auto max-w-2xl">
         <header className="mb-10">
-          <Link
-            href="/login"
-            className="text-sm text-text-muted hover:text-text-primary"
-          >
-            ← Back
-          </Link>
+          <BackLink />
           <h1 className="mt-6 font-display text-3xl font-semibold text-text-primary">
             Privacy Policy
           </h1>

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -171,7 +171,7 @@ export default function RegisterPage() {
             {usernameStatus === "taken" && (
               <p className="mt-1 text-xs text-danger">
                 Taken{usernameSuggestion && (
-                  <> — try <button type="button" onClick={() => { setUsername(usernameSuggestion); setUsernameManual(true); }} className="text-accent underline">{usernameSuggestion}</button></>
+                  <>, try <button type="button" onClick={() => { setUsername(usernameSuggestion); setUsernameManual(true); }} className="text-accent underline">{usernameSuggestion}</button></>
                 )}
               </p>
             )}

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -137,7 +137,7 @@ export default function RegisterPage() {
       <div className="w-full max-w-sm">
         <div className="mb-10 text-center">
           <h1 className="font-display text-3xl font-semibold text-text-primary">Create Account</h1>
-          <p className="mt-1.5 text-sm text-text-muted">Join PFV2</p>
+          <p className="mt-1.5 text-sm text-text-muted">Join The Better Decision</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-5">
           {error && <div className={errorCls}>{error}</div>}

--- a/frontend/app/settings/billing/page.tsx
+++ b/frontend/app/settings/billing/page.tsx
@@ -122,7 +122,7 @@ export default function BillingPage() {
         {/* Beta Notice */}
         <div className="rounded-lg border border-accent/30 bg-accent/5 p-4">
           <p className="text-sm text-accent">
-            The Better Decision is in beta — no charges will be applied. Subscription management is fully functional for testing.
+            The Better Decision is in beta. No charges will be applied. Subscription management is fully functional for testing.
           </p>
         </div>
 
@@ -151,7 +151,7 @@ export default function BillingPage() {
                 </div>
                 {isTrialing && (
                   <p className="text-sm text-text-muted">
-                    Trial ends {sub?.trial_end} — {trialDaysLeft} day{trialDaysLeft !== 1 ? "s" : ""} remaining
+                    Trial ends {sub?.trial_end}, {trialDaysLeft} day{trialDaysLeft !== 1 ? "s" : ""} remaining
                   </p>
                 )}
                 {isCanceled && sub?.current_period_end && (

--- a/frontend/app/settings/billing/page.tsx
+++ b/frontend/app/settings/billing/page.tsx
@@ -122,7 +122,7 @@ export default function BillingPage() {
         {/* Beta Notice */}
         <div className="rounded-lg border border-accent/30 bg-accent/5 p-4">
           <p className="text-sm text-accent">
-            PFV2 is in beta — no charges will be applied. Subscription management is fully functional for testing.
+            The Better Decision is in beta — no charges will be applied. Subscription management is fully functional for testing.
           </p>
         </div>
 

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -197,10 +197,10 @@ export default function OrganizationSettingsPage() {
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-text-primary">
-                    Current: {currentPeriod.start_date} — {currentPeriod.end_date ?? "open"}
+                    Current: {currentPeriod.start_date} to {currentPeriod.end_date ?? "open"}
                   </p>
                   <p className="text-xs text-text-muted">
-                    {currentPeriod.end_date ? "Closed" : "Open — transactions are being recorded"}
+                    {currentPeriod.end_date ? "Closed" : "Open, transactions are being recorded"}
                   </p>
                 </div>
                 {!currentPeriod.end_date && (

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -162,7 +162,7 @@ export default function SecurityPage() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "pfv2-recovery-codes.txt";
+    a.download = "the-better-decision-recovery-codes.txt";
     a.click();
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   }

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -153,7 +153,7 @@ export default function SecurityPage() {
   }
 
   function downloadCodes(codes: string[]) {
-    const text = "The Better Decision — Recovery Codes\n" +
+    const text = "The Better Decision: Recovery Codes\n" +
       "===================\n\n" +
       "Store these codes in a safe place.\n" +
       "Each code can only be used once.\n\n" +

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -153,7 +153,7 @@ export default function SecurityPage() {
   }
 
   function downloadCodes(codes: string[]) {
-    const text = "PFV2 Recovery Codes\n" +
+    const text = "The Better Decision — Recovery Codes\n" +
       "===================\n\n" +
       "Store these codes in a safe place.\n" +
       "Each code can only be used once.\n\n" +

--- a/frontend/app/setup/page.tsx
+++ b/frontend/app/setup/page.tsx
@@ -57,7 +57,7 @@ export default function SetupPage() {
 
       <div className="w-full max-w-md">
         <div className="mb-10 text-center">
-          <h1 className="font-display text-3xl font-semibold text-text-primary">Welcome to PFV2</h1>
+          <h1 className="font-display text-3xl font-semibold text-text-primary">Welcome to The Better Decision</h1>
           <p className="mt-2 text-sm text-text-secondary">Create your administrator account to get started.</p>
         </div>
         <div className="rounded-lg border border-border bg-surface p-6">

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 
 export const metadata: Metadata = {
-  title: "Terms of Service — PFV2",
-  description: "The agreement between you and PFV2 when you use the service.",
+  title: "Terms of Service — The Better Decision",
+  description: "The agreement between you and The Better Decision when you use the service.",
 };
 
 const EFFECTIVE_DATE = "April 21, 2026";
@@ -32,8 +32,8 @@ export default function TermsOfServicePage() {
         <div className="space-y-8 text-text-primary [&_h2]:font-display [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mb-3 [&_h2]:mt-8 [&_p]:text-sm [&_p]:leading-relaxed [&_p]:text-text-secondary [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-sm [&_ul]:leading-relaxed [&_ul]:text-text-secondary [&_li]:mt-1">
           <section>
             <p>
-              Welcome to PFV2. These Terms of Service (&ldquo;Terms&rdquo;)
-              govern your use of the PFV2 personal finance application
+              Welcome to The Better Decision. These Terms of Service (&ldquo;Terms&rdquo;)
+              govern your use of The Better Decision personal finance application
               operated by Flamarion Jorge. By creating an account or using
               the service you agree to these Terms.
             </p>
@@ -42,13 +42,13 @@ export default function TermsOfServicePage() {
           <section>
             <h2>1. The service</h2>
             <p>
-              PFV2 lets you track personal or small-organization finances:
+              The Better Decision lets you track personal or small-organization finances:
               accounts, transactions, budgets, forecasts, recurring items,
               and related tooling. It&rsquo;s a bookkeeping and planning
               tool, not a bank, broker, or financial advisor.
             </p>
             <p>
-              <strong>Beta notice.</strong> PFV2 is in an early stage.
+              <strong>Beta notice.</strong> The Better Decision is in an early stage.
               Features may change, data models may evolve, and we may need
               to reset or migrate parts of the service. We will give
               reasonable notice and make best-effort data preservation
@@ -138,7 +138,7 @@ export default function TermsOfServicePage() {
           <section>
             <h2>6. Not financial advice</h2>
             <p>
-              PFV2 displays numbers, forecasts, and categorizations based on
+              The Better Decision displays numbers, forecasts, and categorizations based on
               the data you enter. Forecasts are estimates, not predictions.
               Nothing in the app is investment advice, legal advice, tax
               advice, or a substitute for a qualified professional.
@@ -149,7 +149,7 @@ export default function TermsOfServicePage() {
           <section>
             <h2>7. Third parties and integrations</h2>
             <p>
-              PFV2 integrates with third-party services (Google for sign-in,
+              The Better Decision integrates with third-party services (Google for sign-in,
               Mailgun for email, Cloudflare for edge, DigitalOcean for
               hosting). Your use of those integrations is additionally
               governed by the third party&rsquo;s terms. We are not
@@ -161,7 +161,7 @@ export default function TermsOfServicePage() {
           <section>
             <h2>8. Intellectual property</h2>
             <p>
-              The PFV2 application, including its code, design, and
+              The Better Decision application, including its code, design, and
               trademarks, belongs to us. These Terms do not grant you any
               rights beyond the license to use the service for its intended
               purpose.

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
+import BackLink from "@/components/ui/BackLink";
 
 export const metadata: Metadata = {
   title: "The Better Decision: Terms of Service",
@@ -15,12 +16,7 @@ export default function TermsOfServicePage() {
       <ThemeToggle className="absolute right-6 top-6" />
       <article className="mx-auto max-w-2xl">
         <header className="mb-10">
-          <Link
-            href="/login"
-            className="text-sm text-text-muted hover:text-text-primary"
-          >
-            ← Back
-          </Link>
+          <BackLink />
           <h1 className="mt-6 font-display text-3xl font-semibold text-text-primary">
             Terms of Service
           </h1>

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 
 export const metadata: Metadata = {
-  title: "Terms of Service — The Better Decision",
+  title: "The Better Decision: Terms of Service",
   description: "The agreement between you and The Better Decision when you use the service.",
 };
 

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -131,7 +131,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       <aside className={`fixed inset-y-0 left-0 z-50 flex w-56 flex-col bg-sidebar-bg transition-transform duration-200 lg:relative lg:translate-x-0 ${sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}`}>
         <div className="flex items-center justify-between px-5 pt-5 pb-6">
           <Link href="/dashboard" className="font-display text-lg font-semibold text-sidebar-text-bright">
-            PFV2
+            TBD
           </Link>
           <button onClick={() => setSidebarOpen(false)} aria-label="Close menu" className="rounded-md p-1 text-sidebar-muted hover:text-sidebar-text-bright lg:hidden">
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -251,7 +251,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         <main className="flex-1 overflow-auto p-4 sm:p-8"><div className="mx-auto max-w-screen-xl">{children}</div></main>
         <footer className="border-t border-border bg-surface px-4 sm:px-8 py-4">
           <div className="flex items-center justify-between text-xs text-text-muted">
-            <span>PFV2 — Personal Finance</span>
+            <span>The Better Decision</span>
             <span>&copy; {new Date().getFullYear()}</span>
           </div>
         </footer>

--- a/frontend/components/landing/FeatureTiles.tsx
+++ b/frontend/components/landing/FeatureTiles.tsx
@@ -5,7 +5,7 @@ const tiles = [
   },
   {
     title: "Plan what's coming",
-    sub: "Budgets, forecasts, and recurring transactions — so surprises stay rare.",
+    sub: "Budgets, forecasts, and recurring transactions, so surprises stay rare.",
   },
   {
     title: "Shared, if you want",

--- a/frontend/components/landing/FeatureTiles.tsx
+++ b/frontend/components/landing/FeatureTiles.tsx
@@ -1,0 +1,43 @@
+const tiles = [
+  {
+    title: "See your money clearly",
+    sub: "All your accounts and transactions, categorized, in one dashboard.",
+  },
+  {
+    title: "Plan what's coming",
+    sub: "Budgets, forecasts, and recurring transactions — so surprises stay rare.",
+  },
+  {
+    title: "Shared, if you want",
+    sub: "Built for households: one org, multiple people, clear boundaries.",
+  },
+  {
+    title: "Your data stays yours",
+    sub: "EU-hosted today. Never sold, never shared, never moved across borders without asking. More regions coming.",
+  },
+];
+
+export default function FeatureTiles() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-16 lg:px-10 lg:py-24">
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 lg:gap-8">
+        {tiles.map((tile, i) => (
+          <div
+            key={tile.title}
+            className="rounded-xl border border-border bg-surface p-6"
+          >
+            <div className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">
+              {String(i + 1).padStart(2, "0")}
+            </div>
+            <h3 className="mb-2 font-display text-lg font-semibold leading-snug text-text-primary">
+              {tile.title}
+            </h3>
+            <p className="text-sm leading-relaxed text-text-secondary">
+              {tile.sub}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/landing/Hero.tsx
+++ b/frontend/components/landing/Hero.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import HeroDashboard from "./HeroDashboard";
+
+export default function Hero() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-16 lg:px-10 lg:py-24">
+      <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
+        <div>
+          <div className="mb-4 text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">
+            The Better Decision
+          </div>
+          <h1 className="font-display font-semibold leading-[1.05] text-text-primary text-[clamp(2.5rem,5vw,4rem)]">
+            There&rsquo;s no best decision.
+            <br />
+            Only better ones.
+          </h1>
+          <p className="mt-6 max-w-lg text-base leading-relaxed text-text-secondary lg:text-lg">
+            The Better Decision is a finance app for normal people. Know
+            what you have, what&rsquo;s coming, and where it goes —
+            without the spreadsheet fatigue.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              href="/register"
+              className="rounded-md bg-accent px-6 py-3 text-sm font-medium text-accent-text hover:bg-accent-hover"
+            >
+              Get started free
+            </Link>
+            <Link
+              href="/login"
+              className="rounded-md border border-border px-6 py-3 text-sm font-medium text-text-primary hover:bg-surface-raised"
+            >
+              Sign in
+            </Link>
+          </div>
+        </div>
+        <div className="lg:pl-8">
+          <HeroDashboard />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/landing/Hero.tsx
+++ b/frontend/components/landing/Hero.tsx
@@ -16,8 +16,8 @@ export default function Hero() {
           </h1>
           <p className="mt-6 max-w-lg text-base leading-relaxed text-text-secondary lg:text-lg">
             The Better Decision is a finance app for normal people. Know
-            what you have, what&rsquo;s coming, and where it goes —
-            without the spreadsheet fatigue.
+            what you have, what&rsquo;s coming, and where it goes. No
+            spreadsheet fatigue.
           </p>
           <div className="mt-8 flex flex-wrap items-center gap-3">
             <Link

--- a/frontend/components/landing/HeroDashboard.tsx
+++ b/frontend/components/landing/HeroDashboard.tsx
@@ -1,0 +1,65 @@
+export default function HeroDashboard() {
+  return (
+    <div
+      aria-hidden
+      className="rounded-xl border border-border bg-surface-raised p-6 shadow-2xl"
+    >
+      <div className="mb-1 text-[10px] font-medium uppercase tracking-[0.12em] text-text-muted">
+        April balance
+      </div>
+      <div className="mb-5 font-display text-3xl font-semibold text-text-primary">
+        €4,283.12
+      </div>
+
+      <div className="mb-1 flex items-end gap-1.5">
+        {[70, 55, 80, 45, 30, 65, 40, 75, 50, 60, 35, 70].map((h, i) => (
+          <div
+            key={i}
+            className={`flex-1 rounded-sm ${i === 4 || i === 6 || i === 10 ? "bg-danger/80" : "bg-accent/80"}`}
+            style={{ height: `${h}px` }}
+          />
+        ))}
+      </div>
+      <div className="mb-5 text-[10px] text-text-muted">
+        Weekly spend · forecast overlay
+      </div>
+
+      <div className="space-y-3">
+        <BudgetRow label="Groceries" spent="€412" limit="€500" percent={82} over={false} />
+        <BudgetRow label="Dining" spent="€189" limit="€150" percent={100} over />
+        <BudgetRow label="Transport" spent="€71" limit="€120" percent={59} over={false} />
+      </div>
+    </div>
+  );
+}
+
+function BudgetRow({
+  label,
+  spent,
+  limit,
+  percent,
+  over,
+}: {
+  label: string;
+  spent: string;
+  limit: string;
+  percent: number;
+  over: boolean;
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex justify-between text-xs text-text-secondary">
+        <span>{label}</span>
+        <span>
+          {spent} / {limit}
+        </span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-border">
+        <div
+          className={`h-full ${over ? "bg-danger" : "bg-accent"}`}
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/landing/HeroDashboard.tsx
+++ b/frontend/components/landing/HeroDashboard.tsx
@@ -15,7 +15,7 @@ export default function HeroDashboard() {
         {[70, 55, 80, 45, 30, 65, 40, 75, 50, 60, 35, 70].map((h, i) => (
           <div
             key={i}
-            className={`flex-1 rounded-sm ${i === 4 || i === 6 || i === 10 ? "bg-danger/80" : "bg-accent/80"}`}
+            className={`flex-1 rounded-sm ${i === 4 || i === 6 || i === 10 ? "bg-danger/80" : "bg-success/80"}`}
             style={{ height: `${h}px` }}
           />
         ))}
@@ -56,7 +56,7 @@ function BudgetRow({
       </div>
       <div className="h-1.5 overflow-hidden rounded-full bg-border">
         <div
-          className={`h-full ${over ? "bg-danger" : "bg-accent"}`}
+          className={`h-full ${over ? "bg-danger" : "bg-success"}`}
           style={{ width: `${Math.min(percent, 100)}%` }}
         />
       </div>

--- a/frontend/components/landing/LandingFooter.tsx
+++ b/frontend/components/landing/LandingFooter.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export default function LandingFooter() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="border-t border-border">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-8 text-xs text-text-muted lg:flex-row lg:items-center lg:justify-between lg:px-10">
+        <div>
+          © {year} The Better Decision
+        </div>
+        <div className="flex flex-wrap items-center gap-5">
+          <Link href="/privacy" className="hover:text-text-primary">
+            Privacy
+          </Link>
+          <Link href="/terms" className="hover:text-text-primary">
+            Terms
+          </Link>
+          {/* TODO: /help 404s until roadmap L5.3 ships. Left linked intentionally so we don't have to edit the footer again; acceptable short-lived gap. */}
+          <Link href="/help" className="hover:text-text-primary">
+            Help
+          </Link>
+          <a
+            href="mailto:hello@thebetterdecision.com"
+            className="hover:text-text-primary"
+          >
+            hello@thebetterdecision.com
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/components/landing/LandingFooter.tsx
+++ b/frontend/components/landing/LandingFooter.tsx
@@ -15,10 +15,9 @@ export default function LandingFooter() {
           <Link href="/terms" className="hover:text-text-primary">
             Terms
           </Link>
-          {/* TODO: /help 404s until roadmap L5.3 ships. Left linked intentionally so we don't have to edit the footer again; acceptable short-lived gap. */}
-          <Link href="/help" className="hover:text-text-primary">
-            Help
-          </Link>
+          {/* Help link intentionally omitted until roadmap L5.3 ships a
+              /help page. Visitors with questions can use the contact
+              email below in the meantime. */}
           <a
             href="mailto:hello@thebetterdecision.com"
             className="hover:text-text-primary"

--- a/frontend/components/landing/LandingPageBody.tsx
+++ b/frontend/components/landing/LandingPageBody.tsx
@@ -23,6 +23,15 @@ export default function LandingPageBody() {
     }
   }, [user, loading, needsSetup, router]);
 
+  // Render a blank shell while auth state resolves OR while we're about to
+  // redirect (logged-in user / needs-setup install). Prevents the public
+  // landing from flashing before router.replace() fires. Anonymous visitors
+  // hit the return below immediately since loading === false and both user
+  // and needsSetup are null.
+  if (loading || user || needsSetup) {
+    return <div className="min-h-screen bg-bg" aria-busy="true" />;
+  }
+
   return (
     <div className="min-h-screen bg-bg text-text-primary">
       <TopNav />

--- a/frontend/components/landing/LandingPageBody.tsx
+++ b/frontend/components/landing/LandingPageBody.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/components/auth/AuthProvider";
+import TopNav from "@/components/landing/TopNav";
+import Hero from "@/components/landing/Hero";
+import FeatureTiles from "@/components/landing/FeatureTiles";
+import SecondCta from "@/components/landing/SecondCta";
+import LandingFooter from "@/components/landing/LandingFooter";
+
+export default function LandingPageBody() {
+  const { user, loading, needsSetup } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading) {
+      if (needsSetup) {
+        router.replace("/setup");
+      } else if (user) {
+        router.replace("/dashboard");
+      }
+    }
+  }, [user, loading, needsSetup, router]);
+
+  return (
+    <div className="min-h-screen bg-bg text-text-primary">
+      <TopNav />
+      <main>
+        <Hero />
+        <FeatureTiles />
+        <SecondCta />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}

--- a/frontend/components/landing/SecondCta.tsx
+++ b/frontend/components/landing/SecondCta.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default function SecondCta() {
+  return (
+    <section className="mx-auto max-w-3xl px-6 py-16 text-center lg:py-20">
+      <h2 className="font-display text-2xl font-semibold text-text-primary lg:text-3xl">
+        Ready to see clearly?
+      </h2>
+      <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed text-text-secondary lg:text-base">
+        No spreadsheets. No shame. Sign up free and start turning
+        opacity into calm.
+      </p>
+      <Link
+        href="/register"
+        className="mt-8 inline-block rounded-md bg-accent px-6 py-3 text-sm font-medium text-accent-text hover:bg-accent-hover"
+      >
+        Get started free
+      </Link>
+    </section>
+  );
+}

--- a/frontend/components/landing/TopNav.tsx
+++ b/frontend/components/landing/TopNav.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+
+export default function TopNav() {
+  return (
+    <nav className="flex items-center justify-between px-6 py-5 lg:px-10">
+      <Link
+        href="/"
+        className="font-display text-lg font-semibold text-text-primary hover:opacity-80"
+      >
+        The Better Decision
+      </Link>
+      <div className="flex items-center gap-4">
+        <Link
+          href="/login"
+          className="text-sm text-text-muted transition-colors hover:text-text-primary"
+        >
+          Sign in
+        </Link>
+        <Link
+          href="/register"
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-text hover:bg-accent-hover"
+        >
+          Get started
+        </Link>
+        <ThemeToggle />
+      </div>
+    </nav>
+  );
+}

--- a/frontend/components/ui/BackLink.tsx
+++ b/frontend/components/ui/BackLink.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+/**
+ * Back-navigation link for public pages (privacy, terms, help).
+ *
+ * Uses the browser's session history so "Back" actually returns to wherever
+ * the user came from — landing, login, an external referrer, etc. When the
+ * page was opened directly (shared URL in a fresh tab, bookmark, etc.),
+ * `window.history.length` is 1 and we fall back to a "Home" link pointing
+ * at the landing so the user always has a way out.
+ */
+export default function BackLink({ className = "" }: { className?: string }) {
+  const router = useRouter();
+  const [canGoBack, setCanGoBack] = useState(false);
+
+  useEffect(() => {
+    // History length > 1 means there's a previous entry for this tab.
+    // This check runs client-side only (useEffect), so there's no SSR
+    // mismatch — we render the "Home" fallback on first paint and upgrade
+    // to "Back" once we know the history state.
+    setCanGoBack(window.history.length > 1);
+  }, []);
+
+  const baseClasses =
+    "text-sm text-text-muted transition-colors hover:text-text-primary";
+  const mergedClasses = className ? `${baseClasses} ${className}` : baseClasses;
+
+  if (canGoBack) {
+    return (
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className={mergedClasses}
+      >
+        ← Back
+      </button>
+    );
+  }
+
+  return (
+    <Link href="/" className={mergedClasses}>
+      ← Home
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

Closes roadmap **L5.1** (Week 3 priority-bump). Single PR covering the new public landing page and the app-wide **PFV2 → The Better Decision** rename so the visitor journey is coherent from first-click through sign-up.

## What's new

- Public landing page at `/`
  - Top nav (wordmark + Sign in + Get started + theme toggle)
  - Hero split layout: "There's no best decision. Only better ones." on the left, pure-CSS schematic dashboard on the right
  - 4 feature tiles: clarity → predictability → shared → trust (numeric markers 01–04)
  - Second CTA block (standard conversion pattern)
  - Landing-specific footer with privacy / terms / help / contact
- Metadata + Open Graph basics on `/` (full SEO baseline lands in L5.2 next)
- Authenticated visitors still redirect to `/dashboard`; setup-needed users still go to `/setup`

## Rebrand scope

Every user-facing string renamed from "PFV2" to "The Better Decision" (short form "TBD" used only in the narrow AppShell sidebar):

- Backend: `APP_NAME` default, `EMAIL_FROM` default, all email subject lines + HTML bodies, FastAPI title
- Frontend: login, register, setup, privacy, terms pages; settings billing + security; AppShell sidebar + footer; root layout metadata
- Docs: README, CONTRIBUTING, CLAUDE.md
- Deploy: `.do/app.yaml` env-var override (important: Swagger UI was still showing "PFV2" on prod until this was fixed — caught by the smoke test)

Internal identifiers left untouched: Python module paths, git repo name (`pfv`), `./pfv` CLI command, docker-compose secrets (`pfv2_secret`), DB user/db names. These aren't user-facing and renaming would be disruptive.

## Verified locally

- `tsc --noEmit` clean across all touched frontend files
- `grep -rn PFV2` across user-facing surface returns 0
- `/` returns 200 with all hero copy, all 4 tile headlines, both CTAs, footer links, and correct metadata
- `/login`, `/register`, `/privacy`, `/terms` all 200 with 0 PFV2 occurrences
- `/docs` Swagger title now reads "The Better Decision - Swagger UI"
- Health + ready endpoints green

## Not verified via CLI (please check in browser before merge)

- Responsive behavior at desktop/tablet/mobile breakpoints (the hero grid should stack below `lg`; tiles should go 4→2→1)
- Theme toggle flipping dark ↔ light across the landing
- Auth-redirect round trip: anonymous → landing; logged in → `/dashboard`
- Recovery codes download filename (now `the-better-decision-recovery-codes.txt`)

## Post-merge reminder

After merge, anyone with an existing local clone will need to update their `.env`:

```bash
# Option A: update to match
sed -i '' 's/^APP_NAME=PFV2$/APP_NAME="The Better Decision"/' .env

# Option B: delete the override entirely — the new default in config.py takes over
```

## Not in this PR (tracked)

- Full SEO baseline — sitemap, robots content, JSON-LD, Lighthouse audit — **L5.2** next
- Real product screenshot replacing the stylized hero visual — Week 9 polish
- Pricing preview — blocked on L2 real billing
- FAQ, testimonials, how-it-works 3-step — Week 9 polish
- Animations / scroll effects — Week 9 polish
- Mailbox aliases setup (`hello@`, `privacy@`, `legal@`, `security@thebetterdecision.com`) — before public launch
- `/help` footer link 404s until L5.3 ships (TODO flagged in `LandingFooter.tsx`)