### PR TITLE
feat(budgets): lock Budget page to current period (past read-only)

### DIFF
--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -6,7 +6,7 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { formatAmount } from "@/lib/format";
+import { formatAmount, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import type { BillingPeriod, Budget, Category } from "@/lib/types";
@@ -46,7 +46,10 @@ export default function BudgetsPage() {
       apiFetch<BillingPeriod[]>("/api/v1/settings/billing-periods"),
     ]);
     setCategories(c ?? []);
-    const pl = p ?? [];
+    // Drop future stubs created by Forecasts /ensure-future. The Budget
+    // page is current-period control + past read-only review only.
+    const today = todayISO();
+    const pl = (p ?? []).filter((bp) => bp.start_date <= today);
     setPeriods(pl);
     // Default to current period (open = no end_date), not index 0
     const currentIdx = pl.findIndex((bp) => bp.end_date === null);
@@ -204,7 +207,7 @@ export default function BudgetsPage() {
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
 
-      {showForm && (
+      {showForm && isCurrentPeriod && (
         <div className={`mb-6 ${card} p-6`}>
           <form onSubmit={handleAdd} className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end">
             <div className="w-full sm:flex-1 sm:min-w-[200px]">
@@ -309,7 +312,7 @@ export default function BudgetsPage() {
                 const transferTargets = masterCategories.filter((c) => c.id !== b.category_id);
                 return (
                   <div key={b.id} className="px-6 py-3">
-                    {editingId === b.id ? (
+                    {editingId === b.id && isCurrentPeriod ? (
                       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                         <span className="text-sm font-medium text-text-primary sm:flex-1">{b.category_name}</span>
                         <input type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)}
@@ -345,7 +348,7 @@ export default function BudgetsPage() {
                             )}
                           </div>
                         </div>
-                        {transferringId === b.id && (
+                        {transferringId === b.id && isCurrentPeriod && (
                           <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
                             <select value={transferCategoryId} onChange={(e) => setTransferCategoryId(e.target.value === "" ? "" : Number(e.target.value))} className={`w-full min-w-0 sm:flex-1 sm:basis-40 ${input}`}>
                               <option value="">Select target category</option>
@@ -378,7 +381,7 @@ export default function BudgetsPage() {
         </div>
       )}
       <ConfirmModal
-        open={confirmDeleteId !== null}
+        open={isCurrentPeriod && confirmDeleteId !== null}
         title="Remove Budget"
         message="Remove this budget? This cannot be undone."
         confirmLabel="Remove"

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -71,6 +71,18 @@ export default function BudgetsPage() {
     }
   }, [loading, user, loadBudgets]);
 
+  // C+ plan: all mutations are current-period-only. If the user
+  // navigates to a past period mid-edit, drop any open form/state so
+  // they can't submit against a closed period.
+  useEffect(() => {
+    if (!isCurrentPeriod) {
+      setShowForm(false);
+      setEditingId(null);
+      setTransferringId(null);
+      setConfirmDeleteId(null);
+    }
+  }, [isCurrentPeriod]);
+
   // Master categories that don't have a budget yet
   const masterCategories = categories.filter((c) => c.parent_id === null && c.type === "expense");
   const budgetedCatIds = new Set(budgets.map((b) => b.category_id));
@@ -157,7 +169,7 @@ export default function BudgetsPage() {
               From Forecast
             </button>
           )}
-          {availableCategories.length > 0 && (
+          {isCurrentPeriod && availableCategories.length > 0 && (
             <button onClick={() => setShowForm(!showForm)} className={`${btnPrimary} min-h-[44px] sm:min-h-0`}>
               {showForm ? "Cancel" : "+ Add Budget"}
             </button>
@@ -181,6 +193,12 @@ export default function BudgetsPage() {
           {!isCurrentPeriod && (
             <button onClick={() => { const idx = periods.findIndex((p) => p.end_date === null); if (idx >= 0) setPeriodIdx(idx); }} className="ml-1 rounded-md px-2 py-1 text-[11px] font-medium text-text-muted hover:bg-surface-raised">Today</button>
           )}
+        </div>
+      )}
+
+      {!isCurrentPeriod && periods.length > 0 && (
+        <div className="mb-5 rounded-md border border-border-subtle bg-surface-raised px-4 py-3 text-sm text-text-secondary">
+          This period is closed — read-only.
         </div>
       )}
 
@@ -318,11 +336,13 @@ export default function BudgetsPage() {
                             <span className={`text-xs tabular-nums ${overBudget ? "text-danger" : "text-text-muted"}`}>
                               {b.percent_used}%
                             </span>
-                            <div className="flex flex-wrap gap-2 ml-auto md:ml-0">
-                              <button onClick={() => { setTransferringId(transferringId === b.id ? null : b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Transfer</button>
-                              <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Edit</button>
-                              <button onClick={() => setConfirmDeleteId(b.id)} className="min-h-[44px] text-xs text-text-muted hover:text-danger md:min-h-0">Remove</button>
-                            </div>
+                            {isCurrentPeriod && (
+                              <div className="flex flex-wrap gap-2 ml-auto md:ml-0">
+                                <button onClick={() => { setTransferringId(transferringId === b.id ? null : b.id); setTransferCategoryId(""); setTransferAmount(""); }} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Transfer</button>
+                                <button onClick={() => { setEditingId(b.id); setEditAmount(String(b.amount)); }} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Edit</button>
+                                <button onClick={() => setConfirmDeleteId(b.id)} className="min-h-[44px] text-xs text-text-muted hover:text-danger md:min-h-0">Remove</button>
+                              </div>
+                            )}
                           </div>
                         </div>
                         {transferringId === b.id && (
@@ -347,7 +367,10 @@ export default function BudgetsPage() {
               })}
               {budgets.length === 0 && (
                 <div className="px-6 py-8 text-center text-sm text-text-muted">
-                  No budgets set. Click &quot;+ Add Budget&quot; to allocate spending limits for your categories.
+                  {isCurrentPeriod
+                    ? <>No budgets set. Click &quot;+ Add Budget&quot; to allocate spending limits for your categories.</>
+                    : <>No budgets were set for this period.</>
+                  }
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

Step 4 of the Budget vs Forecast 1.0 plan. The C+ decision said "Budget = current-period control only — past periods stay navigable for review but can't be mutated; future budgeting doesn't exist as a separate surface." This PR enforces that on the Budget page UI.

## Page-level gates on \`isCurrentPeriod\`

- "+ Add Budget" header button hidden on past periods.
- "From Forecast" header button was already correctly gated when it shipped; no change.
- Per-row \`Transfer\` / \`Edit\` / \`Remove\` buttons hidden so the row stays visible (history matters for review) but inert.
- Read-only banner under the period navigation when viewing a past period: "This period is closed — read-only."
- Empty-state copy on past periods drops the "+ Add Budget" hint ("No budgets were set for this period.") since the action isn't available.

## Auto-cancel on period switch

\`useEffect\` watching \`isCurrentPeriod\` clears \`showForm\`, \`editingId\`, \`transferringId\`, and \`confirmDeleteId\` when navigating to a past period mid-edit. Stops a stale Add/Edit form from misleadingly suggesting a closed period can still be modified.

## Scope intentionally limited

No backend change. The mutating endpoints (\`POST\`/\`PUT\`/\`DELETE\` on \`/api/v1/budgets\`) still accept past-period writes — the C+ scope treats this as a UI guard rather than a server-side enforcement. If we later need server-side locking (e.g., once we add admin tools that bypass the UI), tightening the service layer is the obvious follow-up. For the launch promise, the front-door gate is enough.

Suites still green: 69 backend, 29 frontend.

## What's left in the C+ plan

Only step 5: polish empty states / copy across both pages.