### PR TITLE
chore: migrate release workflow to semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,86 +3,27 @@ name: Release
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
-      - "**/*.md"
-      - ".github/workflows/**"
-      - ".superpowers/**"
-      - ".gitignore"
-      - "LICENSE"
 
 permissions:
   contents: write
+  issues: read
+  pull-requests: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Get latest tag
-        id: latest_tag
-        run: |
-          tag=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-          if [ -z "$tag" ]; then
-            echo "tag=v0.0.0" >> "$GITHUB_OUTPUT"
-            echo "No existing tags, starting from v0.0.0"
-          else
-            echo "tag=$tag" >> "$GITHUB_OUTPUT"
-            echo "Latest tag: $tag"
-          fi
-
-      - name: Determine next version
-        id: next_version
-        run: |
-          current="${{ steps.latest_tag.outputs.tag }}"
-          current="${current#v}"
-          IFS='.' read -r major minor patch <<< "$current"
-
-          # Get commits since last tag (or all commits if no tag)
-          if git rev-parse "v${current}" >/dev/null 2>&1; then
-            commits=$(git log "v${current}..HEAD" --oneline)
-          else
-            commits=$(git log --oneline -20)
-          fi
-
-          echo "Commits since last release:"
-          echo "$commits"
-
-          # Determine bump type from conventional commits
-          if echo "$commits" | grep -qiE '^[a-f0-9]+ .*BREAKING CHANGE|^[a-f0-9]+ [a-z]+!:'; then
-            major=$((major + 1)); minor=0; patch=0
-            bump="major"
-          elif echo "$commits" | grep -qiE '^[a-f0-9]+ feat'; then
-            minor=$((minor + 1)); patch=0
-            bump="minor"
-          else
-            patch=$((patch + 1))
-            bump="patch"
-          fi
-
-          version="v${major}.${minor}.${patch}"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "bump=$bump" >> "$GITHUB_OUTPUT"
-          echo "Bump: $bump -> $version"
-
-      - name: Create release
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v6
+        with:
+          semantic_version: 24
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@8
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          version="${{ steps.next_version.outputs.version }}"
-          previous="${{ steps.latest_tag.outputs.tag }}"
-
-          if [ "$previous" = "v0.0.0" ]; then
-            notes_flag="--generate-notes"
-          else
-            notes_flag="--generate-notes --notes-start-tag $previous"
-          fi
-
-          gh release create "$version" \
-            --title "$version" \
-            --target main \
-            $notes_flag
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,8 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+    ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary
Replaces the ~80-line custom bash version-bumping logic in `release.yml` with [`cycjimmy/semantic-release-action@v6`](https://github.com/cycjimmy/semantic-release-action) and a small `.releaserc.json` config.

External behavior is unchanged: a GitHub release per version bump on push to `main`, with auto-generated notes. The win is replacing brittle bash regex with the conventional-commits preset, which correctly handles scopes, multi-line `BREAKING CHANGE` footers, and revert commits.

## Configuration choice
- **Option B (GitHub-releases-only):** no `CHANGELOG.md` committed back to the repo — release notes live on the `/releases` page. Avoids the PAT requirement that `@semantic-release/git` would have on a protected branch.
- Upgrading to Option A (full `CHANGELOG.md` with PAT) is tracked in the roadmap as low-priority tech debt.

## Notes
- Plugins are explicitly listed in `.releaserc.json` to exclude the default `@semantic-release/npm` (this repo doesn't publish to npm).
- `paths-ignore` is removed — semantic-release already no-ops when no `feat`/`fix`/`perf`/`!:` commit exists since the last tag.
- This PR overlaps with #91 only in `release.yml`. Either merges first cleanly: if #91 lands first, the rebase here is a trivial "take this version" since the file is rewritten.