### PR TITLE
feat(transfers): PR-B.5 edit relaxation on linked rows

### DIFF
--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -45,6 +45,7 @@ class TransactionUpdate(BaseModel):
     amount: Optional[Decimal] = Field(default=None, gt=0, max_digits=12, decimal_places=2)
     type: Optional[Literal["income", "expense"]] = None
     status: Optional[Literal["settled", "pending"]] = None
+    settled_date: Optional[datetime.date] = None
     date: Optional[datetime.date] = None
 
     @field_validator("description")

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -249,7 +249,19 @@ async def update_transaction(
     tx = rows.get(transaction_id)
     if tx is None:
         raise NotFoundError("Transaction")
+
+    # Race detection: the unlocked preview saw an unlinked row, but a concurrent
+    # pair_existing_transactions may have linked it. If the locked tx now has a
+    # linked_transaction_id that wasn't in our lock set, our partner-aware guards
+    # would silently skip — corrupting the pair.
+    if tx.linked_transaction_id is not None and tx.linked_transaction_id not in rows:
+        raise ConflictError("Transaction state changed; refresh and retry")
+
     partner = rows.get(tx.linked_transaction_id) if tx.linked_transaction_id is not None else None
+
+    # Bidirectional integrity: the link must be symmetric.
+    if partner is not None and partner.linked_transaction_id != tx.id:
+        raise ConflictError("Transfer pair link integrity violated; refresh and retry")
 
     # 2. Linked-row schema-level guards
     if partner is not None:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -24,6 +24,7 @@ from app.models.transaction import Transaction, TransactionStatus, TransactionTy
 from app.schemas.transaction import TransactionCreate, TransactionResponse, TransactionUpdate, TransferCreate
 from app.services.category_rules_service import learn_from_choice
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.transaction_filters import is_reportable_transaction
 
 logger = structlog.get_logger()
 
@@ -218,22 +219,57 @@ async def create_transaction(
 async def update_transaction(
     db: AsyncSession, org_id: int, transaction_id: int, body: TransactionUpdate
 ) -> Transaction:
-    result = await db.execute(
+    """F2 policy: per-leg edits on linked rows under invariant guards. Amount
+    mirrors atomically. Type and linked_transaction_id immutable on linked rows.
+    See spec §5.3 (`~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-03-transfers-between-accounts-design.md`).
+    """
+    # 1. Pre-read to discover partner (unlocked) and lock both in sorted ID order
+    preview = await db.scalar(
+        select(Transaction).where(
+            Transaction.id == transaction_id, Transaction.org_id == org_id
+        )
+    )
+    if preview is None:
+        raise NotFoundError("Transaction")
+
+    ids_to_lock = [transaction_id]
+    if preview.linked_transaction_id is not None:
+        ids_to_lock.append(preview.linked_transaction_id)
+    ids_to_lock.sort()
+
+    locked = await db.execute(
         select(Transaction)
         .options(*_load_opts())
-        .where(Transaction.id == transaction_id, Transaction.org_id == org_id)
+        .where(Transaction.id.in_(ids_to_lock), Transaction.org_id == org_id)
+        .order_by(Transaction.id)
         .with_for_update()
         .execution_options(populate_existing=True)
     )
-    tx = result.scalar_one_or_none()
+    rows = {r.id: r for r in locked.scalars().all()}
+    tx = rows.get(transaction_id)
     if tx is None:
         raise NotFoundError("Transaction")
+    partner = rows.get(tx.linked_transaction_id) if tx.linked_transaction_id is not None else None
 
-    if tx.linked_transaction_id is not None:
-        raise ConflictError("Cannot edit a transfer transaction. Delete and recreate it instead.")
+    # 2. Linked-row schema-level guards
+    if partner is not None:
+        if body.type is not None:
+            raise ValidationError("Type is immutable on transfer legs")
+        if body.account_id is not None:
+            new_acct = await db.scalar(
+                select(Account).where(
+                    Account.id == body.account_id, Account.org_id == org_id
+                )
+            )
+            if new_acct is None:
+                raise ValidationError("Account not found")
+            if new_acct.id == partner.account_id:
+                raise ValidationError("Account must differ from partner's account")
+            if new_acct.currency != partner.account.currency:
+                raise ValidationError("New account currency must match partner's currency")
 
-    # Validate references regardless of status
-    if body.account_id is not None and body.account_id != tx.account_id:
+    # Validate references regardless of linked status
+    if body.account_id is not None and body.account_id != tx.account_id and partner is None:
         await validate_account(db, body.account_id, org_id)
     if body.category_id is not None:
         await validate_category(db, body.category_id, org_id)
@@ -247,20 +283,30 @@ async def update_transaction(
     new_account_id = body.account_id if body.account_id is not None else old_account_id
     new_status = TransactionStatus(body.status) if body.status is not None else old_status
 
-    async with db.begin_nested():
-        # Revert old balance if it was settled
-        if old_status == TransactionStatus.SETTLED:
-            if new_account_id == old_account_id:
-                account = await get_account_for_update(db, old_account_id, org_id)
-                revert_balance(account, old_amount, old_type)
-            else:
-                first_id, second_id = sorted([old_account_id, new_account_id])
-                first = await get_account_for_update(db, first_id, org_id)
-                second = await get_account_for_update(db, second_id, org_id)
-                old_account = first if old_account_id == first_id else second
-                revert_balance(old_account, old_amount, old_type)
+    # 3. Lock affected accounts in sorted ID order
+    account_ids_to_lock: set[int] = set()
+    if old_status == TransactionStatus.SETTLED or new_status == TransactionStatus.SETTLED:
+        account_ids_to_lock.add(old_account_id)
+        account_ids_to_lock.add(new_account_id)
+    if partner is not None and body.amount is not None:
+        if partner.status == TransactionStatus.SETTLED:
+            account_ids_to_lock.add(partner.account_id)
+    accounts: dict[int, Account] = {}
+    for aid in sorted(account_ids_to_lock):
+        accounts[aid] = await get_account_for_update(db, aid, org_id)
 
-        # Apply field updates
+    amount_was_changed = body.amount is not None
+    pre_edit_amount = old_amount  # for telemetry
+
+    async with db.begin_nested():
+        # 4a: revert this leg if currently SETTLED
+        if old_status == TransactionStatus.SETTLED:
+            revert_balance(accounts[old_account_id], old_amount, old_type)
+        # 4b: revert partner if linked + amount-change + partner currently SETTLED
+        if partner is not None and amount_was_changed and partner.status == TransactionStatus.SETTLED:
+            revert_balance(accounts[partner.account_id], partner.amount, partner.type)
+
+        # 4c: apply per-leg field updates
         _apply_field_updates(tx, body)
         if body.category_id is not None:
             tx.category_id = body.category_id
@@ -268,24 +314,68 @@ async def update_transaction(
             tx.account_id = body.account_id
         if body.status is not None:
             tx.status = new_status
-            if new_status == TransactionStatus.SETTLED and old_status != TransactionStatus.SETTLED:
+        # settled_date semantics (§5.2):
+        # - status pending → settled_date = None
+        # - status settled with body.settled_date → use it
+        # - transition to settled with no settled_date → today
+        if body.status is not None and new_status == TransactionStatus.PENDING:
+            tx.settled_date = None
+        elif new_status == TransactionStatus.SETTLED:
+            if body.settled_date is not None:
+                tx.settled_date = body.settled_date
+            elif old_status != TransactionStatus.SETTLED:
                 tx.settled_date = datetime.date.today()
-            elif new_status == TransactionStatus.PENDING and old_status == TransactionStatus.SETTLED:
-                tx.settled_date = None
+        elif body.settled_date is not None:
+            # Status unchanged but settled_date provided
+            if tx.status == TransactionStatus.SETTLED:
+                tx.settled_date = body.settled_date
 
-        # Apply new balance if now settled
-        if new_status == TransactionStatus.SETTLED:
-            new_account = await get_account_for_update(db, tx.account_id, org_id)
-            apply_balance(new_account, tx.amount, tx.type)
+        # 4d: amount mirror to partner
+        if partner is not None and amount_was_changed:
+            partner.amount = body.amount
+
+        # 4e: apply this leg with new state if SETTLED
+        if tx.status == TransactionStatus.SETTLED:
+            apply_balance(accounts[tx.account_id], tx.amount, tx.type)
+        # 4f: apply partner with new state if linked + amount change + partner SETTLED
+        if partner is not None and amount_was_changed and partner.status == TransactionStatus.SETTLED:
+            apply_balance(accounts[partner.account_id], partner.amount, partner.type)
+
+        await db.flush()
+
+        # 5. Post-update invariant re-check (only when linked)
+        if partner is not None:
+            if tx.org_id != partner.org_id:
+                raise ValidationError("Pair org mismatch after edit")
+            if tx.account_id == partner.account_id:
+                raise ValidationError("Pair on same account after edit")
+            if abs(tx.amount) != abs(partner.amount):
+                raise ValidationError("Pair amount mismatch after edit")
+            if {tx.type, partner.type} != {TransactionType.EXPENSE, TransactionType.INCOME}:
+                raise ValidationError("Pair must have opposite types after edit")
+            if tx.account.currency != partner.account.currency:
+                raise ValidationError("Pair currencies differ after edit")
+
+        if amount_was_changed and partner is not None:
+            await logger.ainfo(
+                "transfers.edit_mirrored",
+                org_id=org_id,
+                edited_id=tx.id,
+                partner_id=partner.id,
+                old_amount=str(pre_edit_amount),
+                new_amount=str(tx.amount),
+            )
 
     await db.commit()
 
-    # Learn only when the category actually changed and the row is not a transfer.
-    # Transfers raise ConflictError above, so by here tx.linked_transaction_id is None.
-    #
-    # Learning is best-effort: a failure here must NOT surface as a 500
-    # to the caller — the user's edit is already committed above.
-    if body.category_id is not None and body.category_id != old_category_id:
+    # Category-learning gate: only learn from reportable rows (not transfer legs).
+    # Wrapped in is_reportable_transaction(tx) — flips from previous "transfers
+    # raise ConflictError above" assumption now that linked rows are editable.
+    if (
+        is_reportable_transaction(tx)
+        and body.category_id is not None
+        and body.category_id != old_category_id
+    ):
         try:
             await learn_from_choice(
                 db,

--- a/backend/tests/schemas/test_transfer_schemas.py
+++ b/backend/tests/schemas/test_transfer_schemas.py
@@ -42,3 +42,18 @@ def test_unpair_request_rejects_extra_fields():
 def test_unpair_request_requires_both_fallbacks():
     with pytest.raises(ValidationError):
         UnpairTransactionRequest(expense_fallback_category_id=1)
+
+
+def test_transaction_update_accepts_settled_date():
+    """settled_date is now a settable field on TransactionUpdate."""
+    from app.schemas.transaction import TransactionUpdate
+    import datetime
+    body = TransactionUpdate(settled_date=datetime.date(2026, 5, 4))
+    assert body.settled_date == datetime.date(2026, 5, 4)
+
+
+def test_transaction_update_settled_date_optional():
+    """settled_date defaults to None."""
+    from app.schemas.transaction import TransactionUpdate
+    body = TransactionUpdate(description="x")
+    assert body.settled_date is None

--- a/backend/tests/services/test_transaction_service_edit_linked.py
+++ b/backend/tests/services/test_transaction_service_edit_linked.py
@@ -199,3 +199,96 @@ async def test_edit_unlinked_row_still_works(db_session):
     result = await transaction_service.update_transaction(db_session, org.id, plain.id, body)
     assert result.description == "updated"
     assert result.amount == Decimal("75")
+
+
+async def test_edit_raises_conflict_when_link_appears_after_preview(db_session):
+    """Synthetic race: row's linked_transaction_id points at a partner not in the
+    locked set. Simulates a concurrent pair landing between unlocked preview
+    and locked SELECT. Must raise ConflictError, not silently bypass guards.
+    """
+    from app.services.exceptions import ConflictError
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add(acct)
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+
+    tx = Transaction(
+        org_id=org.id, account_id=acct.id, category_id=cat.id,
+        description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(tx)
+    await db_session.commit()
+
+    # Patch the unlocked preview path so it returns an unlinked snapshot,
+    # while the actual DB row gets a stale linked_transaction_id pointing at
+    # a non-existent partner. The locked SELECT then returns a tx with a
+    # linked_transaction_id that isn't in the lock set.
+    from sqlalchemy import text as _sql_text, update as _sql_update
+    # Set a stale link to a non-existent partner id. Disable FK enforcement
+    # for the synthetic write since prod rows would never satisfy FK either
+    # in this race window — the partner row exists but isn't in our lock set.
+    fake_partner_id = tx.id + 9999
+    await db_session.execute(_sql_text("PRAGMA foreign_keys=OFF"))
+    await db_session.execute(
+        _sql_update(Transaction).where(Transaction.id == tx.id).values(linked_transaction_id=fake_partner_id)
+    )
+    await db_session.commit()
+    await db_session.execute(_sql_text("PRAGMA foreign_keys=ON"))
+
+    with pytest.raises(ConflictError):
+        await transaction_service.update_transaction(
+            db_session, org.id, tx.id, TransactionUpdate(amount=Decimal("20"))
+        )
+
+
+async def test_edit_raises_conflict_on_bidirectional_link_violation(db_session):
+    """If the partner's linked_transaction_id doesn't point back to tx, the
+    pair is corrupted. Edits must raise ConflictError, not proceed.
+    """
+    from app.services.exceptions import ConflictError
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=Decimal("0"), currency="EUR")
+    db_session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+
+    expense = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    income = Transaction(
+        org_id=org.id, account_id=dst.id, category_id=cat.id,
+        description="x", amount=Decimal("10"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add_all([expense, income])
+    await db_session.flush()
+    # Asymmetric link: expense thinks income is its partner, but income's link
+    # points elsewhere (None to simulate a corrupted half-pair).
+    expense.linked_transaction_id = income.id
+    income.linked_transaction_id = None
+    await db_session.commit()
+
+    with pytest.raises(ConflictError):
+        await transaction_service.update_transaction(
+            db_session, org.id, expense.id, TransactionUpdate(amount=Decimal("20"))
+        )

--- a/backend/tests/services/test_transaction_service_edit_linked.py
+++ b/backend/tests/services/test_transaction_service_edit_linked.py
@@ -1,0 +1,201 @@
+"""F2 edit policy on linked transfer pairs (PR-B.5)."""
+import pytest
+import pytest_asyncio
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import Base
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.schemas.transaction import TransactionUpdate
+from app.services import transaction_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_pair_with_balances(session: AsyncSession, src_balance, dst_balance, amount, currency="EUR"):
+    """Seed a linked transfer pair with the given account balances reflecting the transfer."""
+    org = Organization(name="T", billing_cycle_day=1)
+    session.add(org)
+    await session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    session.add(at)
+    await session.flush()
+    src = Account(org_id=org.id, name="Src", account_type_id=at.id, balance=src_balance, currency=currency)
+    dst = Account(org_id=org.id, name="Dst", account_type_id=at.id, balance=dst_balance, currency=currency)
+    session.add_all([src, dst])
+    cat = Category(org_id=org.id, name="Transfer", slug="transfer", type=CategoryType.BOTH, is_system=True)
+    session.add(cat)
+    await session.flush()
+    expense = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="t", amount=amount, type=TransactionType.EXPENSE,
+        status=TransactionStatus.SETTLED, date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    income = Transaction(
+        org_id=org.id, account_id=dst.id, category_id=cat.id,
+        description="t", amount=amount, type=TransactionType.INCOME,
+        status=TransactionStatus.SETTLED, date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    session.add_all([expense, income])
+    await session.flush()
+    expense.linked_transaction_id = income.id
+    income.linked_transaction_id = expense.id
+    await session.commit()
+    return org, src, dst, expense, income
+
+
+async def test_edit_linked_row_amount_mirrors_to_partner(db_session):
+    """PATCH amount on EXPENSE leg → partner's amount mirrors atomically; both balances re-applied."""
+    org, src, dst, exp, inc = await _seed_pair_with_balances(
+        db_session, src_balance=Decimal("400"), dst_balance=Decimal("100"), amount=Decimal("100"),
+    )
+    # Increase amount from 100 to 150
+    body = TransactionUpdate(amount=Decimal("150"))
+    result = await transaction_service.update_transaction(db_session, org.id, exp.id, body)
+
+    # Partner amount mirrored
+    partner = await db_session.scalar(select(Transaction).where(Transaction.id == inc.id))
+    assert partner.amount == Decimal("150")
+    assert result.amount == Decimal("150")
+
+    # Balances re-applied: src goes from 400 (post-100-expense) to 350 (post-150-expense),
+    # dst goes from 100 (post-100-income) to 150 (post-150-income).
+    await db_session.refresh(src)
+    await db_session.refresh(dst)
+    assert src.balance == Decimal("350")
+    assert dst.balance == Decimal("150")
+
+
+async def test_edit_linked_row_type_rejected(db_session):
+    """PATCH type on linked row → ValidationError."""
+    from app.services.exceptions import ValidationError
+    org, src, dst, exp, inc = await _seed_pair_with_balances(
+        db_session, src_balance=Decimal("400"), dst_balance=Decimal("100"), amount=Decimal("100"),
+    )
+    body = TransactionUpdate(type="income")  # try to flip the expense leg to income
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(db_session, org.id, exp.id, body)
+
+
+async def test_edit_linked_row_account_id_validates_currency(db_session):
+    """PATCH account_id on linked row to a different-currency account → ValidationError."""
+    from app.services.exceptions import ValidationError
+    org, src, dst, exp, inc = await _seed_pair_with_balances(
+        db_session, src_balance=Decimal("400"), dst_balance=Decimal("100"), amount=Decimal("100"),
+    )
+    # Add a USD account
+    at = await db_session.scalar(select(AccountType).where(AccountType.org_id == org.id))
+    usd_acct = Account(org_id=org.id, name="USD", account_type_id=at.id, balance=Decimal("0"), currency="USD")
+    db_session.add(usd_acct)
+    await db_session.commit()
+
+    body = TransactionUpdate(account_id=usd_acct.id)
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(db_session, org.id, exp.id, body)
+
+
+async def test_edit_linked_row_account_id_rejects_partner_account(db_session):
+    """PATCH expense leg's account_id to the partner's (income leg's) account → ValidationError."""
+    from app.services.exceptions import ValidationError
+    org, src, dst, exp, inc = await _seed_pair_with_balances(
+        db_session, src_balance=Decimal("400"), dst_balance=Decimal("100"), amount=Decimal("100"),
+    )
+    body = TransactionUpdate(account_id=inc.account_id)
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(db_session, org.id, exp.id, body)
+
+
+async def test_edit_linked_row_per_leg_status_independent(db_session):
+    """PATCH status on one leg leaves partner status untouched."""
+    org, src, dst, exp, inc = await _seed_pair_with_balances(
+        db_session, src_balance=Decimal("400"), dst_balance=Decimal("100"), amount=Decimal("100"),
+    )
+    body = TransactionUpdate(status="pending")
+    result = await transaction_service.update_transaction(db_session, org.id, exp.id, body)
+    assert result.status == TransactionStatus.PENDING
+    assert result.settled_date is None  # cleared on pending
+
+    # Partner unchanged
+    partner = await db_session.scalar(select(Transaction).where(Transaction.id == inc.id))
+    assert partner.status == TransactionStatus.SETTLED
+
+
+async def test_edit_linked_row_settled_date_with_provided_value(db_session):
+    """status=settled with provided settled_date uses provided date."""
+    org, src, dst, exp, inc = await _seed_pair_with_balances(
+        db_session, src_balance=Decimal("400"), dst_balance=Decimal("100"), amount=Decimal("100"),
+    )
+    # Move expense leg to pending first
+    await transaction_service.update_transaction(db_session, org.id, exp.id, TransactionUpdate(status="pending"))
+    # Now back to settled with a specific settled_date
+    body = TransactionUpdate(status="settled", settled_date=date(2026, 5, 5))
+    result = await transaction_service.update_transaction(db_session, org.id, exp.id, body)
+    assert result.status == TransactionStatus.SETTLED
+    assert result.settled_date == date(2026, 5, 5)
+
+
+async def test_edit_linked_row_settled_date_defaults_to_today_on_transition(db_session):
+    """Transition to settled with NO settled_date provided sets today."""
+    import datetime as dt
+    org, src, dst, exp, inc = await _seed_pair_with_balances(
+        db_session, src_balance=Decimal("400"), dst_balance=Decimal("100"), amount=Decimal("100"),
+    )
+    await transaction_service.update_transaction(db_session, org.id, exp.id, TransactionUpdate(status="pending"))
+    body = TransactionUpdate(status="settled")
+    result = await transaction_service.update_transaction(db_session, org.id, exp.id, body)
+    assert result.status == TransactionStatus.SETTLED
+    assert result.settled_date == dt.date.today()
+
+
+async def test_edit_unlinked_row_still_works(db_session):
+    """Plain (non-transfer) row edits still work as before — no regression."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct = Account(org_id=org.id, name="A", account_type_id=at.id, balance=Decimal("500"), currency="EUR")
+    db_session.add(acct)
+    cat = Category(org_id=org.id, name="C", slug="c", type=CategoryType.BOTH, is_system=True)
+    db_session.add(cat)
+    await db_session.flush()
+    plain = Transaction(
+        org_id=org.id, account_id=acct.id, category_id=cat.id,
+        description="orig", amount=Decimal("50"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db_session.add(plain)
+    await db_session.commit()
+    body = TransactionUpdate(description="updated", amount=Decimal("75"))
+    result = await transaction_service.update_transaction(db_session, org.id, plain.id, body)
+    assert result.description == "updated"
+    assert result.amount == Decimal("75")


### PR DESCRIPTION
## Summary

PR-B.5 lands the **F2 edit-relaxation policy** on linked transfer rows. Per-leg edits are now allowed under invariant guards. Amount mirrors atomically. `type` and `linked_transaction_id` remain immutable on linked rows. The previous blanket `ConflictError("Cannot edit a transfer transaction…")` reject is gone.

### Changes

- **Schema** (`app/schemas/transaction.py`): `TransactionUpdate` gains an optional `settled_date: date | None = None` field. Per-leg settled date control during update.
- **Service** (`app/services/transaction_service.py`): `update_transaction` rewritten per spec §5.3:
  - Pre-read partner via `linked_transaction_id`. Lock both rows in sorted-ID order with `FOR UPDATE` + `populate_existing=True`.
  - On linked rows: reject `body.type`. Validate `body.account_id` exists, differs from partner's account, and matches partner currency.
  - Lock affected accounts (own old + new + partner's when amount mirrors) in sorted-ID order.
  - Inside `db.begin_nested()`: revert balances → apply field updates → mirror `partner.amount` (single-currency invariant) → apply new balances.
  - Post-mutation invariant re-check (org, account-distinct, abs-amount equality, opposite types, currency); rollback savepoint on violation.
  - `transfers.edit_mirrored` event emitted with `old_amount` / `new_amount` as **strings** per spec §6.1.
  - Category-learning gate now wrapped in `is_reportable_transaction(tx)` — only learns from non-transfer rows.
- **`settled_date` semantics**:
  - `status=pending` → `settled_date = None`.
  - `status=settled` with provided `settled_date` → use it.
  - Transition `pending → settled` with no `settled_date` → today.
  - `status` unchanged + `settled_date` on settled row → use it; on pending row → silently no-op.

### Tests

- 2 new schema tests (settled_date field).
- 8 new service tests (`test_transaction_service_edit_linked.py`): amount mirror, type rejection, currency-mismatch rejection, partner-account rejection, per-leg status independence, settled_date variants, unlinked-row no-regression.
- Backend baseline: 296 → **306 passed, 2 skipped** (+10 tests; no regressions).

### Lock-ordering

Matches `convert_and_create_leg` (post-review-fix in PR-B): tx FIRST (sorted-ID for pairs), accounts SECOND (sorted-ID). Deadlock-free against concurrent updates and convert calls.

### Sizing

341 insertions / 34 deletions across 4 files. Well within review budget — deliberately split off PR-B for this reason.

### Non-goals (this PR)

- Import-side wiring — PR-C.
- Frontend re-enable of the Edit button on linked rows — PR-D (will pair with this backend change).
- Cross-currency edit support — D-track, deferred indefinitely.

Spec: `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-03-transfers-between-accounts-design.md` §5.