### PR TITLE
feat(l4.11): plan features + org feature overrides

### DIFF
--- a/backend/alembic/versions/028_plan_features_and_org_overrides.py
+++ b/backend/alembic/versions/028_plan_features_and_org_overrides.py
@@ -1,0 +1,102 @@
+"""Add plans.features JSON + org_feature_overrides table.
+
+Revision ID: 028_plan_features
+Revises: 027
+Create Date: 2026-05-02
+
+L4.11 — adds:
+  * plans.features JSON NOT NULL DEFAULT (JSON_OBJECT())
+    Backfilled from legacy ai_budget_enabled / ai_forecast_enabled /
+    ai_smart_plan_enabled columns. ai.autocategorize defaults False.
+    Legacy columns survive for one release as rollback ballast (CLEANUP-029).
+
+  * org_feature_overrides table — single-current per-org boolean overrides
+    keyed on UNIQUE(org_id, feature_key).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
+
+revision = "028_plan_features"
+down_revision = "027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add plans.features JSON column with default {}.
+    op.add_column(
+        "plans",
+        sa.Column(
+            "features",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("(JSON_OBJECT())"),
+        ),
+    )
+
+    # 2. Backfill features from legacy ai_* columns. Pass the dict directly;
+    #    sa.JSON serializes it as a JSON object. Do NOT json.dumps() — that
+    #    stores a quoted string scalar.
+    plans_t = table(
+        "plans",
+        column("id", sa.Integer),
+        column("ai_budget_enabled", sa.Boolean),
+        column("ai_forecast_enabled", sa.Boolean),
+        column("ai_smart_plan_enabled", sa.Boolean),
+        column("features", sa.JSON),
+    )
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.select(
+            plans_t.c.id,
+            plans_t.c.ai_budget_enabled,
+            plans_t.c.ai_forecast_enabled,
+            plans_t.c.ai_smart_plan_enabled,
+        )
+    ).fetchall()
+    for row in rows:
+        features = {
+            "ai.budget":         bool(row.ai_budget_enabled),
+            "ai.forecast":       bool(row.ai_forecast_enabled),
+            "ai.smart_plan":     bool(row.ai_smart_plan_enabled),
+            "ai.autocategorize": False,
+        }
+        conn.execute(
+            plans_t.update()
+            .where(plans_t.c.id == row.id)
+            .values(features=features)
+        )
+
+    # 3. Create org_feature_overrides table.
+    op.create_table(
+        "org_feature_overrides",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "org_id",
+            sa.Integer,
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("feature_key", sa.String(64), nullable=False),
+        sa.Column("value", sa.Boolean, nullable=False),
+        sa.Column(
+            "set_by",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("set_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at", sa.DateTime, nullable=True),
+        sa.Column("note", sa.Text, nullable=True),
+        sa.UniqueConstraint("org_id", "feature_key", name="uq_org_feature"),
+    )
+    op.create_index("ix_ofo_expires_at", "org_feature_overrides", ["expires_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ofo_expires_at", table_name="org_feature_overrides")
+    op.drop_table("org_feature_overrides")
+    op.drop_column("plans", "features")

--- a/backend/alembic/versions/028_plan_features_and_org_overrides.py
+++ b/backend/alembic/versions/028_plan_features_and_org_overrides.py
@@ -26,7 +26,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # 1. Add plans.features JSON column with default {}.
     op.add_column(
         "plans",
         sa.Column(
@@ -37,9 +36,8 @@ def upgrade() -> None:
         ),
     )
 
-    # 2. Backfill features from legacy ai_* columns. Pass the dict directly;
-    #    sa.JSON serializes it as a JSON object. Do NOT json.dumps() — that
-    #    stores a quoted string scalar.
+    # Pass the dict directly; sa.JSON serializes it as a JSON object.
+    # Do NOT json.dumps() — that stores a quoted string scalar.
     plans_t = table(
         "plans",
         column("id", sa.Integer),
@@ -70,7 +68,6 @@ def upgrade() -> None:
             .values(features=features)
         )
 
-    # 3. Create org_feature_overrides table.
     op.create_table(
         "org_feature_overrides",
         sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),

--- a/backend/app/auth/feature_catalog.py
+++ b/backend/app/auth/feature_catalog.py
@@ -1,0 +1,37 @@
+"""L4.11 — Feature catalog and canonical PlanFeatures model.
+
+The catalog invariant is "actively gated OR reserved by a locked
+near-term roadmap dependency." `ai.autocategorize` qualifies via LAI.1.
+Adding a key is a one-line edit here + a one-line edit in
+frontend/lib/feature-catalog.ts; the drift-guard test pins parity.
+"""
+from __future__ import annotations
+
+from typing import Literal, get_args
+
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
+
+
+FeatureKey = Literal[
+    "ai.budget",
+    "ai.forecast",
+    "ai.smart_plan",
+    "ai.autocategorize",
+]
+
+ALL_FEATURE_KEYS: frozenset[str] = frozenset(get_args(FeatureKey))
+
+
+class PlanFeatures(BaseModel):
+    """Canonical persisted shape of plans.features.
+
+    Every plan write canonicalizes through this model so storage
+    always contains the full closed set of keys with strict-bool values.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    ai_budget:         StrictBool = Field(default=False, alias="ai.budget")
+    ai_forecast:       StrictBool = Field(default=False, alias="ai.forecast")
+    ai_smart_plan:     StrictBool = Field(default=False, alias="ai.smart_plan")
+    ai_autocategorize: StrictBool = Field(default=False, alias="ai.autocategorize")

--- a/backend/app/auth/feature_deps.py
+++ b/backend/app/auth/feature_deps.py
@@ -1,0 +1,59 @@
+"""L4.11 — FastAPI dependencies for feature gating.
+
+get_current_org_features is scoped to the authenticated user's own org;
+DO NOT reuse it for cross-org admin reads. Admin endpoints call
+feature_service.get_features(db, target_org_id) directly after
+require_permission("orgs.view").
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.feature_catalog import ALL_FEATURE_KEYS, FeatureKey
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.user import User
+from app.services import feature_service
+from app.services.feature_service import UnknownFeatureKey
+
+
+_CACHE_ATTR = "_org_features_cache"
+
+
+async def get_current_org_features(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> dict[str, bool]:
+    """Per-request cache of effective features for the auth user's own org.
+
+    DO NOT use for cross-org admin reads — admin endpoints call
+    feature_service.get_features(db, target_org_id) directly.
+    """
+    cache: dict[int, dict[str, bool]] = getattr(request.state, _CACHE_ATTR, None) or {}
+    if user.org_id not in cache:
+        cache[user.org_id] = await feature_service.get_features(db, user.org_id)
+        setattr(request.state, _CACHE_ATTR, cache)
+    return cache[user.org_id]
+
+
+def require_feature(key: FeatureKey) -> Callable:
+    """Dependency factory. Raises UnknownFeatureKey at module-import time
+    if `key` isn't in the catalog — typos fail on backend startup, not
+    at first request.
+    """
+    if key not in ALL_FEATURE_KEYS:
+        raise UnknownFeatureKey(key)
+
+    async def _dep(features=Depends(get_current_org_features)) -> dict[str, bool]:
+        if not features[key]:
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "feature_not_enabled", "feature_key": key},
+            )
+        return features
+
+    return _dep

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.subscription import Plan, Subscription, SubscriptionStatus, Bill
 from app.models.invitation import Invitation
 from app.models.category_rule import CategoryRule, RuleSource
 from app.models.merchant_dictionary import MerchantDictionaryEntry
+from app.models.feature_override import OrgFeatureOverride  # noqa: F401
 
 __all__ = [
     "Base",
@@ -42,4 +43,5 @@ __all__ = [
     "CategoryRule",
     "RuleSource",
     "MerchantDictionaryEntry",
+    "OrgFeatureOverride",
 ]

--- a/backend/app/models/feature_override.py
+++ b/backend/app/models/feature_override.py
@@ -1,0 +1,36 @@
+"""Per-org boolean feature override.
+
+Single-current per (org, feature_key) — UNIQUE constraint at the DB
+level. DELETE = revoke. Override row presence wins over plan features
+(D5: row-presence resolver semantic).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class OrgFeatureOverride(Base):
+    __tablename__ = "org_feature_overrides"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    feature_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    value: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    set_by: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    set_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (UniqueConstraint("org_id", "feature_key", name="uq_org_feature"),)

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from typing import Optional
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     Date,
     DateTime,
@@ -54,14 +55,8 @@ class Plan(Base):
     # Feature limits — null means unlimited
     max_users: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     retention_days: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    ai_budget_enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
