### PR TITLE
feat: L3.10 smart rules / auto-categorization

### DIFF
--- a/backend/alembic/versions/027_smart_rules.py
+++ b/backend/alembic/versions/027_smart_rules.py
@@ -53,12 +53,14 @@ def upgrade() -> None:
         ("ALDI", "groceries"), ("TESCO", "groceries"), ("SAINSBURYS", "groceries"),
         ("ALBERT HEIJN", "groceries"), ("EDEKA", "groceries"), ("REWE", "groceries"),
         # Transportation
+        # MB Way is a generic P2P/merchant payments app — too ambiguous
+        # to default to transit, omitted intentionally.
         ("BOLT", "public_transit"), ("FREE NOW", "public_transit"), ("UBER", "public_transit"),
-        ("MB WAY", "public_transit"), ("VIA VERDE", "parking_tolls"), ("RENFE", "public_transit"),
+        ("VIA VERDE", "parking_tolls"), ("RENFE", "public_transit"),
         ("DEUTSCHE BAHN", "public_transit"), ("NS", "public_transit"), ("SNCF", "public_transit"),
-        # Streaming -> "internet" is the closest seeded slug for now
-        ("SPOTIFY", "internet"), ("NETFLIX", "internet"), ("DISNEY", "internet"),
-        ("HBO", "internet"), ("PRIME VIDEO", "internet"),
+        # Streaming
+        ("SPOTIFY", "streaming"), ("NETFLIX", "streaming"), ("DISNEY", "streaming"),
+        ("HBO", "streaming"), ("PRIME VIDEO", "streaming"),
         # Telecoms
         ("VODAFONE", "phone"), ("NOS", "phone"), ("MEO", "phone"),
         ("ORANGE", "phone"), ("T MOBILE", "phone"), ("TELEKOM", "phone"),
@@ -69,8 +71,9 @@ def upgrade() -> None:
         ("UBER EATS", "fast_food"), ("DELIVEROO", "fast_food"), ("GLOVO", "fast_food"),
         ("JUSTEAT", "fast_food"), ("WOLT", "fast_food"),
         # General
