### PR TITLE
feat(transfers): PR-C import integration

### DIFF
--- a/backend/app/schemas/import_schemas.py
+++ b/backend/app/schemas/import_schemas.py
@@ -4,7 +4,9 @@ import datetime
 from decimal import Decimal
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.transaction import DuplicateCandidate, TransferCandidate
 
 
 # ── Preview Response ─────────────────────────────────────────────────────────
@@ -20,11 +22,27 @@ class ImportPreviewRow(BaseModel):
     type: Literal["income", "expense"]
     counterparty: str | None = None
     transaction_type: str | None = None
+
+    # Existing duplicate-detection (different from transfer-leg duplicate)
     is_duplicate: bool = False
     duplicate_transaction_id: int | None = None
-    is_potential_transfer: bool = False
+
+    # Smart-rules suggestion
     suggested_category_id: int | None = None
     suggestion_source: Literal["org_rule", "shared_dictionary", "default"] | None = None
+
+    # Detector 1: matches an already-linked leg on the same account → drop default
+    is_duplicate_of_linked_leg: bool = False
+    duplicate_candidate: DuplicateCandidate | None = None
+    default_action_drop: bool = False
+
+    # Detector 2: cross-account un-linked match (transfer-pair candidate)
+    transfer_match_action: Literal["none", "pair_with", "suggest_pair", "choose_candidate"] = "none"
+    transfer_match_confidence: Literal["same_day", "near_date", "multi_candidate"] | None = None
+    pair_with_transaction_id: int | None = None
+    transfer_candidates: list[TransferCandidate] = []
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class ImportPreviewResponse(BaseModel):
@@ -35,7 +53,12 @@ class ImportPreviewResponse(BaseModel):
     file_name: str
     total_rows: int
     duplicate_count: int
-    transfer_candidate_count: int
+
+    # New per-spec §3.2 summary counters
+    auto_paired_count: int = 0
+    suggested_pair_count: int = 0
+    multi_candidate_count: int = 0
+    duplicate_of_linked_count: int = 0
 
 
 # ── Confirm Request ──────────────────────────────────────────────────────────
@@ -51,10 +74,19 @@ class ImportConfirmRow(BaseModel):
     type: Literal["income", "expense"]
     category_id: int | None = None  # None → use default_category_id
     skip: bool = False
-    is_transfer: bool = False
-    transfer_account_id: int | None = None  # required when is_transfer=True
-    suggested_category_id: int | None = None  # echoed back from preview for accept-vs-override detection
+
+    # Spec §3.2 confirm-row action mapping
+    action: Literal["create", "pair_with_existing", "drop_as_duplicate"] = "create"
+    pair_with_transaction_id: int | None = None      # required iff action == "pair_with_existing"
+    duplicate_of_transaction_id: int | None = None   # required iff action == "drop_as_duplicate"
+    transfer_category_id: int | None = None
+    recategorize: bool = True
+
+    # Echoed back from preview for accept-vs-override detection
+    suggested_category_id: int | None = None
     suggestion_source: Literal["org_rule", "shared_dictionary", "default"] | None = None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class ImportConfirmRequest(BaseModel):
@@ -63,6 +95,8 @@ class ImportConfirmRequest(BaseModel):
     account_id: int
     default_category_id: int
     rows: list[ImportConfirmRow]
+
+    model_config = ConfigDict(extra="forbid")
 
 
 # ── Confirm Response ─────────────────────────────────────────────────────────
@@ -76,9 +110,16 @@ class ImportRowError(BaseModel):
 
 
 class ImportConfirmResponse(BaseModel):
-    """Result of the import execution."""
+    """Result of the import execution.
 
-    imported_count: int
-    skipped_count: int
+    Counters sum to the total submitted rows:
+      imported_count + paired_count + dropped_duplicate_count
+        + skipped_count + error_count == total_rows.
+    """
+
+    imported_count: int          # plain rows created via action == "create"
+    paired_count: int = 0        # rows confirmed action == "pair_with_existing"
+    dropped_duplicate_count: int = 0   # rows confirmed action == "drop_as_duplicate"
+    skipped_count: int           # rows with skip=True
     error_count: int
     errors: list[ImportRowError]

--- a/backend/app/services/category_rules_service.py
+++ b/backend/app/services/category_rules_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.category import Category
 from app.models.category_rule import CategoryRule, RuleSource
 from app.models.merchant_dictionary import MerchantDictionaryEntry
+from app.services.transaction_filters import is_transfer_leg
 
 # URL scheme prefix (HTTP / HTTPS) — stripped before bank-noise so `HTTPS://AMAZON…` collapses cleanly.
 _URL_SCHEME = re.compile(r"^\s*HTTPS?://", re.IGNORECASE)
@@ -159,26 +160,21 @@ def normalize_description(raw: str) -> str:
 
 
 def should_skip_learning(obj) -> bool:
-    """True for any object representing a transfer.
+    """True for any object representing a transfer leg.
 
