### PR TITLE
chore: ignore local IDE tooling and skip release on .gitignore changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - "**/*.md"
       - ".github/workflows/**"
       - ".superpowers/**"
+      - ".gitignore"
       - "LICENSE"
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ mysql_data/
 .claude/
 .superpowers/
 .playwright-mcp/
+.cursor/
+.mcp.json
 # docs/ is intentionally kept out of the repo until we start a real user-
 # facing documentation / manual effort. Design decision records and
 # planning artifacts live in ~/.claude/projects/<slug>/specs/ (local).


### PR DESCRIPTION
## Summary
- Add `.cursor/` and `.mcp.json` to `.gitignore` so personal Cursor and Claude Code MCP config no longer appear as untracked.
- Add `.gitignore` to `release.yml` `paths-ignore` so this PR (and future gitignore-only changes) do not trigger a release/version bump.

`deploy.yml` already restricts to `backend/`, `frontend/`, `nginx/`, `.do/`, `docker-compose*.yml`, and `Dockerfile*`, so it will not fire on this change.