-    ai_forecast_enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
-    ai_smart_plan_enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
+    features: Mapped[dict] = mapped_column(
+        JSON, nullable=False, server_default="(JSON_OBJECT())"
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -56,7 +56,7 @@ class Plan(Base):
     max_users: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     retention_days: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     features: Mapped[dict] = mapped_column(
-        JSON, nullable=False, server_default="(JSON_OBJECT())"
+        JSON, nullable=False, default=dict
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -9,6 +9,7 @@ this router's `/api/v1/admin/*` prefix.
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.feature_catalog import ALL_FEATURE_KEYS
 from app.auth.permissions import require_permission
 from app.database import get_db
 from app.services.admin_dashboard_service import build_dashboard_payload
@@ -23,3 +24,17 @@ router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 async def get_dashboard(db: AsyncSession = Depends(get_db)) -> dict:
     """KPIs + system-health snapshot for the `/admin` home page."""
     return await build_dashboard_payload(db)
+
+
+@router.get(
+    "/feature-catalog",
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
+async def get_feature_catalog():
+    """Return the catalog of feature keys.
+
+    Sorted output for deterministic snapshot diffs. plans.manage gates
+    this — anyone who can edit plan features needs to know which keys
+    exist.
+    """
+    return {"keys": sorted(ALL_FEATURE_KEYS)}

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -13,18 +13,25 @@ message client-side, full detail server-side.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
+from app.auth.feature_catalog import ALL_FEATURE_KEYS
 from app.auth.permissions import require_permission
 from app.database import get_db
+from app.deps import get_current_user
+from app.models.feature_override import OrgFeatureOverride
 from app.models.subscription import SubscriptionStatus
 from app.models.user import User
 from app.schemas.admin_orgs import OrgDeleteRequest, SubscriptionUpdateRequest
+from app.schemas.feature_override import FeatureOverrideUpsert, OrgFeatureOverrideResponse
 from app.services import admin_orgs_service
-from app.services.exceptions import NotFoundError, ValidationError
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 logger = structlog.stdlib.get_logger()
+log = structlog.get_logger()
 
 router = APIRouter(prefix="/api/v1/admin/orgs", tags=["admin-orgs"])
 
@@ -145,3 +152,99 @@ async def delete_org(
         deleted_rows_by_table=counts,
     )
     return {"deleted": counts}
+
+
+# ── Feature overrides (L4.11) ─────────────────────────────────────────────
+
+
+def _validate_feature_key(key: str) -> None:
+    if key not in ALL_FEATURE_KEYS:
+        raise ValidationError(f"Unknown feature key: {key!r}")
+
+
+async def _override_to_response(row: OrgFeatureOverride, db: AsyncSession) -> dict:
+    """Resolve set_by_email by joining to users."""
+    from datetime import datetime
+
+    email = None
+    if row.set_by is not None:
+        email = await db.scalar(select(User.email).where(User.id == row.set_by))
+    is_expired = row.expires_at is not None and row.expires_at <= datetime.utcnow()
+    return {
+        "feature_key": row.feature_key,
+        "value": row.value,
+        "set_by": row.set_by,
+        "set_by_email": email,
+        "set_at": row.set_at.isoformat() if row.set_at else None,
+        "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+        "note": row.note,
+        "is_expired": is_expired,
+    }
+
+
+@router.put(
+    "/{org_id}/feature-overrides/{feature_key}",
+    response_model=OrgFeatureOverrideResponse,
+)
+async def set_feature_override(
+    org_id: int,
+    feature_key: str,
+    body: FeatureOverrideUpsert,
+    user: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        _validate_feature_key(feature_key)
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    existing = await db.scalar(
+        select(OrgFeatureOverride).where(
+            OrgFeatureOverride.org_id == org_id,
+            OrgFeatureOverride.feature_key == feature_key,
+        )
+    )
+    old_value = existing.value if existing else None
+    old_expires_at = existing.expires_at if existing else None
+
+    try:
+        async with db.begin_nested():
+            if existing is None:
+                row = OrgFeatureOverride(
+                    org_id=org_id,
+                    feature_key=feature_key,
+                    value=body.value,
+                    set_by=user.id,
+                    expires_at=body.expires_at,
+                    note=body.note,
+                )
+                db.add(row)
+            else:
+                existing.value = body.value
+                existing.set_by = user.id
+                existing.expires_at = body.expires_at
+                existing.note = body.note
+                row = existing
+        await db.commit()
+        await db.refresh(row)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Override changed concurrently; retry.",
+        )
+
+    log.info(
+        "admin.org.feature.set",
+        target_org_id=org_id,
+        feature_key=feature_key,
+        old_value=old_value,
+        new_value=body.value,
+        old_expires_at=old_expires_at.isoformat() if old_expires_at else None,
+        new_expires_at=body.expires_at.isoformat() if body.expires_at else None,
+        actor_user_id=user.id,
+        actor_email=user.email,
+        note_present=body.note is not None,
+    )
+
+    return await _override_to_response(row, db)

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -23,11 +23,12 @@ from app.auth.permissions import require_permission
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.feature_override import OrgFeatureOverride
-from app.models.subscription import SubscriptionStatus
-from app.models.user import User
+from app.models.subscription import Plan, Subscription, SubscriptionStatus
+from app.models.user import Organization, User
 from app.schemas.admin_orgs import OrgDeleteRequest, SubscriptionUpdateRequest
 from app.schemas.feature_override import FeatureOverrideUpsert, OrgFeatureOverrideResponse
-from app.services import admin_orgs_service
+from app.schemas.feature_state import FeatureStateResponse
+from app.services import admin_orgs_service, feature_service
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 logger = structlog.stdlib.get_logger()
@@ -291,3 +292,75 @@ async def revoke_feature_override(
         actor_email=user.email,
     )
     return Response(status_code=204)
+
+
+# ── Feature state composite (T16) ────────────────────────────────────────
+
+
+@router.get(
+    "/{org_id}/feature-state",
+    response_model=FeatureStateResponse,
+)
+async def get_feature_state(
+    org_id: int,
+    user: User = Depends(require_permission("orgs.view")),
+    db: AsyncSession = Depends(get_db),
+):
+    # 404 explicit on missing target org. Resolver fail-closed (all-False)
+    # is for product feature gates against the auth user's own org;
+    # admin reads have a different contract.
+    from datetime import datetime
+
+    org = await db.scalar(select(Organization).where(Organization.id == org_id))
+    if org is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    plan_features = await feature_service._fetch_plan_features(db, org_id)
+
+    plan_row = await db.execute(
+        select(Plan.id, Plan.name, Plan.slug)
+        .join(Subscription, Subscription.plan_id == Plan.id)
+        .where(Subscription.org_id == org_id)
+    )
+    plan_data = plan_row.first()
+    plan_summary = (
+        {"id": plan_data.id, "name": plan_data.name, "slug": plan_data.slug}
+        if plan_data else None
+    )
+
+    # All overrides (active + expired) joined to setter email.
+    rows = await db.execute(
+        select(OrgFeatureOverride, User.email)
+        .outerjoin(User, User.id == OrgFeatureOverride.set_by)
+        .where(OrgFeatureOverride.org_id == org_id)
+    )
+    now = datetime.utcnow()
+    overrides_by_key: dict[str, dict] = {}
+    for row, email in rows.all():
+        if row.feature_key not in ALL_FEATURE_KEYS:
+            continue  # defensive filter
+        is_expired = row.expires_at is not None and row.expires_at <= now
+        overrides_by_key[row.feature_key] = {
+            "feature_key": row.feature_key,
+            "value": row.value,
+            "set_by": row.set_by,
+            "set_by_email": email,
+            "set_at": row.set_at.isoformat() if row.set_at else None,
+            "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+            "note": row.note,
+            "is_expired": is_expired,
+        }
+
+    feature_rows = []
+    for key in sorted(ALL_FEATURE_KEYS):
+        plan_default = plan_features.get(key, False)
+        ovr = overrides_by_key.get(key)
+        effective = ovr["value"] if (ovr and not ovr["is_expired"]) else plan_default
+        feature_rows.append({
+            "key": key,
+            "plan_default": plan_default,
+            "effective": effective,
+            "override": ovr,
+        })
+
+    return {"plan": plan_summary, "features": feature_rows}

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -12,6 +12,8 @@ exists. FK / SQL diagnostics never bleed into 500 bodies — generic
 message client-side, full detail server-side.
 """
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -165,8 +167,6 @@ def _validate_feature_key(key: str) -> None:
 
 async def _override_to_response(row: OrgFeatureOverride, db: AsyncSession) -> dict:
     """Resolve set_by_email by joining to users."""
-    from datetime import datetime
-
     email = None
     if row.set_by is not None:
         email = await db.scalar(select(User.email).where(User.id == row.set_by))
@@ -199,6 +199,15 @@ async def set_feature_override(
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
+    org_exists = await db.scalar(
+        select(Organization.id).where(Organization.id == org_id)
+    )
+    if org_exists is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+
     existing = await db.scalar(
         select(OrgFeatureOverride).where(
             OrgFeatureOverride.org_id == org_id,
@@ -223,6 +232,7 @@ async def set_feature_override(
             else:
                 existing.value = body.value
                 existing.set_by = user.id
+                existing.set_at = datetime.utcnow()
                 existing.expires_at = body.expires_at
                 existing.note = body.note
                 row = existing
@@ -267,6 +277,15 @@ async def revoke_feature_override(
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
+    org_exists = await db.scalar(
+        select(Organization.id).where(Organization.id == org_id)
+    )
+    if org_exists is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+
     existing = await db.scalar(
         select(OrgFeatureOverride).where(
             OrgFeatureOverride.org_id == org_id,
@@ -309,8 +328,6 @@ async def get_feature_state(
     # 404 explicit on missing target org. Resolver fail-closed (all-False)
     # is for product feature gates against the auth user's own org;
     # admin reads have a different contract.
-    from datetime import datetime
-
     org = await db.scalar(select(Organization).where(Organization.id == org_id))
     if org is None:
         raise HTTPException(status_code=404, detail="Organization not found")

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -12,7 +12,7 @@ exists. FK / SQL diagnostics never bleed into 500 bodies — generic
 message client-side, full detail server-side.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -248,3 +248,46 @@ async def set_feature_override(
     )
 
     return await _override_to_response(row, db)
+
+
+@router.delete(
+    "/{org_id}/feature-overrides/{feature_key}",
+    status_code=204,
+)
+async def revoke_feature_override(
+    org_id: int,
+    feature_key: str,
+    user: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+):
+    # 400 if key isn't in the catalog (matches PUT translation).
+    try:
+        _validate_feature_key(feature_key)
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    existing = await db.scalar(
+        select(OrgFeatureOverride).where(
+            OrgFeatureOverride.org_id == org_id,
+            OrgFeatureOverride.feature_key == feature_key,
+        )
+    )
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"FeatureOverride {org_id}/{feature_key} not found",
+        )
+
+    old_value = existing.value
+    await db.delete(existing)
+    await db.commit()
+
+    log.info(
+        "admin.org.feature.revoked",
+        target_org_id=org_id,
+        feature_key=feature_key,
+        old_value=old_value,
+        actor_user_id=user.id,
+        actor_email=user.email,
+    )
+    return Response(status_code=204)

--- a/backend/app/routers/plans.py
+++ b/backend/app/routers/plans.py
@@ -7,7 +7,7 @@ from app.database import get_db
 from app.deps import get_current_user
 from app.models.subscription import Plan, Subscription
 from app.models.user import User
-from app.schemas.subscription import PlanCreate, PlanResponse, PlanUpdate
+from app.schemas.subscription import PlanCreate, PlanDuplicateRequest, PlanResponse, PlanUpdate
 from app.services.plan_service import canonicalize_features
 
 router = APIRouter(prefix="/api/v1/plans", tags=["plans"])
@@ -160,3 +160,44 @@ async def delete_plan(
 
     plan.is_active = False
     await db.commit()
+
+
+@router.post(
+    "/{plan_id}/duplicate",
+    response_model=PlanResponse,
+    status_code=201,
+    dependencies=[Depends(require_permission("plans.manage"))],
+)
+async def duplicate_plan(
+    plan_id: int,
+    body: PlanDuplicateRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Clone a plan with is_custom=True. Reject 409 on slug conflict."""
+    src = (await db.execute(select(Plan).where(Plan.id == plan_id))).scalar_one_or_none()
+    if src is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    slug_taken = await db.scalar(select(Plan.id).where(Plan.slug == body.slug))
+    if slug_taken is not None:
+        raise HTTPException(status_code=409, detail="Plan slug already exists")
+
+    clone = Plan(
+        name=body.name,
+        slug=body.slug,
+        description=src.description,
+        is_custom=True,
+        is_active=True,
+        sort_order=src.sort_order,
+        price_monthly=src.price_monthly,
+        price_yearly=src.price_yearly,
+        max_users=src.max_users,
+        retention_days=src.retention_days,
+        # Re-canonicalize so the clone always has the full closed-set keys
+        # even if the source somehow drifted.
+        features=canonicalize_features(src.features or {}),
+    )
+    db.add(clone)
+    await db.commit()
+    await db.refresh(clone)
+    return clone

--- a/backend/app/routers/plans.py
+++ b/backend/app/routers/plans.py
@@ -8,6 +8,7 @@ from app.deps import get_current_user
 from app.models.subscription import Plan, Subscription
 from app.models.user import User
 from app.schemas.subscription import PlanCreate, PlanResponse, PlanUpdate
+from app.services.plan_service import canonicalize_features
 
 router = APIRouter(prefix="/api/v1/plans", tags=["plans"])
 
@@ -78,7 +79,9 @@ async def create_plan(
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="Plan slug already exists")
 
-    plan = Plan(**body.model_dump())
+    payload = body.model_dump()
+    payload["features"] = canonicalize_features(payload.get("features") or {})
+    plan = Plan(**payload)
     db.add(plan)
     await db.commit()
     await db.refresh(plan)
@@ -115,6 +118,11 @@ async def update_plan(
                 status_code=409,
                 detail=f"Cannot deactivate plan — {org_count} organization(s) are currently on it",
             )
+
+    if "features" in update_data:
+        update_data["features"] = canonicalize_features(
+            update_data["features"] or {}, existing=plan.features
+        )
 
     for field, value in update_data.items():
         setattr(plan, field, value)

--- a/backend/app/routers/subscriptions.py
+++ b/backend/app/routers/subscriptions.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.user import Role, User
-from app.schemas.subscription import ChangePlanRequest, SubscriptionResponse
+from app.schemas.subscription import ChangePlanRequest, PlanResponse, SubscriptionResponse
 from app.services import subscription_service
 
 router = APIRouter(prefix="/api/v1/subscriptions", tags=["subscriptions"])
@@ -22,22 +22,8 @@ def _sub_response(sub, plan) -> dict:
     return {
         "id": sub.id,
         "org_id": sub.org_id,
-        "plan": {
-            "id": plan.id,
-            "name": plan.name,
-            "slug": plan.slug,
-            "description": plan.description,
-            "is_custom": plan.is_custom,
-            "is_active": plan.is_active,
-            "sort_order": plan.sort_order,
-            "price_monthly": float(plan.price_monthly),
-            "price_yearly": float(plan.price_yearly),
-            "max_users": plan.max_users,
-            "retention_days": plan.retention_days,
-            "ai_budget_enabled": plan.ai_budget_enabled,
-            "ai_forecast_enabled": plan.ai_forecast_enabled,
-            "ai_smart_plan_enabled": plan.ai_smart_plan_enabled,
-        },
+        # PlanResponse handles features + CLEANUP-029 derived ai_*_enabled fields.
+        "plan": PlanResponse.model_validate(plan).model_dump(),
         "status": sub.status.value,
         "billing_interval": sub.billing_interval.value,
         "trial_start": sub.trial_start.isoformat() if sub.trial_start else None,

--- a/backend/app/schemas/feature_override.py
+++ b/backend/app/schemas/feature_override.py
@@ -1,0 +1,30 @@
+"""Request/response schemas for org feature overrides."""
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
+
+
+class FeatureOverrideUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    value:      StrictBool
+    expires_at: datetime | None = None
+    note:       str | None = Field(default=None, max_length=500)
+
+
+class OrgFeatureOverrideResponse(BaseModel):
+    """The wire shape for an org feature override row.
+
+    set_by_email is server-resolved from the joined users row.
+    is_expired is server-derived: expires_at IS NOT NULL AND expires_at <= NOW().
+    """
+    model_config = ConfigDict(from_attributes=True)
+
+    feature_key: str
+    value: bool
+    set_by: int | None
+    set_by_email: str | None
+    set_at: datetime
+    expires_at: datetime | None
+    note: str | None
+    is_expired: bool

--- a/backend/app/schemas/feature_state.py
+++ b/backend/app/schemas/feature_state.py
@@ -1,0 +1,24 @@
+"""Composite feature-state response for L4.3 admin org drill-down."""
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.feature_override import OrgFeatureOverrideResponse
+
+
+class PlanSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    slug: str
+
+
+class FeatureStateRow(BaseModel):
+    key: str
+    plan_default: bool
+    effective: bool
+    override: OrgFeatureOverrideResponse | None
+
+
+class FeatureStateResponse(BaseModel):
+    plan: PlanSummary | None
+    features: list[FeatureStateRow]

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -1,9 +1,13 @@
 from decimal import Decimal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, computed_field, field_validator
+
+from app.auth.feature_catalog import PlanFeatures
 
 
 class PlanResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     name: str
     slug: str
@@ -15,14 +19,38 @@ class PlanResponse(BaseModel):
     price_yearly: Decimal
     max_users: int | None
     retention_days: int | None
-    ai_budget_enabled: bool
-    ai_forecast_enabled: bool
-    ai_smart_plan_enabled: bool
+    features: dict[str, bool]
 
-    model_config = {"from_attributes": True}
+    @field_validator("features", mode="before")
+    @classmethod
+    def _canonicalize_features(cls, v):
+        # Defensive read-side canonicalization. If storage somehow
+        # drifts (manual SQL, partial migration), the wire shape stays
+        # canonical so consumers don't break.
+        return PlanFeatures.model_validate(v or {}).model_dump(by_alias=True)
+
+    # CLEANUP-029: remove the three computed fields below when migration
+    # 029 ships. Frontend `Plan` type and `/settings/billing/page.tsx`
+    # tier-descriptor logic also migrate to read `features` directly.
+    @computed_field  # type: ignore[misc]
+    @property
+    def ai_budget_enabled(self) -> bool:
+        return self.features.get("ai.budget", False)
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def ai_forecast_enabled(self) -> bool:
+        return self.features.get("ai.forecast", False)
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def ai_smart_plan_enabled(self) -> bool:
+        return self.features.get("ai.smart_plan", False)
 
 
 class PlanCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(min_length=1, max_length=100)
     slug: str = Field(min_length=1, max_length=50, pattern=r"^[a-z0-9-]+$")
     description: str = ""
@@ -32,12 +60,12 @@ class PlanCreate(BaseModel):
     price_yearly: Decimal = Field(ge=0, default=0)
     max_users: int | None = Field(default=None, ge=1)
     retention_days: int | None = Field(default=None, ge=1)
-    ai_budget_enabled: bool = False
-    ai_forecast_enabled: bool = False
-    ai_smart_plan_enabled: bool = False
+    features: dict[str, StrictBool] = Field(default_factory=dict)
 
 
 class PlanUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str | None = Field(default=None, min_length=1, max_length=100)
     description: str | None = None
     is_custom: bool | None = None
@@ -47,9 +75,14 @@ class PlanUpdate(BaseModel):
     price_yearly: Decimal | None = Field(default=None, ge=0)
     max_users: int | None = Field(default=None, ge=1)
     retention_days: int | None = Field(default=None, ge=1)
-    ai_budget_enabled: bool | None = None
-    ai_forecast_enabled: bool | None = None
-    ai_smart_plan_enabled: bool | None = None
+    features: dict[str, StrictBool] | None = None
+
+
+class PlanDuplicateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=100)
+    slug: str = Field(min_length=1, max_length=50, pattern=r"^[a-z0-9-]+$")
 
 
 class SubscriptionResponse(BaseModel):

--- a/backend/app/services/admin_orgs_service.py
+++ b/backend/app/services/admin_orgs_service.py
@@ -24,6 +24,7 @@ from app.models.billing import BillingPeriod
 from app.models.budget import Budget
 from app.models.category import Category
 from app.models.category_rule import CategoryRule
+from app.models.feature_override import OrgFeatureOverride
 from app.models.forecast_plan import ForecastPlan, ForecastPlanItem
 from app.models.invitation import Invitation
 from app.models.recurring import RecurringTransaction
@@ -328,6 +329,16 @@ async def delete_org_cascade(
 
     counts["settings"] = (
         await db.execute(delete(OrgSetting).where(OrgSetting.org_id == org_id))
+    ).rowcount or 0
+
+    # L4.11: per-org feature overrides. set_by FKs to users with
+    # ON DELETE SET NULL, but the override row is org-scoped — wipe
+    # before users so the count reflects every override the org owned
+    # (rather than depending on FK semantics to nulls vs. cascades).
+    counts["org_feature_overrides"] = (
+        await db.execute(
+            delete(OrgFeatureOverride).where(OrgFeatureOverride.org_id == org_id)
+        )
     ).rowcount or 0
 
     counts["users"] = (

--- a/backend/app/services/feature_service.py
+++ b/backend/app/services/feature_service.py
@@ -1,0 +1,74 @@
+"""L4.11 — feature entitlement resolver.
+
+Pure service layer. No FastAPI dependencies. The resolver order is
+defaults → plan.features → active org override. Override row presence
+(not row.value truthiness) is what wins, so a row with value=False
+correctly denies an otherwise plan-granted feature.
+"""
+from __future__ import annotations
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.feature_catalog import ALL_FEATURE_KEYS, PlanFeatures
+from app.models.feature_override import OrgFeatureOverride
+from app.models.subscription import Plan, Subscription
+
+
+class UnknownFeatureKey(Exception):
+    """Programmer error: gate-site key not in the catalog.
+
+    Deliberately does NOT subclass app.services.exceptions.ValidationError
+    so it surfaces as HTTP 500, not 400 — bad input from app code is an
+    operational alert, not a user-facing validation error.
+    """
+
+    def __init__(self, key: str):
+        self.key = key
+        super().__init__(f"Unknown feature key: {key!r}")
+
+
+async def get_features(db: AsyncSession, org_id: int) -> dict[str, bool]:
+    """Return the effective feature map for an org.
+
+    Resolution order: defaults (False) → plan.features → active override.
+    Fail-closed if the org has no subscription (returns all-False).
+    """
+    plan_features = await _fetch_plan_features(db, org_id)
+    overrides = await _fetch_active_overrides(db, org_id)
+
+    merged = {key: False for key in ALL_FEATURE_KEYS}
+    merged.update(plan_features)
+    merged.update(overrides)
+    return merged
+
+
+async def has_feature(db: AsyncSession, org_id: int, key: str) -> bool:
+    if key not in ALL_FEATURE_KEYS:
+        raise UnknownFeatureKey(key)
+    features = await get_features(db, org_id)
+    return features[key]
+
+
+async def _fetch_plan_features(db: AsyncSession, org_id: int) -> dict[str, bool]:
+    row = await db.execute(
+        select(Plan.features)
+        .join(Subscription, Subscription.plan_id == Plan.id)
+        .where(Subscription.org_id == org_id)
+    )
+    raw = row.scalar_one_or_none() or {}
+    # Read-side validation: bad DB data must fail loudly.
+    return PlanFeatures.model_validate(raw).model_dump(by_alias=True)
+
+
+async def _fetch_active_overrides(db: AsyncSession, org_id: int) -> dict[str, bool]:
+    rows = await db.execute(
+        select(OrgFeatureOverride.feature_key, OrgFeatureOverride.value)
+        .where(OrgFeatureOverride.org_id == org_id)
+        .where(or_(
+            OrgFeatureOverride.expires_at.is_(None),
+            OrgFeatureOverride.expires_at > func.now(),
+        ))
+    )
+    # Defensive filter — a stale row predating a catalog key removal must not leak.
+    return {r.feature_key: r.value for r in rows.all() if r.feature_key in ALL_FEATURE_KEYS}

--- a/backend/app/services/plan_service.py
+++ b/backend/app/services/plan_service.py
@@ -1,0 +1,29 @@
+"""Plan-write canonicalization. The single chokepoint for plans.features writes.
+
+All plan create / update / duplicate paths run their incoming partial
+features through canonicalize_features so storage stays canonical
+(full closed-set, alias keys, strict bool).
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from app.auth.feature_catalog import ALL_FEATURE_KEYS, PlanFeatures
+from app.services.exceptions import ValidationError
+
+
+def canonicalize_features(
+    partial: Mapping[str, bool],
+    existing: Mapping[str, bool] | None = None,
+) -> dict[str, bool]:
+    """Merge a partial feature dict with the existing one and return
+    the canonical (full closed-set, alias-keyed) dict.
+
+    Raises ValidationError on unknown feature keys (HTTP 400 surface).
+    """
+    unknown = set(partial) - ALL_FEATURE_KEYS
+    if unknown:
+        raise ValidationError(f"Unknown feature keys: {sorted(unknown)}")
+
+    merged = {**(existing or {}), **partial}
+    return PlanFeatures.model_validate(merged).model_dump(by_alias=True)

--- a/backend/tests/auth/test_feature_deps.py
+++ b/backend/tests/auth/test_feature_deps.py
@@ -1,0 +1,18 @@
+"""Tests for require_feature factory-time validation.
+
+A typo'd key must fail at module import time, not at first request.
+"""
+import pytest
+
+from app.auth.feature_deps import require_feature
+from app.services.feature_service import UnknownFeatureKey
+
+
+def test_require_feature_unknown_key_raises_at_factory_time():
+    with pytest.raises(UnknownFeatureKey):
+        require_feature("ai.totally_made_up")
+
+
+def test_require_feature_known_key_returns_callable():
+    dep = require_feature("ai.autocategorize")
+    assert callable(dep)

--- a/backend/tests/migrations/test_028_features_backfill.py
+++ b/backend/tests/migrations/test_028_features_backfill.py
@@ -3,12 +3,24 @@
 Asserts that plans.features after upgrade contains canonical alias-key
 booleans for every seeded plan, and that the stored value is a JSON
 object (not a JSON string scalar).
+
+Skipped unless PFV_RUN_MYSQL_TESTS=1 because this exercises real MySQL
+(JSON_TYPE, post-upgrade dataset). The default DATABASE_URL is MySQL
+even in environments where no MySQL service is running, so the explicit
+opt-in flag is the only reliable signal.
 """
+import os
+
 from sqlalchemy import select, text
 import pytest
 
 from app.database import get_db
 from app.models.subscription import Plan
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("PFV_RUN_MYSQL_TESTS") != "1",
+    reason="MySQL-only migration test; set PFV_RUN_MYSQL_TESTS=1 to run.",
+)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/migrations/test_028_features_backfill.py
+++ b/backend/tests/migrations/test_028_features_backfill.py
@@ -1,0 +1,48 @@
+"""Migration 028 backfill verification.
+
+Asserts that plans.features after upgrade contains canonical alias-key
+booleans for every seeded plan, and that the stored value is a JSON
+object (not a JSON string scalar).
+"""
+from sqlalchemy import select, text
+import pytest
+
+from app.database import get_db
+from app.models.subscription import Plan
+
+
+@pytest.mark.asyncio
+async def test_seeded_plans_have_canonical_features():
+    async for db in get_db():
+        plans = (await db.execute(select(Plan).order_by(Plan.slug))).scalars().all()
+        assert len(plans) >= 2, "expected Free + Pro seed plans"
+
+        for plan in plans:
+            assert isinstance(plan.features, dict), (
+                f"{plan.slug}: features stored as {type(plan.features).__name__}, "
+                "expected dict — backfill likely json.dumps'd a string scalar"
+            )
+            assert set(plan.features.keys()) == {
+                "ai.budget", "ai.forecast", "ai.smart_plan", "ai.autocategorize"
+            }, f"{plan.slug}: unexpected keys {plan.features.keys()}"
+
+            # ai.autocategorize is always False post-backfill (LAI.1 not yet shipped).
+            assert plan.features["ai.autocategorize"] is False, (
+                f"{plan.slug}: ai.autocategorize should be False post-backfill"
+            )
+        break
+
+
+@pytest.mark.asyncio
+async def test_features_stored_as_json_object_not_string():
+    """MySQL-only: JSON_TYPE must report OBJECT, not STRING."""
+    async for db in get_db():
+        result = await db.execute(text(
+            "SELECT id, JSON_TYPE(features) AS json_type FROM plans"
+        ))
+        for row in result.all():
+            assert row.json_type == "OBJECT", (
+                f"plan id={row.id}: features stored as {row.json_type}, "
+                "expected OBJECT — backfill regression"
+            )
+        break

--- a/backend/tests/routers/test_admin_feature_catalog.py
+++ b/backend/tests/routers/test_admin_feature_catalog.py
@@ -1,0 +1,136 @@
+"""Router tests for L4.11 admin feature-catalog endpoint.
+
+`GET /api/v1/admin/feature-catalog` exposes the canonical set of
+feature keys for the admin UI's plan-features editor. plans.manage
+gates it — anyone who can edit plan features needs to know which keys
+exist. This file pins the auth gate and the deterministic sort order.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.routers.admin import router as admin_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """One org with a superadmin and a regular user."""
+    async with factory() as db:
+        org = Organization(name="Admin Org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        sa = User(
+            org_id=org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=org.id, username="user",
+            email="user@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+        await db.commit()
+        return {"admin_user_id": sa.id, "plain_user_id": plain.id}
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+@pytest.mark.asyncio
+async def test_catalog_returns_sorted_keys(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/feature-catalog")
+    assert res.status_code == 200
+    assert res.json() == {
+        "keys": [
+            "ai.autocategorize",
+            "ai.budget",
+            "ai.forecast",
+            "ai.smart_plan",
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_catalog_requires_plans_manage(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/feature-catalog")
+    assert res.status_code == 403

--- a/backend/tests/routers/test_admin_feature_overrides.py
+++ b/backend/tests/routers/test_admin_feature_overrides.py
@@ -307,3 +307,81 @@ async def test_delete_requires_orgs_manage(session_factory):
             f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
         )
     assert res.status_code == 403
+
+
+# ── Missing-org / set_at refresh (review fixes) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_put_returns_404_for_missing_org(session_factory):
+    """A nonexistent target org_id must surface as 404, not as the
+    FK-collision 409 "Override changed concurrently" message."""
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            "/api/v1/admin/orgs/999999/feature-overrides/ai.budget",
+            json={"value": True},
+        )
+    assert res.status_code == 404
+    assert "Organization not found" in res.json().get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_404_for_missing_org(session_factory):
+    """DELETE on a nonexistent org should also 404 with the explicit
+    'Organization not found' message (not the override-not-found one)."""
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            "/api/v1/admin/orgs/999999/feature-overrides/ai.budget",
+        )
+    assert res.status_code == 404
+    assert "Organization not found" in res.json().get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_put_refreshes_set_at_on_update(session_factory):
+    """Updating an existing override must advance set_at so the UI
+    can show 'last set at' rather than the original grant time."""
+    from datetime import datetime
+    from sqlalchemy import select as _select
+
+    from app.models.feature_override import OrgFeatureOverride
+
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    past = datetime(2026, 1, 1, 0, 0, 0)
+
+    with TestClient(app) as client:
+        first = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            json={"value": True},
+        )
+        assert first.status_code == 200
+
+    # Force the seeded row's set_at into the past so the second PUT
+    # has something concrete to advance past.
+    async with session_factory() as db:
+        row = (
+            await db.execute(
+                _select(OrgFeatureOverride).where(
+                    OrgFeatureOverride.org_id == seed["target_id"],
+                    OrgFeatureOverride.feature_key == "ai.budget",
+                )
+            )
+        ).scalar_one()
+        row.set_at = past
+        await db.commit()
+
+    with TestClient(app) as client:
+        second = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            json={"value": False},
+        )
+    assert second.status_code == 200
+    new_set_at = second.json()["set_at"]
+    # ISO-8601 is lexicographically ordered, so a string compare suffices,
+    # but parsing is more explicit.
+    assert datetime.fromisoformat(new_set_at) > past

--- a/backend/tests/routers/test_admin_feature_overrides.py
+++ b/backend/tests/routers/test_admin_feature_overrides.py
@@ -242,3 +242,68 @@ async def test_put_requires_orgs_manage(session_factory):
             json={"value": True},
         )
     assert res.status_code == 403
+
+
+# ── DELETE ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_revokes_existing_override(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        put_res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            json={"value": True},
+        )
+        assert put_res.status_code == 200
+
+        with patch("app.routers.admin_orgs.log") as mock_log:
+            del_res = client.delete(
+                f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            )
+
+    assert del_res.status_code == 204
+    assert del_res.content == b""
+
+    mock_log.info.assert_called_once()
+    args, kwargs = mock_log.info.call_args
+    assert args[0] == "admin.org.feature.revoked"
+    assert kwargs["target_org_id"] == seed["target_id"]
+    assert kwargs["feature_key"] == "ai.budget"
+    assert kwargs["old_value"] is True
+    assert kwargs["actor_user_id"] == seed["admin_user_id"]
+    assert kwargs["actor_email"] == seed["admin_email"]
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_404_when_no_override(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+        )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_key_returns_400(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.totally_made_up",
+        )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_orgs_manage(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+        )
+    assert res.status_code == 403

--- a/backend/tests/routers/test_admin_feature_overrides.py
+++ b/backend/tests/routers/test_admin_feature_overrides.py
@@ -1,0 +1,244 @@
+"""Router tests for L4.11 admin feature-override PUT endpoint.
+
+`PUT /api/v1/admin/orgs/{org_id}/feature-overrides/{feature_key}`
+upserts a per-org boolean override and emits a structured
+`admin.org.feature.set` audit event. orgs.manage gates the endpoint
+(superadmin short-circuits in the current permission scheme). Note
+text never lands in the audit payload, only `note_present` does.
+
+DELETE coverage lives in `test_admin_feature_overrides_delete.py`
+(T15) and aggregate state coverage in `test_admin_feature_state.py`
+(T16) — keep this file PUT-only.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.routers.admin_orgs import router as admin_orgs_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_orgs_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """Two orgs: 'Admin Org' (with the superadmin) and 'Target' (the
+    one we'll set overrides on)."""
+    async with factory() as db:
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target = Organization(name="Target Inc", billing_cycle_day=1)
+        db.add_all([admin_org, target])
+        await db.commit()
+        sa = User(
+            org_id=admin_org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=target.id, username="t_owner",
+            email="t_owner@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+        await db.commit()
+        return {
+            "admin_user_id": sa.id,
+            "admin_email": sa.email,
+            "admin_org_id": admin_org.id,
+            "target_id": target.id,
+            "plain_user_id": plain.id,
+        }
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+# ── PUT happy-paths ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_put_sets_new_override(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with patch("app.routers.admin_orgs.log") as mock_log:
+        with TestClient(app) as client:
+            res = client.put(
+                f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+                json={"value": True, "note": "internal beta"},
+            )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["feature_key"] == "ai.budget"
+    assert body["value"] is True
+    assert body["set_by"] == seed["admin_user_id"]
+    assert body["set_by_email"] == seed["admin_email"]
+    assert body["is_expired"] is False
+
+    mock_log.info.assert_called_once()
+    args, kwargs = mock_log.info.call_args
+    assert args[0] == "admin.org.feature.set"
+    assert kwargs["target_org_id"] == seed["target_id"]
+    assert kwargs["feature_key"] == "ai.budget"
+    assert kwargs["old_value"] is None
+    assert kwargs["new_value"] is True
+    assert kwargs["note_present"] is True
+    assert kwargs["actor_email"] == seed["admin_email"]
+    # Note text NEVER lands in the audit payload.
+    assert "note" not in kwargs or kwargs.get("note") is None
+    assert "internal beta" not in str(kwargs.values())
+
+
+@pytest.mark.asyncio
+async def test_put_updates_existing_override(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        first = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.forecast",
+            json={"value": True},
+        )
+        assert first.status_code == 200
+        assert first.json()["value"] is True
+
+        with patch("app.routers.admin_orgs.log") as mock_log:
+            second = client.put(
+                f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.forecast",
+                json={"value": False, "note": "rolled back"},
+            )
+
+    assert second.status_code == 200
+    body = second.json()
+    assert body["value"] is False
+    assert body["set_by_email"] == seed["admin_email"]
+
+    mock_log.info.assert_called_once()
+    args, kwargs = mock_log.info.call_args
+    assert args[0] == "admin.org.feature.set"
+    assert kwargs["old_value"] is True
+    assert kwargs["new_value"] is False
+    assert kwargs["note_present"] is True
+
+
+# ── PUT validation rejections ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_unknown_key(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.totally_made_up",
+            json={"value": True},
+        )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_put_strict_bool_rejects_string(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            json={"value": "true"},
+        )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_extra_fields_rejected(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            json={"value": True, "extra": "x"},
+        )
+    assert res.status_code == 422
+
+
+# ── auth gate ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_put_requires_orgs_manage(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            json={"value": True},
+        )
+    assert res.status_code == 403

--- a/backend/tests/routers/test_admin_feature_state.py
+++ b/backend/tests/routers/test_admin_feature_state.py
@@ -1,0 +1,297 @@
+"""Router tests for L4.11 admin feature-state composite endpoint (T16).
+
+`GET /api/v1/admin/orgs/{org_id}/feature-state` composes plan
+defaults with active org overrides into a per-key list ordered by
+`sorted(ALL_FEATURE_KEYS)`. Each row carries `plan_default`,
+`effective`, and the (optional) override block with the setter's
+email resolved server-side.
+
+Auth gate is `orgs.view` — superadmin short-circuits in the current
+permission scheme; non-superadmin gets 403.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.auth.feature_catalog import ALL_FEATURE_KEYS
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization, Role, User
+from app.routers.admin_orgs import router as admin_orgs_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_orgs_router)
+    return app
+
+
+async def _seed(factory, *, plan_slug: str, plan_name: str, plan_features: dict) -> dict:
+    """Two orgs, one plan, one subscription on the target org.
+
+    Returns a dict with seeded IDs/emails for assertions.
+    """
+    async with factory() as db:
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target = Organization(name="Target Inc", billing_cycle_day=1)
+        db.add_all([admin_org, target])
+        await db.commit()
+
+        plan = Plan(slug=plan_slug, name=plan_name, features=plan_features)
+        db.add(plan)
+        await db.commit()
+
+        sub = Subscription(
+            org_id=target.id,
+            plan_id=plan.id,
+            status=SubscriptionStatus.ACTIVE,
+            billing_interval=BillingInterval.MONTHLY,
+        )
+        db.add(sub)
+        await db.commit()
+
+        sa = User(
+            org_id=admin_org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=target.id, username="t_owner",
+            email="t_owner@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+        await db.commit()
+
+        return {
+            "admin_user_id": sa.id,
+            "admin_email": sa.email,
+            "admin_org_id": admin_org.id,
+            "target_id": target.id,
+            "plain_user_id": plain.id,
+            "plan_id": plan.id,
+            "plan_slug": plan.slug,
+            "plan_name": plan.name,
+        }
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_feature_state_returns_all_keys(session_factory):
+    """Pro plan with ai.budget=True. Body has plan summary and 4 sorted rows."""
+    pro_features = {
+        "ai.budget": True,
+        "ai.forecast": False,
+        "ai.smart_plan": False,
+        "ai.autocategorize": False,
+    }
+    seed = await _seed(
+        session_factory,
+        plan_slug="pro",
+        plan_name="Pro",
+        plan_features=pro_features,
+    )
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(f"/api/v1/admin/orgs/{seed['target_id']}/feature-state")
+
+    assert res.status_code == 200
+    body = res.json()
+
+    assert body["plan"] is not None
+    assert body["plan"]["slug"] == "pro"
+    assert body["plan"]["id"] == seed["plan_id"]
+    assert body["plan"]["name"] == "Pro"
+
+    rows = body["features"]
+    assert isinstance(rows, list)
+    assert len(rows) == 4
+
+    keys = [r["key"] for r in rows]
+    assert keys == sorted(ALL_FEATURE_KEYS)
+    assert keys == sorted(
+        ["ai.budget", "ai.forecast", "ai.smart_plan", "ai.autocategorize"]
+    )
+
+    by_key = {r["key"]: r for r in rows}
+    assert by_key["ai.budget"]["plan_default"] is True
+    assert by_key["ai.budget"]["effective"] is True
+    assert by_key["ai.budget"]["override"] is None
+    for k in ("ai.forecast", "ai.smart_plan", "ai.autocategorize"):
+        assert by_key[k]["plan_default"] is False
+        assert by_key[k]["effective"] is False
+        assert by_key[k]["override"] is None
+
+
+@pytest.mark.asyncio
+async def test_feature_state_effective_reflects_override(session_factory):
+    """Free plan (all-False) + PUT ai.budget=True → effective=True, override block populated."""
+    free_features = {
+        "ai.budget": False,
+        "ai.forecast": False,
+        "ai.smart_plan": False,
+        "ai.autocategorize": False,
+    }
+    seed = await _seed(
+        session_factory,
+        plan_slug="free",
+        plan_name="Free",
+        plan_features=free_features,
+    )
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        put_res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
+            json={"value": True, "note": "internal beta"},
+        )
+        assert put_res.status_code == 200
+
+        res = client.get(f"/api/v1/admin/orgs/{seed['target_id']}/feature-state")
+
+    assert res.status_code == 200
+    body = res.json()
+
+    assert body["plan"] is not None
+    assert body["plan"]["slug"] == "free"
+
+    by_key = {r["key"]: r for r in body["features"]}
+
+    budget_row = by_key["ai.budget"]
+    assert budget_row["plan_default"] is False
+    assert budget_row["effective"] is True
+    assert budget_row["override"] is not None
+    assert budget_row["override"]["value"] is True
+    assert budget_row["override"]["set_by_email"] == seed["admin_email"]
+    assert budget_row["override"]["set_by"] == seed["admin_user_id"]
+    assert budget_row["override"]["is_expired"] is False
+    assert budget_row["override"]["feature_key"] == "ai.budget"
+
+    # Other keys unchanged: plan_default=False, no override.
+    for k in ("ai.forecast", "ai.smart_plan", "ai.autocategorize"):
+        assert by_key[k]["plan_default"] is False
+        assert by_key[k]["effective"] is False
+        assert by_key[k]["override"] is None
+
+
+@pytest.mark.asyncio
+async def test_feature_state_404_on_missing_org(session_factory):
+    """Bogus org_id → 404, not all-False fallback."""
+    pro_features = {
+        "ai.budget": True,
+        "ai.forecast": False,
+        "ai.smart_plan": False,
+        "ai.autocategorize": False,
+    }
+    await _seed(
+        session_factory,
+        plan_slug="pro",
+        plan_name="Pro",
+        plan_features=pro_features,
+    )
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs/999999/feature-state")
+
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_feature_state_requires_orgs_view(session_factory):
+    """Non-superadmin caller → 403 even on a valid org."""
+    pro_features = {
+        "ai.budget": True,
+        "ai.forecast": False,
+        "ai.smart_plan": False,
+        "ai.autocategorize": False,
+    }
+    seed = await _seed(
+        session_factory,
+        plan_slug="pro",
+        plan_name="Pro",
+        plan_features=pro_features,
+    )
+
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get(f"/api/v1/admin/orgs/{seed['target_id']}/feature-state")
+
+    assert res.status_code == 403

--- a/backend/tests/routers/test_plans_duplicate.py
+++ b/backend/tests/routers/test_plans_duplicate.py
@@ -1,0 +1,218 @@
+"""Router tests for L4.11 plan duplicate endpoint.
+
+`POST /api/v1/plans/{plan_id}/duplicate` clones an existing plan with
+`is_custom=True` and re-canonicalizes features so the clone always
+has the full closed-set feature keys. plans.manage gates the
+endpoint (superadmin short-circuits in the current permission scheme).
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.subscription import Plan
+from app.models.user import Organization, Role, User
+from app.routers.plans import router as plans_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(plans_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """One org + superadmin + plain user, plus a 'pro' source plan
+    with ai.budget=True and an 'enterprise' plan we can collide
+    against on slug."""
+    async with factory() as db:
+        org = Organization(name="Admin Org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        sa = User(
+            org_id=org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=org.id, username="plain",
+            email="plain@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+
+        pro = Plan(
+            name="Pro",
+            slug="pro",
+            description="Pro plan",
+            is_custom=False,
+            is_active=True,
+            sort_order=10,
+            price_monthly=Decimal("19.99"),
+            price_yearly=Decimal("199.00"),
+            max_users=10,
+            retention_days=365,
+            features={"ai.budget": True, "ai.forecast": False, "ai.smart_plan": False},
+        )
+        enterprise = Plan(
+            name="Enterprise",
+            slug="enterprise",
+            description="Enterprise plan",
+            is_custom=False,
+            is_active=True,
+            sort_order=20,
+            price_monthly=Decimal("99.00"),
+            price_yearly=Decimal("990.00"),
+            max_users=None,
+            retention_days=None,
+            features={"ai.budget": True, "ai.forecast": True, "ai.smart_plan": True},
+        )
+        db.add_all([pro, enterprise])
+        await db.commit()
+
+        return {
+            "admin_user_id": sa.id,
+            "plain_user_id": plain.id,
+            "pro_id": pro.id,
+            "enterprise_id": enterprise.id,
+        }
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+# ── happy path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_clones_with_is_custom_true(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/plans/{seed['pro_id']}/duplicate",
+            json={"name": "Pro - ACME", "slug": "pro-acme"},
+        )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["name"] == "Pro - ACME"
+    assert body["slug"] == "pro-acme"
+    assert body["is_custom"] is True
+    assert body["is_active"] is True
+    # features carry through (and are canonicalized)
+    assert body["features"]["ai.budget"] is True
+    assert body["features"]["ai.forecast"] is False
+    assert body["features"]["ai.smart_plan"] is False
+
+
+# ── 409 on slug conflict ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_409_on_slug_conflict(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/plans/{seed['pro_id']}/duplicate",
+            json={"name": "Whatever", "slug": "enterprise"},
+        )
+    assert res.status_code == 409
+
+
+# ── 404 on missing source ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_404_on_missing_source(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/plans/999999/duplicate",
+            json={"name": "Ghost", "slug": "ghost"},
+        )
+    assert res.status_code == 404
+
+
+# ── auth gate ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_requires_plans_manage(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/plans/{seed['pro_id']}/duplicate",
+            json={"name": "Pro - ACME", "slug": "pro-acme"},
+        )
+    assert res.status_code == 403

--- a/backend/tests/schemas/test_plan_response_shim.py
+++ b/backend/tests/schemas/test_plan_response_shim.py
@@ -1,0 +1,68 @@
+"""Compatibility-shim contract for L4.11.
+
+Verifies PlanResponse.features is canonical and the three legacy
+ai_*_enabled fields derive from it. This is the most-likely-to-regress
+contract during the shim window.
+"""
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.subscription import PlanCreate, PlanResponse, PlanUpdate
+
+
+def test_plan_response_legacy_fields_derive_from_features():
+    plan = PlanResponse(
+        id=1, name="Pro", slug="pro", description="", is_custom=False,
+        is_active=True, sort_order=1,
+        price_monthly=10, price_yearly=100,
+        max_users=None, retention_days=None,
+        features={"ai.budget": True, "ai.forecast": False, "ai.smart_plan": True, "ai.autocategorize": False},
+    )
+    payload = plan.model_dump()
+
+    # Canonical features are the source.
+    assert payload["features"]["ai.budget"] is True
+    assert payload["features"]["ai.forecast"] is False
+    assert payload["features"]["ai.smart_plan"] is True
+
+    # Legacy booleans derive from features (CLEANUP-029).
+    assert payload["ai_budget_enabled"] is True
+    assert payload["ai_forecast_enabled"] is False
+    assert payload["ai_smart_plan_enabled"] is True
+
+
+def test_plan_response_features_canonicalizes_missing_keys():
+    """If storage somehow drifts, response still emits the canonical shape."""
+    plan = PlanResponse(
+        id=1, name="X", slug="x", description="", is_custom=False,
+        is_active=True, sort_order=0,
+        price_monthly=0, price_yearly=0,
+        max_users=None, retention_days=None,
+        features={"ai.budget": True},  # incomplete on purpose
+    )
+    out = plan.model_dump()["features"]
+    assert out["ai.budget"] is True
+    assert out["ai.forecast"] is False
+    assert out["ai.smart_plan"] is False
+    assert out["ai.autocategorize"] is False
+
+
+def test_plan_create_rejects_legacy_ai_payload():
+    with pytest.raises(ValidationError):
+        PlanCreate.model_validate({
+            "name": "X", "slug": "x",
+            "ai_budget_enabled": True,  # legacy field — extra="forbid" rejects
+        })
+
+
+def test_plan_update_rejects_legacy_ai_payload():
+    with pytest.raises(ValidationError):
+        PlanUpdate.model_validate({"ai_budget_enabled": True})
+
+
+def test_plan_create_accepts_features_partial():
+    pc = PlanCreate.model_validate({
+        "name": "X", "slug": "x",
+        "features": {"ai.budget": True},
+    })
+    assert pc.features == {"ai.budget": True}

--- a/backend/tests/services/test_admin_orgs_service.py
+++ b/backend/tests/services/test_admin_orgs_service.py
@@ -24,6 +24,7 @@ from app.models.billing import BillingPeriod
 from app.models.budget import Budget
 from app.models.category import Category, CategoryType
 from app.models.category_rule import CategoryRule, RuleSource
+from app.models.feature_override import OrgFeatureOverride
 from app.models.merchant_dictionary import MerchantDictionaryEntry
 from app.models.forecast_plan import (
     ForecastItemType,
@@ -200,7 +201,16 @@ async def _seed_full_org(factory, *, name: str = "Acme") -> dict:
             match_count=1,
             source=RuleSource.USER_PICK,
         )
-        db.add_all([plan_item, invite, rule])
+        # L4.11: per-org feature override. The cascade must wipe these
+        # before deleting users (set_by FKs to users with ON DELETE SET
+        # NULL, but the override row itself is org-scoped).
+        override = OrgFeatureOverride(
+            org_id=org.id,
+            feature_key="ai.budget",
+            value=False,
+            set_by=owner.id,
+        )
+        db.add_all([plan_item, invite, rule, override])
         await db.commit()
 
         return {"org_id": org.id, "owner_id": owner.id}
@@ -241,12 +251,14 @@ async def test_delete_org_cascade_removes_all_children_and_keeps_other_org(
     assert result["transactions"] == 1
     assert result["categories"] == 2  # master + sub
     assert result["category_rules"] == 1
+    assert result["org_feature_overrides"] == 1
     # Order isn't asserted — just that every table reports.
     expected_tables = {
         "transactions", "forecast_plan_items", "budgets", "invitations",
         "recurring_transactions", "forecast_plans", "billing_periods",
         "accounts", "account_types", "category_rules", "categories",
-        "settings", "users", "subscriptions", "organizations",
+        "settings", "org_feature_overrides", "users", "subscriptions",
+        "organizations",
     }
     assert expected_tables <= set(result.keys())
 
@@ -259,12 +271,14 @@ async def test_delete_org_cascade_removes_all_children_and_keeps_other_org(
         assert await _count(db, Subscription, org_id=target["org_id"]) == 0
         assert await _count(db, Invitation, org_id=target["org_id"]) == 0
         assert await _count(db, CategoryRule, org_id=target["org_id"]) == 0
+        assert await _count(db, OrgFeatureOverride, org_id=target["org_id"]) == 0
         # Sibling org survives intact.
         assert await _count(db, Organization, id=keep["org_id"]) == 1
         assert await _count(db, User, org_id=keep["org_id"]) == 2
         assert await _count(db, Transaction, org_id=keep["org_id"]) == 1
         assert await _count(db, Category, org_id=keep["org_id"]) == 2
         assert await _count(db, CategoryRule, org_id=keep["org_id"]) == 1
+        assert await _count(db, OrgFeatureOverride, org_id=keep["org_id"]) == 1
         # merchant_dictionary is shared (no org_id) — must NOT be touched.
         from sqlalchemy import func
         md_count = await db.scalar(

--- a/backend/tests/services/test_feature_service.py
+++ b/backend/tests/services/test_feature_service.py
@@ -1,0 +1,300 @@
+"""Service-layer tests for L4.11 — feature entitlement resolver.
+
+Resolver semantics (D5): defaults → plan.features → active override.
+Override row PRESENCE wins, not row.value truthiness — a row with
+value=False correctly denies an otherwise plan-granted feature.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.feature_override import OrgFeatureOverride
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization
+from app.services.exceptions import ValidationError
+from app.services.feature_service import (
+    UnknownFeatureKey,
+    get_features,
+    has_feature,
+)
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Helpers — small inline seed builders. Each test calls these as needed.
+# ---------------------------------------------------------------------------
+
+async def _make_org(db: AsyncSession, name: str = "Acme") -> Organization:
+    org = Organization(name=name, billing_cycle_day=1)
+    db.add(org)
+    await db.commit()
+    return org
+
+
+async def _make_plan(
+    db: AsyncSession, *, slug: str, name: str, features: dict
+) -> Plan:
+    plan = Plan(slug=slug, name=name, features=features)
+    db.add(plan)
+    await db.commit()
+    return plan
+
+
+async def _make_subscription(
+    db: AsyncSession, *, org_id: int, plan_id: int
+) -> Subscription:
+    sub = Subscription(
+        org_id=org_id,
+        plan_id=plan_id,
+        status=SubscriptionStatus.ACTIVE,
+        billing_interval=BillingInterval.MONTHLY,
+    )
+    db.add(sub)
+    await db.commit()
+    return sub
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_default_false_when_no_subscription(session_factory):
+    """Org with no subscription: resolver fails closed (all-False)."""
+    async with session_factory() as db:
+        org = await _make_org(db, name="NoSub")
+
+        features = await get_features(db, org.id)
+
+        assert features == {
+            "ai.budget": False,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_plan_grant_resolves_to_true(session_factory):
+    """Pro plan with ai.budget=True, ai.forecast=False resolves correctly."""
+    async with session_factory() as db:
+        org = await _make_org(db, name="ProOrg")
+        plan = await _make_plan(
+            db,
+            slug="pro",
+            name="Pro",
+            features={
+                "ai.budget": True,
+                "ai.forecast": False,
+                "ai.smart_plan": False,
+                "ai.autocategorize": False,
+            },
+        )
+        await _make_subscription(db, org_id=org.id, plan_id=plan.id)
+
+        assert await has_feature(db, org.id, "ai.budget") is True
+        assert await has_feature(db, org.id, "ai.forecast") is False
+
+
+@pytest.mark.asyncio
+async def test_override_grants_above_plan_default(session_factory):
+    """Free plan (all-False) + override ai.budget=True → resolver True."""
+    async with session_factory() as db:
+        org = await _make_org(db, name="FreeOrg")
+        plan = await _make_plan(
+            db,
+            slug="free",
+            name="Free",
+            features={
+                "ai.budget": False,
+                "ai.forecast": False,
+                "ai.smart_plan": False,
+                "ai.autocategorize": False,
+            },
+        )
+        await _make_subscription(db, org_id=org.id, plan_id=plan.id)
+
+        db.add(OrgFeatureOverride(
+            org_id=org.id, feature_key="ai.budget", value=True,
+        ))
+        await db.commit()
+
+        assert await has_feature(db, org.id, "ai.budget") is True
+
+
+@pytest.mark.asyncio
+async def test_override_deny_beats_plan_grant(session_factory):
+    """Pro plan (all-True) + override ai.budget=False → resolver False.
+
+    This locks in the row-presence semantic from D5: an override row
+    with value=False correctly denies an otherwise plan-granted feature.
+    """
+    async with session_factory() as db:
+        org = await _make_org(db, name="DenyOrg")
+        plan = await _make_plan(
+            db,
+            slug="pro",
+            name="Pro",
+            features={
+                "ai.budget": True,
+                "ai.forecast": True,
+                "ai.smart_plan": True,
+                "ai.autocategorize": True,
+            },
+        )
+        await _make_subscription(db, org_id=org.id, plan_id=plan.id)
+
+        db.add(OrgFeatureOverride(
+            org_id=org.id, feature_key="ai.budget", value=False,
+        ))
+        await db.commit()
+
+        assert await has_feature(db, org.id, "ai.budget") is False
+        # Sanity: the other plan grants are unaffected.
+        assert await has_feature(db, org.id, "ai.forecast") is True
+
+
+@pytest.mark.asyncio
+async def test_expired_override_ignored(session_factory):
+    """Expired override is ignored — plan grant wins."""
+    async with session_factory() as db:
+        org = await _make_org(db, name="ExpiredOrg")
+        plan = await _make_plan(
+            db,
+            slug="pro",
+            name="Pro",
+            features={
+                "ai.budget": True,
+                "ai.forecast": False,
+                "ai.smart_plan": False,
+                "ai.autocategorize": False,
+            },
+        )
+        await _make_subscription(db, org_id=org.id, plan_id=plan.id)
+
+        db.add(OrgFeatureOverride(
+            org_id=org.id,
+            feature_key="ai.budget",
+            value=False,
+            expires_at=datetime.utcnow() - timedelta(days=1),
+        ))
+        await db.commit()
+
+        assert await has_feature(db, org.id, "ai.budget") is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_key_raises_unknown_feature_key(session_factory):
+    """has_feature with an unknown key raises UnknownFeatureKey."""
+    async with session_factory() as db:
+        org = await _make_org(db, name="UnknownKeyOrg")
+
+        with pytest.raises(UnknownFeatureKey):
+            await has_feature(db, org.id, "ai.totally_made_up")
+
+
+@pytest.mark.asyncio
+async def test_unknown_feature_key_not_a_validation_error(session_factory):
+    """UnknownFeatureKey must NOT subclass ValidationError.
+
+    It's a programmer error (HTTP 500), not user input (HTTP 400).
+    """
+    async with session_factory() as db:
+        org = await _make_org(db, name="NotValidationErrOrg")
+
+        try:
+            await has_feature(db, org.id, "ai.totally_made_up")
+        except UnknownFeatureKey as e:
+            assert not isinstance(e, ValidationError)
+        else:
+            pytest.fail("UnknownFeatureKey was not raised")
+
+
+@pytest.mark.asyncio
+async def test_malformed_plan_features_fails_loudly(session_factory):
+    """Plan with an unknown features key must fail read-side validation.
+
+    We bypass canonicalization by writing the raw dict directly to the
+    Plan row. The resolver's PlanFeatures.model_validate must reject
+    `extra="forbid"` keys with a Pydantic ValidationError.
+    """
+    async with session_factory() as db:
+        org = await _make_org(db, name="MalformedOrg")
+        plan = await _make_plan(
+            db,
+            slug="malformed",
+            name="Malformed",
+            features={"unknown.bogus": True},
+        )
+        await _make_subscription(db, org_id=org.id, plan_id=plan.id)
+
+        with pytest.raises(Exception):
+            await get_features(db, org.id)
+
+
+@pytest.mark.asyncio
+async def test_defensive_filter_on_override_rows(session_factory):
+    """Stale override row with a key no longer in the catalog must not leak.
+
+    Simulates a row predating a catalog key removal — it bypasses
+    write-time validation but the resolver's defensive filter drops it.
+    """
+    async with session_factory() as db:
+        org = await _make_org(db, name="StaleOverrideOrg")
+        plan = await _make_plan(
+            db,
+            slug="pro",
+            name="Pro",
+            features={
+                "ai.budget": True,
+                "ai.forecast": False,
+                "ai.smart_plan": False,
+                "ai.autocategorize": False,
+            },
+        )
+        await _make_subscription(db, org_id=org.id, plan_id=plan.id)
+
+        db.add(OrgFeatureOverride(
+            org_id=org.id, feature_key="ancient.key", value=True,
+        ))
+        await db.commit()
+
+        features = await get_features(db, org.id)
+
+        assert "ancient.key" not in features
+        assert features["ai.budget"] is True

--- a/backend/tests/services/test_plan_service.py
+++ b/backend/tests/services/test_plan_service.py
@@ -1,0 +1,49 @@
+"""Tests for plan_service.canonicalize_features."""
+import pytest
+
+from app.auth.feature_catalog import ALL_FEATURE_KEYS
+from app.services.exceptions import ValidationError
+from app.services.plan_service import canonicalize_features
+
+
+def test_canonicalize_partial_merges_with_existing():
+    existing = {"ai.budget": True, "ai.forecast": False, "ai.smart_plan": False, "ai.autocategorize": False}
+    out = canonicalize_features({"ai.forecast": True}, existing=existing)
+    assert out == {
+        "ai.budget": True,
+        "ai.forecast": True,
+        "ai.smart_plan": False,
+        "ai.autocategorize": False,
+    }
+
+
+def test_canonicalize_full_overwrite_no_existing():
+    out = canonicalize_features({"ai.budget": True})
+    assert set(out.keys()) == ALL_FEATURE_KEYS
+    assert out["ai.budget"] is True
+    assert out["ai.forecast"] is False
+    assert out["ai.smart_plan"] is False
+    assert out["ai.autocategorize"] is False
+
+
+def test_canonicalize_unknown_key_raises():
+    with pytest.raises(ValidationError) as exc:
+        canonicalize_features({"ai.totally_made_up": True})
+    assert "ai.totally_made_up" in exc.value.detail
+
+
+def test_canonicalize_strict_bool_rejects_string():
+    with pytest.raises(Exception):  # Pydantic ValidationError
+        canonicalize_features({"ai.budget": "true"})
+
+
+def test_canonicalize_strict_bool_rejects_int():
+    with pytest.raises(Exception):
+        canonicalize_features({"ai.budget": 1})
+
+
+def test_canonicalize_returns_alias_keys():
+    out = canonicalize_features({"ai.budget": True})
+    # Must be dotted-keys (the storage shape), not snake_case.
+    assert "ai.budget" in out
+    assert "ai_budget" not in out

--- a/backend/tests/test_deploy_workflow.py
+++ b/backend/tests/test_deploy_workflow.py
@@ -18,7 +18,28 @@ multiple times in production:
 """
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+
+def _find_repo_root(start: Path) -> Path:
+    """Walk upward from `start` until a directory containing both
+    `.github/workflows/deploy.yml` and `.do/app.yaml` is found.
+
+    `Path(__file__).parents[2]` worked when these tests ran from a host
+    checkout but resolved to `/` inside the backend container (where the
+    test file lives at `/app/tests/test_deploy_workflow.py`). Walking
+    upward is robust to either layout.
+    """
+    for candidate in [start, *start.parents]:
+        if (candidate / ".github" / "workflows" / "deploy.yml").exists() and (
+            candidate / ".do" / "app.yaml"
+        ).exists():
+            return candidate
+    raise RuntimeError(
+        "Could not locate repo root containing .github/workflows/deploy.yml "
+        "and .do/app.yaml. Run these tests from a checked-out repo."
+    )
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve())
 DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
 APP_SPEC = REPO_ROOT / ".do" / "app.yaml"
 

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -6,10 +6,13 @@ import { useParams, useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
+import ChangePlanModal from "@/components/admin/ChangePlanModal";
+import FeatureOverridesCard from "@/components/admin/FeatureOverridesCard";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { isSuperadmin } from "@/lib/auth";
 import {
   btnPrimary,
+  btnSecondary,
   card,
   cardHeader,
   cardTitle,
@@ -71,9 +74,11 @@ export default function AdminOrgDetailPage() {
   // Subscription edit state
   const [subStatus, setSubStatus] = useState<string>("");
   const [subTrialEnd, setSubTrialEnd] = useState<string>("");
-  const [subPlanId, setSubPlanId] = useState<string>("");
   const [subPeriodEnd, setSubPeriodEnd] = useState<string>("");
   const [plans, setPlans] = useState<PlanOption[]>([]);
+
+  // Change-plan modal
+  const [showChangePlan, setShowChangePlan] = useState(false);
 
   // Delete confirmation
   const [confirmName, setConfirmName] = useState("");
@@ -101,7 +106,6 @@ export default function AdminOrgDetailPage() {
       const sub = d.subscription as Subscription;
       setSubStatus(sub.status ?? "");
       setSubTrialEnd(sub.trial_end ?? "");
-      setSubPlanId(sub.plan_id ? String(sub.plan_id) : "");
       setSubPeriodEnd(sub.current_period_end ?? "");
     } catch (err) {
       setError(extractErrorMessage(err, "Failed to load"));
@@ -123,9 +127,6 @@ export default function AdminOrgDetailPage() {
       const sub = detail?.subscription as Subscription;
       if (subStatus && subStatus !== sub.status) body.status = subStatus;
       if (subTrialEnd && subTrialEnd !== sub.trial_end) body.trial_end = subTrialEnd;
-      if (subPlanId && Number(subPlanId) !== sub.plan_id) {
-        body.plan_id = Number(subPlanId);
-      }
       if (subPeriodEnd && subPeriodEnd !== sub.current_period_end) {
         body.current_period_end = subPeriodEnd;
       }
@@ -182,6 +183,8 @@ export default function AdminOrgDetailPage() {
 
   const sub = detail.subscription as Subscription;
   const confirmMatches = confirmName === detail.name;
+  const currentPlanName =
+    plans.find((p) => p.slug === sub.plan_slug)?.name ?? sub.plan_slug ?? "—";
 
   return (
     <AppShell>
@@ -224,20 +227,20 @@ export default function AdminOrgDetailPage() {
             </dd>
           </dl>
 
-          <form onSubmit={saveSubscription} className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:items-end">
-            <div>
-              <label htmlFor="sub-plan" className={label}>Plan</label>
-              <select
-                id="sub-plan"
-                value={subPlanId}
-                onChange={(e) => setSubPlanId(e.target.value)}
-                className={input}
-              >
-                {plans.map((p) => (
-                  <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-              </select>
-            </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-text-secondary">
+              Plan: <strong className="text-text-primary">{currentPlanName}</strong>
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowChangePlan(true)}
+              className={btnSecondary}
+            >
+              Change plan
+            </button>
+          </div>
+
+          <form onSubmit={saveSubscription} className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 lg:items-end">
             <div>
               <label htmlFor="sub-status" className={label}>Status</label>
               <select
@@ -271,12 +274,24 @@ export default function AdminOrgDetailPage() {
                 className={input}
               />
             </div>
-            <div className="lg:col-span-4">
+            <div className="lg:col-span-3">
               <button type="submit" className={btnPrimary}>Save</button>
             </div>
           </form>
         </div>
       </section>
+
+      {showChangePlan && (
+        <ChangePlanModal
+          orgId={detail.id}
+          currentPlanSlug={sub.plan_slug ?? ""}
+          onClose={() => setShowChangePlan(false)}
+          onChanged={async () => { await refresh(); }}
+        />
+      )}
+
+      {/* Feature overrides card */}
+      <FeatureOverridesCard orgId={detail.id} />
 
       {/* Members card */}
       <section className={`${card} mb-6`}>

--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -4,8 +4,10 @@ import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import DuplicatePlanModal from "@/components/system/DuplicatePlanModal";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { FEATURE_LABELS } from "@/lib/feature-catalog";
 import {
   input,
   label,
@@ -18,7 +20,16 @@ import {
   success as successCls,
   pageTitle,
 } from "@/lib/styles";
-import type { Plan } from "@/lib/types";
+import type { FeatureKey, Plan, PlanFeatures } from "@/lib/types";
+
+const DEFAULT_FEATURES: PlanFeatures = {
+  "ai.budget": false,
+  "ai.forecast": false,
+  "ai.smart_plan": false,
+  "ai.autocategorize": false,
+};
+
+const FEATURE_KEYS = Object.keys(FEATURE_LABELS) as FeatureKey[];
 
 interface PlanWithCount extends Plan {
   org_count?: number;
@@ -32,6 +43,7 @@ export default function SystemPlansPage() {
   const [successMsg, setSuccessMsg] = useState("");
   const [editing, setEditing] = useState<PlanWithCount | null>(null);
   const [creating, setCreating] = useState(false);
+  const [duplicateSource, setDuplicateSource] = useState<PlanWithCount | null>(null);
   const [confirmAction, setConfirmAction] = useState<{
     title: string;
     message: string;
@@ -48,6 +60,7 @@ export default function SystemPlansPage() {
   const [formRetentionDays, setFormRetentionDays] = useState("");
   const [formIsCustom, setFormIsCustom] = useState(false);
   const [formSortOrder, setFormSortOrder] = useState("0");
+  const [formFeatures, setFormFeatures] = useState<PlanFeatures>({ ...DEFAULT_FEATURES });
 
   useEffect(() => {
     if (!loading && (!user || !user.is_superadmin)) router.replace("/dashboard");
@@ -76,6 +89,7 @@ export default function SystemPlansPage() {
     setFormRetentionDays("");
     setFormIsCustom(false);
     setFormSortOrder("0");
+    setFormFeatures({ ...DEFAULT_FEATURES });
   }
 
   function openEdit(plan: PlanWithCount) {
@@ -90,6 +104,7 @@ export default function SystemPlansPage() {
     setFormRetentionDays(plan.retention_days != null ? String(plan.retention_days) : "");
     setFormIsCustom(plan.is_custom);
     setFormSortOrder(String(plan.sort_order));
+    setFormFeatures({ ...DEFAULT_FEATURES, ...(plan.features ?? {}) });
   }
 
   function openCreate() {
@@ -111,6 +126,7 @@ export default function SystemPlansPage() {
       retention_days: formRetentionDays ? parseInt(formRetentionDays) : null,
       is_custom: formIsCustom,
       sort_order: parseInt(formSortOrder) || 0,
+      features: formFeatures,
     };
 
     try {
@@ -217,6 +233,32 @@ export default function SystemPlansPage() {
               <input type="checkbox" id="is_custom" checked={formIsCustom} onChange={(e) => setFormIsCustom(e.target.checked)} />
               <label htmlFor="is_custom" className="text-sm text-text-secondary">Custom plan</label>
             </div>
+            <div className="col-span-1 sm:col-span-2 mt-2 border-t border-border pt-4">
+              <h3 className="mb-3 text-sm font-semibold text-text-primary">Features</h3>
+              <div className="flex flex-col gap-3">
+                {FEATURE_KEYS.map((key) => {
+                  const meta = FEATURE_LABELS[key];
+                  const inputId = `feature-${key}`;
+                  return (
+                    <div key={key} className="flex items-start gap-3">
+                      <input
+                        type="checkbox"
+                        id={inputId}
+                        className="mt-1"
+                        checked={formFeatures[key] ?? false}
+                        onChange={(e) =>
+                          setFormFeatures((prev) => ({ ...prev, [key]: e.target.checked }))
+                        }
+                      />
+                      <label htmlFor={inputId} className="flex flex-col text-sm">
+                        <span className="font-medium text-text-primary">{meta.label}</span>
+                        <span className="text-xs text-text-muted">{meta.description}</span>
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
             <div className="col-span-1 sm:col-span-2 flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end sm:gap-3">
               <button
                 type="button"
@@ -268,6 +310,7 @@ export default function SystemPlansPage() {
                   </td>
                   <td className="px-4 py-3 text-right space-x-2">
                     <button onClick={() => openEdit(plan)} className="text-xs text-accent hover:underline">Edit</button>
+                    <button onClick={() => setDuplicateSource(plan)} className="text-xs text-accent hover:underline">Duplicate</button>
                     {plan.is_active && (
                       <button onClick={() => handleDelete(plan)} className="text-xs text-text-muted hover:text-danger">Deactivate</button>
                     )}
@@ -290,6 +333,18 @@ export default function SystemPlansPage() {
         }}
         onCancel={() => setConfirmAction(null)}
       />
+
+      {duplicateSource && (
+        <DuplicatePlanModal
+          source={duplicateSource}
+          onClose={() => setDuplicateSource(null)}
+          onDuplicated={() => {
+            setSuccessMsg("Plan duplicated");
+            setTimeout(() => setSuccessMsg(""), 3000);
+            void loadPlans();
+          }}
+        />
+      )}
     </AppShell>
   );
 }

--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -116,9 +116,8 @@ export default function SystemPlansPage() {
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError("");
-    const body = {
+    const common = {
       name: formName,
-      slug: formSlug,
       description: formDescription,
       price_monthly: parseFloat(formPriceMonthly) || 0,
       price_yearly: parseFloat(formPriceYearly) || 0,
@@ -131,15 +130,16 @@ export default function SystemPlansPage() {
 
     try {
       if (editing) {
+        // PlanUpdate forbids extra fields and has no `slug` field — omit it on edit.
         await apiFetch(`/api/v1/plans/${editing.id}`, {
           method: "PUT",
-          body: JSON.stringify(body),
+          body: JSON.stringify(common),
         });
         setSuccessMsg("Plan updated");
       } else {
         await apiFetch("/api/v1/plans", {
           method: "POST",
-          body: JSON.stringify(body),
+          body: JSON.stringify({ ...common, slug: formSlug }),
         });
         setSuccessMsg("Plan created");
       }

--- a/frontend/components/admin/ChangePlanModal.tsx
+++ b/frontend/components/admin/ChangePlanModal.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { btnPrimary, btnSecondary, card, error as errorCls, input, label } from "@/lib/styles";
+import type { Plan } from "@/lib/types";
+
+interface Props {
+  orgId: number;
+  currentPlanSlug: string;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+export default function ChangePlanModal({ orgId, currentPlanSlug, onClose, onChanged }: Props) {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [planId, setPlanId] = useState<number | "">("");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    apiFetch<Plan[]>("/api/v1/plans/all").then((all) => {
+      setPlans(all);
+      const current = all.find((p) => p.slug === currentPlanSlug);
+      if (current) setPlanId(current.id);
+    });
+  }, [currentPlanSlug]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (planId === "") return;
+    setSubmitting(true);
+    setErrorMsg("");
+    try {
+      // Existing L4.3 subscription override endpoint accepts plan_id.
+      await apiFetch(`/api/v1/admin/orgs/${orgId}/subscription`, {
+        method: "PUT",
+        body: JSON.stringify({ plan_id: planId }),
+      });
+      onChanged();
+      onClose();
+    } catch (err) {
+      setErrorMsg(extractErrorMessage(err, "Failed to change plan"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
+        <h2 className="mb-4 text-lg font-semibold">Change plan</h2>
+        {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}
+        <label className={label}>Plan</label>
+        <select
+          value={planId}
+          onChange={(e) => setPlanId(e.target.value === "" ? "" : Number(e.target.value))}
+          className={input}
+        >
+          <option value="">Select plan...</option>
+          {plans.map((p) => (
+            <option key={p.id} value={p.id}>{p.name} ({p.slug})</option>
+          ))}
+        </select>
+        <div className="mt-4 flex justify-end gap-2">
+          <button type="button" onClick={onClose} className={btnSecondary}>Cancel</button>
+          <button type="submit" disabled={submitting || planId === ""} className={btnPrimary}>
+            {submitting ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/components/admin/FeatureOverridesCard.tsx
+++ b/frontend/components/admin/FeatureOverridesCard.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { FEATURE_LABELS } from "@/lib/feature-catalog";
+import { btnPrimary, btnSecondary, card, cardHeader, cardTitle, error as errorCls, input, label } from "@/lib/styles";
+import type { FeatureKey, FeatureStateResponse, FeatureStateRow } from "@/lib/types";
+import Spinner from "@/components/ui/Spinner";
+
+interface Props {
+  orgId: number;
+}
+
+export default function FeatureOverridesCard({ orgId }: Props) {
+  const [state, setState] = useState<FeatureStateResponse | null>(null);
+  const [errorMsg, setErrorMsg] = useState("");
+  const [editing, setEditing] = useState<FeatureStateRow | null>(null);
+
+  const load = useCallback(async () => {
+    setErrorMsg("");
+    try {
+      const data = await apiFetch<FeatureStateResponse>(
+        `/api/v1/admin/orgs/${orgId}/feature-state`,
+      );
+      setState(data);
+    } catch (err) {
+      setErrorMsg(extractErrorMessage(err, "Failed to load feature state"));
+    }
+  }, [orgId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleRevoke(key: FeatureKey) {
+    try {
+      await apiFetch(`/api/v1/admin/orgs/${orgId}/feature-overrides/${key}`, {
+        method: "DELETE",
+      });
+      await load();
+    } catch (err) {
+      setErrorMsg(extractErrorMessage(err, "Failed to revoke override"));
+    }
+  }
+
+  if (state === null && !errorMsg) {
+    return <div className={card}><Spinner /></div>;
+  }
+
+  return (
+    <div className={card}>
+      <div className={cardHeader}>
+        <h2 className={cardTitle}>Feature overrides</h2>
+      </div>
+      {errorMsg && <div className={`${errorCls} m-4`}>{errorMsg}</div>}
+      <div className="divide-y divide-border">
+        {state?.features.map((row) => (
+          <FeatureRow
+            key={row.key}
+            row={row}
+            onEdit={() => setEditing(row)}
+            onRevoke={() => handleRevoke(row.key)}
+          />
+        ))}
+      </div>
+
+      {editing && (
+        <FeatureOverrideEditModal
+          orgId={orgId}
+          row={editing}
+          onClose={() => setEditing(null)}
+          onSaved={async () => { await load(); setEditing(null); }}
+        />
+      )}
+    </div>
+  );
+}
+
+function FeatureRow({ row, onEdit, onRevoke }: { row: FeatureStateRow; onEdit: () => void; onRevoke: () => void }) {
+  const meta = FEATURE_LABELS[row.key];
+  const ovr = row.override;
+  return (
+    <div className={`p-4 ${ovr?.is_expired ? "opacity-60" : ""}`}>
+      <div className="font-medium">{meta.label}</div>
+      <div className="mt-1 text-sm text-text-muted">
+        Plan default: {row.plan_default ? "✓" : "✗"}{" • "}
+        Effective: {row.effective ? "✓" : "✗"}
+        {ovr && (
+          <> • set by {ovr.set_by_email ?? "unknown"}{ovr.expires_at && ` until ${ovr.expires_at}`}</>
+        )}
+      </div>
+      <div className="mt-2 flex gap-2">
+        <button onClick={onEdit} className={btnSecondary}>Edit</button>
+        {ovr && <button onClick={onRevoke} className={btnSecondary}>Revoke</button>}
+      </div>
+    </div>
+  );
+}
+
+function FeatureOverrideEditModal({
+  orgId, row, onClose, onSaved,
+}: {
+  orgId: number; row: FeatureStateRow; onClose: () => void; onSaved: () => void;
+}) {
+  const [value, setValue] = useState<boolean>(row.override?.value ?? row.plan_default);
+  const [expiresAtLocal, setExpiresAtLocal] = useState<string>(
+    row.override?.expires_at ? toLocalInput(row.override.expires_at) : "",
+  );
+  const [note, setNote] = useState<string>(row.override?.note ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setErrorMsg("");
+    try {
+      await apiFetch(`/api/v1/admin/orgs/${orgId}/feature-overrides/${row.key}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          value,
+          expires_at: expiresAtLocal ? new Date(expiresAtLocal).toISOString() : null,
+          note: note || null,
+        }),
+      });
+      onSaved();
+    } catch (err) {
+      setErrorMsg(extractErrorMessage(err, "Failed to save override"));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
+        <h2 className="mb-4 text-lg font-semibold">{FEATURE_LABELS[row.key].label}</h2>
+        {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}
+        <div className="mb-3">
+          <label className={label}>Value</label>
+          <select
+            value={String(value)}
+            onChange={(e) => setValue(e.target.value === "true")}
+            className={input}
+          >
+            <option value="true">Granted</option>
+            <option value="false">Denied</option>
+          </select>
+        </div>
+        <div className="mb-3">
+          <label className={label}>Expires at (your local time, stored as UTC)</label>
+          <input
+            type="datetime-local"
+            value={expiresAtLocal}
+            onChange={(e) => setExpiresAtLocal(e.target.value)}
+            className={input}
+          />
+        </div>
+        <div className="mb-4">
+          <label className={label}>Note (max 500 chars)</label>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            maxLength={500}
+            className={`${input} min-h-[80px]`}
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className={btnSecondary}>Cancel</button>
+          <button type="submit" disabled={submitting} className={btnPrimary}>
+            {submitting ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function toLocalInput(iso: string): string {
+  // Convert ISO UTC to "YYYY-MM-DDTHH:mm" for datetime-local input.
+  const d = new Date(iso);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/frontend/components/system/DuplicatePlanModal.tsx
+++ b/frontend/components/system/DuplicatePlanModal.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { btnPrimary, btnSecondary, card, error as errorCls, input, label } from "@/lib/styles";
+import type { Plan } from "@/lib/types";
+
+interface Props {
+  source: Plan;
+  onClose: () => void;
+  onDuplicated: (plan: Plan) => void;
+}
+
+// Local slug helper. No other call site needs this; intentionally not promoted to a shared lib.
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Props) {
+  const [name, setName] = useState(`${source.name} (copy)`);
+  const [slug, setSlug] = useState(slugify(`${source.name}-copy`));
+  const [errorMsg, setErrorMsg] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrorMsg("");
+    setSubmitting(true);
+    try {
+      const plan = await apiFetch<Plan>(`/api/v1/plans/${source.id}/duplicate`, {
+        method: "POST",
+        body: JSON.stringify({ name, slug }),
+      });
+      onDuplicated(plan);
+      onClose();
+    } catch (err) {
+      setErrorMsg(extractErrorMessage(err, "Failed to duplicate plan"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
+        <h2 className="mb-4 text-lg font-semibold">Duplicate plan</h2>
+        {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}
+        <div className="mb-3">
+          <label className={label}>Name</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setSlug(slugify(e.target.value));
+            }}
+            className={input}
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className={label}>Slug</label>
+          <input
+            type="text"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            className={input}
+            pattern="^[a-z0-9-]+$"
+            required
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className={btnSecondary}>Cancel</button>
+          <button type="submit" disabled={submitting} className={btnPrimary}>
+            {submitting ? "Duplicating..." : "Duplicate"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/lib/feature-catalog.ts
+++ b/frontend/lib/feature-catalog.ts
@@ -1,0 +1,20 @@
+import type { FeatureKey } from "@/lib/types";
+
+export const FEATURE_LABELS: Record<FeatureKey, { label: string; description: string }> = {
+  "ai.budget": {
+    label: "AI Budget Rebalancing",
+    description: "Suggests budget adjustments from spending patterns and one-time events.",
+  },
+  "ai.forecast": {
+    label: "AI Smart Forecast",
+    description: "Seasonality-aware forecast on top of the deterministic projection.",
+  },
+  "ai.smart_plan": {
+    label: "AI Goal-Based Plans",
+    description: "Generates a savings + budget plan to hit a stated goal by a target date.",
+  },
+  "ai.autocategorize": {
+    label: "AI Auto-Categorization",
+    description: "LLM fallback for transactions the deterministic rules can't categorize.",
+  },
+};

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -229,6 +229,9 @@ export interface Plan {
   price_yearly: number;
   max_users: number | null;
   retention_days: number | null;
+  features: PlanFeatures;
+
+  // CLEANUP-029: remove the three fields below when migration 029 ships.
   ai_budget_enabled: boolean;
   ai_forecast_enabled: boolean;
   ai_smart_plan_enabled: boolean;
@@ -246,4 +249,42 @@ export interface SubscriptionDetail {
   trial_end: string | null;
   current_period_start: string | null;
   current_period_end: string | null;
+}
+
+// L4.11 feature entitlements -------------------------------------------------
+
+export type FeatureKey =
+  | "ai.budget"
+  | "ai.forecast"
+  | "ai.smart_plan"
+  | "ai.autocategorize";
+
+export interface PlanFeatures {
+  "ai.budget": boolean;
+  "ai.forecast": boolean;
+  "ai.smart_plan": boolean;
+  "ai.autocategorize": boolean;
+}
+
+export interface OrgFeatureOverride {
+  feature_key: FeatureKey;
+  value: boolean;
+  set_by: number | null;
+  set_by_email: string | null;
+  set_at: string;          // ISO 8601 UTC
+  expires_at: string | null;  // ISO 8601 UTC
+  note: string | null;
+  is_expired: boolean;
+}
+
+export interface FeatureStateRow {
+  key: FeatureKey;
+  plan_default: boolean;
+  effective: boolean;
+  override: OrgFeatureOverride | null;
+}
+
+export interface FeatureStateResponse {
+  plan: { id: number; name: string; slug: string } | null;
+  features: FeatureStateRow[];
 }

--- a/frontend/tests/app/admin-org-detail-page.test.tsx
+++ b/frontend/tests/app/admin-org-detail-page.test.tsx
@@ -48,6 +48,16 @@ const DETAIL = {
   counts: { transactions: 5, accounts: 1, budgets: 0, forecast_plans: 0 },
 };
 
+const FEATURE_STATE = {
+  plan: { id: 1, name: "Free", slug: "free" },
+  features: [
+    { key: "ai.budget", plan_default: true, effective: true, override: null },
+    { key: "ai.forecast", plan_default: false, effective: false, override: null },
+    { key: "ai.smart_plan", plan_default: false, effective: false, override: null },
+    { key: "ai.autocategorize", plan_default: false, effective: false, override: null },
+  ],
+};
+
 
 describe("AdminOrgDetailPage — Danger zone gating", () => {
   const apiFetchMock = vi.mocked(apiFetch);
@@ -65,6 +75,7 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
 
   it("disables the delete button until the org name is typed exactly", async () => {
     apiFetchMock.mockImplementation(((url: string) => {
+      if (url === `/api/v1/admin/orgs/42/feature-state`) return Promise.resolve(FEATURE_STATE);
       if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
       if (url === "/api/v1/plans") return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
       return Promise.resolve(undefined);
@@ -82,11 +93,12 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
     expect(deleteBtn).not.toBeDisabled();
   });
 
-  it("posts plan_id and current_period_end when admin changes them", async () => {
+  it("posts current_period_end when admin changes the date and saves", async () => {
     apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
       if (url.startsWith("/api/v1/admin/orgs/42/subscription") && opts?.method === "PUT") {
         return Promise.resolve({ before: {}, after: {} });
       }
+      if (url === `/api/v1/admin/orgs/42/feature-state`) return Promise.resolve(FEATURE_STATE);
       if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
       if (url === "/api/v1/plans") {
         return Promise.resolve([
@@ -99,9 +111,6 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
     render(<AdminOrgDetailPage />);
 
     await screen.findByRole("heading", { name: "Acme" });
-    fireEvent.change(screen.getByLabelText(/^Plan$/i), {
-      target: { value: "2" },
-    });
     fireEvent.change(screen.getByLabelText(/Period end/i), {
       target: { value: "2026-12-31" },
     });
@@ -113,7 +122,6 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
         expect.objectContaining({
           method: "PUT",
           body: JSON.stringify({
-            plan_id: 2,
             current_period_end: "2026-12-31",
           }),
         }),
@@ -121,8 +129,116 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
     });
   });
 
+  it("Change plan modal posts plan_id to subscription endpoint", async () => {
+    apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url.startsWith("/api/v1/admin/orgs/42/subscription") && opts?.method === "PUT") {
+        return Promise.resolve({ before: {}, after: {} });
+      }
+      if (url === `/api/v1/admin/orgs/42/feature-state`) return Promise.resolve(FEATURE_STATE);
+      if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
+      if (url === "/api/v1/plans") {
+        return Promise.resolve([
+          { id: 1, slug: "free", name: "Free" },
+          { id: 2, slug: "pro", name: "Pro" },
+        ]);
+      }
+      if (url === "/api/v1/plans/all") {
+        return Promise.resolve([
+          { id: 1, slug: "free", name: "Free" },
+          { id: 2, slug: "pro", name: "Pro" },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByRole("heading", { name: "Acme" });
+    fireEvent.click(screen.getByRole("button", { name: /Change plan/i }));
+
+    // Modal opens; wait for the modal heading to confirm it mounted, then for
+    // the Pro option to load (modal fetches /api/v1/plans/all asynchronously).
+    await screen.findByRole("heading", { name: /Change plan/i });
+    await screen.findByRole("option", { name: /Pro \(pro\)/i });
+
+    // Pick the Pro plan via the modal's select. The page also has a Status
+    // <select>, so grab all comboboxes and pick the modal's (rendered last).
+    const comboboxes = screen.getAllByRole("combobox");
+    const planSelect = comboboxes[comboboxes.length - 1];
+    fireEvent.change(planSelect, { target: { value: "2" } });
+
+    // Submit: there are now two "Save" buttons (the page's + the modal's).
+    // The modal's submit button is the last one rendered.
+    const saveButtons = screen.getAllByRole("button", { name: /^Save$/i });
+    fireEvent.click(saveButtons[saveButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/42/subscription",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ plan_id: 2 }),
+        }),
+      );
+    });
+  });
+
+  it("renders Change plan button", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === `/api/v1/admin/orgs/42/feature-state`) return Promise.resolve(FEATURE_STATE);
+      if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
+      if (url === "/api/v1/plans") return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<AdminOrgDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Change plan/i })).toBeInTheDocument();
+    });
+  });
+
+  it("FeatureOverridesCard renders feature-state rows with override metadata", async () => {
+    const featureStateWithOverride = {
+      plan: { id: 1, name: "Free", slug: "free" },
+      features: [
+        { key: "ai.budget", plan_default: true, effective: true, override: null },
+        {
+          key: "ai.forecast",
+          plan_default: false,
+          effective: true,
+          override: {
+            feature_key: "ai.forecast",
+            value: true,
+            set_by: 1,
+            set_by_email: "root@platform.io",
+            set_at: "2026-05-01T10:00:00Z",
+            expires_at: null,
+            note: "manual grant",
+            is_expired: false,
+          },
+        },
+        { key: "ai.smart_plan", plan_default: false, effective: false, override: null },
+        { key: "ai.autocategorize", plan_default: false, effective: false, override: null },
+      ],
+    };
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === `/api/v1/admin/orgs/42/feature-state`) return Promise.resolve(featureStateWithOverride);
+      if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
+      if (url === "/api/v1/plans") return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<AdminOrgDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/AI Budget Rebalancing/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/AI Smart Forecast/i)).toBeInTheDocument();
+    // Override metadata for the row that has set_by_email.
+    expect(screen.getByText(/set by root@platform\.io/i)).toBeInTheDocument();
+  });
+
   it("posts the confirm_name and routes back to /admin/orgs after delete", async () => {
     apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url === `/api/v1/admin/orgs/42/feature-state`) return Promise.resolve(FEATURE_STATE);
       if (url.startsWith("/api/v1/admin/orgs/42") && (!opts || opts.method !== "DELETE")) {
         return Promise.resolve(DETAIL);
       }

--- a/frontend/tests/app/system-plans-page.test.tsx
+++ b/frontend/tests/app/system-plans-page.test.tsx
@@ -93,6 +93,43 @@ describe("/system/plans page — Features section + Duplicate", () => {
     expect(screen.getByText("AI Auto-Categorization")).toBeInTheDocument();
   });
 
+  it("Edit Save sends features without slug", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/plans/all") return Promise.resolve([PRO_PLAN]);
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SystemPlansPage />);
+
+    const editButton = await screen.findByRole("button", { name: /^Edit$/i });
+    fireEvent.click(editButton);
+
+    // Wait for the editor to render the feature checkboxes.
+    await screen.findByText("AI Auto-Categorization");
+
+    // Toggle ai.autocategorize. The checkbox has id="feature-ai.autocategorize".
+    const autocatCheckbox = document.getElementById("feature-ai.autocategorize") as HTMLInputElement;
+    expect(autocatCheckbox).toBeTruthy();
+    fireEvent.click(autocatCheckbox);
+
+    // Click the form's Save button.
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      const editCall = apiFetchMock.mock.calls.find(
+        ([url, opts]) =>
+          typeof url === "string" &&
+          url.includes("/api/v1/plans/1") &&
+          (opts as RequestInit | undefined)?.method === "PUT",
+      );
+      expect(editCall).toBeDefined();
+      const body = JSON.parse((editCall![1] as RequestInit).body as string);
+      expect(body).not.toHaveProperty("slug");
+      expect(body).toHaveProperty("features");
+      expect(body.features["ai.autocategorize"]).toBe(true);
+    });
+  });
+
   it("Duplicate row action opens the Duplicate plan modal", async () => {
     apiFetchMock.mockImplementation(((url: string) => {
       if (url === "/api/v1/plans/all") return Promise.resolve([PRO_PLAN]);

--- a/frontend/tests/app/system-plans-page.test.tsx
+++ b/frontend/tests/app/system-plans-page.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import SystemPlansPage from "@/app/system/plans/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/system/plans",
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const SUPERADMIN = {
+  id: 1, username: "root", email: "root@platform.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Platform",
+  billing_cycle_day: 1, is_superadmin: true, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const PRO_PLAN = {
+  id: 1,
+  name: "Pro",
+  slug: "pro",
+  description: "",
+  is_custom: false,
+  is_active: true,
+  sort_order: 1,
+  price_monthly: 10,
+  price_yearly: 100,
+  max_users: null,
+  retention_days: null,
+  features: {
+    "ai.budget": true,
+    "ai.forecast": false,
+    "ai.smart_plan": false,
+    "ai.autocategorize": false,
+  },
+  ai_budget_enabled: true,
+  ai_forecast_enabled: false,
+  ai_smart_plan_enabled: false,
+};
+
+describe("/system/plans page — Features section + Duplicate", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+  });
+
+  it("renders one Features row per catalog key in the editor", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/plans/all") return Promise.resolve([PRO_PLAN]);
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SystemPlansPage />);
+
+    // Wait for the row to render before opening the editor.
+    const editButton = await screen.findByRole("button", { name: /^Edit$/i });
+    fireEvent.click(editButton);
+
+    // The four FEATURE_LABELS labels should each appear in the editor.
+    await screen.findByText("AI Budget Rebalancing");
+    expect(screen.getByText("AI Smart Forecast")).toBeInTheDocument();
+    expect(screen.getByText("AI Goal-Based Plans")).toBeInTheDocument();
+    expect(screen.getByText("AI Auto-Categorization")).toBeInTheDocument();
+  });
+
+  it("Duplicate row action opens the Duplicate plan modal", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/plans/all") return Promise.resolve([PRO_PLAN]);
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SystemPlansPage />);
+
+    const duplicateButton = await screen.findByRole("button", { name: /^Duplicate$/i });
+    fireEvent.click(duplicateButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /Duplicate plan/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/fixtures/feature-catalog.json
+++ b/frontend/tests/fixtures/feature-catalog.json
@@ -1,0 +1,8 @@
+{
+  "keys": [
+    "ai.autocategorize",
+    "ai.budget",
+    "ai.forecast",
+    "ai.smart_plan"
+  ]
+}

--- a/frontend/tests/lib/feature-catalog.test.ts
+++ b/frontend/tests/lib/feature-catalog.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { FEATURE_LABELS } from "@/lib/feature-catalog";
+import catalog from "../fixtures/feature-catalog.json";
+
+describe("feature-catalog drift guard", () => {
+  it("every backend catalog key has a UI label", () => {
+    for (const key of catalog.keys) {
+      expect(FEATURE_LABELS).toHaveProperty(key);
+    }
+  });
+
+  it("FEATURE_LABELS contains no orphaned keys", () => {
+    for (const key of Object.keys(FEATURE_LABELS)) {
+      expect(catalog.keys).toContain(key);
+    }
+  });
+});

--- a/scripts/regen_feature_catalog_fixture.py
+++ b/scripts/regen_feature_catalog_fixture.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Regenerate frontend/tests/fixtures/feature-catalog.json.
+
+Reads ALL_FEATURE_KEYS from backend/app/auth/feature_catalog.py and
+writes a sorted JSON list to the fixture used by the frontend drift
+test. Run after adding or removing a feature key.
+
+This is explicit (manual) — never invoked from a test.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.auth.feature_catalog import ALL_FEATURE_KEYS  # noqa: E402
+
+FIXTURE = ROOT / "frontend" / "tests" / "fixtures" / "feature-catalog.json"
+
+payload = {"keys": sorted(ALL_FEATURE_KEYS)}
+FIXTURE.write_text(json.dumps(payload, indent=2) + "\n")
+print(f"wrote {FIXTURE} with {len(payload['keys'])} keys")


### PR DESCRIPTION
## Summary

Replaces the three `plans.ai_*_enabled` columns with a `plans.features` JSON catalog and introduces per-org boolean overrides keyed on `(org_id, feature_key)`. Single resolver, strict catalog validation at every layer, admin UI for plan duplication, plan assignment, and override management.

**Compatibility shim** — `PlanResponse` derives the three legacy `ai_*_enabled` booleans from `features` for one release via `@computed_field`. **CLEANUP-029** (follow-up PR, tracked in `project_roadmap.md` TECHNICAL DEBT) drops the legacy columns and the shim. `# CLEANUP-029` and `// CLEANUP-029` markers tag every shim site for greppable removal.

Spec: `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-02-l4-11-plan-features-org-overrides-design.md`

## What's in here

**Schema (Slice 1):**
- Migration 028: `plans.features JSON NOT NULL` with backfill (`JSON_TYPE = OBJECT` verified); `org_feature_overrides` table with `UNIQUE(org_id, feature_key)`, `set_by` / `set_at`, `expires_at`, `note`.
- `OrgFeatureOverride` model + registration.
- `Plan` model: legacy `ai_*_enabled` mappings dropped (columns survive in DB until 029 as rollback ballast); `features: Mapped[dict]` with Python-side `default=dict` for cross-DB compat.
- `feature_catalog.py` with `FeatureKey` Literal + `PlanFeatures` Pydantic (StrictBool, alias keys, `extra="forbid"`).
- `plan_service.canonicalize_features` chokepoint for plan writes.
- `PlanResponse` shim + `PlanCreate` / `PlanUpdate` `extra="forbid"` reject legacy payloads.

**Resolver + endpoints (Slice 2):**
- `feature_service.get_features` + `has_feature` with row-presence override semantic (deny override beats plan grant).
- `feature_deps.require_feature` factory-time `UnknownFeatureKey` raise; per-request cache via `request.state._org_features_cache`.
- `GET /api/v1/admin/feature-catalog` (plans.manage).
- `PUT /DELETE /api/v1/admin/orgs/{org_id}/feature-overrides/{feature_key}` (orgs.manage); 404 on missing org, structured `admin.org.feature.set` / `revoked` audit events with `target_org_id`, `actor_email`, `note_present`. Update refreshes `set_at`.
- `GET /api/v1/admin/orgs/{org_id}/feature-state` composite (orgs.view); per-key `plan_default`, `effective`, `override` with server-resolved `set_by_email`. 404 on missing org.
- `POST /api/v1/plans/{plan_id}/duplicate` (plans.manage); clones with `is_custom=True`, 409 on slug conflict.
- `delete_org_cascade` extended to count + delete `org_feature_overrides`.

**Admin UI (Slice 3):**
- Frontend types: `FeatureKey`, `PlanFeatures`, `OrgFeatureOverride`, `FeatureStateRow`, `FeatureStateResponse`. Legacy `ai_*_enabled` retained on `Plan` with `// CLEANUP-029` tag.
- `frontend/lib/feature-catalog.ts` with `FEATURE_LABELS` + checked-in fixture + read-only drift-guard test.
- `scripts/regen_feature_catalog_fixture.py` for explicit (manual) regeneration.
- `DuplicatePlanModal` with local slug helper.
- `ChangePlanModal` (splits plan-change affordance out of the broader subscription-override form).
- `FeatureOverridesCard` with edit modal, ISO-UTC `expires_at` handling, revoke action, expired-row greying.
- `/system/plans` page: Features section in editor, Duplicate row action.
- `/admin/orgs/[id]` page: Change-plan affordance + FeatureOverridesCard wired in; `plan_id` removed from the broader subscription-override form.

## Tests

- **Backend:** 248 passed, 2 skipped (MySQL-only migration tests gated behind `PFV_RUN_MYSQL_TESTS=1`).
- **Frontend:** 60 passed across 18 test files.
- New: 9 feature_service tests, 6 plan_service tests, 5 PlanResponse shim tests, 2 migration backfill tests, 2 feature_deps tests, 2 catalog endpoint tests, 13 override CRUD tests (PUT/DELETE/404-on-missing-org/set_at-refresh), 4 feature-state tests, 4 plan duplicate tests, cascade extension. Frontend: 2 drift-guard tests, 2 system-plans tests, 3 new admin-org-detail tests.

## Pre-merge gates

- `alembic upgrade head` verified end-to-end against MySQL 8 (down/up cycle, JSON_TYPE = OBJECT on all backfilled rows).
- `_find_repo_root()` walk-upward fix for `test_deploy_workflow.py` (was breaking on container layout) shipped as part of Slice 1 baseline patch.

## Out of scope (carried forward)

- LAI.1 wiring (separate PR; reads `has_feature("ai.autocategorize")`).
- L4.7 audit table integration (when L4.7 lands, `admin.org.feature.*` payloads persist without call-site changes).
- Per-user feature flags.
- Bulk override editor.
- Cross-plan feature copy.
- Override expiry-cleanup sweep (tracked in TECHNICAL DEBT).
- `org_plan_limit_overrides` for non-boolean limits.
- `/settings/billing/page.tsx` migration to read `features` directly — intentionally deferred to CLEANUP-029.
- `datetime.utcnow()` deprecation cleanup — tracked in TECHNICAL DEBT.

## Review slices

The branch was reviewed at three checkpoints (T9 / T20 / pre-PR). Suggested reading order:

1. **Schema + canonicalization** — migration 028, `Plan` model, `feature_catalog.py`, `plan_service.canonicalize_features`, `PlanResponse` shim.
2. **Resolver + endpoints** — `feature_service.py`, `feature_deps.py`, override CRUD on `admin_orgs.py`, `feature-state` composite, plan duplicate.
3. **Admin UI** — three new components + two page wirings, plus the drift-guard fixture.