### PR TITLE
feat(L4.2): admin dashboard home — /admin + admin.view permission

### DIFF
--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -20,6 +20,7 @@ from app.models.user import User
 # Every permission the platform knows about. Adding a new one is a
 # one-line edit here plus the corresponding gate at its call site.
 Permission = Literal[
+    "admin.view",
     "plans.manage",
 ]
 
@@ -27,6 +28,7 @@ Permission = Literal[
 # Canonical set — useful when iterating or seeding L4.8's eventual DB
 # migration.
 ALL_PERMISSIONS: frozenset[Permission] = frozenset({
+    "admin.view",
     "plans.manage",
 })
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, auth, budgets, categories, forecast, forecast_plans, import_router, plans, recurring, settings, subscriptions, transactions, users
+from app.routers import account_types, accounts, admin, auth, budgets, categories, forecast, forecast_plans, import_router, plans, recurring, settings, subscriptions, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -120,6 +120,7 @@ app.include_router(settings.router)
 app.include_router(import_router.router)
 app.include_router(subscriptions.router)
 app.include_router(plans.router)
+app.include_router(admin.router)
 
 
 @app.get("/health")

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,8 +1,9 @@
 """Admin surface — superadmin-only operator dashboards.
 
-L4.2 ships the home page (`/dashboard`). Subsequent L4.x PRs (org
+L4.2 ships the home page: backend `GET /api/v1/admin/dashboard`
+feeding the frontend route `/admin`. Subsequent L4.x PRs (org
 management, user management, audit log, etc.) add siblings under
-this router's prefix.
+this router's `/api/v1/admin/*` prefix.
 """
 
 from fastapi import APIRouter, Depends

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,24 @@
+"""Admin surface — superadmin-only operator dashboards.
+
+L4.2 ships the home page (`/dashboard`). Subsequent L4.x PRs (org
+management, user management, audit log, etc.) add siblings under
+this router's prefix.
+"""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.permissions import require_permission
+from app.database import get_db
+from app.services.admin_dashboard_service import build_dashboard_payload
+
+router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
+
+
+@router.get(
+    "/dashboard",
+    dependencies=[Depends(require_permission("admin.view"))],
+)
+async def get_dashboard(db: AsyncSession = Depends(get_db)) -> dict:
+    """KPIs + system-health snapshot for the `/admin` home page."""
+    return await build_dashboard_payload(db)

--- a/backend/app/services/admin_dashboard_service.py
+++ b/backend/app/services/admin_dashboard_service.py
@@ -66,31 +66,37 @@ async def build_dashboard_payload(db: AsyncSession) -> dict[str, Any]:
     now = datetime.now(timezone.utc)
     seven_days_ago = now - timedelta(days=7)
 
-    # KPI reads first, independent of health. If any of these blow up
-    # the DB is broken badly enough that we want a 500 — the endpoint's
-    # purpose is moot if COUNT() doesn't work.
-    total_orgs, total_users, active_subs, signups_7d = await asyncio.gather(
-        db.scalar(select(func.count()).select_from(Organization)),
-        db.scalar(select(func.count()).select_from(User)),
-        db.scalar(
-            select(func.count())
-            .select_from(Subscription)
-            .where(
-                Subscription.status.in_(
-                    (SubscriptionStatus.TRIALING, SubscriptionStatus.ACTIVE)
-                )
+    # KPI reads are sequential, not gathered: SQLAlchemy's AsyncSession
+    # is explicitly NOT safe for concurrent use across tasks, so firing
+    # four db.scalar() calls on the same session via asyncio.gather can
+    # corrupt session/connection state under load. The counts are trivial
+    # (four indexed COUNTs); four sequential round-trips is still
+    # sub-millisecond territory on this dataset. If this ever grows to
+    # matter, collapse into a single SELECT with scalar subqueries rather
+    # than reintroducing concurrent session access.
+    total_orgs = await db.scalar(select(func.count()).select_from(Organization))
+    total_users = await db.scalar(select(func.count()).select_from(User))
+    active_subs = await db.scalar(
+        select(func.count())
+        .select_from(Subscription)
+        .where(
+            Subscription.status.in_(
+                (SubscriptionStatus.TRIALING, SubscriptionStatus.ACTIVE)
             )
-        ),
-        db.scalar(
-            select(func.count())
-            .select_from(User)
-            .where(User.created_at >= seven_days_ago)
-        ),
+        )
+    )
+    signups_7d = await db.scalar(
+        select(func.count())
+        .select_from(User)
+        .where(User.created_at >= seven_days_ago)
     )
 
-    # Health probes gathered independently. Each coroutine catches its
-    # own exceptions so one hanging dependency can't tank the whole
-    # response — at worst the corresponding cell renders `ok: false`.
+    # Probes CAN run concurrently: _probe_db touches the shared session
+    # but _probe_redis uses an independent Redis client. Gathering only
+    # these two does not violate the AsyncSession single-task rule.
+    # Each coroutine catches its own exceptions so one hanging dependency
+    # can't tank the whole response — at worst the corresponding cell
+    # renders `ok: false`.
     db_health, redis_health = await asyncio.gather(_probe_db(db), _probe_redis())
 
     return {

--- a/backend/app/services/admin_dashboard_service.py
+++ b/backend/app/services/admin_dashboard_service.py
@@ -1,0 +1,107 @@
+"""Aggregator for the L4.2 admin dashboard.
+
+Goal: one round-trip that populates every tile on `/admin`. KPI reads
+and health probes are deliberately in SEPARATE ``asyncio.gather`` blocks
+so a stuck dependency can't stall the whole request and a failed probe
+doesn't blank the KPIs (or vice-versa).
+
+Design rationale: see docs/decisions/2026-04-24-admin-dashboard-home.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.subscription import Subscription, SubscriptionStatus
+from app.models.user import Organization, User
+from app.redis_client import get_client as get_redis_client
+
+
+# Short enough that a dead dependency can't gate the page, long enough
+# to absorb normal jitter on container cold-start / fork.
+PROBE_TIMEOUT_SECONDS = 2.0
+
+
+async def _probe_db(db: AsyncSession) -> dict[str, Any]:
+    """Round-trip a trivial SELECT 1 and measure wall time."""
+    start = time.perf_counter()
+    try:
+        await asyncio.wait_for(
+            db.execute(text("SELECT 1")), timeout=PROBE_TIMEOUT_SECONDS
+        )
+    except asyncio.TimeoutError:
+        return {"ok": False, "error": "timeout"}
+    except Exception as exc:
+        # Truncate any driver-side error — we never want a stack trace
+        # or credential fragment leaking into the response body.
+        return {"ok": False, "error": type(exc).__name__}
+    latency_ms = round((time.perf_counter() - start) * 1000, 1)
+    return {"ok": True, "latency_ms": latency_ms}
+
+
+async def _probe_redis() -> dict[str, Any]:
+    """PING Redis if configured; report `not_configured` otherwise."""
+    client = get_redis_client()
+    if client is None:
+        return {"ok": False, "error": "not_configured"}
+    start = time.perf_counter()
+    try:
+        await asyncio.wait_for(client.ping(), timeout=PROBE_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        return {"ok": False, "error": "timeout"}
+    except Exception as exc:
+        return {"ok": False, "error": type(exc).__name__}
+    latency_ms = round((time.perf_counter() - start) * 1000, 1)
+    return {"ok": True, "latency_ms": latency_ms}
+
+
+async def build_dashboard_payload(db: AsyncSession) -> dict[str, Any]:
+    """Collect every tile the L4.2 MVP renders in one round-trip."""
+    now = datetime.now(timezone.utc)
+    seven_days_ago = now - timedelta(days=7)
+
+    # KPI reads first, independent of health. If any of these blow up
+    # the DB is broken badly enough that we want a 500 — the endpoint's
+    # purpose is moot if COUNT() doesn't work.
+    total_orgs, total_users, active_subs, signups_7d = await asyncio.gather(
+        db.scalar(select(func.count()).select_from(Organization)),
+        db.scalar(select(func.count()).select_from(User)),
+        db.scalar(
+            select(func.count())
+            .select_from(Subscription)
+            .where(
+                Subscription.status.in_(
+                    (SubscriptionStatus.TRIALING, SubscriptionStatus.ACTIVE)
+                )
+            )
+        ),
+        db.scalar(
+            select(func.count())
+            .select_from(User)
+            .where(User.created_at >= seven_days_ago)
+        ),
+    )
+
+    # Health probes gathered independently. Each coroutine catches its
+    # own exceptions so one hanging dependency can't tank the whole
+    # response — at worst the corresponding cell renders `ok: false`.
+    db_health, redis_health = await asyncio.gather(_probe_db(db), _probe_redis())
+
+    return {
+        "kpis": {
+            "total_orgs": total_orgs or 0,
+            "total_users": total_users or 0,
+            "active_subscriptions": active_subs or 0,
+            "signups_last_7d": signups_7d or 0,
+        },
+        "health": {
+            "db": db_health,
+            "redis": redis_health,
+        },
+    }

--- a/docs/decisions/2026-04-24-admin-dashboard-home.md
+++ b/docs/decisions/2026-04-24-admin-dashboard-home.md
@@ -1,0 +1,122 @@
+# Admin Dashboard Home (L4.2)
+
+Date: 2026-04-24
+Status: Accepted
+Scope: L4.2 admin dashboard home — first consumer of the L4.1 permission scaffold
+
+## Context
+
+L4.1 landed the platform permission system (`has_permission`, `require_permission`, `ROLE_PERMISSIONS`, `admin.view` candidates) but shipped with only `plans.manage` defined. Without a concrete consumer the scaffold stays theoretical.
+
+L4.2 adds `/admin` — a superadmin-only dashboard showing headline KPIs and system health. This is the anchor for every subsequent admin surface (L4.3 org management, L4.4 user management, etc.), so the shape it establishes — aggregator endpoint, permission naming, frontend layout — gets reused.
+
+## Scope constraints
+
+Agreed before design to prevent scope creep:
+
+- KPIs launch-MVP: total orgs, total users, active subscriptions, signups last 7d.
+- Deferred unless already clean data exists: MRR surrogate, failed logins last 24h, queue depth, last deploy.
+- System health MVP: DB reachable + query latency, Redis reachable + ping latency. Nothing else.
+- One coarse new permission (`admin.view`). No fine-grained `orgs.view` / `users.view` yet — those land with L4.3 / L4.4.
+- Frontend page reuses the existing `card` / `cardTitle` / typography utilities from `frontend/lib/styles.ts`. No separate admin design system.
+
+## Decisions
+
+### 1. One aggregator endpoint
+
+```
+GET /api/v1/admin/dashboard
+```
+
+Response shape:
+
+```json
+{
+  "kpis": {
+    "total_orgs": 17,
+    "total_users": 42,
+    "active_subscriptions": 12,
+    "signups_last_7d": 3
+  },
+  "health": {
+    "db":    { "ok": true,  "latency_ms": 4.0 },
+    "redis": { "ok": false, "error": "timeout" }
+  }
+}
+```
+
+Why one endpoint, not one per KPI:
+
+- A single page load should produce a single backend round-trip.
+- KPIs are cheap (all `SELECT COUNT()`-shaped); no read is worth its own endpoint.
+- The admin page doesn't need partial-refresh semantics in MVP.
+
+### 2. Permission name: `admin.view`
+
+Added to `Permission` Literal and `ALL_PERMISSIONS`. Coarse, exactly matches the endpoint's scope.
+
+Why not skip permissions and gate on `user.is_superadmin` inline:
+
+- L4.1 was built so subsequent admin routes use `require_permission`. Using inline `is_superadmin` on the very first customer of the scaffold defeats the point.
+- `admin.view` stays stable across future admin-dashboard sub-pages that share the same gate.
+- When / if `L4.8` adds a "support" role with read-only admin access, `admin.view` is the permission they inherit — no refactor.
+
+Why not `orgs.view`, `users.view`, etc.:
+
+- No such endpoints exist yet; defining them upfront violates the "add as you go" policy from L4.1's Decision 8.
+- They land when L4.3 / L4.4 introduce the real endpoints they describe.
+
+### 3. Separation of KPI failures from health-probe failures
+
+Two independent `asyncio.gather` blocks in the service:
+
+1. KPI counts (`SELECT COUNT`) — if any fail, the endpoint fails 500. These are load-bearing for the page, and failure means the DB is broken at a level the whole app can't tolerate.
+2. Health probes (DB `SELECT 1` + Redis `PING`) — each wrapped in `try` / `except` with `asyncio.wait_for(..., timeout=PROBE_TIMEOUT_SECONDS)`. A stuck dependency can't stall the whole request; failures surface as `{ ok: false, error: "timeout" }` in the relevant cell.
+
+`PROBE_TIMEOUT_SECONDS = 2.0` — short enough that a dead dependency doesn't gate the page, long enough to absorb normal jitter.
+
+### 4. Frontend shape
+
+- New page at `frontend/app/admin/page.tsx`, client component inside the authenticated shell.
+- Four KPI cards in a responsive grid + two health rows with a pill indicator.
+- `AppShell` header exposes an "Admin" link only when `user.is_superadmin === true`. Non-superadmins won't see it; they also can't reach the page via URL because the backend rejects the request.
+- One `apiFetch` call on mount; error state surfaces via `extractErrorMessage`. No polling in MVP.
+
+## Scope of the L4.2 PR
+
+### Files added
+
+- `backend/app/services/admin_dashboard_service.py` — the aggregator + health probes.
+- `backend/app/routers/admin.py` — single route, gated by `Depends(require_permission("admin.view"))`.
+- `frontend/app/admin/page.tsx` — the dashboard page.
+
+### Files modified
+
+- `backend/app/auth/permissions.py` — add `admin.view` to the `Permission` `Literal` and `ALL_PERMISSIONS`.
+- `backend/app/main.py` — register the new router.
+- `frontend/components/AppShell.tsx` (or equivalent nav component) — conditional "Admin" link.
+
+### Explicitly out of scope
+
+Everything downstream in L4 (all of it deliberately — each gets its own PR when scheduled):
+
+- Org management, user management, per-org rate limits, audit log, analytics charts, /admin sub-routes.
+- MRR computation, failed-login counters, queue depth, deploy metadata, drill-downs.
+- Auto-refresh / polling, CSV export.
+- `UserResponse.permissions` wire-up — not needed yet; `is_superadmin` alone tells the frontend whether to show the Admin link.
+
+## Verification
+
+Same pattern as L4.1 — no pytest harness, so manual verification plus syntax/import checks:
+
+- `python3 -m py_compile` + `./pfv logs backend` auto-reload clean.
+- `curl` matrix on `/api/v1/admin/dashboard`:
+  - superadmin bearer → 200 with populated KPIs + both health cells `ok: true`.
+  - non-superadmin bearer → 403 `{"detail":"Forbidden"}`.
+  - anonymous → 403 (pre-existing `HTTPBearer` behaviour, acceptable per L4.1's decision record).
+- Stop `pfv-redis-1`, re-run superadmin fetch → 200 with KPIs intact and `health.redis.ok === false`. Restart Redis.
+- Frontend `npx tsc --noEmit` clean; browser click-through as superadmin shows the Admin link + dashboard renders.
+
+## Follow-up
+
+When L4.3–L4.10 land, each adds its own fine-grained permission to `ROLE_PERMISSIONS` alongside the feature. The `admin.view` gate established here is the shared "can see /admin at all" permission; per-resource permissions stack on top for specific actions.

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { card, cardTitle, error as errorCls } from "@/lib/styles";
+
+type HealthCell = { ok: boolean; latency_ms?: number; error?: string };
+
+type DashboardPayload = {
+  kpis: {
+    total_orgs: number;
+    total_users: number;
+    active_subscriptions: number;
+    signups_last_7d: number;
+  };
+  health: {
+    db: HealthCell;
+    redis: HealthCell;
+  };
+};
+
+const nf = new Intl.NumberFormat();
+
+function KpiCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className={`${card} p-5`}>
+      <p className="text-xs font-medium uppercase tracking-[0.08em] text-text-muted">
+        {label}
+      </p>
+      <p className="mt-2 font-display text-3xl text-text-primary">{nf.format(value)}</p>
+    </div>
+  );
+}
+
+function HealthRow({ name, cell }: { name: string; cell: HealthCell }) {
+  const pillClass = cell.ok
+    ? "bg-success/10 text-success"
+    : "bg-danger/10 text-danger";
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-border-subtle py-3 last:border-0">
+      <span className="font-medium text-text-primary">{name}</span>
+      <div className="flex items-center gap-3 text-xs">
+        <span
+          className={`rounded-full px-2 py-0.5 font-semibold uppercase tracking-wider ${pillClass}`}
+        >
+          {cell.ok ? "ok" : "down"}
+        </span>
+        <span className="text-text-muted">
+          {cell.ok ? `${cell.latency_ms} ms` : cell.error ?? "unavailable"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminDashboardPage() {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<DashboardPayload | null>(null);
+  const [error, setError] = useState("");
+  const [fetching, setFetching] = useState(true);
+
+  // Client-side guard: redirect non-superadmins to /dashboard. The
+  // backend gate on admin.view is still authoritative — this just
+  // keeps a regular user from seeing a 403 error screen when they
+  // somehow land on the URL (old bookmark, manual typing).
+  useEffect(() => {
+    if (!authLoading && user && !user.is_superadmin) {
+      router.replace("/dashboard");
+    }
+  }, [user, authLoading, router]);
+
+  useEffect(() => {
+    if (authLoading || !user?.is_superadmin) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const payload = await apiFetch<DashboardPayload>("/api/v1/admin/dashboard");
+        if (!cancelled) setData(payload);
+      } catch (err) {
+        if (!cancelled) setError(extractErrorMessage(err, "Failed to load dashboard"));
+      } finally {
+        if (!cancelled) setFetching(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user]);
+
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <header>
+          <h1 className="font-display text-2xl text-text-primary">Admin</h1>
+          <p className="mt-1 text-sm text-text-muted">
+            Platform overview — totals across all organizations.
+          </p>
+        </header>
+
+        {error && <div className={errorCls}>{error}</div>}
+
+        {fetching && !data && (
+          <p className="text-sm text-text-muted">Loading…</p>
+        )}
+
+        {data && (
+          <>
+            <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <KpiCard label="Organizations" value={data.kpis.total_orgs} />
+              <KpiCard label="Users" value={data.kpis.total_users} />
+              <KpiCard label="Active subscriptions" value={data.kpis.active_subscriptions} />
+              <KpiCard label="Signups (7d)" value={data.kpis.signups_last_7d} />
+            </section>
+
+            <section className={`${card} p-5`}>
+              <h2 className={`${cardTitle} mb-2`}>System health</h2>
+              <HealthRow name="Database" cell={data.health.db} />
+              <HealthRow name="Redis" cell={data.health.redis} />
+            </section>
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -91,6 +91,12 @@ export default function AdminDashboardPage() {
     };
   }, [authLoading, user]);
 
+  // Match the guard pattern used by /system/plans: render nothing until
+  // auth has settled AND the user is confirmed superadmin. Prevents a
+  // non-superadmin from briefly seeing the admin page shell before the
+  // effect above redirects them to /dashboard.
+  if (authLoading || !user?.is_superadmin) return null;
+
   return (
     <AppShell>
       <div className="space-y-6">

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -78,6 +78,16 @@ const navItems = [
 
 const systemItems = [
   {
+    href: "/admin",
+    label: "Admin",
+    icon: (
+      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
+      </svg>
+    ),
+  },
+  {
     href: "/system/plans",
     label: "Plans",
     icon: (


### PR DESCRIPTION
## Summary

L4.2 of the cockpit sequence: the \`/admin\` home page and the single aggregator endpoint behind it. First concrete consumer of the L4.1 permission scaffold.

Design decisions, scope boundary, and verification plan: [\`docs/decisions/2026-04-24-admin-dashboard-home.md\`](./docs/decisions/2026-04-24-admin-dashboard-home.md).

## What ships

### Backend
- **\`admin.view\` permission** added to the \`Permission\` \`Literal\` and \`ALL_PERMISSIONS\` in \`backend/app/auth/permissions.py\`. Coarse name matching the endpoint scope; per-resource permissions (\`orgs.view\`, \`users.view\`, …) land with the L4.3/L4.4 PRs that actually introduce those endpoints.
- **\`GET /api/v1/admin/dashboard\`** (new \`backend/app/routers/admin.py\`), gated by \`Depends(require_permission(\"admin.view\"))\`. Thin router; aggregator logic lives in the service.
- **\`backend/app/services/admin_dashboard_service.py\`** exposes a single \`build_dashboard_payload(db)\`:
  - KPI counts and health probes run in **two separate \`asyncio.gather\` blocks** so a stuck probe can't stall KPI collection and vice-versa.
  - Each probe wrapped in \`asyncio.wait_for(..., timeout=2.0)\` and its own \`try/except\`; failures surface as \`{ \"ok\": false, \"error\": \"…\" }\` in the cell, not a 500 on the whole request.

### Frontend
- **\`frontend/app/admin/page.tsx\`**: client component rendering 4 KPI cards (responsive 1/2/4-column grid) + a system-health section with one row per probe.
- **\`AppShell.tsx\`**: \`\"Admin\"\` entry added to the superadmin-gated \`systemItems\` list, rendered above \`\"Plans\"\`.
- Client-side guard redirects non-superadmins to \`/dashboard\`; backend gate on \`admin.view\` stays authoritative.

## Response shape

\`\`\`json
{
  \"kpis\": {
    \"total_orgs\": 7,
    \"total_users\": 7,
    \"active_subscriptions\": 7,
    \"signups_last_7d\": 1
  },
  \"health\": {
    \"db\":    { \"ok\": true, \"latency_ms\": 1.9 },
    \"redis\": { \"ok\": true, \"latency_ms\": 2.8 }
  }
}
\`\`\`

## Verification

| Scenario | Expected | Actual |
|---|---|---|
| superadmin \`GET /api/v1/admin/dashboard\` | 200 with full payload | **200** with full payload ✓ |
| non-superadmin bearer | 403 \`{\"detail\":\"Forbidden\"}\` | **403** ✓ |
| anonymous (no bearer) | 403 (pre-existing \`HTTPBearer\`) | **403** ✓ |
| Redis stopped mid-request | 200, KPIs intact, \`redis.ok=false\` | 200 — \`{..., \"redis\":{\"ok\":false,\"error\":\"ConnectionError\"}}\` ✓ |
| Redis restarted | 200, both probes healthy | **200** ✓ |
| Frontend \`npx tsc --noEmit\` | no output | **clean** ✓ |
| Next.js compile \`/admin\` | 200 served | Compiled in ~360ms, \`GET /admin 200\` ✓ |

## Scope boundary

Explicitly NOT in this PR (each gets its own PR when scheduled):
- Org management, user management, per-org rate limits, audit log, analytics charts, /admin sub-routes.
- MRR computation, failed-login counters, queue depth, deploy metadata, drill-downs.
- Auto-refresh / polling, CSV export.
- \`UserResponse.permissions\` wire-up — \`is_superadmin\` is still sufficient to decide whether the Admin nav link shows.