### PR TITLE
fix(infra): commit domains: block so workflow can't strip custom domain

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,5 +1,14 @@
 name: pfv
 region: ams
+# Custom domain MUST stay declared here. With `app_spec_location` driving
+# every deploy, anything missing from this file is removed from the live
+# app on push — same failure mode as missing SECRET envs. Stripping the
+# domain breaks Cloudflare's origin TLS handshake and takes the public
+# site down even when the components are healthy (we hit that on the
+# 2026-04-25 PR #89 merge).
+domains:
+  - domain: app.thebetterdecision.com
+    type: PRIMARY
 features:
   - buildpack-stack=ubuntu-22
 ingress:

--- a/backend/tests/test_deploy_workflow.py
+++ b/backend/tests/test_deploy_workflow.py
@@ -59,6 +59,23 @@ def test_migrate_job_binds_database_url():
     )
 
 
+def test_app_spec_declares_custom_domain():
+    """The `app_spec_location` workflow path strips anything not in the
+    file — same trap as missing SECRET envs. Without the `domains:` block
+    the custom domain falls off the live app, Cloudflare's origin TLS
+    handshake fails, and the public site goes dark even though backend
+    and frontend components are healthy. (Hit on PR #89 merge,
+    2026-04-25.)"""
+    spec = APP_SPEC.read_text()
+    assert "domain: app.thebetterdecision.com" in spec, (
+        "Spec must declare app.thebetterdecision.com as a domain — "
+        "anything not in this file is removed from the live app on push."
+    )
+    assert "type: PRIMARY" in spec, (
+        "Custom domain must be marked PRIMARY for ingress routing."
+    )
+
+
 def test_backend_service_declares_all_required_secrets():
     """Every SECRET the backend reads at boot MUST appear in the backend
     service block. Missing-from-spec equals removed-from-live on push,


### PR DESCRIPTION
## Summary
PR #89 stopped the workflow from wiping SECRETs, but exposed the same trap one layer up: `.do/app.yaml` had no `domains:` block, so the merge push detached `app.thebetterdecision.com` from the app. Components stayed healthy (DO direct ingress returned 200) but Cloudflare's origin TLS handshake to the now-detached domain failed and the public site went dark.

Hotfix: declare the domain in the file + lock it down with a regression test.

Production has been restored via `doctl apps update --spec` from a preserved snapshot that still had the domains block. This PR mirrors that block into the repo so the next merge doesn't recreate the outage.

## Changes
- **`.do/app.yaml`**: add `domains: [{domain: app.thebetterdecision.com, type: PRIMARY}]` at the top with a comment noting why missing-from-spec means stripped-from-live under the `app_spec_location` push model.
- **`backend/tests/test_deploy_workflow.py`**: add `test_app_spec_declares_custom_domain` — the fifth guard against this class of failure.

## Verification
- 5/5 deploy-workflow guards pass.
- YAML parses with the expected `domains:` / `services:` / `jobs:` shape.
- Live spec already has the domain restored via the manual doctl push; merging this PR will re-push the same shape with no further drift.