### PR TITLE
fix(dashboard): read real forecast_plans, drop synthetic /api/v1/forecast

### DIFF
--- a/backend/app/routers/forecast_plans.py
+++ b/backend/app/routers/forecast_plans.py
@@ -27,6 +27,18 @@ async def get_plan(
     return await svc.get_or_create_plan(db, current_user.org_id, period_start=period_start)
 
 
+@router.get("/current", response_model=ForecastPlanResponse | None)
+async def get_current_plan(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    period_start: datetime.date | None = Query(default=None),
+):
+    """Read-only fetch — returns the plan for the period or null. Never
+    creates a draft as a side effect. The Dashboard uses this so loading
+    it doesn't auto-spawn empty plans in the DB."""
+    return await svc.get_plan_for_period(db, current_user.org_id, period_start=period_start)
+
+
 @router.post("/populate", response_model=ForecastPlanResponse)
 async def populate_plan(
     current_user: User = Depends(get_current_user),

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -240,6 +240,30 @@ async def get_or_create_plan(
     return await _build_response(db, org_id, plan)
 
 
+async def get_plan_for_period(
+    db: AsyncSession, org_id: int, period_start: datetime.date | None = None,
+) -> ForecastPlanResponse | None:
+    """Read-only: return the plan for a period, or None if none exists.
+
+    Unlike get_or_create_plan, this does NOT auto-create a draft when no
+    plan is present. The Dashboard reads through this so that visiting it
+    doesn't pollute the database with empty drafts. The Forecasts page
+    keeps using get_or_create_plan because users land there to set one up.
+    """
+    period = await resolve_period(db, org_id, period_start)
+    result = await db.execute(
+        select(ForecastPlan).where(
+            ForecastPlan.org_id == org_id,
+            ForecastPlan.billing_period_id == period.id,
+        )
+    )
+    plan = result.scalar_one_or_none()
+    if plan is None:
+        return None
+    await db.refresh(plan, ["billing_period", "items"])
+    return await _build_response(db, org_id, plan)
+
+
 async def populate_from_sources(
     db: AsyncSession, org_id: int, period_start: datetime.date | None = None,
 ) -> ForecastPlanResponse:

--- a/backend/tests/services/test_forecast_plan_get_plan.py
+++ b/backend/tests/services/test_forecast_plan_get_plan.py
@@ -1,0 +1,128 @@
+"""Tests for forecast_plan_service.get_plan_for_period — pins the
+read-only behavior the Dashboard relies on. The function must never
+auto-create a draft, and must hand back the existing plan with items
+when one is present.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.billing import BillingPeriod
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import (
+    ForecastItemType,
+    ForecastPlan,
+    ForecastPlanItem,
+    ItemSource,
+    PlanStatus,
+)
+from app.models.user import Organization
+from app.services import forecast_plan_service
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_org_and_period(factory: async_sessionmaker[AsyncSession]) -> dict:
+    org_id = 1
+    start = datetime.date(2026, 4, 1)
+    async with factory() as db:
+        db.add(Organization(id=org_id, name="org", billing_cycle_day=1))
+        await db.commit()
+        bp = BillingPeriod(org_id=org_id, start_date=start, end_date=None)
+        db.add(bp)
+        await db.commit()
+        return {"org_id": org_id, "period_start": start, "period_id": bp.id}
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_plan_exists(session_factory):
+    seed = await _seed_org_and_period(session_factory)
+
+    async with session_factory() as db:
+        result = await forecast_plan_service.get_plan_for_period(
+            db, org_id=seed["org_id"], period_start=seed["period_start"],
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_does_not_auto_create_plan_on_read(session_factory):
+    """Calling get_plan_for_period must not insert any forecast_plans rows.
+
+    The whole point of this function vs get_or_create_plan is that
+    Dashboard reads stay side-effect-free.
+    """
+    seed = await _seed_org_and_period(session_factory)
+
+    async with session_factory() as db:
+        for _ in range(3):
+            await forecast_plan_service.get_plan_for_period(
+                db, org_id=seed["org_id"], period_start=seed["period_start"],
+            )
+
+    async with session_factory() as db:
+        rows = (await db.execute(select(ForecastPlan))).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_returns_plan_with_items_when_present(session_factory):
+    seed = await _seed_org_and_period(session_factory)
+
+    async with session_factory() as db:
+        master = Category(
+            org_id=seed["org_id"], name="Groceries",
+            slug="groceries", type=CategoryType.EXPENSE,
+        )
+        db.add(master)
+        await db.commit()
+
+        plan = ForecastPlan(
+            org_id=seed["org_id"], billing_period_id=seed["period_id"],
+            status=PlanStatus.DRAFT,
+        )
+        db.add(plan)
+        await db.commit()
+        item = ForecastPlanItem(
+            plan_id=plan.id, org_id=seed["org_id"], category_id=master.id,
+            type=ForecastItemType.EXPENSE, planned_amount=Decimal("500"),
+            source=ItemSource.MANUAL,
+        )
+        db.add(item)
+        await db.commit()
+
+    async with session_factory() as db:
+        result = await forecast_plan_service.get_plan_for_period(
+            db, org_id=seed["org_id"], period_start=seed["period_start"],
+        )
+
+    assert result is not None
+    assert result.status == "draft"
+    assert result.period_start == seed["period_start"]
+    assert len(result.items) == 1
+    assert result.items[0].category_name == "Groceries"
+    assert result.items[0].planned_amount == Decimal("500")
+    assert result.items[0].actual_amount == Decimal("0")
+    assert result.total_planned_expense == Decimal("500")

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -136,9 +136,6 @@ export default function DashboardPage() {
     if (bds) setBudgets(bds);
     // null is a valid response (no plan yet) — set state so empty-state UI renders.
     if (p === 0) setForecast(fc ?? null);
-    // Successful reload — clear any stale error from a prior failed attempt
-    // (e.g. the brief window before realPeriodStart was loaded).
-    setError("");
     setFetching(false);
   }, [monthFrom, monthTo, realPeriodStart]);
 
@@ -156,7 +153,13 @@ export default function DashboardPage() {
   }, [loading, user, loadRefs]);
 
   useEffect(() => {
-    if (!loading && user) {
+    // Gate the period-scoped load on a real billing period being in
+    // state. Two reasons: (a) the pre-refs request would race the real
+    // one and could overwrite transactions/forecast/budgets state with
+    // a calendar-fallback window if it resolved out of order; (b) it
+    // would always fail anyway against the strict resolve_period for
+    // salary-cycle orgs whose period doesn't start on the 1st.
+    if (!loading && user && realPeriodStart) {
       setFetching(true);
       // Same class of bug as the loadRefs catch above: a failed
       // transaction fetch used to clear the spinner and vanish. Now
@@ -166,7 +169,7 @@ export default function DashboardPage() {
         setFetching(false);
       });
     }
-  }, [loading, user, loadTransactions, page]);
+  }, [loading, user, loadTransactions, page, realPeriodStart]);
 
   function handleTypeChange(t: "income" | "expense") {
     setFormType(t);

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -14,20 +14,30 @@ import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveCo
 import CategorySelect from "@/components/ui/CategorySelect";
 import type { Account, BillingPeriod, Budget, Category, Transaction } from "@/lib/types";
 
-interface Forecast {
+interface ForecastPlanItem {
+  id: number;
+  plan_id: number;
+  category_id: number;
+  category_name: string;
+  parent_id: number | null;
+  type: "income" | "expense";
+  planned_amount: string;
+  source: "manual" | "recurring" | "history";
+  actual_amount: string;
+  variance: string;
+}
+
+interface ForecastPlan {
+  id: number;
+  billing_period_id: number;
   period_start: string;
-  period_end: string;
-  executed_income: string;
-  executed_expense: string;
-  executed_net: string;
-  pending_income: string;
-  pending_expense: string;
-  recurring_income: string;
-  recurring_expense: string;
-  forecast_income: string;
-  forecast_expense: string;
-  forecast_net: string;
-  categories: { category_id: number; category_name: string; executed: string; pending: string; recurring: string; forecast: string }[];
+  period_end: string | null;
+  status: "draft" | "active";
+  total_planned_income: string;
+  total_planned_expense: string;
+  total_actual_income: string;
+  total_actual_expense: string;
+  items: ForecastPlanItem[];
 }
 
 const PAGE_SIZE = 10;
@@ -43,7 +53,7 @@ export default function DashboardPage() {
   const [periods, setPeriods] = useState<BillingPeriod[]>([]);
   const [billingCycleDay, setBillingCycleDay] = useState(user?.billing_cycle_day ?? 1);
   const [periodIdx, setPeriodIdx] = useState(0);
-  const [forecast, setForecast] = useState<Forecast | null>(null);
+  const [forecast, setForecast] = useState<ForecastPlan | null>(null);
   const [fetching, setFetching] = useState(true);
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -100,20 +110,21 @@ export default function DashboardPage() {
 
   const loadTransactions = useCallback(async (p: number) => {
     const budgetUrl = monthFrom ? `/api/v1/budgets?period_start=${monthFrom}` : "/api/v1/budgets";
-    const forecastUrl = monthFrom ? `/api/v1/forecast?period_start=${monthFrom}` : "/api/v1/forecast";
+    const forecastUrl = monthFrom ? `/api/v1/forecast-plans/current?period_start=${monthFrom}` : "/api/v1/forecast-plans/current";
     const dateFilter = `date_from=${monthFrom}${monthTo ? `&date_to=${monthTo}` : ""}`;
     const [pageData, allData, bds, fc] = await Promise.all([
       apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
       p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?limit=200&${dateFilter}`) : null,
       p === 0 ? apiFetch<Budget[]>(budgetUrl) : null,
-      p === 0 ? apiFetch<Forecast>(forecastUrl) : null,
+      p === 0 ? apiFetch<ForecastPlan | null>(forecastUrl) : null,
     ]);
     const page_txs = pageData ?? [];
     setHasMore(page_txs.length > PAGE_SIZE);
     setTransactions(page_txs.slice(0, PAGE_SIZE));
     if (allData) setAllTransactions(allData);
     if (bds) setBudgets(bds);
-    if (fc) setForecast(fc);
+    // null is a valid response (no plan yet) — set state so empty-state UI renders.
+    if (p === 0) setForecast(fc ?? null);
     setFetching(false);
   }, [monthFrom, monthTo]);
 
@@ -474,31 +485,39 @@ export default function DashboardPage() {
             {/* Forecast */}
             <div className={`${card} p-5`}>
               <h2 className={`mb-4 ${cardTitle}`}>Forecast</h2>
-              {forecast ? (
-                <>
-                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Income</p>
-                      <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_income)}</p>
-                      {Number(forecast.pending_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_income)} pending</p>}
-                      {Number(forecast.recurring_income) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_income)} recurring</p>}
+              {forecast ? (() => {
+                const plannedIncome = Number(forecast.total_planned_income);
+                const plannedExpense = Number(forecast.total_planned_expense);
+                const actualIncome = Number(forecast.total_actual_income);
+                const actualExpense = Number(forecast.total_actual_expense);
+                const plannedNet = plannedIncome - plannedExpense;
+                return (
+                  <>
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                      <div>
+                        <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Income (planned)</p>
+                        <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(plannedIncome)}</p>
+                        {actualIncome > 0 && <p className="text-[10px] text-text-muted">{formatAmount(actualIncome)} actual</p>}
+                      </div>
+                      <div>
+                        <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Expenses (planned)</p>
+                        <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(plannedExpense)}</p>
+                        {actualExpense > 0 && <p className="text-[10px] text-text-muted">{formatAmount(actualExpense)} actual</p>}
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Expenses</p>
-                      <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(forecast.forecast_expense)}</p>
-                      {Number(forecast.pending_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.pending_expense)} pending</p>}
-                      {Number(forecast.recurring_expense) > 0 && <p className="text-[10px] text-text-muted">+{formatAmount(forecast.recurring_expense)} recurring</p>}
+                    <div className="mt-4 pt-3 border-t border-border-subtle">
+                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Projected Net</p>
+                      <p className={`mt-1 font-display text-2xl tabular-nums ${plannedNet >= 0 ? "text-accent" : "text-danger"}`}>
+                        {plannedNet >= 0 ? "+" : ""}{formatAmount(plannedNet)}
+                      </p>
                     </div>
-                  </div>
-                  <div className="mt-4 pt-3 border-t border-border-subtle">
-                    <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Projected Net</p>
-                    <p className={`mt-1 font-display text-2xl tabular-nums ${Number(forecast.forecast_net) >= 0 ? "text-accent" : "text-danger"}`}>
-                      {Number(forecast.forecast_net) >= 0 ? "+" : ""}{formatAmount(forecast.forecast_net)}
-                    </p>
-                  </div>
-                </>
-              ) : (
-                <p className="text-sm text-text-muted py-4">No forecast data</p>
+                  </>
+                );
+              })() : (
+                <div className="py-4 text-center">
+                  <p className="text-sm text-text-muted mb-2">No forecast for this period yet.</p>
+                  <Link href="/forecast-plans" className="text-sm text-accent hover:text-accent-hover">Set up a forecast →</Link>
+                </div>
               )}
             </div>
           </div>
@@ -650,45 +669,53 @@ export default function DashboardPage() {
             {/* Forecast comparison — planned vs actual per category */}
             <div className={`${card} overflow-hidden p-5`}>
               <h2 className={`mb-3 ${cardTitle}`}>Forecast by Category</h2>
-              {forecast && forecast.categories.length > 0 ? (
-                <div style={{ height: Math.max(Math.min(forecast.categories.length, 8) * 32, 100) }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={forecast.categories.slice(0, 8).map((c) => ({
-                        name: c.category_name.length > 12 ? c.category_name.slice(0, 12) + "…" : c.category_name,
-                        planned: Number(c.forecast),
-                        actual: Number(c.executed),
-                      }))}
-                      layout="vertical"
-                      margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
-                    >
-                      <XAxis type="number" hide />
-                      <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
-                      <Tooltip
-                        formatter={(v, name) => [
-                          formatAmount(Number(v)),
-                          name === "planned" ? <span style={{ color: "#D4A64A" }}>Planned</span> : <span style={{ color: "#4ade80" }}>Actual</span>,
-                        ]}
-                        contentStyle={{ fontSize: "11px" }}
-                      />
-                      <Bar dataKey="planned" fill="#D4A64A" radius={[4, 4, 4, 4]} animationDuration={600}
-                        cursor="pointer"
-                        onClick={(_, idx) => {
-                          const name = forecast?.categories[idx]?.category_name;
-                          if (name) setChartFilter(chartFilter === name ? null : name);
-                        }}
-                      />
-                      <Bar dataKey="actual" fill="#4ade80" radius={[4, 4, 4, 4]} animationDuration={600}>
-                        {forecast.categories.slice(0, 8).map((c, i) => (
-                          <Cell key={i} fill={Number(c.executed) > Number(c.forecast) ? "#f87171" : "#4ade80"} />
-                        ))}
-                      </Bar>
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              ) : (
-                <p className="text-sm text-text-muted py-6 text-center">No forecast data</p>
-              )}
+              {(() => {
+                const expenseItems = forecast?.items.filter((it) => it.type === "expense") ?? [];
+                if (forecast && expenseItems.length > 0) {
+                  return (
+                    <div style={{ height: Math.max(Math.min(expenseItems.length, 8) * 32, 100) }}>
+                      <ResponsiveContainer width="100%" height="100%">
+                        <BarChart
+                          data={expenseItems.slice(0, 8).map((it) => ({
+                            name: it.category_name.length > 12 ? it.category_name.slice(0, 12) + "…" : it.category_name,
+                            planned: Number(it.planned_amount),
+                            actual: Number(it.actual_amount),
+                          }))}
+                          layout="vertical"
+                          margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
+                        >
+                          <XAxis type="number" hide />
+                          <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
+                          <Tooltip
+                            formatter={(v, name) => [
+                              formatAmount(Number(v)),
+                              name === "planned" ? <span style={{ color: "#D4A64A" }}>Planned</span> : <span style={{ color: "#4ade80" }}>Actual</span>,
+                            ]}
+                            contentStyle={{ fontSize: "11px" }}
+                          />
+                          <Bar dataKey="planned" fill="#D4A64A" radius={[4, 4, 4, 4]} animationDuration={600}
+                            cursor="pointer"
+                            onClick={(_, idx) => {
+                              const name = expenseItems[idx]?.category_name;
+                              if (name) setChartFilter(chartFilter === name ? null : name);
+                            }}
+                          />
+                          <Bar dataKey="actual" fill="#4ade80" radius={[4, 4, 4, 4]} animationDuration={600}>
+                            {expenseItems.slice(0, 8).map((it, i) => (
+                              <Cell key={i} fill={Number(it.actual_amount) > Number(it.planned_amount) ? "#f87171" : "#4ade80"} />
+                            ))}
+                          </Bar>
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  );
+                }
+                return (
+                  <p className="text-sm text-text-muted py-6 text-center">
+                    No forecast yet. <Link href="/forecast-plans" className="text-accent">Set one up</Link>.
+                  </p>
+                );
+              })()}
               <div className="mt-2 flex gap-3 text-[10px] text-text-muted">
                 <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Planned</span>
                 <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#4ade80" }} /> Under plan</span>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -79,9 +79,15 @@ export default function DashboardPage() {
   const [dashSortField, setDashSortField] = useState<"date" | "description" | "amount">("date");
   const [dashSortDir, setDashSortDir] = useState<"asc" | "desc">("desc");
 
-  // Selected period (navigate with arrows)
+  // Selected period (navigate with arrows). On first paint before
+  // loadRefs() finishes this is null — distinguish that from "we have a
+  // real period" so we don't query period-scoped endpoints with a
+  // calendar-month fallback that the backend won't recognize.
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : period;
-  const monthFrom = selectedPeriod?.start_date ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
+  const realPeriodStart: string | null = selectedPeriod?.start_date ?? null;
+  // monthFrom drives transaction date filters (which don't go through
+  // resolve_period), so the calendar fallback is fine there.
+  const monthFrom = realPeriodStart ?? formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
   // For open periods, compute expected end from billing cycle day
   const monthTo =
     selectedPeriod?.end_date
@@ -109,8 +115,13 @@ export default function DashboardPage() {
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {
-    const budgetUrl = monthFrom ? `/api/v1/budgets?period_start=${monthFrom}` : "/api/v1/budgets";
-    const forecastUrl = monthFrom ? `/api/v1/forecast-plans/current?period_start=${monthFrom}` : "/api/v1/forecast-plans/current";
+    // Omit period_start until refs have loaded a real billing period.
+    // /api/v1/budgets and /api/v1/forecast-plans/current both resolve to
+    // the current open period when period_start is absent — and the
+    // strict resolver rejects calendar-month dates that don't match a
+    // BillingPeriod row (salary-cycle orgs start mid-month).
+    const budgetUrl = realPeriodStart ? `/api/v1/budgets?period_start=${realPeriodStart}` : "/api/v1/budgets";
+    const forecastUrl = realPeriodStart ? `/api/v1/forecast-plans/current?period_start=${realPeriodStart}` : "/api/v1/forecast-plans/current";
     const dateFilter = `date_from=${monthFrom}${monthTo ? `&date_to=${monthTo}` : ""}`;
     const [pageData, allData, bds, fc] = await Promise.all([
       apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
@@ -125,8 +136,11 @@ export default function DashboardPage() {
     if (bds) setBudgets(bds);
     // null is a valid response (no plan yet) — set state so empty-state UI renders.
     if (p === 0) setForecast(fc ?? null);
+    // Successful reload — clear any stale error from a prior failed attempt
+    // (e.g. the brief window before realPeriodStart was loaded).
+    setError("");
     setFetching(false);
-  }, [monthFrom, monthTo]);
+  }, [monthFrom, monthTo, realPeriodStart]);
 
   useEffect(() => {
     if (!loading && user) {
@@ -506,7 +520,7 @@ export default function DashboardPage() {
                       </div>
                     </div>
                     <div className="mt-4 pt-3 border-t border-border-subtle">
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Projected Net</p>
+                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Planned Net</p>
                       <p className={`mt-1 font-display text-2xl tabular-nums ${plannedNet >= 0 ? "text-accent" : "text-danger"}`}>
                         {plannedNet >= 0 ? "+" : ""}{formatAmount(plannedNet)}
                       </p>


### PR DESCRIPTION
## Summary

Step 2 of the Budget vs Forecast 1.0 plan (Option C+, decided 2026-04-30 — see \`project_budget_forecast_decision.md\`). Removes the visible contradiction where the Dashboard showed a "phantom forecast" synthesized from transactions while the Forecasts page maintained an entirely separate persisted plan that never reached the dashboard.

PR #96 was the prerequisite that aligned ForecastPlan actuals to the same rules budget spent already used (\`settled_date\` + transfer exclusion). This PR can rewire safely because the numbers will now match.

## Backend

- \`forecast_plan_service.get_plan_for_period\` — read-only query returning the plan for the period or \`None\`. Unlike \`get_or_create_plan\` it never inserts a draft, so a Dashboard page-load no longer pollutes the DB with empty rows.
- \`GET /api/v1/forecast-plans/current\` — endpoint over the new function. Returns \`ForecastPlanResponse | None\`. The existing \`GET /api/v1/forecast-plans\` is left alone because the Forecasts page legitimately wants the create-on-read behavior.

## Frontend

- Dashboard stops calling \`/api/v1/forecast\` (the synthetic endpoint).
- Forecast tile now shows planned income/expense + actual underneath + projected net (planned_income - planned_expense).
- "Forecast by Category" chart filters to expense items only (matches the "spending vs plan" intent it always had — the synthetic endpoint also only fed it expense data, just via a different code path).
- Both empty states CTA into \`/forecast-plans\` so the user can create a plan or copy from a previous period.

## Side effect (intentional)

The phantom-forecast bug from \`project_forecast_bugs_2026_04_26.md\` falls out as a consequence — the dashboard no longer synthesizes anything from transactions, so the subcategory bleed is gone too. Both bugs from that note close with this PR.

## Tests

- 3 new tests pin the read-only contract: returns \`None\` when no plan, does not auto-create on repeat reads, returns plan + items + actuals when present.
- 64 backend / 29 frontend pass.