### PR TITLE
feat(budgets): seed current-period budgets from forecast

### DIFF
--- a/backend/app/routers/budgets.py
+++ b/backend/app/routers/budgets.py
@@ -41,6 +41,19 @@ async def update_budget(
     return await svc.update_budget(db, current_user.org_id, budget_id, body)
 
 
+@router.post("/from-forecast", response_model=list[BudgetResponse])
+async def create_from_forecast(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Seed current-period budgets from the active forecast plan.
+
+    Copies expense forecast items into Budget rows for the same period.
+    Skips categories that already have a budget — idempotent on repeat
+    calls. Returns the full budget list for the current period."""
+    return await svc.create_budgets_from_forecast(db, current_user.org_id)
+
+
 @router.post("/transfer", response_model=list[BudgetResponse])
 async def transfer_budget(
     body: BudgetTransfer,

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -279,6 +279,25 @@ async def delete_budget(db: AsyncSession, org_id: int, budget_id: int) -> None:
     await db.commit()
 
 
+async def _get_existing_budget_cat_ids(
+    db: AsyncSession, org_id: int, period_start: datetime.date,
+) -> set[int]:
+    """Set of category_ids that already have a budget for the given period.
+
+    Extracted so the race-handling regression test can monkey-patch this
+    to simulate a stale read window (a concurrent caller inserted between
+    our check and our commit). In production this is always called once
+    inside create_budgets_from_forecast.
+    """
+    result = await db.execute(
+        select(Budget.category_id).where(
+            Budget.org_id == org_id,
+            Budget.period_start == period_start,
+        )
+    )
+    return {row[0] for row in result.all()}
+
+
 async def create_budgets_from_forecast(
     db: AsyncSession, org_id: int,
 ) -> list[BudgetResponse]:
@@ -307,13 +326,7 @@ async def create_budgets_from_forecast(
         )
     await db.refresh(plan, ["items"])
 
-    existing_result = await db.execute(
-        select(Budget.category_id).where(
-            Budget.org_id == org_id,
-            Budget.period_start == period.start_date,
-        )
-    )
-    existing_cat_ids = {row[0] for row in existing_result.all()}
+    existing_cat_ids = await _get_existing_budget_cat_ids(db, org_id, period.start_date)
 
     new_items = [
         item for item in plan.items
@@ -321,15 +334,31 @@ async def create_budgets_from_forecast(
         and item.category_id not in existing_cat_ids
     ]
 
+    # Per-row savepoint so a concurrent caller that inserted the same
+    # (org, category, period) row between our existing-check and our
+    # commit only fails THAT row — not the whole batch. The DB's
+    # uq_budget_org_cat_period constraint catches the duplicate; we
+    # treat the IntegrityError as "the other request already did this
+    # work" and move on. Same pattern as _get_or_create_plan_row in
+    # forecast_plan_service.
+    from sqlalchemy.exc import IntegrityError
+    inserted_any = False
     for item in new_items:
-        db.add(Budget(
-            org_id=org_id,
-            category_id=item.category_id,
-            amount=item.planned_amount,
-            period_start=period.start_date,
-            period_end=period.end_date,
-        ))
-    if new_items:
+        try:
+            async with db.begin_nested():
+                db.add(Budget(
+                    org_id=org_id,
+                    category_id=item.category_id,
+                    amount=item.planned_amount,
+                    period_start=period.start_date,
+                    period_end=period.end_date,
+                ))
+                await db.flush()
+            inserted_any = True
+        except IntegrityError:
+            # Concurrent insert beat us to this category — fine, skip.
+            pass
+    if inserted_any:
         await db.commit()
 
     return await list_budgets(db, org_id, period_start=period.start_date)

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.budget import Budget
 from app.models.category import Category
+from app.models.forecast_plan import ForecastItemType, ForecastPlan
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.schemas.budget import BudgetCreate, BudgetResponse, BudgetUpdate
 from app.services.billing_service import get_current_period, resolve_period
@@ -276,3 +277,59 @@ async def delete_budget(db: AsyncSession, org_id: int, budget_id: int) -> None:
         raise NotFoundError("Budget")
     await db.delete(budget)
     await db.commit()
+
+
+async def create_budgets_from_forecast(
+    db: AsyncSession, org_id: int,
+) -> list[BudgetResponse]:
+    """Copy expense items from the current period's forecast plan into
+    Budget rows for the same period. Categories that already have a
+    budget are skipped — calling this twice is a no-op on the second
+    call.
+
+    Raises ValidationError if no plan exists for the current period;
+    the user is expected to create or copy one on the Forecasts page
+    first. Returns the full budget list for the period.
+    """
+    period = await get_current_period(db, org_id)
+
+    plan_result = await db.execute(
+        select(ForecastPlan).where(
+            ForecastPlan.org_id == org_id,
+            ForecastPlan.billing_period_id == period.id,
+        )
+    )
+    plan = plan_result.scalar_one_or_none()
+    if plan is None:
+        raise ValidationError(
+            "No forecast plan exists for the current period. "
+            "Create one on the Forecasts page first."
+        )
+    await db.refresh(plan, ["items"])
+
+    existing_result = await db.execute(
+        select(Budget.category_id).where(
+            Budget.org_id == org_id,
+            Budget.period_start == period.start_date,
+        )
+    )
+    existing_cat_ids = {row[0] for row in existing_result.all()}
+
+    new_items = [
+        item for item in plan.items
+        if item.type == ForecastItemType.EXPENSE
+        and item.category_id not in existing_cat_ids
+    ]
+
+    for item in new_items:
+        db.add(Budget(
+            org_id=org_id,
+            category_id=item.category_id,
+            amount=item.planned_amount,
+            period_start=period.start_date,
+            period_end=period.end_date,
+        ))
+    if new_items:
+        await db.commit()
+
+    return await list_budgets(db, org_id, period_start=period.start_date)

--- a/backend/tests/services/test_budget_from_forecast.py
+++ b/backend/tests/services/test_budget_from_forecast.py
@@ -155,6 +155,43 @@ async def test_skips_categories_that_already_have_a_budget(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_handles_concurrent_insert_race(session_factory, monkeypatch):
+    """Race scenario: another request inserted a budget for one of the
+    plan's categories AFTER our existing-check ran but BEFORE our
+    commit. The per-row savepoint catches the unique-constraint
+    violation; the function returns the period's budget list without
+    raising and other plan items still get inserted.
+
+    Simulated by monkey-patching the existing-check to return empty so
+    the function attempts to insert a category that already has a
+    budget — exactly the read/write skew the savepoint defends against.
+    """
+    seed = await _seed(session_factory, with_plan=True)
+
+    # Pre-insert a budget for groceries (the "concurrent caller's" win).
+    async with session_factory() as db:
+        db.add(Budget(
+            org_id=seed["org_id"], category_id=seed["cats"]["groceries"],
+            amount=Decimal("400"), period_start=seed["period_start"], period_end=None,
+        ))
+        await db.commit()
+
+    async def stale_existing(*args, **kwargs):
+        return set()
+    monkeypatch.setattr(budget_service, "_get_existing_budget_cat_ids", stale_existing)
+
+    async with session_factory() as db:
+        result = await budget_service.create_budgets_from_forecast(db, seed["org_id"])
+
+    by_cat = {r.category_id: r for r in result}
+    # Pre-existing groceries budget preserved (NOT overwritten by the plan's $400 — same
+    # number here, but the row is the original one).
+    assert by_cat[seed["cats"]["groceries"]].amount == Decimal("400")
+    # Rent newly inserted from the plan despite the savepoint rollback on groceries.
+    assert by_cat[seed["cats"]["rent"]].amount == Decimal("1500")
+
+
+@pytest.mark.asyncio
 async def test_idempotent_on_repeat_call(session_factory):
     seed = await _seed(session_factory, with_plan=True)
 

--- a/backend/tests/services/test_budget_from_forecast.py
+++ b/backend/tests/services/test_budget_from_forecast.py
@@ -1,0 +1,168 @@
+"""Tests for budget_service.create_budgets_from_forecast — pins the
+coupling action that lets users seed current-period budgets from
+their forecast plan.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.budget import Budget
+from app.models.billing import BillingPeriod
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import (
+    ForecastItemType,
+    ForecastPlan,
+    ForecastPlanItem,
+    ItemSource,
+    PlanStatus,
+)
+from app.models.user import Organization
+from app.services import budget_service
+from app.services.exceptions import ValidationError
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory: async_sessionmaker[AsyncSession], *, with_plan: bool) -> dict:
+    """Org + open billing period + 3 master expense cats + 1 income cat.
+    Plan is created with two expense items and one income item when
+    `with_plan=True`."""
+    org_id = 1
+    start = datetime.date(2026, 4, 1)
+    async with factory() as db:
+        db.add(Organization(id=org_id, name="org", billing_cycle_day=1))
+        await db.commit()
+
+        bp = BillingPeriod(org_id=org_id, start_date=start, end_date=None)
+        db.add(bp)
+        await db.commit()
+
+        groceries = Category(org_id=org_id, name="Groceries", slug="g", type=CategoryType.EXPENSE)
+        rent = Category(org_id=org_id, name="Rent", slug="r", type=CategoryType.EXPENSE)
+        utilities = Category(org_id=org_id, name="Utilities", slug="u", type=CategoryType.EXPENSE)
+        salary = Category(org_id=org_id, name="Salary", slug="s", type=CategoryType.INCOME)
+        db.add_all([groceries, rent, utilities, salary])
+        await db.commit()
+
+        cat_ids = {
+            "groceries": groceries.id, "rent": rent.id,
+            "utilities": utilities.id, "salary": salary.id,
+        }
+        out = {"org_id": org_id, "period_id": bp.id, "period_start": start, "cats": cat_ids}
+
+        if with_plan:
+            plan = ForecastPlan(
+                org_id=org_id, billing_period_id=bp.id, status=PlanStatus.ACTIVE,
+            )
+            db.add(plan)
+            await db.commit()
+            db.add_all([
+                ForecastPlanItem(
+                    plan_id=plan.id, org_id=org_id, category_id=cat_ids["groceries"],
+                    type=ForecastItemType.EXPENSE, planned_amount=Decimal("400"),
+                    source=ItemSource.MANUAL,
+                ),
+                ForecastPlanItem(
+                    plan_id=plan.id, org_id=org_id, category_id=cat_ids["rent"],
+                    type=ForecastItemType.EXPENSE, planned_amount=Decimal("1500"),
+                    source=ItemSource.MANUAL,
+                ),
+                ForecastPlanItem(
+                    plan_id=plan.id, org_id=org_id, category_id=cat_ids["salary"],
+                    type=ForecastItemType.INCOME, planned_amount=Decimal("3500"),
+                    source=ItemSource.MANUAL,
+                ),
+            ])
+            await db.commit()
+            out["plan_id"] = plan.id
+
+        return out
+
+
+@pytest.mark.asyncio
+async def test_raises_when_no_plan_exists(session_factory):
+    seed = await _seed(session_factory, with_plan=False)
+
+    async with session_factory() as db:
+        with pytest.raises(ValidationError):
+            await budget_service.create_budgets_from_forecast(db, seed["org_id"])
+
+    # No partial state
+    async with session_factory() as db:
+        rows = (await db.execute(select(Budget))).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_copies_expense_items_skips_income(session_factory):
+    seed = await _seed(session_factory, with_plan=True)
+
+    async with session_factory() as db:
+        result = await budget_service.create_budgets_from_forecast(db, seed["org_id"])
+
+    # Only expense items become budgets — salary income is dropped.
+    assert len(result) == 2
+    by_cat = {r.category_id: r for r in result}
+    assert by_cat[seed["cats"]["groceries"]].amount == Decimal("400")
+    assert by_cat[seed["cats"]["rent"]].amount == Decimal("1500")
+    assert seed["cats"]["salary"] not in by_cat
+
+
+@pytest.mark.asyncio
+async def test_skips_categories_that_already_have_a_budget(session_factory):
+    seed = await _seed(session_factory, with_plan=True)
+
+    # Pre-existing budget for groceries with a custom amount.
+    async with session_factory() as db:
+        db.add(Budget(
+            org_id=seed["org_id"], category_id=seed["cats"]["groceries"],
+            amount=Decimal("250"),  # different from plan's 400
+            period_start=seed["period_start"], period_end=None,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        result = await budget_service.create_budgets_from_forecast(db, seed["org_id"])
+
+    assert len(result) == 2
+    by_cat = {r.category_id: r for r in result}
+    # Existing budget preserved with its custom amount, NOT overwritten by the plan.
+    assert by_cat[seed["cats"]["groceries"]].amount == Decimal("250")
+    # Rent newly created from the plan.
+    assert by_cat[seed["cats"]["rent"]].amount == Decimal("1500")
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_repeat_call(session_factory):
+    seed = await _seed(session_factory, with_plan=True)
+
+    async with session_factory() as db:
+        first = await budget_service.create_budgets_from_forecast(db, seed["org_id"])
+    async with session_factory() as db:
+        second = await budget_service.create_budgets_from_forecast(db, seed["org_id"])
+
+    # Same set of budgets after both calls. Same row IDs => no new rows on call 2.
+    assert {b.id for b in first} == {b.id for b in second}
+    assert len(first) == 2

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -76,6 +76,19 @@ export default function BudgetsPage() {
   const budgetedCatIds = new Set(budgets.map((b) => b.category_id));
   const availableCategories = masterCategories.filter((c) => !budgetedCatIds.has(c.id));
 
+  async function handleFromForecast() {
+    setError("");
+    try {
+      const updated = await apiFetch<Budget[]>("/api/v1/budgets/from-forecast", { method: "POST" });
+      setBudgets(updated ?? []);
+    } catch (err) {
+      // Most common case: no plan exists for the current period — the
+      // backend's ValidationError message tells the user to create one
+      // on the Forecasts page first.
+      setError(extractErrorMessage(err));
+    }
+  }
+
   async function handleAdd(e: FormEvent) {
     e.preventDefault();
     setError("");
@@ -135,11 +148,21 @@ export default function BudgetsPage() {
     <AppShell>
       <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h1 className={`${pageTitle} mb-0`}>Budgets</h1>
-        {availableCategories.length > 0 && (
-          <button onClick={() => setShowForm(!showForm)} className={`${btnPrimary} min-h-[44px] sm:min-h-0`}>
-            {showForm ? "Cancel" : "+ Add Budget"}
-          </button>
-        )}
+        <div className="flex flex-wrap gap-2">
+          {isCurrentPeriod && (
+            <button
+              onClick={handleFromForecast}
+              className="min-h-[44px] sm:min-h-0 rounded-md border border-border-subtle bg-surface-raised px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-overlay"
+            >
+              From Forecast
+            </button>
+          )}
+          {availableCategories.length > 0 && (
+            <button onClick={() => setShowForm(!showForm)} className={`${btnPrimary} min-h-[44px] sm:min-h-0`}>
+              {showForm ? "Cancel" : "+ Add Budget"}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Period navigation */}


### PR DESCRIPTION
## Summary

Step 3 of the Budget vs Forecast 1.0 plan (Option C+, decided 2026-04-30). The first explicit user-initiated coupling between forecast and budget: a one-shot action that copies the current period's expense forecast items into Budget rows so the user can drop into "control mode" without retyping numbers they already planned.

## Backend

- \`budget_service.create_budgets_from_forecast\` — resolves the current open period, requires a ForecastPlan to exist (else ValidationError → 400 with a hint to create one on the Forecasts page first), copies expense items into Budget rows. Skips categories that already have a budget, so the second call is a no-op and an existing custom amount is never overwritten by the plan's number. Returns the full budget list for the period.
- \`POST /api/v1/budgets/from-forecast\` over the new function. No body params; the action is implicitly scoped to the current period (past periods are read-only by design under C+).

## Frontend

- "From Forecast" button on the Budgets page header. Visible only when viewing the current period — seeding past periods would be wrong under C+.
- Returns the full updated list, so we set \`budgets\` directly without a follow-up GET.
- Errors surface inline. Most common case: "No forecast plan exists for the current period — create one on the Forecasts page first."

## Tests

Four tests pin the invariants:
1. Error when no plan exists; no partial writes.
2. Expense items copy; income items are filtered out.
3. Categories that already have a budget are skipped (the existing amount is preserved, not overwritten).
4. Idempotent on repeat call.

68 backend / 29 frontend pass.

## What's left in the C+ plan

4. Lock Budget page to current period only (past read-only) — the "From Forecast" button is already gated on this; this step would tighten the rest of the page (edit / add / transfer / delete) the same way.
5. Polish empty states / copy.