### PR TITLE
feat(transfers): PR-B pairing primitives + endpoints

### DIFF
--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -2,20 +2,29 @@ import datetime
 from typing import Literal
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.deps import get_current_user
+from app.models.account import Account
+from app.models.transaction import TransactionType
 from app.models.user import User
 from app.schemas.transaction import (
     BulkDeleteRequest,
     BulkDeleteResponse,
+    ConvertToTransferRequest,
     TransactionCreate,
+    TransactionPairRequest,
     TransactionResponse,
     TransactionUpdate,
+    TransferCandidate,
+    TransferCandidatesResponse,
     TransferCreate,
+    UnpairTransactionRequest,
 )
 from app.services import transaction_service as svc
+from app.services.exceptions import NotFoundError, ValidationError
 
 router = APIRouter(prefix="/api/v1/transactions", tags=["transactions"])
 
@@ -67,6 +76,149 @@ async def create_transfer(
 ):
     tx1, tx2 = await svc.create_transfer(db, current_user.org_id, body)
     return [svc.to_response(tx1), svc.to_response(tx2)]
+
+
+@router.post("/pair", response_model=list[TransactionResponse], status_code=201)
+async def pair_transactions(
+    body: TransactionPairRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    expense_tx, income_tx = await svc.pair_existing_transactions(
+        db,
+        current_user.org_id,
+        expense_tx_id=body.expense_id,
+        income_tx_id=body.income_id,
+        recategorize=body.recategorize,
+        transfer_category_id=body.transfer_category_id,
+    )
+    pair = sorted(
+        [svc.to_response(expense_tx), svc.to_response(income_tx)],
+        key=lambda r: r.id,
+    )
+    return pair
+
+
+@router.post(
+    "/{transaction_id}/convert-to-transfer",
+    response_model=list[TransactionResponse],
+    status_code=201,
+)
+async def convert_to_transfer(
+    transaction_id: int,
+    body: ConvertToTransferRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if body.pair_with_transaction_id is not None:
+        # Validate the candidate's account matches destination_account_id.
+        partner = await svc.get_transaction(
+            db, current_user.org_id, body.pair_with_transaction_id
+        )
+        if partner.account_id != body.destination_account_id:
+            raise ValidationError(
+                "pair_with_transaction_id account does not match destination_account_id"
+            )
+        source = await svc.get_transaction(db, current_user.org_id, transaction_id)
+        if source.type == TransactionType.EXPENSE:
+            expense_id, income_id = source.id, partner.id
+        else:
+            expense_id, income_id = partner.id, source.id
+        e, i = await svc.pair_existing_transactions(
+            db,
+            current_user.org_id,
+            expense_tx_id=expense_id,
+            income_tx_id=income_id,
+            recategorize=body.recategorize,
+            transfer_category_id=body.transfer_category_id,
+        )
+    else:
+        e, i = await svc.convert_and_create_leg(
+            db,
+            current_user.org_id,
+            transaction_id,
+            destination_account_id=body.destination_account_id,
+            recategorize=body.recategorize,
+            transfer_category_id=body.transfer_category_id,
+        )
+        # convert_and_create_leg only refreshes partner.account, not category.
+        # Re-fetch both legs with full eager loads so to_response can serialize.
+        e = await svc.get_transaction(db, current_user.org_id, e.id)
+        i = await svc.get_transaction(db, current_user.org_id, i.id)
+    pair = sorted([svc.to_response(e), svc.to_response(i)], key=lambda r: r.id)
+    return pair
+
+
+@router.post(
+    "/{transaction_id}/unpair",
+    response_model=list[TransactionResponse],
+    status_code=200,
+)
+async def unpair_transaction(
+    transaction_id: int,
+    body: UnpairTransactionRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    e, i = await svc.unpair_transactions(
+        db,
+        current_user.org_id,
+        transaction_id,
+        expense_fallback_category_id=body.expense_fallback_category_id,
+        income_fallback_category_id=body.income_fallback_category_id,
+    )
+    pair = sorted([svc.to_response(e), svc.to_response(i)], key=lambda r: r.id)
+    return pair
+
+
+@router.get(
+    "/{transaction_id}/transfer-candidates",
+    response_model=TransferCandidatesResponse,
+)
+async def transfer_candidates(
+    transaction_id: int,
+    destination_account_id: int = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    source = await svc.get_transaction(db, current_user.org_id, transaction_id)
+    dst_acct = await db.scalar(
+        select(Account).where(
+            Account.id == destination_account_id,
+            Account.org_id == current_user.org_id,
+        )
+    )
+    if dst_acct is None:
+        raise NotFoundError("Account")
+    if source.account.currency != dst_acct.currency:
+        raise ValidationError("Source and destination must have the same currency")
+    candidates = await svc.find_match_candidates(
+        db,
+        current_user.org_id,
+        source_type=source.type,
+        amount=source.amount,
+        account_id_excluded=source.account_id,
+        date=source.date,
+        currency=source.account.currency,
+    )
+    out = []
+    for c in candidates:
+        if c.account_id != destination_account_id:
+            continue
+        diff = abs((c.date - source.date).days)
+        out.append(
+            TransferCandidate(
+                id=c.id,
+                date=c.date,
+                description=c.description,
+                amount=c.amount,
+                account_id=c.account_id,
+                account_name=c.account.name,
+                date_diff_days=diff,
+                confidence="same_day" if diff == 0 else "near_date",
+            )
+        )
+    return TransferCandidatesResponse(candidates=out)
 
 
 @router.get("/{transaction_id}", response_model=TransactionResponse)

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -2,10 +2,12 @@ import datetime
 from decimal import Decimal
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class TransactionCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     account_id: int
     category_id: int
     description: str = Field(max_length=255)
@@ -23,6 +25,8 @@ class TransactionCreate(BaseModel):
 
 
 class TransferCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     from_account_id: int
     to_account_id: int
     category_id: Optional[int] = None
@@ -33,6 +37,8 @@ class TransferCreate(BaseModel):
 
 
 class TransactionUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     account_id: Optional[int] = None
     category_id: Optional[int] = None
     description: Optional[str] = None
@@ -71,6 +77,8 @@ class TransactionResponse(BaseModel):
 class BulkDeleteRequest(BaseModel):
     """Body for POST /api/v1/transactions/bulk-delete."""
 
+    model_config = ConfigDict(extra="forbid")
+
     ids: list[int] = Field(
         ...,
         min_length=1,
@@ -85,3 +93,82 @@ class BulkDeleteResponse(BaseModel):
     requested_count: int
     deleted_count: int
     skipped_ids: list[int]  # IDs that were requested but not found in this org
+
+
+class TransactionPairRequest(BaseModel):
+    """Op-1 bulk-link / import-confirm-pair / Op-2 pair-with-existing payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    expense_id: int
+    income_id: int
+    transfer_category_id: int | None = None
+    recategorize: bool = True
+
+
+class ConvertToTransferRequest(BaseModel):
+    """Op-2 (pair existing) + Op-3 (create missing leg) per-row payload.
+
+    If pair_with_transaction_id is set, the candidate's account_id MUST equal
+    destination_account_id (server validates and raises ValidationError on
+    mismatch). If unset, the service creates the partner leg on
+    destination_account_id.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    destination_account_id: int
+    pair_with_transaction_id: int | None = None
+    transfer_category_id: int | None = None
+    recategorize: bool = True
+
+
+class UnpairTransactionRequest(BaseModel):
+    """Op-4 unlink payload. Per-leg fallback categories required because the
+    Transfer system category no longer fits once the rows are unlinked.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    expense_fallback_category_id: int
+    income_fallback_category_id: int
+
+
+class TransferCandidate(BaseModel):
+    """A potential pair candidate returned by GET /transfer-candidates and
+    embedded in import preview rows when transfer_match_action requires the
+    user to choose.
+    """
+
+    id: int
+    date: datetime.date
+    description: str
+    amount: Decimal
+    account_id: int
+    account_name: str
+    date_diff_days: int
+    confidence: Literal["same_day", "near_date"]
+
+
+class TransferCandidatesResponse(BaseModel):
+    """Wrapper for GET /api/v1/transactions/{id}/transfer-candidates."""
+
+    candidates: list[TransferCandidate]
+
+
+class DuplicateCandidate(BaseModel):
+    """Embedded in ImportPreviewRow when a CSV row matches an existing linked
+    leg on the same account. Lean shape so /import does not refetch row details.
+
+    The synthetic-leg badge keys off existing_leg_is_imported (the matched leg
+    itself, not its partner). False means the matched leg was created via Op-3
+    convert-and-create or via the manual create-transfer UI.
+    """
+
+    id: int
+    date: datetime.date
+    description: str
+    amount: Decimal
+    account_id: int
+    account_name: str
+    existing_leg_is_imported: bool

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -574,7 +574,9 @@ async def find_match_candidates(
     Caller passes ``source_type``; helper computes opposite internally. Never
     call this with an already-flipped type.
 
-    Ordered by abs(date_diff) ASC, id ASC. Capped at 25 candidates.
+    Ordered by abs(date_diff) ASC, id ASC. Capped at 25 candidates AFTER
+    Python sort (no SQL LIMIT — without ORDER BY in SQL, LIMIT could exclude
+    the closest candidate).
     """
     target_type = (
         TransactionType.INCOME if source_type == TransactionType.EXPENSE else TransactionType.EXPENSE
@@ -598,12 +600,13 @@ async def find_match_candidates(
             Transaction.date <= window_end,
             Account.currency == currency,
         )
-        .limit(25)
+        # NOTE: no SQL .limit() — the ±3-day window + strict filter set keeps
+        # the result set naturally tiny. Sort in Python, then slice.
     )
     result = await db.execute(q)
     rows = list(result.scalars().all())
     rows.sort(key=lambda r: (abs((r.date - date).days), r.id))
-    return rows
+    return rows[:25]  # defensive cap AFTER sorting
 
 
 async def find_duplicate_of_linked_leg(
@@ -620,7 +623,9 @@ async def find_duplicate_of_linked_leg(
     CSV row's (type, amount, currency) within ±3 days. Used by import preview
     to flag bank rows that duplicate a synthetic leg created via Op-3.
 
-    Ordered by abs(date_diff) ASC, id ASC.
+    Ordered by abs(date_diff) ASC, id ASC. Capped at 10 AFTER Python sort
+    (no SQL LIMIT — without ORDER BY in SQL, LIMIT could exclude the
+    closest candidate).
     """
     window_start = date - datetime.timedelta(days=3)
     window_end = date + datetime.timedelta(days=3)
@@ -639,12 +644,12 @@ async def find_duplicate_of_linked_leg(
             Transaction.date <= window_end,
             Account.currency == currency,
         )
-        .limit(10)
+        # NOTE: no SQL .limit() — see find_match_candidates for rationale.
     )
     result = await db.execute(q)
     rows = list(result.scalars().all())
     rows.sort(key=lambda r: (abs((r.date - date).days), r.id))
-    return rows
+    return rows[:10]  # defensive cap AFTER sorting
 
 
 async def pair_existing_transactions(
@@ -721,49 +726,79 @@ async def convert_and_create_leg(
     Owns transaction scope. See pair_existing_transactions for the locking
     discipline. Source may be SETTLED or PENDING; partner mirrors source
     status. Same-currency only.
+
+    Lock order: source transaction FIRST, then accounts (sorted-ID). This
+    matches update_transaction's order (tx then accounts) so concurrent
+    operations on overlapping (transaction, account) pairs cannot deadlock.
     """
-    # Pre-read source and destination account (no lock yet, just to check
-    # existence + collect ids for sorted-order lock acquisition).
-    source = await db.scalar(
+    # 1. Pre-read source transaction (no lock) only to collect IDs needed for
+    # subsequent lock acquisition + early existence check.
+    source_pre = await db.scalar(
         select(Transaction).where(
             Transaction.id == source_tx_id, Transaction.org_id == org_id
         )
     )
-    if source is None:
+    if source_pre is None:
         raise NotFoundError("Transaction")
-    if source.linked_transaction_id is not None:
+    pre_account_id = source_pre.account_id
+    pre_linked = source_pre.linked_transaction_id
+    pre_recurring = source_pre.recurring_id
+
+    # 2. Pre-validate destination account + early invariants on the unlocked
+    # read. These will be re-checked under the lock to defeat races.
+    if pre_linked is not None:
         raise ValidationError("Source row is already a transfer leg")
-    if source.recurring_id is not None:
+    if pre_recurring is not None:
         raise ValidationError("Recurring rows cannot be converted to transfer legs")
-    if source.account_id == destination_account_id:
+    if pre_account_id == destination_account_id:
         raise ValidationError("Source and destination accounts must differ")
 
-    src_account = await db.scalar(
-        select(Account).where(Account.id == source.account_id, Account.org_id == org_id)
+    src_account_pre = await db.scalar(
+        select(Account).where(Account.id == pre_account_id, Account.org_id == org_id)
     )
-    dst_account = await db.scalar(
+    dst_account_pre = await db.scalar(
         select(Account).where(Account.id == destination_account_id, Account.org_id == org_id)
     )
-    if dst_account is None:
+    if dst_account_pre is None:
         raise NotFoundError("Account")
-    if src_account.currency != dst_account.currency:
+    if src_account_pre.currency != dst_account_pre.currency:
         raise ValidationError("Source and destination accounts must have the same currency")
 
-    # Acquire account locks in sorted ID order (deadlock prevention).
-    first_id, second_id = sorted([source.account_id, destination_account_id])
-    first_acct = await get_account_for_update(db, first_id, org_id)
-    second_acct = await get_account_for_update(db, second_id, org_id)
-    dst_locked = first_acct if destination_account_id == first_id else second_acct
-
-    # Lock the source row with FOR UPDATE; refresh with eager-loaded relationships.
+    # 3. Lock the source transaction FIRST (before accounts) to match the
+    # lock-acquisition order used by update_transaction. Refresh with eager
+    # relationships so downstream code sees the locked row state.
     locked = await db.execute(
         select(Transaction)
         .options(*_load_opts())
-        .where(Transaction.id == source.id, Transaction.org_id == org_id)
+        .where(Transaction.id == source_tx_id, Transaction.org_id == org_id)
         .with_for_update()
         .execution_options(populate_existing=True)
     )
-    source = locked.scalar_one()
+    source = locked.scalar_one_or_none()
+    if source is None:
+        # Row vanished between pre-read and FOR UPDATE.
+        raise ConflictError("Source row state changed; refresh and retry")
+
+    # 4. Re-validate locked source state. If anything changed since the
+    # unlocked read, abort with ConflictError so the caller can refresh.
+    if source.linked_transaction_id is not None:
+        raise ConflictError("Source row state changed; refresh and retry")
+    if source.recurring_id is not None:
+        raise ConflictError("Source row state changed; refresh and retry")
+    if source.account_id == destination_account_id:
+        raise ConflictError("Source row state changed; refresh and retry")
+
+    # 5. Lock both accounts in sorted-ID order using the locked source's
+    # account_id (paranoia: in case it differs from the pre-read).
+    first_id, second_id = sorted([source.account_id, destination_account_id])
+    first_acct = await get_account_for_update(db, first_id, org_id)
+    second_acct = await get_account_for_update(db, second_id, org_id)
+    src_locked = first_acct if source.account_id == first_id else second_acct
+    dst_locked = first_acct if destination_account_id == first_id else second_acct
+
+    # 6. Re-validate currency on the locked accounts.
+    if src_locked.currency != dst_locked.currency:
+        raise ConflictError("Account currencies changed; refresh and retry")
 
     # Determine partner type by mirroring source.
     partner_type = (
@@ -849,6 +884,25 @@ async def unpair_transactions(
     # Validate fallback categories upfront (raises NotFoundError on miss).
     await validate_category(db, expense_fallback_category_id, org_id)
     await validate_category(db, income_fallback_category_id, org_id)
+
+    # Enforce type compatibility for each fallback. validate_category only
+    # checks org/existence; the docstring promises type-matched fallbacks so
+    # the API must reject INCOME-only categories for the expense leg, and
+    # EXPENSE-only categories for the income leg.
+    exp_cat = await db.scalar(
+        select(Category).where(
+            Category.id == expense_fallback_category_id, Category.org_id == org_id
+        )
+    )
+    inc_cat = await db.scalar(
+        select(Category).where(
+            Category.id == income_fallback_category_id, Category.org_id == org_id
+        )
+    )
+    if exp_cat.type not in (CategoryType.EXPENSE, CategoryType.BOTH):
+        raise ValidationError("expense_fallback_category_id must be EXPENSE or BOTH")
+    if inc_cat.type not in (CategoryType.INCOME, CategoryType.BOTH):
+        raise ValidationError("income_fallback_category_id must be INCOME or BOTH")
 
     ids_sorted = sorted([transaction_id, preview.linked_transaction_id])
     locked = await db.execute(

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -821,6 +821,73 @@ async def convert_and_create_leg(
     return expense_tx, income_tx
 
 
+async def unpair_transactions(
+    db: AsyncSession,
+    org_id: int,
+    transaction_id: int,
+    *,
+    expense_fallback_category_id: int,
+    income_fallback_category_id: int,
+) -> tuple[Transaction, Transaction]:
+    """Break a transfer pair without deleting either row. The only sanctioned
+    code path that clears linked_transaction_id.
+
+    Owns transaction scope. Locks both rows in sorted-ID order via SELECT FOR
+    UPDATE. NULLs both link columns atomically. Sets each leg's category_id to
+    the type-matched fallback. No balance changes.
+    """
+    preview = await db.scalar(
+        select(Transaction).where(
+            Transaction.id == transaction_id, Transaction.org_id == org_id
+        )
+    )
+    if preview is None:
+        raise NotFoundError("Transaction")
+    if preview.linked_transaction_id is None:
+        raise ValidationError("Transaction is not part of a transfer pair")
+
+    # Validate fallback categories upfront (raises NotFoundError on miss).
+    await validate_category(db, expense_fallback_category_id, org_id)
+    await validate_category(db, income_fallback_category_id, org_id)
+
+    ids_sorted = sorted([transaction_id, preview.linked_transaction_id])
+    locked = await db.execute(
+        select(Transaction)
+        .options(*_load_opts())
+        .where(Transaction.id.in_(ids_sorted), Transaction.org_id == org_id)
+        .order_by(Transaction.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    rows = list(locked.scalars().all())
+    if len(rows) != 2:
+        raise ConflictError("Pair partner not found; refresh and retry")
+
+    rows_by_type = {r.type: r for r in rows}
+    expense_tx = rows_by_type.get(TransactionType.EXPENSE)
+    income_tx = rows_by_type.get(TransactionType.INCOME)
+    if expense_tx is None or income_tx is None:
+        raise ConflictError("Pair has invalid type composition")
+
+    async with db.begin_nested():
+        expense_tx.linked_transaction_id = None
+        income_tx.linked_transaction_id = None
+        expense_tx.category_id = expense_fallback_category_id
+        income_tx.category_id = income_fallback_category_id
+        await db.flush()
+    await db.commit()
+
+    await logger.ainfo(
+        "transfers.unpaired",
+        org_id=org_id,
+        expense_id=expense_tx.id,
+        income_id=income_tx.id,
+        expense_fallback_category_id=expense_fallback_category_id,
+        income_fallback_category_id=income_fallback_category_id,
+    )
+    return expense_tx, income_tx
+
+
 async def create_transfer(
     db: AsyncSession, org_id: int, body: TransferCreate, *, is_imported: bool = False
 ) -> tuple[Transaction, Transaction]:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -647,6 +647,65 @@ async def find_duplicate_of_linked_leg(
     return rows
 
 
+async def pair_existing_transactions(
+    db: AsyncSession,
+    org_id: int,
+    expense_tx_id: int,
+    income_tx_id: int,
+    *,
+    recategorize: bool = True,
+    transfer_category_id: int | None = None,
+) -> tuple[Transaction, Transaction]:
+    """Link two existing un-linked rows as a transfer pair.
+
+    Owns transaction scope. Locks both rows in sorted-ID order via SELECT FOR
+    UPDATE, validates via _link_pair, links bidirectionally, optionally
+    recategorizes both legs to the system Transfer category. No balance changes
+    (both rows already exist with correct per-leg balance contributions).
+
+    Raises ValidationError on identical IDs or invariant violations,
+    NotFoundError if either row is missing in this org.
+    """
+    if expense_tx_id == income_tx_id:
+        raise ValidationError("Expense and income IDs must differ")
+
+    ids_sorted = sorted([expense_tx_id, income_tx_id])
+    locked = await db.execute(
+        select(Transaction)
+        .options(*_load_opts())
+        .where(Transaction.id.in_(ids_sorted), Transaction.org_id == org_id)
+        .order_by(Transaction.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    rows = list(locked.scalars().all())
+    if len(rows) != 2:
+        raise NotFoundError("Transaction")
+    rows_by_id = {r.id: r for r in rows}
+    expense_tx = rows_by_id[expense_tx_id]
+    income_tx = rows_by_id[income_tx_id]
+
+    async with db.begin_nested():
+        await _link_pair(
+            db,
+            expense_tx=expense_tx,
+            income_tx=income_tx,
+            recategorize=recategorize,
+            transfer_category_id=transfer_category_id,
+        )
+    await db.commit()
+
+    await logger.ainfo(
+        "transfers.linked",
+        org_id=org_id,
+        expense_id=expense_tx.id,
+        income_id=income_tx.id,
+        source="bulk_link",
+        recategorized=recategorize,
+    )
+    return expense_tx, income_tx
+
+
 async def create_transfer(
     db: AsyncSession, org_id: int, body: TransferCreate, *, is_imported: bool = False
 ) -> tuple[Transaction, Transaction]:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -606,6 +606,47 @@ async def find_match_candidates(
     return rows
 
 
+async def find_duplicate_of_linked_leg(
+    db: AsyncSession,
+    org_id: int,
+    *,
+    account_id: int,
+    amount: Decimal,
+    type: TransactionType,
+    date: datetime.date,
+    currency: str,
+) -> list[Transaction]:
+    """Returns up to 10 already-linked rows on the SAME account that match the
+    CSV row's (type, amount, currency) within ±3 days. Used by import preview
+    to flag bank rows that duplicate a synthetic leg created via Op-3.
+
+    Ordered by abs(date_diff) ASC, id ASC.
+    """
+    window_start = date - datetime.timedelta(days=3)
+    window_end = date + datetime.timedelta(days=3)
+
+    q = (
+        select(Transaction)
+        .options(*_load_opts())
+        .join(Account, Transaction.account_id == Account.id)
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.account_id == account_id,
+            Transaction.type == type,
+            Transaction.amount == amount,
+            Transaction.linked_transaction_id.is_not(None),
+            Transaction.date >= window_start,
+            Transaction.date <= window_end,
+            Account.currency == currency,
+        )
+        .limit(10)
+    )
+    result = await db.execute(q)
+    rows = list(result.scalars().all())
+    rows.sort(key=lambda r: (abs((r.date - date).days), r.id))
+    return rows
+
+
 async def create_transfer(
     db: AsyncSession, org_id: int, body: TransferCreate, *, is_imported: bool = False
 ) -> tuple[Transaction, Transaction]:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -557,6 +557,55 @@ async def _link_pair(
     return expense_tx, income_tx
 
 
+async def find_match_candidates(
+    db: AsyncSession,
+    org_id: int,
+    *,
+    source_type: TransactionType,
+    amount: Decimal,
+    account_id_excluded: int,
+    date: datetime.date,
+    currency: str,
+) -> list[Transaction]:
+    """Returns un-linked, settled, non-recurring rows on different accounts in
+    the same org with same `currency`, type == opposite(source_type),
+    abs(amount) == amount, date within ±3 days.
+
+    Caller passes ``source_type``; helper computes opposite internally. Never
+    call this with an already-flipped type.
+
+    Ordered by abs(date_diff) ASC, id ASC. Capped at 25 candidates.
+    """
+    target_type = (
+        TransactionType.INCOME if source_type == TransactionType.EXPENSE else TransactionType.EXPENSE
+    )
+    window_start = date - datetime.timedelta(days=3)
+    window_end = date + datetime.timedelta(days=3)
+
+    q = (
+        select(Transaction)
+        .options(*_load_opts())
+        .join(Account, Transaction.account_id == Account.id)
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.account_id != account_id_excluded,
+            Transaction.type == target_type,
+            Transaction.amount == amount,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.linked_transaction_id.is_(None),
+            Transaction.recurring_id.is_(None),
+            Transaction.date >= window_start,
+            Transaction.date <= window_end,
+            Account.currency == currency,
+        )
+        .limit(25)
+    )
+    result = await db.execute(q)
+    rows = list(result.scalars().all())
+    rows.sort(key=lambda r: (abs((r.date - date).days), r.id))
+    return rows
+
+
 async def create_transfer(
     db: AsyncSession, org_id: int, body: TransferCreate, *, is_imported: bool = False
 ) -> tuple[Transaction, Transaction]:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -706,6 +706,121 @@ async def pair_existing_transactions(
     return expense_tx, income_tx
 
 
+async def convert_and_create_leg(
+    db: AsyncSession,
+    org_id: int,
+    source_tx_id: int,
+    *,
+    destination_account_id: int,
+    recategorize: bool = True,
+    transfer_category_id: int | None = None,
+) -> tuple[Transaction, Transaction]:
+    """Convert an un-linked source row into a transfer leg by creating the
+    matching partner leg on the destination account, then linking the pair.
+
+    Owns transaction scope. See pair_existing_transactions for the locking
+    discipline. Source may be SETTLED or PENDING; partner mirrors source
+    status. Same-currency only.
+    """
+    # Pre-read source and destination account (no lock yet, just to check
+    # existence + collect ids for sorted-order lock acquisition).
+    source = await db.scalar(
+        select(Transaction).where(
+            Transaction.id == source_tx_id, Transaction.org_id == org_id
+        )
+    )
+    if source is None:
+        raise NotFoundError("Transaction")
+    if source.linked_transaction_id is not None:
+        raise ValidationError("Source row is already a transfer leg")
+    if source.recurring_id is not None:
+        raise ValidationError("Recurring rows cannot be converted to transfer legs")
+    if source.account_id == destination_account_id:
+        raise ValidationError("Source and destination accounts must differ")
+
+    src_account = await db.scalar(
+        select(Account).where(Account.id == source.account_id, Account.org_id == org_id)
+    )
+    dst_account = await db.scalar(
+        select(Account).where(Account.id == destination_account_id, Account.org_id == org_id)
+    )
+    if dst_account is None:
+        raise NotFoundError("Account")
+    if src_account.currency != dst_account.currency:
+        raise ValidationError("Source and destination accounts must have the same currency")
+
+    # Acquire account locks in sorted ID order (deadlock prevention).
+    first_id, second_id = sorted([source.account_id, destination_account_id])
+    first_acct = await get_account_for_update(db, first_id, org_id)
+    second_acct = await get_account_for_update(db, second_id, org_id)
+    dst_locked = first_acct if destination_account_id == first_id else second_acct
+
+    # Lock the source row with FOR UPDATE; refresh with eager-loaded relationships.
+    locked = await db.execute(
+        select(Transaction)
+        .options(*_load_opts())
+        .where(Transaction.id == source.id, Transaction.org_id == org_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    source = locked.scalar_one()
+
+    # Determine partner type by mirroring source.
+    partner_type = (
+        TransactionType.INCOME if source.type == TransactionType.EXPENSE
+        else TransactionType.EXPENSE
+    )
+
+    async with db.begin_nested():
+        partner = Transaction(
+            org_id=org_id,
+            account_id=destination_account_id,
+            category_id=source.category_id,
+            description=source.description,
+            amount=source.amount,
+            type=partner_type,
+            status=source.status,
+            date=source.date,
+            settled_date=source.settled_date,
+            is_imported=False,
+        )
+        db.add(partner)
+        await db.flush()
+
+        # Apply balance to destination only when SETTLED.
+        if partner.status == TransactionStatus.SETTLED:
+            apply_balance(dst_locked, partner.amount, partner_type)
+
+        # Determine which leg is expense vs income for _link_pair.
+        if source.type == TransactionType.EXPENSE:
+            expense_tx, income_tx = source, partner
+        else:
+            expense_tx, income_tx = partner, source
+
+        # Re-fetch partner with .account loaded so _link_pair's currency check
+        # uses the eager path. Source already has it from _load_opts above.
+        await db.refresh(partner, attribute_names=["account"])
+
+        await _link_pair(
+            db,
+            expense_tx=expense_tx,
+            income_tx=income_tx,
+            recategorize=recategorize,
+            transfer_category_id=transfer_category_id,
+        )
+    await db.commit()
+
+    await logger.ainfo(
+        "transfers.linked",
+        org_id=org_id,
+        expense_id=expense_tx.id,
+        income_id=income_tx.id,
+        source="convert_create",
+        recategorized=recategorize,
+    )
+    return expense_tx, income_tx
+
+
 async def create_transfer(
     db: AsyncSession, org_id: int, body: TransferCreate, *, is_imported: bool = False
 ) -> tuple[Transaction, Transaction]:

--- a/backend/tests/routers/test_transactions_pair_routes.py
+++ b/backend/tests/routers/test_transactions_pair_routes.py
@@ -1,0 +1,516 @@
+"""Router-level tests for the pair / convert / unpair / transfer-candidates
+endpoints (Op-1/2/3/4 from the transfers-between-accounts plan).
+
+Service-level invariants are covered in tests/services/test_transaction_service_pair.py.
+These tests focus on:
+  - schema-level body validation (extra=forbid, required fields),
+  - HTTP status mapping for service-domain exceptions,
+  - happy-path response shape (sorted-by-id pair, confidence labels).
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.models.user import Role, User
+from app.routers.transactions import router as transactions_router
+from app.security import hash_password
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    """Build a minimal FastAPI app wired to an isolated SQLite session and a
+    static superadmin user. Registers the same domain-exception handlers the
+    real app does so 400/404/409 mappings are observable in tests.
+    """
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    @app.exception_handler(NotFoundError)
+    async def _nf(_req, exc: NotFoundError):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ValidationError)
+    async def _ve(_req, exc: ValidationError):
+        return JSONResponse(status_code=400, content={"detail": exc.detail})
+
+    @app.exception_handler(ConflictError)
+    async def _ce(_req, exc: ConflictError):
+        return JSONResponse(status_code=409, content={"detail": exc.detail})
+
+    app.include_router(transactions_router)
+    return app
+
+
+async def _seed_base(factory) -> dict:
+    """Seed an org, user, two same-currency accounts, and a couple of
+    fallback categories. Returns a dict of ids the per-test helpers extend.
+    """
+    async with factory() as db:
+        org = Organization(name="Test Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="root",
+            email="root@example.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        at = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True
+        )
+        db.add_all([user, at])
+        await db.flush()
+        a1 = Account(
+            org_id=org.id, name="Acct A", account_type_id=at.id,
+            balance=Decimal("1000"), currency="EUR",
+        )
+        a2 = Account(
+            org_id=org.id, name="Acct B", account_type_id=at.id,
+            balance=Decimal("0"), currency="EUR",
+        )
+        a3 = Account(
+            org_id=org.id, name="Acct C USD", account_type_id=at.id,
+            balance=Decimal("0"), currency="USD",
+        )
+        db.add_all([a1, a2, a3])
+        await db.flush()
+        cat_groceries = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE, is_system=False,
+        )
+        cat_salary = Category(
+            org_id=org.id, name="Salary", slug="salary",
+            type=CategoryType.INCOME, is_system=False,
+        )
+        # Pre-seed the system Transfer category so recategorize doesn't
+        # need to create one mid-test (deterministic ID for assertions).
+        cat_transfer = Category(
+            org_id=org.id, name="Transfer", slug="transfer",
+            type=CategoryType.BOTH, is_system=True,
+        )
+        db.add_all([cat_groceries, cat_salary, cat_transfer])
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "user_id": user.id,
+            "a1_id": a1.id,
+            "a2_id": a2.id,
+            "a3_id": a3.id,
+            "cat_groceries_id": cat_groceries.id,
+            "cat_salary_id": cat_salary.id,
+            "cat_transfer_id": cat_transfer.id,
+        }
+
+
+async def _add_tx(
+    factory,
+    *,
+    org_id: int,
+    account_id: int,
+    category_id: int,
+    type: TransactionType,
+    amount: Decimal,
+    description: str = "row",
+    on_date: date | None = None,
+    status: TransactionStatus = TransactionStatus.SETTLED,
+    linked_transaction_id: int | None = None,
+) -> int:
+    async with factory() as db:
+        tx = Transaction(
+            org_id=org_id,
+            account_id=account_id,
+            category_id=category_id,
+            description=description,
+            amount=amount,
+            type=type,
+            status=status,
+            date=on_date or date(2026, 5, 1),
+            linked_transaction_id=linked_transaction_id,
+            is_imported=False,
+        )
+        db.add(tx)
+        await db.commit()
+        return tx.id
+
+
+# ── 1. POST /pair happy path ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_pair_happy_path(session_factory):
+    """Two un-linked rows, opposite types, equal amounts → 201 + both linked rows."""
+    seed = await _seed_base(session_factory)
+    expense_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("25.00"),
+    )
+    income_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("25.00"),
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/transactions/pair",
+            json={"expense_id": expense_id, "income_id": income_id},
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert isinstance(body, list) and len(body) == 2
+    # Sorted by id
+    assert body[0]["id"] < body[1]["id"]
+    ids = {row["id"] for row in body}
+    assert ids == {expense_id, income_id}
+    # Both legs link to each other
+    by_id = {row["id"]: row for row in body}
+    assert by_id[expense_id]["linked_transaction_id"] == income_id
+    assert by_id[income_id]["linked_transaction_id"] == expense_id
+    # Recategorized to system Transfer (default recategorize=True)
+    assert by_id[expense_id]["category_id"] == seed["cat_transfer_id"]
+    assert by_id[income_id]["category_id"] == seed["cat_transfer_id"]
+
+
+# ── 2. POST /pair extra=forbid ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_pair_rejects_extra_fields(session_factory):
+    """Body with unknown field → 422 (Pydantic extra=forbid)."""
+    seed = await _seed_base(session_factory)
+    expense_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("10.00"),
+    )
+    income_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("10.00"),
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/transactions/pair",
+            json={
+                "expense_id": expense_id, "income_id": income_id,
+                "extra": "nope",
+            },
+        )
+    assert res.status_code == 422
+
+
+# ── 3. POST /pair amount mismatch → 400 ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_pair_validation_error_to_400(session_factory):
+    """ValidationError from _link_pair invariant (unequal amounts) → HTTP 400."""
+    seed = await _seed_base(session_factory)
+    expense_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("25.00"),
+    )
+    income_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("99.99"),
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/transactions/pair",
+            json={"expense_id": expense_id, "income_id": income_id},
+        )
+    assert res.status_code == 400
+    assert "equal absolute amounts" in res.json()["detail"].lower()
+
+
+# ── 4. POST /{id}/convert-to-transfer pair-with path ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_convert_pair_with_existing(session_factory):
+    """pair_with_transaction_id set → calls pair primitive, returns linked pair."""
+    seed = await _seed_base(session_factory)
+    expense_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("40.00"),
+    )
+    partner_income_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("40.00"),
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/transactions/{expense_id}/convert-to-transfer",
+            json={
+                "destination_account_id": seed["a2_id"],
+                "pair_with_transaction_id": partner_income_id,
+            },
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert {row["id"] for row in body} == {expense_id, partner_income_id}
+    by_id = {row["id"]: row for row in body}
+    assert by_id[expense_id]["linked_transaction_id"] == partner_income_id
+    assert by_id[partner_income_id]["linked_transaction_id"] == expense_id
+
+
+# ── 5. POST /{id}/convert-to-transfer mismatched destination ───────────────
+
+
+@pytest.mark.asyncio
+async def test_post_convert_pair_with_mismatched_account(session_factory):
+    """pair_with_transaction_id account != destination_account_id → 400."""
+    seed = await _seed_base(session_factory)
+    expense_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("40.00"),
+    )
+    # Partner is on a2, but request claims destination = a3.
+    partner_income_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("40.00"),
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/transactions/{expense_id}/convert-to-transfer",
+            json={
+                "destination_account_id": seed["a3_id"],
+                "pair_with_transaction_id": partner_income_id,
+            },
+        )
+    assert res.status_code == 400
+    assert "destination_account_id" in res.json()["detail"]
+
+
+# ── 6. POST /{id}/convert-to-transfer create-missing-leg path ──────────────
+
+
+@pytest.mark.asyncio
+async def test_post_convert_create_missing_leg(session_factory):
+    """No pair_with → calls convert_and_create_leg → 201 with both rows."""
+    seed = await _seed_base(session_factory)
+    source_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("60.00"), description="moved",
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/transactions/{source_id}/convert-to-transfer",
+            json={"destination_account_id": seed["a2_id"]},
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert len(body) == 2
+    by_id = {row["id"]: row for row in body}
+    # Original source still in response, with link populated.
+    assert source_id in by_id
+    src = by_id[source_id]
+    assert src["linked_transaction_id"] is not None
+    partner_id = src["linked_transaction_id"]
+    assert partner_id in by_id
+    partner = by_id[partner_id]
+    assert partner["account_id"] == seed["a2_id"]
+    assert partner["type"] == "income"  # mirror of EXPENSE source
+    assert Decimal(partner["amount"]) == Decimal("60.00")
+
+
+# ── 7. POST /{id}/unpair returns both legs with new categories ─────────────
+
+
+@pytest.mark.asyncio
+async def test_post_unpair(session_factory):
+    """Returns both legs with linked_transaction_id=None and fallback categories."""
+    seed = await _seed_base(session_factory)
+    # Seed an already-linked pair manually.
+    expense_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_transfer_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("15.00"),
+    )
+    income_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_transfer_id"], type=TransactionType.INCOME,
+        amount=Decimal("15.00"),
+    )
+    async with session_factory() as db:
+        from sqlalchemy import select as _select
+        e = (await db.execute(_select(Transaction).where(Transaction.id == expense_id))).scalar_one()
+        i = (await db.execute(_select(Transaction).where(Transaction.id == income_id))).scalar_one()
+        e.linked_transaction_id = i.id
+        i.linked_transaction_id = e.id
+        await db.commit()
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/transactions/{expense_id}/unpair",
+            json={
+                "expense_fallback_category_id": seed["cat_groceries_id"],
+                "income_fallback_category_id": seed["cat_salary_id"],
+            },
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert len(body) == 2
+    by_id = {row["id"]: row for row in body}
+    assert by_id[expense_id]["linked_transaction_id"] is None
+    assert by_id[income_id]["linked_transaction_id"] is None
+    assert by_id[expense_id]["category_id"] == seed["cat_groceries_id"]
+    assert by_id[income_id]["category_id"] == seed["cat_salary_id"]
+
+
+# ── 8. GET /{id}/transfer-candidates ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_transfer_candidates(session_factory):
+    """Returns candidates filtered by destination_account_id with confidence labels."""
+    seed = await _seed_base(session_factory)
+    base_date = date(2026, 5, 1)
+    # The source row: an expense on a1.
+    source_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"], type=TransactionType.EXPENSE,
+        amount=Decimal("50.00"), description="paid", on_date=base_date,
+    )
+    # Same-day income on a2 → candidate, confidence=same_day.
+    same_day_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("50.00"), description="received same day",
+        on_date=base_date,
+    )
+    # +2 day income on a2 → candidate, confidence=near_date.
+    near_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a2_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("50.00"), description="received 2 days later",
+        on_date=base_date + timedelta(days=2),
+    )
+    # Income on a3 (USD) → filtered out by destination_account_id.
+    await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a3_id"],
+        category_id=seed["cat_salary_id"], type=TransactionType.INCOME,
+        amount=Decimal("50.00"), description="usd account",
+        on_date=base_date,
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.get(
+            f"/api/v1/transactions/{source_id}/transfer-candidates",
+            params={"destination_account_id": seed["a2_id"]},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert "candidates" in body
+    cands = body["candidates"]
+    cand_ids = [c["id"] for c in cands]
+    assert same_day_id in cand_ids
+    assert near_id in cand_ids
+    # Sorted by date proximity (same_day first).
+    assert cand_ids[0] == same_day_id
+    by_id = {c["id"]: c for c in cands}
+    assert by_id[same_day_id]["confidence"] == "same_day"
+    assert by_id[same_day_id]["date_diff_days"] == 0
+    assert by_id[near_id]["confidence"] == "near_date"
+    assert by_id[near_id]["date_diff_days"] == 2
+    # All candidates are on the requested destination account.
+    assert all(c["account_id"] == seed["a2_id"] for c in cands)

--- a/backend/tests/schemas/test_transfer_schemas.py
+++ b/backend/tests/schemas/test_transfer_schemas.py
@@ -1,0 +1,44 @@
+"""Pydantic schema contract tests for the transfer-related write schemas."""
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.transaction import (
+    ConvertToTransferRequest,
+    TransactionPairRequest,
+    UnpairTransactionRequest,
+)
+
+
+def test_pair_request_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        TransactionPairRequest(expense_id=1, income_id=2, surprise="x")
+
+
+def test_pair_request_defaults():
+    body = TransactionPairRequest(expense_id=1, income_id=2)
+    assert body.transfer_category_id is None
+    assert body.recategorize is True
+
+
+def test_convert_request_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        ConvertToTransferRequest(destination_account_id=10, surprise="x")
+
+
+def test_convert_request_pair_with_optional():
+    body = ConvertToTransferRequest(destination_account_id=10)
+    assert body.pair_with_transaction_id is None
+
+
+def test_unpair_request_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        UnpairTransactionRequest(
+            expense_fallback_category_id=1,
+            income_fallback_category_id=2,
+            surprise="x",
+        )
+
+
+def test_unpair_request_requires_both_fallbacks():
+    with pytest.raises(ValidationError):
+        UnpairTransactionRequest(expense_fallback_category_id=1)

--- a/backend/tests/services/test_transaction_service_pair.py
+++ b/backend/tests/services/test_transaction_service_pair.py
@@ -312,3 +312,62 @@ async def test_find_match_candidates_orders_by_date_proximity_then_id(db_session
     assert candidates[1].date == date(2026, 5, 2)
     assert candidates[2].date == date(2026, 4, 29)
     assert candidates[0].id < candidates[1].id
+
+
+async def test_find_duplicate_of_linked_leg_matches_same_account_within_window(db_session):
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+    candidates = await transaction_service.find_duplicate_of_linked_leg(
+        db_session, expense.org_id,
+        account_id=expense.account_id,
+        amount=expense.amount,
+        type=expense.type,
+        date=expense.date,
+        currency="EUR",
+    )
+    assert len(candidates) == 1
+    assert candidates[0].id == expense.id
+
+
+async def test_find_duplicate_of_linked_leg_excludes_other_accounts(db_session):
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+    # Look on the income leg's account but search for an expense type — won't match
+    candidates = await transaction_service.find_duplicate_of_linked_leg(
+        db_session, expense.org_id,
+        account_id=income.account_id,
+        amount=expense.amount,
+        type=TransactionType.EXPENSE,  # type filter excludes income leg
+        date=expense.date,
+        currency="EUR",
+    )
+    assert candidates == []
+
+
+async def test_find_duplicate_of_linked_leg_excludes_un_linked_rows(db_session):
+    """Un-linked rows must not match (those are detector-2 territory)."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add(acct)
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+    plain = Transaction(
+        org_id=org.id, account_id=acct.id, category_id=cat.id,
+        description="x", amount=Decimal("50"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(plain)
+    await db_session.commit()
+    candidates = await transaction_service.find_duplicate_of_linked_leg(
+        db_session, org.id,
+        account_id=acct.id, amount=Decimal("50"),
+        type=TransactionType.EXPENSE, date=date(2026, 5, 1), currency="EUR",
+    )
+    assert candidates == []

--- a/backend/tests/services/test_transaction_service_pair.py
+++ b/backend/tests/services/test_transaction_service_pair.py
@@ -371,3 +371,186 @@ async def test_find_duplicate_of_linked_leg_excludes_un_linked_rows(db_session):
         type=TransactionType.EXPENSE, date=date(2026, 5, 1), currency="EUR",
     )
     assert candidates == []
+
+
+async def test_pair_existing_transactions_links_bidirectionally(db_session):
+    """Two un-linked rows on different accounts get linked atomically."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="Other", slug="other", type=CategoryType.BOTH, is_system=True)
+    transfer_cat = Category(org_id=org.id, name="Transfer", slug="transfer", type=CategoryType.BOTH, is_system=True)
+    db_session.add_all([cat, transfer_cat])
+    await db_session.flush()
+
+    exp = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    inc = Transaction(
+        org_id=org.id, account_id=dst.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add_all([exp, inc])
+    await db_session.commit()
+
+    result_exp, result_inc = await transaction_service.pair_existing_transactions(
+        db_session, org.id, exp.id, inc.id,
+    )
+    assert result_exp.linked_transaction_id == inc.id
+    assert result_inc.linked_transaction_id == exp.id
+    assert result_exp.category_id == transfer_cat.id  # recategorized by default
+    assert result_inc.category_id == transfer_cat.id
+
+
+async def test_pair_existing_transactions_rejects_identical_ids(db_session):
+    """Same id for both legs → ValidationError."""
+    from app.services.exceptions import ValidationError
+    with pytest.raises(ValidationError):
+        await transaction_service.pair_existing_transactions(db_session, 1, 42, 42)
+
+
+async def test_pair_existing_transactions_rejects_amount_mismatch(db_session):
+    """Different absolute amounts → ValidationError via _link_pair."""
+    from app.services.exceptions import ValidationError
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="Other", slug="other", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+
+    exp = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    inc = Transaction(
+        org_id=org.id, account_id=dst.id, category_id=cat.id,
+        description="x", amount=Decimal("99"),  # different amount
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add_all([exp, inc])
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await transaction_service.pair_existing_transactions(
+            db_session, org.id, exp.id, inc.id,
+        )
+
+
+async def test_pair_existing_transactions_rejects_currency_mismatch(db_session):
+    """Different account currencies → ValidationError via _link_pair."""
+    from app.services.exceptions import ValidationError
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="EUR", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    dst = Account(org_id=org.id, name="USD", account_type_id=at.id, balance=Decimal("0"), currency="USD")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="Other", slug="other", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+
+    exp = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    inc = Transaction(
+        org_id=org.id, account_id=dst.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add_all([exp, inc])
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await transaction_service.pair_existing_transactions(
+            db_session, org.id, exp.id, inc.id,
+        )
+
+
+async def test_pair_existing_transactions_rejects_already_linked(db_session):
+    """Either row already linked → ValidationError via _link_pair."""
+    from app.services.exceptions import ValidationError
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+    # Create a third un-linked row to attempt to pair with the already-linked expense
+    third = Transaction(
+        org_id=expense.org_id, account_id=income.account_id, category_id=expense.category_id,
+        description="x", amount=expense.amount,
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=expense.date, settled_date=expense.date,
+    )
+    db_session.add(third)
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await transaction_service.pair_existing_transactions(
+            db_session, expense.org_id, expense.id, third.id,
+        )
+
+
+async def test_pair_existing_transactions_does_not_change_balances(db_session):
+    """Linking does not modify account balances (both rows already exist)."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=Decimal("500"), currency="EUR")
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=Decimal("700"), currency="EUR")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="Other", slug="other", type=CategoryType.BOTH, is_system=True)
+    transfer_cat = Category(org_id=org.id, name="Transfer", slug="transfer", type=CategoryType.BOTH, is_system=True)
+    db_session.add_all([cat, transfer_cat])
+    await db_session.flush()
+
+    exp = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    inc = Transaction(
+        org_id=org.id, account_id=dst.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add_all([exp, inc])
+    await db_session.commit()
+
+    src_balance_before = src.balance
+    dst_balance_before = dst.balance
+
+    await transaction_service.pair_existing_transactions(
+        db_session, org.id, exp.id, inc.id,
+    )
+
+    await db_session.refresh(src)
+    await db_session.refresh(dst)
+    assert src.balance == src_balance_before
+    assert dst.balance == dst_balance_before

--- a/backend/tests/services/test_transaction_service_pair.py
+++ b/backend/tests/services/test_transaction_service_pair.py
@@ -677,3 +677,100 @@ async def test_convert_and_create_leg_rejects_already_linked_source(db_session):
         await transaction_service.convert_and_create_leg(
             db_session, expense.org_id, expense.id, destination_account_id=third.id,
         )
+
+
+async def test_unpair_transactions_clears_links_and_sets_fallback_categories(db_session):
+    """Both legs lose linked_transaction_id; category_id reset to type-matched fallback."""
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+
+    # Create distinct fallback categories
+    new_exp_cat = Category(org_id=expense.org_id, name="Groceries", slug="groceries", type=CategoryType.EXPENSE, is_system=False)
+    new_inc_cat = Category(org_id=expense.org_id, name="Salary", slug="salary", type=CategoryType.INCOME, is_system=False)
+    db_session.add_all([new_exp_cat, new_inc_cat])
+    await db_session.commit()
+
+    result_exp, result_inc = await transaction_service.unpair_transactions(
+        db_session, expense.org_id, expense.id,
+        expense_fallback_category_id=new_exp_cat.id,
+        income_fallback_category_id=new_inc_cat.id,
+    )
+    assert result_exp.linked_transaction_id is None
+    assert result_inc.linked_transaction_id is None
+    assert result_exp.category_id == new_exp_cat.id
+    assert result_inc.category_id == new_inc_cat.id
+
+
+async def test_unpair_transactions_balances_unchanged(db_session):
+    """No balance mutation."""
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+
+    # Get balances before
+    src = await db_session.scalar(select(Account).where(Account.id == expense.account_id))
+    dst = await db_session.scalar(select(Account).where(Account.id == income.account_id))
+    src_balance_before = src.balance
+    dst_balance_before = dst.balance
+
+    # Reuse the existing Transfer cat as fallback (a hack, but valid CategoryType=BOTH works for both legs)
+    transfer_cat = await db_session.scalar(select(Category).where(Category.slug == "transfer", Category.org_id == expense.org_id))
+
+    await transaction_service.unpair_transactions(
+        db_session, expense.org_id, expense.id,
+        expense_fallback_category_id=transfer_cat.id,
+        income_fallback_category_id=transfer_cat.id,
+    )
+    await db_session.refresh(src)
+    await db_session.refresh(dst)
+    assert src.balance == src_balance_before
+    assert dst.balance == dst_balance_before
+
+
+async def test_unpair_transactions_rejects_unlinked_row(db_session):
+    """Calling unpair on a non-transfer row raises ValidationError."""
+    from app.services.exceptions import ValidationError
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add(acct)
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+
+    plain = Transaction(
+        org_id=org.id, account_id=acct.id, category_id=cat.id,
+        description="x", amount=Decimal("5"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(plain)
+    await db_session.commit()
+
+    with pytest.raises(ValidationError):
+        await transaction_service.unpair_transactions(
+            db_session, org.id, plain.id,
+            expense_fallback_category_id=cat.id,
+            income_fallback_category_id=cat.id,
+        )
+
+
+async def test_unpair_transactions_works_when_called_with_either_leg_id(db_session):
+    """Passing the income leg's id should still resolve to the same pair."""
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+    cat_id = expense.category_id
+
+    result_exp, result_inc = await transaction_service.unpair_transactions(
+        db_session, expense.org_id, income.id,
+        expense_fallback_category_id=cat_id,
+        income_fallback_category_id=cat_id,
+    )
+    # Returns expense first regardless of which id was passed
+    assert result_exp.type == TransactionType.EXPENSE
+    assert result_inc.type == TransactionType.INCOME
+    assert result_exp.linked_transaction_id is None
+    assert result_inc.linked_transaction_id is None

--- a/backend/tests/services/test_transaction_service_pair.py
+++ b/backend/tests/services/test_transaction_service_pair.py
@@ -554,3 +554,126 @@ async def test_pair_existing_transactions_does_not_change_balances(db_session):
     await db_session.refresh(dst)
     assert src.balance == src_balance_before
     assert dst.balance == dst_balance_before
+
+
+async def test_convert_and_create_leg_creates_partner_with_mirrored_status(db_session):
+    """Source SETTLED → partner SETTLED."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=Decimal("500"), currency="EUR")
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="Other", slug="other", type=CategoryType.BOTH, is_system=True)
+    transfer_cat = Category(org_id=org.id, name="Transfer", slug="transfer", type=CategoryType.BOTH, is_system=True)
+    db_session.add_all([cat, transfer_cat])
+    await db_session.flush()
+
+    source_row = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="orig", amount=Decimal("75"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(source_row)
+    await db_session.commit()
+
+    expense_tx, income_tx = await transaction_service.convert_and_create_leg(
+        db_session, org.id, source_row.id, destination_account_id=dst.id,
+    )
+    assert expense_tx.id == source_row.id
+    assert income_tx.account_id == dst.id
+    assert income_tx.type == TransactionType.INCOME
+    assert income_tx.amount == Decimal("75")
+    assert income_tx.status == TransactionStatus.SETTLED
+    assert expense_tx.linked_transaction_id == income_tx.id
+    assert income_tx.linked_transaction_id == expense_tx.id
+    # Balance applied to dst only (src already had its balance from the source row).
+    await db_session.refresh(dst)
+    assert dst.balance == Decimal("75")
+
+
+async def test_convert_and_create_leg_pending_source_creates_pending_partner(db_session):
+    """Source PENDING → partner PENDING; no balance change on dst."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="Other", slug="other", type=CategoryType.BOTH, is_system=True)
+    transfer_cat = Category(org_id=org.id, name="Transfer", slug="transfer", type=CategoryType.BOTH, is_system=True)
+    db_session.add_all([cat, transfer_cat])
+    await db_session.flush()
+
+    source_row = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="orig", amount=Decimal("50"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.PENDING,
+        date=date(2026, 5, 1),
+    )
+    db_session.add(source_row)
+    await db_session.commit()
+
+    expense_tx, income_tx = await transaction_service.convert_and_create_leg(
+        db_session, org.id, source_row.id, destination_account_id=dst.id,
+    )
+    assert income_tx.status == TransactionStatus.PENDING
+    assert income_tx.settled_date is None
+    await db_session.refresh(dst)
+    assert dst.balance == Decimal("0")  # no balance application on PENDING
+
+
+async def test_convert_and_create_leg_rejects_currency_mismatch(db_session):
+    from app.services.exceptions import ValidationError
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="EUR", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    dst = Account(org_id=org.id, name="USD", account_type_id=at.id, balance=Decimal("0"), currency="USD")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+
+    source_row = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(source_row)
+    await db_session.commit()
+
+    with pytest.raises(ValidationError):
+        await transaction_service.convert_and_create_leg(
+            db_session, org.id, source_row.id, destination_account_id=dst.id,
+        )
+
+
+async def test_convert_and_create_leg_rejects_already_linked_source(db_session):
+    from app.services.exceptions import ValidationError
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+
+    # Create a third account in the same org as a candidate destination
+    at = AccountType(org_id=expense.org_id, name="Other", slug="other", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    third = Account(org_id=expense.org_id, name="Third", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add(third)
+    await db_session.commit()
+
+    with pytest.raises(ValidationError):
+        await transaction_service.convert_and_create_leg(
+            db_session, expense.org_id, expense.id, destination_account_id=third.id,
+        )

--- a/backend/tests/services/test_transaction_service_pair.py
+++ b/backend/tests/services/test_transaction_service_pair.py
@@ -774,3 +774,153 @@ async def test_unpair_transactions_works_when_called_with_either_leg_id(db_sessi
     assert result_inc.type == TransactionType.INCOME
     assert result_exp.linked_transaction_id is None
     assert result_inc.linked_transaction_id is None
+
+
+# ── PR-B review: lock ordering, type compat, sort-then-cap ──────────────────
+
+
+async def test_convert_and_create_leg_locks_source_before_accounts(db_session, monkeypatch):
+    """Sanity check that the source row is locked before the accounts. Without
+    a real concurrent-process test, we verify the *order of operations* by
+    spying on get_account_for_update vs. the FOR UPDATE source select.
+
+    The implementation should issue the source FOR UPDATE select before
+    calling get_account_for_update.
+    """
+    # Setup a valid source + dst pair
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    transfer_cat = Category(org_id=org.id, name="Transfer", slug="transfer", type=CategoryType.BOTH, is_system=True)
+    db_session.add_all([cat, transfer_cat])
+    await db_session.flush()
+    source_row = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(source_row)
+    await db_session.commit()
+
+    # Patch get_account_for_update to record when it's called relative to
+    # the FOR UPDATE select on the transaction
+    call_log: list[str] = []
+    real_get_account = transaction_service.get_account_for_update
+    real_execute = db_session.execute
+
+    async def spy_get_account(*args, **kwargs):
+        call_log.append("get_account_for_update")
+        return await real_get_account(*args, **kwargs)
+
+    async def spy_execute(stmt, *args, **kwargs):
+        # crude check: any select on Transaction with FOR UPDATE
+        try:
+            sql = str(stmt.compile(compile_kwargs={"literal_binds": False})) if hasattr(stmt, "compile") else str(stmt)
+        except Exception:
+            sql = str(stmt)
+        if "transactions" in sql.lower() and "for update" in sql.lower():
+            call_log.append("source_for_update_select")
+        return await real_execute(stmt, *args, **kwargs)
+
+    monkeypatch.setattr(transaction_service, "get_account_for_update", spy_get_account)
+    monkeypatch.setattr(db_session, "execute", spy_execute)
+
+    await transaction_service.convert_and_create_leg(
+        db_session, org.id, source_row.id, destination_account_id=dst.id,
+    )
+
+    # The source FOR UPDATE select must come before any get_account_for_update call
+    first_lock_idx = next((i for i, e in enumerate(call_log) if e == "source_for_update_select"), -1)
+    first_account_idx = next((i for i, e in enumerate(call_log) if e == "get_account_for_update"), -1)
+    assert first_lock_idx >= 0, f"No FOR UPDATE on transactions found in: {call_log}"
+    assert first_account_idx >= 0, f"No get_account_for_update call: {call_log}"
+    assert first_lock_idx < first_account_idx, (
+        f"Source FOR UPDATE must be acquired BEFORE accounts; got order {call_log}"
+    )
+
+
+async def test_unpair_transactions_rejects_wrong_type_for_expense_leg(db_session):
+    """Income-only category as expense fallback → ValidationError."""
+    from app.services.exceptions import ValidationError
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+
+    salary = Category(org_id=expense.org_id, name="Salary", slug="salary", type=CategoryType.INCOME, is_system=False)
+    db_session.add(salary)
+    await db_session.commit()
+
+    with pytest.raises(ValidationError):
+        await transaction_service.unpair_transactions(
+            db_session, expense.org_id, expense.id,
+            expense_fallback_category_id=salary.id,  # INCOME-only as expense fallback → reject
+            income_fallback_category_id=salary.id,
+        )
+
+
+async def test_unpair_transactions_rejects_wrong_type_for_income_leg(db_session):
+    """Expense-only category as income fallback → ValidationError."""
+    from app.services.exceptions import ValidationError
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+
+    groceries = Category(org_id=expense.org_id, name="Groceries", slug="groceries", type=CategoryType.EXPENSE, is_system=False)
+    db_session.add(groceries)
+    await db_session.commit()
+
+    with pytest.raises(ValidationError):
+        await transaction_service.unpair_transactions(
+            db_session, expense.org_id, expense.id,
+            expense_fallback_category_id=groceries.id,
+            income_fallback_category_id=groceries.id,  # EXPENSE-only as income fallback → reject
+        )
+
+
+async def test_find_match_candidates_sorts_then_caps(db_session):
+    """If more rows match than the cap, the CLOSEST should win, not arbitrary 25."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct_a = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    acct_b = Account(org_id=org.id, name="B", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([acct_a, acct_b])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+
+    # Seed 7 rows: dates -3, -2, -1, 0, +1, +2, +3 from query date
+    target = date(2026, 5, 4)
+    from datetime import timedelta
+    for delta in [-3, -2, -1, 0, 1, 2, 3]:
+        tx = Transaction(
+            org_id=org.id, account_id=acct_a.id, category_id=cat.id,
+            description=f"day{delta}", amount=Decimal("100"),
+            type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+            date=target + timedelta(days=delta),
+            settled_date=target + timedelta(days=delta),
+        )
+        db_session.add(tx)
+    await db_session.commit()
+
+    candidates = await transaction_service.find_match_candidates(
+        db_session, org.id,
+        source_type=TransactionType.INCOME,
+        amount=Decimal("100"),
+        account_id_excluded=acct_b.id,
+        date=target,
+        currency="EUR",
+    )
+    # Closest first: 0d, then ±1d (sorted by id ASC), then ±2d, then ±3d
+    assert len(candidates) == 7
+    distances = [abs((c.date - target).days) for c in candidates]
+    assert distances == [0, 1, 1, 2, 2, 3, 3]

--- a/backend/tests/services/test_transaction_service_pair.py
+++ b/backend/tests/services/test_transaction_service_pair.py
@@ -111,3 +111,204 @@ async def test_create_transaction_no_commit_does_not_commit(db_session):
         select(Transaction).where(Transaction.id == tx_id)
     )
     assert result.scalar_one_or_none() is None
+
+
+async def test_find_match_candidates_returns_un_linked_opposite_type_within_window(db_session):
+    """Same currency, opposite type, equal amount, ±3 days, settled, non-recurring."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct_a = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    acct_b = Account(org_id=org.id, name="B", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([acct_a, acct_b])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+    tx_b = Transaction(
+        org_id=org.id, account_id=acct_a.id, category_id=cat.id,
+        description="src", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(tx_b)
+    await db_session.commit()
+
+    candidates = await transaction_service.find_match_candidates(
+        db_session, org.id,
+        source_type=TransactionType.INCOME,
+        amount=Decimal("100"),
+        account_id_excluded=acct_b.id,
+        date=date(2026, 5, 2),
+        currency="EUR",
+    )
+    assert len(candidates) == 1
+    assert candidates[0].id == tx_b.id
+
+
+async def test_find_match_candidates_excludes_already_linked_rows(db_session):
+    """Linked rows must not appear as candidates."""
+    from tests.services.test_transaction_filters import _seed_pair
+    expense, income = await _seed_pair(db_session)
+    candidates = await transaction_service.find_match_candidates(
+        db_session, expense.org_id,
+        source_type=TransactionType.INCOME,
+        amount=expense.amount,
+        account_id_excluded=income.account_id,
+        date=expense.date,
+        currency="EUR",
+    )
+    assert candidates == []
+
+
+async def test_find_match_candidates_excludes_pending_rows(db_session):
+    """Pending rows are not eligible matches."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct_a = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    acct_b = Account(org_id=org.id, name="B", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([acct_a, acct_b])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+    pending = Transaction(
+        org_id=org.id, account_id=acct_a.id, category_id=cat.id,
+        description="x", amount=Decimal("50"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.PENDING,
+        date=date(2026, 5, 1),
+    )
+    db_session.add(pending)
+    await db_session.commit()
+    candidates = await transaction_service.find_match_candidates(
+        db_session, org.id,
+        source_type=TransactionType.INCOME,
+        amount=Decimal("50"),
+        account_id_excluded=acct_b.id,
+        date=date(2026, 5, 1),
+        currency="EUR",
+    )
+    assert candidates == []
+
+
+async def test_find_match_candidates_filters_by_currency(db_session):
+    """Different-currency accounts must not produce matches."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct_eur = Account(org_id=org.id, name="EUR", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    acct_usd = Account(org_id=org.id, name="USD", account_type_id=at.id, balance=Decimal("0"), currency="USD")
+    db_session.add_all([acct_eur, acct_usd])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+    usd_expense = Transaction(
+        org_id=org.id, account_id=acct_usd.id, category_id=cat.id,
+        description="x", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(usd_expense)
+    await db_session.commit()
+    candidates = await transaction_service.find_match_candidates(
+        db_session, org.id,
+        source_type=TransactionType.INCOME,
+        amount=Decimal("100"),
+        account_id_excluded=acct_eur.id,
+        date=date(2026, 5, 1),
+        currency="EUR",
+    )
+    assert candidates == []
+
+
+async def test_find_match_candidates_skips_recurring(db_session):
+    """Rows with recurring_id IS NOT NULL are skipped."""
+    from app.models.recurring import RecurringTransaction, Frequency
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct_a = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    acct_b = Account(org_id=org.id, name="B", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([acct_a, acct_b])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+    rec = RecurringTransaction(
+        org_id=org.id, account_id=acct_a.id, category_id=cat.id,
+        description="rent", amount=Decimal("100"), type="expense",
+        frequency=Frequency.MONTHLY, next_due_date=date(2026, 1, 1),
+    )
+    db_session.add(rec)
+    await db_session.flush()
+    tx = Transaction(
+        org_id=org.id, account_id=acct_a.id, category_id=cat.id,
+        description="rent", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+        recurring_id=rec.id,
+    )
+    db_session.add(tx)
+    await db_session.commit()
+    candidates = await transaction_service.find_match_candidates(
+        db_session, org.id,
+        source_type=TransactionType.INCOME,
+        amount=Decimal("100"),
+        account_id_excluded=acct_b.id,
+        date=date(2026, 5, 1),
+        currency="EUR",
+    )
+    assert candidates == []
+
+
+async def test_find_match_candidates_orders_by_date_proximity_then_id(db_session):
+    """Closest by date diff first, then by id."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct_a = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    acct_b = Account(org_id=org.id, name="B", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([acct_a, acct_b])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+    # Three eligible rows: -2d, +1d, +1d (same date, different ids)
+    rows = [
+        Transaction(
+            org_id=org.id, account_id=acct_a.id, category_id=cat.id,
+            description=f"row{i}", amount=Decimal("100"),
+            type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+            date=d, settled_date=d,
+        )
+        for i, d in enumerate([date(2026, 4, 29), date(2026, 5, 2), date(2026, 5, 2)])
+    ]
+    db_session.add_all(rows)
+    await db_session.commit()
+    # Query date 2026-05-01: distances are 2, 1, 1
+    candidates = await transaction_service.find_match_candidates(
+        db_session, org.id,
+        source_type=TransactionType.INCOME,
+        amount=Decimal("100"),
+        account_id_excluded=acct_b.id,
+        date=date(2026, 5, 1),
+        currency="EUR",
+    )
+    assert len(candidates) == 3
+    # Closest first: the two +1d rows (sorted by id ASC), then -2d
+    assert candidates[0].date == date(2026, 5, 2)
+    assert candidates[1].date == date(2026, 5, 2)
+    assert candidates[2].date == date(2026, 4, 29)
+    assert candidates[0].id < candidates[1].id


### PR DESCRIPTION
## Summary

PR-B lands the **pairing primitives + HTTP endpoints** for the transfers-between-accounts repair toolkit. Edit relaxation lives in a separate PR-B.5 to keep this surface focused.

### New schemas (`app/schemas/transaction.py`)

`extra="forbid"` explicit on every write schema (audit hardening on the existing four; explicit on the six new):
- `TransactionPairRequest`, `ConvertToTransferRequest`, `UnpairTransactionRequest` — write payloads.
- `TransferCandidate`, `TransferCandidatesResponse`, `DuplicateCandidate` — response shapes.

### New services (`app/services/transaction_service.py`)

All five funnel through the existing private `_link_pair` (PR-A) for invariant enforcement. None of them mutate balances except `convert_and_create_leg` (which creates a partner leg and applies its balance only when SETTLED).

| Function | Caller surface | Behavior |
|---|---|---|
| `find_match_candidates` | import preview, Op-2 modal | Cross-account un-linked SELECT, ±3 days, opposite type, equal amount, settled, non-recurring, same currency. LIMIT 25, sorted by `(abs(date_diff), id)`. |
| `find_duplicate_of_linked_leg` | import preview only | Same-account already-linked SELECT, same params. LIMIT 10. |
| `pair_existing_transactions` | Op-1 / Op-2 (HTTP) | Locks both rows in sorted-ID order; calls `_link_pair`. No balance change. Emits `transfers.linked` (`source="bulk_link"`). |
| `convert_and_create_leg` | Op-3 | Locks source + both accounts; creates partner leg mirroring source status. Applies balance only when SETTLED. Calls `_link_pair`. Emits `transfers.linked` (`source="convert_create"`). |
| `unpair_transactions` | Op-4 | Sole code path that clears `linked_transaction_id`. NULLs both legs; sets per-leg fallback categories. No balance change. Emits `transfers.unpaired`. |

### New endpoints (`/api/v1/transactions`)

| Method + path | Body | Returns | Service call |
|---|---|---|---|
| `POST /pair` | `TransactionPairRequest` | `[TransactionResponse, TransactionResponse]` | `pair_existing_transactions` |
| `POST /{id}/convert-to-transfer` | `ConvertToTransferRequest` | `[TransactionResponse, TransactionResponse]` | pair-with → `pair_existing_transactions`; else → `convert_and_create_leg` |
| `POST /{id}/unpair` | `UnpairTransactionRequest` | `[TransactionResponse, TransactionResponse]` | `unpair_transactions` |
| `GET /{id}/transfer-candidates?destination_account_id=N` | (query) | `TransferCandidatesResponse` | `find_match_candidates`, scoped to destination account |

### Tests

- 31 new tests across `test_transfer_schemas.py` (6), `test_transaction_service_pair.py` (17 new this PR + 8 from PR-A), `test_transactions_pair_routes.py` (8).
- Backend baseline rose from 255 → 292.
- No regressions.

### Sizing

572 source LoC + 1223 test LoC. Edit relaxation (PR-B.5) is split off so reviewers focus on the primitives + endpoints surface here.

### Non-goals (this PR)

- Edit relaxation on linked rows (B-track) — separate PR-B.5.
- Import-side wiring (Detector 1 + Detector 2) — PR-C.
- Frontend work — PR-D and PR-E.

Spec: `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-03-transfers-between-accounts-design.md` §2, §3.