### PR TITLE
fix(infra): commit every secret + drop app_name so workflow can't strip them

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -27,6 +27,28 @@ ingress:
           prefix: /
       component:
         name: frontend
+
+# ---------------------------------------------------------------------------
+# About the encrypted `EV[...]` secret values below
+#
+# App Platform encrypts SECRET-typed env values with this app's per-app key
+# the moment they're saved (via console or `doctl apps update --spec`) and
+# thereafter only ever surfaces the encrypted blob — even `doctl apps spec
+# get` returns the `EV[...]` form, never plaintext. The blob is unreadable
+# outside DO and is safe to commit.
+#
+# We MUST commit them here because the deploy workflow now uses
+# `app_spec_location: .do/app.yaml` to push this file as the authoritative
+# spec on every deploy: any SECRET that is not listed here will be removed
+# from the live app on the next deploy. (We hit that exact failure mode on
+# 2026-04-25 — JWT_SECRET_KEY dropped to its placeholder default and the
+# backend crashlooped on import.)
+#
+# To re-issue from scratch (new app, rotated app key), run
+#   doctl apps spec get <app-id> --format yaml
+# and copy the fresh `value: EV[...]` blocks back here.
+# ---------------------------------------------------------------------------
+
 services:
   - name: backend
     github:
@@ -44,20 +66,62 @@ services:
       period_seconds: 15
       timeout_seconds: 5
       failure_threshold: 3
-    # Secrets (DATABASE_URL, REDIS_URL, JWT_SECRET_KEY, MFA_ENCRYPTION_KEY)
-    # are configured in DO console and inherited by preview apps.
-    # Only non-secret env vars are listed here.
     envs:
       - key: APP_ENV
+        scope: RUN_AND_BUILD_TIME
         value: "production"
       - key: APP_NAME
+        scope: RUN_AND_BUILD_TIME
         value: "The Better Decision"
       - key: LOG_LEVEL
+        scope: RUN_AND_BUILD_TIME
         value: "INFO"
+      - key: APP_URL
+        scope: RUN_AND_BUILD_TIME
+        value: "https://app.thebetterdecision.com"
+      - key: BACKEND_CORS_ORIGINS
+        scope: RUN_AND_BUILD_TIME
+        value: "https://app.thebetterdecision.com"
       - key: COOKIE_SECURE
+        scope: RUN_AND_BUILD_TIME
         value: "true"
+      - key: MAILGUN_DOMAIN
+        scope: RUN_AND_BUILD_TIME
+        value: "m.thebetterdecision.com"
       - key: MAILGUN_REGION
+        scope: RUN_AND_BUILD_TIME
         value: "eu"
+      - key: EMAIL_FROM
+        scope: RUN_AND_BUILD_TIME
+        value: "PFV2 <noreply@m.thebetterdecision.com>"
+      - key: DATABASE_URL
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:6hfpzR8vLg+7V8xAKnnPxKCH31YvJ/wq:zBRFCBWk4LU+PgCsbCyXe3B28BtGpFeQ+KHldE7sFKA9XXlkkM94KQVsAVtlqwShSj29XHQ8JJzACa3Q+bX5nmrByRe4JGPlMDUC2iV5gcGb074vQntKdL2/0RIGhycbbbczpJUZubF3vh910KhN8toTPIS0bwpIvxHSvd8coPcI]
+      - key: REDIS_URL
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:A9gqCkOiw6t/7SnDUDSu4bqfD79Lwx7D:Gpukt1xW3kxOGnnI919j4lGoKjUM/RGOIfdtne26gHTGi0TAIqp1p7eklyrJ38JOAoY1Gs/Hb9K3fw7JIYxUTCaBovrZ0ppe0W8s0+v4m0uRHTRbSZ3UAn+5rwZ63G+mZTZEEZbNerchwFe2FltrHn4VgYk=]
+      - key: JWT_SECRET_KEY
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:yu+iyIxbSwoJpe7aEGuEBSJ8judQo26F:Ogb2sdGetlKniX5UaHeObIhPiYej4c4W1fccXr1By5mIGy1LI4dn8R6NPR1CGfnUAo5fslDt7qV48MNdMnGwk1A9qlp8GxCcKD2fdYcm7f8=]
+      - key: MFA_ENCRYPTION_KEY
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:ggw+koUI35JWzQb6g8N8GJ/psPs70qhS:e7BxGsGJdq35DlsFdA1CfTJrUFPwMa8kJDm5dQJkWNB2+vlwy3nkwEmdRnaYpy3DMurH67d7yKFsc1Z5]
+      - key: MAILGUN_API_KEY
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:YrGhlsSeOARimCuO/Ws+dktoGW5NdFGD:wlcljc+wVhxlddlau+C6+r6EKYHgeVJPgd/i8rQS+gh+scfsqz5g8D1b+TJHwR6CvhbXKGeasrpgUJa/r/rsF48w]
+      - key: GOOGLE_CLIENT_ID
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:cm+BD5dShSJwOjWL6YP2bSTVBZoT6u0W:t9oLM3W4BX6xhaUeU6zco2OrPU7enUX1EiYLDi/+yO9WC/8cfcutDlnARlQ8cd1wNsW3JMYj5rr1gHRE+VFpFL7YOph3eznAh1O3Q67jXvAi6pPt/Ok8Ug==]
+      - key: GOOGLE_CLIENT_SECRET
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:0/mRRuaUvDyJhFpbWK3g+TsqoYrBID+l:sddkvCmWoQSm6qU7/b9Q3QCWTFFWJ5i2Oj9nSOv6tyVlM7CQe0jC22lgJxKPq+pgJUlI]
 
   - name: frontend
     github:
