### PR TITLE
fix(db): pool_pre_ping + pool_recycle to survive DO network idle drops

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -20,10 +20,16 @@ def _build_connect_args() -> dict:
     return {}
 
 
+# DO's network layer silently drops idle TCP to managed MySQL after ~10 min,
+# but the server-side wait_timeout is 8 hours — so without pre_ping the pool
+# hands out dead sockets and the next query fails with "Lost connection
+# during query" (error 2013). Recycle well below the network idle threshold.
 engine = create_async_engine(
     settings.database_url,
     echo=False,
     connect_args=_build_connect_args(),
+    pool_pre_ping=True,
+    pool_recycle=1800,
 )
 
 async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)


### PR DESCRIPTION
## Summary

The Google SSO 500 reported today turned out to be unrelated to the avatar_url fix from migration 025. Production is at revision 025 and `users.avatar_url` is VARCHAR(2048) as expected, so that earlier fix is intact.

The real bug is a stale connection pool. Same `OperationalError (2013, 'Lost connection to MySQL server during query')` has been hitting multiple endpoints over multiple days:

- Apr 27 11:40 → `/api/v1/auth/status`
- Apr 28 06:15 → `/api/v1/auth/me`
- Apr 28 15:33 → `/api/v1/auth/status`
- Apr 29 07:00 → `/api/v1/auth/google/callback`

Gaps of 9–19h between requests, with idle backend connections sitting `Sleep` in the MySQL processlist. DO's network layer silently RSTs idle TCP after ~10 min, but the server-side `wait_timeout` is 8 hours, so the SQLAlchemy pool hands out dead sockets and the next query fails.

The engine in `backend/app/database.py` had no `pool_pre_ping` or `pool_recycle` (unchanged since the SSL-support commit).

## Change

- `pool_pre_ping=True` — cheap validation before each checkout, transparent reconnect on dead sockets
- `pool_recycle=1800` — proactively recycle at 30 min, well below the network idle threshold and far below the 8h `wait_timeout`