-    Duck-typed:
-      - ORM Transaction → uses ``linked_transaction_id`` (non-None means it's
-        paired with another leg, i.e. a transfer).
-      - ImportPreviewRow / ImportConfirmRow → uses ``is_transfer``.
-
-    Either attribute being truthy short-circuits to True. Objects with neither
-    attribute return False.
+    Now that ImportConfirmRow no longer carries an is_transfer field (PR-C),
+    transfer-leg detection is single-source: the ORM Transaction's
+    ``linked_transaction_id``, accessed via ``is_transfer_leg``. The
+    ``hasattr`` guard preserves duck-typing safety: any non-Transaction object
+    passed through (e.g. a bare Pydantic row in legacy callers) returns False
+    rather than raising AttributeError.
 
     Why: transfers don't have a meaningful merchant — they're inter-account
     movement. Learning a rule from a transfer would map "TRANSFER TO SAVINGS"
     to whatever category the user picked for accounting purposes, which would
     then mis-categorize legitimate same-merchant payments later.
     """
-    if getattr(obj, "linked_transaction_id", None) is not None:
-        return True
-    if getattr(obj, "is_transfer", False):
-        return True
-    return False
+    return is_transfer_leg(obj) if hasattr(obj, "linked_transaction_id") else False
 
 
 InferSource = Literal["org_rule", "shared_dictionary", "default"]

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -19,7 +19,7 @@ from app.schemas.import_schemas import (
     ImportPreviewResponse,
     ImportRowError,
 )
-from app.schemas.transaction import TransactionCreate, TransferCreate
+from app.schemas.transaction import TransactionCreate
 from app.services import transaction_service
 from app.services.category_rules_service import (
     bump_shared_vote,
@@ -28,13 +28,9 @@ from app.services.category_rules_service import (
     normalize_description,
     should_skip_learning,
 )
-from app.services.exceptions import ValidationError
 from app.services.import_parser import ParsedRow
 
 logger = structlog.get_logger()
-
-# Transaction types that suggest an inter-account transfer
-_TRANSFER_TYPES = {"online banking"}
 
 
 async def build_preview(
@@ -70,30 +66,18 @@ async def build_preview(
 
     preview_rows: list[ImportPreviewRow] = []
     duplicate_count = 0
-    transfer_count = 0
 
     for row in parsed_rows:
         dup_id = existing_map.get((row.date, row.amount, row.description))
         is_dup = dup_id is not None
 
-        # ── Transfer detection: heuristic on transaction_type ──
-        is_transfer = bool(
-            row.transaction_type
-            and row.transaction_type.lower() in _TRANSFER_TYPES
+        # ── Smart-rules suggestion ──
+        suggested_category_id, suggestion_source = await infer_category(
+            db, org_id=org_id, description=row.description
         )
-
-        # ── Smart-rules suggestion (skipped for transfers) ──
-        suggested_category_id: int | None = None
-        suggestion_source: str | None = None
-        if not is_transfer:
-            suggested_category_id, suggestion_source = await infer_category(
-                db, org_id=org_id, description=row.description
-            )
 
         if is_dup:
             duplicate_count += 1
-        if is_transfer:
-            transfer_count += 1
 
         preview_rows.append(
             ImportPreviewRow(
@@ -106,9 +90,16 @@ async def build_preview(
                 transaction_type=row.transaction_type,
                 is_duplicate=is_dup,
                 duplicate_transaction_id=dup_id,
-                is_potential_transfer=is_transfer,
                 suggested_category_id=suggested_category_id,
                 suggestion_source=suggestion_source,
+                # Detector wiring lands in C2; defaults below stand in for now.
+                is_duplicate_of_linked_leg=False,
+                duplicate_candidate=None,
+                default_action_drop=False,
+                transfer_match_action="none",
+                transfer_match_confidence=None,
+                pair_with_transaction_id=None,
+                transfer_candidates=[],
             )
         )
 
@@ -131,7 +122,11 @@ async def build_preview(
         file_name=file_name,
         total_rows=len(preview_rows),
         duplicate_count=duplicate_count,
-        transfer_candidate_count=transfer_count,
+        # Detector wiring lands in C2; counters are zeroed defaults for now.
+        auto_paired_count=0,
+        suggested_pair_count=0,
+        multi_candidate_count=0,
+        duplicate_of_linked_count=0,
     )
 
 
@@ -171,107 +166,82 @@ async def execute_import(
 
         category_id = row.category_id or body.default_category_id
 
-        # Validate transfer rows have a target account
-        if row.is_transfer and not row.transfer_account_id:
-            errors.append(ImportRowError(row_number=row.row_number, error="Transfer requires a target account"))
-            continue
-
         try:
-            if row.is_transfer and row.transfer_account_id:
-                # Determine direction: the imported account is source for expenses,
-                # destination for income.
-                if row.type == "expense":
-                    from_id = body.account_id
-                    to_id = row.transfer_account_id
-                else:
-                    from_id = row.transfer_account_id
-                    to_id = body.account_id
+            # PR-C C1: only the create branch is wired. The pair_with_existing
+            # and drop_as_duplicate branches land in C3.
+            tx_body = TransactionCreate(
+                account_id=body.account_id,
+                category_id=category_id,
+                description=row.description,
+                amount=row.amount,
+                type=row.type,
+                date=row.date,
+            )
+            await transaction_service.create_transaction(
+                db, org_id, tx_body, is_imported=True
+            )
 
-                transfer_body = TransferCreate(
-                    from_account_id=from_id,
-                    to_account_id=to_id,
-                    description=row.description,
-                    amount=row.amount,
-                    date=row.date,
+            # ── Learn from the user's category choice ────────────────
+            # Skip transfers (linked rows) and rows with no category at
+            # all. The double commit (create_transaction commits the txn,
+            # this block commits the rule + vote separately) is
+            # intentional — keeps a learn-failure from rolling back the
+            # imported transaction.
+            if row.category_id is not None and not should_skip_learning(row):
+                accepted = (
+                    row.suggested_category_id is not None
+                    and row.suggested_category_id == row.category_id
                 )
-                await transaction_service.create_transfer(
-                    db, org_id, transfer_body, is_imported=True
-                )
-            else:
-                tx_body = TransactionCreate(
-                    account_id=body.account_id,
-                    category_id=category_id,
-                    description=row.description,
-                    amount=row.amount,
-                    type=row.type,
-                    date=row.date,
-                )
-                await transaction_service.create_transaction(
-                    db, org_id, tx_body, is_imported=True
-                )
-
-                # ── Learn from the user's category choice ────────────────
-                # Skip transfers (the transfer branch above never reaches
-                # this block) and rows with no category at all. The double
-                # commit (create_transaction commits the txn, this block
-                # commits the rule + vote separately) is intentional —
-                # keeps a learn-failure from rolling back the imported
-                # transaction.
-                if row.category_id is not None and not should_skip_learning(row):
-                    accepted = (
-                        row.suggested_category_id is not None
-                        and row.suggested_category_id == row.category_id
+                source = "user_pick" if accepted else "user_edit"
+                # Learning is best-effort: a failure here must NOT
+                # bubble out as a row error. The transaction itself
+                # has already committed (see create_transaction
+                # above) — the row is imported regardless.
+                try:
+                    await learn_from_choice(
+                        db,
+                        org_id=org_id,
+                        description=row.description,
+                        category_id=row.category_id,
+                        source=source,
                     )
-                    source = "user_pick" if accepted else "user_edit"
-                    # Learning is best-effort: a failure here must NOT
-                    # bubble out as a row error. The transaction itself
-                    # has already committed (see create_transaction
-                    # above) — the row is imported regardless.
-                    try:
-                        await learn_from_choice(
-                            db,
-                            org_id=org_id,
-                            description=row.description,
-                            category_id=row.category_id,
-                            source=source,
-                        )
-                        if (
-                            accepted and share_merchant_data
-                            and row.suggestion_source == "shared_dictionary"
-                        ):
-                            await bump_shared_vote(db, description=row.description)
-                        await db.commit()
-                    except Exception as exc:
-                        await db.rollback()
-                        await logger.awarning(
-                            "smart_rules.learn_failed",
-                            org_id=org_id,
-                            op="execute_import",
-                            row_number=row.row_number,
-                            error=str(exc),
-                            error_type=type(exc).__name__,
-                        )
+                    if (
+                        accepted and share_merchant_data
+                        and row.suggestion_source == "shared_dictionary"
+                    ):
+                        await bump_shared_vote(db, description=row.description)
+                    await db.commit()
+                except Exception as exc:
+                    await db.rollback()
+                    await logger.awarning(
+                        "smart_rules.learn_failed",
+                        org_id=org_id,
+                        op="execute_import",
+                        row_number=row.row_number,
+                        error=str(exc),
+                        error_type=type(exc).__name__,
+                    )
 
-                    # Counters always update — the user's choice was
-                    # registered against an imported row, even if the
-                    # rule write failed and got logged above.
-                    learned_count += 1
-                    if accepted:
-                        accepted_count += 1
-                    elif row.suggested_category_id is not None:
-                        overridden_count += 1
+                # Counters always update — the user's choice was
+                # registered against an imported row, even if the
+                # rule write failed and got logged above.
+                learned_count += 1
+                if accepted:
+                    accepted_count += 1
+                elif row.suggested_category_id is not None:
+                    overridden_count += 1
 
-                # Metric collection — fires for EVERY imported non-transfer
-                # row, including default-category fallthroughs (row.category_id
-                # is None and the user relied on default_category_id). This
-                # is the architect-mandated signal for "uncategorizable on
-                # import" and must NOT be gated on row.category_id.
-                if not should_skip_learning(row):
-                    source_split[row.suggestion_source or "default"] += 1
-                    if row.suggestion_source in ("default", None):
-                        token = normalize_description(row.description)
-                        if token:
-                            miss_tokens.add(token)
+            # Metric collection — fires for EVERY imported non-transfer
+            # row, including default-category fallthroughs (row.category_id
+            # is None and the user relied on default_category_id). This
+            # is the architect-mandated signal for "uncategorizable on
+            # import" and must NOT be gated on row.category_id.
+            if not should_skip_learning(row):
+                source_split[row.suggestion_source or "default"] += 1
+                if row.suggestion_source in ("default", None):
+                    token = normalize_description(row.description)
+                    if token:
+                        miss_tokens.add(token)
 
             imported_count += 1
 

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -10,8 +10,9 @@ import structlog
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.account import Account
 from app.models.settings import OrgSetting
-from app.models.transaction import Transaction
+from app.models.transaction import Transaction, TransactionType
 from app.schemas.import_schemas import (
     ImportConfirmRequest,
     ImportConfirmResponse,
@@ -19,8 +20,16 @@ from app.schemas.import_schemas import (
     ImportPreviewResponse,
     ImportRowError,
 )
-from app.schemas.transaction import TransactionCreate
+from app.schemas.transaction import (
+    DuplicateCandidate,
+    TransactionCreate,
+    TransferCandidate,
+)
 from app.services import transaction_service
+from app.services.transaction_service import (
+    find_duplicate_of_linked_leg,
+    find_match_candidates,
+)
 from app.services.category_rules_service import (
     bump_shared_vote,
     infer_category,
@@ -42,8 +51,15 @@ async def build_preview(
 ) -> ImportPreviewResponse:
     """Build a preview response: flag duplicates and potential transfers."""
 
-    # Validate account belongs to this org
-    await transaction_service.validate_account(db, account_id, org_id)
+    # Validate account belongs to this org and load it for currency.
+    # Detectors filter cross-account candidates by Account.currency; we need
+    # the destination's currency to keep the match space sensible.
+    destination_account = await db.scalar(
+        select(Account).where(Account.id == account_id, Account.org_id == org_id)
+    )
+    if destination_account is None:
+        # Match validate_account semantics: surface the same error shape.
+        await transaction_service.validate_account(db, account_id, org_id)
 
     # ── Batch duplicate check: single query for the CSV date range ──
     min_date = min(r.date for r in parsed_rows)
@@ -79,6 +95,81 @@ async def build_preview(
         if is_dup:
             duplicate_count += 1
 
+        # ── Detector 1: same-account already-linked match → flag duplicate-of-linked-leg ──
+        row_tx_type = (
+            TransactionType.EXPENSE if row.type == "expense" else TransactionType.INCOME
+        )
+        dup_linked_candidates = await find_duplicate_of_linked_leg(
+            db, org_id,
+            account_id=account_id,
+            amount=row.amount,
+            type=row_tx_type,
+            date=row.date,
+            currency=destination_account.currency,
+        )
+        is_dup_of_linked = bool(dup_linked_candidates)
+        duplicate_candidate_obj: DuplicateCandidate | None = None
+        if is_dup_of_linked:
+            c0 = dup_linked_candidates[0]
+            duplicate_candidate_obj = DuplicateCandidate(
+                id=c0.id,
+                date=c0.date,
+                description=c0.description,
+                amount=c0.amount,
+                account_id=c0.account_id,
+                account_name=c0.account.name,
+                existing_leg_is_imported=c0.is_imported,
+            )
+
+        # ── Detector 2: cross-account un-linked match → suggest transfer pair ──
+        # Skipped when Detector 1 fires — a duplicate-of-linked-leg already has
+        # an answer (default action: drop), so cross-account suggestions would
+        # only confuse the user.
+        if is_dup_of_linked:
+            action: str = "none"
+            confidence: str | None = None
+            pair_with_id: int | None = None
+            candidate_models: list[TransferCandidate] = []
+        else:
+            match_candidates = await find_match_candidates(
+                db, org_id,
+                source_type=row_tx_type,
+                amount=row.amount,
+                account_id_excluded=account_id,
+                date=row.date,
+                currency=destination_account.currency,
+            )
+            if not match_candidates:
+                action, confidence, pair_with_id, candidate_models = (
+                    "none", None, None, [],
+                )
+            elif len(match_candidates) >= 2:
+                action = "choose_candidate"
+                confidence = "multi_candidate"
+                pair_with_id = None
+                candidate_models = [
+                    TransferCandidate(
+                        id=c.id,
+                        date=c.date,
+                        description=c.description,
+                        amount=c.amount,
+                        account_id=c.account_id,
+                        account_name=c.account.name,
+                        date_diff_days=abs((c.date - row.date).days),
+                        confidence="same_day" if c.date == row.date else "near_date",
+                    )
+                    for c in match_candidates
+                ]
+            else:
+                c0 = match_candidates[0]
+                diff = abs((c0.date - row.date).days)
+                if diff == 0:
+                    action, confidence = "pair_with", "same_day"
+                else:
+                    action, confidence = "suggest_pair", "near_date"
+                pair_with_id = c0.id
+                candidate_models = []
+
         preview_rows.append(
             ImportPreviewRow(
                 row_number=row.row_number,
@@ -92,14 +183,15 @@ async def build_preview(
                 duplicate_transaction_id=dup_id,
                 suggested_category_id=suggested_category_id,
                 suggestion_source=suggestion_source,
-                # Detector wiring lands in C2; defaults below stand in for now.
-                is_duplicate_of_linked_leg=False,
-                duplicate_candidate=None,
-                default_action_drop=False,
-                transfer_match_action="none",
-                transfer_match_confidence=None,
-                pair_with_transaction_id=None,
-                transfer_candidates=[],
+                # Detector 1 outputs.
+                is_duplicate_of_linked_leg=is_dup_of_linked,
+                duplicate_candidate=duplicate_candidate_obj,
+                default_action_drop=is_dup_of_linked,
+                # Detector 2 outputs.
+                transfer_match_action=action,
+                transfer_match_confidence=confidence,
+                pair_with_transaction_id=pair_with_id,
+                transfer_candidates=candidate_models,
             )
         )
 
@@ -116,17 +208,39 @@ async def build_preview(
         source_split=dict(source_split),
     )
 
+    # ── Detector summary counters + telemetry (spec §3.2) ──
+    auto_paired_count = sum(
+        1 for r in preview_rows if r.transfer_match_action == "pair_with"
+    )
+    suggested_pair_count = sum(
+        1 for r in preview_rows if r.transfer_match_action == "suggest_pair"
+    )
+    multi_candidate_count = sum(
+        1 for r in preview_rows if r.transfer_match_action == "choose_candidate"
+    )
+    duplicate_of_linked_count = sum(
+        1 for r in preview_rows if r.is_duplicate_of_linked_leg
+    )
+    await logger.ainfo(
+        "import.preview.matched",
+        org_id=org_id,
+        file_name=file_name,
+        auto_paired=auto_paired_count,
+        suggested=suggested_pair_count,
+        multi_candidate=multi_candidate_count,
+        duplicate_of_linked=duplicate_of_linked_count,
+    )
+
     return ImportPreviewResponse(
         rows=preview_rows,
         account_id=account_id,
         file_name=file_name,
         total_rows=len(preview_rows),
         duplicate_count=duplicate_count,
-        # Detector wiring lands in C2; counters are zeroed defaults for now.
-        auto_paired_count=0,
-        suggested_pair_count=0,
-        multi_candidate_count=0,
-        duplicate_of_linked_count=0,
+        auto_paired_count=auto_paired_count,
+        suggested_pair_count=suggested_pair_count,
+        multi_candidate_count=multi_candidate_count,
+        duplicate_of_linked_count=duplicate_of_linked_count,
     )
 
 

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -26,7 +26,11 @@ from app.schemas.transaction import (
     TransferCandidate,
 )
 from app.services import transaction_service
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 from app.services.transaction_service import (
+    _create_transaction_no_commit,
+    _link_pair,
+    _load_opts,
     find_duplicate_of_linked_leg,
     find_match_candidates,
 )
@@ -249,14 +253,39 @@ async def execute_import(
     org_id: int,
     body: ImportConfirmRequest,
 ) -> ImportConfirmResponse:
-    """Create transactions for all confirmed (non-skipped) rows.
+    """Create / pair / drop transactions for all confirmed (non-skipped) rows.
 
-    Uses the existing create_transaction / create_transfer service functions
-    so all validation, balance mutations, and locking are preserved.
+    Per-row branches (spec §3.3):
+      action="create"             → plain insert via _create_transaction_no_commit.
+      action="pair_with_existing" → insert new leg + atomically link to a
+                                    locked partner via _link_pair. Single
+                                    nested savepoint per row guarantees
+                                    rollback on any failure inside the pair.
+      action="drop_as_duplicate"  → server-side revalidate the duplicate-of-
+                                    linked-leg candidate, then skip insert.
+
+    Each row runs inside its own ``db.begin_nested()`` savepoint so failures
+    in the pair branch (e.g. _link_pair raises after the new leg flushed)
+    cleanly roll back the partial work without taking the whole batch with it.
+    Smart-rules learning runs OUTSIDE the savepoint per row, best-effort:
+    a learn failure must NOT bubble out as a row error or roll back the
+    imported transaction.
     """
