### PR TITLE
fix(sso): refresh cookie dropped on Google callback + profile backfill

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response, Cookie, status
+from fastapi.responses import RedirectResponse
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -834,19 +835,22 @@ async def google_login(response: Response):
 async def google_callback(
     code: str,
     state: str,
-    response: Response,
     db: AsyncSession = Depends(get_db),
     oauth_state: str | None = Cookie(default=None),
 ):
-    """Handle Google OAuth callback — exchange code for tokens, create or login user."""
+    """Handle Google OAuth callback — exchange code for tokens, create or login user.
+
+    IMPORTANT: this handler returns a RedirectResponse directly, so all cookie
+    writes (set_cookie / delete_cookie) MUST be applied to the returned response
+    object. FastAPI does not merge cookies set on an injected Response parameter
+    into a directly-returned Response — they would be silently dropped, which
+    is what previously broke the refresh-cookie round-trip for SSO logins.
+    """
     _validate_google_config()
 
     # Validate CSRF state
     if not oauth_state or oauth_state != state:
         raise HTTPException(status_code=400, detail="Invalid OAuth state — possible CSRF")
-
-    # Clear the state cookie
-    response.delete_cookie("oauth_state", path="/api/v1/auth/google")
 
     # Exchange authorization code for tokens
     try:
@@ -912,8 +916,25 @@ async def google_callback(
         if not user.is_active:
             raise HTTPException(status_code=403, detail="Account is deactivated")
         # google_verified is guaranteed True by the guard above.
+        mutated = False
         if not user.email_verified:
             user.email_verified = True
+            mutated = True
+        # Backfill profile fields from Google only when ours are empty so
+        # we never overwrite values the user has edited themselves. Useful
+        # when a password-registered user later links via Google and our
+        # side never had the name/avatar populated.
+        if not user.first_name and first_name:
+            user.first_name = first_name
+            mutated = True
+        if not user.last_name and last_name:
+            user.last_name = last_name
+            mutated = True
+        picture = google_user.get("picture")
+        if not user.avatar_url and picture:
+            user.avatar_url = picture
+            mutated = True
+        if mutated:
             await db.commit()
     else:
         # New user — register with Google profile
@@ -952,15 +973,27 @@ async def google_callback(
 
     if user.mfa_enabled:
         mfa_token = create_mfa_challenge_token(user.id)
-        return Response(
+        resp = RedirectResponse(
+            url=f"{app_settings.app_url}/mfa-verify?mfa_token={mfa_token}",
             status_code=302,
-            headers={"Location": f"{app_settings.app_url}/mfa-verify?mfa_token={mfa_token}"},
         )
+        resp.delete_cookie("oauth_state", path="/api/v1/auth/google")
+        return resp
 
     access_token = create_access_token(user.id, user.org_id, user.role.value)
     refresh_token = create_refresh_token(user.id)
 
-    response.set_cookie(
+    # Redirect to frontend with the access token in the URL fragment. The
+    # fragment stays client-side (not sent to servers, not logged), while
+    # the refresh token is set as an HttpOnly cookie so apiFetch can use
+    # it on /auth/refresh. Both cookies MUST be set on this returned
+    # response — see the handler docstring for the FastAPI caveat.
+    resp = RedirectResponse(
+        url=f"{app_settings.app_url}/auth/google/callback#token={access_token}",
+        status_code=302,
+    )
+    resp.delete_cookie("oauth_state", path="/api/v1/auth/google")
+    resp.set_cookie(
         key="refresh_token",
         value=refresh_token,
         httponly=True,
@@ -969,10 +1002,4 @@ async def google_callback(
         max_age=7 * 24 * 60 * 60,
         path="/api/v1/auth/refresh",
     )
-
-    # Redirect to frontend with token in URL fragment (not query string)
-    # Fragments are not sent to the server, preventing leaks in logs/Referer headers
-    return Response(
-        status_code=302,
-        headers={"Location": f"{app_settings.app_url}/auth/google/callback#token={access_token}"},
-    )
+    return resp


### PR DESCRIPTION
## Root cause

\`google_callback\` set \`refresh_token\` via \`response.set_cookie(...)\` on the FastAPI-injected \`Response\` parameter, then returned a freshly-constructed \`Response(status_code=302, ...)\`. **FastAPI only merges cookies from the injected response when the handler returns a pydantic model / dict — it does NOT merge them into a directly-returned \`Response\`.** The refresh cookie was silently dropped on every SSO login.

Empirically verified:

\`\`\`python
@app.get('/a')
def a(response: Response):
    response.set_cookie('x', '1')
    return Response(status_code=302, headers={'Location': '/y'})
# Set-Cookie on the response: None
\`\`\`

## Symptoms this fixes

All three of the user-reported SSO issues trace back to the missing refresh cookie:

1. **New user lands on /login instead of /dashboard.** Backend creates user, frontend callback sets the URL-fragment access token, \`/auth/me\` returns 200 — but \`AuthProvider.restore()\` then POSTs \`/auth/refresh\` which 401s because no cookie. PR #77's \`apiFetch\` dispatches \`auth:unauthenticated\`, \`AppShell\` redirects to /login even though the SSO flow just succeeded seconds ago.
2. **Existing user sign-in loop.** Same 401-on-refresh leaves the session unanchored, AuthProvider clears \`user\`, \`AppShell\` bounces back to /login every retry.
3. **Profile update returns 403 \"Not Authenticated\".** \`accessToken\` was cleared by the same \`auth:unauthenticated\` event, so \`apiFetch\` sends no \`Authorization\` header; HTTPBearer returns 403.

Log evidence on \`main\`:

\`\`\`
GET  /api/v1/auth/google/callback  302
POST /api/v1/auth/refresh          401  <-- no cookie, restore fails
POST /api/v1/auth/refresh          401  <-- apiFetch silent retry also fails
GET  /api/v1/auth/me               200  <-- fragment token works briefly
PUT  /api/v1/users/me              403  <-- state already wiped, no Authorization header
\`\`\`

## Changes

- Build a \`RedirectResponse\` and call \`set_cookie\` / \`delete_cookie\` on it directly (both MFA and non-MFA branches had the same shape).
- Drop the unused \`response: Response\` parameter.
- Docstring on the handler documents the FastAPI caveat so this doesn't get reintroduced.
- Secondary: for existing users signing in via Google, backfill \`first_name\` / \`last_name\` / \`avatar_url\` from the Google profile **only when our side is empty**. Conservative — never overwrites values the user edited. Resolves the \"profile data not updated\" observation for password-registered users who later link via Google with empty name fields.

## Verification

- Syntax + reload clean.
- TestClient harness confirms: \`response.set_cookie\` on injected \`Response\` + direct \`Response(...)\` return => no \`Set-Cookie\` header. \`RedirectResponse.set_cookie\` on returned response => \`Set-Cookie\` present.
- Real Google OAuth round-trip needs manual verification locally (requires the live Client ID/Secret the user has configured in their .env). Expected flow post-fix: callback response carries \`Set-Cookie: refresh_token=...; HttpOnly; Path=/api/v1/auth/refresh\`, subsequent \`POST /auth/refresh\` returns 200.