### PR TITLE
fix(transactions): clean amount seeding + rebalance edit-row columns (L3.9)

### DIFF
--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -7,7 +7,7 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { formatAmount, formatLocalDate, todayISO } from "@/lib/format";
+import { formatAmount, formatLocalDate, toEditAmount, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import CategorySelect from "@/components/ui/CategorySelect";
 import type { Account, Category, Transaction } from "@/lib/types";
@@ -318,7 +318,7 @@ function TransactionsPageContent() {
   function startEdit(tx: Transaction) {
     setEditingId(tx.id);
     setEditDesc(tx.description);
-    setEditAmount(String(tx.amount));
+    setEditAmount(toEditAmount(tx.amount));
     setEditType(tx.type);
     setEditStatus(tx.status);
     setEditDate(tx.date);
@@ -635,9 +635,9 @@ function TransactionsPageContent() {
                   { field: "date" as const, label: "Date", span: "col-span-2", align: "" },
                   { field: "description" as const, label: "Description", span: "col-span-2", align: "" },
                   { field: "account_name" as const, label: "Account", span: "col-span-2", align: "" },
-                  { field: "category_name" as const, label: "Category", span: "col-span-2", align: "" },
+                  { field: "category_name" as const, label: "Category", span: "col-span-1", align: "" },
                   { field: "status" as const, label: "Status", span: "col-span-1", align: "text-center" },
-                  { field: "amount" as const, label: "Amount", span: "col-span-1", align: "text-right" },
+                  { field: "amount" as const, label: "Amount", span: "col-span-2", align: "text-right" },
                 ]).map((col) => (
                   <button key={col.field} onClick={() => toggleSort(col.field)} className={`${col.span} ${col.align} hover:text-text-primary transition-colors`}>
                     {col.label}{sortField === col.field ? (sortDir === "asc" ? " ↑" : " ↓") : ""}
@@ -670,14 +670,14 @@ function TransactionsPageContent() {
                               className="h-4 w-4"
                             />
                           </span>
-                          <span className="col-span-2"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} /></span>
+                          <span className="col-span-2 min-w-0"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm w-full ${input}`} /></span>
                           <span className="col-span-2"><input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
                           <span className="col-span-2">
                             <select aria-label="Account" value={editAccountId} onChange={(e) => setEditAccountId(e.target.value === "" ? "" : Number(e.target.value))} className={`text-sm ${input}`}>
                               {accounts.map((a) => <option key={a.id} value={a.id}>{a.name}{!a.is_active ? " (inactive)" : ""}</option>)}
                             </select>
                           </span>
-                          <span className="col-span-2">
+                          <span className="col-span-1 min-w-0">
                             <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} />
                           </span>
                           <span className="col-span-1">
@@ -686,12 +686,12 @@ function TransactionsPageContent() {
                               <option value="pending">Pending</option>
                             </select>
                           </span>
-                          <span className="col-span-1 flex gap-1">
-                            <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-[11px] w-14 ${input}`}>
+                          <span className="col-span-2 flex gap-1 min-w-0">
+                            <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-[11px] !w-14 shrink-0 ${input}`}>
                               <option value="expense">-</option>
                               <option value="income">+</option>
                             </select>
-                            <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm w-20 ${input}`} />
+                            <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm flex-1 min-w-0 ${input}`} />
                           </span>
                           <span className="col-span-1 flex justify-end gap-2">
                             <button onClick={handleSaveEdit} className="text-xs text-accent hover:text-accent-hover">Save</button>
@@ -711,12 +711,12 @@ function TransactionsPageContent() {
                           </span>
                           <span className="col-span-2 text-sm tabular-nums text-text-secondary">{tx.date}</span>
                           <span className="col-span-2 text-sm text-text-primary">{tx.description}</span>
-                          <span className="col-span-2 text-sm text-text-secondary">
+                          <span className="col-span-2 text-sm text-text-secondary truncate">
                             {isTransfer && linkedTx
                               ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
                               : tx.account_name}
                           </span>
-                          <span className="col-span-2 text-sm text-text-secondary">{tx.category_name}</span>
+                          <span className="col-span-1 text-sm text-text-secondary truncate">{tx.category_name}</span>
                           <span className="col-span-1 text-center">
                             {isTransfer ? (
                               <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
@@ -736,7 +736,7 @@ function TransactionsPageContent() {
                               </button>
                             )}
                           </span>
-                          <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
+                          <span className={`col-span-2 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
                             {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                           </span>
                           <span className="col-span-1 flex justify-end gap-2">

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -5,6 +5,15 @@ export function formatAmount(value: number | string): string {
   });
 }
 
+// Plain "DDDD.DD" string for seeding `<input type="number">` controlled
+// values. The runtime shape of `Transaction.amount` is the JSON-string
+// from a Pydantic Decimal (`"19.99"`), but the TypeScript type lies and
+// claims `number`; either way, going through `Number(...).toFixed(2)`
+// produces a clean two-decimal string the input can render exactly.
+export function toEditAmount(value: number | string): string {
+  return Number(value).toFixed(2);
+}
+
 export function formatLocalDate(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");

--- a/frontend/tests/lib/format.test.ts
+++ b/frontend/tests/lib/format.test.ts
@@ -1,7 +1,17 @@
-import { formatAmount, formatLocalDate, todayISO } from "@/lib/format";
+import { formatAmount, formatLocalDate, toEditAmount, todayISO } from "@/lib/format";
 
 
 describe("format utilities", () => {
+  it("normalizes amounts for inline-edit seeding to a clean two-decimal string", () => {
+    // L3.9 — defense for the case where the JSON-string Decimal arrives as
+    // an IEEE 754 number (19.989999...): the inline-edit input must seed
+    // "19.99" exactly so a save-without-touch round-trips cleanly.
+    expect(toEditAmount("19.99")).toBe("19.99");
+    expect(toEditAmount(19.989999771118164)).toBe("19.99");
+    expect(toEditAmount(0)).toBe("0.00");
+    expect(toEditAmount("100")).toBe("100.00");
+  });
+
   it("formats numeric strings and negative values with two decimals", () => {
     const formatter = new Intl.NumberFormat(undefined, {
       minimumFractionDigits: 2,


### PR DESCRIPTION
## Summary

Two related fixes to the inline transaction edit on \`/transactions\`:

**1. Amount seeding hygiene.** \`startEdit\` now seeds \`editAmount\` via a new \`toEditAmount(value)\` helper = \`Number(value).toFixed(2)\`. The backend serializes Decimal as a JSON string (\`\"19.99\"\`), but the TypeScript \`Transaction.amount: number\` declaration combined with \`<input type=\"number\">\`'s float round-trip lets IEEE 754 noise leak into the spinbutton's \`aria-valuenow\` (\`19.989999...\`) when seeding via \`String(tx.amount)\`. Going through \`Number → toFixed(2)\` makes the input show \"19.99\" exactly. Verified live: a no-touch save now PUTs \`amount: \"19.99\"\` cleanly.

**2. Edit-row layout.** Before this fix the type select + amount input were crammed into a single \`col-span-1\` cell that collapsed under Save/Cancel, leaving the amount input ~26 px wide (effectively invisible). Reasoned-through rebalance:

| Cell | Before | After |
|---|---|---|
| Date | col-span-2 | col-span-2 *(unchanged — native picker needs ~130 px)* |
| Description | col-span-2 | col-span-2 |
| Account | col-span-2 | col-span-2 |
| Category | col-span-2 | **col-span-1** with \`truncate\` (\"Food & Dini…\") |
| Status | col-span-1 | col-span-1 |
| Type + Amount | col-span-1 | **col-span-2** |
| Actions | col-span-1 | col-span-1 |

The shared \`input\` class includes \`w-full\`, which was overriding the type select's \`w-14\`. Forced via \`!w-14\` so the type stays compact and amount gets the rest of the flex.

## Tests

- \`frontend/tests/lib/format.test.ts\`: pins \`toEditAmount(19.989999771118164) === \"19.99\"\` plus the trivial round-trip cases. Frontend suite 30/30 (was 29).

## Screenshots

After: amount input visible at ~129 px, type select at 56 px, date input at 189 px showing the full \`30/04/2026\` plus the calendar icon.

## Out of scope (deferred)

- The TypeScript \`Transaction.amount: number\` declaration is still wrong (runtime value is the JSON string). Every call site already wraps with \`Number()\` or \`formatAmount()\`, so the lie is contained — but the type should eventually flip to \`string\`. Audit-and-flip is a separate PR.