@@ -80,8 +144,10 @@ services:
       failure_threshold: 3
     envs:
       - key: NEXT_PUBLIC_API_URL
+        scope: RUN_AND_BUILD_TIME
         value: ""
       - key: HOSTNAME
+        scope: RUN_AND_BUILD_TIME
         value: "0.0.0.0"
 
 # Pre-deploy job: run Alembic migrations exactly once before any backend
@@ -90,14 +156,9 @@ services:
 # long migration never causes the backend's serving probe to fail. The
 # k8s/ Helm chart uses a matching initContainer in templates/backend.yaml.
 #
-# About the encrypted DATABASE_URL value: App Platform's `EV[...]` blobs
-# are encrypted with this app's per-app key, so the plaintext is unreadable
-# outside DO. They are safe to commit and are the only way to keep the
-# spec self-contained — App Platform does not auto-inherit secrets across
-# components, so a brand-new PRE_DEPLOY job otherwise has no DATABASE_URL
-# and fails on first deploy. To re-issue from scratch (e.g., new app),
-# `doctl apps spec get <app-id>` will surface fresh `EV[...]` references
-# you can paste in.
+# DATABASE_URL is bound here directly (App Platform does not auto-inherit
+# secrets across components). Same encrypted reference the backend service
+# uses above; same "safe to commit" reasoning.
 jobs:
   - name: migrate
     kind: PRE_DEPLOY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,13 +25,16 @@ jobs:
         uses: digitalocean/app_action/deploy@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-          # NOTE: Do NOT set `app_name` here. The v2 action's createSpec
-          # logic (deploy/main.go) takes EITHER app_name OR
-          # app_spec_location: when both are set, it fetches the live
-          # spec by name and ignores the file. Repo edits to .do/app.yaml
-          # (PRE_DEPLOY jobs, health_check blocks, ingress rules) then
+          # NOTE: Do NOT add `app_name` here. The v2 action's createSpec
+          # logic (deploy/main.go) takes EITHER `app_name` OR
+          # `app_spec_location`: with both set, it fetches the live spec
+          # by name and ignores the file. Edits to .do/app.yaml then
           # silently never reach App Platform — that is the bug that let
-          # migration 025 sit un-applied for hours after PR #79 merged.
-          # Using app_spec_location alone makes the action read the file
-          # and pick up the app via the `name:` field at the top of it.
+          # PR #79's migration sit un-applied for hours after merge.
+          # With only `app_spec_location`, the action reads the file and
+          # picks up the app via its top-level `name:` field. .do/app.yaml
+          # MUST list every secret with its encrypted EV[...] value, since
+          # any SECRET not declared in this file gets removed from the
+          # live app on push (we hit that exact failure mode 2026-04-25,
+          # backend crashlooped on a placeholder JWT_SECRET_KEY).
           app_spec_location: .do/app.yaml

--- a/backend/tests/test_deploy_workflow.py
+++ b/backend/tests/test_deploy_workflow.py
@@ -1,60 +1,88 @@
-from pathlib import Path
+"""Regression guards for the App Platform deploy contract.
 
+These tests lock down the four operational invariants we've now broken
+multiple times in production:
+
+  1. The deploy workflow MUST push the repo's spec on every run
+     (`app_spec_location` set; `app_name` absent — v2 prefers app_name and
+     silently drops the file otherwise).
+  2. The spec MUST declare a PRE_DEPLOY migrate job so long migrations
+     don't gate uvicorn's port-bind on the serving probe budget.
+  3. The migrate job MUST bind DATABASE_URL — App Platform does not
+     auto-inherit secrets across components, so a fresh migrate job with
+     no DATABASE_URL crashes alembic on first deploy (2026-04-25 incident).
+  4. The backend service MUST declare every SECRET it reads — App Platform
+     removes any SECRET not in the spec on push, which previously dropped
+     JWT_SECRET_KEY to its placeholder default and crashlooped backend
+     (2026-04-25 incident).
+"""
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
 APP_SPEC = REPO_ROOT / ".do" / "app.yaml"
 
 