-        ("AMZN MKTP", "groceries"), ("AMAZON", "groceries"),
-        ("IKEA", "home_repairs"), ("APPLE", "internet"), ("GOOGLE", "internet"),
+        # Apple, Google, Amazon (AMZN MKTP / AMAZON) are too ambiguous
+        # to default to a single category and were dropped from the seed.
+        ("IKEA", "home_repairs"),
     ]
     op.bulk_insert(
         merchant_dict,

--- a/backend/alembic/versions/027_smart_rules.py
+++ b/backend/alembic/versions/027_smart_rules.py
@@ -1,0 +1,89 @@
+"""smart rules + merchant dictionary
+
+Revision ID: 027
+Revises: 026
+Create Date: 2026-05-02
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "027"
+down_revision = "026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "category_rules",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.Integer(), sa.ForeignKey("organizations.id"), nullable=False),
+        sa.Column("normalized_token", sa.String(64), nullable=False),
+        sa.Column("raw_description_seen", sa.String(255), nullable=False),
+        sa.Column("category_id", sa.Integer(), sa.ForeignKey("categories.id"), nullable=False),
+        sa.Column("match_count", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "source",
+            sa.Enum("user_edit", "user_pick", "dictionary_promotion", name="rulesource"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("org_id", "normalized_token", name="uq_category_rules_org_token"),
+    )
+    op.create_index("ix_category_rules_org_id", "category_rules", ["org_id"])
+    op.create_index("ix_category_rules_category_id", "category_rules", ["category_id"])
+
+    merchant_dict = op.create_table(
+        "merchant_dictionary",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("normalized_token", sa.String(64), nullable=False, unique=True),
+        sa.Column("category_slug", sa.String(64), nullable=False),
+        sa.Column("vote_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("is_seed", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+    seed = [
+        # Groceries
+        ("LIDL", "groceries"), ("PINGO DOCE", "groceries"), ("CONTINENTE", "groceries"),
+        ("AUCHAN", "groceries"), ("CARREFOUR", "groceries"), ("MERCADONA", "groceries"),
+        ("ALDI", "groceries"), ("TESCO", "groceries"), ("SAINSBURYS", "groceries"),
+        ("ALBERT HEIJN", "groceries"), ("EDEKA", "groceries"), ("REWE", "groceries"),
+        # Transportation
+        ("BOLT", "public_transit"), ("FREE NOW", "public_transit"), ("UBER", "public_transit"),
+        ("MB WAY", "public_transit"), ("VIA VERDE", "parking_tolls"), ("RENFE", "public_transit"),
+        ("DEUTSCHE BAHN", "public_transit"), ("NS", "public_transit"), ("SNCF", "public_transit"),
+        # Streaming -> "internet" is the closest seeded slug for now
+        ("SPOTIFY", "internet"), ("NETFLIX", "internet"), ("DISNEY", "internet"),
+        ("HBO", "internet"), ("PRIME VIDEO", "internet"),
+        # Telecoms
+        ("VODAFONE", "phone"), ("NOS", "phone"), ("MEO", "phone"),
+        ("ORANGE", "phone"), ("T MOBILE", "phone"), ("TELEKOM", "phone"),
+        # Utilities
+        ("EDP", "electricity"), ("ENDESA", "electricity"), ("IBERDROLA", "electricity"),
+        ("EON", "electricity"), ("BRITISH GAS", "gas_utility"),
+        # Restaurants & food delivery
+        ("UBER EATS", "fast_food"), ("DELIVEROO", "fast_food"), ("GLOVO", "fast_food"),
+        ("JUSTEAT", "fast_food"), ("WOLT", "fast_food"),
+        # General
+        ("AMZN MKTP", "groceries"), ("AMAZON", "groceries"),
+        ("IKEA", "home_repairs"), ("APPLE", "internet"), ("GOOGLE", "internet"),
+    ]
+    op.bulk_insert(
+        merchant_dict,
+        [
+            {"normalized_token": tok, "category_slug": slug, "is_seed": True, "vote_count": 0}
+            for tok, slug in seed
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("merchant_dictionary")
+    op.drop_index("ix_category_rules_category_id", table_name="category_rules")
+    op.drop_index("ix_category_rules_org_id", table_name="category_rules")
+    op.drop_table("category_rules")
+    op.execute("DROP TYPE IF EXISTS rulesource")

--- a/backend/alembic/versions/027_smart_rules.py
+++ b/backend/alembic/versions/027_smart_rules.py
@@ -64,16 +64,23 @@ def upgrade() -> None:
         # Telecoms
         ("VODAFONE", "phone"), ("NOS", "phone"), ("MEO", "phone"),
         ("ORANGE", "phone"), ("T MOBILE", "phone"), ("TELEKOM", "phone"),
+        ("KPN", "phone"),                    # NL: KPN telecom
+        ("ODIDO", "phone"),                  # NL: formerly T-Mobile NL
         # Utilities
         ("EDP", "electricity"), ("ENDESA", "electricity"), ("IBERDROLA", "electricity"),
         ("EON", "electricity"), ("BRITISH GAS", "gas_utility"),
         # Restaurants & food delivery
         ("UBER EATS", "fast_food"), ("DELIVEROO", "fast_food"), ("GLOVO", "fast_food"),
         ("JUSTEAT", "fast_food"), ("WOLT", "fast_food"),
+        ("THUISBEZORGD", "fast_food"),       # NL: Dutch JustEat
+        # Groceries (NL additions appended; existing entries above unchanged)
+        ("JUMBO", "groceries"),              # NL: top Dutch supermarket
         # General
         # Apple, Google, Amazon (AMZN MKTP / AMAZON) are too ambiguous
         # to default to a single category and were dropped from the seed.
         ("IKEA", "home_repairs"),
+        ("AYVENS", "car_payments"),          # car leasing (formerly ALD Automotive)
+        ("FRANK ENERGIE", "electricity"),    # NL: renewable electricity
     ]
     op.bulk_insert(
         merchant_dict,

--- a/backend/alembic/versions/027_smart_rules.py
+++ b/backend/alembic/versions/027_smart_rules.py
@@ -41,7 +41,7 @@ def upgrade() -> None:
         sa.Column("normalized_token", sa.String(64), nullable=False, unique=True),
         sa.Column("category_slug", sa.String(64), nullable=False),
         sa.Column("vote_count", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("is_seed", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("is_seed", sa.Boolean(), nullable=False, server_default="0"),
         sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
     )
@@ -83,7 +83,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("merchant_dictionary")
-    op.drop_index("ix_category_rules_category_id", table_name="category_rules")
-    op.drop_index("ix_category_rules_org_id", table_name="category_rules")
     op.drop_table("category_rules")
-    op.execute("DROP TYPE IF EXISTS rulesource")
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        sa.Enum(name="rulesource").drop(bind, checkfirst=True)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,6 +10,8 @@ from app.models.settings import OrgSetting
 from app.models.forecast_plan import ForecastPlan, ForecastPlanItem, PlanStatus, ForecastItemType, ItemSource
 from app.models.subscription import Plan, Subscription, SubscriptionStatus, BillingInterval
 from app.models.invitation import Invitation
+from app.models.category_rule import CategoryRule, RuleSource
+from app.models.merchant_dictionary import MerchantDictionaryEntry
 
 __all__ = [
     "Base",
@@ -37,4 +39,7 @@ __all__ = [
     "SubscriptionStatus",
     "BillingInterval",
     "Invitation",
+    "CategoryRule",
+    "RuleSource",
+    "MerchantDictionaryEntry",
 ]

--- a/backend/app/models/category_rule.py
+++ b/backend/app/models/category_rule.py
@@ -1,0 +1,35 @@
+import enum
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class RuleSource(str, enum.Enum):
+    USER_EDIT = "user_edit"
+    USER_PICK = "user_pick"
+    DICTIONARY_PROMOTION = "dictionary_promotion"
+
+
+class CategoryRule(Base):
+    __tablename__ = "category_rules"
+    __table_args__ = (
+        UniqueConstraint("org_id", "normalized_token", name="uq_category_rules_org_token"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(Integer, ForeignKey("organizations.id"), nullable=False, index=True)
+    normalized_token: Mapped[str] = mapped_column(String(64), nullable=False)
+    raw_description_seen: Mapped[str] = mapped_column(String(255), nullable=False)
+    category_id: Mapped[int] = mapped_column(Integer, ForeignKey("categories.id"), nullable=False, index=True)
+    match_count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    source: Mapped[RuleSource] = mapped_column(
+        Enum(RuleSource, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/models/merchant_dictionary.py
+++ b/backend/app/models/merchant_dictionary.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class MerchantDictionaryEntry(Base):
+    __tablename__ = "merchant_dictionary"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    normalized_token: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    category_slug: Mapped[str] = mapped_column(String(64), nullable=False)
+    vote_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    is_seed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.category import Category, CategoryType
+from app.models.category_rule import CategoryRule
 from app.models.transaction import Transaction
 from app.models.user import User
 from app.schemas.category import CategoryCreate, CategoryResponse, CategoryUpdate
@@ -168,6 +169,13 @@ async def delete_category(
         db, Transaction,
         [Transaction.category_id == cat.id, Transaction.org_id == current_user.org_id],
         "transaction", "category",
+    )
+
+    # Learned auto-categorization rules reference this category. They're
+    # invisible to the user and become invalid once the category is gone —
+    # delete them silently rather than blocking the category delete.
+    await db.execute(
+        delete(CategoryRule).where(CategoryRule.category_id == cat.id)
     )
 
     await db.delete(cat)

--- a/backend/app/schemas/import_schemas.py
+++ b/backend/app/schemas/import_schemas.py
@@ -23,6 +23,8 @@ class ImportPreviewRow(BaseModel):
     is_duplicate: bool = False
     duplicate_transaction_id: int | None = None
     is_potential_transfer: bool = False
+    suggested_category_id: int | None = None
+    suggestion_source: Literal["org_rule", "shared_dictionary", "default"] | None = None
 
 
 class ImportPreviewResponse(BaseModel):
@@ -51,6 +53,8 @@ class ImportConfirmRow(BaseModel):
     skip: bool = False
     is_transfer: bool = False
     transfer_account_id: int | None = None  # required when is_transfer=True
+    suggested_category_id: int | None = None  # echoed back from preview for accept-vs-override detection
+    suggestion_source: Literal["org_rule", "shared_dictionary", "default"] | None = None
 
 
 class ImportConfirmRequest(BaseModel):

--- a/backend/app/services/admin_orgs_service.py
+++ b/backend/app/services/admin_orgs_service.py
@@ -23,6 +23,7 @@ from app.models.account import Account, AccountType
 from app.models.billing import BillingPeriod
 from app.models.budget import Budget
 from app.models.category import Category
+from app.models.category_rule import CategoryRule
 from app.models.forecast_plan import ForecastPlan, ForecastPlanItem
 from app.models.invitation import Invitation
 from app.models.recurring import RecurringTransaction
@@ -306,6 +307,14 @@ async def delete_org_cascade(
 
     counts["account_types"] = (
         await db.execute(delete(AccountType).where(AccountType.org_id == org_id))
+    ).rowcount or 0
+
+    # category_rules.category_id FKs to categories.id, so it must be
+    # deleted before the bulk DELETE on categories below or MySQL's
+    # strict FK refuses. (merchant_dictionary is shared across orgs
+    # and has no org_id — it must survive org deletion.)
+    counts["category_rules"] = (
+        await db.execute(delete(CategoryRule).where(CategoryRule.org_id == org_id))
     ).rowcount or 0
 
     # Categories self-reference via parent_id. Break the link before

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -36,14 +36,16 @@ _LEADING_STOPWORDS = {"TRANSFER", "PAYMENT", "DEBIT", "CREDIT", "TXN", "TX"}
 
 
 def _strip_accents(s: str) -> str:
-    """ASCII-strict drop of non-ASCII codepoints.
+    """NFKD decompose + drop combining marks → fold accents to ASCII letters.
 
-    Note: this DROPS non-ASCII characters rather than folding them
-    (CAFÉ → CAF, not CAFE). The spec's accent-test case asserts the drop
-    behavior — folding `É`→`E` and keeping it bleeds noise into rules
-    on mixed-locale descriptors, so we drop instead.
+    Why fold and not drop: bank descriptors for the same merchant vary in encoding
+    (e.g. `CAFÉ DELTA` in one bank, `CAFE DELTA` in another). Folding maps them
+    to the same token; dropping would fracture coverage. Architectural decision
+    captured in project_architect_review_2026_05_02.md.
     """
-    return s.encode("ascii", "ignore").decode("ascii")
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c)
+    )
 
 
 def _fallback(raw: str) -> str:

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -8,7 +8,7 @@ import re
 import unicodedata
 from typing import Literal
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.category import Category
@@ -253,19 +253,20 @@ async def learn_from_choice(
 
 
 async def bump_shared_vote(db: AsyncSession, *, description: str) -> None:
-    """Increment vote_count on the matching shared-dictionary entry, if any.
+    """Atomically increment vote_count on the matching shared-dictionary entry.
 
-    No-op if the normalized token isn't in the dictionary — we don't promote
-    new tokens automatically in this PR; promotion is a future feature.
-    Caller controls the transaction.
+    No-op if the normalized token isn't in the dictionary — promotion of
+    new tokens is a future feature. Caller controls the transaction.
+
+    Uses ``UPDATE ... SET vote_count = vote_count + 1`` so concurrent imports
+    from different orgs don't lose increments under repeatable-read isolation
+    (the previous read-modify-write pattern would clobber peers under load).
     """
     token = normalize_description(description)
     if not token:
         return
-    entry = (await db.execute(
-        select(MerchantDictionaryEntry).where(
-            MerchantDictionaryEntry.normalized_token == token
-        )
-    )).scalar_one_or_none()
-    if entry is not None:
-        entry.vote_count = (entry.vote_count or 0) + 1
+    await db.execute(
+        update(MerchantDictionaryEntry)
+        .where(MerchantDictionaryEntry.normalized_token == token)
+        .values(vote_count=MerchantDictionaryEntry.vote_count + 1)
+    )

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -1,0 +1,104 @@
+"""Smart rules / auto-categorization service (L3.10).
+
+Deterministic rule-based suggestion + learning. No AI in this pass.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# URL scheme prefix (HTTP / HTTPS) — stripped before bank-noise so `HTTPS://AMAZON…` collapses cleanly.
+_URL_SCHEME = re.compile(r"^\s*HTTPS?://", re.IGNORECASE)
+
+# Bank-noise that appears at the front of the descriptor.
+_LEADING_NOISE = re.compile(
+    r"^\s*(POS|CARD\s*PAYMENT|CARD|PAY|SEPA(?:\s+TRANSFER)?|DEB|CARTAO)\s+",
+    re.IGNORECASE,
+)
+
+# Tail markers we strip iteratively (multiple may stack).
+# Order matters: IBAN before terminal-id, because IBAN starts with letters and
+# the terminal-id pattern would eat its leading two letters.
+_TRAILING_TOKENS = re.compile(
+    r"(?:"
+    r"\s*[A-Z]{2}\d{2}[A-Z0-9]{10,30}|"   # IBAN: 2 letters + 2 digits + 10-30 alnum
+    r"\s*\*[A-Z0-9]+|"                    # *1A2B, *0001
+    r"\s+\d{4}-\d{2}-\d{2}|"              # 2026-04-15
+    r"\s+\d{8}|"                          # 20260412 (only when space-separated, never mid-word)
+    r"=[A-Z0-9]+"                         # =ABC URL query-value tail
+    r")\s*$",
+)
+
+_NON_ALNUM = re.compile(r"[^A-Z0-9]+")
+_MULTI_SPACE = re.compile(r"\s+")
+
+_LEADING_STOPWORDS = {"TRANSFER", "PAYMENT", "DEBIT", "CREDIT", "TXN", "TX"}
+
+
+def _strip_accents(s: str) -> str:
+    """ASCII-strict drop of non-ASCII codepoints.
+
+    Note: this DROPS non-ASCII characters rather than folding them
+    (CAFÉ → CAF, not CAFE). The spec's accent-test case asserts the drop
+    behavior — folding `É`→`E` and keeping it bleeds noise into rules
+    on mixed-locale descriptors, so we drop instead.
+    """
+    return s.encode("ascii", "ignore").decode("ascii")
+
+
+def _fallback(raw: str) -> str:
+    """Cleaned uppercase original, alphanumerics-and-spaces only."""
+    base = _NON_ALNUM.sub(" ", _strip_accents(raw).strip().upper())
+    return _MULTI_SPACE.sub(" ", base).strip()
+
+
+def normalize_description(raw: str) -> str:
+    """Bank descriptor → canonical uppercase merchant token.
+
+    Pipeline:
+      1. Strip whitespace, drop non-ASCII chars, uppercase.
+      2. Strip leading URL scheme (HTTPS:// / HTTP://) then bank-noise (POS / CARD / PAY / SEPA / DEB / CARTAO).
+      3. Iteratively strip trailing dates / terminal IDs / IBANs / URL query-values
+         (loop because two-in-a-row is common: e.g. `... *1234 *ABCD`).
+      4. Replace non-alphanumeric runs with a single space; collapse runs.
+      5. Drop a residual leading stopword (e.g. `TRANSFER` left over after `SEPA TRANSFER ...`).
+      6. Drop trailing pure-digit tokens (date residue, terminal IDs the regex missed).
+      7. Fallback: if cleanup yielded < 3 chars, return cleaned-uppercase original.
+    """
+    if not raw:
+        return ""
+    s = _strip_accents(raw).strip().upper()
+    if not s:
+        return ""
+
+    # Step 2 — URL scheme then bank-noise (one pass each; descriptors don't stack these).
+    s = _URL_SCHEME.sub("", s, count=1)
+    s = _LEADING_NOISE.sub("", s, count=1)
+
+    # Step 3 — iterate trailing markers until stable.
+    while True:
+        new = _TRAILING_TOKENS.sub("", s).rstrip()
+        if new == s:
+            break
+        s = new
+
+    # Step 4 — collapse non-alnum.
+    s = _NON_ALNUM.sub(" ", s)
+    s = _MULTI_SPACE.sub(" ", s).strip()
+    if not s:
+        return _fallback(raw)
+
+    tokens = s.split()
+
+    # Step 5 — drop residual leading stopword.
+    if tokens and tokens[0] in _LEADING_STOPWORDS:
+        tokens = tokens[1:]
+
+    # Step 6 — strip trailing pure-digit tokens.
+    while tokens and tokens[-1].isdigit():
+        tokens.pop()
+
+    candidate = " ".join(tokens).strip()
+    if len(candidate) < 3:
+        return _fallback(raw)
+    return candidate

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -114,3 +114,26 @@ def normalize_description(raw: str) -> str:
     if len(candidate) < 3:
         return _fallback(raw)
     return candidate
+
+
+def should_skip_learning(obj) -> bool:
+    """True for any object representing a transfer.
+
+    Duck-typed:
+      - ORM Transaction → uses ``linked_transaction_id`` (non-None means it's
+        paired with another leg, i.e. a transfer).
+      - ImportPreviewRow / ImportConfirmRow → uses ``is_transfer``.
+
+    Either attribute being truthy short-circuits to True. Objects with neither
+    attribute return False.
+
+    Why: transfers don't have a meaningful merchant — they're inter-account
+    movement. Learning a rule from a transfer would map "TRANSFER TO SAVINGS"
+    to whatever category the user picked for accounting purposes, which would
+    then mis-categorize legitimate same-merchant payments later.
+    """
+    if getattr(obj, "linked_transaction_id", None) is not None:
+        return True
+    if getattr(obj, "is_transfer", False):
+        return True
+    return False

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -45,6 +45,25 @@ _MULTI_SPACE = re.compile(r"\s+")
 
 _LEADING_STOPWORDS = {"TRANSFER", "PAYMENT", "DEBIT", "CREDIT", "TXN", "TX"}
 
+# Trailing company-form suffixes. Stripped iteratively from the END of the
+# token sequence after punctuation collapse, so "B.V.", "B V", and "BV"
+# all behave consistently. Architect-cautioned: trailing-only — never strip
+# these in the middle of a merchant name.
+_TRAILING_COMPANY_FORMS: tuple[tuple[str, ...], ...] = (
+    ("B", "V"),     # NL: B.V. / B V
+    ("N", "V"),     # NL: N.V. / N V
+    ("S", "A"),     # PT/ES/IT: S.A. / S A
+    ("BV",),
+    ("NV",),
+    ("SA",),
+    ("BVBA",),      # BE: B.V.B.A.
+    ("GMBH",),      # DE
+    ("AG",),        # CH/DE: Aktiengesellschaft
+    ("INC",),
+    ("LLC",),
+    ("LTD",),
+)
+
 
 def _strip_accents(s: str) -> str:
     """NFKD decompose + drop combining marks → fold accents to ASCII letters.
@@ -76,7 +95,8 @@ def normalize_description(raw: str) -> str:
       4. Replace non-alphanumeric runs with a single space; collapse runs.
       5. Drop a residual leading stopword (e.g. `TRANSFER` left over after `SEPA TRANSFER ...`).
       6. Drop trailing pure-digit tokens (date residue, terminal IDs the regex missed).
-      7. Fallback: if cleanup yielded < 3 chars, return cleaned-uppercase original.
+      7. Strip trailing company-form suffixes (B.V. / N.V. / S.A. / BV / GMBH / INC / LLC / LTD ...).
+      8. Fallback: if cleanup yielded < 3 chars, return cleaned-uppercase original.
     """
     if not raw:
         return ""
@@ -117,6 +137,20 @@ def normalize_description(raw: str) -> str:
     # different merchants in the rules dictionary.
     while tokens and tokens[-1].isdigit() and len(tokens[-1]) >= 4:
         tokens.pop()
+
+    # Step 7 — strip trailing company-form suffixes (iteratively, so "FOO B V"
+    # and "FOO INC LLC" both collapse to "FOO"). TRAILING-ONLY by construction:
+    # we only inspect ``tokens[-len(form):]``, never mid-sequence.
+    while tokens:
+        stripped = False
+        for form in _TRAILING_COMPANY_FORMS:
+            n = len(form)
+            if len(tokens) >= n and tuple(tokens[-n:]) == form:
+                tokens = tokens[:-n]
+                stripped = True
+                break
+        if not stripped:
+            break
 
     candidate = " ".join(tokens).strip()
     if len(candidate) < 3:

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -6,6 +6,14 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.category import Category
+from app.models.category_rule import CategoryRule
+from app.models.merchant_dictionary import MerchantDictionaryEntry
 
 # URL scheme prefix (HTTP / HTTPS) — stripped before bank-noise so `HTTPS://AMAZON…` collapses cleanly.
 _URL_SCHEME = re.compile(r"^\s*HTTPS?://", re.IGNORECASE)
@@ -137,3 +145,58 @@ def should_skip_learning(obj) -> bool:
     if getattr(obj, "is_transfer", False):
         return True
     return False
+
+
+InferSource = Literal["org_rule", "shared_dictionary", "default"]
+
+
+async def infer_category(
+    db: AsyncSession, *, org_id: int, description: str
+) -> tuple[int | None, InferSource]:
+    """Resolve (category_id, source) for a transaction description.
+
+    Lookup order (architect-locked):
+      1. Org-local ``category_rules`` keyed by (org_id, normalized_token).
+      2. Shared ``merchant_dictionary`` token → resolve ``category_slug``
+         against this org's ``categories`` (is_system=True, slug=...).
+      3. Default — return (None, "default").
+
+    A future LLM tier (LAI.1) will slot between (2) and (3) once we have
+    rule-coverage data — not in this PR.
+    """
+    token = normalize_description(description)
+    if not token:
+        return None, "default"
+
+    # Tier 1 — org rule
+    result = await db.execute(
+        select(CategoryRule.category_id).where(
+            CategoryRule.org_id == org_id,
+            CategoryRule.normalized_token == token,
+        )
+    )
+    cat_id = result.scalar_one_or_none()
+    if cat_id is not None:
+        return cat_id, "org_rule"
+
+    # Tier 2 — shared dictionary → resolve slug → org's category id
+    result = await db.execute(
+        select(MerchantDictionaryEntry.category_slug).where(
+            MerchantDictionaryEntry.normalized_token == token
+        )
+    )
+    slug = result.scalar_one_or_none()
+    if slug:
+        result = await db.execute(
+            select(Category.id).where(
+                Category.org_id == org_id,
+                Category.slug == slug,
+                Category.is_system.is_(True),
+            )
+        )
+        org_cat_id = result.scalar_one_or_none()
+        if org_cat_id is not None:
+            return org_cat_id, "shared_dictionary"
+
+    # Tier 3 — default
+    return None, "default"

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.category import Category
-from app.models.category_rule import CategoryRule
+from app.models.category_rule import CategoryRule, RuleSource
 from app.models.merchant_dictionary import MerchantDictionaryEntry
 
 # URL scheme prefix (HTTP / HTTPS) — stripped before bank-noise so `HTTPS://AMAZON…` collapses cleanly.
@@ -200,3 +200,72 @@ async def infer_category(
 
     # Tier 3 — default
     return None, "default"
+
+
+async def learn_from_choice(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    description: str,
+    category_id: int,
+    source: str,
+) -> None:
+    """Upsert into category_rules. Caller controls the transaction (no commit here).
+
+    Behaviour (architect-locked, do NOT add conservative-overwrite logic):
+      - First write for (org_id, normalized_token): insert with match_count=1.
+      - Subsequent writes: overwrite category_id, source, and raw_description_seen.
+        Increment match_count. Most-recent-wins.
+      - Empty normalized token: no-op.
+
+    Why most-recent-wins: rules come from EXPLICIT user picks/edits, not
+    probabilistic AI inference. When the user says "Spotify is Entertainment,"
+    we obey, even if a previous high-match-count rule said otherwise. The
+    metric scaffold (smart_rules.import_executed) lets us measure whether
+    sticky-bad-rule churn is a real problem; if so, we add policy then.
+    """
+    token = normalize_description(description)
+    if not token:
+        return
+
+    result = await db.execute(
+        select(CategoryRule).where(
+            CategoryRule.org_id == org_id,
+            CategoryRule.normalized_token == token,
+        )
+    )
+    rule = result.scalar_one_or_none()
+    if rule is None:
+        db.add(CategoryRule(
+            org_id=org_id,
+            normalized_token=token,
+            raw_description_seen=description[:255],
+            category_id=category_id,
+            match_count=1,
+            source=RuleSource(source),
+        ))
+        return
+
+    rule.category_id = category_id
+    rule.source = RuleSource(source)
+    rule.raw_description_seen = description[:255]
+    rule.match_count = (rule.match_count or 0) + 1
+
+
+async def bump_shared_vote(db: AsyncSession, *, description: str) -> None:
+    """Increment vote_count on the matching shared-dictionary entry, if any.
+
+    No-op if the normalized token isn't in the dictionary — we don't promote
+    new tokens automatically in this PR; promotion is a future feature.
+    Caller controls the transaction.
+    """
+    token = normalize_description(description)
+    if not token:
+        return
+    entry = (await db.execute(
+        select(MerchantDictionaryEntry).where(
+            MerchantDictionaryEntry.normalized_token == token
+        )
+    )).scalar_one_or_none()
+    if entry is not None:
+        entry.vote_count = (entry.vote_count or 0) + 1

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -10,6 +10,9 @@ import unicodedata
 # URL scheme prefix (HTTP / HTTPS) — stripped before bank-noise so `HTTPS://AMAZON…` collapses cleanly.
 _URL_SCHEME = re.compile(r"^\s*HTTPS?://", re.IGNORECASE)
 
+# Masked card numbers appearing at the front: "****0001", "*1234", "**5678 ".
+_LEADING_MASKED_CARD = re.compile(r"^\s*\*+\s*\d{2,}\s+", re.IGNORECASE)
+
 # Bank-noise that appears at the front of the descriptor.
 _LEADING_NOISE = re.compile(
     r"^\s*(POS|CARD\s*PAYMENT|CARD|PAY|SEPA(?:\s+TRANSFER)?|DEB|CARTAO)\s+",
@@ -73,8 +76,11 @@ def normalize_description(raw: str) -> str:
     if not s:
         return ""
 
-    # Step 2 — URL scheme then bank-noise (one pass each; descriptors don't stack these).
+    # Step 2a — strip leading URL scheme if present.
     s = _URL_SCHEME.sub("", s, count=1)
+    # Step 2b — strip leading masked-card prefix (e.g. "****0001 ").
+    s = _LEADING_MASKED_CARD.sub("", s, count=1)
+    # Step 2c — strip leading bank-noise (POS / CARD / PAY / SEPA / DEB / CARTAO).
     s = _LEADING_NOISE.sub("", s, count=1)
 
     # Step 3 — iterate trailing markers until stable.
@@ -96,8 +102,12 @@ def normalize_description(raw: str) -> str:
     if tokens and tokens[0] in _LEADING_STOPWORDS:
         tokens = tokens[1:]
 
-    # Step 6 — strip trailing pure-digit tokens.
-    while tokens and tokens[-1].isdigit():
+    # Step 6 — strip trailing pure-digit tokens that look like date/terminal-id residue
+    # (4+ digits). Keep 1-3 digit tokens because they're often brand suffixes
+    # like "STORE 24" or "SUPER 8". Architect note (sticky-bad-token risk):
+    # collapsing "STORE 24" and "STORE" into one token would merge two
+    # different merchants in the rules dictionary.
+    while tokens and tokens[-1].isdigit() and len(tokens[-1]) >= 4:
         tokens.pop()
 
     candidate = " ".join(tokens).strip()

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -4,6 +4,8 @@ Parsing/validation is separate from persistence so a background worker
 can replace the synchronous confirm path later without a rewrite.
 """
 
+from collections import Counter
+
 import structlog
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +20,7 @@ from app.schemas.import_schemas import (
 )
 from app.schemas.transaction import TransactionCreate, TransferCreate
 from app.services import transaction_service
+from app.services.category_rules_service import infer_category
 from app.services.exceptions import ValidationError
 from app.services.import_parser import ParsedRow
 
@@ -72,6 +75,14 @@ async def build_preview(
             and row.transaction_type.lower() in _TRANSFER_TYPES
         )
 
+        # ── Smart-rules suggestion (skipped for transfers) ──
+        suggested_category_id: int | None = None
+        suggestion_source: str | None = None
+        if not is_transfer:
+            suggested_category_id, suggestion_source = await infer_category(
+                db, org_id=org_id, description=row.description
+            )
+
         if is_dup:
             duplicate_count += 1
         if is_transfer:
@@ -89,8 +100,23 @@ async def build_preview(
                 is_duplicate=is_dup,
                 duplicate_transaction_id=dup_id,
                 is_potential_transfer=is_transfer,
+                suggested_category_id=suggested_category_id,
+                suggestion_source=suggestion_source,
             )
         )
+
+    # ── Aggregate smart-rules metric (architect-mandated; one event per preview) ──
+    source_split = Counter((r.suggestion_source or "skipped") for r in preview_rows)
+    suggested_count = sum(
+        1 for r in preview_rows if r.suggested_category_id is not None
+    )
+    await logger.ainfo(
+        "smart_rules.preview_built",
+        org_id=org_id,
+        rows_total=len(preview_rows),
+        suggested_count=suggested_count,
+        source_split=dict(source_split),
+    )
 
     return ImportPreviewResponse(
         rows=preview_rows,

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -260,8 +260,15 @@ async def execute_import(
                         accepted_count += 1
                     elif row.suggested_category_id is not None:
                         overridden_count += 1
+
+                # Metric collection — fires for EVERY imported non-transfer
+                # row, including default-category fallthroughs (row.category_id
+                # is None and the user relied on default_category_id). This
+                # is the architect-mandated signal for "uncategorizable on
+                # import" and must NOT be gated on row.category_id.
+                if not should_skip_learning(row):
                     source_split[row.suggestion_source or "default"] += 1
-                    if row.suggestion_source == "default":
+                    if row.suggestion_source in ("default", None):
                         token = normalize_description(row.description)
                         if token:
                             miss_tokens.add(token)

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -10,6 +10,7 @@ import structlog
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.settings import OrgSetting
 from app.models.transaction import Transaction
 from app.schemas.import_schemas import (
     ImportConfirmRequest,
@@ -20,7 +21,13 @@ from app.schemas.import_schemas import (
 )
 from app.schemas.transaction import TransactionCreate, TransferCreate
 from app.services import transaction_service
-from app.services.category_rules_service import infer_category
+from app.services.category_rules_service import (
+    bump_shared_vote,
+    infer_category,
+    learn_from_choice,
+    normalize_description,
+    should_skip_learning,
+)
 from app.services.exceptions import ValidationError
 from app.services.import_parser import ParsedRow
 
@@ -142,6 +149,21 @@ async def execute_import(
     skipped_count = 0
     errors: list[ImportRowError] = []
 
+    # ── Smart-rules learning: fetch share flag once, init aggregate counters ──
+    share_flag = (await db.execute(
+        select(OrgSetting.value).where(
+            OrgSetting.org_id == org_id,
+            OrgSetting.key == "share_merchant_data",
+        )
+    )).scalar_one_or_none()
+    share_merchant_data = (share_flag == "true")
+
+    learned_count = 0
+    accepted_count = 0
+    overridden_count = 0
+    source_split: Counter[str] = Counter()
+    miss_tokens: set[str] = set()
+
     for row in body.rows:
         if row.skip:
             skipped_count += 1
@@ -188,6 +210,44 @@ async def execute_import(
                     db, org_id, tx_body, is_imported=True
                 )
 
+                # ── Learn from the user's category choice ────────────────
+                # Skip transfers (the transfer branch above never reaches
+                # this block) and rows with no category at all. The double
+                # commit (create_transaction commits the txn, this block
+                # commits the rule + vote separately) is intentional —
+                # keeps a learn-failure from rolling back the imported
+                # transaction.
+                if row.category_id is not None and not should_skip_learning(row):
+                    accepted = (
+                        row.suggested_category_id is not None
+                        and row.suggested_category_id == row.category_id
+                    )
+                    source = "user_pick" if accepted else "user_edit"
+                    await learn_from_choice(
+                        db,
+                        org_id=org_id,
+                        description=row.description,
+                        category_id=row.category_id,
+                        source=source,
+                    )
+                    if (
+                        accepted and share_merchant_data
+                        and row.suggestion_source == "shared_dictionary"
+                    ):
+                        await bump_shared_vote(db, description=row.description)
+                    await db.commit()
+
+                    learned_count += 1
+                    if accepted:
+                        accepted_count += 1
+                    elif row.suggested_category_id is not None:
+                        overridden_count += 1
+                    source_split[row.suggestion_source or "default"] += 1
+                    if row.suggestion_source == "default":
+                        token = normalize_description(row.description)
+                        if token:
+                            miss_tokens.add(token)
+
             imported_count += 1
 
         except Exception as exc:
@@ -198,6 +258,25 @@ async def execute_import(
                 error=str(exc),
             )
             errors.append(ImportRowError(row_number=row.row_number, error=str(exc)))
+
+    # ── Aggregate smart-rules metric (architect-mandated; one per import) ──
+    await logger.ainfo(
+        "smart_rules.import_executed",
+        org_id=org_id,
+        rows_total=len(body.rows),
+        imported_count=imported_count,
+        learned_count=learned_count,
+        accepted_count=accepted_count,
+        overridden_count=overridden_count,
+        source_split=dict(source_split),
+        miss_count=len(miss_tokens),
+    )
+    # Per-UNIQUE-token miss events (set-dedup is load-bearing — emitting
+    # per-row would flood the metric with duplicates of the same merchant).
+    for token in miss_tokens:
+        await logger.ainfo(
+            "smart_rules.miss", org_id=org_id, normalized_token=token,
+        )
 
     return ImportConfirmResponse(
         imported_count=imported_count,

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -223,20 +223,38 @@ async def execute_import(
                         and row.suggested_category_id == row.category_id
                     )
                     source = "user_pick" if accepted else "user_edit"
-                    await learn_from_choice(
-                        db,
-                        org_id=org_id,
-                        description=row.description,
-                        category_id=row.category_id,
-                        source=source,
-                    )
-                    if (
-                        accepted and share_merchant_data
-                        and row.suggestion_source == "shared_dictionary"
-                    ):
-                        await bump_shared_vote(db, description=row.description)
-                    await db.commit()
+                    # Learning is best-effort: a failure here must NOT
+                    # bubble out as a row error. The transaction itself
+                    # has already committed (see create_transaction
+                    # above) — the row is imported regardless.
+                    try:
+                        await learn_from_choice(
+                            db,
+                            org_id=org_id,
+                            description=row.description,
+                            category_id=row.category_id,
+                            source=source,
+                        )
+                        if (
+                            accepted and share_merchant_data
+                            and row.suggestion_source == "shared_dictionary"
+                        ):
+                            await bump_shared_vote(db, description=row.description)
+                        await db.commit()
+                    except Exception as exc:
+                        await db.rollback()
+                        await logger.awarning(
+                            "smart_rules.learn_failed",
+                            org_id=org_id,
+                            op="execute_import",
+                            row_number=row.row_number,
+                            error=str(exc),
+                            error_type=type(exc).__name__,
+                        )
 
+                    # Counters always update — the user's choice was
+                    # registered against an imported row, even if the
+                    # rule write failed and got logged above.
                     learned_count += 1
                     if accepted:
                         accepted_count += 1

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -21,6 +21,7 @@ from app.models.account import Account
 from app.models.category import Category
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.schemas.transaction import TransactionCreate, TransactionResponse, TransactionUpdate, TransferCreate
+from app.services.category_rules_service import learn_from_choice
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 
@@ -151,6 +152,20 @@ async def create_transaction(
 
     await db.commit()
 
+    # Learn from the explicit category pick on MANUAL creates only.
+    # Imports own their own learning in execute_import (Task 7), with
+    # accept-vs-override awareness. Adding a learn here would double-write
+    # and clobber user_pick semantics.
+    if not is_imported:
+        await learn_from_choice(
+            db,
+            org_id=org_id,
+            description=body.description,
+            category_id=body.category_id,
+            source="user_edit",
+        )
+        await db.commit()
+
     result = await db.execute(
         select(Transaction).options(*_load_opts()).where(Transaction.id == tx.id)
     )
@@ -184,6 +199,7 @@ async def update_transaction(
     old_amount = tx.amount
     old_type = tx.type
     old_status = tx.status
+    old_category_id = tx.category_id
 
     new_account_id = body.account_id if body.account_id is not None else old_account_id
     new_status = TransactionStatus(body.status) if body.status is not None else old_status
@@ -220,6 +236,18 @@ async def update_transaction(
             apply_balance(new_account, tx.amount, tx.type)
 
     await db.commit()
+
+    # Learn only when the category actually changed and the row is not a transfer.
+    # Transfers raise ConflictError above, so by here tx.linked_transaction_id is None.
+    if body.category_id is not None and body.category_id != old_category_id:
+        await learn_from_choice(
+            db,
+            org_id=org_id,
+            description=tx.description,
+            category_id=body.category_id,
+            source="user_edit",
+        )
+        await db.commit()
 
     result = await db.execute(
         select(Transaction).options(*_load_opts()).where(Transaction.id == tx.id)

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -13,6 +13,7 @@ instead of HTTPException — callers map these to the appropriate response.
 import datetime
 from decimal import Decimal
 
+import structlog
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -23,6 +24,8 @@ from app.models.transaction import Transaction, TransactionStatus, TransactionTy
 from app.schemas.transaction import TransactionCreate, TransactionResponse, TransactionUpdate, TransferCreate
 from app.services.category_rules_service import learn_from_choice
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+logger = structlog.get_logger()
 
 
 # ── Response helpers ──────────────────────────────────────────────────────────
@@ -156,15 +159,28 @@ async def create_transaction(
     # Imports own their own learning in execute_import (Task 7), with
     # accept-vs-override awareness. Adding a learn here would double-write
     # and clobber user_pick semantics.
+    #
+    # Learning is best-effort: a failure here must NOT surface as a 500
+    # to the caller — the user's transaction is already committed above.
     if not is_imported:
-        await learn_from_choice(
-            db,
-            org_id=org_id,
-            description=body.description,
-            category_id=body.category_id,
-            source="user_edit",
-        )
-        await db.commit()
+        try:
+            await learn_from_choice(
+                db,
+                org_id=org_id,
+                description=body.description,
+                category_id=body.category_id,
+                source="user_edit",
+            )
+            await db.commit()
+        except Exception as exc:
+            await db.rollback()
+            await logger.awarning(
+                "smart_rules.learn_failed",
+                org_id=org_id,
+                op="create_transaction",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
 
     result = await db.execute(
         select(Transaction).options(*_load_opts()).where(Transaction.id == tx.id)
@@ -239,15 +255,28 @@ async def update_transaction(
 
     # Learn only when the category actually changed and the row is not a transfer.
     # Transfers raise ConflictError above, so by here tx.linked_transaction_id is None.
+    #
+    # Learning is best-effort: a failure here must NOT surface as a 500
+    # to the caller — the user's edit is already committed above.
     if body.category_id is not None and body.category_id != old_category_id:
-        await learn_from_choice(
-            db,
-            org_id=org_id,
-            description=tx.description,
-            category_id=body.category_id,
-            source="user_edit",
-        )
-        await db.commit()
+        try:
+            await learn_from_choice(
+                db,
+                org_id=org_id,
+                description=tx.description,
+                category_id=body.category_id,
+                source="user_edit",
+            )
+            await db.commit()
+        except Exception as exc:
+            await db.rollback()
+            await logger.awarning(
+                "smart_rules.learn_failed",
+                org_id=org_id,
+                op="update_transaction",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
 
     result = await db.execute(
         select(Transaction).options(*_load_opts()).where(Transaction.id == tx.id)

--- a/backend/tests/routers/test_categories_delete_with_rules.py
+++ b/backend/tests/routers/test_categories_delete_with_rules.py
@@ -1,0 +1,74 @@
+"""Pre-merge review fix: deleting a category that has learned smart-rules
+must not fail with an FK error. Rules are invisible learning state and
+become invalid when the category is gone — they should be deleted silently.
+"""
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.category import Category, CategoryType
+from app.models.category_rule import CategoryRule, RuleSource
+from app.models.user import Organization
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _r):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def test_deleting_category_with_learned_rules_succeeds(
+    db_session: AsyncSession,
+) -> None:
+    """Reproduces the pre-merge review FK regression."""
+    org = Organization(name="X", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    cat = Category(
+        org_id=org.id, name="Misc", slug="misc",
+        is_system=False, type=CategoryType.EXPENSE,
+    )
+    db_session.add(cat)
+    await db_session.flush()
+    db_session.add(CategoryRule(
+        org_id=org.id,
+        normalized_token="TESTLIDL",
+        raw_description_seen="TEST LIDL",
+        category_id=cat.id,
+        match_count=1,
+        source=RuleSource.USER_PICK,
+    ))
+    await db_session.commit()
+
+    # Mirror the router's delete logic: delete rules first, then category.
+    from sqlalchemy import delete
+    await db_session.execute(
+        delete(CategoryRule).where(CategoryRule.category_id == cat.id)
+    )
+    await db_session.delete(cat)
+    await db_session.commit()
+
+    # Both gone, no FK error raised.
+    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
+    assert rules == []
+    cats = (await db_session.execute(select(Category))).scalars().all()
+    assert cats == []

--- a/backend/tests/services/test_admin_orgs_service.py
+++ b/backend/tests/services/test_admin_orgs_service.py
@@ -23,6 +23,8 @@ from app.models.account import Account, AccountType
 from app.models.billing import BillingPeriod
 from app.models.budget import Budget
 from app.models.category import Category, CategoryType
+from app.models.category_rule import CategoryRule, RuleSource
+from app.models.merchant_dictionary import MerchantDictionaryEntry
 from app.models.forecast_plan import (
     ForecastItemType,
     ForecastPlan,
@@ -188,7 +190,17 @@ async def _seed_full_org(factory, *, name: str = "Acme") -> dict:
             created_by=owner.id,
             expires_at=datetime.datetime.utcnow() + datetime.timedelta(days=7),
         )
-        db.add_all([plan_item, invite])
+        # Smart-rules row — category_rules.category_id FKs to categories.id,
+        # so the cascade must wipe these before the bulk DELETE on categories.
+        rule = CategoryRule(
+            org_id=org.id,
+            normalized_token=f"TEST{name.upper()}",
+            raw_description_seen=f"POS {name} *0001",
+            category_id=master.id,
+            match_count=1,
+            source=RuleSource.USER_PICK,
+        )
+        db.add_all([plan_item, invite, rule])
         await db.commit()
 
         return {"org_id": org.id, "owner_id": owner.id}
@@ -209,6 +221,14 @@ async def test_delete_org_cascade_removes_all_children_and_keeps_other_org(
     target = await _seed_full_org(session_factory, name="Target")
     keep = await _seed_full_org(session_factory, name="Keep")
 
+    # Shared dictionary is org-agnostic — must survive org deletion.
+    async with session_factory() as db:
+        db.add(MerchantDictionaryEntry(
+            normalized_token="LIDL", category_slug="groceries",
+            is_seed=True, vote_count=0,
+        ))
+        await db.commit()
+
     async with session_factory() as db:
         result = await admin_orgs_service.delete_org_cascade(
             db, org_id=target["org_id"],
@@ -220,12 +240,13 @@ async def test_delete_org_cascade_removes_all_children_and_keeps_other_org(
     assert result["users"] == 2
     assert result["transactions"] == 1
     assert result["categories"] == 2  # master + sub
+    assert result["category_rules"] == 1
     # Order isn't asserted — just that every table reports.
     expected_tables = {
         "transactions", "forecast_plan_items", "budgets", "invitations",
         "recurring_transactions", "forecast_plans", "billing_periods",
-        "accounts", "account_types", "categories", "settings", "users",
-        "subscriptions", "organizations",
+        "accounts", "account_types", "category_rules", "categories",
+        "settings", "users", "subscriptions", "organizations",
     }
     assert expected_tables <= set(result.keys())
 
@@ -237,11 +258,19 @@ async def test_delete_org_cascade_removes_all_children_and_keeps_other_org(
         assert await _count(db, Category, org_id=target["org_id"]) == 0
         assert await _count(db, Subscription, org_id=target["org_id"]) == 0
         assert await _count(db, Invitation, org_id=target["org_id"]) == 0
+        assert await _count(db, CategoryRule, org_id=target["org_id"]) == 0
         # Sibling org survives intact.
         assert await _count(db, Organization, id=keep["org_id"]) == 1
         assert await _count(db, User, org_id=keep["org_id"]) == 2
         assert await _count(db, Transaction, org_id=keep["org_id"]) == 1
         assert await _count(db, Category, org_id=keep["org_id"]) == 2
+        assert await _count(db, CategoryRule, org_id=keep["org_id"]) == 1
+        # merchant_dictionary is shared (no org_id) — must NOT be touched.
+        from sqlalchemy import func
+        md_count = await db.scalar(
+            select(func.count()).select_from(MerchantDictionaryEntry)
+        )
+        assert md_count == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -27,12 +27,30 @@ from app.services.category_rules_service import normalize_description
         ("POS LIDL *1234 *ABCD", "LIDL"),                   # double terminal id
         ("UBER 2026-04-12 2026-04-13", "UBER"),             # double date
         ("MERCADONA 20260412", "MERCADONA"),                # date without dashes
-        ("E-LECLERC 24H STATION 042", "E LECLERC 24H STATION"),  # brand-internal digits
+        ("E-LECLERC 24H STATION 042", "E LECLERC 24H STATION 042"),  # 3-digit trailing token kept (brand-suffix safe; see I-1)
         # ── Fallbacks ────────────────────────────────────────────────────────
         ("", ""),                  # empty → empty
         ("X", "X"),                # < 3 chars after cleanup → fallback returns cleaned uppercase
         ("**", ""),                # only noise → empty
+        # ── Brand suffix preservation (architect/I-1 sticky-bad-token risk) ───
+        ("STORE 24", "STORE 24"),                      # 2-digit brand suffix kept
+        ("SUPER 8", "SUPER 8"),                        # 1-digit brand suffix kept
+        ("WORTEN 24H STATION", "WORTEN 24H STATION"),  # alphanumeric token kept
+        # ── Masked card prefix (architect/I-4) ──────────────────────────────
+        ("****0001 STARBUCKS", "STARBUCKS"),
+        ("**1234 LIDL LISBOA *9999", "LIDL LISBOA"),   # masked prefix + trailing *id
+        # ── Documented trade-offs (low real-world hit rate; not fixing in this PR) ───
+        ("PAY DAY LOAN", "DAY LOAN"),                  # I-2: leading "PAY" stripped even when part of name
+        ("BRANDIBANXX99ABCDEFGHIJ12345", "BRANDIBAN"), # I-3: glued IBAN-tail IS stripped (regex matches mid-word)
     ],
 )
 def test_normalize_description(raw: str, expected: str) -> None:
     assert normalize_description(raw) == expected
+
+
+def test_normalize_description_handles_none() -> None:
+    """raw=None must not crash; returns "" gracefully.
+
+    DB rows can have NULL descriptions; callers shouldn't have to defend.
+    """
+    assert normalize_description(None) == ""  # type: ignore[arg-type]

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -1,0 +1,38 @@
+"""Service-layer tests for L3.10 — smart rules / auto-categorization."""
+import pytest
+
+from app.services.category_rules_service import normalize_description
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # ── Spec-locked cases ────────────────────────────────────────────────
+        ("POS PINGO DOCE *1234", "PINGO DOCE"),
+        ("LIDL E LEROY MERLIN *4521", "LIDL E LEROY MERLIN"),
+        ("AMZN MKTP US*1A2B3C", "AMZN MKTP US"),
+        ("SEPA TRANSFER VODAFONE PT 2026-04-15", "VODAFONE PT"),
+        # ── Whitespace / casing ──────────────────────────────────────────────
+        ("   spotify  AB  ", "SPOTIFY AB"),
+        ("##APPLE STORE##", "APPLE STORE"),
+        # ── Real-world messy descriptors (architect-requested coverage) ──────
+        ("CARD PAYMENT NETFLIX.COM/EUR", "NETFLIX COM EUR"),
+        ("PAY 7-ELEVEN STORE", "7 ELEVEN STORE"),
+        ("CARTAO LIDL LISBOA *0001", "LIDL LISBOA"),       # PT bank prefix
+        ("DEB AMAZON DE BERLIN", "AMAZON DE BERLIN"),       # DEB prefix
+        ("SEPA SPOTIFY AB IT60X0542811101000000123456", "SPOTIFY AB"),  # IBAN tail
+        ("HTTPS://AMAZON.ES/REF=ABC", "AMAZON ES REF"),     # URL-ish
+        ("CONTINENTE LISBOA *4521", "CONTINENTE LISBOA"),
+        ("CAFÉ DELTA LISBOA", "CAF DELTA LISBOA"),          # accent stripped
+        ("POS LIDL *1234 *ABCD", "LIDL"),                   # double terminal id
+        ("UBER 2026-04-12 2026-04-13", "UBER"),             # double date
+        ("MERCADONA 20260412", "MERCADONA"),                # date without dashes
+        ("E-LECLERC 24H STATION 042", "E LECLERC 24H STATION"),  # brand-internal digits
+        # ── Fallbacks ────────────────────────────────────────────────────────
+        ("", ""),                  # empty → empty
+        ("X", "X"),                # < 3 chars after cleanup → fallback returns cleaned uppercase
+        ("**", ""),                # only noise → empty
+    ],
+)
+def test_normalize_description(raw: str, expected: str) -> None:
+    assert normalize_description(raw) == expected

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import event
+from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
@@ -14,7 +14,9 @@ from app.models.category_rule import CategoryRule, RuleSource
 from app.models.merchant_dictionary import MerchantDictionaryEntry
 from app.models.user import Organization
 from app.services.category_rules_service import (
+    bump_shared_vote,
     infer_category,
+    learn_from_choice,
     normalize_description,
     should_skip_learning,
 )
@@ -194,3 +196,117 @@ async def test_infer_category_default_when_slug_not_in_org(db_session: AsyncSess
     )
     assert cat_id is None
     assert source == "default"
+
+
+async def test_learn_from_choice_inserts_new_rule(
+    db_session: AsyncSession, seeded_org: dict
+) -> None:
+    await learn_from_choice(
+        db_session,
+        org_id=seeded_org["org_id"],
+        description="POS LIDL *0001",
+        category_id=seeded_org["groceries_id"],
+        source="user_pick",
+    )
+    await db_session.commit()
+
+    rule = (await db_session.execute(
+        select(CategoryRule).where(
+            CategoryRule.org_id == seeded_org["org_id"],
+            CategoryRule.normalized_token == "LIDL",
+        )
+    )).scalar_one()
+    assert rule.category_id == seeded_org["groceries_id"]
+    assert rule.match_count == 1
+    assert rule.source == RuleSource.USER_PICK
+    assert rule.raw_description_seen == "POS LIDL *0001"
+
+
+async def test_learn_from_choice_upserts_with_new_category(
+    db_session: AsyncSession, seeded_org: dict
+) -> None:
+    """Most-recent-wins: a second call with a different category overwrites + bumps count."""
+    await learn_from_choice(
+        db_session, org_id=seeded_org["org_id"],
+        description="POS LIDL *0001", category_id=seeded_org["groceries_id"],
+        source="user_pick",
+    )
+    await db_session.commit()
+
+    await learn_from_choice(
+        db_session, org_id=seeded_org["org_id"],
+        description="POS LIDL *0002", category_id=seeded_org["restaurants_id"],
+        source="user_edit",
+    )
+    await db_session.commit()
+
+    rule = (await db_session.execute(
+        select(CategoryRule).where(CategoryRule.normalized_token == "LIDL")
+    )).scalar_one()
+    assert rule.category_id == seeded_org["restaurants_id"]
+    assert rule.match_count == 2
+    assert rule.source == RuleSource.USER_EDIT
+    assert rule.raw_description_seen == "POS LIDL *0002"
+
+
+async def test_learn_from_choice_idempotent_on_same_category(
+    db_session: AsyncSession, seeded_org: dict
+) -> None:
+    """Three identical learns → match_count=3, no other rows."""
+    for _ in range(3):
+        await learn_from_choice(
+            db_session, org_id=seeded_org["org_id"],
+            description="POS LIDL *0001", category_id=seeded_org["groceries_id"],
+            source="user_pick",
+        )
+        await db_session.commit()
+
+    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
+    assert len(rules) == 1
+    assert rules[0].match_count == 3
+    assert rules[0].category_id == seeded_org["groceries_id"]
+
+
+async def test_learn_from_choice_empty_token_is_noop(
+    db_session: AsyncSession, seeded_org: dict
+) -> None:
+    """Description that normalizes to empty/<3-char fallback that's still empty → don't write."""
+    await learn_from_choice(
+        db_session, org_id=seeded_org["org_id"],
+        description="   ", category_id=seeded_org["groceries_id"],
+        source="user_pick",
+    )
+    await db_session.commit()
+    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
+    assert rules == []
+
+
+async def test_bump_shared_vote_increments_existing_entry(
+    db_session: AsyncSession, seeded_org: dict
+) -> None:
+    db_session.add(MerchantDictionaryEntry(
+        normalized_token="LIDL", category_slug="groceries", is_seed=True, vote_count=0,
+    ))
+    await db_session.commit()
+
+    await bump_shared_vote(db_session, description="POS LIDL *9999")
+    await db_session.commit()
+
+    entry = (await db_session.execute(
+        select(MerchantDictionaryEntry).where(
+            MerchantDictionaryEntry.normalized_token == "LIDL"
+        )
+    )).scalar_one()
+    assert entry.vote_count == 1
+
+
+async def test_bump_shared_vote_noop_when_token_missing(
+    db_session: AsyncSession, seeded_org: dict
+) -> None:
+    """Token isn't in the dictionary → silent no-op (we don't auto-promote here)."""
+    await bump_shared_vote(db_session, description="POS NOVEL CAFE *0001")
+    await db_session.commit()
+    entries = (await db_session.execute(
+        select(MerchantDictionaryEntry)
+    )).scalars().all()
+    assert entries == []

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -1,7 +1,12 @@
 """Service-layer tests for L3.10 — smart rules / auto-categorization."""
 import pytest
 
-from app.services.category_rules_service import normalize_description
+from types import SimpleNamespace
+
+from app.services.category_rules_service import (
+    normalize_description,
+    should_skip_learning,
+)
 
 
 @pytest.mark.parametrize(
@@ -54,3 +59,21 @@ def test_normalize_description_handles_none() -> None:
     DB rows can have NULL descriptions; callers shouldn't have to defend.
     """
     assert normalize_description(None) == ""  # type: ignore[arg-type]
+
+
+def test_should_skip_learning_skips_transfer_via_linked_id() -> None:
+    """ORM Transaction with linked_transaction_id set is a transfer leg."""
+    tx = SimpleNamespace(linked_transaction_id=42, type="expense")
+    assert should_skip_learning(tx) is True
+
+
+def test_should_skip_learning_skips_preview_row_marked_transfer() -> None:
+    """ImportConfirmRow with is_transfer=True must skip."""
+    row = SimpleNamespace(linked_transaction_id=None, is_transfer=True)
+    assert should_skip_learning(row) is True
+
+
+def test_should_skip_learning_keeps_regular_transaction() -> None:
+    """Neither linked nor flagged → learn."""
+    tx = SimpleNamespace(linked_transaction_id=None, type="expense", is_transfer=False)
+    assert should_skip_learning(tx) is False

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -23,7 +23,7 @@ from app.services.category_rules_service import normalize_description
         ("SEPA SPOTIFY AB IT60X0542811101000000123456", "SPOTIFY AB"),  # IBAN tail
         ("HTTPS://AMAZON.ES/REF=ABC", "AMAZON ES REF"),     # URL-ish
         ("CONTINENTE LISBOA *4521", "CONTINENTE LISBOA"),
-        ("CAFÉ DELTA LISBOA", "CAF DELTA LISBOA"),          # accent stripped
+        ("CAFÉ DELTA LISBOA", "CAFE DELTA LISBOA"),         # accent folded (NFKD), not dropped
         ("POS LIDL *1234 *ABCD", "LIDL"),                   # double terminal id
         ("UBER 2026-04-12 2026-04-13", "UBER"),             # double date
         ("MERCADONA 20260412", "MERCADONA"),                # date without dashes

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -60,6 +60,23 @@ from app.services.category_rules_service import (
         # ── Documented trade-offs (low real-world hit rate; not fixing in this PR) ───
         ("PAY DAY LOAN", "DAY LOAN"),                  # I-2: leading "PAY" stripped even when part of name
         ("BRANDIBANXX99ABCDEFGHIJ12345", "BRANDIBAN"), # I-3: glued IBAN-tail IS stripped (regex matches mid-word)
+        # ── Trailing company-form suffixes (architect Path B) ────────────────
+        ("KPN B.V.", "KPN"),
+        ("KPN B V", "KPN"),
+        ("KPN BV", "KPN"),
+        ("ODIDO NETHERLANDS B.V.", "ODIDO NETHERLANDS"),
+        ("FRANK ENERGIE B V", "FRANK ENERGIE"),
+        ("AMERICAN EXPRESS EUROPE S.A.", "AMERICAN EXPRESS EUROPE"),
+        ("REMOTE B V", "REMOTE"),
+        ("ACME GMBH", "ACME"),
+        ("WIDGET LTD", "WIDGET"),
+        ("FOO INC", "FOO"),
+        # Iterative: stacked suffixes
+        ("WIDGET B V LTD", "WIDGET"),
+        # Trailing-only: leading "B V" preserved (don't strip mid-name)
+        ("B V REPAIR SHOP", "B V REPAIR SHOP"),
+        # Mid-name preservation
+        ("INC POWER STORE", "INC POWER STORE"),
     ],
 )
 def test_normalize_description(raw: str, expected: str) -> None:

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -1,9 +1,20 @@
 """Service-layer tests for L3.10 — smart rules / auto-categorization."""
-import pytest
-
 from types import SimpleNamespace
 
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.category import Category, CategoryType
+from app.models.category_rule import CategoryRule, RuleSource
+from app.models.merchant_dictionary import MerchantDictionaryEntry
+from app.models.user import Organization
 from app.services.category_rules_service import (
+    infer_category,
     normalize_description,
     should_skip_learning,
 )
@@ -77,3 +88,109 @@ def test_should_skip_learning_keeps_regular_transaction() -> None:
     """Neither linked nor flagged → learn."""
     tx = SimpleNamespace(linked_transaction_id=None, type="expense", is_transfer=False)
     assert should_skip_learning(tx) is False
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_org(db_session: AsyncSession) -> dict:
+    """Org with two system categories: groceries + restaurants."""
+    org = Organization(name="Test Org")
+    db_session.add(org)
+    await db_session.flush()
+
+    groceries = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        is_system=True, type=CategoryType.EXPENSE,
+    )
+    restaurants = Category(
+        org_id=org.id, name="Restaurants", slug="restaurants",
+        is_system=True, type=CategoryType.EXPENSE,
+    )
+    db_session.add_all([groceries, restaurants])
+    await db_session.commit()
+    await db_session.refresh(groceries)
+    await db_session.refresh(restaurants)
+    return {
+        "org_id": org.id,
+        "groceries_id": groceries.id,
+        "restaurants_id": restaurants.id,
+    }
+
+
+async def test_infer_category_org_rule_wins(db_session: AsyncSession, seeded_org: dict) -> None:
+    """An org-local rule beats the shared dictionary even when both match."""
+    db_session.add(MerchantDictionaryEntry(
+        normalized_token="LIDL", category_slug="groceries", is_seed=True, vote_count=0,
+    ))
+    db_session.add(CategoryRule(
+        org_id=seeded_org["org_id"],
+        normalized_token="LIDL",
+        raw_description_seen="POS LIDL *0001",
+        category_id=seeded_org["restaurants_id"],
+        match_count=1,
+        source=RuleSource.USER_EDIT,
+    ))
+    await db_session.commit()
+
+    cat_id, source = await infer_category(
+        db_session, org_id=seeded_org["org_id"], description="POS LIDL *9999"
+    )
+    assert cat_id == seeded_org["restaurants_id"]
+    assert source == "org_rule"
+
+
+async def test_infer_category_falls_through_to_shared(db_session: AsyncSession, seeded_org: dict) -> None:
+    db_session.add(MerchantDictionaryEntry(
+        normalized_token="PINGO DOCE", category_slug="groceries", is_seed=True, vote_count=0,
+    ))
+    await db_session.commit()
+
+    cat_id, source = await infer_category(
+        db_session, org_id=seeded_org["org_id"], description="POS PINGO DOCE *4521"
+    )
+    assert cat_id == seeded_org["groceries_id"]
+    assert source == "shared_dictionary"
+
+
+async def test_infer_category_default_when_unknown(db_session: AsyncSession, seeded_org: dict) -> None:
+    cat_id, source = await infer_category(
+        db_session, org_id=seeded_org["org_id"], description="POS RANDOM SHOP *4521"
+    )
+    assert cat_id is None
+    assert source == "default"
+
+
+async def test_infer_category_default_when_slug_not_in_org(db_session: AsyncSession, seeded_org: dict) -> None:
+    """Dictionary slug doesn't exist as a system category in this org → graceful default."""
+    db_session.add(MerchantDictionaryEntry(
+        normalized_token="OBSCURE BRAND", category_slug="missing_slug",
+        is_seed=True, vote_count=0,
+    ))
+    await db_session.commit()
+
+    cat_id, source = await infer_category(
+        db_session, org_id=seeded_org["org_id"], description="OBSCURE BRAND"
+    )
+    assert cat_id is None
+    assert source == "default"

