### PR TITLE
fix: surface dashboard load errors + scrub mfa_token from logs (F-P1-4 + F-P1-2)

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -123,13 +123,28 @@ export default function DashboardPage() {
   }, [monthFrom, monthTo]);
 
   useEffect(() => {
-    if (!loading && user) loadRefs().catch(() => {});
+    if (!loading && user) {
+      // Previously `.catch(() => {})` — any failure here (backend 500,
+      // network blip) left the dashboard with stale or missing
+      // reference data and no visible error, the user's only clue
+      // being widgets that silently fail to populate. Surface it
+      // through the existing error banner instead.
+      loadRefs().catch((err) => {
+        setError(extractErrorMessage(err, "Failed to load dashboard data"));
+      });
+    }
   }, [loading, user, loadRefs]);
 
   useEffect(() => {
     if (!loading && user) {
       setFetching(true);
-      loadTransactions(page).catch(() => setFetching(false));
+      // Same class of bug as the loadRefs catch above: a failed
+      // transaction fetch used to clear the spinner and vanish. Now
+      // the error surfaces alongside the rest of the load failures.
+      loadTransactions(page).catch((err) => {
+        setError(extractErrorMessage(err, "Failed to load transactions"));
+        setFetching(false);
+      });
     }
   }, [loading, user, loadTransactions, page]);
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
  */
 
 const SENSITIVE_PARAMS = new Set([
-  "token", "code", "access_token", "refresh_token", "key", "secret", "password",
+  "token", "code", "access_token", "refresh_token", "mfa_token", "key", "secret", "password",
 ]);
 
 function sanitizeQuery(search: string): string | undefined {


### PR DESCRIPTION
## Scope

Two small frontend defensive fixes from the 2026-04-23 sweep bundled into one PR — both are tiny and reviewing them separately is pure overhead.

## F-P1-4 — Dashboard load errors no longer silently swallowed

Two sister \`.catch()\` handlers on \`frontend/app/dashboard/page.tsx\` previously ate load failures:

| Before | Effect |
|---|---|
| \`loadRefs().catch(() => {})\` | Backend 500 / network blip left accounts, categories, budgets, billing period/cycle empty. No banner; widgets silently failed to populate. |
| \`loadTransactions(page).catch(() => setFetching(false))\` | Spinner cleared but user never knew *why* — page looked "done loading" while showing nothing. |

Now both route through the existing \`setError\` + \`<div className={errorCls}>{error}</div>\` banner (rendered at \`page.tsx:314\`). No new state, no new UI. Per-path fallback strings on \`extractErrorMessage\` keep the message readable if a non-\`Error\`-like value gets thrown.

## F-P1-2 — \`mfa_token\` scrubbed from access logs

Not hypothetical in this codebase as-is. The Google SSO callback already redirects MFA-enabled SSO users to:

\`\`\`
{app_url}/mfa-verify?mfa_token={mfa_token}
\`\`\`

The frontend middleware's \`SENSITIVE_PARAMS\` set did exact-match on query key names — it redacted \`token\`, \`code\`, \`access_token\`, \`refresh_token\`, \`key\`, \`secret\`, \`password\`, but **not \`mfa_token\`**. So every MFA-enabled SSO sign-in was logging the token in cleartext into DO / nginx access logs and browser history.

One-line addition to the set scrubs the value at the edge.

## Verification

| Check | Result |
|---|---|
| \`npx tsc --noEmit\` | clean |
| Before-fix log line (simulated) | \`{"query":"mfa_token=should_be_scrubbed_12345", ...}\` |
| After-fix log line (rebuilt frontend) | \`{"query":"mfa_token=%5BREDACTED%5D", ...}\` ✓ |
| Existing error render path | unchanged — same \`error\` state, same banner |
| Backend / API contract | untouched |

\`middleware.ts\` isn't in the dev volume mount, so a rebuild was needed to probe it empirically — noted inline in the commit for future edits.

## Known follow-up (explicitly NOT in this PR)

Whether SSO-MFA should use a URL fragment like the access-token callback already does, so the token doesn't appear in the network request at all between backend redirect and frontend read. That's a coordinated backend/frontend change and deserves its own design think. Recorded for future consideration.