### PR TITLE
fix(sso): widen avatar_url to 2048, guard Google URL length

### DIFF
--- a/backend/alembic/versions/025_widen_avatar_url.py
+++ b/backend/alembic/versions/025_widen_avatar_url.py
@@ -1,0 +1,48 @@
+"""widen users.avatar_url to fit long CDN URLs
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-04-24 08:30:00.000000
+
+Google profile pictures routinely exceed 500 characters (900+ chars is
+common for the lh3.googleusercontent.com URL shape). The previous
+VARCHAR(500) caused Google SSO to 500 when persisting the avatar_url
+on both new-user create and existing-user profile backfill. 2048 is
+the practical URL length limit across mainstream browsers and CDNs.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '025'
+down_revision: Union[str, None] = '024'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "users",
+        "avatar_url",
+        existing_type=sa.String(500),
+        type_=sa.String(2048),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Downgrade is lossy — any row storing a URL > 500 chars would be
+    # truncated by MySQL on the ALTER. That is the whole reason we widened
+    # the column in the first place, so the downgrade path accepts the
+    # truncation risk on rollback.
+    op.alter_column(
+        "users",
+        "avatar_url",
+        existing_type=sa.String(2048),
+        type_=sa.String(500),
+        existing_nullable=True,
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -8,6 +8,12 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.models.base import Base
 
 
+# Single source of truth for the avatar_url length ceiling. The DB column,
+# the ProfileUpdate schema, and the Google SSO guard all import this so a
+# future bump only happens in one place (plus an Alembic ALTER migration).
+AVATAR_URL_MAX_LENGTH = 2048
+
+
 class Role(str, enum.Enum):
     OWNER = "owner"
     ADMIN = "admin"
@@ -42,7 +48,9 @@ class User(Base):
     first_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    avatar_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(
+        String(AVATAR_URL_MAX_LENGTH), nullable=True
+    )
     email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     password_hash: Mapped[str] = mapped_column(String(128), nullable=False)
     role: Mapped[Role] = mapped_column(

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -42,7 +42,7 @@ class User(Base):
     first_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     password_hash: Mapped[str] = mapped_column(String(128), nullable=False)
     role: Mapped[Role] = mapped_column(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -796,6 +796,26 @@ async def mfa_email_verify(
 # ── Google SSO ───────────────────────────────────────────────────────────────
 
 
+# Keep in sync with User.avatar_url column width (VARCHAR(2048), migration 025).
+_AVATAR_URL_MAX = 2048
+
+
+def _safe_avatar_url(url: str | None) -> str | None:
+    """Accept a Google avatar URL only if it fits the column.
+
+    Google profile pictures routinely run 900+ chars and the column is now
+    sized for 2048, but outlier URLs do exist in the wild. Dropping to None
+    on overflow keeps the commit from crashing and lets the user upload
+    their own avatar later via profile edit — strictly better than storing
+    a truncated, broken URL.
+    """
+    if not url:
+        return None
+    if len(url) > _AVATAR_URL_MAX:
+        return None
+    return url
+
+
 def _validate_google_config() -> None:
     """Raise 501 if Google SSO is not fully configured."""
     if not app_settings.google_client_id or not app_settings.google_client_secret:
@@ -930,7 +950,7 @@ async def google_callback(
         if not user.last_name and last_name:
             user.last_name = last_name
             mutated = True
-        picture = google_user.get("picture")
+        picture = _safe_avatar_url(google_user.get("picture"))
         if not user.avatar_url and picture:
             user.avatar_url = picture
             mutated = True
@@ -954,7 +974,7 @@ async def google_callback(
             email=email,
             first_name=first_name,
             last_name=last_name,
-            avatar_url=google_user.get("picture"),
+            avatar_url=_safe_avatar_url(google_user.get("picture")),
             password_hash=hash_password(secrets.token_urlsafe(32)),
             email_verified=True,  # guaranteed by the verified_email guard
             role=Role.OWNER,

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -15,7 +15,7 @@ from app.deps import get_current_user
 from app.models.account import AccountType, SYSTEM_ACCOUNT_TYPES
 from app.models.settings import OrgSetting
 from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
-from app.models.user import Organization, Role, User
+from app.models.user import AVATAR_URL_MAX_LENGTH, Organization, Role, User
 from app.models.subscription import Subscription, Plan
 from app.services import subscription_service
 from app.schemas.auth import (
@@ -796,22 +796,20 @@ async def mfa_email_verify(
 # ── Google SSO ───────────────────────────────────────────────────────────────
 
 
-# Keep in sync with User.avatar_url column width (VARCHAR(2048), migration 025).
-_AVATAR_URL_MAX = 2048
-
-
 def _safe_avatar_url(url: str | None) -> str | None:
     """Accept a Google avatar URL only if it fits the column.
 
