### PR TITLE
fix(auth): re-auth + verification reset on email change (S-P1-2 + S-P2-1)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -243,7 +243,7 @@ async def register(
     await db.commit()
 
     # Send verification email in background — don't block registration
-    token = create_email_verification_token(user.id)
+    token = create_email_verification_token(user.id, user.email)
     background_tasks.add_task(send_verification_email, user.email, token)
 
     return _user_response(user, org)
@@ -508,6 +508,19 @@ async def verify_email(request: Request, body: VerifyEmailRequest, db: AsyncSess
             detail="Invalid or expired verification token",
         )
 
+    # S-P2-1: the token binds the email it was issued for. Reject any
+    # token whose email no longer matches the user's current address —
+    # that means the user changed email after the token was issued and
+    # this link would otherwise verify a stale address. A token without
+    # an `email` claim is a pre-migration token and is rejected outright
+    # so the new binding is always enforced.
+    token_email = payload.get("email")
+    if not token_email or token_email != user.email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired verification token",
+        )
+
     user.email_verified = True
     await db.commit()
     return {"detail": "Email verified"}
@@ -524,7 +537,7 @@ async def resend_verification(
     if current_user.email_verified:
         return {"detail": "Email already verified"}
 
-    token = create_email_verification_token(current_user.id)
+    token = create_email_verification_token(current_user.id, current_user.email)
     await send_verification_email(current_user.email, token)
     return {"detail": "Verification email sent"}
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,7 +15,8 @@ from app.schemas.auth import (
     UserResponse,
 )
 from app.schemas.user import PasswordChange, ProfileUpdate
-from app.security import hash_password, verify_password
+from app.security import create_email_verification_token, hash_password, verify_password
+from app.services.email_service import send_verification_email
 
 _USERNAME_RE = re.compile(USERNAME_PATTERN)
 
@@ -45,6 +46,7 @@ def _user_response(user: User) -> UserResponse:
 @router.put("/me", response_model=UserResponse)
 async def update_profile(
     body: ProfileUpdate,
+    background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -75,7 +77,20 @@ async def update_profile(
             )
         current_user.username = body.username
 
-    if body.email is not None and body.email != current_user.email:
+    email_changing = (
+        body.email is not None and body.email != current_user.email
+    )
+    if email_changing:
+        # Closes S-P1-2: without re-auth, a session-only compromise could
+        # swap the recovery channel to an attacker-controlled inbox and
+        # convert a transient hijack into persistent account takeover.
+        if not body.current_password or not verify_password(
+            body.current_password, current_user.password_hash
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is required and must be correct to change email",
+            )
         existing = await db.execute(
             select(User).where(User.email == body.email)
         )
@@ -84,7 +99,24 @@ async def update_profile(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Email already taken",
             )
-        current_user.email = body.email
+        # Capture the new email now (body.email survives the pydantic
+        # validation; current_user.email is still the old one until the
+        # assignment below).
+        new_email = body.email
+        current_user.email = new_email
+        # New address is unverified by definition; force the user back
+        # through the verify-email flow before any trust is granted.
+        current_user.email_verified = False
+        # Kill every existing access/refresh token. If an attacker
+        # already holds one and happened to get the current password,
+        # the change is still logged out globally and a real user
+        # re-authenticates from scratch.
+        current_user.sessions_invalidated_at = datetime.now(timezone.utc)
+        # Issue a fresh verification token bound to the new email
+        # (S-P2-1) and deliver it in the background so the handler
+        # does not block on SMTP.
+        token = create_email_verification_token(current_user.id, new_email)
+        background_tasks.add_task(send_verification_email, new_email, token)
 
     sent = body.model_fields_set
     if "first_name" in sent:

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -16,6 +16,11 @@ class ProfileUpdate(BaseModel):
     last_name: str | None = Field(default=None, max_length=100)
     phone: str | None = Field(default=None, max_length=20)
     avatar_url: str | None = Field(default=None, max_length=AVATAR_URL_MAX_LENGTH)
+    # Required by the PUT /users/me handler when `email` is being changed.
+    # Not required for any other profile field. See S-P1-2 — changing
+    # email without re-auth is a takeover-persistence vector when a
+    # session is compromised.
+    current_password: str | None = Field(default=None, max_length=128)
 
     @field_validator("avatar_url")
     @classmethod

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -107,11 +107,19 @@ def create_mfa_email_token(user_id: int, code: str) -> tuple[str, str]:
     return token, jti
 
 
-def create_email_verification_token(user_id: int) -> str:
-    """Create a token for email verification (24 hours)."""
+def create_email_verification_token(user_id: int, email: str) -> str:
+    """Create a token for email verification (24 hours).
+
+    The email is baked into the token so a token issued for one address
+    can't be used to verify a different address if the user changes
+    their email between issuance and click (S-P2-1). The /verify-email
+    handler rejects the token if the email claim does not match the
+    user's current email.
+    """
     expire = datetime.now(timezone.utc) + timedelta(hours=24)
     payload = {
         "sub": str(user_id),
+        "email": email,
         "type": "email_verify",
         "exp": expire,
     }

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { FormEvent, useEffect, useState } from "react";
 import SettingsLayout from "@/components/SettingsLayout";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -15,6 +16,11 @@ export default function SettingsProfilePage() {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
+  // Only consulted when the email is being changed. Backend rejects
+  // email changes that lack a correct current password — this mirrors
+  // the /me/password endpoint's re-auth requirement and closes the
+  // email-change account-takeover chain (S-P1-2).
+  const [currentPassword, setCurrentPassword] = useState("");
 
   useEffect(() => {
     if (user) {
@@ -29,6 +35,8 @@ export default function SettingsProfilePage() {
   const [profileMsg, setProfileMsg] = useState("");
   const [profileErr, setProfileErr] = useState("");
   const [savingProfile, setSavingProfile] = useState(false);
+
+  const emailChanging = email !== (user?.email ?? "");
 
   async function handleProfileSubmit(e: FormEvent) {
     e.preventDefault();
@@ -50,12 +58,30 @@ export default function SettingsProfilePage() {
         return;
       }
 
+      if ("email" in payload) {
+        if (!currentPassword) {
+          setProfileErr(
+            "Enter your current password to change your email. If you signed in with Google and never set one, reset your password first.",
+          );
+          return;
+        }
+        payload.current_password = currentPassword;
+      }
+
       await apiFetch<User>("/api/v1/users/me", {
         method: "PUT",
         body: JSON.stringify(payload),
       });
       await refreshMe();
-      setProfileMsg("Profile updated");
+      setCurrentPassword("");
+      // Nudge the user toward the next step — changing email logs every
+      // session out and leaves email_verified=false until they click
+      // the new verification link.
+      setProfileMsg(
+        "email" in payload
+          ? "Profile updated. Check your new inbox for a verification link — you'll need to sign in again."
+          : "Profile updated",
+      );
     } catch (err) { setProfileErr(extractErrorMessage(err)); }
     finally { setSavingProfile(false); }
   }
@@ -107,6 +133,29 @@ export default function SettingsProfilePage() {
               <label htmlFor="profile-email" className={label}>Email</label>
               <input id="profile-email" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} className={input} />
             </div>
+            {emailChanging && (
+              <div>
+                <label htmlFor="profile-current-password" className={label}>
+                  Current password <span className="text-xs text-text-muted">(required to change email)</span>
+                </label>
+                <input
+                  id="profile-current-password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  className={input}
+                />
+                <p className="mt-1 text-xs text-text-muted">
+                  Signed in with Google and never set a password?{" "}
+                  <Link href="/forgot-password" className="text-accent hover:underline">
+                    Reset it first
+                  </Link>
+                  , then come back to change your email.
+                </p>
+              </div>
+            )}
             <div>
               <label htmlFor="profile-phone" className={label}>Phone</label>
               <input id="profile-phone" type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} className={input} placeholder="+1 234 567 8900" />


### PR DESCRIPTION
## Summary

Closes the account-takeover persistence chain the 2026-04-23 code sweep flagged as **S-P1-2** and the related **S-P2-1** stale-verification-token gap. Both live in the same code path, so this PR takes them together — the marginal cost of fixing S-P2-1 once we're already editing \`verify-email\` is tiny, and leaving it open would keep the same class of issue partially alive.

## The attack this closes (S-P1-2)

Before this PR, \`PUT /api/v1/users/me\` would update \`email\` without requiring current-password re-auth and would keep \`email_verified=True\` on the new address. An actor with **any** compromised session (XSS, stolen refresh cookie, physical access, malware) could:

1. swap the recovery email to an inbox they control
2. log out
3. trigger \`/forgot-password\`
4. receive the reset link at the attacker-controlled inbox
5. permanent takeover from a transient hijack

## Fix

| Layer | Before | After |
|---|---|---|
| \`ProfileUpdate\` schema | no \`current_password\` | optional \`current_password: str \\| None\` (only used when \`email\` is actually changing) |
| \`PUT /users/me\` — email change | writes silently | **400** unless \`current_password\` matches the user's hash |
| \`email_verified\` | stays \`True\` | reset to \`False\` on change |
| Sessions | untouched | \`sessions_invalidated_at = now()\` — every existing access/refresh token is killed; real user re-auths from scratch, any attacker-held token stops working |
| Verification email | not sent | dispatched to the **new** address via \`BackgroundTasks\` |
| \`create_email_verification_token\` | binds only \`user_id\` | binds \`user_id\` + \`email\`; \`verify-email\` rejects tokens whose \`email\` claim doesn't match the user's current address (S-P2-1) — also rejects legacy tokens without the claim so the binding is always enforced |

## Verification (live stack, user 2 password temporarily set + restored)

| # | Scenario | Expected | Got |
|---|---|---|---|
| 1 | \`PUT /users/me\` change email, no \`current_password\` | 400 | **400** ✓ |
| 2 | \`PUT /users/me\` change email, wrong \`current_password\` | 400 | **400** ✓ |
| 3 | \`PUT /users/me\` non-email field, no \`current_password\` | 200 (no regression) | **200** ✓ |
| 4 | \`PUT /users/me\` change email, correct \`current_password\` | 200 + side effects | **200**; \`email_verified=False\`, \`sessions_invalidated_at\` set ✓ |
| 5 | Old access token after email change | 401 | **401** ✓ |
| 6 | \`POST /auth/verify-email\` — legacy token, no \`email\` claim | 400 | **400** ✓ |
| 7 | \`POST /auth/verify-email\` — token binding a stale email | 400 | **400** ✓ |
| 8 | \`POST /auth/verify-email\` — token binding current email | 200, \`email_verified\` flips to True | **200** ✓ |

## Explicit out of scope (recorded for follow-up)

- Notification email to the **old** address on change. Adds a defense-in-depth layer for the narrow case where both session and password are compromised — the real user can see the change happened and contact support. Needs a new email template; left for a follow-up.
- Pending-email-change workflow (industry standard pattern — new address goes into a \`pending\` state, requires confirmation from the OLD inbox before the switch applies). Bigger schema + flow change; out of this PR's scope.