### PR TITLE
feat(admin): org management control plane (L4.3)

### DIFF
--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -22,6 +22,8 @@ from app.models.user import User
 Permission = Literal[
     "admin.view",
     "plans.manage",
+    "orgs.view",
+    "orgs.manage",
 ]
 
 
@@ -30,6 +32,8 @@ Permission = Literal[
 ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "admin.view",
     "plans.manage",
+    "orgs.view",
+    "orgs.manage",
 })
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, auth, budgets, categories, forecast, forecast_plans, import_router, org_members, plans, recurring, settings, subscriptions, transactions, users
+from app.routers import account_types, accounts, admin, admin_orgs, auth, budgets, categories, forecast, forecast_plans, import_router, org_members, plans, recurring, settings, subscriptions, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -123,6 +123,7 @@ app.include_router(import_router.router)
 app.include_router(subscriptions.router)
 app.include_router(plans.router)
 app.include_router(admin.router)
+app.include_router(admin_orgs.router)
 app.include_router(org_members.router)
 
 

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -1,0 +1,147 @@
+"""Admin org-management router (L4.3).
+
+Mounted at `/api/v1/admin/orgs`. Auth via the platform `orgs.view` /
+`orgs.manage` permissions (superadmin short-circuits both today;
+fine-grained roles can land later via L4.8 without touching this
+file).
+
+Destructive endpoints (DELETE, PUT subscription) emit a single
+structlog event — prefix `admin.org.*` — so an operator can later
+attribute who did what to whom even before the L4.7 audit table
+exists. FK / SQL diagnostics never bleed into 500 bodies — generic
+message client-side, full detail server-side.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+import structlog
+
+from app.auth.permissions import require_permission
+from app.database import get_db
+from app.models.subscription import SubscriptionStatus
+from app.models.user import User
+from app.schemas.admin_orgs import OrgDeleteRequest, SubscriptionUpdateRequest
+from app.services import admin_orgs_service
+from app.services.exceptions import NotFoundError, ValidationError
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/admin/orgs", tags=["admin-orgs"])
+
+
+@router.get(
+    "",
+    dependencies=[Depends(require_permission("orgs.view"))],
+)
+async def list_orgs(
+    q: str | None = Query(default=None, max_length=120),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+):
+    return await admin_orgs_service.list_orgs(db, q=q, limit=limit, offset=offset)
+
+
+@router.get(
+    "/{org_id}",
+    dependencies=[Depends(require_permission("orgs.view"))],
+)
+async def get_org_detail(org_id: int, db: AsyncSession = Depends(get_db)):
+    try:
+        return await admin_orgs_service.get_org_detail(db, org_id=org_id)
+    except NotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+
+@router.put("/{org_id}/subscription")
+async def update_org_subscription(
+    org_id: int,
+    body: SubscriptionUpdateRequest,
+    current_user: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        # Look up name once for the audit event.
+        detail = await admin_orgs_service.get_org_detail(db, org_id=org_id)
+    except NotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    try:
+        before, after = await admin_orgs_service.update_subscription(
+            db,
+            org_id=org_id,
+            plan_id=body.plan_id,
+            status=SubscriptionStatus(body.status) if body.status else None,
+            trial_end=body.trial_end,
+            current_period_end=body.current_period_end,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    await db.commit()
+
+    await logger.ainfo(
+        "admin.org.subscription.override",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=org_id,
+        target_org_name=detail["name"],
+        before=before,
+        after=after,
+    )
+    return {"before": before, "after": after}
+
+
+@router.delete("/{org_id}")
+async def delete_org(
+    org_id: int,
+    body: OrgDeleteRequest,
+    current_user: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+):
+    if org_id == current_user.org_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot delete your own organization",
+        )
+
+    try:
+        detail = await admin_orgs_service.get_org_detail(db, org_id=org_id)
+    except NotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    if body.confirm_name.strip() != detail["name"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="confirm_name does not match organization name",
+        )
+
+    try:
+        counts = await admin_orgs_service.delete_org_cascade(db, org_id=org_id)
+        await db.commit()
+    except Exception as e:  # noqa: BLE001 — translate to generic 500 + log.
+        await db.rollback()
+        await logger.aerror(
+            "admin.org.delete.failed",
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=detail["name"],
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete organization",
+        )
+
+    await logger.ainfo(
+        "admin.org.delete",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=org_id,
+        target_org_name=detail["name"],
+        deleted_rows_by_table=counts,
+    )
+    return {"deleted": counts}

--- a/backend/app/schemas/admin_orgs.py
+++ b/backend/app/schemas/admin_orgs.py
@@ -1,0 +1,18 @@
+"""Pydantic schemas for L4.3 admin org management."""
+from __future__ import annotations
+
+import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SubscriptionUpdateRequest(BaseModel):
+    plan_id: Optional[int] = None
+    status: Optional[Literal["trialing", "active", "past_due", "canceled"]] = None
+    trial_end: Optional[datetime.date] = None
+    current_period_end: Optional[datetime.date] = None
+
+
+class OrgDeleteRequest(BaseModel):
+    confirm_name: str = Field(min_length=1, max_length=200)

--- a/backend/app/services/admin_orgs_service.py
+++ b/backend/app/services/admin_orgs_service.py
@@ -58,62 +58,81 @@ async def list_orgs(
 ) -> dict:
     """Paginated org list for the admin table.
 
