### PR TITLE
feat(auth): block local login until email verified (L1.8)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -35,6 +35,7 @@ from app.schemas.auth import (
     MfaSetupResponse,
     MfaVerifyRequest,
     RegisterRequest,
+    ResendVerificationPublicRequest,
     ResetPasswordRequest,
     TokenResponse,
     UsernameCheckResponse,
@@ -272,6 +273,15 @@ async def login(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Account is deactivated",
+        )
+
+    if not user.email_verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "email_not_verified",
+                "message": "Please verify your email to sign in.",
+            },
         )
 
     # If MFA is enabled, return a challenge token instead of access tokens
@@ -540,6 +550,33 @@ async def resend_verification(
     token = create_email_verification_token(current_user.id, current_user.email)
     await send_verification_email(current_user.email, token)
     return {"detail": "Verification email sent"}
+
+
+@router.post("/resend-verification-public")
+@limiter.limit("3/hour")
+async def resend_verification_public(
+    request: Request,
+    body: ResendVerificationPublicRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Unauthenticated resend used by the login screen when an unverified
+    user is blocked by the email gate (L1.8). Returns the same response
+    shape regardless of whether the login matches a real, active,
+    unverified user — no enumeration."""
+    GENERIC_OK = {
+        "detail": "If that account exists and is unverified, a new email has been sent."
+    }
+
+    result = await db.execute(
+        select(User).where(or_(User.username == body.login, User.email == body.login))
+    )
+    user = result.scalar_one_or_none()
+    if user is None or not user.is_active or user.email_verified:
+        return GENERIC_OK
+
+    token = create_email_verification_token(user.id, user.email)
+    await send_verification_email(user.email, token)
+    return GENERIC_OK
 
 
 # ── MFA ─────────────────────────────────────────────────────────────────────

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -29,6 +29,10 @@ class LoginRequest(BaseModel):
     password: str = Field(max_length=128)
 
 
+class ResendVerificationPublicRequest(BaseModel):
+    login: str = Field(min_length=1, max_length=120)
+
+
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"

--- a/backend/tests/auth/test_login_email_gate.py
+++ b/backend/tests/auth/test_login_email_gate.py
@@ -1,0 +1,239 @@
+"""L1.8 — block local login until email is verified.
+
+Pins the new gate on `POST /api/v1/auth/login` and the unauthenticated
+sibling endpoint `POST /api/v1/auth/resend-verification-public` that the
+login screen calls to re-trigger the verification email when the user
+can't get an access token yet.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers import auth as auth_module
+from app.routers.auth import router as auth_router
+from app.security import hash_password
+
+
+PASSWORD = "S3cret-Pass!"
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    """Each test starts with an empty rate-limiter state. Several tests in
+    this file hit `/login` and `/resend-verification-public`, both of
+    which carry rate limits; without resetting they bleed across tests."""
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+@pytest.fixture(autouse=True)
+def stub_send_verification_email(monkeypatch):
+    """Capture verification-email sends without hitting the network. Tests
+    that need to assert on sent mail re-bind the captured list."""
+    sent: list[tuple[str, str]] = []
+
+    async def fake_send(email: str, token: str) -> None:
+        sent.append((email, token))
+
+    monkeypatch.setattr(auth_module, "send_verification_email", fake_send)
+    return sent
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    # slowapi requires the limiter on app.state plus the rate-limit handler
+    # for any decorated route to function under TestClient.
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(
+    factory,
+    *,
+    email_verified: bool,
+    is_active: bool = True,
+    username: str = "alice",
+    email: str = "alice@example.com",
+) -> int:
+    async with factory() as db:
+        org = Organization(name="org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=email,
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=is_active,
+            email_verified=email_verified,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+@pytest.mark.asyncio
+async def test_login_blocks_unverified_local_user_with_structured_detail(
+    session_factory,
+):
+    await _seed_user(session_factory, email_verified=False)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+
+    assert res.status_code == 403
+    assert res.json()["detail"] == {
+        "code": "email_not_verified",
+        "message": "Please verify your email to sign in.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_login_succeeds_for_verified_user(session_factory):
+    await _seed_user(session_factory, email_verified=True)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+
+    assert res.status_code == 200
+    assert "access_token" in res.json()
+
+
+@pytest.mark.asyncio
+async def test_login_deactivated_takes_priority_over_unverified(session_factory):
+    """Deactivated wins over unverified — preserves precedence with the
+    pre-L1.8 handler."""
+    await _seed_user(session_factory, email_verified=False, is_active=False)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+
+    assert res.status_code == 403
+    assert res.json()["detail"] == "Account is deactivated"
+
+
+@pytest.mark.asyncio
+async def test_resend_public_sends_for_unverified_user(
+    session_factory, stub_send_verification_email
+):
+    await _seed_user(session_factory, email_verified=False)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/resend-verification-public",
+            json={"login": "alice"},
+        )
+
+    assert res.status_code == 200
+    assert len(stub_send_verification_email) == 1
+    assert stub_send_verification_email[0][0] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_resend_public_no_op_for_verified_user(
+    session_factory, stub_send_verification_email
+):
+    await _seed_user(session_factory, email_verified=True)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/resend-verification-public",
+            json={"login": "alice@example.com"},
+        )
+
+    # No enumeration — same 200 body whether the user exists, is verified,
+    # or doesn't exist.
+    assert res.status_code == 200
+    assert stub_send_verification_email == []
+
+
+@pytest.mark.asyncio
+async def test_resend_public_no_op_for_unknown_login(
+    session_factory, stub_send_verification_email
+):
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/resend-verification-public",
+            json={"login": "ghost@example.com"},
+        )
+
+    assert res.status_code == 200
+    assert stub_send_verification_email == []
+
+
+@pytest.mark.asyncio
+async def test_resend_public_rate_limit(
+    session_factory, stub_send_verification_email
+):
+    """Limit is `3/hour` per IP — fourth call within the window returns 429."""
+    await _seed_user(session_factory, email_verified=False)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        for _ in range(3):
+            ok = client.post(
+                "/api/v1/auth/resend-verification-public",
+                json={"login": "alice"},
+            )
+            assert ok.status_code == 200
+        throttled = client.post(
+            "/api/v1/auth/resend-verification-public",
+            json={"login": "alice"},
+        )
+
+    assert throttled.status_code == 429

--- a/frontend/components/auth/LoginPageBody.tsx
+++ b/frontend/components/auth/LoginPageBody.tsx
@@ -90,6 +90,12 @@ export default function LoginPageBody() {
               <p>{error}</p>
               {unverifiedLogin && (
                 <div className="mt-2">
+                  <p className="text-xs text-text-muted">
+                    For{" "}
+                    <span className="font-medium text-text-secondary">
+                      {unverifiedLogin}
+                    </span>
+                  </p>
                   {resendState === "sent" ? (
                     <p className="text-xs text-text-muted">
                       Verification email sent. Check your inbox.

--- a/frontend/components/auth/LoginPageBody.tsx
+++ b/frontend/components/auth/LoginPageBody.tsx
@@ -5,8 +5,10 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth, MfaRequiredError } from "@/components/auth/AuthProvider";
 import ThemeToggle from "@/components/ui/ThemeToggle";
-import { apiFetch } from "@/lib/api";
+import { ApiResponseError, apiFetch } from "@/lib/api";
 import { input, label, btnPrimary, btnSecondary, error as errorCls } from "@/lib/styles";
+
+type ResendState = "idle" | "sending" | "sent" | "failed";
 
 export default function LoginPageBody() {
   const { user, login, loading, needsSetup } = useAuth();
@@ -15,6 +17,11 @@ export default function LoginPageBody() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  // Snapshotted at the moment the email-not-verified error fires so the
+  // resend button targets the same login the user actually tried, even
+  // if they edit the input afterward.
+  const [unverifiedLogin, setUnverifiedLogin] = useState<string | null>(null);
+  const [resendState, setResendState] = useState<ResendState>("idle");
 
   useEffect(() => {
     if (!loading && needsSetup) router.replace("/setup");
@@ -24,6 +31,8 @@ export default function LoginPageBody() {
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError("");
+    setUnverifiedLogin(null);
+    setResendState("idle");
     setSubmitting(true);
     try {
       await login(loginId, password);
@@ -34,9 +43,26 @@ export default function LoginPageBody() {
         router.push("/mfa-verify");
         return;
       }
+      if (err instanceof ApiResponseError && err.code === "email_not_verified") {
+        setUnverifiedLogin(loginId);
+      }
       setError(err instanceof Error ? err.message : "Login failed");
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function handleResendVerification() {
+    if (!unverifiedLogin) return;
+    setResendState("sending");
+    try {
+      await apiFetch("/api/v1/auth/resend-verification-public", {
+        method: "POST",
+        body: JSON.stringify({ login: unverifiedLogin }),
+      });
+      setResendState("sent");
+    } catch {
+      setResendState("failed");
     }
   }
 
@@ -59,7 +85,33 @@ export default function LoginPageBody() {
           <p className="mt-1.5 text-sm text-text-muted">Sign in</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-5">
-          {error && <div className={errorCls}>{error}</div>}
+          {error && (
+            <div className={errorCls} role="alert">
+              <p>{error}</p>
+              {unverifiedLogin && (
+                <div className="mt-2">
+                  {resendState === "sent" ? (
+                    <p className="text-xs text-text-muted">
+                      Verification email sent. Check your inbox.
+                    </p>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={handleResendVerification}
+                      disabled={resendState === "sending"}
+                      className="text-xs font-medium text-accent hover:text-accent-hover disabled:opacity-50"
+                    >
+                      {resendState === "sending"
+                        ? "Sending..."
+                        : resendState === "failed"
+                          ? "Send failed — try again"
+                          : "Resend verification email"}
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
           <div>
             <label htmlFor="login-id" className={label}>Email or Username</label>
             <input id="login-id" type="text" required value={loginId} onChange={(e) => setLoginId(e.target.value)} className={input} autoComplete="username" placeholder="you@example.com" />

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -89,6 +89,7 @@ export async function apiFetch<T>(
   if (!res.ok) {
     const body = await res.json().catch(() => ({ detail: res.statusText }));
     let message: string;
+    let code: string | undefined;
     if (Array.isArray(body.detail)) {
       // FastAPI 422 validation error: detail is a list of
       // { loc, msg, type, ... } objects. Flatten to "field: message"
@@ -105,10 +106,21 @@ export async function apiFetch<T>(
         .join("; ");
     } else if (typeof body.detail === "string") {
       message = body.detail;
+    } else if (
+      body.detail &&
+      typeof body.detail === "object" &&
+      typeof (body.detail as { message?: unknown }).message === "string"
+    ) {
+      // Structured error: backend returns { detail: { code, message } }.
+      // Used for the L1.8 email-verified gate so the login screen can
+      // distinguish unverified from deactivated without string matching.
+      const d = body.detail as { code?: unknown; message: string };
+      message = d.message;
+      if (typeof d.code === "string") code = d.code;
     } else {
       message = "Request failed";
     }
-    throw new ApiResponseError(res.status, message);
+    throw new ApiResponseError(res.status, message, code, body.detail);
   }
 
   // 204 No Content
@@ -126,7 +138,9 @@ export function extractErrorMessage(err: unknown, fallback = "Failed"): string {
 export class ApiResponseError extends Error {
   constructor(
     public status: number,
-    message: string
+    message: string,
+    public code?: string,
+    public detail?: unknown
   ) {
     super(message);
     this.name = "ApiResponseError";

--- a/frontend/tests/components/login-page-body.test.tsx
+++ b/frontend/tests/components/login-page-body.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import LoginPageBody from "@/components/auth/LoginPageBody";
+import { ApiResponseError, apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+
+describe("LoginPageBody — email-not-verified flow", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+  const loginMock = vi.fn();
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    loginMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: null,
+      loading: false,
+      needsSetup: false,
+      login: loginMock,
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("snapshots the submitted login so resend uses the value at error time, not the edited value", async () => {
+    loginMock.mockRejectedValue(
+      new ApiResponseError(
+        403,
+        "Please verify your email to sign in.",
+        "email_not_verified",
+        { code: "email_not_verified", message: "Please verify your email to sign in." },
+      ),
+    );
+    apiFetchMock.mockResolvedValue({ detail: "ok" } as never);
+
+    render(<LoginPageBody />);
+
+    const idInput = screen.getByLabelText(/Email or Username/i) as HTMLInputElement;
+    const pwInput = screen.getByLabelText(/Password/i) as HTMLInputElement;
+
+    fireEvent.change(idInput, { target: { value: "alice" } });
+    fireEvent.change(pwInput, { target: { value: "S3cret-Pass!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+    const resendBtn = await screen.findByRole("button", {
+      name: /Resend verification email/i,
+    });
+
+    // User edits the input *after* the error fires.
+    fireEvent.change(idInput, { target: { value: "bob" } });
+
+    fireEvent.click(resendBtn);
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/auth/resend-verification-public",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ login: "alice" }),
+        }),
+      );
+    });
+  });
+
+  it("does not show the resend button for non-email-verification errors", async () => {
+    loginMock.mockRejectedValue(
+      new ApiResponseError(401, "Invalid credentials"),
+    );
+
+    render(<LoginPageBody />);
+
+    fireEvent.change(screen.getByLabelText(/Email or Username/i), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(screen.getByLabelText(/Password/i), {
+      target: { value: "wrong" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+    await screen.findByText(/Invalid credentials/i);
+
+    expect(
+      screen.queryByRole("button", { name: /Resend verification email/i }),
+    ).toBeNull();
+  });
+});

--- a/frontend/tests/components/login-page-body.test.tsx
+++ b/frontend/tests/components/login-page-body.test.tsx
@@ -89,6 +89,36 @@ describe("LoginPageBody — email-not-verified flow", () => {
     });
   });
 
+  it("shows the login the resend action targets, even if the user edits the input", async () => {
+    loginMock.mockRejectedValue(
+      new ApiResponseError(
+        403,
+        "Please verify your email to sign in.",
+        "email_not_verified",
+        { code: "email_not_verified", message: "Please verify your email to sign in." },
+      ),
+    );
+
+    render(<LoginPageBody />);
+
+    const idInput = screen.getByLabelText(/Email or Username/i) as HTMLInputElement;
+    const pwInput = screen.getByLabelText(/Password/i) as HTMLInputElement;
+
+    fireEvent.change(idInput, { target: { value: "alice" } });
+    fireEvent.change(pwInput, { target: { value: "S3cret-Pass!" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+    await screen.findByRole("button", { name: /Resend verification email/i });
+
+    // The targeted login is rendered visibly next to the resend button.
+    expect(screen.getByText("alice")).toBeTruthy();
+
+    // User edits the input after the error fires; the displayed target stays "alice".
+    fireEvent.change(idInput, { target: { value: "bob" } });
+    expect(screen.getByText("alice")).toBeTruthy();
+    expect(screen.queryByText("bob")).toBeNull();
+  });
+
   it("does not show the resend button for non-email-verification errors", async () => {
     loginMock.mockRejectedValue(
       new ApiResponseError(401, "Invalid credentials"),

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -130,6 +130,34 @@ describe("apiFetch", () => {
 
     expect(result).toBeUndefined();
   });
+
+  it("surfaces structured detail on the thrown ApiResponseError", async () => {
+    // L1.8: backend returns { detail: { code, message } } for the
+    // email-verified gate so the login screen can branch without
+    // string-matching the message.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          detail: {
+            code: "email_not_verified",
+            message: "Please verify your email to sign in.",
+          },
+        },
+        { status: 403 },
+      ),
+    );
+
+    await expect(apiFetch("/api/v1/auth/login", { method: "POST" })).rejects.toMatchObject({
+      name: "ApiResponseError",
+      status: 403,
+      code: "email_not_verified",
+      message: "Please verify your email to sign in.",
+      detail: {
+        code: "email_not_verified",
+        message: "Please verify your email to sign in.",
+      },
+    });
+  });
 });
 
 


### PR DESCRIPTION
## Summary

Local-account login now requires `email_verified=True`. Returns a structured 403 `{detail: {code, message}}` so the login UI can surface a "Resend verification email" button instead of a dead-end error. SSO is untouched (Google's `verified_email` gate already enforces this on `/auth/google/callback`).

New unauthenticated endpoint `POST /api/v1/auth/resend-verification-public` accepts the same `{login}` the user typed, no-enumeration response (same 200 body whether the account exists / is verified / doesn't exist), rate-limited 3/hour per IP. The existing authed `/resend-verification` is unchanged (still used by Settings → Security).

`ApiResponseError` now carries optional `code` and `detail` so callers can branch without string-matching the message. The login screen snapshots the submitted login at the moment the error fires, so the resend button targets the originally-typed value even if the user edits the input afterward.

## Tests

- 7 new backend (`backend/tests/auth/test_login_email_gate.py`): gate fires for unverified, succeeds for verified, deactivated wins precedence, resend sends mail for valid unverified user, no-enumeration for verified/unknown, rate limit at 4th request.
- 1 new frontend (`frontend/tests/lib/api.test.ts`): structured detail surfaces `code` + `detail` on `ApiResponseError`.
- 2 new frontend (`frontend/tests/components/login-page-body.test.tsx`): resend uses snapshotted login (not the edited input), resend button absent for non-email-verification errors.

Backend: 76 passed (was 69). Frontend: 32 passed (was 29).

## Pre-merge ops check

Run against prod once before approving:

```sql
SELECT COUNT(*) FROM users WHERE email_verified = 0 AND is_active = 1;
SELECT id, email, username, created_at
FROM users
WHERE email_verified = 0 AND is_active = 1
ORDER BY created_at;
```

- 0 rows → ship.
- > 0 known testers → flip them with a guarded `UPDATE` first.
- > 0 unknowns → backfill migration before merge.

## Out of scope (follow-ups)

- Per-account / per-login resend throttle (today is per-IP only). Defensible against distributed resend abuse.
- L4.4 admin "manually verify email" action — natural fit when User management lands.