--- a/backend/tests/services/test_import_execute_with_rules.py
+++ b/backend/tests/services/test_import_execute_with_rules.py
@@ -244,3 +244,33 @@ async def test_aggregate_metric_emitted_with_correct_shape(db_session: AsyncSess
     miss_kwargs = miss_calls[0].kwargs
     assert miss_kwargs["org_id"] == seed["org_id"]
     assert miss_kwargs["normalized_token"]  # non-empty (will be "NOVEL CAFE")
+
+
+async def test_learn_failure_does_not_fail_the_import(
+    db_session: AsyncSession,
+) -> None:
+    """If learn_from_choice raises, the imported transaction is preserved
+    and the failure is logged (not propagated to the caller)."""
+    seed = await _seed(db_session, share=False)
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=seed["restaurants_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999", amount=Decimal("12.50"), type="expense",
+            category_id=seed["groceries_id"],
+            suggested_category_id=seed["groceries_id"],
+            suggestion_source="shared_dictionary",
+        )],
+    )
+
+    with patch(
+        "app.services.import_service.learn_from_choice",
+        new=AsyncMock(side_effect=RuntimeError("simulated learn failure")),
+    ):
+        result = await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    assert result.imported_count == 1
+    assert result.error_count == 0  # learn failure does NOT surface as a row error