-    `last_user_created_at` is a soft proxy ("Newest member") for
-    activity until L4.7 audit log lands.
+    Served by a single SELECT with LEFT JOIN to subscriptions/plans
+    plus correlated user-count subqueries — bounded query cost
+    regardless of page size. `last_user_created_at` is a soft proxy
+    ("Newest member") for activity until L4.7 audit log lands.
     """
-    base = select(Organization)
-    if q:
-        base = base.where(Organization.name.ilike(f"%{q}%"))
+    user_count_sq = (
+        select(func.count())
+        .select_from(User)
+        .where(User.org_id == Organization.id)
+        .correlate(Organization)
+        .scalar_subquery()
+    )
+    active_user_count_sq = (
+        select(func.count())
+        .select_from(User)
+        .where(User.org_id == Organization.id, User.is_active.is_(True))
+        .correlate(Organization)
+        .scalar_subquery()
+    )
+    newest_member_sq = (
+        select(func.max(User.created_at))
+        .where(User.org_id == Organization.id)
+        .correlate(Organization)
+        .scalar_subquery()
+    )
 
-    total = await db.scalar(
-        select(func.count()).select_from(base.subquery())
-    ) or 0
+    stmt = (
+        select(
+            Organization.id,
+            Organization.name,
+            Organization.created_at,
+            Subscription.status,
+            Subscription.trial_end,
+            Plan.slug,
+            user_count_sq.label("user_count"),
+            active_user_count_sq.label("active_user_count"),
+            newest_member_sq.label("last_user_created_at"),
+        )
+        .select_from(Organization)
+        .outerjoin(Subscription, Subscription.org_id == Organization.id)
+        .outerjoin(Plan, Plan.id == Subscription.plan_id)
+    )
+    if q:
+        stmt = stmt.where(Organization.name.ilike(f"%{q}%"))
+
+    total_stmt = select(func.count()).select_from(Organization)
+    if q:
+        total_stmt = total_stmt.where(Organization.name.ilike(f"%{q}%"))
+    total = (await db.scalar(total_stmt)) or 0
 
     rows = (
         await db.execute(
-            base.order_by(Organization.created_at.desc())
+            stmt.order_by(Organization.created_at.desc())
             .limit(limit)
             .offset(offset)
         )
-    ).scalars().all()
+    ).all()
 
-    items: list[dict] = []
-    for org in rows:
-        sub = (
-            await db.execute(
-                select(Subscription).where(Subscription.org_id == org.id)
-            )
-        ).scalar_one_or_none()
-        plan = None
-        if sub is not None:
-            plan = (
-                await db.execute(select(Plan).where(Plan.id == sub.plan_id))
-            ).scalar_one_or_none()
-        user_count = await db.scalar(
-            select(func.count()).select_from(User).where(User.org_id == org.id)
-        ) or 0
-        active_user_count = await db.scalar(
-            select(func.count())
-            .select_from(User)
-            .where(User.org_id == org.id, User.is_active.is_(True))
-        ) or 0
-        last_user_created_at = await db.scalar(
-            select(func.max(User.created_at)).where(User.org_id == org.id)
-        )
-
-        items.append({
-            "id": org.id,
-            "name": org.name,
-            "plan_slug": plan.slug if plan else None,
-            "subscription_status": sub.status.value if sub else None,
-            "trial_end": sub.trial_end.isoformat() if sub and sub.trial_end else None,
-            "user_count": user_count,
-            "active_user_count": active_user_count,
-            "created_at": org.created_at.isoformat() if org.created_at else None,
+    items = [
+        {
+            "id": row.id,
+            "name": row.name,
+            "plan_slug": row.slug,
+            "subscription_status": row.status.value if row.status else None,
+            "trial_end": row.trial_end.isoformat() if row.trial_end else None,
+            "user_count": row.user_count or 0,
+            "active_user_count": row.active_user_count or 0,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
             "last_user_created_at": (
-                last_user_created_at.isoformat() if last_user_created_at else None
+                row.last_user_created_at.isoformat()
+                if row.last_user_created_at else None
             ),
-        })
+        }
+        for row in rows
+    ]
 
     return {"items": items, "total": total, "limit": limit, "offset": offset}
 

--- a/backend/app/services/admin_orgs_service.py
+++ b/backend/app/services/admin_orgs_service.py
@@ -1,0 +1,317 @@
+"""Admin org-management service (L4.3).
+
+Three concerns live here, kept out of the router so they're testable
+in isolation:
+
+- `list_orgs` / `get_org_detail` — read shapes for the admin UI.
+- `update_subscription` — superadmin-only subscription override.
+- `delete_org_cascade` — removes the org and every row tied to it,
+  in a dependency-safe order. The category self-FK is broken first
+  by nulling `parent_id`, otherwise MySQL's strict FK refuses the
+  bulk DELETE.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Optional
+
+from sqlalchemy import delete, func, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account, AccountType
+from app.models.billing import BillingPeriod
+from app.models.budget import Budget
+from app.models.category import Category
+from app.models.forecast_plan import ForecastPlan, ForecastPlanItem
+from app.models.invitation import Invitation
+from app.models.recurring import RecurringTransaction
+from app.models.settings import OrgSetting
+from app.models.subscription import Plan, Subscription, SubscriptionStatus
+from app.models.transaction import Transaction
+from app.models.user import Organization, User
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+def _serialize_subscription(sub: Optional[Subscription], plan: Optional[Plan]) -> dict:
+    if sub is None:
+        return {}
+    return {
+        "status": sub.status.value,
+        "plan_id": sub.plan_id,
+        "plan_slug": plan.slug if plan else None,
+        "trial_start": sub.trial_start.isoformat() if sub.trial_start else None,
+        "trial_end": sub.trial_end.isoformat() if sub.trial_end else None,
+        "current_period_start": sub.current_period_start.isoformat() if sub.current_period_start else None,
+        "current_period_end": sub.current_period_end.isoformat() if sub.current_period_end else None,
+        "created_at": sub.created_at.isoformat() if sub.created_at else None,
+        "updated_at": sub.updated_at.isoformat() if sub.updated_at else None,
+    }
+
+
+async def list_orgs(
+    db: AsyncSession,
+    *,
+    q: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict:
+    """Paginated org list for the admin table.
+
+    `last_user_created_at` is a soft proxy ("Newest member") for
+    activity until L4.7 audit log lands.
+    """
+    base = select(Organization)
+    if q:
+        base = base.where(Organization.name.ilike(f"%{q}%"))
+
+    total = await db.scalar(
+        select(func.count()).select_from(base.subquery())
+    ) or 0
+
+    rows = (
+        await db.execute(
+            base.order_by(Organization.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+    ).scalars().all()
+
+    items: list[dict] = []
+    for org in rows:
+        sub = (
+            await db.execute(
+                select(Subscription).where(Subscription.org_id == org.id)
+            )
+        ).scalar_one_or_none()
+        plan = None
+        if sub is not None:
+            plan = (
+                await db.execute(select(Plan).where(Plan.id == sub.plan_id))
+            ).scalar_one_or_none()
+        user_count = await db.scalar(
+            select(func.count()).select_from(User).where(User.org_id == org.id)
+        ) or 0
+        active_user_count = await db.scalar(
+            select(func.count())
+            .select_from(User)
+            .where(User.org_id == org.id, User.is_active.is_(True))
+        ) or 0
+        last_user_created_at = await db.scalar(
+            select(func.max(User.created_at)).where(User.org_id == org.id)
+        )
+
+        items.append({
+            "id": org.id,
+            "name": org.name,
+            "plan_slug": plan.slug if plan else None,
+            "subscription_status": sub.status.value if sub else None,
+            "trial_end": sub.trial_end.isoformat() if sub and sub.trial_end else None,
+            "user_count": user_count,
+            "active_user_count": active_user_count,
+            "created_at": org.created_at.isoformat() if org.created_at else None,
+            "last_user_created_at": (
+                last_user_created_at.isoformat() if last_user_created_at else None
+            ),
+        })
+
+    return {"items": items, "total": total, "limit": limit, "offset": offset}
+
+
+async def get_org_detail(db: AsyncSession, *, org_id: int) -> dict:
+    org = (
+        await db.execute(select(Organization).where(Organization.id == org_id))
+    ).scalar_one_or_none()
+    if org is None:
+        raise NotFoundError("Organization")
+
+    sub = (
+        await db.execute(select(Subscription).where(Subscription.org_id == org_id))
+    ).scalar_one_or_none()
+    plan = None
+    if sub is not None:
+        plan = (
+            await db.execute(select(Plan).where(Plan.id == sub.plan_id))
+        ).scalar_one_or_none()
+
+    members = (
+        await db.execute(
+            select(User).where(User.org_id == org_id).order_by(User.username)
+        )
+    ).scalars().all()
+
+    counts = {
+        "transactions": await db.scalar(
+            select(func.count()).select_from(Transaction).where(Transaction.org_id == org_id)
+        ) or 0,
+        "accounts": await db.scalar(
+            select(func.count()).select_from(Account).where(Account.org_id == org_id)
+        ) or 0,
+        "budgets": await db.scalar(
+            select(func.count()).select_from(Budget).where(Budget.org_id == org_id)
+        ) or 0,
+        "forecast_plans": await db.scalar(
+            select(func.count()).select_from(ForecastPlan).where(ForecastPlan.org_id == org_id)
+        ) or 0,
+    }
+
+    return {
+        "id": org.id,
+        "name": org.name,
+        "billing_cycle_day": org.billing_cycle_day,
+        "created_at": org.created_at.isoformat() if org.created_at else None,
+        "subscription": _serialize_subscription(sub, plan),
+        "members": [
+            {
+                "id": u.id, "username": u.username, "email": u.email,
+                "role": u.role.value, "is_active": u.is_active,
+                "email_verified": u.email_verified,
+                "created_at": u.created_at.isoformat() if u.created_at else None,
+            }
+            for u in members
+        ],
+        "counts": counts,
+    }
+
+
+async def update_subscription(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    plan_id: Optional[int] = None,
+    status: Optional[SubscriptionStatus] = None,
+    trial_end: Optional[datetime.date] = None,
+    current_period_end: Optional[datetime.date] = None,
+) -> tuple[dict, dict]:
+    """Apply provided fields to the org's subscription. Returns
+    `(before, after)` dicts containing ONLY the fields that changed —
+    the caller logs this for audit. Raises NotFoundError if the org
+    has no subscription, ValidationError if `plan_id` doesn't exist.
+    """
+    sub = (
+        await db.execute(select(Subscription).where(Subscription.org_id == org_id))
+    ).scalar_one_or_none()
+    if sub is None:
+        raise NotFoundError("Subscription")
+
+    if plan_id is not None:
+        plan = (
+            await db.execute(select(Plan).where(Plan.id == plan_id))
+        ).scalar_one_or_none()
+        if plan is None:
+            raise ValidationError("Unknown plan_id")
+
+    before: dict = {}
+    after: dict = {}
+
+    def _track(field: str, new_value, current):
+        before[field] = (
+            current.isoformat() if hasattr(current, "isoformat") else
+            (current.value if hasattr(current, "value") else current)
+        )
+        after[field] = (
+            new_value.isoformat() if hasattr(new_value, "isoformat") else
+            (new_value.value if hasattr(new_value, "value") else new_value)
+        )
+
+    if plan_id is not None and plan_id != sub.plan_id:
+        _track("plan_id", plan_id, sub.plan_id)
+        sub.plan_id = plan_id
+    if status is not None and status != sub.status:
+        _track("status", status, sub.status)
+        sub.status = status
+    if trial_end is not None and trial_end != sub.trial_end:
+        _track("trial_end", trial_end, sub.trial_end)
+        sub.trial_end = trial_end
+    if current_period_end is not None and current_period_end != sub.current_period_end:
+        _track("current_period_end", current_period_end, sub.current_period_end)
+        sub.current_period_end = current_period_end
+
+    await db.flush()
+    return before, after
+
+
+async def delete_org_cascade(
+    db: AsyncSession, *, org_id: int
+) -> dict[str, int]:
+    """Delete the org and every row that references it.
+
+    Returns a dict of `{table_name: row_count_deleted}` so the caller
+    can log it for audit. Caller commits.
+    """
+    org = (
+        await db.execute(select(Organization).where(Organization.id == org_id))
+    ).scalar_one_or_none()
+    if org is None:
+        raise NotFoundError("Organization")
+
+    counts: dict[str, int] = {}
+
+    # Order matters: delete children before parents.
+    # transactions reference accounts, categories, recurring → first.
+    counts["transactions"] = (
+        await db.execute(delete(Transaction).where(Transaction.org_id == org_id))
+    ).rowcount or 0
+
+    counts["forecast_plan_items"] = (
+        await db.execute(
+            delete(ForecastPlanItem).where(ForecastPlanItem.org_id == org_id)
+        )
+    ).rowcount or 0
+
+    counts["budgets"] = (
+        await db.execute(delete(Budget).where(Budget.org_id == org_id))
+    ).rowcount or 0
+
+    counts["invitations"] = (
+        await db.execute(delete(Invitation).where(Invitation.org_id == org_id))
+    ).rowcount or 0
+
+    counts["recurring_transactions"] = (
+        await db.execute(
+            delete(RecurringTransaction).where(RecurringTransaction.org_id == org_id)
+        )
+    ).rowcount or 0
+
+    counts["forecast_plans"] = (
+        await db.execute(delete(ForecastPlan).where(ForecastPlan.org_id == org_id))
+    ).rowcount or 0
+
+    counts["billing_periods"] = (
+        await db.execute(delete(BillingPeriod).where(BillingPeriod.org_id == org_id))
+    ).rowcount or 0
+
+    counts["accounts"] = (
+        await db.execute(delete(Account).where(Account.org_id == org_id))
+    ).rowcount or 0
+
+    counts["account_types"] = (
+        await db.execute(delete(AccountType).where(AccountType.org_id == org_id))
+    ).rowcount or 0
+
+    # Categories self-reference via parent_id. Break the link before
+    # the bulk DELETE so MySQL's strict FK doesn't refuse.
+    await db.execute(
+        update(Category).where(Category.org_id == org_id).values(parent_id=None)
+    )
+    counts["categories"] = (
+        await db.execute(delete(Category).where(Category.org_id == org_id))
+    ).rowcount or 0
+
+    counts["settings"] = (
+        await db.execute(delete(OrgSetting).where(OrgSetting.org_id == org_id))
+    ).rowcount or 0
+
+    counts["users"] = (
+        await db.execute(delete(User).where(User.org_id == org_id))
+    ).rowcount or 0
+
+    counts["subscriptions"] = (
+        await db.execute(delete(Subscription).where(Subscription.org_id == org_id))
+    ).rowcount or 0
+
+    counts["organizations"] = (
+        await db.execute(delete(Organization).where(Organization.id == org_id))
+    ).rowcount or 0
+
+    return counts

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -45,7 +45,12 @@ def make_client(user: User) -> TestClient:
 
 
 def test_all_permissions_contains_known_platform_permissions() -> None:
-    assert ALL_PERMISSIONS == frozenset({"admin.view", "plans.manage"})
+    assert ALL_PERMISSIONS == frozenset({
+        "admin.view",
+        "plans.manage",
+        "orgs.view",
+        "orgs.manage",
+    })
 
 
 def test_has_permission_grants_everything_to_superadmins() -> None:

--- a/backend/tests/routers/test_admin_orgs.py
+++ b/backend/tests/routers/test_admin_orgs.py
@@ -1,0 +1,258 @@
+"""Router tests for L4.3 admin org management endpoints.
+
+Service-layer behavior is pinned in
+`tests/services/test_admin_orgs_service.py`. This file pins the auth
+gate (superadmin via `orgs.view` / `orgs.manage`), the typed-confirm
+delete contract, the self-org self-protect guard, and the structured
+audit log emissions.
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+import structlog
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization, Role, User
+from app.routers.admin_orgs import router as admin_orgs_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_orgs_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """Two orgs: 'Admin Org' (with the superadmin) and 'Target' (the
+    one we'll act on)."""
+    async with factory() as db:
+        plan = Plan(slug="free", name="Free")
+        db.add(plan)
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target = Organization(name="Target Inc", billing_cycle_day=1)
+        db.add_all([admin_org, target])
+        await db.commit()
+        sa = User(
+            org_id=admin_org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        owner = User(
+            org_id=target.id, username="t_owner",
+            email="t_owner@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, owner])
+        await db.commit()
+        target_sub = Subscription(
+            org_id=target.id, plan_id=plan.id,
+            status=SubscriptionStatus.TRIALING,
+            billing_interval=BillingInterval.MONTHLY,
+            trial_end=datetime.date.today() + datetime.timedelta(days=14),
+        )
+        admin_sub = Subscription(
+            org_id=admin_org.id, plan_id=plan.id,
+            status=SubscriptionStatus.ACTIVE,
+            billing_interval=BillingInterval.MONTHLY,
+        )
+        db.add_all([target_sub, admin_sub])
+        await db.commit()
+        return {
+            "admin_user_id": sa.id,
+            "admin_org_id": admin_org.id,
+            "target_id": target.id,
+            "owner_id": owner.id,
+        }
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+# ── auth gates ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_403_for_non_superadmin(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_200_for_superadmin(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] >= 2
+    names = sorted(item["name"] for item in body["items"])
+    assert "Admin Org" in names and "Target Inc" in names
+
+
+# ── drill-down ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_org_detail_200(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(f"/api/v1/admin/orgs/{seed['target_id']}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["name"] == "Target Inc"
+    assert body["subscription"]["status"] == "trialing"
+    usernames = sorted(m["username"] for m in body["members"])
+    assert usernames == ["t_owner"]
+
+
+@pytest.mark.asyncio
+async def test_get_org_detail_404(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs/99999")
+    assert res.status_code == 404
+
+
+# ── subscription override ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_put_subscription_changes_status(session_factory, caplog):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/subscription",
+            json={"status": "active"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["before"]["status"] == "trialing"
+    assert body["after"]["status"] == "active"
+
+
+# ── delete with typed-confirm ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_org_requires_typed_confirm_name(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.request(
+            "DELETE",
+            f"/api/v1/admin/orgs/{seed['target_id']}",
+            json={"confirm_name": "wrong"},
+        )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_org_succeeds_with_correct_confirm_name(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.request(
+            "DELETE",
+            f"/api/v1/admin/orgs/{seed['target_id']}",
+            json={"confirm_name": "Target Inc"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    # Audit-friendly row counts surfaced in the response.
+    assert body["deleted"]["organizations"] == 1
+    assert body["deleted"]["users"] == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_org_refuses_actor_self_org(session_factory):
+    """Self-protect: superadmin cannot delete the org their account
+    lives in — would lock themselves out."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.request(
+            "DELETE",
+            f"/api/v1/admin/orgs/{seed['admin_org_id']}",
+            json={"confirm_name": "Admin Org"},
+        )
+    assert res.status_code == 409

--- a/backend/tests/services/test_admin_orgs_service.py
+++ b/backend/tests/services/test_admin_orgs_service.py
@@ -273,6 +273,39 @@ async def test_list_orgs_paginates_and_returns_metadata(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_list_orgs_is_not_n_plus_one(session_factory):
+    """Pin the design intent: list_orgs must serve a paged result in a
+    bounded number of SQL round-trips, not one fetch per row. Five
+    orgs at limit=10 should not balloon the cursor count."""
+    for i in range(5):
+        await _seed_full_org(session_factory, name=f"Org{i}")
+
+    queries: list[str] = []
+
+    async with session_factory() as db:
+        bind = db.get_bind()
+        sync_engine = bind.sync_engine if hasattr(bind, "sync_engine") else bind
+
+        @event.listens_for(sync_engine, "before_cursor_execute")
+        def _capture(conn, cursor, statement, params, context, executemany):  # noqa: ARG001
+            stripped = statement.strip().split()[0].upper()
+            if stripped in {"SELECT", "WITH"}:
+                queries.append(statement)
+
+        try:
+            page = await admin_orgs_service.list_orgs(db, limit=10, offset=0)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _capture)
+
+        assert len(page["items"]) == 5
+        # 5 orgs at the previous N+1 implementation = 1 (count) + 1
+        # (orgs) + 5 * 5 (sub, plan, user, active_user, newest) = 27.
+        # Tighten the bound to something a single grouped query can
+        # comfortably stay under.
+        assert len(queries) < 10, f"Too many SELECTs: {len(queries)} → {queries}"
+
+
+@pytest.mark.asyncio
 async def test_list_orgs_search_filters_by_name(session_factory):
     await _seed_full_org(session_factory, name="Acme")
     await _seed_full_org(session_factory, name="Beta")

--- a/backend/tests/services/test_admin_orgs_service.py
+++ b/backend/tests/services/test_admin_orgs_service.py
@@ -1,0 +1,345 @@
+"""Service-layer tests for L4.3 — admin org management.
+
+The fixture enables `PRAGMA foreign_keys=ON` so SQLite enforces
+referential integrity the way MySQL would in prod. Without that,
+deleting a parent table (categories, users, accounts) before its
+children would silently succeed under SQLite while exploding under
+MySQL.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.billing import BillingPeriod
+from app.models.budget import Budget
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import (
+    ForecastItemType,
+    ForecastPlan,
+    ForecastPlanItem,
+    ItemSource,
+    PlanStatus,
+)
+from app.models.invitation import Invitation
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.settings import OrgSetting
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import admin_orgs_service
+from app.services.exceptions import NotFoundError, ValidationError
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    # Enable FK enforcement so SQLite catches violations the way MySQL
+    # would. Without this, parent rows can be deleted while children
+    # still reference them — the test would pass but prod would explode.
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_full_org(factory, *, name: str = "Acme") -> dict:
+    """Build a fully-loaded org so the cascade test exercises every
+    child table that references org_id (or transitively does)."""
+    async with factory() as db:
+        plan = (
+            await db.execute(select(Plan).where(Plan.slug == "free"))
+        ).scalar_one_or_none()
+        if plan is None:
+            plan = Plan(slug="free", name="Free")
+            db.add(plan)
+            await db.commit()
+
+        org = Organization(name=name, billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        owner = User(
+            org_id=org.id, username=f"{name}_owner",
+            email=f"{name}_owner@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        member = User(
+            org_id=org.id, username=f"{name}_member",
+            email=f"{name}_member@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([owner, member])
+        await db.commit()
+
+        sub = Subscription(
+            org_id=org.id, plan_id=plan.id,
+            status=SubscriptionStatus.TRIALING,
+            billing_interval=BillingInterval.MONTHLY,
+            trial_start=datetime.date.today(),
+            trial_end=datetime.date.today() + datetime.timedelta(days=14),
+        )
+        db.add(sub)
+
+        atype = AccountType(org_id=org.id, name="Checking", slug="checking")
+        db.add(atype)
+        await db.commit()
+
+        account = Account(
+            org_id=org.id, account_type_id=atype.id,
+            name="Main", balance=Decimal("100.00"),
+        )
+        master = Category(
+            org_id=org.id, name="Food", slug="food",
+            type=CategoryType.EXPENSE,
+        )
+        db.add_all([account, master])
+        await db.commit()
+
+        # Self-FK row — child category referencing the master. The
+        # cascade must null parent_id before deleting categories or
+        # the FK explodes.
+        sub_cat = Category(
+            org_id=org.id, parent_id=master.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        db.add(sub_cat)
+        bp = BillingPeriod(
+            org_id=org.id,
+            start_date=datetime.date.today().replace(day=1),
+            end_date=None,
+        )
+        db.add(bp)
+        await db.commit()
+
+        recurring = RecurringTransaction(
+            org_id=org.id, account_id=account.id, category_id=master.id,
+            description="Rent", amount=Decimal("1500.00"),
+            type="expense", frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date.today(),
+        )
+        db.add(recurring)
+        await db.commit()
+
+        tx = Transaction(
+            org_id=org.id, account_id=account.id, category_id=master.id,
+            recurring_id=recurring.id,
+            description="Lunch", amount=Decimal("12.34"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.SETTLED,
+            date=datetime.date.today(),
+            settled_date=datetime.date.today(),
+        )
+        budget = Budget(
+            org_id=org.id, category_id=master.id,
+            amount=Decimal("400.00"),
+            period_start=datetime.date.today().replace(day=1),
+        )
+        plan_row = ForecastPlan(
+            org_id=org.id, billing_period_id=bp.id, status=PlanStatus.ACTIVE,
+        )
+        setting = OrgSetting(
+            org_id=org.id, key=f"{name}_setting", value="x",
+        )
+        db.add_all([tx, budget, plan_row, setting])
+        await db.commit()
+
+        plan_item = ForecastPlanItem(
+            plan_id=plan_row.id, org_id=org.id, category_id=master.id,
+            type=ForecastItemType.EXPENSE, source=ItemSource.MANUAL,
+            planned_amount=Decimal("400.00"),
+        )
+        invite = Invitation(
+            org_id=org.id, email=f"invitee_{name}@acme.io",
+            role=Role.MEMBER, open_email=f"invitee_{name}@acme.io",
+            created_by=owner.id,
+            expires_at=datetime.datetime.utcnow() + datetime.timedelta(days=7),
+        )
+        db.add_all([plan_item, invite])
+        await db.commit()
+
+        return {"org_id": org.id, "owner_id": owner.id}
+
+
+async def _count(db, model, **filt) -> int:
+    from sqlalchemy import func
+    stmt = select(func.count()).select_from(model)
+    for k, v in filt.items():
+        stmt = stmt.where(getattr(model, k) == v)
+    return (await db.scalar(stmt)) or 0
+
+
+@pytest.mark.asyncio
+async def test_delete_org_cascade_removes_all_children_and_keeps_other_org(
+    session_factory,
+):
+    target = await _seed_full_org(session_factory, name="Target")
+    keep = await _seed_full_org(session_factory, name="Keep")
+
+    async with session_factory() as db:
+        result = await admin_orgs_service.delete_org_cascade(
+            db, org_id=target["org_id"],
+        )
+        await db.commit()
+
+    # Returned row counts surface what was removed (used by the audit log).
+    assert result["organizations"] == 1
+    assert result["users"] == 2
+    assert result["transactions"] == 1
+    assert result["categories"] == 2  # master + sub
+    # Order isn't asserted — just that every table reports.
+    expected_tables = {
+        "transactions", "forecast_plan_items", "budgets", "invitations",
+        "recurring_transactions", "forecast_plans", "billing_periods",
+        "accounts", "account_types", "categories", "settings", "users",
+        "subscriptions", "organizations",
+    }
+    assert expected_tables <= set(result.keys())
+
+    async with session_factory() as db:
+        # Target gone everywhere.
+        assert await _count(db, Organization, id=target["org_id"]) == 0
+        assert await _count(db, User, org_id=target["org_id"]) == 0
+        assert await _count(db, Transaction, org_id=target["org_id"]) == 0
+        assert await _count(db, Category, org_id=target["org_id"]) == 0
+        assert await _count(db, Subscription, org_id=target["org_id"]) == 0
+        assert await _count(db, Invitation, org_id=target["org_id"]) == 0
+        # Sibling org survives intact.
+        assert await _count(db, Organization, id=keep["org_id"]) == 1
+        assert await _count(db, User, org_id=keep["org_id"]) == 2
+        assert await _count(db, Transaction, org_id=keep["org_id"]) == 1
+        assert await _count(db, Category, org_id=keep["org_id"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_org_404_when_missing(session_factory):
+    async with session_factory() as db:
+        with pytest.raises(NotFoundError):
+            await admin_orgs_service.delete_org_cascade(db, org_id=99999)
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_paginates_and_returns_metadata(session_factory):
+    a = await _seed_full_org(session_factory, name="Alpha")
+    b = await _seed_full_org(session_factory, name="Beta")
+    async with session_factory() as db:
+        page = await admin_orgs_service.list_orgs(db, limit=10, offset=0)
+        # Paginated envelope
+        assert page["total"] >= 2
+        assert page["limit"] == 10
+        assert page["offset"] == 0
+        names = sorted(item["name"] for item in page["items"])
+        assert "Alpha" in names and "Beta" in names
+        # Metadata for one row — pick Alpha
+        alpha = next(item for item in page["items"] if item["name"] == "Alpha")
+        assert alpha["id"] == a["org_id"]
+        assert alpha["user_count"] == 2
+        assert alpha["active_user_count"] == 2
+        # Subscription metadata flows through
+        assert alpha["subscription_status"] == "trialing"
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_search_filters_by_name(session_factory):
+    await _seed_full_org(session_factory, name="Acme")
+    await _seed_full_org(session_factory, name="Beta")
+    async with session_factory() as db:
+        page = await admin_orgs_service.list_orgs(db, q="bet", limit=10, offset=0)
+        names = [item["name"] for item in page["items"]]
+        assert names == ["Beta"]
+
+
+@pytest.mark.asyncio
+async def test_get_org_detail_returns_subscription_members_and_counts(session_factory):
+    target = await _seed_full_org(session_factory, name="Detail")
+    async with session_factory() as db:
+        d = await admin_orgs_service.get_org_detail(db, org_id=target["org_id"])
+        assert d["name"] == "Detail"
+        assert d["subscription"]["status"] == "trialing"
+        assert d["subscription"]["plan_slug"] == "free"
+        # Members include both seeded users.
+        usernames = sorted(m["username"] for m in d["members"])
+        assert usernames == ["Detail_member", "Detail_owner"]
+        # Counts roll up from the seed.
+        assert d["counts"]["transactions"] == 1
+        assert d["counts"]["accounts"] == 1
+        assert d["counts"]["budgets"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_org_detail_404_when_missing(session_factory):
+    async with session_factory() as db:
+        with pytest.raises(NotFoundError):
+            await admin_orgs_service.get_org_detail(db, org_id=99999)
+
+
+@pytest.mark.asyncio
+async def test_update_subscription_changes_only_provided_fields(session_factory):
+    target = await _seed_full_org(session_factory, name="Sub")
+    async with session_factory() as db:
+        before, after = await admin_orgs_service.update_subscription(
+            db,
+            org_id=target["org_id"],
+            status=SubscriptionStatus.ACTIVE,
+            trial_end=datetime.date.today() + datetime.timedelta(days=30),
+        )
+        await db.commit()
+        assert before["status"] == "trialing"
+        assert after["status"] == "active"
+        # Diff also captures the trial_end change.
+        assert before["trial_end"] != after["trial_end"]
+        # Unchanged fields are NOT in either dict.
+        assert "plan_id" not in before
+        assert "plan_id" not in after
+
+
+@pytest.mark.asyncio
+async def test_update_subscription_404_when_missing(session_factory):
+    async with session_factory() as db:
+        with pytest.raises(NotFoundError):
+            await admin_orgs_service.update_subscription(
+                db, org_id=99999, status=SubscriptionStatus.ACTIVE,
+            )
+
+
+@pytest.mark.asyncio
+async def test_update_subscription_rejects_unknown_plan(session_factory):
+    target = await _seed_full_org(session_factory, name="BadPlan")
+    async with session_factory() as db:
+        with pytest.raises(ValidationError):
+            await admin_orgs_service.update_subscription(
+                db, org_id=target["org_id"], plan_id=99999,
+            )

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { isSuperadmin } from "@/lib/auth";
+import {
+  btnPrimary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  label,
+  pageTitle,
+} from "@/lib/styles";
+
+type Subscription = {
+  status: string;
+  plan_id: number;
+  plan_slug: string | null;
+  trial_start: string | null;
+  trial_end: string | null;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type Member = {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  is_active: boolean;
+  email_verified: boolean;
+  created_at: string | null;
+};
+
+type OrgDetail = {
+  id: number;
+  name: string;
+  billing_cycle_day: number;
+  created_at: string | null;
+  subscription: Subscription | Record<string, never>;
+  members: Member[];
+  counts: { transactions: number; accounts: number; budgets: number; forecast_plans: number };
+};
+
+const STATUS_OPTIONS = ["trialing", "active", "past_due", "canceled"];
+
+export default function AdminOrgDetailPage() {
+  const params = useParams();
+  const orgId = Number(params?.id);
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [detail, setDetail] = useState<OrgDetail | null>(null);
+  const [error, setError] = useState("");
+  const [info, setInfo] = useState("");
+
+  // Subscription edit state
+  const [subStatus, setSubStatus] = useState<string>("");
+  const [subTrialEnd, setSubTrialEnd] = useState<string>("");
+
+  // Delete confirmation
+  const [confirmName, setConfirmName] = useState("");
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!isSuperadmin(user)) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  async function refresh() {
+    try {
+      const d = await apiFetch<OrgDetail>(`/api/v1/admin/orgs/${orgId}`);
+      setDetail(d);
+      const sub = d.subscription as Subscription;
+      setSubStatus(sub.status ?? "");
+      setSubTrialEnd(sub.trial_end ?? "");
+    } catch (err) {
+      setError(extractErrorMessage(err, "Failed to load"));
+    }
+  }
+
+  useEffect(() => {
+    if (loading || !user || !isSuperadmin(user) || !orgId) return;
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, user, orgId]);
+
+  async function saveSubscription(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    setInfo("");
+    try {
+      const body: Record<string, unknown> = {};
+      const sub = detail?.subscription as Subscription;
+      if (subStatus && subStatus !== sub.status) body.status = subStatus;
+      if (subTrialEnd && subTrialEnd !== sub.trial_end) body.trial_end = subTrialEnd;
+      if (Object.keys(body).length === 0) {
+        setInfo("No changes.");
+        return;
+      }
+      await apiFetch(`/api/v1/admin/orgs/${orgId}/subscription`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+      setInfo("Subscription updated.");
+      await refresh();
+    } catch (err) {
+      setError(extractErrorMessage(err, "Update failed"));
+    }
+  }
+
+  async function handleDelete() {
+    if (!detail) return;
+    setError("");
+    setDeleting(true);
+    try {
+      await apiFetch(`/api/v1/admin/orgs/${orgId}`, {
+        method: "DELETE",
+        body: JSON.stringify({ confirm_name: confirmName }),
+      });
+      router.push("/admin/orgs");
+    } catch (err) {
+      setError(extractErrorMessage(err, "Delete failed"));
+      setDeleting(false);
+    }
+  }
+
+  if (loading || !user || !isSuperadmin(user)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <AppShell>
+        {error ? (
+          <div className={errorCls} role="alert">{error}</div>
+        ) : (
+          <Spinner />
+        )}
+      </AppShell>
+    );
+  }
+
+  const sub = detail.subscription as Subscription;
+  const confirmMatches = confirmName === detail.name;
+
+  return (
+    <AppShell>
+      <div className="mb-4 flex items-center gap-2 text-sm text-text-muted">
+        <Link href="/admin/orgs" className="text-accent hover:text-accent-hover">
+          Organizations
+        </Link>
+        <span>/</span>
+        <span className="text-text-secondary">{detail.name}</span>
+      </div>
+      <h1 className={pageTitle}>{detail.name}</h1>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">{error}</div>
+      )}
+      {info && (
+        <div className="mb-4 rounded-md border border-border bg-surface-raised px-4 py-3 text-sm text-text-secondary">
+          {info}
+        </div>
+      )}
+
+      {/* Subscription card */}
+      <section className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Subscription</h2>
+        </div>
+        <div className="px-6 py-5 space-y-4">
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+            <dt className="text-text-muted">Plan</dt>
+            <dd className="text-text-primary">{sub.plan_slug ?? "—"}</dd>
+            <dt className="text-text-muted">Created</dt>
+            <dd className="text-text-secondary">{sub.created_at?.slice(0, 10) ?? "—"}</dd>
+            <dt className="text-text-muted">Trial start → end</dt>
+            <dd className="text-text-secondary">
+              {(sub.trial_start ?? "—")} → {(sub.trial_end ?? "—")}
+            </dd>
+            <dt className="text-text-muted">Period start → end</dt>
+            <dd className="text-text-secondary">
+              {(sub.current_period_start ?? "—")} → {(sub.current_period_end ?? "—")}
+            </dd>
+          </dl>
+
+          <form onSubmit={saveSubscription} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div>
+              <label htmlFor="sub-status" className={label}>Status</label>
+              <select
+                id="sub-status"
+                value={subStatus}
+                onChange={(e) => setSubStatus(e.target.value)}
+                className={input}
+              >
+                {STATUS_OPTIONS.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="sub-trial-end" className={label}>Trial end</label>
+              <input
+                id="sub-trial-end"
+                type="date"
+                value={subTrialEnd}
+                onChange={(e) => setSubTrialEnd(e.target.value)}
+                className={input}
+              />
+            </div>
+            <button type="submit" className={btnPrimary}>Save</button>
+          </form>
+        </div>
+      </section>
+
+      {/* Members card */}
+      <section className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Members ({detail.members.length})</h2>
+        </div>
+        <div className="overflow-x-auto px-6 py-4">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="py-2 pr-4">Username</th>
+                <th className="py-2 pr-4">Email</th>
+                <th className="py-2 pr-4">Role</th>
+                <th className="py-2 pr-4">Active</th>
+                <th className="py-2">Verified</th>
+              </tr>
+            </thead>
+            <tbody>
+              {detail.members.map((m) => (
+                <tr key={m.id} className="border-b border-border-subtle">
+                  <td className="py-2 pr-4 text-text-primary">{m.username}</td>
+                  <td className="py-2 pr-4 text-text-secondary">{m.email}</td>
+                  <td className="py-2 pr-4 text-text-secondary">{m.role}</td>
+                  <td className="py-2 pr-4 text-text-secondary">{m.is_active ? "yes" : "no"}</td>
+                  <td className="py-2 text-text-secondary">{m.email_verified ? "yes" : "no"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Counts card */}
+      <section className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Data</h2>
+        </div>
+        <div className="grid grid-cols-2 gap-4 px-6 py-5 sm:grid-cols-4">
+          <div>
+            <p className="text-xs text-text-muted">Transactions</p>
+            <p className="font-display text-2xl text-text-primary">{detail.counts.transactions}</p>
+          </div>
+          <div>
+            <p className="text-xs text-text-muted">Accounts</p>
+            <p className="font-display text-2xl text-text-primary">{detail.counts.accounts}</p>
+          </div>
+          <div>
+            <p className="text-xs text-text-muted">Budgets</p>
+            <p className="font-display text-2xl text-text-primary">{detail.counts.budgets}</p>
+          </div>
+          <div>
+            <p className="text-xs text-text-muted">Forecast plans</p>
+            <p className="font-display text-2xl text-text-primary">{detail.counts.forecast_plans}</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Danger zone */}
+      <section className={`${card} border-danger/40`}>
+        <div className={cardHeader}>
+          <h2 className={`${cardTitle} text-danger`}>Danger zone</h2>
+        </div>
+        <div className="px-6 py-5 space-y-3">
+          <p className="text-sm text-text-secondary">
+            Permanently delete <strong className="text-text-primary">{detail.name}</strong>.
+            This removes the org and every transaction, account, budget, plan,
+            invitation, and member tied to it. The action cannot be undone.
+          </p>
+          <p className="text-sm text-text-secondary">
+            Type the organization name to confirm:
+          </p>
+          <input
+            type="text"
+            aria-label="Confirm organization name"
+            value={confirmName}
+            onChange={(e) => setConfirmName(e.target.value)}
+            placeholder={detail.name}
+            className={`${input} max-w-sm`}
+          />
+          <div>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={!confirmMatches || deleting}
+              className="rounded-md bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
+            >
+              {deleting ? "Deleting…" : "Delete organization"}
+            </button>
+          </div>
+        </div>
+      </section>
+    </AppShell>
+  );
+}

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -51,6 +51,12 @@ type OrgDetail = {
   counts: { transactions: number; accounts: number; budgets: number; forecast_plans: number };
 };
 
+type PlanOption = {
+  id: number;
+  slug: string;
+  name: string;
+};
+
 const STATUS_OPTIONS = ["trialing", "active", "past_due", "canceled"];
 
 export default function AdminOrgDetailPage() {
@@ -65,6 +71,9 @@ export default function AdminOrgDetailPage() {
   // Subscription edit state
   const [subStatus, setSubStatus] = useState<string>("");
   const [subTrialEnd, setSubTrialEnd] = useState<string>("");
+  const [subPlanId, setSubPlanId] = useState<string>("");
+  const [subPeriodEnd, setSubPeriodEnd] = useState<string>("");
+  const [plans, setPlans] = useState<PlanOption[]>([]);
 
   // Delete confirmation
   const [confirmName, setConfirmName] = useState("");
@@ -83,11 +92,17 @@ export default function AdminOrgDetailPage() {
 
   async function refresh() {
     try {
-      const d = await apiFetch<OrgDetail>(`/api/v1/admin/orgs/${orgId}`);
+      const [d, planList] = await Promise.all([
+        apiFetch<OrgDetail>(`/api/v1/admin/orgs/${orgId}`),
+        apiFetch<PlanOption[]>("/api/v1/plans"),
+      ]);
       setDetail(d);
+      setPlans(planList ?? []);
       const sub = d.subscription as Subscription;
       setSubStatus(sub.status ?? "");
       setSubTrialEnd(sub.trial_end ?? "");
+      setSubPlanId(sub.plan_id ? String(sub.plan_id) : "");
+      setSubPeriodEnd(sub.current_period_end ?? "");
     } catch (err) {
       setError(extractErrorMessage(err, "Failed to load"));
     }
@@ -108,6 +123,12 @@ export default function AdminOrgDetailPage() {
       const sub = detail?.subscription as Subscription;
       if (subStatus && subStatus !== sub.status) body.status = subStatus;
       if (subTrialEnd && subTrialEnd !== sub.trial_end) body.trial_end = subTrialEnd;
+      if (subPlanId && Number(subPlanId) !== sub.plan_id) {
+        body.plan_id = Number(subPlanId);
+      }
+      if (subPeriodEnd && subPeriodEnd !== sub.current_period_end) {
+        body.current_period_end = subPeriodEnd;
+      }
       if (Object.keys(body).length === 0) {
         setInfo("No changes.");
         return;
@@ -203,7 +224,20 @@ export default function AdminOrgDetailPage() {
             </dd>
           </dl>
 
-          <form onSubmit={saveSubscription} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <form onSubmit={saveSubscription} className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:items-end">
+            <div>
+              <label htmlFor="sub-plan" className={label}>Plan</label>
+              <select
+                id="sub-plan"
+                value={subPlanId}
+                onChange={(e) => setSubPlanId(e.target.value)}
+                className={input}
+              >
+                {plans.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+            </div>
             <div>
               <label htmlFor="sub-status" className={label}>Status</label>
               <select
@@ -227,7 +261,19 @@ export default function AdminOrgDetailPage() {
                 className={input}
               />
             </div>
-            <button type="submit" className={btnPrimary}>Save</button>
+            <div>
+              <label htmlFor="sub-period-end" className={label}>Period end</label>
+              <input
+                id="sub-period-end"
+                type="date"
+                value={subPeriodEnd}
+                onChange={(e) => setSubPeriodEnd(e.target.value)}
+                className={input}
+              />
+            </div>
+            <div className="lg:col-span-4">
+              <button type="submit" className={btnPrimary}>Save</button>
+            </div>
           </form>
         </div>
       </section>

--- a/frontend/app/admin/orgs/page.tsx
+++ b/frontend/app/admin/orgs/page.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { isSuperadmin } from "@/lib/auth";
+import {
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  pageTitle,
+} from "@/lib/styles";
+
+type OrgRow = {
+  id: number;
+  name: string;
+  plan_slug: string | null;
+  subscription_status: string | null;
+  trial_end: string | null;
+  user_count: number;
+  active_user_count: number;
+  created_at: string | null;
+  last_user_created_at: string | null;
+};
+
+type OrgListResponse = {
+  items: OrgRow[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+const PAGE_SIZE = 50;
+
+export default function AdminOrgsPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<OrgListResponse | null>(null);
+  const [error, setError] = useState("");
+  const [q, setQ] = useState("");
+  const [offset, setOffset] = useState(0);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!isSuperadmin(user)) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (loading || !user || !isSuperadmin(user)) return;
+    setFetching(true);
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+    });
+    if (q.trim()) params.set("q", q.trim());
+    apiFetch<OrgListResponse>(`/api/v1/admin/orgs?${params.toString()}`)
+      .then((d) => setData(d))
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
+      .finally(() => setFetching(false));
+  }, [loading, user, q, offset]);
+
+  if (loading || !user || !isSuperadmin(user)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <h1 className={pageTitle}>Organizations</h1>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>All organizations</h2>
+        </div>
+        <div className="px-6 py-4">
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => {
+              setOffset(0);
+              setQ(e.target.value);
+            }}
+            placeholder="Search by name…"
+            className={`${input} w-full max-w-sm`}
+            aria-label="Search organizations"
+          />
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3">Name</th>
+                <th className="px-6 py-3">Plan</th>
+                <th className="px-6 py-3">Status</th>
+                <th className="px-6 py-3">Users</th>
+                <th className="px-6 py-3">Newest member</th>
+                <th className="px-6 py-3">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && (
+                <tr>
+                  <td colSpan={6} className="px-6 py-6 text-center text-text-muted">
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!fetching && data?.items.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-6 py-6 text-center text-text-muted">
+                    No organizations match.
+                  </td>
+                </tr>
+              )}
+              {!fetching &&
+                data?.items.map((row) => (
+                  <tr key={row.id} className="border-b border-border-subtle">
+                    <td className="px-6 py-3">
+                      <Link
+                        href={`/admin/orgs/${row.id}`}
+                        className="text-accent hover:text-accent-hover"
+                      >
+                        {row.name}
+                      </Link>
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary">
+                      {row.plan_slug ?? "—"}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary">
+                      {row.subscription_status ?? "—"}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.active_user_count} / {row.user_count}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.last_user_created_at?.slice(0, 10) ?? "—"}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.created_at?.slice(0, 10) ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+
+        {data && data.total > PAGE_SIZE && (
+          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
+            <span>
+              {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
+              {data.total}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                disabled={offset + PAGE_SIZE >= data.total}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -135,8 +135,21 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   const superadmin = checkSuperadmin(user);
 
+  // All hrefs that could potentially match the current pathname.
+  // Used to break ties: when both `/admin` and `/admin/orgs` would
+  // match the path `/admin/orgs` under a naive prefix check, only
+  // the longest match wins so the parent doesn't double-highlight.
+  const allHrefs = [...navItems, ...systemItems].map((i) => i.href);
   function isActive(href: string) {
-    return pathname === href || pathname.startsWith(href + "/");
+    if (pathname === href) return true;
+    if (!pathname.startsWith(href + "/")) return false;
+    const longerMatch = allHrefs.some(
+      (other) =>
+        other !== href &&
+        other.length > href.length &&
+        (pathname === other || pathname.startsWith(other + "/")),
+    );
+    return !longerMatch;
   }
 
   return (

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -88,6 +88,15 @@ const systemItems = [
     ),
   },
   {
+    href: "/admin/orgs",
+    label: "Organizations",
+    icon: (
+      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
+      </svg>
+    ),
+  },
+  {
     href: "/system/plans",
     label: "Plans",
     icon: (

--- a/frontend/tests/app/admin-org-detail-page.test.tsx
+++ b/frontend/tests/app/admin-org-detail-page.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AdminOrgDetailPage from "@/app/admin/orgs/[id]/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return { ...actual, useAuth: vi.fn(), AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</> };
+});
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  useParams: () => ({ id: "42" }),
+  usePathname: () => "/admin/orgs/42",
+}));
+
+
+const SUPERADMIN = {
+  id: 1, username: "root", email: "root@platform.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner", org_id: 1, org_name: "Platform",
+  billing_cycle_day: 1, is_superadmin: true, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const DETAIL = {
+  id: 42, name: "Acme", billing_cycle_day: 1,
+  created_at: "2026-04-15T10:00:00",
+  subscription: {
+    status: "trialing", plan_id: 1, plan_slug: "free",
+    trial_start: "2026-04-15", trial_end: "2026-05-15",
+    current_period_start: null, current_period_end: null,
+    created_at: "2026-04-15T10:00:00", updated_at: "2026-04-15T10:00:00",
+  },
+  members: [
+    { id: 9, username: "owner", email: "o@a.io", role: "owner", is_active: true, email_verified: true, created_at: null },
+  ],
+  counts: { transactions: 5, accounts: 1, budgets: 0, forecast_plans: 0 },
+};
+
+
+describe("AdminOrgDetailPage — Danger zone gating", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    pushMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+  });
+
+  it("disables the delete button until the org name is typed exactly", async () => {
+    apiFetchMock.mockResolvedValueOnce(DETAIL as never);
+    render(<AdminOrgDetailPage />);
+
+    const deleteBtn = await screen.findByRole("button", { name: /Delete organization/i });
+    expect(deleteBtn).toBeDisabled();
+
+    const confirmInput = screen.getByLabelText(/Confirm organization name/i);
+    fireEvent.change(confirmInput, { target: { value: "acme" } }); // wrong case
+    expect(deleteBtn).toBeDisabled();
+
+    fireEvent.change(confirmInput, { target: { value: "Acme" } });
+    expect(deleteBtn).not.toBeDisabled();
+  });
+
+  it("posts the confirm_name and routes back to /admin/orgs after delete", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(DETAIL as never)
+      .mockResolvedValueOnce({ deleted: { organizations: 1 } } as never);
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByRole("heading", { name: "Acme" });
+    fireEvent.change(screen.getByLabelText(/Confirm organization name/i), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Delete organization/i }));
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/42",
+        expect.objectContaining({
+          method: "DELETE",
+          body: JSON.stringify({ confirm_name: "Acme" }),
+        }),
+      );
+      expect(pushMock).toHaveBeenCalledWith("/admin/orgs");
+    });
+  });
+});

--- a/frontend/tests/app/admin-org-detail-page.test.tsx
+++ b/frontend/tests/app/admin-org-detail-page.test.tsx
@@ -64,7 +64,11 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
   });
 
   it("disables the delete button until the org name is typed exactly", async () => {
-    apiFetchMock.mockResolvedValueOnce(DETAIL as never);
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
+      if (url === "/api/v1/plans") return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
+      return Promise.resolve(undefined);
+    }) as never);
     render(<AdminOrgDetailPage />);
 
     const deleteBtn = await screen.findByRole("button", { name: /Delete organization/i });
@@ -78,10 +82,56 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
     expect(deleteBtn).not.toBeDisabled();
   });
 
+  it("posts plan_id and current_period_end when admin changes them", async () => {
+    apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url.startsWith("/api/v1/admin/orgs/42/subscription") && opts?.method === "PUT") {
+        return Promise.resolve({ before: {}, after: {} });
+      }
+      if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
+      if (url === "/api/v1/plans") {
+        return Promise.resolve([
+          { id: 1, slug: "free", name: "Free" },
+          { id: 2, slug: "pro", name: "Pro" },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByRole("heading", { name: "Acme" });
+    fireEvent.change(screen.getByLabelText(/^Plan$/i), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText(/Period end/i), {
+      target: { value: "2026-12-31" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/42/subscription",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            plan_id: 2,
+            current_period_end: "2026-12-31",
+          }),
+        }),
+      );
+    });
+  });
+
   it("posts the confirm_name and routes back to /admin/orgs after delete", async () => {
-    apiFetchMock
-      .mockResolvedValueOnce(DETAIL as never)
-      .mockResolvedValueOnce({ deleted: { organizations: 1 } } as never);
+    apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url.startsWith("/api/v1/admin/orgs/42") && (!opts || opts.method !== "DELETE")) {
+        return Promise.resolve(DETAIL);
+      }
+      if (url === "/api/v1/plans") return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
+      if (url === "/api/v1/admin/orgs/42" && opts?.method === "DELETE") {
+        return Promise.resolve({ deleted: { organizations: 1 } });
+      }
+      return Promise.resolve(undefined);
+    }) as never);
     render(<AdminOrgDetailPage />);
 
     await screen.findByRole("heading", { name: "Acme" });

--- a/frontend/tests/app/admin-orgs-page.test.tsx
+++ b/frontend/tests/app/admin-orgs-page.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AdminOrgsPage from "@/app/admin/orgs/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return { ...actual, useAuth: vi.fn(), AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</> };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/orgs",
+}));
+
+
+const SUPERADMIN = {
+  id: 1, username: "root", email: "root@platform.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner", org_id: 1, org_name: "Platform",
+  billing_cycle_day: 1, is_superadmin: true, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+describe("AdminOrgsPage", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders the orgs table from the API", async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: 10, name: "Acme", plan_slug: "free",
+          subscription_status: "trialing", trial_end: "2026-05-15",
+          user_count: 3, active_user_count: 2,
+          created_at: "2026-04-15T10:00:00",
+          last_user_created_at: "2026-04-30T10:00:00",
+        },
+      ],
+      total: 1, limit: 50, offset: 0,
+    } as never);
+
+    render(<AdminOrgsPage />);
+
+    await screen.findByText("Acme");
+    expect(screen.getByText("free")).toBeInTheDocument();
+    expect(screen.getByText("trialing")).toBeInTheDocument();
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+  });
+
+  it("redirects non-superadmin users away from the page", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+
+    render(<AdminOrgsPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Operator surface at \`/admin/orgs\` for the platform superadmin — list, drill-down, subscription override, and cascade delete. Sets the foundation that L4.4 (user management), L4.5 (revenue), and L4.7 (audit log) build on.

## Endpoints

| Method | Path | Permission | Purpose |
|---|---|---|---|
| GET | \`/api/v1/admin/orgs?q=&limit=&offset=\` | \`orgs.view\` | Paginated table with plan, status, user counts, newest-member date |
| GET | \`/api/v1/admin/orgs/{id}\` | \`orgs.view\` | Drill: subscription, members, data counts |
| PUT | \`/api/v1/admin/orgs/{id}/subscription\` | \`orgs.manage\` | Override status / plan / trial_end / current_period_end. Returns before/after diff |
| DELETE | \`/api/v1/admin/orgs/{id}\` | \`orgs.manage\` | Cascade delete; body \`{confirm_name}\` must match org.name; refuses actor's own org |

## Reviewer asks addressed (from design pre-flight)

- **Categories self-FK**: \`UPDATE categories SET parent_id=NULL\` before bulk DELETE. Test fixture enables \`PRAGMA foreign_keys=ON\` on SQLite so the cascade test catches what MySQL would catch — verified by deliberately failing the test before adding the parent_id nulling step.
- **Subscription shape matches the model**: \`trialing\` (not \`trial\`), \`trial_start/trial_end/current_period_start/current_period_end/created_at/updated_at\` — no invented \`started_at\`.
- **Audit logs without L4.7**: structured \`structlog\` events \`admin.org.delete\` and \`admin.org.subscription.override\` carry actor + target + before/after / deleted_rows_by_table. Generic 500 body on cascade failure; full diagnostic in server log only.
- **AppShell nav**: \`/admin/orgs\` link added to systemItems, gated on \`is_superadmin\`.
- **Pinned permissions test**: \`ALL_PERMISSIONS\` expectation updated to include \`orgs.view\` + \`orgs.manage\`.
- **\"Newest member\" column** label (not \"activity\"), keeping the soft proxy until L4.7 audit log lands.

## Test counts

- Backend: 114 → 131 (+17 — 9 service, 8 router, 1 permissions assert update)
- Frontend: 40 → 44 (+4 — table renders, non-superadmin redirect, danger-zone gating, delete-then-route)

## Out of scope (intentional)

- **Impersonation**: footgun without L4.7 audit log; will land paired with it.
- **Recent activity feed**: depends on L4.7 events.

## Live smoke

Backend container restarted clean, endpoints respond as expected on the local stack (auth gate verified via 403 on a non-superadmin token).