### PR TITLE
fix(dashboard): exclude transfer halves from income/expense/category totals (L3.5)

### DIFF
--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -34,12 +34,16 @@ async def _compute_spent(
 
     # Use settled_date for budget computation — transactions count against
     # the billing period in which they settled, not when the purchase happened.
+    # Transfer halves are persisted as type=expense with a non-null
+    # linked_transaction_id; excluding them keeps budget spent aligned with
+    # the dashboard donut when a transfer is tagged under a budgeted category.
     q = select(func.coalesce(func.sum(Transaction.amount), 0)).where(
         Transaction.org_id == org_id,
         Transaction.category_id.in_(all_cat_ids),
         Transaction.type == TransactionType.EXPENSE,
         Transaction.status == TransactionStatus.SETTLED,
         Transaction.settled_date >= period_start,
+        Transaction.linked_transaction_id.is_(None),
     )
     # If period is still open (no end_date), include all from start_date onward
     if period_end is not None:

--- a/backend/app/services/forecast_service.py
+++ b/backend/app/services/forecast_service.py
@@ -59,6 +59,11 @@ async def compute_forecast(
     # ── Executed (settled) — uses settled_date for period assignment ─────
     # Transactions count against the period in which they settled,
     # not when the purchase happened (important for CC late settlements).
+    #
+    # Transfer halves are persisted as type=income/expense with a non-null
+    # linked_transaction_id; excluding them keeps executed/pending totals
+    # aligned with the dashboard client-side aggregates and with how users
+    # think about real income vs. real spending.
     executed_income = await db.scalar(
         select(func.coalesce(func.sum(Transaction.amount), 0)).where(
             Transaction.org_id == org_id,
@@ -66,6 +71,7 @@ async def compute_forecast(
             Transaction.status == TransactionStatus.SETTLED,
             Transaction.settled_date >= p_start,
             Transaction.settled_date <= p_end,
+            Transaction.linked_transaction_id.is_(None),
         )
     ) or Decimal("0")
 
@@ -76,6 +82,7 @@ async def compute_forecast(
             Transaction.status == TransactionStatus.SETTLED,
             Transaction.settled_date >= p_start,
             Transaction.settled_date <= p_end,
+            Transaction.linked_transaction_id.is_(None),
         )
     ) or Decimal("0")
 
@@ -87,6 +94,7 @@ async def compute_forecast(
             Transaction.status == TransactionStatus.PENDING,
             Transaction.date >= p_start,
             Transaction.date <= p_end,
+            Transaction.linked_transaction_id.is_(None),
         )
     ) or Decimal("0")
 
@@ -97,6 +105,7 @@ async def compute_forecast(
             Transaction.status == TransactionStatus.PENDING,
             Transaction.date >= p_start,
             Transaction.date <= p_end,
+            Transaction.linked_transaction_id.is_(None),
         )
     ) or Decimal("0")
 
@@ -125,7 +134,9 @@ async def compute_forecast(
             d = advance_date(d, r.frequency)
 
     # ── Per-category breakdown ────────────────────────────────────────────
-    # Executed by category (uses settled_date for period assignment)
+    # Executed by category (uses settled_date for period assignment).
+    # Exclude transfer halves so Forecast by Category matches the
+    # dashboard donut.
     cat_exec_result = await db.execute(
         select(
             Transaction.category_id,
@@ -136,6 +147,7 @@ async def compute_forecast(
             Transaction.status == TransactionStatus.SETTLED,
             Transaction.settled_date >= p_start,
             Transaction.settled_date <= p_end,
+            Transaction.linked_transaction_id.is_(None),
         ).group_by(Transaction.category_id)
     )
     cat_executed = {row[0]: Decimal(str(row[1])) for row in cat_exec_result.all()}
@@ -151,6 +163,7 @@ async def compute_forecast(
             Transaction.status == TransactionStatus.PENDING,
             Transaction.date >= p_start,
             Transaction.date <= p_end,
+            Transaction.linked_transaction_id.is_(None),
         ).group_by(Transaction.category_id)
     )
     cat_pending = {row[0]: Decimal(str(row[1])) for row in cat_pend_result.all()}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -237,9 +237,12 @@ export default function DashboardPage() {
   // Precompute tx map for O(1) linked lookups
   const txMap = new Map(allTransactions.map((tx) => [tx.id, tx]));
 
-  // Totals from ALL period transactions (not just the paginated page)
-  const totalIncome = allTransactions.filter((tx) => tx.type === "income" && tx.status === "settled").reduce((s, tx) => s + Number(tx.amount), 0);
-  const totalExpense = allTransactions.filter((tx) => tx.type === "expense" && tx.status === "settled").reduce((s, tx) => s + Number(tx.amount), 0);
+  // Totals from ALL period transactions (not just the paginated page).
+  // Transfer halves are persisted as type=income/expense with a non-null
+  // linked_transaction_id pointing at the counterpart; exclude them so
+  // internal transfers don't inflate either the income or expense tile.
+  const totalIncome = allTransactions.filter((tx) => tx.type === "income" && tx.status === "settled" && tx.linked_transaction_id == null).reduce((s, tx) => s + Number(tx.amount), 0);
+  const totalExpense = allTransactions.filter((tx) => tx.type === "expense" && tx.status === "settled" && tx.linked_transaction_id == null).reduce((s, tx) => s + Number(tx.amount), 0);
 
   // Pending totals per account from all period transactions
   const pendingByAccount = allTransactions
@@ -250,9 +253,11 @@ export default function DashboardPage() {
       return acc;
     }, {});
 
-  // Spending by category from all period transactions
+  // Spending by category from all period transactions. Transfer expense
+  // halves carry linked_transaction_id; excluding them here stops transfers
+  // from polluting the Spending by Category donut.
   const spendingByCategory = allTransactions
-    .filter((tx) => tx.type === "expense" && tx.status === "settled")
+    .filter((tx) => tx.type === "expense" && tx.status === "settled" && tx.linked_transaction_id == null)
     .reduce<Record<string, number>>((acc, tx) => {
       acc[tx.category_name] = (acc[tx.category_name] || 0) + Number(tx.amount);
       return acc;


### PR DESCRIPTION
## Summary

Transfers on the dashboard were double-counted. Internal account-to-account transfers are persisted as two linked rows — source side \`type=expense\`, destination side \`type=income\`, both with a non-null \`linked_transaction_id\` (see \`backend/app/services/transaction_service.py:create_transfer\`). Three dashboard aggregations filtered only on \`type\` + \`status\`, so the transfer halves leaked in:

| Metric | Before | After |
|---|---|---|
| Monthly Income tile | real income + transfers | real income |
| Monthly Expense tile | real expense + transfers | real expense |
| Spending by Category donut | transfers appear under whatever category the transfer is tagged with | transfers excluded |

## Fix

One predicate added to each filter: \`tx.linked_transaction_id == null\`. Same code block, three expressions, same bug.

## Scope

Roadmap \`L3.5\` explicitly scopes the donut. The Income/Expense tile bugs share the exact same cause and live three and four lines away; fixing them together avoids leaving known-wrong totals on the same view.

## Not touched (deliberate)

- \`pendingByAccount\` (\`frontend/app/dashboard/page.tsx:245-251\`) legitimately includes pending transfer halves — per-account pending needs to reflect the eventual balance delta of each account.
- The transaction list dedup at \`frontend/app/dashboard/page.tsx:267-273\` was already correct (hides one side of each pair from the list).

## Follow-up

Server-side dashboard analytics aggregation is tracked as \`P1.1\` in the roadmap — when that lands, the same linked_transaction_id exclusion moves into the SQL query.