-    Google profile pictures routinely run 900+ chars and the column is now
-    sized for 2048, but outlier URLs do exist in the wild. Dropping to None
-    on overflow keeps the commit from crashing and lets the user upload
-    their own avatar later via profile edit — strictly better than storing
-    a truncated, broken URL.
+    Google profile pictures routinely run 900+ chars and the column is
+    sized for AVATAR_URL_MAX_LENGTH, but outlier URLs do exist in the
+    wild. Dropping to None on overflow keeps the commit from crashing and
+    lets the user upload their own avatar later via profile edit — strictly
+    better than storing a truncated, broken URL. Sharing the cap with the
+    ProfileUpdate schema means a client can also round-trip whatever we
+    stored through PUT /users/me without hitting a 422.
     """
     if not url:
         return None
-    if len(url) > _AVATAR_URL_MAX:
+    if len(url) > AVATAR_URL_MAX_LENGTH:
         return None
     return url
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
+from app.models.user import AVATAR_URL_MAX_LENGTH
+
 
 class ProfileUpdate(BaseModel):
     # Base bounds only (DoS protection). The 3-char minimum and pattern
@@ -13,7 +15,7 @@ class ProfileUpdate(BaseModel):
     first_name: str | None = Field(default=None, max_length=100)
     last_name: str | None = Field(default=None, max_length=100)
     phone: str | None = Field(default=None, max_length=20)
-    avatar_url: str | None = Field(default=None, max_length=500)
+    avatar_url: str | None = Field(default=None, max_length=AVATAR_URL_MAX_LENGTH)
 
     @field_validator("avatar_url")
     @classmethod


### PR DESCRIPTION
## Hotfix for #78

My bad — I did not reproduce the full SSO round-trip locally before requesting merge on #78, and the backfill path surfaced a pre-existing column-width bug on every existing-user Google sign-in.

### What broke

\`users.avatar_url\` is \`VARCHAR(500)\`. Google profile pictures at \`lh3.googleusercontent.com\` routinely exceed that — the URL in the 500 stack trace was **937 characters**. PR #78's existing-user profile backfill added \`user.avatar_url = picture\` which now fires on every sign-in, crashing the commit with:

\`\`\`
pymysql.err.DataError: (1406, \"Data too long for column 'avatar_url' at row 1\")
\`\`\`

This fault is **older than #78** — the new-user create path already does \`avatar_url=google_user.get(\"picture\")\` into the same column. It just never triggered because testing historically used short-picture accounts. The backfill merely made it universal.

### Fix

1. **Alembic 025** alters \`users.avatar_url\` from \`VARCHAR(500)\` to \`VARCHAR(2048)\` — the practical URL ceiling across mainstream browsers and CDNs. Confirmed at the DB level (\`information_schema.columns.COLUMN_TYPE = 'varchar(2048)'\`).
2. **Model widened** to match (\`String(2048)\`).
3. **\`_safe_avatar_url()\` helper** drops URLs over the column width instead of crashing — belt-and-suspenders for outliers. User can still upload their own avatar via profile edit.
4. Both Google SSO paths (new-user insert, existing-user backfill) funnel through the helper.

### Verification this time

- Reproduced the 1406 error pre-migration.
- Post-migration, wrote a **937-char URL** (matching the failing case) to \`avatar_url\` via a live DB round-trip: committed cleanly.
- Unit-tested \`_safe_avatar_url\` bounds: None, empty, normal, =2048 (pass), 2049 (drop).
- Backend reload clean, \`/api/v1/auth/status\` 200.
- Still need you to smoke-test the end-to-end SSO flow locally before merging this one — same advice, properly heeded this time.

## Process note

Reviewing without a real round-trip on an auth code path was the mistake. For SSO specifically, no amount of TestClient stubbing catches column-width mismatches that only appear under real Google URLs. Locking that in as a personal rule: **any change to the Google callback gets a real Sign-in-with-Google click before PR-ready.**