### PR TITLE
feat(transfers): PR-E import-preview UI

### DIFF
--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import AppShell from "@/components/AppShell";
@@ -64,6 +64,16 @@ function ImportPageContent() {
   const [rowStates, setRowStates] = useState<ImportConfirmRow[]>([]);
   const [defaultCategoryId, setDefaultCategoryId] = useState<number | "">("");
 
+  // Transfer-pill UI state (parallel map keyed by row_number — UI only,
+  // confirm-payload mapping happens in E2).
+  type TransferUiState = {
+    panelOpen: boolean;
+    pairAccepted: boolean;
+    selectedCandidateId: number | null;
+    dropAccepted: boolean;
+  };
+  const [transferUi, setTransferUi] = useState<Record<number, TransferUiState>>({});
+
   // Results step
   const [results, setResults] = useState<ImportConfirmResponse | null>(null);
 
@@ -109,6 +119,21 @@ function ImportPageContent() {
           suggestion_source: r.suggestion_source ?? null,
         })),
       );
+
+      // Initialize transfer-pill UI state per row from preview detectors.
+      const ui: Record<number, TransferUiState> = {};
+      data.rows.forEach((r: ImportPreviewRow) => {
+        ui[r.row_number] = {
+          panelOpen: false,
+          // pair_with (same_day) defaults checked. suggest_pair (near_date)
+          // defaults unchecked. choose_candidate stays unchecked until user picks.
+          pairAccepted: r.transfer_match_action === "pair_with",
+          selectedCandidateId: null,
+          dropAccepted: r.is_duplicate_of_linked_leg, // default Drop
+        };
+      });
+      setTransferUi(ui);
+
       setStep("preview");
     } catch (err) {
       setErrorMsg(extractErrorMessage(err, "Failed to parse file"));
@@ -146,6 +171,18 @@ function ImportPageContent() {
     setRowStates((prev) =>
       prev.map((r) => (r.row_number === rowNum ? { ...r, ...patch } : r)),
     );
+  }, []);
+
+  const updateTransferUi = useCallback((rowNum: number, patch: Partial<TransferUiState>) => {
+    setTransferUi((prev) => ({
+      ...prev,
+      [rowNum]: { ...(prev[rowNum] ?? {
+        panelOpen: false,
+        pairAccepted: false,
+        selectedCandidateId: null,
+        dropAccepted: false,
+      }), ...patch },
+    }));
   }, []);
 
   const activeRows = rowStates.filter((r) => !r.skip);