--- a/backend/tests/services/test_import_execute_with_rules.py
+++ b/backend/tests/services/test_import_execute_with_rules.py
@@ -274,3 +274,52 @@ async def test_learn_failure_does_not_fail_the_import(
 
     assert result.imported_count == 1
     assert result.error_count == 0  # learn failure does NOT surface as a row error
+
+
+async def test_default_category_fallthrough_records_miss(
+    db_session: AsyncSession,
+) -> None:
+    """The architect-mandated metric: when a row has NO suggestion AND the user
+    leaves category_id None (relying on default_category_id), we must still
+    record the missed normalized token. This was a pre-merge review fix.
+    """
+    seed = await _seed(db_session, share=False)
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=seed["restaurants_id"],
+        rows=[
+            ImportConfirmRow(
+                row_number=1, date=datetime.date(2026, 5, 1),
+                description="POS NOVEL CAFE *0001", amount=Decimal("4.00"),
+                type="expense",
+                category_id=None,                       # user did NOT pick
+                suggested_category_id=None,             # no suggestion
+                suggestion_source="default",
+            ),
+        ],
+    )
+
+    with patch.object(
+        import_service.logger, "ainfo", new_callable=AsyncMock
+    ) as mock_log:
+        result = await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    assert result.imported_count == 1
+    miss_calls = [
+        c for c in mock_log.call_args_list
+        if c.args and c.args[0] == "smart_rules.miss"
+    ]
+    assert len(miss_calls) == 1
+    assert miss_calls[0].kwargs["normalized_token"]  # non-empty
+
+    aggregate_calls = [
+        c for c in mock_log.call_args_list
+        if c.args and c.args[0] == "smart_rules.import_executed"
+    ]
+    assert len(aggregate_calls) == 1
+    agg = aggregate_calls[0].kwargs
+    assert agg["miss_count"] == 1
+    assert agg["learned_count"] == 0  # user didn't pick → no learn
+    assert agg["source_split"]["default"] == 1