-    imported_count = 0
+    imported_count = 0          # plain creates only (action="create")
+    paired_count = 0
+    dropped_duplicate_count = 0
     skipped_count = 0
     errors: list[ImportRowError] = []
+
+    # Destination account for currency lookups (used by both pair partner
+    # validation and drop_as_duplicate revalidation).
+    destination_account = await db.scalar(
+        select(Account).where(
+            Account.id == body.account_id, Account.org_id == org_id
+        )
+    )
+    if destination_account is None:
+        await transaction_service.validate_account(db, body.account_id, org_id)
 
     # ── Smart-rules learning: fetch share flag once, init aggregate counters ──
     share_flag = (await db.execute(
@@ -272,6 +301,7 @@ async def execute_import(
     overridden_count = 0
     source_split: Counter[str] = Counter()
     miss_tokens: set[str] = set()
+    paired_pair_ids: list[tuple[int, int]] = []
 
     for row in body.rows:
         if row.skip:
@@ -279,101 +309,237 @@ async def execute_import(
             continue
 
         category_id = row.category_id or body.default_category_id
+        action_taken: str | None = None
+        new_tx: Transaction | None = None
 
         try:
-            # PR-C C1: only the create branch is wired. The pair_with_existing
-            # and drop_as_duplicate branches land in C3.
-            tx_body = TransactionCreate(
-                account_id=body.account_id,
-                category_id=category_id,
-                description=row.description,
-                amount=row.amount,
-                type=row.type,
-                date=row.date,
-            )
-            await transaction_service.create_transaction(
-                db, org_id, tx_body, is_imported=True
-            )
-
-            # ── Learn from the user's category choice ────────────────
-            # Skip transfers (linked rows) and rows with no category at
-            # all. The double commit (create_transaction commits the txn,
-            # this block commits the rule + vote separately) is
-            # intentional — keeps a learn-failure from rolling back the
-            # imported transaction.
-            if row.category_id is not None and not should_skip_learning(row):
-                accepted = (
-                    row.suggested_category_id is not None
-                    and row.suggested_category_id == row.category_id
-                )
-                source = "user_pick" if accepted else "user_edit"
-                # Learning is best-effort: a failure here must NOT
-                # bubble out as a row error. The transaction itself
-                # has already committed (see create_transaction
-                # above) — the row is imported regardless.
-                try:
-                    await learn_from_choice(
-                        db,
-                        org_id=org_id,
+            async with db.begin_nested():
+                if row.action == "create":
+                    tx_body = TransactionCreate(
+                        account_id=body.account_id,
+                        category_id=category_id,
                         description=row.description,
-                        category_id=row.category_id,
-                        source=source,
+                        amount=row.amount,
+                        type=row.type,
+                        date=row.date,
                     )
-                    if (
-                        accepted and share_merchant_data
-                        and row.suggestion_source == "shared_dictionary"
-                    ):
-                        await bump_shared_vote(db, description=row.description)
-                    await db.commit()
-                except Exception as exc:
-                    await db.rollback()
-                    await logger.awarning(
-                        "smart_rules.learn_failed",
-                        org_id=org_id,
-                        op="execute_import",
-                        row_number=row.row_number,
-                        error=str(exc),
-                        error_type=type(exc).__name__,
+                    new_tx = await _create_transaction_no_commit(
+                        db, org_id, tx_body, is_imported=True
+                    )
+                    action_taken = "create"
+
+                elif row.action == "pair_with_existing":
+                    if row.pair_with_transaction_id is None:
+                        raise ValidationError(
+                            "pair_with_transaction_id required when "
+                            "action='pair_with_existing'"
+                        )
+                    tx_body = TransactionCreate(
+                        account_id=body.account_id,
+                        category_id=category_id,
+                        description=row.description,
+                        amount=row.amount,
+                        type=row.type,
+                        date=row.date,
+                    )
+                    new_tx = await _create_transaction_no_commit(
+                        db, org_id, tx_body, is_imported=True
                     )
 
-                # Counters always update — the user's choice was
-                # registered against an imported row, even if the
-                # rule write failed and got logged above.
-                learned_count += 1
-                if accepted:
-                    accepted_count += 1
-                elif row.suggested_category_id is not None:
-                    overridden_count += 1
+                    # Lock partner row with FOR UPDATE + populate_existing so
+                    # the eligibility re-check reads the freshest server state
+                    # (defends against a concurrent pair landing between
+                    # preview and confirm).
+                    partner_locked = await db.execute(
+                        select(Transaction)
+                        .options(*_load_opts())
+                        .where(
+                            Transaction.id == row.pair_with_transaction_id,
+                            Transaction.org_id == org_id,
+                        )
+                        .with_for_update()
+                        .execution_options(populate_existing=True)
+                    )
+                    partner = partner_locked.scalar_one_or_none()
+                    if partner is None:
+                        raise ConflictError(
+                            "Partner row no longer exists; re-preview"
+                        )
+                    if partner.linked_transaction_id is not None:
+                        raise ConflictError(
+                            "Partner row is already linked; re-preview"
+                        )
+                    if partner.recurring_id is not None:
+                        raise ConflictError(
+                            "Partner row is recurring; re-preview"
+                        )
+                    if partner.account.currency != destination_account.currency:
+                        raise ConflictError(
+                            "Currency mismatch detected at confirm; re-preview"
+                        )
 
-            # Metric collection — fires for EVERY imported non-transfer
-            # row, including default-category fallthroughs (row.category_id
-            # is None and the user relied on default_category_id). This
-            # is the architect-mandated signal for "uncategorizable on
-            # import" and must NOT be gated on row.category_id.
-            if not should_skip_learning(row):
-                source_split[row.suggestion_source or "default"] += 1
-                if row.suggestion_source in ("default", None):
-                    token = normalize_description(row.description)
-                    if token:
-                        miss_tokens.add(token)
+                    # Determine which leg is expense / income.
+                    if new_tx.type == TransactionType.EXPENSE:
+                        expense_tx, income_tx = new_tx, partner
+                    else:
+                        expense_tx, income_tx = partner, new_tx
 
-            imported_count += 1
+                    await _link_pair(
+                        db,
+                        expense_tx=expense_tx,
+                        income_tx=income_tx,
+                        recategorize=row.recategorize,
+                        transfer_category_id=row.transfer_category_id,
+                    )
+                    paired_pair_ids.append((new_tx.id, partner.id))
+                    action_taken = "pair_with_existing"
 
-        except Exception as exc:
-            await db.rollback()
+                elif row.action == "drop_as_duplicate":
+                    if row.duplicate_of_transaction_id is None:
+                        raise ValidationError(
+                            "duplicate_of_transaction_id required when "
+                            "action='drop_as_duplicate'"
+                        )
+                    row_tx_type = (
+                        TransactionType.EXPENSE
+                        if row.type == "expense"
+                        else TransactionType.INCOME
+                    )
+                    dup_check = await find_duplicate_of_linked_leg(
+                        db, org_id,
+                        account_id=body.account_id,
+                        amount=row.amount,
+                        type=row_tx_type,
+                        date=row.date,
+                        currency=destination_account.currency,
+                    )
+                    candidate_ids = {c.id for c in dup_check}
+                    if row.duplicate_of_transaction_id not in candidate_ids:
+                        raise ConflictError(
+                            "Duplicate candidate no longer matches; re-preview"
+                        )
+                    action_taken = "drop_as_duplicate"
+
+        except (ConflictError, ValidationError, NotFoundError) as exc:
+            # Domain failures: row-level error, batch continues.
+            errors.append(
+                ImportRowError(row_number=row.row_number, error=str(exc))
+            )
             await logger.awarning(
                 "import_row_failed",
                 row_number=row.row_number,
                 error=str(exc),
+                error_type=type(exc).__name__,
             )
-            errors.append(ImportRowError(row_number=row.row_number, error=str(exc)))
+            continue
+        except Exception as exc:
+            # Unexpected failures: surface as row-level error, batch continues.
+            errors.append(
+                ImportRowError(row_number=row.row_number, error=str(exc))
+            )
+            await logger.awarning(
+                "import_row_failed",
+                row_number=row.row_number,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            continue
+
+        # Per-action counter increments + telemetry (post-savepoint commit).
+        if action_taken == "create":
+            imported_count += 1
+        elif action_taken == "pair_with_existing":
+            paired_count += 1
+            await logger.ainfo(
+                "transfers.linked",
+                org_id=org_id,
+                expense_id=expense_tx.id,
+                income_id=income_tx.id,
+                source="import_pair",
+                recategorized=row.recategorize,
+            )
+        elif action_taken == "drop_as_duplicate":
+            dropped_duplicate_count += 1
+            await logger.ainfo(
+                "import.dropped_duplicate_leg",
+                org_id=org_id,
+                csv_row_index=row.row_number,
+                duplicate_of_transaction_id=row.duplicate_of_transaction_id,
+                account_id=body.account_id,
+                amount=str(row.amount),  # spec §6.1: amount as string
+            )
+
+        # ── Best-effort learning from the user's category choice ───────────
+        # Runs OUTSIDE the per-row savepoint so a learn failure doesn't undo
+        # the transaction. Skipped for paired rows (transfer legs — the
+        # description is bank-noise, not a meaningful merchant) and dropped
+        # rows (no transaction was created).
+        if action_taken == "create" and row.category_id is not None and not should_skip_learning(new_tx):
+            accepted = (
+                row.suggested_category_id is not None
+                and row.suggested_category_id == row.category_id
+            )
+            source = "user_pick" if accepted else "user_edit"
+            try:
+                await learn_from_choice(
+                    db,
+                    org_id=org_id,
+                    description=row.description,
+                    category_id=row.category_id,
+                    source=source,
+                )
+                if (
+                    accepted and share_merchant_data
+                    and row.suggestion_source == "shared_dictionary"
+                ):
+                    await bump_shared_vote(db, description=row.description)
+                await db.commit()
+            except Exception as exc:
+                await db.rollback()
+                await logger.awarning(
+                    "smart_rules.learn_failed",
+                    org_id=org_id,
+                    op="execute_import",
+                    row_number=row.row_number,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+
+            # Counters always update — the user's choice was registered
+            # against an imported row, even if the rule write failed.
+            learned_count += 1
+            if accepted:
+                accepted_count += 1
+            elif row.suggested_category_id is not None:
+                overridden_count += 1
+
+        # Metric collection — fires for EVERY imported plain-create row,
+        # including default-category fallthroughs (row.category_id is None
+        # and the user relied on default_category_id). Architect-mandated
+        # "uncategorizable on import" signal; must NOT be gated on
+        # row.category_id. Paired/dropped rows are excluded here because
+        # paired rows aren't "missing a merchant rule" (they're transfers)
+        # and dropped rows didn't create a transaction.
+        if action_taken == "create" and not should_skip_learning(new_tx):
+            source_split[row.suggestion_source or "default"] += 1
+            if row.suggestion_source in ("default", None):
+                token = normalize_description(row.description)
+                if token:
+                    miss_tokens.add(token)
+
+    # Final commit for any savepoints whose changes haven't been flushed to
+    # the outer transaction yet (savepoint commit only releases to the outer
+    # transaction; we still owe the outer commit).
+    await db.commit()
 
     # ── Aggregate smart-rules metric (architect-mandated; one per import) ──
+    # rows_total preserves its original meaning: total submitted rows.
     await logger.ainfo(
         "smart_rules.import_executed",
         org_id=org_id,
         rows_total=len(body.rows),
         imported_count=imported_count,
+        paired_count=paired_count,
         learned_count=learned_count,
         accepted_count=accepted_count,
         overridden_count=overridden_count,
@@ -387,8 +553,19 @@ async def execute_import(
             "smart_rules.miss", org_id=org_id, normalized_token=token,
         )
 
+    # ── Per-execute confirm summary (transfer-aware) ──
+    await logger.ainfo(
+        "import.confirmed.transfers",
+        org_id=org_id,
+        paired_count=paired_count,
+        dropped_duplicate_count=dropped_duplicate_count,
+        plain_created_count=imported_count,
+    )
+
     return ImportConfirmResponse(
         imported_count=imported_count,
+        paired_count=paired_count,
+        dropped_duplicate_count=dropped_duplicate_count,
         skipped_count=skipped_count,
         error_count=len(errors),
         errors=errors,

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
 from app.models.settings import OrgSetting
-from app.models.transaction import Transaction, TransactionType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.schemas.import_schemas import (
     ImportConfirmRequest,
     ImportConfirmResponse,
@@ -373,6 +373,14 @@ async def execute_import(
                         raise ConflictError(
                             "Partner row is recurring; re-preview"
                         )
+                    if partner.status != TransactionStatus.SETTLED:
+                        # find_match_candidates only suggests SETTLED rows;
+                        # if partner flipped to PENDING after preview, the
+                        # pair invariant could break — bounce the user to
+                        # re-preview.
+                        raise ConflictError(
+                            "Partner row no longer settled; re-preview"
+                        )
                     if partner.account.currency != destination_account.currency:
                         raise ConflictError(
                             "Currency mismatch detected at confirm; re-preview"
@@ -474,6 +482,11 @@ async def execute_import(
         # the transaction. Skipped for paired rows (transfer legs — the
         # description is bank-noise, not a meaningful merchant) and dropped
         # rows (no transaction was created).
+        #
+        # Isolated in its OWN nested savepoint so a learn-side failure cannot
+        # roll back successfully imported rows that share the outer
+        # transaction. begin_nested() rolls back the savepoint automatically
+        # on exception, leaving the outer transaction untouched.
         if action_taken == "create" and row.category_id is not None and not should_skip_learning(new_tx):
             accepted = (
                 row.suggested_category_id is not None
@@ -481,21 +494,24 @@ async def execute_import(
             )
             source = "user_pick" if accepted else "user_edit"
             try:
-                await learn_from_choice(
-                    db,
-                    org_id=org_id,
-                    description=row.description,
-                    category_id=row.category_id,
-                    source=source,
-                )
-                if (
-                    accepted and share_merchant_data
-                    and row.suggestion_source == "shared_dictionary"
-                ):
-                    await bump_shared_vote(db, description=row.description)
-                await db.commit()
+                async with db.begin_nested():
+                    await learn_from_choice(
+                        db,
+                        org_id=org_id,
+                        description=row.description,
+                        category_id=row.category_id,
+                        source=source,
+                    )
+                    if (
+                        accepted and share_merchant_data
+                        and row.suggestion_source == "shared_dictionary"
+                    ):
+                        await bump_shared_vote(db, description=row.description)
+                # savepoint released on normal exit; outer transaction unchanged
             except Exception as exc:
-                await db.rollback()
+                # savepoint already rolled back by the begin_nested context
+                # manager; outer transaction (with imports + paired rows)
+                # untouched.
                 await logger.awarning(
                     "smart_rules.learn_failed",
                     org_id=org_id,

--- a/backend/tests/services/test_category_rules_service.py
+++ b/backend/tests/services/test_category_rules_service.py
@@ -97,15 +97,9 @@ def test_should_skip_learning_skips_transfer_via_linked_id() -> None:
     assert should_skip_learning(tx) is True
 
 
-def test_should_skip_learning_skips_preview_row_marked_transfer() -> None:
-    """ImportConfirmRow with is_transfer=True must skip."""
-    row = SimpleNamespace(linked_transaction_id=None, is_transfer=True)
-    assert should_skip_learning(row) is True
-
-
 def test_should_skip_learning_keeps_regular_transaction() -> None:
-    """Neither linked nor flagged → learn."""
-    tx = SimpleNamespace(linked_transaction_id=None, type="expense", is_transfer=False)
+    """No linked-leg link → learn."""
+    tx = SimpleNamespace(linked_transaction_id=None, type="expense")
     assert should_skip_learning(tx) is False
 
 

--- a/backend/tests/services/test_import_execute_with_rules.py
+++ b/backend/tests/services/test_import_execute_with_rules.py
@@ -295,7 +295,13 @@ async def test_learn_failure_does_not_fail_the_import(
     db_session: AsyncSession,
 ) -> None:
     """If learn_from_choice raises, the imported transaction is preserved
-    and the failure is logged (not propagated to the caller)."""
+    and the failure is logged (not propagated to the caller).
+
+    PR-C review high-severity regression: the learn block must NOT roll back
+    successfully imported rows that share the outer transaction. The fix
+    isolates learn in a nested savepoint so a learn-side failure rolls back
+    only the savepoint, not the outer commit.
+    """
     seed = await _seed(db_session, share=False)
     body = ImportConfirmRequest(
         account_id=seed["account_id"],
@@ -319,6 +325,19 @@ async def test_learn_failure_does_not_fail_the_import(
 
     assert result.imported_count == 1
     assert result.error_count == 0  # learn failure does NOT surface as a row error
+
+    # Imported row must still be in the DB — savepoint isolation prevents
+    # the learn rollback from taking the import with it.
+    persisted = (await db_session.execute(
+        select(Transaction).where(
+            Transaction.org_id == seed["org_id"],
+            Transaction.description == "POS LIDL *9999",
+        )
+    )).scalars().all()
+    assert len(persisted) == 1, (
+        "imported row should survive learn failure; "
+        "savepoint isolation regression"
+    )
 
 
 async def test_default_category_fallthrough_records_miss(

--- a/backend/tests/services/test_import_execute_with_rules.py
+++ b/backend/tests/services/test_import_execute_with_rules.py
@@ -14,6 +14,7 @@ import datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
+import pytest
 import pytest_asyncio
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
@@ -154,27 +155,15 @@ async def test_accept_without_opt_in_does_not_bump_shared(db_session: AsyncSessi
     assert entry.vote_count == 0
 
 
+@pytest.mark.skip(
+    reason=(
+        "Legacy is_transfer/transfer_account_id confirm path. PR-C C1 "
+        "dropped these schema fields. PR-C C3 reintroduces transfer-on-confirm "
+        "via action='pair_with_existing' and replaces this test."
+    )
+)
 async def test_transfer_row_does_not_learn(db_session: AsyncSession) -> None:
-    seed = await _seed(db_session, share=True)
-    other = Account(
-        org_id=seed["org_id"], account_type_id=seed["account_type_id"],
-        name="Savings", balance=Decimal("0"),
-    )
-    db_session.add(other)
-    await db_session.commit()
-
-    body = ImportConfirmRequest(
-        account_id=seed["account_id"],
-        default_category_id=seed["restaurants_id"],
-        rows=[ImportConfirmRow(
-            row_number=1, date=datetime.date(2026, 5, 1),
-            description="POS LIDL *9999", amount=Decimal("12.50"), type="expense",
-            is_transfer=True, transfer_account_id=other.id,
-        )],
-    )
-    await import_service.execute_import(db_session, org_id=seed["org_id"], body=body)
-    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
-    assert rules == []
+    pass
 
 
 async def test_aggregate_metric_emitted_with_correct_shape(db_session: AsyncSession) -> None:

--- a/backend/tests/services/test_import_execute_with_rules.py
+++ b/backend/tests/services/test_import_execute_with_rules.py
@@ -14,7 +14,6 @@ import datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
-import pytest
 import pytest_asyncio
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
@@ -27,6 +26,7 @@ from app.models.category import Category, CategoryType
 from app.models.category_rule import CategoryRule, RuleSource
 from app.models.merchant_dictionary import MerchantDictionaryEntry
 from app.models.settings import OrgSetting
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.models.user import Organization
 from app.schemas.import_schemas import ImportConfirmRequest, ImportConfirmRow
 from app.services import import_service
@@ -155,15 +155,71 @@ async def test_accept_without_opt_in_does_not_bump_shared(db_session: AsyncSessi
     assert entry.vote_count == 0
 
 
-@pytest.mark.skip(
-    reason=(
-        "Legacy is_transfer/transfer_account_id confirm path. PR-C C1 "
-        "dropped these schema fields. PR-C C3 reintroduces transfer-on-confirm "
-        "via action='pair_with_existing' and replaces this test."
-    )
-)
 async def test_transfer_row_does_not_learn(db_session: AsyncSession) -> None:
-    pass
+    """Paired rows (action='pair_with_existing') must NOT trigger smart-rules
+    learning. The new ORM Transaction has linked_transaction_id set after
+    _link_pair, so should_skip_learning (now via is_transfer_leg) returns
+    True and the learn-from-choice block is skipped.
+    """
+    seed = await _seed(db_session, share=False)
+    # Build a partner on a SEPARATE account (transfers require different
+    # accounts). Reuse the existing checking account as source; create a
+    # second account for the partner leg.
+    other_acct = Account(
+        org_id=seed["org_id"], account_type_id=seed["account_type_id"],
+        name="Savings", balance=Decimal("0"), currency="EUR",
+    )
+    db_session.add(other_acct)
+    await db_session.flush()
+    # Make sure the source account also has a currency for the pair partner check.
+    src_acct = (await db_session.execute(
+        select(Account).where(Account.id == seed["account_id"])
+    )).scalar_one()
+    src_acct.currency = "EUR"
+    transfer_cat = Category(
+        org_id=seed["org_id"], name="Transfer", slug="transfer",
+        is_system=True, type=CategoryType.BOTH,
+    )
+    db_session.add(transfer_cat)
+    await db_session.flush()
+    # Un-linked income leg on the partner account.
+    partner = Transaction(
+        org_id=seed["org_id"], account_id=other_acct.id,
+        category_id=transfer_cat.id, description="incoming-xfer",
+        amount=Decimal("12.50"),
+        type=TransactionType.INCOME,
+        status=TransactionStatus.SETTLED,
+        date=datetime.date(2026, 5, 1),
+        settled_date=datetime.date(2026, 5, 1),
+    )
+    db_session.add(partner)
+    await db_session.commit()
+
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=transfer_cat.id,
+        rows=[ImportConfirmRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999",  # would normally learn → "LIDL"
+            amount=Decimal("12.50"), type="expense",
+            category_id=transfer_cat.id,
+            action="pair_with_existing",
+            pair_with_transaction_id=partner.id,
+            recategorize=False,
+            # Echo a suggestion so we'd see learning if it ran.
+            suggested_category_id=seed["groceries_id"],
+            suggestion_source="shared_dictionary",
+        )],
+    )
+    await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+
+    # No CategoryRule should have been written for the LIDL token; the
+    # paired row's linked_transaction_id is non-None so should_skip_learning
+    # short-circuits learn_from_choice and the source_split miss path.
+    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
+    assert rules == []
 
 
 async def test_aggregate_metric_emitted_with_correct_shape(db_session: AsyncSession) -> None:

--- a/backend/tests/services/test_import_preview_with_rules.py
+++ b/backend/tests/services/test_import_preview_with_rules.py
@@ -87,9 +87,10 @@ async def test_preview_attaches_shared_dictionary_suggestion(
     assert result.rows[0].suggestion_source == "shared_dictionary"
 
 
-async def test_preview_no_suggestion_for_transfer_row(
+async def test_preview_legacy_online_banking_string_no_longer_triggers_transfer(
     db_session: AsyncSession,
 ) -> None:
+    """PR-C C1 removed the transaction_type heuristic; the row is now plain."""
     seed = await _seed(db_session)
     rows = [
         ParsedRow(
@@ -102,9 +103,13 @@ async def test_preview_no_suggestion_for_transfer_row(
         db_session, org_id=seed["org_id"], account_id=seed["account_id"],
         file_name="t.csv", parsed_rows=rows,
     )
-    assert result.rows[0].is_potential_transfer is True
-    assert result.rows[0].suggested_category_id is None
-    assert result.rows[0].suggestion_source is None
+    # PR-C C1 removed the `transaction_type=='online banking'` heuristic.
+    # C2 wires real detectors instead; with no DB matches, action is "none".
+    assert result.rows[0].transfer_match_action == "none"
+    # The smart-rules suggestion no longer skips on the legacy heuristic.
+    # POS LIDL still resolves via the shared dictionary seed.
+    assert result.rows[0].suggested_category_id == seed["groceries_id"]
+    assert result.rows[0].suggestion_source == "shared_dictionary"
 
 
 async def test_preview_default_source_when_no_match(

--- a/backend/tests/services/test_import_service_transfers.py
+++ b/backend/tests/services/test_import_service_transfers.py
@@ -1,6 +1,7 @@
-"""Detector 1 + Detector 2 wiring in build_preview (PR-C C2).
+"""Detector 1 + Detector 2 wiring in build_preview (PR-C C2) +
+execute_import confirm-branch wiring (PR-C C3).
 
-Covers spec §3.1 / §3.2:
+Covers spec §3.1 / §3.2 / §3.3:
   Detector 1 = find_duplicate_of_linked_leg → is_duplicate_of_linked_leg=True
               + duplicate_candidate populated + default_action_drop=True.
   Detector 2 = find_match_candidates → transfer_match_action set per
@@ -8,13 +9,15 @@ Covers spec §3.1 / §3.2:
   Precedence: Detector 1 wins; Detector 2 is skipped on the same row.
   Summary counters in ImportPreviewResponse mirror per-row actions.
   Telemetry: one import.preview.matched event per preview.
+  C3 confirm: action="pair_with_existing" inserts + links atomically;
+              action="drop_as_duplicate" revalidates server-side and skips.
 """
 import datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
 import pytest_asyncio
-from sqlalchemy import event
+from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
@@ -24,6 +27,7 @@ from app.models.account import Account, AccountType
 from app.models.category import Category, CategoryType
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.models.user import Organization
+from app.schemas.import_schemas import ImportConfirmRequest, ImportConfirmRow
 from app.services import import_service
 from app.services.import_parser import ParsedRow
 
@@ -456,3 +460,254 @@ async def test_legacy_online_banking_string_no_longer_triggers_transfer_flag(
     assert result.suggested_pair_count == 0
     assert result.multi_candidate_count == 0
     assert result.duplicate_of_linked_count == 0
+
+
+# ── PR-C C3 confirm-branch tests ─────────────────────────────────────────────
+
+
+async def test_confirm_pair_with_existing_creates_and_links_atomically(
+    db_session: AsyncSession,
+) -> None:
+    """Happy path: action='pair_with_existing' inserts the new leg,
+    locks the partner, and links both rows under a single per-row savepoint.
+    Both legs end up linked; transfers.linked telemetry is emitted with
+    source='import_pair'.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    # Partner: un-linked income on dst (the OTHER account).
+    partner = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("50"),
+        type=TransactionType.INCOME, when=when, description="incoming-xfer",
+    )
+
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="ATM WITHDRAW", amount=Decimal("50"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="pair_with_existing",
+            pair_with_transaction_id=partner.id,
+            recategorize=False,  # already on Transfer category
+        )],
+    )
+
+    with patch.object(
+        import_service.logger, "ainfo", new_callable=AsyncMock,
+    ) as spy:
+        result = await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    assert result.imported_count == 0
+    assert result.paired_count == 1
+    assert result.dropped_duplicate_count == 0
+    assert result.error_count == 0
+
+    # Both legs are linked.
+    new_leg = (await db_session.execute(
+        select(Transaction).where(
+            Transaction.account_id == seed["src_id"],
+            Transaction.type == TransactionType.EXPENSE,
+        )
+    )).scalar_one()
+    await db_session.refresh(partner)
+    assert new_leg.linked_transaction_id == partner.id
+    assert partner.linked_transaction_id == new_leg.id
+
+    # Telemetry: transfers.linked with source='import_pair'.
+    linked_calls = [
+        c for c in spy.call_args_list
+        if c.args and c.args[0] == "transfers.linked"
+    ]
+    assert len(linked_calls) == 1
+    assert linked_calls[0].kwargs["source"] == "import_pair"
+    assert linked_calls[0].kwargs["recategorized"] is False
+
+
+async def test_confirm_pair_with_existing_atomicity_rollback(
+    db_session: AsyncSession,
+) -> None:
+    """Force _link_pair to raise after _create_transaction_no_commit succeeds.
+    The new CSV leg must NOT be present in the DB after the rollback (the
+    per-row savepoint catches it). The partner must remain un-linked.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    partner = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("75"),
+        type=TransactionType.INCOME, when=when, description="incoming-xfer",
+    )
+
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="ATM WITHDRAW", amount=Decimal("75"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="pair_with_existing",
+            pair_with_transaction_id=partner.id,
+        )],
+    )
+
+    with patch(
+        "app.services.import_service._link_pair",
+        new=AsyncMock(side_effect=RuntimeError("simulated link failure")),
+    ):
+        result = await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    # Failure surfaces as a row error.
+    assert result.paired_count == 0
+    assert result.imported_count == 0
+    assert result.error_count == 1
+    assert "simulated link failure" in result.errors[0].error
+
+    # The new CSV leg must NOT exist (savepoint rolled back).
+    new_legs = (await db_session.execute(
+        select(Transaction).where(
+            Transaction.account_id == seed["src_id"],
+            Transaction.description == "ATM WITHDRAW",
+        )
+    )).scalars().all()
+    assert new_legs == [], "new CSV leg should be rolled back"
+
+    # Partner remains un-linked.
+    await db_session.refresh(partner)
+    assert partner.linked_transaction_id is None
+
+
+async def test_confirm_drop_as_duplicate_revalidates_server_side(
+    db_session: AsyncSession,
+) -> None:
+    """Preview returned a duplicate-of-linked-leg candidate; before confirm,
+    the candidate gets unpaired (so it would no longer match — it has no
+    linked_transaction_id anymore). Confirm with action='drop_as_duplicate'
+    must raise ConflictError ('re-preview'), surfaced as a row error.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    # Linked pair: expense leg on src. This is the would-be duplicate target.
+    expense, income = await _add_linked_pair(
+        db_session,
+        org_id=seed["org_id"],
+        expense_account_id=seed["src_id"],
+        income_account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"],
+        amount=Decimal("10"),
+        when=when,
+        is_imported=False,
+    )
+
+    # Between preview and confirm: unpair the candidate.
+    expense.linked_transaction_id = None
+    income.linked_transaction_id = None
+    await db_session.commit()
+
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="ATM", amount=Decimal("10"),
+            type="expense",
+            action="drop_as_duplicate",
+            duplicate_of_transaction_id=expense.id,
+        )],
+    )
+
+    result = await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+
+    assert result.dropped_duplicate_count == 0
+    assert result.error_count == 1
+    assert "re-preview" in result.errors[0].error.lower()
+
+
+async def test_confirm_response_counters_match_actions(
+    db_session: AsyncSession,
+) -> None:
+    """Mix of action='create', 'pair_with_existing', 'drop_as_duplicate' rows
+    in one batch. Each counter increments correctly; sum + skipped + errors
+    equals total submitted.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    # Partner for pair branch.
+    partner = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("100"),
+        type=TransactionType.INCOME, when=when, description="incoming-xfer",
+    )
+    # Linked-leg target for drop branch (preserve linked state through confirm).
+    linked_expense, _linked_income = await _add_linked_pair(
+        db_session,
+        org_id=seed["org_id"],
+        expense_account_id=seed["src_id"],
+        income_account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"],
+        amount=Decimal("20"),
+        when=when,
+    )
+
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[
+            # plain create
+            ImportConfirmRow(
+                row_number=1, date=when,
+                description="POS COFFEE", amount=Decimal("3.50"),
+                type="expense",
+                category_id=seed["transfer_cat_id"],
+                action="create",
+            ),
+            # pair_with_existing
+            ImportConfirmRow(
+                row_number=2, date=when,
+                description="ATM WITHDRAW", amount=Decimal("100"),
+                type="expense",
+                category_id=seed["transfer_cat_id"],
+                action="pair_with_existing",
+                pair_with_transaction_id=partner.id,
+                recategorize=False,
+            ),
+            # drop_as_duplicate (still linked → revalidation passes).
+            ImportConfirmRow(
+                row_number=3, date=when,
+                description="ATM REPLAY", amount=Decimal("20"),
+                type="expense",
+                action="drop_as_duplicate",
+                duplicate_of_transaction_id=linked_expense.id,
+            ),
+        ],
+    )
+
+    result = await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+
+    assert result.imported_count == 1
+    assert result.paired_count == 1
+    assert result.dropped_duplicate_count == 1
+    assert result.skipped_count == 0
+    assert result.error_count == 0
+    # Counters sum to total submitted rows.
+    total = (
+        result.imported_count + result.paired_count
+        + result.dropped_duplicate_count + result.skipped_count
+        + result.error_count
+    )
+    assert total == len(body.rows)

--- a/backend/tests/services/test_import_service_transfers.py
+++ b/backend/tests/services/test_import_service_transfers.py
@@ -711,3 +711,61 @@ async def test_confirm_response_counters_match_actions(
         + result.error_count
     )
     assert total == len(body.rows)
+
+
+async def test_confirm_pair_with_existing_rejects_pending_partner(
+    db_session: AsyncSession,
+) -> None:
+    """Stale-preview test (PR-C review fix 3): partner became PENDING between
+    preview and confirm. find_match_candidates only suggests SETTLED rows,
+    so a partner whose status flipped after preview must be rejected at
+    confirm to preserve the pair invariant.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    # Partner: un-linked SETTLED income on dst (eligible at preview-time).
+    partner = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("60"),
+        type=TransactionType.INCOME, when=when, description="incoming-xfer",
+    )
+
+    # Between preview and confirm: partner flipped to PENDING.
+    partner.status = TransactionStatus.PENDING
+    await db_session.commit()
+
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="ATM WITHDRAW", amount=Decimal("60"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="pair_with_existing",
+            pair_with_transaction_id=partner.id,
+        )],
+    )
+
+    result = await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+
+    # Surfaces as a row error; not paired.
+    assert result.paired_count == 0
+    assert result.imported_count == 0
+    assert result.error_count == 1
+    assert "re-preview" in result.errors[0].error.lower()
+
+    # Partner remains un-linked.
+    await db_session.refresh(partner)
+    assert partner.linked_transaction_id is None
+    # The new CSV leg must NOT exist (savepoint rolled back).
+    new_legs = (await db_session.execute(
+        select(Transaction).where(
+            Transaction.account_id == seed["src_id"],
+            Transaction.description == "ATM WITHDRAW",
+        )
+    )).scalars().all()
+    assert new_legs == []

--- a/backend/tests/services/test_import_service_transfers.py
+++ b/backend/tests/services/test_import_service_transfers.py
@@ -1,0 +1,458 @@
+"""Detector 1 + Detector 2 wiring in build_preview (PR-C C2).
+
+Covers spec §3.1 / §3.2:
+  Detector 1 = find_duplicate_of_linked_leg → is_duplicate_of_linked_leg=True
+              + duplicate_candidate populated + default_action_drop=True.
+  Detector 2 = find_match_candidates → transfer_match_action set per
+              candidate count and date proximity.
+  Precedence: Detector 1 wins; Detector 2 is skipped on the same row.
+  Summary counters in ImportPreviewResponse mirror per-row actions.
+  Telemetry: one import.preview.matched event per preview.
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization
+from app.services import import_service
+from app.services.import_parser import ParsedRow
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_two_accounts(db: AsyncSession) -> dict:
+    """Seed an org, two EUR accounts (src=destination, dst=other), and a
+    Transfer category. Returns dict with ids needed by tests.
+    """
+    org = Organization(name="X", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    atype = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True,
+    )
+    db.add(atype)
+    await db.flush()
+    src = Account(
+        org_id=org.id, account_type_id=atype.id, name="Src",
+        balance=Decimal("0"), currency="EUR",
+    )
+    dst = Account(
+        org_id=org.id, account_type_id=atype.id, name="Dst",
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add_all([src, dst])
+    await db.flush()
+    transfer_cat = Category(
+        org_id=org.id, name="Transfer", slug="transfer",
+        is_system=True, type=CategoryType.BOTH,
+    )
+    db.add(transfer_cat)
+    await db.commit()
+    return {
+        "org_id": org.id,
+        "src_id": src.id,
+        "dst_id": dst.id,
+        "transfer_cat_id": transfer_cat.id,
+    }
+
+
+async def _add_linked_pair(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    expense_account_id: int,
+    income_account_id: int,
+    category_id: int,
+    amount: Decimal,
+    when: datetime.date,
+    is_imported: bool = False,
+) -> tuple[Transaction, Transaction]:
+    expense = Transaction(
+        org_id=org_id, account_id=expense_account_id, category_id=category_id,
+        description="link", amount=amount, type=TransactionType.EXPENSE,
+        status=TransactionStatus.SETTLED, date=when, settled_date=when,
+        is_imported=is_imported,
+    )
+    income = Transaction(
+        org_id=org_id, account_id=income_account_id, category_id=category_id,
+        description="link", amount=amount, type=TransactionType.INCOME,
+        status=TransactionStatus.SETTLED, date=when, settled_date=when,
+        is_imported=is_imported,
+    )
+    db.add_all([expense, income])
+    await db.flush()
+    expense.linked_transaction_id = income.id
+    income.linked_transaction_id = expense.id
+    await db.commit()
+    return expense, income
+
+
+async def _add_unlinked(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    account_id: int,
+    category_id: int,
+    amount: Decimal,
+    type: TransactionType,
+    when: datetime.date,
+    description: str = "u",
+) -> Transaction:
+    tx = Transaction(
+        org_id=org_id, account_id=account_id, category_id=category_id,
+        description=description, amount=amount, type=type,
+        status=TransactionStatus.SETTLED, date=when, settled_date=when,
+    )
+    db.add(tx)
+    await db.commit()
+    await db.refresh(tx)
+    return tx
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+async def test_detector_1_flags_duplicate_of_linked_leg(db_session: AsyncSession) -> None:
+    """A CSV row matching an already-linked leg on the same account should be
+    flagged is_duplicate_of_linked_leg + default_action_drop, with the
+    duplicate_candidate populated.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    # Existing linked pair: expense leg on src (the destination of import).
+    expense, _income = await _add_linked_pair(
+        db_session,
+        org_id=seed["org_id"],
+        expense_account_id=seed["src_id"],
+        income_account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"],
+        amount=Decimal("10"),
+        when=when,
+        is_imported=False,  # synthetic leg from Op-3 convert-and-create
+    )
+
+    rows = [
+        ParsedRow(
+            row_number=1, date=when, description="ATM",
+            amount=Decimal("10"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"],
+        account_id=seed["src_id"], file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].is_duplicate_of_linked_leg is True
+    assert result.rows[0].default_action_drop is True
+    assert result.rows[0].duplicate_candidate is not None
+    assert result.rows[0].duplicate_candidate.id == expense.id
+    assert result.rows[0].duplicate_candidate.account_id == seed["src_id"]
+    assert result.rows[0].duplicate_candidate.existing_leg_is_imported is False
+    # Detector 2 must NOT also fire on the same row.
+    assert result.rows[0].transfer_match_action == "none"
+    # Counters reflect Detector 1.
+    assert result.duplicate_of_linked_count == 1
+    assert result.auto_paired_count == 0
+
+
+async def test_detector_2_same_day_single_match_pair_with(
+    db_session: AsyncSession,
+) -> None:
+    """A single un-linked income leg on the other account on the same date
+    yields action='pair_with' + same_day confidence.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    # Un-linked income on dst → CSV row is expense on src ⇒ pair candidate.
+    other = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("25"),
+        type=TransactionType.INCOME, when=when,
+    )
+
+    rows = [
+        ParsedRow(
+            row_number=1, date=when, description="POS COFFEE",
+            amount=Decimal("25"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"],
+        account_id=seed["src_id"], file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].transfer_match_action == "pair_with"
+    assert result.rows[0].transfer_match_confidence == "same_day"
+    assert result.rows[0].pair_with_transaction_id == other.id
+    assert result.rows[0].transfer_candidates == []
+    assert result.rows[0].is_duplicate_of_linked_leg is False
+    assert result.auto_paired_count == 1
+    assert result.suggested_pair_count == 0
+    assert result.multi_candidate_count == 0
+
+
+async def test_detector_2_near_date_single_match_suggest_pair(
+    db_session: AsyncSession,
+) -> None:
+    """A single match within ±3 days but not same-day yields
+    action='suggest_pair' + near_date confidence.
+    """
+    seed = await _seed_two_accounts(db_session)
+    csv_date = datetime.date(2026, 5, 3)
+    other_date = datetime.date(2026, 5, 1)  # 2 days off
+    other = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("40"),
+        type=TransactionType.INCOME, when=other_date,
+    )
+
+    rows = [
+        ParsedRow(
+            row_number=1, date=csv_date, description="POS COFFEE",
+            amount=Decimal("40"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"],
+        account_id=seed["src_id"], file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].transfer_match_action == "suggest_pair"
+    assert result.rows[0].transfer_match_confidence == "near_date"
+    assert result.rows[0].pair_with_transaction_id == other.id
+    assert result.suggested_pair_count == 1
+    assert result.auto_paired_count == 0
+
+
+async def test_detector_2_multi_candidate_choose(
+    db_session: AsyncSession,
+) -> None:
+    """≥2 candidates → action='choose_candidate', candidates list populated,
+    pair_with_transaction_id None.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    a = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("15"),
+        type=TransactionType.INCOME, when=when, description="A",
+    )
+    b = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("15"),
+        type=TransactionType.INCOME, when=when, description="B",
+    )
+
+    rows = [
+        ParsedRow(
+            row_number=1, date=when, description="POS",
+            amount=Decimal("15"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"],
+        account_id=seed["src_id"], file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].transfer_match_action == "choose_candidate"
+    assert result.rows[0].transfer_match_confidence == "multi_candidate"
+    assert result.rows[0].pair_with_transaction_id is None
+    candidate_ids = {c.id for c in result.rows[0].transfer_candidates}
+    assert candidate_ids == {a.id, b.id}
+    # confidence per-candidate is same_day (both share the CSV date).
+    for c in result.rows[0].transfer_candidates:
+        assert c.confidence == "same_day"
+        assert c.date_diff_days == 0
+        assert c.account_id == seed["dst_id"]
+        assert c.account_name == "Dst"
+    assert result.multi_candidate_count == 1
+
+
+async def test_detector_1_takes_precedence_over_detector_2(
+    db_session: AsyncSession,
+) -> None:
+    """When both detectors could fire, only Detector 1 runs. Detector 2
+    output is the 'none' default.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    # Detector 1 ammo: linked expense leg on src.
+    await _add_linked_pair(
+        db_session,
+        org_id=seed["org_id"],
+        expense_account_id=seed["src_id"],
+        income_account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"],
+        amount=Decimal("99"),
+        when=when,
+    )
+    # Detector 2 ammo: un-linked income leg on dst that would otherwise pair.
+    other = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("99"),
+        type=TransactionType.INCOME, when=when,
+    )
+
+    rows = [
+        ParsedRow(
+            row_number=1, date=when, description="ATM",
+            amount=Decimal("99"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"],
+        account_id=seed["src_id"], file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].is_duplicate_of_linked_leg is True
+    assert result.rows[0].default_action_drop is True
+    # Detector 2 must be silent on this row.
+    assert result.rows[0].transfer_match_action == "none"
+    assert result.rows[0].pair_with_transaction_id is None
+    assert result.rows[0].transfer_candidates == []
+    # Counters: only the duplicate-of-linked counter advances.
+    assert result.duplicate_of_linked_count == 1
+    assert result.auto_paired_count == 0
+    assert result.suggested_pair_count == 0
+    assert result.multi_candidate_count == 0
+    # And the other un-linked candidate exists in the DB but was ignored.
+    assert other.id is not None
+
+
+async def test_summary_counters_match_per_row_actions_and_emit_metric(
+    db_session: AsyncSession,
+) -> None:
+    """A 3-row preview: pair_with, suggest_pair, none → counters match;
+    exactly one import.preview.matched event with the right shape.
+    """
+    seed = await _seed_two_accounts(db_session)
+    same_day = datetime.date(2026, 5, 5)
+    near_csv = datetime.date(2026, 5, 5)
+    near_other = datetime.date(2026, 5, 3)
+    # Row 1: same-day single match → pair_with
+    auto_partner = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("11"),
+        type=TransactionType.INCOME, when=same_day, description="P1",
+    )
+    # Row 2: near-date single match → suggest_pair
+    suggest_partner = await _add_unlinked(
+        db_session,
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"], amount=Decimal("22"),
+        type=TransactionType.INCOME, when=near_other, description="P2",
+    )
+    # Row 3: no match → none
+
+    rows = [
+        ParsedRow(
+            row_number=1, date=same_day, description="auto-pair",
+            amount=Decimal("11"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+        ParsedRow(
+            row_number=2, date=near_csv, description="suggest-pair",
+            amount=Decimal("22"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+        ParsedRow(
+            row_number=3, date=same_day, description="lonely",
+            amount=Decimal("999"), type="expense",
+            counterparty=None, transaction_type=None,
+        ),
+    ]
+    with patch.object(
+        import_service.logger, "ainfo", new_callable=AsyncMock,
+    ) as spy:
+        result = await import_service.build_preview(
+            db_session, org_id=seed["org_id"],
+            account_id=seed["src_id"], file_name="t.csv", parsed_rows=rows,
+        )
+
+    assert [r.transfer_match_action for r in result.rows] == [
+        "pair_with", "suggest_pair", "none",
+    ]
+    assert result.rows[0].pair_with_transaction_id == auto_partner.id
+    assert result.rows[1].pair_with_transaction_id == suggest_partner.id
+    assert result.auto_paired_count == 1
+    assert result.suggested_pair_count == 1
+    assert result.multi_candidate_count == 0
+    assert result.duplicate_of_linked_count == 0
+
+    matched_calls = [
+        c for c in spy.call_args_list
+        if c.args and c.args[0] == "import.preview.matched"
+    ]
+    assert len(matched_calls) == 1, "exactly one matched-summary event per preview"
+    kwargs = matched_calls[0].kwargs
+    assert kwargs["org_id"] == seed["org_id"]
+    assert kwargs["file_name"] == "t.csv"
+    assert kwargs["auto_paired"] == 1
+    assert kwargs["suggested"] == 1
+    assert kwargs["multi_candidate"] == 0
+    assert kwargs["duplicate_of_linked"] == 0
+
+
+async def test_legacy_online_banking_string_no_longer_triggers_transfer_flag(
+    db_session: AsyncSession,
+) -> None:
+    """The pre-PR-C heuristic on `transaction_type=='online banking'` is gone.
+    With no DB candidates, the row is plain (action='none'), and counters
+    are zero.
+    """
+    seed = await _seed_two_accounts(db_session)
+    rows = [
+        ParsedRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS COFFEE", amount=Decimal("3.50"),
+            type="expense", counterparty=None, transaction_type="Online Banking",
+        ),
+    ]
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"],
+        account_id=seed["src_id"], file_name="t.csv", parsed_rows=rows,
+    )
+    assert result.rows[0].transfer_match_action == "none"
+    assert result.rows[0].is_duplicate_of_linked_leg is False
+    assert result.rows[0].pair_with_transaction_id is None
+    assert result.rows[0].transfer_candidates == []
+    assert result.auto_paired_count == 0
+    assert result.suggested_pair_count == 0
+    assert result.multi_candidate_count == 0
+    assert result.duplicate_of_linked_count == 0

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -104,8 +104,7 @@ function ImportPageContent() {
           type: r.type,
           category_id: r.suggested_category_id ?? null,
           skip: r.is_duplicate, // pre-skip duplicates
-          is_transfer: false,
-          transfer_account_id: null,
+          action: "create" as const,
           suggested_category_id: r.suggested_category_id ?? null,
           suggestion_source: r.suggestion_source ?? null,
         })),
@@ -293,7 +292,7 @@ function ImportPageContent() {
                   let rowBg = "";
                   if (rowState.skip) rowBg = "opacity-40";
                   else if (isDup) rowBg = "bg-warning-dim";
-                  else if (isTransfer || rowState.is_transfer) rowBg = "bg-accent/5";
+                  else if (isTransfer) rowBg = "bg-accent/5";
 
                   return (
                     <tr key={previewRow.row_number} className={`border-b border-border ${rowBg}`}>
@@ -319,7 +318,7 @@ function ImportPageContent() {
                       </td>
                       <td className="px-4 py-2 capitalize text-text-secondary">{previewRow.type}</td>
                       <td className="px-4 py-2">
-                        {!rowState.skip && !rowState.is_transfer && (
+                        {!rowState.skip && (
                           <div className="flex items-center">
                             <CategorySelect
                               id={`cat-${previewRow.row_number}`}
@@ -353,39 +352,7 @@ function ImportPageContent() {
                         )}
                       </td>
                       <td className="px-4 py-2">
-                        {!rowState.skip && (
-                          <div className="flex items-center gap-2">
-                            <input
-                              type="checkbox"
-                              checked={rowState.is_transfer}
-                              onChange={(e) =>
-                                updateRow(previewRow.row_number, {
-                                  is_transfer: e.target.checked,
-                                  transfer_account_id: null,
-                                })
-                              }
-                              className="rounded border-border"
-                            />
-                            {rowState.is_transfer && (
-                              <select
-                                value={rowState.transfer_account_id ?? ""}
-                                onChange={(e) =>
-                                  updateRow(previewRow.row_number, {
-                                    transfer_account_id: e.target.value === "" ? null : Number(e.target.value),
-                                  })
-                                }
-                                className={input + " !w-40"}
-                              >
-                                <option value="">Select account...</option>
-                                {activeAccounts
-                                  .filter((a) => a.id !== preview.account_id)
-                                  .map((a) => (
-                                    <option key={a.id} value={a.id}>{a.name}</option>
-                                  ))}
-                              </select>
-                            )}
-                          </div>
-                        )}
+                        {/* Transfer-pair UI ships in PR-E (pill + chooser per spec §4.6) */}
                       </td>
                     </tr>
                   );

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -193,8 +193,13 @@ export interface ImportConfirmRow {
   type: "income" | "expense";
   category_id: number | null;
   skip: boolean;
-  is_transfer: boolean;
-  transfer_account_id: number | null;
+  // Spec §3.2 confirm-row action mapping
+  action?: "create" | "pair_with_existing" | "drop_as_duplicate";
+  pair_with_transaction_id?: number | null;
+  duplicate_of_transaction_id?: number | null;
+  transfer_category_id?: number | null;
+  recategorize?: boolean;
+  // Echoed from preview for accept-vs-override smart-rules detection
   suggested_category_id?: number | null;
   suggestion_source?: SuggestionSource | null;
 }


### PR DESCRIPTION
## Summary

PR-C lands the **import-side wiring** for transfers between accounts. The legacy CSV string heuristic is gone, replaced by two cross-row detectors and three action-based confirm branches.

### Schema changes (`app/schemas/import_schemas.py`)

- **Removed (legacy):** `ImportPreviewRow.is_potential_transfer`; `ImportPreviewResponse.transfer_candidate_count`; `ImportConfirmRow.is_transfer` and `transfer_account_id`.
- **Added (preview side):** `ImportPreviewRow.{is_duplicate_of_linked_leg, duplicate_candidate, default_action_drop, transfer_match_action, transfer_match_confidence, pair_with_transaction_id, transfer_candidates}`. `ImportPreviewResponse.{auto_paired_count, suggested_pair_count, multi_candidate_count, duplicate_of_linked_count}`.
- **Added (confirm side):** `ImportConfirmRow.{action, pair_with_transaction_id, duplicate_of_transaction_id, transfer_category_id, recategorize}`. `ImportConfirmResponse.{paired_count, dropped_duplicate_count}`.
- `ConfigDict(extra="forbid")` explicit on all write schemas in this file.

### Preview detectors (`build_preview`)

- **Detector 1** (`find_duplicate_of_linked_leg`) fires first per row: same account, same type, same amount, same currency, ±3 days, already linked → flag `is_duplicate_of_linked_leg=True`, `default_action_drop=True`.
- **Detector 2** (`find_match_candidates`) runs only if Detector 1 didn't fire: cross-account un-linked match → `transfer_match_action` ∈ `{none, pair_with, suggest_pair, choose_candidate}` based on candidate count and date proximity.
- Destination account loaded once before the row loop (no N+1).
- Telemetry: `import.preview.matched` per build.
- Legacy `_TRANSFER_TYPES = {"online banking"}` removed.

### Confirm branches (`execute_import`)

- **`action="create"`**: existing path; uses `_create_transaction_no_commit` inside per-row savepoint. Smart-rules learning preserved (best-effort, gated to `create` rows only).
- **`action="pair_with_existing"`**: atomic per-row savepoint:
  1. `_create_transaction_no_commit` for the new CSV leg.
  2. Lock partner with `FOR UPDATE` + `populate_existing=True`. Re-validate un-linked / non-recurring / currency match.
  3. `_link_pair(...)` directly (NOT `pair_existing_transactions`, which would commit early).
  4. Telemetry: `transfers.linked` with `source="import_pair"`.
- **`action="drop_as_duplicate"`**: server-side revalidation via `find_duplicate_of_linked_leg` with identical params to Detector 1; ConflictError on candidate-set drift. Telemetry: `import.dropped_duplicate_leg` with string `amount`.
- After loop: `import.confirmed.transfers` per execute.
- `smart_rules.import_executed` gains `paired_count` (preserves `rows_total` semantics).

### Deferred A5 swap landed (C2.5)

`should_skip_learning(obj)` in `category_rules_service.py:177` — dead `is_transfer` duck-type fallback removed. Now uses `is_transfer_leg(obj)` (PR-A's helper) with a `hasattr` guard. Single-source-of-truth detection via `linked_transaction_id`.

### Tests

- 11 new transfer-import service tests (`test_import_service_transfers.py`).
- 1 re-enabled test (`test_transfer_row_does_not_learn`, rewritten to use `action="pair_with_existing"`).
- Backend baseline 308 → **318 passed, 2 skipped** (+10 net).
- No regressions on existing import / smart-rules / category-rules tests.

### Sizing

1,225 insertions / 170 deletions across 7 files.

### Non-goals

- Frontend wiring of the new pill column / panels / Review filter — PR-E.
- Frontend transactions-page repair UI — PR-D (depends on PR-B/B.5 backends).

Spec: `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-03-transfers-between-accounts-design.md` §3.