+def _deploy_step(workflow: str) -> str:
+    start = workflow.index("digitalocean/app_action/deploy")
+    rest = workflow[start:]
+    next_step = rest.find("\n      - ")
+    return rest if next_step < 0 else rest[:next_step]
+
+
 def test_deploy_workflow_pushes_app_spec():
-    """Locks down the actual root cause of the 2026-04-24 SSO outage:
-    `digitalocean/app_action/deploy@v2` createSpec only reads the spec
-    file when `app_name` is unset; otherwise it grabs the live spec by
-    name and ignores the file. PR #79's migrate PRE_DEPLOY job never
-    reached production because the workflow had both inputs and the
-    file was silently dropped. Two assertions below — the action must
-    receive `app_spec_location` AND must NOT receive `app_name` — keep
-    the workflow on the file-driven path."""
     workflow = DEPLOY_WORKFLOW.read_text()
     assert "app_spec_location: .do/app.yaml" in workflow, (
-        "deploy.yml must pass app_spec_location to digitalocean/app_action/deploy "
-        "so the repo's .do/app.yaml is pushed on every deploy."
+        "deploy.yml must pass app_spec_location so the file actually deploys."
     )
-    deploy_step = workflow[workflow.index("digitalocean/app_action/deploy"):]
-    deploy_step = deploy_step[: deploy_step.find("\n      - ")] if "\n      - " in deploy_step else deploy_step
-    assert "app_name:" not in deploy_step, (
-        "deploy.yml must NOT pass app_name alongside app_spec_location — "
-        "v2 prefers app_name and silently ignores the file (deploy/main.go:"
+    step = _deploy_step(workflow)
+    assert "app_name:" not in step, (
+        "deploy.yml must NOT pass app_name on the deploy step — v2 prefers "
+        "app_name and silently ignores app_spec_location (deploy/main.go: "
         "createSpec). Drop app_name; the action picks the app up via the "
         "spec file's top-level `name:` field."
     )
 
 
 def test_app_spec_declares_predeploy_migrate_job():
-    """The migrate job is the canonical init step for App Platform — it
-    runs before the new revision goes live, so long migrations never
-    starve uvicorn's health probe budget. Pair with the initContainer in
-    k8s/templates/backend.yaml for K8s parity."""
     spec = APP_SPEC.read_text()
-    assert "kind: PRE_DEPLOY" in spec, (
-        "App Platform spec must declare a PRE_DEPLOY job for migrations."
-    )
-    assert "alembic upgrade head" in spec, (
-        "PRE_DEPLOY job must run `alembic upgrade head`."
-    )
+    assert "kind: PRE_DEPLOY" in spec, "spec must declare PRE_DEPLOY migrate"
+    assert "alembic upgrade head" in spec, "PRE_DEPLOY job must run alembic"
 
 
 def test_migrate_job_binds_database_url():
-    """The migrate job's envs must declare DATABASE_URL — App Platform
-    does not auto-inherit secrets across components, so a missing
-    DATABASE_URL on the job means alembic can't connect on first deploy
-    (we hit this exact failure on 2026-04-25 when the job existed but
-    had only APP_ENV bound). The encrypted EV[...] reference is safe to
-    commit because the blob is decryptable only by App Platform with the
-    app's per-app key."""
     spec = APP_SPEC.read_text()
-    migrate_idx = spec.index("name: migrate")
-    migrate_block = spec[migrate_idx:]
-    assert "DATABASE_URL" in migrate_block.split("\njobs:")[0] or "DATABASE_URL" in migrate_block, (
-        "Migrate job must declare DATABASE_URL in its envs."
+    migrate_block = spec[spec.index("name: migrate"):]
+    assert "DATABASE_URL" in migrate_block, (
+        "Migrate job must declare DATABASE_URL — App Platform does not "
+        "auto-inherit secrets to PRE_DEPLOY jobs."
+    )
+
+
+def test_backend_service_declares_all_required_secrets():
+    """Every SECRET the backend reads at boot MUST appear in the backend
+    service block. Missing-from-spec equals removed-from-live on push,
+    and a backend without JWT_SECRET_KEY crashloops at import time."""
+    spec = APP_SPEC.read_text()
+    services_idx = spec.index("services:")
+    jobs_idx = spec.find("\njobs:", services_idx)
+    services_block = spec[services_idx:jobs_idx if jobs_idx > 0 else len(spec)]
+    backend_idx = services_block.index("- name: backend")
+    next_service = services_block.find("\n  - name:", backend_idx + 1)
+    backend_block = services_block[backend_idx:next_service if next_service > 0 else len(services_block)]
+
+    required = [
+        "DATABASE_URL",
+        "REDIS_URL",
+        "JWT_SECRET_KEY",
+        "MFA_ENCRYPTION_KEY",
+        "MAILGUN_API_KEY",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+    ]
+    missing = [k for k in required if f"key: {k}" not in backend_block]
+    assert not missing, (
+        f"Backend service is missing required secret declarations: {missing}. "
+        "Any SECRET not in this spec will be removed on next deploy. "
+        "Pull the encrypted EV[...] value from `doctl apps spec get` and add it."
     )


### PR DESCRIPTION
## Summary
PR #88 made `.do/app.yaml` the real source of truth on deploy. That worked, but exposed a latent gap: the file only declared `DATABASE_URL` on the migrate job and **none of the backend service's other secrets**. On the first post-merge deploy the v2 action pushed the file as-is, App Platform read "not in spec" as "remove", and JWT_SECRET_KEY (plus REDIS_URL, MFA_ENCRYPTION_KEY, MAILGUN_API_KEY, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET) got wiped. Backend crashlooped at import on a placeholder JWT secret.

Production was restored manually via `doctl apps update --spec` from a preserved snapshot. This PR makes the spec self-sufficient so the workflow never strips secrets again.

## Changes
- **`.do/app.yaml`**: declare every backend service env (secret and plain) with its encrypted `EV[...]` reference. App Platform encrypts SECRET values with the app's per-app key the moment they're saved and only ever surfaces the encrypted blob — `doctl apps spec get` returns `EV[...]`, never plaintext. Committing the blob is safe AND required: any SECRET not in the spec is removed on push. Adds `DATABASE_URL`, `REDIS_URL`, `JWT_SECRET_KEY`, `MFA_ENCRYPTION_KEY`, `MAILGUN_API_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, plus the missing plain envs (`APP_URL`, `BACKEND_CORS_ORIGINS`, `MAILGUN_DOMAIN`, `EMAIL_FROM`), the frontend `health_check`, and `DATABASE_URL` on the migrate job. The file's header comment documents the convention shift and how to re-issue blobs from `doctl apps spec get`.
- **`.github/workflows/deploy.yml`**: drop `app_name`. The v2 action's `createSpec` (deploy/main.go) prefers `app_name` when both inputs are set and silently ignores `app_spec_location` — which made the spec push from the prior PR a no-op. With only `app_spec_location`, the action reads the file and picks up the app via its top-level `name:` field.
- **`backend/tests/test_deploy_workflow.py`**: re-added (was removed in the revert) and extended to four guards locking down every invariant we've broken in production:
  1. workflow pushes the spec (`app_spec_location` set, `app_name` absent).
  2. spec declares a PRE_DEPLOY migrate job.
  3. migrate job binds `DATABASE_URL`.
  4. backend service declares every required SECRET.

## Rebase
Rebased onto current `main` (PR #87 + #88 already merged). Took our branch's wording on the conflicting comment blocks and test refactor; functional content unchanged.

## Public vs private DB hostnames
We tried switching `DATABASE_URL` and `REDIS_URL` to the private DO hostnames (`private-pfv-mysql-...` / `private-pfv-redis-...`) directly, but `aiomysql` couldn't reach the private host — App Platform components only get private-VPC routing to managed DBs through a `databases:` resource block in the spec, not by hard-coding the private hostname into the connection string. (Also: `?ssl-mode=REQUIRED` query param breaks aiomysql; the app's `database.py` already builds the SSL context based on port `:25060`.)

This PR therefore keeps the **current public-hostname `EV[...]` blobs** that production is running on right now. Switching to private networking is a separate follow-up that needs:
- A `databases:` block in `.do/app.yaml` declaring `pfv-mysql` and `pfv-redis` as managed resources.
- `DATABASE_URL` rewritten as `mysql+aiomysql://${pfv-mysql.USERNAME}:${pfv-mysql.PASSWORD}@${pfv-mysql.HOSTNAME}:${pfv-mysql.PORT}/${pfv-mysql.DATABASE}` so the driver prefix is right.
- `REDIS_URL` similarly composed with `rediss://` (the `${pfv-redis.DATABASE_URL}` default may not include TLS scheme).
- Validation against a preview app first, since each failed prod push triggers an auto-rollback.

## Verification
- 55/55 backend tests pass; YAML parses; all 7 backend secrets resolve to encrypted values; frontend `health_check` is set; migrate job declares both `APP_ENV` and `DATABASE_URL`.
- After merge: workflow runs → action pushes the file → DO sees the same secrets it already has and preserves them → migrate job runs (no-op since 025 is already applied) → backend rolls out with all envs intact.