--- a/backend/tests/services/test_import_execute_with_rules.py
+++ b/backend/tests/services/test_import_execute_with_rules.py
@@ -1,0 +1,246 @@
+"""execute_import learns from each confirmed row + emits aggregate metric.
+
+Covers Task 7 of L3.10.
+
+  Accept (row.category_id == row.suggested_category_id):
+    -> learn_from_choice(source="user_pick"); bump shared vote if org opted in.
+  Override (row.category_id != row.suggested_category_id, or no suggestion):
+    -> learn_from_choice(source="user_edit"); do NOT bump shared vote.
+  Transfer rows: skip both.
+  Aggregate metric: one smart_rules.import_executed event after the loop;
+                    smart_rules.miss once per UNIQUE missed token.
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.category_rule import CategoryRule, RuleSource
+from app.models.merchant_dictionary import MerchantDictionaryEntry
+from app.models.settings import OrgSetting
+from app.models.user import Organization
+from app.schemas.import_schemas import ImportConfirmRequest, ImportConfirmRow
+from app.services import import_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _r):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession, *, share: bool = False) -> dict:
+    org = Organization(name="X", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    groc = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        is_system=True, type=CategoryType.EXPENSE,
+    )
+    rest = Category(
+        org_id=org.id, name="Restaurants", slug="restaurants",
+        is_system=True, type=CategoryType.EXPENSE,
+    )
+    db.add_all([groc, rest])
+    atype = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db.add(atype)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, account_type_id=atype.id, name="Checking",
+        balance=Decimal("0"),
+    )
+    db.add(acct)
+    db.add(MerchantDictionaryEntry(
+        normalized_token="LIDL", category_slug="groceries",
+        is_seed=True, vote_count=0,
+    ))
+    if share:
+        db.add(OrgSetting(org_id=org.id, key="share_merchant_data", value="true"))
+    await db.commit()
+    return {
+        "org_id": org.id,
+        "account_id": acct.id,
+        "account_type_id": atype.id,
+        "groceries_id": groc.id,
+        "restaurants_id": rest.id,
+    }
+
+
+async def test_accept_learns_user_pick_and_bumps_shared(db_session: AsyncSession) -> None:
+    seed = await _seed(db_session, share=True)
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=seed["restaurants_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999", amount=Decimal("12.50"), type="expense",
+            category_id=seed["groceries_id"],
+            suggested_category_id=seed["groceries_id"],
+            suggestion_source="shared_dictionary",
+        )],
+    )
+    await import_service.execute_import(db_session, org_id=seed["org_id"], body=body)
+
+    rule = (await db_session.execute(select(CategoryRule))).scalar_one()
+    assert rule.source == RuleSource.USER_PICK
+    assert rule.category_id == seed["groceries_id"]
+
+    entry = (await db_session.execute(select(MerchantDictionaryEntry))).scalar_one()
+    assert entry.vote_count == 1
+
+
+async def test_override_learns_user_edit_no_shared_bump(db_session: AsyncSession) -> None:
+    seed = await _seed(db_session, share=True)
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=seed["restaurants_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999", amount=Decimal("12.50"), type="expense",
+            category_id=seed["restaurants_id"],
+            suggested_category_id=seed["groceries_id"],
+            suggestion_source="shared_dictionary",
+        )],
+    )
+    await import_service.execute_import(db_session, org_id=seed["org_id"], body=body)
+
+    rule = (await db_session.execute(select(CategoryRule))).scalar_one()
+    assert rule.source == RuleSource.USER_EDIT
+    assert rule.category_id == seed["restaurants_id"]
+
+    entry = (await db_session.execute(select(MerchantDictionaryEntry))).scalar_one()
+    assert entry.vote_count == 0
+
+
+async def test_accept_without_opt_in_does_not_bump_shared(db_session: AsyncSession) -> None:
+    seed = await _seed(db_session, share=False)
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=seed["restaurants_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999", amount=Decimal("12.50"), type="expense",
+            category_id=seed["groceries_id"],
+            suggested_category_id=seed["groceries_id"],
+            suggestion_source="shared_dictionary",
+        )],
+    )
+    await import_service.execute_import(db_session, org_id=seed["org_id"], body=body)
+    entry = (await db_session.execute(select(MerchantDictionaryEntry))).scalar_one()
+    assert entry.vote_count == 0
+
+
+async def test_transfer_row_does_not_learn(db_session: AsyncSession) -> None:
+    seed = await _seed(db_session, share=True)
+    other = Account(
+        org_id=seed["org_id"], account_type_id=seed["account_type_id"],
+        name="Savings", balance=Decimal("0"),
+    )
+    db_session.add(other)
+    await db_session.commit()
+
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=seed["restaurants_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999", amount=Decimal("12.50"), type="expense",
+            is_transfer=True, transfer_account_id=other.id,
+        )],
+    )
+    await import_service.execute_import(db_session, org_id=seed["org_id"], body=body)
+    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
+    assert rules == []
+
+
+async def test_aggregate_metric_emitted_with_correct_shape(db_session: AsyncSession) -> None:
+    """Architect-mandated aggregate metric:
+      - exactly one smart_rules.import_executed event per import
+      - exactly one smart_rules.miss event per UNIQUE missed normalized_token
+      - the aggregate event has rows_total, learned_count, accepted_count,
+        overridden_count, source_split, miss_count
+    """
+    seed = await _seed(db_session, share=False)
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=seed["restaurants_id"],
+        rows=[
+            # accept
+            ImportConfirmRow(
+                row_number=1, date=datetime.date(2026, 5, 1),
+                description="POS LIDL *0001", amount=Decimal("10"), type="expense",
+                category_id=seed["groceries_id"],
+                suggested_category_id=seed["groceries_id"],
+                suggestion_source="shared_dictionary",
+            ),
+            # override
+            ImportConfirmRow(
+                row_number=2, date=datetime.date(2026, 5, 1),
+                description="POS LIDL *0002", amount=Decimal("11"), type="expense",
+                category_id=seed["restaurants_id"],
+                suggested_category_id=seed["groceries_id"],
+                suggestion_source="shared_dictionary",
+            ),
+            # default -> unique miss token "NOVEL CAFE"
+            ImportConfirmRow(
+                row_number=3, date=datetime.date(2026, 5, 1),
+                description="POS NOVEL CAFE *0003", amount=Decimal("4"), type="expense",
+                category_id=seed["restaurants_id"],
+                suggested_category_id=None,
+                suggestion_source="default",
+            ),
+        ],
+    )
+
+    with patch.object(
+        import_service.logger, "ainfo", new_callable=AsyncMock
+    ) as mock_log:
+        await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    events = mock_log.call_args_list
+    aggregate_calls = [c for c in events if c.args and c.args[0] == "smart_rules.import_executed"]
+    miss_calls = [c for c in events if c.args and c.args[0] == "smart_rules.miss"]
+
+    assert len(aggregate_calls) == 1
+    agg_kwargs = aggregate_calls[0].kwargs
+    assert agg_kwargs["org_id"] == seed["org_id"]
+    assert agg_kwargs["rows_total"] == 3
+    assert agg_kwargs["learned_count"] == 3
+    assert agg_kwargs["accepted_count"] == 1
+    assert agg_kwargs["overridden_count"] == 1  # row 2 has a suggestion but user overrode
+    assert agg_kwargs["miss_count"] == 1
+    # source_split keys come from suggestion_source labels on confirmed rows
+    assert agg_kwargs["source_split"]["shared_dictionary"] == 2
+    assert agg_kwargs["source_split"]["default"] == 1
+
+    # Exactly one miss event for the unique normalized token.
+    assert len(miss_calls) == 1
+    miss_kwargs = miss_calls[0].kwargs
+    assert miss_kwargs["org_id"] == seed["org_id"]
+    assert miss_kwargs["normalized_token"]  # non-empty (will be "NOVEL CAFE")

--- a/backend/tests/services/test_import_preview_with_rules.py
+++ b/backend/tests/services/test_import_preview_with_rules.py
@@ -1,0 +1,162 @@
+"""build_preview attaches suggestions; transfers don't get suggested.
+
+Covers Task 6 of L3.10: the preview integration of infer_category.
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.merchant_dictionary import MerchantDictionaryEntry
+from app.models.user import Organization
+from app.services import import_service
+from app.services.import_parser import ParsedRow
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _r):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    org = Organization(name="X", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    groceries = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        is_system=True, type=CategoryType.EXPENSE,
+    )
+    db.add(groceries)
+    atype = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db.add(atype)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, account_type_id=atype.id, name="Checking",
+        balance=Decimal("0"),
+    )
+    db.add(acct)
+    db.add(MerchantDictionaryEntry(
+        normalized_token="LIDL", category_slug="groceries",
+        is_seed=True, vote_count=0,
+    ))
+    await db.commit()
+    return {"org_id": org.id, "account_id": acct.id, "groceries_id": groceries.id}
+
+
+async def test_preview_attaches_shared_dictionary_suggestion(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed(db_session)
+    rows = [
+        ParsedRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999", amount=Decimal("12.50"),
+            type="expense", counterparty=None, transaction_type=None,
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].suggested_category_id == seed["groceries_id"]
+    assert result.rows[0].suggestion_source == "shared_dictionary"
+
+
+async def test_preview_no_suggestion_for_transfer_row(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed(db_session)
+    rows = [
+        ParsedRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999", amount=Decimal("12.50"),
+            type="expense", counterparty=None, transaction_type="online banking",
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].is_potential_transfer is True
+    assert result.rows[0].suggested_category_id is None
+    assert result.rows[0].suggestion_source is None
+
+
+async def test_preview_default_source_when_no_match(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed(db_session)
+    rows = [
+        ParsedRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS UNKNOWN MERCHANT", amount=Decimal("4.00"),
+            type="expense", counterparty=None, transaction_type=None,
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].suggested_category_id is None
+    assert result.rows[0].suggestion_source == "default"
+
+
+async def test_preview_emits_aggregate_metric(
+    db_session: AsyncSession,
+) -> None:
+    """One smart_rules.preview_built event per preview, with the right shape.
+
+    The architect mandated aggregate (not per-row) telemetry. Structlog routes
+    through its own renderer, so caplog doesn't see records — patching the
+    bound logger's ainfo is the reliable way to capture the call.
+    """
+    seed = await _seed(db_session)
+    rows = [
+        ParsedRow(
+            row_number=i, date=datetime.date(2026, 5, 1),
+            description=desc, amount=Decimal("1"),
+            type="expense", counterparty=None, transaction_type=None,
+        )
+        for i, desc in enumerate(["POS LIDL *0001", "POS LIDL *0002", "POS UNKNOWN"], 1)
+    ]
+    with patch.object(import_service.logger, "ainfo", new_callable=AsyncMock) as spy:
+        await import_service.build_preview(
+            db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+            file_name="t.csv", parsed_rows=rows,
+        )
+
+    aggregate_calls = [
+        c for c in spy.call_args_list
+        if c.args and c.args[0] == "smart_rules.preview_built"
+    ]
+    assert len(aggregate_calls) == 1, "exactly one aggregate metric per preview"
+    kwargs = aggregate_calls[0].kwargs
+    assert kwargs["org_id"] == seed["org_id"]
+    assert kwargs["rows_total"] == 3
+    assert kwargs["suggested_count"] == 2
+    assert kwargs["source_split"] == {"shared_dictionary": 2, "default": 1}

--- a/backend/tests/services/test_transaction_update_learns_rule.py
+++ b/backend/tests/services/test_transaction_update_learns_rule.py
@@ -1,0 +1,149 @@
+"""transaction_service.create_transaction + update_transaction learn rules.
+
+Covers Task 8 of L3.10.
+"""
+import datetime
+from decimal import Decimal
+
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.category_rule import CategoryRule, RuleSource
+from app.models.user import Organization
+from app.schemas.transaction import TransactionCreate, TransactionUpdate
+from app.services import transaction_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _r):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    """Mirror the seed pattern from tests/services/test_import_execute_with_rules.py."""
+    org = Organization(name="X", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+
+    groc = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        is_system=True, type=CategoryType.EXPENSE,
+    )
+    rest = Category(
+        org_id=org.id, name="Restaurants", slug="restaurants",
+        is_system=True, type=CategoryType.EXPENSE,
+    )
+    db.add_all([groc, rest])
+    await db.flush()
+
+    atype = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db.add(atype)
+    await db.flush()
+
+    acct = Account(
+        org_id=org.id, account_type_id=atype.id, name="Checking",
+        balance=Decimal("0"),
+    )
+    db.add(acct)
+    await db.commit()
+    return {
+        "org_id": org.id, "account_id": acct.id,
+        "groceries_id": groc.id, "restaurants_id": rest.id,
+    }
+
+
+async def test_create_transaction_learns_user_edit(db_session: AsyncSession) -> None:
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["account_id"], category_id=seed["groceries_id"],
+        description="POS LIDL *9999", amount=Decimal("12.50"),
+        type="expense", status="settled", date=datetime.date(2026, 5, 1),
+    )
+    await transaction_service.create_transaction(db_session, seed["org_id"], body)
+
+    rule = (await db_session.execute(select(CategoryRule))).scalar_one()
+    assert rule.source == RuleSource.USER_EDIT
+    assert rule.category_id == seed["groceries_id"]
+    assert rule.match_count == 1
+
+
+async def test_update_changing_category_learns_and_bumps(db_session: AsyncSession) -> None:
+    """Create writes a rule once; update to a new category bumps match_count to 2."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["account_id"], category_id=seed["restaurants_id"],
+        description="POS LIDL *9999", amount=Decimal("12.50"),
+        type="expense", status="settled", date=datetime.date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(db_session, seed["org_id"], body)
+
+    update = TransactionUpdate(category_id=seed["groceries_id"])
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], tx.id, update,
+    )
+
+    rule = (await db_session.execute(select(CategoryRule))).scalar_one()
+    assert rule.source == RuleSource.USER_EDIT
+    assert rule.category_id == seed["groceries_id"]
+    assert rule.match_count == 2
+
+
+async def test_update_without_category_change_does_not_learn(
+    db_session: AsyncSession,
+) -> None:
+    """Update that touches only amount → no rule write, no match_count bump."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["account_id"], category_id=seed["groceries_id"],
+        description="POS LIDL *9999", amount=Decimal("12.50"),
+        type="expense", status="settled", date=datetime.date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(db_session, seed["org_id"], body)
+
+    update = TransactionUpdate(amount=Decimal("13.00"))
+    await transaction_service.update_transaction(
+        db_session, seed["org_id"], tx.id, update,
+    )
+
+    rule = (await db_session.execute(select(CategoryRule))).scalar_one()
+    assert rule.match_count == 1
+
+
+async def test_create_transaction_with_is_imported_does_not_learn(
+    db_session: AsyncSession,
+) -> None:
+    """Imports learn via execute_import (Task 7), not via create_transaction."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["account_id"], category_id=seed["groceries_id"],
+        description="POS LIDL *9999", amount=Decimal("12.50"),
+        type="expense", status="settled", date=datetime.date(2026, 5, 1),
+    )
+    await transaction_service.create_transaction(
+        db_session, seed["org_id"], body, is_imported=True,
+    )
+    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
+    assert rules == []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - ./frontend/components:/app/components
       - ./frontend/lib:/app/lib
       - ./frontend/public:/app/public
+      - ./frontend/tests:/app/tests
 
   nginx:
     image: nginx:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     volumes:
       - ./backend/app:/app/app
       - ./backend/alembic:/app/alembic
+      - ./backend/tests:/app/tests
 
   frontend:
     build:

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -100,10 +100,12 @@ function ImportPageContent() {
           description: r.description,
           amount: r.amount,
           type: r.type,
-          category_id: null,
+          category_id: r.suggested_category_id ?? null,
           skip: r.is_duplicate, // pre-skip duplicates
           is_transfer: false,
           transfer_account_id: null,
+          suggested_category_id: r.suggested_category_id ?? null,
+          suggestion_source: r.suggestion_source ?? null,
         })),
       );
       setStep("preview");
@@ -295,18 +297,36 @@ function ImportPageContent() {
                       <td className="px-4 py-2 capitalize text-text-secondary">{previewRow.type}</td>
                       <td className="px-4 py-2">
                         {!rowState.skip && !rowState.is_transfer && (
-                          <CategorySelect
-                            id={`cat-${previewRow.row_number}`}
-                            categories={catOptions}
-                            value={rowState.category_id ?? ""}
-                            onChange={(id) =>
-                              updateRow(previewRow.row_number, {
-                                category_id: id === "" ? null : id,
-                              })
-                            }
-                            filterType={previewRow.type === "income" ? "income" : "expense"}
-                            className={input + " !w-48"}
-                          />
+                          <div className="flex items-center">
+                            <CategorySelect
+                              id={`cat-${previewRow.row_number}`}
+                              categories={catOptions}
+                              value={rowState.category_id ?? ""}
+                              onChange={(id) =>
+                                updateRow(previewRow.row_number, {
+                                  category_id: id === "" ? null : id,
+                                })
+                              }
+                              filterType={previewRow.type === "income" ? "income" : "expense"}
+                              className={input + " !w-48"}
+                            />
+                            {previewRow.suggestion_source === "org_rule" && (
+                              <span
+                                className="ml-2 text-xs text-text-muted"
+                                data-testid="suggestion-badge"
+                              >
+                                Auto · org rule
+                              </span>
+                            )}
+                            {previewRow.suggestion_source === "shared_dictionary" && (
+                              <span
+                                className="ml-2 text-xs text-text-muted"
+                                data-testid="suggestion-badge"
+                              >
+                                Auto · shared
+                              </span>
+                            )}
+                          </div>
                         )}
                       </td>
                       <td className="px-4 py-2">

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -10,6 +10,7 @@ import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { projectedPeriodEnd } from "@/lib/format";
 import { isAdmin } from "@/lib/auth";
 import MembersSection from "@/components/settings/MembersSection";
+import SmartRulesSection from "@/components/settings/SmartRulesSection";
 import {
   input,
   label,
@@ -359,11 +360,12 @@ export default function OrganizationSettingsPage() {
       </div>
 
       {user && (
-        <div className="mt-6">
+        <div className="mt-6 space-y-6">
           <MembersSection
             currentUserId={user.id}
             currentRole={user.role as "owner" | "admin" | "member"}
           />
+          <SmartRulesSection />
         </div>
       )}
 

--- a/frontend/components/settings/SmartRulesSection.tsx
+++ b/frontend/components/settings/SmartRulesSection.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+} from "@/lib/styles";
+import type { OrgSetting } from "@/lib/types";
+
+const SETTING_KEY = "share_merchant_data";
+
+export default function SmartRulesSection() {
+  const [enabled, setEnabled] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const settings = await apiFetch<OrgSetting[]>("/api/v1/settings");
+        if (cancelled) return;
+        const row = settings.find((s) => s.key === SETTING_KEY);
+        setEnabled(row?.value === "true");
+      } catch {
+        // Network/permission error, leave default-off; server is the source of truth.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function toggle() {
+    if (saving || loading) return;
+    const next = !enabled;
+    setSaving(true);
+    setError("");
+    try {
+      await apiFetch("/api/v1/settings", {
+        method: "PUT",
+        body: JSON.stringify({ key: SETTING_KEY, value: next ? "true" : "false" }),
+      });
+      setEnabled(next);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not update preference"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className={card}>
+      <header className={cardHeader}>
+        <h2 className={cardTitle}>Smart rules</h2>
+      </header>
+      <div className="p-6">
+        {error && (
+          <div className={`${errorCls} mb-4`} role="alert">
+            {error}
+          </div>
+        )}
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm text-text-primary">
+              Share anonymized merchant data
+            </p>
+            <p className="mt-1 max-w-md text-xs text-text-muted">
+              Help improve auto-categorization for everyone (anonymized, only
+              merchant tokens, never your transaction details).
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label="Share merchant data"
+            disabled={loading || saving}
+            onClick={toggle}
+            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition disabled:opacity-50 ${
+              enabled ? "bg-emerald-500" : "bg-gray-300"
+            }`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+                enabled ? "translate-x-5" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -159,6 +159,8 @@ export interface ForecastPlan {
 
 // ── Import ──────────────────────────────────────────────────────────────────
 
+export type SuggestionSource = "org_rule" | "shared_dictionary" | "default";
+
 export interface ImportPreviewRow {
   row_number: number;
   date: string;
@@ -170,6 +172,8 @@ export interface ImportPreviewRow {
   is_duplicate: boolean;
   duplicate_transaction_id: number | null;
   is_potential_transfer: boolean;
+  suggested_category_id?: number | null;
+  suggestion_source?: SuggestionSource | null;
 }
 
 export interface ImportPreviewResponse {
@@ -191,6 +195,8 @@ export interface ImportConfirmRow {
   skip: boolean;
   is_transfer: boolean;
   transfer_account_id: number | null;
+  suggested_category_id?: number | null;
+  suggestion_source?: SuggestionSource | null;
 }
 
 export interface ImportConfirmRequest {

--- a/frontend/tests/components/import-suggestion-badge.test.tsx
+++ b/frontend/tests/components/import-suggestion-badge.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Smart-rules badge regression test.
+ *
+ * The import page renders a small "Auto · org rule" / "Auto · shared" badge
+ * next to a row's category dropdown when the backend supplied a suggestion.
+ * No badge for source=default or null/undefined.
+ *
+ * This test extracts the badge logic into a tiny component for unit testing
+ * because rendering the entire ImportPage requires a heavy mock of SWR + auth +
+ * file upload state. The badge logic is the only new client behavior; testing
+ * it in isolation is the lowest-cost regression net.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { SuggestionSource } from "@/lib/types";
+
+function SuggestionBadge({ source }: { source?: SuggestionSource | null }) {
+  if (source === "org_rule") {
+    return (
+      <span data-testid="suggestion-badge" className="ml-2 text-xs text-text-muted">
+        Auto · org rule
+      </span>
+    );
+  }
+  if (source === "shared_dictionary") {
+    return (
+      <span data-testid="suggestion-badge" className="ml-2 text-xs text-text-muted">
+        Auto · shared
+      </span>
+    );
+  }
+  return null;
+}
+
+describe("SuggestionBadge", () => {
+  it("renders 'Auto · org rule' for org_rule source", () => {
+    render(<SuggestionBadge source="org_rule" />);
+    expect(screen.getByTestId("suggestion-badge")).toHaveTextContent(
+      /Auto · org rule/,
+    );
+  });
+
+  it("renders 'Auto · shared' for shared_dictionary source", () => {
+    render(<SuggestionBadge source="shared_dictionary" />);
+    expect(screen.getByTestId("suggestion-badge")).toHaveTextContent(
+      /Auto · shared/,
+    );
+  });
+
+  it("renders nothing for source=default", () => {
+    render(<SuggestionBadge source="default" />);
+    expect(screen.queryByTestId("suggestion-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for null/undefined source", () => {
+    const { rerender } = render(<SuggestionBadge source={null} />);
+    expect(screen.queryByTestId("suggestion-badge")).not.toBeInTheDocument();
+    rerender(<SuggestionBadge source={undefined} />);
+    expect(screen.queryByTestId("suggestion-badge")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/smart-rules-section.test.tsx
+++ b/frontend/tests/components/smart-rules-section.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import SmartRulesSection from "@/components/settings/SmartRulesSection";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+describe("SmartRulesSection", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("loads the current value (off) and reflects it in the switch", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/settings") {
+        return Promise.resolve([
+          { key: "session_lifetime_days", value: "30" },
+          { key: "share_merchant_data", value: "false" },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SmartRulesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  it("loads the current value (on) when key is 'true'", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/settings") {
+        return Promise.resolve([{ key: "share_merchant_data", value: "true" }]);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SmartRulesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
+  it("defaults to off when the key is absent from settings", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/settings") {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SmartRulesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  it("PUTs the setting on click and flips the visible state", async () => {
+    apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url === "/api/v1/settings" && (!opts || opts.method !== "PUT")) {
+        return Promise.resolve([]);
+      }
+      if (url === "/api/v1/settings" && opts?.method === "PUT") {
+        return Promise.resolve({ key: "share_merchant_data", value: "true" });
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SmartRulesSection />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+
+    expect(apiFetchMock).toHaveBeenLastCalledWith(
+      "/api/v1/settings",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ key: "share_merchant_data", value: "true" }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two-tier deterministic auto-categorization on import preview and transaction edit. Lookup order: `category_rules` (per-org, learned from explicit user picks/edits) → `merchant_dictionary` (shared, EU+NL seed) → default. Architect-locked direction; AI fallback (LAI.1) explicitly out of scope; lookup chain is extensible so it can slot in later.

**Highlights:**
- Migration 027 adds `category_rules` and `merchant_dictionary` tables with a 43-merchant seed (Iberian + UK + a small NL set: KPN, ODIDO, JUMBO, THUISBEZORGD, AYVENS, FRANK ENERGIE).
- New `category_rules_service` with `normalize_description`, `infer_category`, `learn_from_choice`, `bump_shared_vote`, `should_skip_learning`.
- Normalization: NFKD accent fold, masked-card-prefix strip, IBAN tail strip, terminal-ID strip, trailing-company-form strip (B.V. / N.V. / S.A. / BVBA / GMBH / AG / INC / LLC / LTD), brand-digit-suffix preservation (`STORE 24` stays `STORE 24`).
- Integrated into `import_service.build_preview` (suggest), `execute_import` (learn on accept/override + bump shared vote when org opted in), `transaction_service.create_transaction` and `update_transaction` (learn on every explicit category pick that isn't a transfer or imported row).
- Aggregate-only metrics (one event per preview, one per import, one per unique missed token). Privacy: only `org_id` and `normalized_token` reach logs; raw descriptions never logged.
- Frontend: import preview pre-fills category dropdown from `suggested_category_id`, renders "Auto · org rule" / "Auto · shared" badge. New `SmartRulesSection` opt-in toggle in `/settings/organization` persists to `org_settings.share_merchant_data` via the existing `/api/v1/settings` endpoint.

**Tests:** +55 backend tests (183 total passing, 5 pre-existing `test_deploy_workflow.py` failures unrelated). +8 frontend tests (53 total passing). All TDD.

**Architectural decisions captured in memory:**
- Most-recent-wins learning (no conservative-overwrite policy yet — architect deferred until metrics show whether sticky-bad-rules are real).
- NFKD fold over ASCII-drop (collapses `CAFÉ DELTA` and `CAFE DELTA` to one token across bank encodings).
- Trailing-only company-form strip (don't strip mid-name; runs after punctuation collapse so B.V., B V, BV behave consistently).
- Locale-aware extension is a long-term thread (P-IL.1-P-IL.6), forward-compatible with the metrics scaffold.

**Spec:** \`~/.claude/projects/-Users-fjorge-src-pfv/memory/project_auto_categorization.md\`
**Plan:** \`~/.claude/projects/-Users-fjorge-src-pfv/plans/2026-05-02-l3-10-smart-rules.md\`
**Architect review:** \`project_architect_review_2026_05_02.md\`
**Localized intelligence thread:** \`project_localized_import_intelligence.md\`

## Notes

- `./pfv reset` is needed locally to pick up the corrected merchant_dictionary seed (the `is_seed=True` insert only runs on a fresh upgrade; existing dev rows still hold the old slugs). Production gets the new seed cleanly because the migration is brand-new there.
- Day-1 coverage on the user's real ING NL CSV is ~3.5%. The deterministic+global seed is intentionally narrow; the metrics scaffold (`smart_rules.miss` per unique token) will surface market-specific gaps for follow-up dictionary expansion. Locale-aware normalization + per-locale dictionary rows are tracked under roadmap section P-IL.
- Two `chore(dev):` commits add `./backend/tests` and `./frontend/tests` to the dev compose volumes so the in-container test workflows pick up new test files without `docker cp`. Scoped to `docker-compose.yml`; no functional impact.