### PR TITLE
fix(infra): make .do/app.yaml the actual source of truth on deploy

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -90,11 +90,14 @@ services:
 # long migration never causes the backend's serving probe to fail. The
 # k8s/ Helm chart uses a matching initContainer in templates/backend.yaml.
 #
-# DATABASE_URL (and any other secrets the migration touches) MUST be bound
-# to this job in the DO console — App Platform does not auto-inherit
-# secrets across components, and the workflow now syncs this spec on every
-# deploy via app_spec_location, so a missing secret here is a hard fail
-# rather than a silent no-op.
+# About the encrypted DATABASE_URL value: App Platform's `EV[...]` blobs
+# are encrypted with this app's per-app key, so the plaintext is unreadable
+# outside DO. They are safe to commit and are the only way to keep the
+# spec self-contained — App Platform does not auto-inherit secrets across
+# components, so a brand-new PRE_DEPLOY job otherwise has no DATABASE_URL
+# and fails on first deploy. To re-issue from scratch (e.g., new app),
+# `doctl apps spec get <app-id>` will surface fresh `EV[...]` references
+# you can paste in.
 jobs:
   - name: migrate
     kind: PRE_DEPLOY
@@ -109,4 +112,9 @@ jobs:
     run_command: alembic upgrade head
     envs:
       - key: APP_ENV
+        scope: RUN_AND_BUILD_TIME
         value: "production"
+      - key: DATABASE_URL
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:6hfpzR8vLg+7V8xAKnnPxKCH31YvJ/wq:zBRFCBWk4LU+PgCsbCyXe3B28BtGpFeQ+KHldE7sFKA9XXlkkM94KQVsAVtlqwShSj29XHQ8JJzACa3Q+bX5nmrByRe4JGPlMDUC2iV5gcGb074vQntKdL2/0RIGhycbbbczpJUZubF3vh910KhN8toTPIS0bwpIvxHSvd8coPcI]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,13 @@ jobs:
         uses: digitalocean/app_action/deploy@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-          app_name: pfv
-          # Push the repo's spec on every deploy. Without this the action
-          # only triggers a redeploy of whatever spec is already live, so
-          # spec edits in PRs (PRE_DEPLOY jobs, health_check blocks,
-          # ingress rules) never reach App Platform — the silent drift
-          # that let migration 025 sit un-applied through PR #79.
+          # NOTE: Do NOT set `app_name` here. The v2 action's createSpec
+          # logic (deploy/main.go) takes EITHER app_name OR
+          # app_spec_location: when both are set, it fetches the live
+          # spec by name and ignores the file. Repo edits to .do/app.yaml
+          # (PRE_DEPLOY jobs, health_check blocks, ingress rules) then
+          # silently never reach App Platform — that is the bug that let
+          # migration 025 sit un-applied for hours after PR #79 merged.
+          # Using app_spec_location alone makes the action read the file
+          # and pick up the app via the `name:` field at the top of it.
           app_spec_location: .do/app.yaml