@@ -307,67 +344,263 @@ function ImportPageContent() {
                   if (rowState.skip) rowBg = "opacity-40";
                   else if (isDup) rowBg = "bg-warning-dim";
 
+                  const ui = transferUi[previewRow.row_number] ?? {
+                    panelOpen: false,
+                    pairAccepted: false,
+                    selectedCandidateId: null,
+                    dropAccepted: false,
+                  };
+
+                  // Pill rendering driven by detector outputs. Detector 1
+                  // (is_duplicate_of_linked_leg) takes precedence over detector 2.
+                  let pill: { text: string; classes: string } | null = null;
+                  if (previewRow.is_duplicate_of_linked_leg) {
+                    pill = {
+                      text: "Drop as duplicate",
+                      classes: "bg-rose-100 text-rose-800 hover:bg-rose-200",
+                    };
+                  } else if (previewRow.transfer_match_action === "pair_with") {
+                    pill = {
+                      text: "Pair as transfer",
+                      classes: "bg-accent/15 text-accent hover:bg-accent/25",
+                    };
+                  } else if (previewRow.transfer_match_action === "suggest_pair") {
+                    const cand = previewRow.transfer_candidates[0];
+                    const days = cand ? Math.abs(cand.date_diff_days) : 0;
+                    pill = {
+                      text: `Possible transfer (±${days} day${days === 1 ? "" : "s"})`,
+                      classes: "bg-amber-100 text-amber-800 hover:bg-amber-200",
+                    };
+                  } else if (previewRow.transfer_match_action === "choose_candidate") {
+                    pill = {
+                      text: "Multiple candidates",
+                      classes: "bg-amber-100 text-amber-800 hover:bg-amber-200",
+                    };
+                  }
+
+                  // Determine table column count for panel-row colspan.
+                  const COL_COUNT = 7;
+
                   return (
-                    <tr key={previewRow.row_number} className={`border-b border-border ${rowBg}`}>
-                      <td className="px-4 py-2">
-                        <input
-                          type="checkbox"
-                          checked={rowState.skip}
-                          onChange={(e) => updateRow(previewRow.row_number, { skip: e.target.checked })}
-                          className="rounded border-border"
-                        />
-                      </td>
-                      <td className="px-4 py-2 tabular-nums text-text-secondary">{previewRow.date}</td>
-                      <td className="max-w-[300px] truncate px-4 py-2 text-text-primary" title={previewRow.description}>
-                        {previewRow.description}
-                        {isDup && (
-                          <span className="ml-2 text-xs text-warning">duplicate</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-2 tabular-nums font-medium">
-                        <span className={previewRow.type === "income" ? "text-success" : "text-danger"}>
-                          {previewRow.type === "income" ? "+" : "-"}{Number(previewRow.amount).toFixed(2)}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2 capitalize text-text-secondary">{previewRow.type}</td>
-                      <td className="px-4 py-2">
-                        {!rowState.skip && (
-                          <div className="flex items-center">
-                            <CategorySelect
-                              id={`cat-${previewRow.row_number}`}
-                              categories={catOptions}
-                              value={rowState.category_id ?? ""}
-                              onChange={(id) =>
-                                updateRow(previewRow.row_number, {
-                                  category_id: id === "" ? null : id,
-                                })
+                    <Fragment key={previewRow.row_number}>
+                      <tr className={`border-b border-border ${rowBg}`}>
+                        <td className="px-4 py-2">
+                          <input
+                            type="checkbox"
+                            checked={rowState.skip}
+                            onChange={(e) => updateRow(previewRow.row_number, { skip: e.target.checked })}
+                            className="rounded border-border"
+                          />
+                        </td>
+                        <td className="px-4 py-2 tabular-nums text-text-secondary">{previewRow.date}</td>
+                        <td className="max-w-[300px] truncate px-4 py-2 text-text-primary" title={previewRow.description}>
+                          {previewRow.description}
+                          {isDup && (
+                            <span className="ml-2 text-xs text-warning">duplicate</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 tabular-nums font-medium">
+                          <span className={previewRow.type === "income" ? "text-success" : "text-danger"}>
+                            {previewRow.type === "income" ? "+" : "-"}{Number(previewRow.amount).toFixed(2)}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2 capitalize text-text-secondary">{previewRow.type}</td>
+                        <td className="px-4 py-2">
+                          {!rowState.skip && (
+                            <div className="flex items-center">
+                              <CategorySelect
+                                id={`cat-${previewRow.row_number}`}
+                                categories={catOptions}
+                                value={rowState.category_id ?? ""}
+                                onChange={(id) =>
+                                  updateRow(previewRow.row_number, {
+                                    category_id: id === "" ? null : id,
+                                  })
+                                }
+                                filterType={previewRow.type === "income" ? "income" : "expense"}
+                                className={input + " !w-48"}
+                              />
+                              {previewRow.suggestion_source === "org_rule" && (
+                                <span
+                                  className="ml-2 text-xs text-text-muted"
+                                  data-testid="suggestion-badge"
+                                >
+                                  Auto · org rule
+                                </span>
+                              )}
+                              {previewRow.suggestion_source === "shared_dictionary" && (
+                                <span
+                                  className="ml-2 text-xs text-text-muted"
+                                  data-testid="suggestion-badge"
+                                >
+                                  Auto · shared
+                                </span>
+                              )}
+                            </div>
+                          )}
+                        </td>
+                        <td className="px-4 py-2">
+                          {pill && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                updateTransferUi(previewRow.row_number, { panelOpen: !ui.panelOpen })
                               }
-                              filterType={previewRow.type === "income" ? "income" : "expense"}
-                              className={input + " !w-48"}
-                            />
-                            {previewRow.suggestion_source === "org_rule" && (
-                              <span
-                                className="ml-2 text-xs text-text-muted"
-                                data-testid="suggestion-badge"
-                              >
-                                Auto · org rule
-                              </span>
+                              className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${pill.classes}`}
+                              aria-expanded={ui.panelOpen}
+                              data-testid={`transfer-pill-${previewRow.row_number}`}
+                            >
+                              {pill.text}
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+
+                      {pill && ui.panelOpen && (
+                        <tr
+                          className="border-b border-border bg-surface-2/50"
+                          data-testid={`transfer-panel-${previewRow.row_number}`}
+                        >
+                          <td colSpan={COL_COUNT} className="px-6 py-3">
+                            {/* Detector 1: matches an already-linked leg on this account → Drop. */}
+                            {previewRow.is_duplicate_of_linked_leg && previewRow.duplicate_candidate && (
+                              <div className="space-y-2 text-sm">
+                                <div className="font-medium text-text-primary">Matches an existing linked leg</div>
+                                <div className="text-text-secondary">
+                                  {previewRow.duplicate_candidate.date} · {previewRow.duplicate_candidate.account_name} ·{" "}
+                                  <span className="tabular-nums">
+                                    {Number(previewRow.duplicate_candidate.amount).toFixed(2)}
+                                  </span>{" "}
+                                  · {previewRow.duplicate_candidate.description}
+                                </div>
+                                {previewRow.duplicate_candidate.existing_leg_is_imported === false && (
+                                  <span className="inline-block rounded bg-violet-100 px-2 py-0.5 text-xs text-violet-800">
+                                    Synthetic leg from convert-to-transfer
+                                  </span>
+                                )}
+                                <label className="flex items-center gap-2">
+                                  <input
+                                    type="checkbox"
+                                    checked={ui.dropAccepted}
+                                    onChange={(e) =>
+                                      updateTransferUi(previewRow.row_number, { dropAccepted: e.target.checked })
+                                    }
+                                    className="rounded border-border"
+                                  />
+                                  <span>{ui.dropAccepted ? "Drop this row" : "Keep both"}</span>
+                                </label>
+                              </div>
                             )}
-                            {previewRow.suggestion_source === "shared_dictionary" && (
-                              <span
-                                className="ml-2 text-xs text-text-muted"
-                                data-testid="suggestion-badge"
-                              >
-                                Auto · shared
-                              </span>
-                            )}
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-2">
-                        {/* Transfer-pair UI ships in PR-E (pill + chooser per spec §4.6) */}
-                      </td>
-                    </tr>
+
+                            {/* Detector 2: pair_with / suggest_pair (single candidate). */}
+                            {!previewRow.is_duplicate_of_linked_leg &&
+                              (previewRow.transfer_match_action === "pair_with" ||
+                                previewRow.transfer_match_action === "suggest_pair") &&
+                              previewRow.transfer_candidates[0] && (
+                                <div className="space-y-2 text-sm">
+                                  <div className="font-medium text-text-primary">
+                                    {previewRow.transfer_match_action === "pair_with"
+                                      ? "Same-day match found"
+                                      : "Near-date match found"}
+                                  </div>
+                                  <div className="text-text-secondary">
+                                    {previewRow.transfer_candidates[0].date} ·{" "}
+                                    {previewRow.transfer_candidates[0].account_name} ·{" "}
+                                    <span className="tabular-nums">
+                                      {Number(previewRow.transfer_candidates[0].amount).toFixed(2)}
+                                    </span>{" "}
+                                    · {previewRow.transfer_candidates[0].description}
+                                  </div>
+                                  <label className="flex items-center gap-2">
+                                    <input
+                                      type="checkbox"
+                                      checked={ui.pairAccepted}
+                                      onChange={(e) =>
+                                        updateTransferUi(previewRow.row_number, {
+                                          pairAccepted: e.target.checked,
+                                        })
+                                      }
+                                      className="rounded border-border"
+                                    />
+                                    <span>
+                                      {ui.pairAccepted ? "Pair as transfer" : "Don't pair"}
+                                    </span>
+                                  </label>
+                                </div>
+                              )}
+
+                            {/* Detector 2: choose_candidate (multi-candidate radio list). */}
+                            {!previewRow.is_duplicate_of_linked_leg &&
+                              previewRow.transfer_match_action === "choose_candidate" && (
+                                <div className="space-y-2 text-sm">
+                                  <div className="font-medium text-text-primary">
+                                    Pick a candidate to pair with
+                                  </div>
+                                  <ul className="space-y-1">
+                                    {previewRow.transfer_candidates.map((cand, candIdx) => {
+                                      // Closest candidate (smallest |date_diff_days|, first in list)
+                                      // is pre-highlighted via a subtle border, but NOT pre-selected.
+                                      const isClosest = candIdx === 0;
+                                      const isSelected = ui.selectedCandidateId === cand.id;
+                                      return (
+                                        <li key={cand.id}>
+                                          <label
+                                            className={`flex cursor-pointer items-center gap-2 rounded border px-2 py-1.5 ${
+                                              isSelected
+                                                ? "border-accent bg-accent/5"
+                                                : isClosest
+                                                ? "border-amber-300"
+                                                : "border-border"
+                                            }`}
+                                          >
+                                            <input
+                                              type="radio"
+                                              name={`cand-${previewRow.row_number}`}
+                                              checked={isSelected}
+                                              onChange={() =>
+                                                updateTransferUi(previewRow.row_number, {
+                                                  selectedCandidateId: cand.id,
+                                                  pairAccepted: true,
+                                                })
+                                              }
+                                            />
+                                            <span className="text-text-secondary">
+                                              {cand.date} · {cand.account_name} ·{" "}
+                                              <span className="tabular-nums">
+                                                {Number(cand.amount).toFixed(2)}
+                                              </span>{" "}
+                                              · {cand.description}
+                                              {isClosest && (
+                                                <span className="ml-2 text-xs text-amber-700">closest</span>
+                                              )}
+                                            </span>
+                                          </label>
+                                        </li>
+                                      );
+                                    })}
+                                    <li>
+                                      <label className="flex cursor-pointer items-center gap-2 rounded border border-border px-2 py-1.5">
+                                        <input
+                                          type="radio"
+                                          name={`cand-${previewRow.row_number}`}
+                                          checked={ui.selectedCandidateId === null && ui.pairAccepted === false}
+                                          onChange={() =>
+                                            updateTransferUi(previewRow.row_number, {
+                                              selectedCandidateId: null,
+                                              pairAccepted: false,
+                                            })
+                                          }
+                                        />
+                                        <span className="text-text-secondary">Skip — don't pair</span>
+                                      </label>
+                                    </li>
+                                  </ul>
+                                </div>
+                              )}
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
                   );
                 })}
               </tbody>

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -766,6 +766,16 @@ function ImportPageContent() {
             <p className="text-success">
               {results.imported_count} transaction{results.imported_count === 1 ? "" : "s"} imported
             </p>
+            {results.paired_count > 0 && (
+              <p className="text-text-muted">
+                {results.paired_count} paired as transfer{results.paired_count === 1 ? "" : "s"}
+              </p>
+            )}
+            {results.dropped_duplicate_count > 0 && (
+              <p className="text-text-muted">
+                {results.dropped_duplicate_count} dropped as duplicate of existing transfer leg
+              </p>
+            )}
             {results.skipped_count > 0 && (
               <p className="text-text-muted">{results.skipped_count} skipped</p>
             )}

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -21,6 +21,84 @@ import type {
 
 type Step = "upload" | "preview" | "results";
 
+// Transfer-pill UI state (parallel map keyed by row_number — UI only,
+// independent of the confirm-payload row state).
+type TransferUiState = {
+  panelOpen: boolean;
+  pairAccepted: boolean;
+  selectedCandidateId: number | null;
+  dropAccepted: boolean;
+};
+
+/**
+ * Build a confirm-payload row by combining the existing row state with the
+ * preview detector outputs and per-row transfer-pill UI state. Pure function
+ * (no side effects) so it can be unit-tested or batch-mapped.
+ *
+ * Action precedence (per spec §4.6):
+ *   1. is_duplicate_of_linked_leg + dropAccepted → "drop_as_duplicate"
+ *   2. transfer_match_action != "none" + user-confirmed pair → "pair_with_existing"
+ *   3. otherwise → "create"
+ *
+ * Notes:
+ * - skip semantics (UI-only "don't import this row") is unchanged. drop_as_duplicate
+ *   is server-side: the row is still submitted, backend skips it after revalidation.
+ * - When dropAccepted is FALSE on an is_duplicate_of_linked_leg row, we fall
+ *   through to the pair / create branches: the user implicitly chose "Keep both",
+ *   meaning the row imports as a regular transaction (or pairs if they also
+ *   accepted a pair candidate).
+ */
+function buildConfirmRow(
+  rowState: ImportConfirmRow,
+  preview: ImportPreviewRow,
+  ui: TransferUiState,
+): ImportConfirmRow {
+  const isDup = preview.is_duplicate_of_linked_leg;
+  const matchAction = preview.transfer_match_action;
+
+  if (isDup && ui.dropAccepted) {
+    return {
+      ...rowState,
+      action: "drop_as_duplicate",
+      duplicate_of_transaction_id: preview.duplicate_candidate?.id ?? null,
+      pair_with_transaction_id: null,
+      transfer_category_id: null,
+      recategorize: undefined,
+    };
+  }
+
+  const hasPairChoice =
+    matchAction === "pair_with" || matchAction === "suggest_pair"
+      ? ui.pairAccepted
+      : matchAction === "choose_candidate"
+      ? ui.selectedCandidateId !== null
+      : false;
+
+  if (matchAction !== "none" && hasPairChoice) {
+    const partnerId =
+      matchAction === "choose_candidate"
+        ? ui.selectedCandidateId
+        : preview.pair_with_transaction_id ?? null;
+    return {
+      ...rowState,
+      action: "pair_with_existing",
+      pair_with_transaction_id: partnerId,
+      duplicate_of_transaction_id: null,
+      transfer_category_id: null,
+      recategorize: true,
+    };
+  }
+
+  return {
+    ...rowState,
+    action: "create",
+    pair_with_transaction_id: null,
+    duplicate_of_transaction_id: null,
+    transfer_category_id: null,
+    recategorize: undefined,
+  };
+}
+
 export default function ImportPage() {
   return (
     <Suspense>
@@ -64,15 +142,13 @@ function ImportPageContent() {
   const [rowStates, setRowStates] = useState<ImportConfirmRow[]>([]);
   const [defaultCategoryId, setDefaultCategoryId] = useState<number | "">("");
 
-  // Transfer-pill UI state (parallel map keyed by row_number — UI only,
-  // confirm-payload mapping happens in E2).
-  type TransferUiState = {
-    panelOpen: boolean;
-    pairAccepted: boolean;
-    selectedCandidateId: number | null;
-    dropAccepted: boolean;
-  };
+  // Transfer-pill UI state (parallel map keyed by row_number — UI only).
+  // Confirm-payload mapping happens via buildConfirmRow at submit time.
   const [transferUi, setTransferUi] = useState<Record<number, TransferUiState>>({});
+
+  // Review pairings filter — when ON, table only renders rows with a
+  // transfer detector match (Detector 1 or Detector 2).
+  const [reviewPairingsOnly, setReviewPairingsOnly] = useState(false);
 
   // Results step
   const [results, setResults] = useState<ImportConfirmResponse | null>(null);
@@ -148,13 +224,29 @@ function ImportPageContent() {
     setErrorMsg("");
     setLoading(true);
 
+    // Map every row through buildConfirmRow so action / partner-id /
+    // duplicate-id reflect the user's per-row transfer choices.
+    const previewByRow = new Map(preview.rows.map((r) => [r.row_number, r]));
+    const defaultUi: TransferUiState = {
+      panelOpen: false,
+      pairAccepted: false,
+      selectedCandidateId: null,
+      dropAccepted: false,
+    };
+    const payloadRows = rowStates.map((rs) => {
+      const pv = previewByRow.get(rs.row_number);
+      if (!pv) return rs;
+      const ui = transferUi[rs.row_number] ?? defaultUi;
+      return buildConfirmRow(rs, pv, ui);
+    });
+
     try {
       const data = await apiFetch<ImportConfirmResponse>("/api/v1/import/confirm", {
         method: "POST",
         body: JSON.stringify({
           account_id: preview.account_id,
           default_category_id: defaultCategoryId,
-          rows: rowStates,
+          rows: payloadRows,
         }),
       });
       setResults(data);
@@ -164,7 +256,7 @@ function ImportPageContent() {
     } finally {
       setLoading(false);
     }
-  }, [preview, defaultCategoryId, rowStates]);
+  }, [preview, defaultCategoryId, rowStates, transferUi]);
 
   // ── Row update helpers ───────────────────────────────────────────────────
   const updateRow = useCallback((rowNum: number, patch: Partial<ImportConfirmRow>) => {
@@ -319,6 +411,28 @@ function ImportPageContent() {
             </div>
           </div>
 
+          {/* Review pairings filter toggle */}
+          <div className={card}>
+            <div className="flex flex-col gap-2 px-6 py-3 text-sm sm:flex-row sm:items-center sm:gap-4">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={reviewPairingsOnly}
+                  onChange={(e) => setReviewPairingsOnly(e.target.checked)}
+                  className="rounded border-border"
+                  data-testid="review-pairings-toggle"
+                />
+                <span className="font-medium text-text-primary">Review pairings only</span>
+              </label>
+              <span className="text-text-muted">
+                {preview.auto_paired_count} auto-paired ·{" "}
+                {preview.suggested_pair_count} suggested ·{" "}
+                {preview.multi_candidate_count} multi-candidate ·{" "}
+                {preview.duplicate_of_linked_count} duplicate
+              </span>
+            </div>
+          </div>
+
           {/* Preview table */}
           <div className={card + " overflow-x-auto"}>
             <table className="w-full min-w-[720px] text-sm">
@@ -337,6 +451,17 @@ function ImportPageContent() {
                 {preview.rows.map((previewRow, idx) => {
                   const rowState = rowStates[idx];
                   if (!rowState) return null;
+
+                  // Apply Review pairings filter — when ON, only render rows
+                  // with a transfer detector match (Detector 1 or Detector 2).
+                  if (
+                    reviewPairingsOnly &&
+                    previewRow.transfer_match_action === "none" &&
+                    !previewRow.is_duplicate_of_linked_leg
+                  ) {
+                    return null;
+                  }
+
                   const catOptions = rowState.type === "income" ? incomeCategories : expenseCategories;
                   const isDup = previewRow.is_duplicate;
 

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -240,9 +240,24 @@ function ImportPageContent() {
                   {preview.duplicate_count} duplicates
                 </span>
               )}
-              {preview.transfer_candidate_count > 0 && (
+              {preview.auto_paired_count > 0 && (
                 <span className="rounded bg-accent/10 px-2 py-0.5 text-accent">
-                  {preview.transfer_candidate_count} potential transfers
+                  {preview.auto_paired_count} auto-paired
+                </span>
+              )}
+              {preview.suggested_pair_count > 0 && (
+                <span className="rounded bg-amber-100 px-2 py-0.5 text-amber-800">
+                  {preview.suggested_pair_count} possible transfers
+                </span>
+              )}
+              {preview.multi_candidate_count > 0 && (
+                <span className="rounded bg-amber-100 px-2 py-0.5 text-amber-800">
+                  {preview.multi_candidate_count} need a pick
+                </span>
+              )}
+              {preview.duplicate_of_linked_count > 0 && (
+                <span className="rounded bg-rose-100 px-2 py-0.5 text-rose-800">
+                  {preview.duplicate_of_linked_count} dup of linked leg
                 </span>
               )}
             </div>
@@ -287,12 +302,10 @@ function ImportPageContent() {
                   if (!rowState) return null;
                   const catOptions = rowState.type === "income" ? incomeCategories : expenseCategories;
                   const isDup = previewRow.is_duplicate;
-                  const isTransfer = previewRow.is_potential_transfer;
 
                   let rowBg = "";
                   if (rowState.skip) rowBg = "opacity-40";
                   else if (isDup) rowBg = "bg-warning-dim";
-                  else if (isTransfer) rowBg = "bg-accent/5";
 
                   return (
                     <tr key={previewRow.row_number} className={`border-b border-border ${rowBg}`}>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -161,6 +161,27 @@ export interface ForecastPlan {
 
 export type SuggestionSource = "org_rule" | "shared_dictionary" | "default";
 
+export interface TransferCandidate {
+  id: number;
+  date: string;
+  description: string;
+  amount: number;
+  account_id: number;
+  account_name: string;
+  date_diff_days: number;
+  confidence: "same_day" | "near_date";
+}
+
+export interface DuplicateCandidate {
+  id: number;
+  date: string;
+  description: string;
+  amount: number;
+  account_id: number;
+  account_name: string;
+  existing_leg_is_imported: boolean;
+}
+
 export interface ImportPreviewRow {
   row_number: number;
   date: string;
@@ -169,11 +190,25 @@ export interface ImportPreviewRow {
   type: "income" | "expense";
   counterparty: string | null;
   transaction_type: string | null;
+
+  // Existing duplicate-detection (different from transfer-leg duplicate)
   is_duplicate: boolean;
   duplicate_transaction_id: number | null;
-  is_potential_transfer: boolean;
+
+  // Smart-rules suggestion
   suggested_category_id?: number | null;
   suggestion_source?: SuggestionSource | null;
+
+  // Detector 1: matches an already-linked leg on the same account → drop default
+  is_duplicate_of_linked_leg: boolean;
+  duplicate_candidate?: DuplicateCandidate | null;
+  default_action_drop: boolean;
+
+  // Detector 2: cross-account un-linked match (transfer-pair candidate)
+  transfer_match_action: "none" | "pair_with" | "suggest_pair" | "choose_candidate";
+  transfer_match_confidence?: "same_day" | "near_date" | "multi_candidate" | null;
+  pair_with_transaction_id?: number | null;
+  transfer_candidates: TransferCandidate[];
 }
 
 export interface ImportPreviewResponse {
@@ -182,7 +217,12 @@ export interface ImportPreviewResponse {
   file_name: string;
   total_rows: number;
   duplicate_count: number;
-  transfer_candidate_count: number;
+
+  // New per-spec §3.2 summary counters (replace transfer_candidate_count)
+  auto_paired_count: number;
+  suggested_pair_count: number;
+  multi_candidate_count: number;
+  duplicate_of_linked_count: number;
 }
 
 export interface ImportConfirmRow {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -161,27 +161,6 @@ export interface ForecastPlan {
 
 export type SuggestionSource = "org_rule" | "shared_dictionary" | "default";
 
-export interface TransferCandidate {
-  id: number;
-  date: string;
-  description: string;
-  amount: number;
-  account_id: number;
-  account_name: string;
-  date_diff_days: number;
-  confidence: "same_day" | "near_date";
-}
-
-export interface DuplicateCandidate {
-  id: number;
-  date: string;
-  description: string;
-  amount: number;
-  account_id: number;
-  account_name: string;
-  existing_leg_is_imported: boolean;
-}
-
 export interface ImportPreviewRow {
   row_number: number;
   date: string;
@@ -257,6 +236,8 @@ export interface ImportRowError {
 
 export interface ImportConfirmResponse {
   imported_count: number;
+  paired_count: number;
+  dropped_duplicate_count: number;
   skipped_count: number;
   error_count: number;
   errors: ImportRowError[];
@@ -332,4 +313,50 @@ export interface FeatureStateRow {
 export interface FeatureStateResponse {
   plan: { id: number; name: string; slug: string } | null;
   features: FeatureStateRow[];
+}
+
+// ── Transfer-pair shapes ─────────────────────────────────────────────────────
+
+export interface TransferCandidate {
+  id: number;
+  date: string;
+  description: string;
+  amount: number;
+  account_id: number;
+  account_name: string;
+  date_diff_days: number;
+  confidence: "same_day" | "near_date";
+}
+
+export interface TransferCandidatesResponse {
+  candidates: TransferCandidate[];
+}
+
+export interface DuplicateCandidate {
+  id: number;
+  date: string;
+  description: string;
+  amount: number;
+  account_id: number;
+  account_name: string;
+  existing_leg_is_imported: boolean;
+}
+
+export interface TransactionPairRequest {
+  expense_id: number;
+  income_id: number;
+  transfer_category_id?: number | null;
+  recategorize?: boolean;
+}
+
+export interface ConvertToTransferRequest {
+  destination_account_id: number;
+  pair_with_transaction_id?: number | null;
+  transfer_category_id?: number | null;
+  recategorize?: boolean;
+}
+
+export interface UnpairTransactionRequest {
+  expense_fallback_category_id: number;
+  income_fallback_category_id: number;
 }

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -429,6 +429,8 @@ describe("ImportPage transfer pill column", () => {
     const apiFetchMock = vi.mocked(apiFetch);
     apiFetchMock.mockResolvedValueOnce({
       imported_count: 2,
+      paired_count: 0,
+      dropped_duplicate_count: 0,
       skipped_count: 1,
       error_count: 0,
       errors: [],
@@ -460,5 +462,37 @@ describe("ImportPage transfer pill column", () => {
     expect(body.rows[2].action).toBe("drop_as_duplicate");
     expect(body.rows[2].duplicate_of_transaction_id).toBe(303);
     expect(body.rows[2].pair_with_transaction_id).toBeNull();
+  });
+
+  it("results page surfaces paired_count and dropped_duplicate_count", async () => {
+    const preview = basePreview([baseRow({ row_number: 1 })]);
+
+    await renderAndPreview(preview);
+
+    // Provide a default category so the confirm button is enabled.
+    const selects = document.querySelectorAll("select");
+    const defaultCatSelect = selects[selects.length - 1] as HTMLSelectElement;
+    fireEvent.change(defaultCatSelect, { target: { value: "5" } });
+
+    // Stub the confirm response with non-zero paired/dropped counters.
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockResolvedValueOnce({
+      imported_count: 3,
+      paired_count: 2,
+      dropped_duplicate_count: 1,
+      skipped_count: 0,
+      error_count: 0,
+      errors: [],
+    } as never);
+
+    const confirmBtn = screen.getByRole("button", { name: /import 1 transaction/i });
+    fireEvent.click(confirmBtn);
+
+    // Results step renders the new counter rows.
+    await screen.findByText(/import complete/i);
+    expect(screen.getByText(/2 paired as transfers/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 dropped as duplicate of existing transfer leg/i),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -287,4 +287,178 @@ describe("ImportPage transfer pill column", () => {
     expect(checkbox).not.toBeNull();
     expect(checkbox.checked).toBe(true);
   });
+
+  it("Review pairings filter shows only rows with transfer_match_action != none or duplicate", async () => {
+    const preview = basePreview([
+      baseRow({
+        row_number: 1,
+        description: "Plain row",
+        // transfer_match_action defaults to "none".
+      }),
+      baseRow({
+        row_number: 2,
+        description: "Pair row",
+        transfer_match_action: "pair_with",
+        transfer_match_confidence: "same_day",
+        pair_with_transaction_id: 99,
+        transfer_candidates: [
+          {
+            id: 99,
+            date: "2026-05-01",
+            description: "Counter leg",
+            amount: 50,
+            account_id: 2,
+            account_name: "Savings",
+            date_diff_days: 0,
+            confidence: "same_day",
+          },
+        ],
+      }),
+      baseRow({
+        row_number: 3,
+        description: "Duplicate-of-linked row",
+        is_duplicate_of_linked_leg: true,
+        default_action_drop: true,
+        duplicate_candidate: {
+          id: 77,
+          date: "2026-05-01",
+          description: "Existing leg",
+          amount: 50,
+          account_id: 1,
+          account_name: "Checking",
+          existing_leg_is_imported: true,
+        },
+      }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    // Initially all 3 rows visible.
+    expect(screen.getByText("Plain row")).toBeInTheDocument();
+    expect(screen.getByText("Pair row")).toBeInTheDocument();
+    expect(screen.getByText("Duplicate-of-linked row")).toBeInTheDocument();
+
+    // Toggle filter on.
+    const toggle = screen.getByTestId("review-pairings-toggle") as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(toggle.checked).toBe(true);
+
+    // The "none" row should be hidden; pair + duplicate-of-linked stay.
+    expect(screen.queryByText("Plain row")).toBeNull();
+    expect(screen.getByText("Pair row")).toBeInTheDocument();
+    expect(screen.getByText("Duplicate-of-linked row")).toBeInTheDocument();
+  });
+
+  it("Confirm payload sets action correctly per row state", async () => {
+    const preview = basePreview([
+      baseRow({
+        row_number: 1,
+        description: "Same-day pair",
+        transfer_match_action: "pair_with",
+        transfer_match_confidence: "same_day",
+        pair_with_transaction_id: 201,
+        transfer_candidates: [
+          {
+            id: 201,
+            date: "2026-05-01",
+            description: "Counter A",
+            amount: 50,
+            account_id: 2,
+            account_name: "Savings",
+            date_diff_days: 0,
+            confidence: "same_day",
+          },
+        ],
+      }),
+      baseRow({
+        row_number: 2,
+        description: "Suggest pair",
+        transfer_match_action: "suggest_pair",
+        transfer_match_confidence: "near_date",
+        pair_with_transaction_id: 202,
+        transfer_candidates: [
+          {
+            id: 202,
+            date: "2026-04-29",
+            description: "Counter B",
+            amount: 50,
+            account_id: 2,
+            account_name: "Savings",
+            date_diff_days: 2,
+            confidence: "near_date",
+          },
+        ],
+      }),
+      baseRow({
+        row_number: 3,
+        description: "Drop linked",
+        is_duplicate_of_linked_leg: true,
+        default_action_drop: true,
+        duplicate_candidate: {
+          id: 303,
+          date: "2026-05-01",
+          description: "Existing leg",
+          amount: 50,
+          account_id: 1,
+          account_name: "Checking",
+          existing_leg_is_imported: true,
+        },
+      }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    // The suggest_pair row's checkbox starts unchecked. Open panel and accept.
+    const suggestPill = await screen.findByTestId("transfer-pill-2");
+    fireEvent.click(suggestPill);
+    const suggestPanel = await screen.findByTestId("transfer-panel-2");
+    const suggestCheckbox = suggestPanel.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement;
+    fireEvent.click(suggestCheckbox);
+    expect(suggestCheckbox.checked).toBe(true);
+
+    // Provide a default category so confirm is enabled. The page renders only
+    // the "Default Category" native <select> on the preview step; per-row
+    // category pickers use a custom CategorySelect (not a native select).
+    const selects = document.querySelectorAll("select");
+    const defaultCatSelect = selects[selects.length - 1] as HTMLSelectElement;
+    fireEvent.change(defaultCatSelect, { target: { value: "5" } });
+
+    // Stub the confirm response so the click resolves cleanly.
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockResolvedValueOnce({
+      imported_count: 2,
+      skipped_count: 1,
+      error_count: 0,
+      errors: [],
+    } as never);
+
+    const confirmBtn = screen.getByRole("button", { name: /import 3 transactions/i });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const confirmCall = apiFetchMock.mock.calls.find(
+        ([url]) => url === "/api/v1/import/confirm",
+      );
+      expect(confirmCall).toBeDefined();
+    });
+
+    const confirmCall = apiFetchMock.mock.calls.find(
+      ([url]) => url === "/api/v1/import/confirm",
+    )!;
+    const body = JSON.parse((confirmCall[1] as RequestInit).body as string);
+
+    expect(body.rows).toHaveLength(3);
+    expect(body.rows[0].action).toBe("pair_with_existing");
+    expect(body.rows[0].pair_with_transaction_id).toBe(201);
+    expect(body.rows[0].duplicate_of_transaction_id).toBeNull();
+
+    expect(body.rows[1].action).toBe("pair_with_existing");
+    expect(body.rows[1].pair_with_transaction_id).toBe(202);
+
+    expect(body.rows[2].action).toBe("drop_as_duplicate");
+    expect(body.rows[2].duplicate_of_transaction_id).toBe(303);
+    expect(body.rows[2].pair_with_transaction_id).toBeNull();
+  });
 });

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -1,0 +1,290 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ImportPage from "@/app/import/page";
+import { apiFetch } from "@/lib/api";
+import type { ImportPreviewResponse, ImportPreviewRow } from "@/lib/types";
+
+// Mock Next.js navigation hooks. The page uses both useRouter and
+// useSearchParams; the latter must implement .get().
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const ACCOUNT = {
+  id: 1,
+  name: "Checking",
+  account_type_id: 1,
+  account_type_name: "Bank",
+  account_type_slug: "bank",
+  balance: 100,
+  currency: "EUR",
+  is_active: true,
+  close_day: null,
+  is_default: true,
+};
+
+const CATEGORY_EXP = {
+  id: 5,
+  name: "Groceries",
+  type: "expense" as const,
+  parent_id: null,
+  parent_name: null,
+  description: null,
+  slug: "groceries",
+  is_system: false,
+  transaction_count: 0,
+};
+
+const CATEGORY_INC = {
+  id: 6,
+  name: "Salary",
+  type: "income" as const,
+  parent_id: null,
+  parent_name: null,
+  description: null,
+  slug: "salary",
+  is_system: false,
+  transaction_count: 0,
+};
+
+function baseRow(overrides: Partial<ImportPreviewRow> = {}): ImportPreviewRow {
+  return {
+    row_number: 1,
+    date: "2026-05-01",
+    description: "Test row",
+    amount: 50,
+    type: "expense",
+    counterparty: null,
+    transaction_type: null,
+    is_duplicate: false,
+    duplicate_transaction_id: null,
+    suggested_category_id: null,
+    suggestion_source: null,
+    is_duplicate_of_linked_leg: false,
+    duplicate_candidate: null,
+    default_action_drop: false,
+    transfer_match_action: "none",
+    transfer_match_confidence: null,
+    pair_with_transaction_id: null,
+    transfer_candidates: [],
+    ...overrides,
+  };
+}
+
+function basePreview(rows: ImportPreviewRow[]): ImportPreviewResponse {
+  return {
+    rows,
+    account_id: 1,
+    file_name: "test.csv",
+    total_rows: rows.length,
+    duplicate_count: 0,
+    auto_paired_count: rows.filter((r) => r.transfer_match_action === "pair_with").length,
+    suggested_pair_count: rows.filter((r) => r.transfer_match_action === "suggest_pair").length,
+    multi_candidate_count: rows.filter((r) => r.transfer_match_action === "choose_candidate").length,
+    duplicate_of_linked_count: rows.filter((r) => r.is_duplicate_of_linked_leg).length,
+  };
+}
+
+/**
+ * Render the page, wait for accounts/categories to load (so the upload form
+ * shows), then trigger the file upload to drop the preview into state.
+ */
+async function renderAndPreview(preview: ImportPreviewResponse) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockImplementation(((url: string) => {
+    if (url === "/api/v1/accounts") return Promise.resolve([ACCOUNT]);
+    if (url === "/api/v1/categories") return Promise.resolve([CATEGORY_EXP, CATEGORY_INC]);
+    if (url === "/api/v1/import/preview") return Promise.resolve(preview);
+    return Promise.resolve(undefined);
+  }) as never);
+
+  render(<ImportPage />);
+
+  // Upload step renders once the categories array is populated.
+  const uploadButton = await screen.findByRole("button", { name: /upload & preview/i });
+
+  // Drop a fake CSV file onto the file input.
+  const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const file = new File(["date,desc,amt\n"], "test.csv", { type: "text/csv" });
+  fireEvent.change(fileInput, { target: { files: [file] } });
+
+  fireEvent.click(uploadButton);
+
+  // Wait for the preview table to render.
+  await screen.findByText("test.csv");
+}
+
+describe("ImportPage transfer pill column", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("renders Pair as transfer pill on same-day match", async () => {
+    const preview = basePreview([
+      baseRow({
+        row_number: 1,
+        transfer_match_action: "pair_with",
+        transfer_match_confidence: "same_day",
+        pair_with_transaction_id: 99,
+        transfer_candidates: [
+          {
+            id: 99,
+            date: "2026-05-01",
+            description: "Counter leg",
+            amount: 50,
+            account_id: 2,
+            account_name: "Savings",
+            date_diff_days: 0,
+            confidence: "same_day",
+          },
+        ],
+      }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    // Pill text visible.
+    const pill = await screen.findByTestId("transfer-pill-1");
+    expect(pill).toHaveTextContent("Pair as transfer");
+
+    // Click pill to open panel and assert checkbox is pre-checked.
+    fireEvent.click(pill);
+    const panel = await screen.findByTestId("transfer-panel-1");
+    const checkbox = panel.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("renders Possible transfer pill on near-date match without preselect", async () => {
+    const preview = basePreview([
+      baseRow({
+        row_number: 1,
+        transfer_match_action: "suggest_pair",
+        transfer_match_confidence: "near_date",
+        pair_with_transaction_id: 99,
+        transfer_candidates: [
+          {
+            id: 99,
+            date: "2026-04-29",
+            description: "Counter leg near",
+            amount: 50,
+            account_id: 2,
+            account_name: "Savings",
+            date_diff_days: 2,
+            confidence: "near_date",
+          },
+        ],
+      }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    const pill = await screen.findByTestId("transfer-pill-1");
+    expect(pill.textContent).toMatch(/Possible transfer/);
+    expect(pill.textContent).toMatch(/±2 days/);
+
+    fireEvent.click(pill);
+    const panel = await screen.findByTestId("transfer-panel-1");
+    const checkbox = panel.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("renders Multiple candidates pill that opens chooser", async () => {
+    const preview = basePreview([
+      baseRow({
+        row_number: 1,
+        transfer_match_action: "choose_candidate",
+        transfer_match_confidence: "multi_candidate",
+        pair_with_transaction_id: null,
+        transfer_candidates: [
+          {
+            id: 101,
+            date: "2026-05-01",
+            description: "First candidate",
+            amount: 50,
+            account_id: 2,
+            account_name: "Savings",
+            date_diff_days: 0,
+            confidence: "same_day",
+          },
+          {
+            id: 102,
+            date: "2026-04-30",
+            description: "Second candidate",
+            amount: 50,
+            account_id: 3,
+            account_name: "Brokerage",
+            date_diff_days: 1,
+            confidence: "near_date",
+          },
+        ],
+      }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    const pill = await screen.findByTestId("transfer-pill-1");
+    expect(pill).toHaveTextContent("Multiple candidates");
+
+    // Click pill to open chooser panel.
+    fireEvent.click(pill);
+    const panel = await screen.findByTestId("transfer-panel-1");
+
+    // Both candidates plus the "Skip — don't pair" radio.
+    const radios = panel.querySelectorAll('input[type="radio"]');
+    expect(radios.length).toBe(3);
+
+    expect(panel.textContent).toContain("First candidate");
+    expect(panel.textContent).toContain("Second candidate");
+
+    // Closest hint is rendered next to candidate 0.
+    expect(panel.textContent).toContain("closest");
+  });
+
+  it("renders Drop as duplicate pill with synthetic-leg badge when existing_leg_is_imported is false", async () => {
+    const preview = basePreview([
+      baseRow({
+        row_number: 1,
+        is_duplicate_of_linked_leg: true,
+        default_action_drop: true,
+        duplicate_candidate: {
+          id: 77,
+          date: "2026-05-01",
+          description: "Existing linked leg",
+          amount: 50,
+          account_id: 1,
+          account_name: "Checking",
+          existing_leg_is_imported: false,
+        },
+      }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    const pill = await screen.findByTestId("transfer-pill-1");
+    expect(pill).toHaveTextContent("Drop as duplicate");
+
+    fireEvent.click(pill);
+    const panel = await screen.findByTestId("transfer-panel-1");
+    expect(panel.textContent).toContain("Synthetic leg from convert-to-transfer");
+
+    // Default Drop checkbox is pre-checked.
+    const checkbox = panel.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

PR-E lands the **frontend wiring on `/import`** for the new transfer detectors and confirm-action mapping. This is the final PR in the transfers-between-accounts series. Depends only on PR-C's backend (already merged); runs disjoint from PR-D (which targets `/transactions`).

### Type updates (`lib/types.ts`)

`ImportPreviewRow` and `ImportPreviewResponse` updated to match the post-PR-C backend schema:
- `ImportPreviewRow` drops `is_potential_transfer`. Adds `is_duplicate_of_linked_leg`, `duplicate_candidate`, `default_action_drop`, `transfer_match_action`, `transfer_match_confidence`, `pair_with_transaction_id`, `transfer_candidates`.
- `ImportPreviewResponse` drops `transfer_candidate_count`. Adds `auto_paired_count`, `suggested_pair_count`, `multi_candidate_count`, `duplicate_of_linked_count`.

### Transfer pill column on `/import` (E1.2)

New per-row pill rendered in the preview table, state-driven by the per-row `transfer_match_action` and `is_duplicate_of_linked_leg`:

| State | Pill text | Default |
|---|---|---|
| `pair_with` (same_day) | "Pair as transfer" | accepted (opt-out) |
| `suggest_pair` (near_date) | "Possible transfer (±N days)" | not accepted (opt-in) |
| `choose_candidate` | "Multiple candidates" | n/a — chooser opens |
| `is_duplicate_of_linked_leg` | "Drop as duplicate" | drop accepted (opt-out) |

Inline panel below each row when the pill is clicked:
- Pair: candidate metadata + Pair / Don't pair checkbox.
- Choose: radio list of `transfer_candidates` (closest pre-highlighted but NOT pre-selected) + "Skip — don't pair" option.
- Drop: matched leg metadata + "Synthetic leg from convert-to-transfer" badge when `existing_leg_is_imported === false` + Drop / Keep both toggle.

State stored as a parallel `Record<number, TransferUiState>` keyed by `row_number` (UI-only state; doesn't touch the confirm payload).

### Review pairings filter + confirm payload mapping (E2)

- New top-of-table toggle "Review pairings only" with summary counts (auto-paired / suggested / multi-candidate / duplicate). When on, filters rows to those with `transfer_match_action !== "none"` OR `is_duplicate_of_linked_leg === true`.
- Pure `buildConfirmRow(rowState, preview, ui)` helper maps each row to the right `action`:
  - `drop_as_duplicate` when row is duplicate-of-linked-leg AND user kept the drop default. Sets `duplicate_of_transaction_id`.
  - `pair_with_existing` when match is accepted (single-candidate accepted, or multi-candidate selected). Sets `pair_with_transaction_id` from preview or selection.
  - `create` otherwise (transfer fields cleared).
- Confirm submission maps every row through the helper and submits the resulting `ImportConfirmRow[]`.
- `skip` semantics untouched — `action="drop_as_duplicate"` is server-side; `skip=true` remains client-side don't-submit.

### Tests

- 6 new tests in `frontend/tests/app/import-page.test.tsx` (4 from E1.2 + 2 from E2): pill rendering per state, synthetic-leg badge, Review filter, action-mapping payload.
- Frontend baseline: 61 → **67 passed** (+6).
- Build: passes.

### Sizing

+942 / -67 across 3 files (1 component, 1 type file, 1 new test file).

### Non-goals

- Backend was untouched; PR-C already shipped detectors + confirm branches + revalidation.
- Cross-currency D-track remains deferred indefinitely.

Spec: \`~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-03-transfers-between-accounts-design.md\` §3.2, §4.6.