### PR TITLE
feat(L4.1): platform permissions foundation

### DIFF
--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -1,0 +1,100 @@
+"""Platform-level authorization primitives.
+
+The in-code role → permission map used to gate platform-only
+(superadmin-scoped) endpoints. Design decisions — the permission-naming
+convention, the is_superadmin short-circuit, the guard-API contract,
+and the migration path to DB-backed RBAC — live in
+docs/decisions/2026-04-24-platform-permissions.md. Do not restate that
+rationale here; update the decision doc if it changes.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
+from fastapi import Depends, HTTPException, status
+
+from app.deps import get_current_user
+from app.models.user import User
+
+
+# Every permission the platform knows about. Adding a new one is a
+# one-line edit here plus the corresponding gate at its call site.
+Permission = Literal[
+    "plans.manage",
+]
+
+
+# Canonical set — useful when iterating or seeding L4.8's eventual DB
+# migration.
+ALL_PERMISSIONS: frozenset[Permission] = frozenset({
+    "plans.manage",
+})
+
+
+# Non-superadmin platform roles land here as they're introduced (L4.8
+# role admin UI). Superadmin is intentionally absent: the is_superadmin
+# short-circuit in has_permission() grants everything, so a new
+# Permission is automatically available to superadmins.
+ROLE_PERMISSIONS: dict[str, frozenset[Permission]] = {}
+
+
+def _platform_roles(user: User) -> frozenset[str]:
+    """Which platform roles this user holds.
+
+    Source of truth today is the is_superadmin bool. When L4.8 adds a
+    platform-role field or assignment table, this resolver is the only
+    place that needs to change.
+    """
+    roles: set[str] = set()
+    if user.is_superadmin:
+        roles.add("superadmin")
+    return frozenset(roles)
+
+
+def has_permission(user: User, permission: Permission) -> bool:
+    """True if the user is authorized for the given permission.
+
+    Evaluation order is deliberate:
+      1. Superadmin short-circuit — is_superadmin grants every
+         permission, including ones added in the future.
+      2. Role lookup via ROLE_PERMISSIONS. Unknown roles contribute no
+         permissions; unknown permission strings resolve to False
+         (deny-by-default) even when passed as str at a dynamic call
+         site.
+    """
+    if user.is_superadmin:
+        return True
+    for role in _platform_roles(user):
+        if permission in ROLE_PERMISSIONS.get(role, frozenset()):
+            return True
+    return False
+
+
+def require_permission(
+    permission: Permission,
+) -> Callable[..., Awaitable[User]]:
+    """FastAPI dependency factory — gates a route behind a permission.
+
+    Auth and authz failures stay distinct:
+      - get_current_user raises 401 on missing / invalid / expired token.
+      - this dependency raises 403 on valid-token-without-permission.
+
+    Returns the authenticated User on success, so a handler that needs
+    the user can inject this dependency in its signature directly and
+    skip declaring get_current_user a second time.
+    """
+
+    async def dependency(
+        current_user: User = Depends(get_current_user),
+    ) -> User:
+        if not has_permission(current_user, permission):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Forbidden",
+            )
+        return current_user
+
+    dependency.__name__ = (
+        f"require_permission_{permission.replace('.', '_')}"
+    )
+    return dependency

--- a/backend/app/routers/plans.py
+++ b/backend/app/routers/plans.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.permissions import require_permission
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.subscription import Plan, Subscription
@@ -9,14 +10,6 @@ from app.models.user import User
 from app.schemas.subscription import PlanCreate, PlanResponse, PlanUpdate
 
 router = APIRouter(prefix="/api/v1/plans", tags=["plans"])
-
-
-def _require_superadmin(user: User) -> None:
-    if not user.is_superadmin:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Superadmin access required",
-        )
 
 
 @router.get("", response_model=list[PlanResponse])
@@ -31,25 +24,28 @@ async def list_plans(
     return result.scalars().all()
 
 
-@router.get("/all", response_model=list[PlanResponse])
+@router.get(
+    "/all",
+    response_model=list[PlanResponse],
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
 async def list_all_plans(
-    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """List all plans including inactive. Superadmin only."""
-    _require_superadmin(current_user)
+    """List all plans including inactive. Requires plans.manage."""
     result = await db.execute(select(Plan).order_by(Plan.sort_order))
     return result.scalars().all()
 
 
-@router.get("/{plan_id}")
+@router.get(
+    "/{plan_id}",
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
 async def get_plan(
     plan_id: int,
-    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get a single plan with org count. Superadmin only."""
-    _require_superadmin(current_user)
+    """Get a single plan with org count. Requires plans.manage."""
     result = await db.execute(select(Plan).where(Plan.id == plan_id))
     plan = result.scalar_one_or_none()
     if plan is None:
@@ -67,15 +63,17 @@ async def get_plan(
     }
 
 
-@router.post("", response_model=PlanResponse, status_code=201)
+@router.post(
+    "",
+    response_model=PlanResponse,
+    status_code=201,
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
 async def create_plan(
     body: PlanCreate,
-    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Create a new plan. Superadmin only."""
-    _require_superadmin(current_user)
-
+    """Create a new plan. Requires plans.manage."""
     existing = await db.execute(select(Plan).where(Plan.slug == body.slug))
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="Plan slug already exists")
@@ -87,16 +85,17 @@ async def create_plan(
     return plan
 
 
-@router.put("/{plan_id}", response_model=PlanResponse)
+@router.put(
+    "/{plan_id}",
+    response_model=PlanResponse,
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
 async def update_plan(
     plan_id: int,
     body: PlanUpdate,
-    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update a plan. Superadmin only."""
-    _require_superadmin(current_user)
-
+    """Update a plan. Requires plans.manage."""
     result = await db.execute(select(Plan).where(Plan.id == plan_id))
     plan = result.scalar_one_or_none()
     if plan is None:
@@ -125,15 +124,16 @@ async def update_plan(
     return plan
 
 
-@router.delete("/{plan_id}", status_code=204)
+@router.delete(
+    "/{plan_id}",
+    status_code=204,
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
 async def delete_plan(
     plan_id: int,
-    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Soft-delete (deactivate) a plan. Superadmin only. Cannot delete if orgs are on it."""
-    _require_superadmin(current_user)
-
+    """Soft-delete (deactivate) a plan. Requires plans.manage. Cannot delete if orgs are on it."""
     result = await db.execute(select(Plan).where(Plan.id == plan_id))
     plan = result.scalar_one_or_none()
     if plan is None:

--- a/docs/decisions/2026-04-24-platform-permissions.md
+++ b/docs/decisions/2026-04-24-platform-permissions.md
@@ -1,0 +1,292 @@
+# Platform Permissions Decisions
+
+Date: 2026-04-24
+Status: Accepted
+Scope: L4.1 permission groundwork for platform-level authorization
+
+## Context
+
+The product already has org-scoped roles on `User.role` (`owner`, `admin`, `member`) and a separate platform-level `is_superadmin` flag.
+
+L4.1 introduces permission checks for platform-only capabilities such as plan management. Before implementation, we needed to lock down:
+
+- where the role-to-permission mapping lives
+- how permissions are named and type-checked
+- how platform roles are resolved from the current user model
+- what is explicitly out of scope for this phase
+
+## Decisions
+
+### 1. Role-to-permission mapping lives in code
+
+We will use an in-code Python mapping, not DB tables and not YAML config.
+
+Planned location:
+
+- `backend/app/auth/permissions.py`
+
+Shape:
+
+```python
+ROLE_PERMISSIONS: dict[str, frozenset[Permission]] = {}
+```
+
+Why:
+
+- fastest path for L4.1
+- no DB schema or seed migration required
+- easy to review in Git
+- current scope is only one platform role path: `is_superadmin`
+
+Rejected for now:
+
+- DB tables (`roles`, `permissions`, `role_permissions`): deferred until L4.8 role admin UI
+- YAML config: adds indirection without solving runtime editability
+
+### 2. Permissions are defined as a typed `Literal`
+
+Permissions will be declared in one place with a `Literal[...]` alias.
+
+Planned shape:
+
+```python
+Permission = Literal[
+    "plans.manage",
+]
+```
+
+Why:
+
+- catches permission-name typos at call sites
+- IDE autocomplete is better than raw string usage
+- keeps the permission namespace explicit
+- simple to extend one permission at a time
+
+Recommended companion constant:
+
+```python
+ALL_PERMISSIONS: frozenset[Permission] = frozenset({
+    "plans.manage",
+})
+```
+
+This gives one canonical set when iterating or seeding later.
+
+### 3. Platform role resolution is separated from permission mapping
+
+Permission evaluation should not read `user.is_superadmin` directly everywhere.
+
+Planned helper:
+
+```python
+def _platform_roles(user: User) -> frozenset[str]:
+    roles: set[str] = set()
+    if user.is_superadmin:
+        roles.add("superadmin")
+    return frozenset(roles)
+```
+
+Why:
+
+- separates assignment source from authorization logic
+- keeps future L4.8 role-assignment changes localized
+- callers continue asking only for permissions
+
+### 4. `is_superadmin` remains a hard bypass
+
+`superadmin` is treated as "grants all permissions" via `has_permission(...)`, not by exhaustively listing every permission in `ROLE_PERMISSIONS`.
+
+Why:
+
+- new permissions automatically apply to superadmins
+- avoids drift when a new permission is added but the map is not updated
+- matches the current product expectation for superadmin access
+
+Important note:
+
+- `_platform_roles()` is still useful as the future seam for role assignment
+- `ROLE_PERMISSIONS` is therefore not the exhaustive source of truth while `is_superadmin` exists as a dedicated bypass
+
+### 5. Existing org roles are out of scope
+
+The existing `User.role` enum (`owner`, `admin`, `member`) remains org-scoped and is not part of L4.1 platform permissions.
+
+Why:
+
+- different concern and scope
+- avoids mixing org authorization with platform authorization
+- keeps L4.1 focused on the platform-only superadmin path
+
+### 6. No new DB field or join table in L4.1
+
+We are not adding a platform-role column or a role-assignment join table in this phase.
+
+Why:
+
+- current source of truth is already `User.is_superadmin`
+- avoids schema cost before there is a UI or operational need for configurable roles
+
+### 7. Guard API — two names, dependency-first
+
+The module exports exactly two callables. No third idiom.
+
+```python
+def has_permission(user: User, permission: Permission) -> bool: ...
+
+def require_permission(
+    permission: Permission,
+) -> Callable[..., Awaitable[User]]: ...
+```
+
+- `has_permission` is the pure predicate, used for in-handler conditional branching only (e.g. shaping a response field based on permission).
+- `require_permission` is a FastAPI dependency factory. It composes with `get_current_user` so 401 (missing / invalid token) stays upstream and 403 (authenticated but insufficient) is the only code path that emerges from the permission check itself.
+- The inner dependency returns `User` on success, so call sites that genuinely need the user can inject it directly and avoid double-declaring `get_current_user`.
+- Evaluation order inside `has_permission` is fixed: `is_superadmin` short-circuits first, then `_platform_roles` + `ROLE_PERMISSIONS`. Unknown roles contribute no permissions; unknown permission strings (passed dynamically) deny by default.
+- The inner dependency's `__name__` is overridden to `require_permission_<permission_with_dots_as_underscores>` so FastAPI's dependency tree stays readable under introspection.
+
+### 8. Route-level dependencies are the default; signature injection only when the handler reads `User`
+
+When a handler does not reference the authenticated user in its body, the gate is applied at the decorator:
+
+```python
+@router.post(
+    "",
+    response_model=PlanResponse,
+    status_code=201,
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
+async def create_plan(
+    body: PlanCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    ...
+```
+
+When the handler actually uses the user (for org scoping, audit logging, conditional response shaping), signature injection returns the authenticated user and avoids a second `Depends(get_current_user)`:
+
+```python
+async def some_handler(
+    current_user: User = Depends(require_permission("orgs.impersonate")),
+    ...
+): ...
+```
+
+Why:
+
+- honest handler signatures — no unused `current_user` parameter on the majority of gated routes
+- same 401/403 semantics either way
+- avoids training future edits to reach for the heavier pattern by default
+
+### 9. Response-body text change is intentional
+
+Prior behaviour: `_require_superadmin` raised `HTTPException(403, detail="Superadmin access required")`. The new `require_permission(...)` raises `HTTPException(403, detail="Forbidden")`.
+
+Status code is unchanged (403). The detail string changes.
+
+This is a user-visible difference: `frontend/lib/api.ts::apiFetch` lifts `detail` into `ApiResponseError.message` and `extractErrorMessage` surfaces that string. A client that previously displayed `"Superadmin access required"` for a 403 will now display `"Forbidden"`.
+
+Accepted intentionally:
+
+- uniform 403 body across all permission gates (L4.2 – L4.10) with no permission-name leakage
+- handler identity available in access logs for server-side debugging
+- existing frontend error paths render the new string without additional wiring
+- the prior string was specific to the old helper; the new string is consistent with the generic guard
+
+If a future product requirement wants a user-visible reason on 403, we'll add it at that point — not pre-emptively.
+
+## Consequences
+
+### Benefits
+
+- low-risk implementation
+- fast path to permission-gated platform features
+- clear migration path to DB-backed RBAC later
+
+### Trade-off accepted
+
+If a configurable non-superadmin platform role is needed before L4.8, we will either:
+
+- deploy a code change to update the in-code map, or
+- bring the DB-backed role work forward
+
+This trade-off is acceptable pre-launch.
+
+## Future Migration Path
+
+When L4.8 introduces role administration:
+
+1. Keep permission names stable.
+2. Create DB-backed role/permission tables.
+3. Seed the initial DB rows from `ALL_PERMISSIONS` and `ROLE_PERMISSIONS`.
+4. Move `has_permission(...)` to read from DB-backed assignments.
+5. Remove or reduce the special-case bypass only if product requirements change.
+
+## Scope of the L4.1 PR
+
+### Files added
+
+- `backend/app/auth/__init__.py` (empty — makes the package explicit)
+- `backend/app/auth/permissions.py` (the module described in decisions 1–7)
+
+### Files modified
+
+- `backend/app/routers/plans.py`:
+  - remove the `_require_superadmin` helper
+  - apply `dependencies=[Depends(require_permission("plans.manage"))]` to `list_all_plans`, `get_plan`, `create_plan`, `update_plan`, `delete_plan`
+  - drop the `current_user` parameter from those five handlers (they never read it)
+  - `list_plans` is intentionally not superadmin-gated and is not touched
+  - leave the `User` / `get_current_user` imports in place because `list_plans` still uses them
+
+No other production file changes. No Alembic migration. No frontend change.
+
+### Explicit out of scope for L4.1
+
+These are intentionally not addressed in this PR; they're recorded here so later readers see deliberate deferral rather than oversight.
+
+1. Hybrid gates in `routers/subscriptions.py` and `routers/settings.py` — org-role-based, addressed in a later authz phase.
+2. The org-level `Role` enum (`OWNER` / `ADMIN` / `MEMBER`) and its inline comparisons across the codebase — stays as-is.
+3. DB-backed `roles` / `permissions` / `role_permissions` tables — scheduled for L4.8.
+4. `UserResponse.permissions: list[str]` field for the frontend — added when the first real granular frontend gate appears (likely L4.2 or L4.5).
+5. Denial / authz-failure audit logging — L4.7.
+6. `has_any_permission` / `has_all_permissions` helpers — deferred until a real call site needs them.
+7. Alternative platform-role assignment paths beyond `is_superadmin=True` — L4.8.
+
+## Verification
+
+No automated test harness exists anywhere in the project today. Verification for L4.1 is:
+
+1. **Syntax + reload.** `python3 -m py_compile backend/app/auth/permissions.py backend/app/routers/plans.py` post-edit. Backend is running under watch-reload; `./pfv logs backend` should show `Application startup complete` with no import errors.
+2. **Grep sweeps** (all should return the noted results):
+   - `grep -rn "_require_superadmin" backend/app` → no matches.
+   - `grep -n "get_current_user" backend/app/routers/plans.py` → only on `list_plans`'s signature.
+   - `grep -n "User" backend/app/routers/plans.py` → still references `User` only if `list_plans` keeps `current_user: User = Depends(get_current_user)`; if even that goes, the import goes too.
+3. **Manual smoke against the five gated handlers** using the seeded superadmin plus a second non-superadmin user:
+
+    | Endpoint | superadmin | non-superadmin | anonymous |
+    |---|---|---|---|
+    | `GET /api/v1/plans` | 200 | 200 (intentionally open) | 401 |
+    | `GET /api/v1/plans/all` | 200 | 403 | 401 |
+    | `GET /api/v1/plans/{id}` | 200 | 403 | 401 |
+    | `POST /api/v1/plans` | 201 | 403 | 401 |
+    | `PUT /api/v1/plans/{id}` | 200 | 403 | 401 |
+    | `DELETE /api/v1/plans/{id}` | 204 | 403 | 401 |
+
+4. **401 vs 403 spot-check.** The same endpoint with no token returns 401 (from `get_current_user` upstream); with a valid non-superadmin token returns 403 (from `require_permission`). Distinction preserved end-to-end.
+
+## Rollout
+
+- Single PR. No Alembic migration. No DO deploy gating.
+- One commit acceptable (or split add-module / convert-callsites if review prefers a narrower diff).
+- Reversibility: one-file revert restores `_require_superadmin` and the five handler signatures. No DB state to unwind.
+- Merge order: L4.1 must land before L4.2 — the admin dashboard route will be the first consumer of the new gate shape.
+
+## Migration pattern for future L4.x PRs
+
+Each subsequent PR in the L4.x series that introduces a new permission follows the same shape, documented here once so the module docstring can stay terse:
+
+1. Add the permission name to the `Permission` `Literal` and to `ALL_PERMISSIONS`.
+2. If a non-superadmin role should grant it, add the entry to `ROLE_PERMISSIONS`. Empty for L4.2 – L4.7; only L4.8 introduces non-superadmin roles.
+3. Gate the route at the decorator via `dependencies=[Depends(require_permission("resource.action"))]`, or inject into the signature if the handler actually reads the user.
+4. If the frontend needs permission-aware UI, add the field to `UserResponse.permissions` (wire-up lands when the first real case appears).
+
+The `backend/app/auth/permissions.py` module docstring points back to this decision doc rather than restating the pattern, so there is one source of truth.

--- a/docs/decisions/2026-04-24-platform-permissions.md
+++ b/docs/decisions/2026-04-24-platform-permissions.md
@@ -139,7 +139,7 @@ def require_permission(
 ```
 
 - `has_permission` is the pure predicate, used for in-handler conditional branching only (e.g. shaping a response field based on permission).
-- `require_permission` is a FastAPI dependency factory. It composes with `get_current_user` so 401 (missing / invalid token) stays upstream and 403 (authenticated but insufficient) is the only code path that emerges from the permission check itself.
+- `require_permission` is a FastAPI dependency factory. It composes with `get_current_user`: `get_current_user` returns 401 for invalid or expired bearer tokens, and missing `Authorization` headers are rejected upstream by FastAPI's `HTTPBearer` with 403. `require_permission` preserves that upstream behaviour and only adds 403 `Forbidden` for authenticated users lacking permission. (The app-wide `HTTPBearer` → 403-on-missing-header behaviour is pre-existing and not changed by this refactor; if we later want strict 401 for anonymous, that's a separate auth-layer change to `get_current_user`.)
 - The inner dependency returns `User` on success, so call sites that genuinely need the user can inject it directly and avoid double-declaring `get_current_user`.
 - Evaluation order inside `has_permission` is fixed: `is_superadmin` short-circuits first, then `_platform_roles` + `ROLE_PERMISSIONS`. Unknown roles contribute no permissions; unknown permission strings (passed dynamically) deny by default.
 - The inner dependency's `__name__` is overridden to `require_permission_<permission_with_dots_as_underscores>` so FastAPI's dependency tree stays readable under introspection.
@@ -264,14 +264,16 @@ No automated test harness exists anywhere in the project today. Verification for
 
     | Endpoint | superadmin | non-superadmin | anonymous |
     |---|---|---|---|
-    | `GET /api/v1/plans` | 200 | 200 (intentionally open) | 401 |
-    | `GET /api/v1/plans/all` | 200 | 403 | 401 |
-    | `GET /api/v1/plans/{id}` | 200 | 403 | 401 |
-    | `POST /api/v1/plans` | 201 | 403 | 401 |
-    | `PUT /api/v1/plans/{id}` | 200 | 403 | 401 |
-    | `DELETE /api/v1/plans/{id}` | 204 | 403 | 401 |
+    | `GET /api/v1/plans` | 200 | 200 (intentionally open) | 403 |
+    | `GET /api/v1/plans/all` | 200 | 403 | 403 |
+    | `GET /api/v1/plans/{id}` | 200 | 403 | 403 |
+    | `POST /api/v1/plans` | 201 | 403 | 403 |
+    | `PUT /api/v1/plans/{id}` | 200 | 403 | 403 |
+    | `DELETE /api/v1/plans/{id}` | 204 | 403 | 403 |
 
-4. **401 vs 403 spot-check.** The same endpoint with no token returns 401 (from `get_current_user` upstream); with a valid non-superadmin token returns 403 (from `require_permission`). Distinction preserved end-to-end.
+    Anonymous callers return 403 (not 401) because FastAPI's `HTTPBearer` intercepts the missing header before `get_current_user` runs — pre-existing app-wide behaviour, not introduced by this refactor.
+
+4. **401 vs 403 spot-check.** The same endpoint with an **invalid or expired** bearer token returns 401 (from `get_current_user` decode failure); with a valid non-superadmin token returns 403 (from `require_permission`). Distinction preserved end-to-end for the authenticated-but-bad-token vs authenticated-but-insufficient-permission cases.
 
 ## Rollout
 


### PR DESCRIPTION
## Summary

Foundation for the L4 control plane / cockpit. Introduces a platform-permissions authorization layer and converts the only call sites in scope — the five superadmin-gated handlers in \`routers/plans.py\`.

Design decisions (context, rationale, trade-offs, out-of-scope): [\`docs/decisions/2026-04-24-platform-permissions.md\`](./docs/decisions/2026-04-24-platform-permissions.md).

## What changes

- New \`backend/app/auth/\` package with \`permissions.py\`:
  - \`Permission\` \`Literal\` namespace + \`ALL_PERMISSIONS\` frozenset
  - empty \`ROLE_PERMISSIONS\` dict (non-superadmin roles land here when L4.8 introduces them)
  - \`_platform_roles()\` resolver — future seam for role assignment
  - \`has_permission()\` predicate with \`is_superadmin\` short-circuit + deny-by-default on unknown roles/permissions
  - \`require_permission()\` FastAPI dependency factory with \`Callable[..., Awaitable[User]]\` return type and introspection-friendly \`__name__\`
- \`routers/plans.py\`: removes \`_require_superadmin\`; \`list_all_plans\`, \`get_plan\`, \`create_plan\`, \`update_plan\`, \`delete_plan\` now gate via \`dependencies=[Depends(require_permission(\"plans.manage\"))]\` at the route decorator. \`list_plans\` stays open to any authenticated user (intentional). Drops the now-unused \`status\` import and the \`current_user\` parameter from all 5 gated handlers (none read it).

## Behaviour

| Caller | \`/plans\` | \`/plans/all\` and the four gated routes |
|---|---|---|
| Superadmin | 200 | 200 / 201 / 204 (no change) |
| Non-superadmin authenticated | 200 | 403 \`{\"detail\":\"Forbidden\"}\` |
| Anonymous (no bearer) | 403 | 403 (\`HTTPBearer\` upstream — unchanged) |
| Invalid / expired bearer | 401 | 401 (\`get_current_user\` — unchanged) |

Non-superadmin 403 detail text changes from \`\"Superadmin access required\"\` to uniform \`\"Forbidden\"\` — intentional simplification documented in Decision 9.

## Scope boundary

Explicitly NOT in this PR (see Decision doc's out-of-scope section): hybrid \`role|is_superadmin\` gates in \`routers/subscriptions.py\` and \`routers/settings.py\`, DB-backed roles (L4.8), \`UserResponse.permissions\` field (L4.2+), denial logging (L4.7), \`has_any\`/\`has_all\` helpers (YAGNI).

## Verification

No pytest harness exists project-wide (technical debt). Verified manually per the decision doc's Verification section:

- Syntax + live-container import smoke clean; backend auto-reload clean after every change.
- \`grep\` sweeps: zero \`_require_superadmin\` references, \`get_current_user\` remains only on \`list_plans\` (2 references total in the file), \`User\` import still used by \`list_plans\`, \`status\` import dropped, \`require_permission\` wired on exactly 6 lines (1 import + 5 gates).
- 6-endpoint curl matrix across superadmin / non-superadmin / anonymous — results table above.
- 403 body text confirmed as \`{\"detail\":\"Forbidden\"}\`.
- Write endpoint spot-check: non-superadmin \`POST /api/v1/plans\` with a valid body still returns 403 (gate rejects before schema validation).

One finding from the matrix — anonymous callers return 403 instead of 401 due to FastAPI's \`HTTPBearer\` default — was traced to pre-existing app-wide behaviour, not a regression from this PR. Decision 7 and the Verification matrix in the decision doc were amended to reflect reality (commit \`ee58d1d\`).

## Commits

- \`f016695\` — decision doc
- \`4e8d23c\` — add \`app/auth/permissions.py\`
- \`26fca0e\` — convert \`routers/plans.py\` call sites
- \`ee58d1d\` — amend decision doc to match observed HTTPBearer semantics