### PR TITLE
chore(ci): scope deploy + release to prod-impacting paths only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,12 +4,17 @@ on:
   push:
     branches: [main]
     paths:
+      # Application code that ships to prod. Any change here may need a redeploy.
       - "backend/**"
       - "frontend/**"
       - "nginx/**"
+      # Prod app spec on DO App Platform. Source of truth for prod runtime config.
       - ".do/**"
-      - "docker-compose*.yml"
+      # Image-build inputs. The Dockerfiles are referenced from .do/app.yaml.
       - "Dockerfile*"
+      # NOTE: docker-compose*.yml is intentionally NOT in this list — it's
+      # local-dev only; prod uses .do/app.yaml. PR #105's two test-mount
+      # tweaks to docker-compose.yml triggered redundant prod deploys.
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Release
 on:
   push:
     branches: [main]
+    # Only fire when the change might actually warrant a release. Chore /
+    # docs / workflow / dev-tooling commits don't ship to users, so running
+    # semantic-release for them is wasted CI minutes (the no-op release
+    # noise on every merge is what prompted this filter, 2026-05-02).
+    # Mirror deploy.yml's allowlist so the two stay in sync.
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "nginx/**"
+      - ".do/**"
+      - "Dockerfile*"
 
 permissions:
   contents: write

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,31 @@
 {
   "branches": ["main"],
   "plugins": [
-    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "scope": "ci", "release": false },
+          { "scope": "deps", "release": false },
+          { "scope": "deps-dev", "release": false },
+          { "scope": "test", "release": false },
+          { "scope": "tests", "release": false },
+          { "scope": "dev", "release": false },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "revert", "release": "patch" },
+          { "type": "chore", "release": false },
+          { "type": "docs", "release": false },
+          { "type": "style", "release": false },
+          { "type": "refactor", "release": false },
+          { "type": "test", "release": false },
+          { "type": "build", "release": false },
+          { "type": "ci", "release": false }
+        ]
+      }
+    ],
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
     "@semantic-release/github"
   ]


### PR DESCRIPTION
## Summary

Three layered fixes to stop wasting CI minutes and prevent meaningless release tags from non-prod commits.

### 1. \`.releaserc.json\` — explicit release rules (the actual policy layer)

The current config relies entirely on the conventionalcommits preset's implicit defaults. Anyone reading the file couldn't tell what does or doesn't release. Made it explicit, with two evaluation layers (scope rules first, type rules second):

- **Scope exclusions** — \`feat(ci)\`, \`feat(deps)\`, \`feat(deps-dev)\`, \`feat(test)\`, \`feat(tests)\`, \`feat(dev)\` will NOT release even though \`feat\` is normally a minor bump. The scope tells us the change doesn't ship to users.
- **Type rules** — \`feat\`→minor, \`fix\`/\`perf\`/\`revert\`→patch, \`BREAKING CHANGE\` (preset default)→major, everything else→false. Same as preset implicit defaults but visible in the config.

### 2. \`release.yml\` — path filter (CI-minutes savings layer)

Previously had no path filter — fired on every merge to \`main\`, including chore/docs/CI-only merges. Even when the no-op of \`releaseRules\` would skip the release, the workflow still ran. Path-allowlist mirrors deploy.yml.

The two layers are complementary:
- **Path filter** prevents the workflow from running at all when nothing in the allowlist changed (CI minutes saved).
- **\`releaseRules\`** ensures that when the workflow DOES run, only commits that genuinely ship to users produce a release tag.

### 3. \`deploy.yml\` — drop \`docker-compose*.yml\` from the allowlist

Compose is dev-only (prod uses \`.do/app.yaml\`). PR #105's two test-mount tweaks to docker-compose.yml each triggered a redundant prod deploy for zero customer impact.

## Net effect

- Chore / docs / tests-only / CI-only / dev-tooling merges → no deploy, no release.
- \`feat(ci): ...\` or \`feat(deps): ...\` → no release tag (the scope says it doesn't ship to users).
- \`feat(rules): ...\` or \`fix(import): ...\` → release as before.

## Notes

- This PR itself only touches \`.github/workflows/\` and \`.releaserc.json\`. Once it merges, it'll exercise its own filter — neither workflow should run.
- \`paths\` and \`paths-ignore\` in GitHub Actions are mutually exclusive, so the deploy-allowlist still includes test directories under \`backend/**\` and \`frontend/**\`. A test-only change inside an app directory will still trigger deploy. That's a bigger rework (switch to \`paths-ignore\` and explicitly exclude test dirs); not addressing it here.