--- a/backend/tests/test_deploy_workflow.py
+++ b/backend/tests/test_deploy_workflow.py
@@ -8,14 +8,25 @@ APP_SPEC = REPO_ROOT / ".do" / "app.yaml"
 
 def test_deploy_workflow_pushes_app_spec():
     """Locks down the actual root cause of the 2026-04-24 SSO outage:
-    `digitalocean/app_action/deploy@v2` only redeploys against the live
-    spec unless `app_spec_location` is set, so PR #79's migrate PRE_DEPLOY
-    job never reached production. If this test fails, the workflow has
-    regressed to the silent-drift state."""
+    `digitalocean/app_action/deploy@v2` createSpec only reads the spec
+    file when `app_name` is unset; otherwise it grabs the live spec by
+    name and ignores the file. PR #79's migrate PRE_DEPLOY job never
+    reached production because the workflow had both inputs and the
+    file was silently dropped. Two assertions below — the action must
+    receive `app_spec_location` AND must NOT receive `app_name` — keep
+    the workflow on the file-driven path."""
     workflow = DEPLOY_WORKFLOW.read_text()
     assert "app_spec_location: .do/app.yaml" in workflow, (
         "deploy.yml must pass app_spec_location to digitalocean/app_action/deploy "
         "so the repo's .do/app.yaml is pushed on every deploy."
+    )
+    deploy_step = workflow[workflow.index("digitalocean/app_action/deploy"):]
+    deploy_step = deploy_step[: deploy_step.find("\n      - ")] if "\n      - " in deploy_step else deploy_step
+    assert "app_name:" not in deploy_step, (
+        "deploy.yml must NOT pass app_name alongside app_spec_location — "
+        "v2 prefers app_name and silently ignores the file (deploy/main.go:"
+        "createSpec). Drop app_name; the action picks the app up via the "
+        "spec file's top-level `name:` field."
     )
 
 
@@ -30,4 +41,20 @@ def test_app_spec_declares_predeploy_migrate_job():
     )
     assert "alembic upgrade head" in spec, (
         "PRE_DEPLOY job must run `alembic upgrade head`."
+    )
+
+
+def test_migrate_job_binds_database_url():
+    """The migrate job's envs must declare DATABASE_URL — App Platform
+    does not auto-inherit secrets across components, so a missing
+    DATABASE_URL on the job means alembic can't connect on first deploy
+    (we hit this exact failure on 2026-04-25 when the job existed but
+    had only APP_ENV bound). The encrypted EV[...] reference is safe to
+    commit because the blob is decryptable only by App Platform with the
+    app's per-app key."""
+    spec = APP_SPEC.read_text()
+    migrate_idx = spec.index("name: migrate")
+    migrate_block = spec[migrate_idx:]
+    assert "DATABASE_URL" in migrate_block.split("\njobs:")[0] or "DATABASE_URL" in migrate_block, (
+        "Migrate job must declare DATABASE_URL in its envs."
     )


### PR DESCRIPTION
## Summary
After PR #87, two latent bugs surfaced. This PR closes them and makes the repo's `.do/app.yaml` the actual source of truth for App Platform on every push.

### What was broken
1. **The v2 action silently dropped the file.** `digitalocean/app_action/deploy@v2`'s `createSpec` (deploy/main.go) takes EITHER `app_name` OR `app_spec_location`; when both are set it grabs the live spec by name and never reads the file. Our workflow had both, so PR #87's `jobs:` block and frontend `health_check` were ignored.
2. **First-deploy chicken-and-egg on PRE_DEPLOY secrets.** Once we pushed the file via `doctl apps update --spec`, the new migrate job had no `DATABASE_URL` bound (App Platform doesn't auto-inherit secrets across components), so alembic crashed with `pymysql OperationalError (2003) "Can't connect to MySQL on 'host'"` and the deploy auto-rolled back.

### Fixes
- `.github/workflows/deploy.yml`: drop `app_name`, keep `app_spec_location: .do/app.yaml`. The action picks up the app via the spec file's top-level `name:` field, and the file drives every deploy from here on.
- `.do/app.yaml`: embed the encrypted `EV[...]` reference for `DATABASE_URL` in the migrate job's envs. App Platform encrypts the blob with the app's per-app key — plaintext is unreadable outside DO and the value is safe to commit. It's also the only way to keep a brand-new PRE_DEPLOY job self-bound to the secret on first deploy without manual console work.
- `backend/tests/test_deploy_workflow.py`: extend the regression guards to assert (a) `app_spec_location` is present, (b) `app_name` is absent on the deploy step, (c) the migrate job declares `DATABASE_URL`.

### Verified live
Pushed the patched spec via `doctl apps update --spec` ahead of this PR. Deploy `ef0563ab` ran the migrate job: `INFO [alembic.runtime.migration] Running upgrade 024 -> 025, widen users.avatar_url to fit long CDN URLs`. Migration 025 is applied on prod, `avatar_url` is now `VARCHAR(2048)`, and Google SSO with long Google profile URLs works end-to-end.

After this PR merges, future migrations + spec edits will reach App Platform automatically — no doctl rituals required.