### PR TITLE
feat(infra): self-hosted MySQL + Redis droplet (terraform + ansible)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,5 +1,16 @@
 name: pfv
 region: ams
+# After running `infra/terraform apply`, set this to
+# `terraform -chdir=infra/terraform output -raw vpc_id` and uncomment.
+# Required for App Platform -> droplet private-IP connectivity once
+# DATABASE_URL / REDIS_URL point at the droplet's 10.42.x.x address.
+# Without it, the app cannot reach the droplet's private interface even
+# if the cloud firewall allows the VPC CIDR.
+# See https://docs.digitalocean.com/products/app-platform/how-to/enable-vpc/
+# Push the spec via `doctl apps update <APP_ID> --spec .do/app.yaml`
+# (NOT via the GH Action — see reference_do_spec_sync.md).
+# vpc:
+#   id: REPLACE_WITH_VPC_UUID_FROM_TERRAFORM
 # Custom domain MUST stay declared here. With `app_spec_location` driving
 # every deploy, anything missing from this file is removed from the live
 # app on push — same failure mode as missing SECRET envs. Stripping the

--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -83,12 +83,20 @@ comfort.
 
 ### 2. Quiesce the app
 
-Take the App Platform service offline so no writes happen during the dump:
+Take the App Platform service offline so no writes happen during the dump.
+Easiest path is the DO web console, which avoids hand-crafting a separate
+zero-instance spec file:
+
+> **DO console** -> App -> Components -> `backend` -> Settings ->
+> Resize -> set instance count to `0` -> Save. App Platform redeploys
+> with no backend replica.
+
+CLI alternative (if you prefer to script it):
 
 ```bash
-# Scale backend to 0 instances. Adjust component name as needed.
-doctl apps update <app-id> --spec <path-to-spec-with-instance-count-zero>
-# Or use the UI: App -> Components -> backend -> Settings -> 0 instances.
+# Edit a copy of .do/app.yaml, set services.backend.instance_count: 0,
+# then push that copy. Restore the original count in step 7.
+doctl apps update <app-id> --spec /tmp/app.yaml.zero
 ```
 
 Confirm `/health` returns "service unavailable" (or the route 502s) before
@@ -117,6 +125,14 @@ mysqldump \
 (`--set-gtid-purged=OFF` keeps the dump portable; the new droplet isn't a
 GTID replica.)
 
+Verify the gzip is intact before moving on — a partial dump can silently
+import most of the data and you only notice rows are missing during smoke
+tests:
+
+```bash
+gunzip -t pfv2_*.sql.gz && echo "dump intact"
+```
+
 ### 4. Import into the droplet
 
 Copy the dump up:
@@ -134,6 +150,8 @@ sudo bash -c 'gunzip -c /var/backups/mysql/migration/pfv2_*.sql.gz | mysql pfv2'
 
 ### 5. Verify
 
+Row counts on the droplet:
+
 ```bash
 mysql pfv2 -e 'SHOW TABLES'
 mysql pfv2 -e 'SELECT COUNT(*) FROM users'
@@ -143,6 +161,21 @@ mysql pfv2 -e 'SELECT COUNT(*) FROM accounts'
 
 Counts should match the managed DB. If you can pre-record managed-side
 counts in step 3, do so and diff here.
+
+Schema sanity (catches a silent migration drift between source and target):
+
+```bash
+# On a workstation with access to both endpoints — managed side:
+mysqldump --no-data --skip-comments \
+  -h <managed-host> -P <managed-port> -u doadmin -p \
+  --ssl-mode=REQUIRED pfv2 | sha256sum
+
+# Droplet side, run as root:
+sudo mysqldump --no-data --skip-comments pfv2 | sha256sum
+```
+
+The two checksums should match. A diff here means CREATE TABLE / INDEX
+DDL drifted somewhere — investigate before proceeding.
 
 ### 6. Update App Platform secrets
 
@@ -162,18 +195,27 @@ future deploys will run Alembic against the OLD database while the app
 serves from the NEW one. State diverges silently and you will not notice
 until something breaks.
 
-Two ways to apply (pick one):
+Two ways to apply, in order of preference:
 
-- **DO web console:** App -> Settings -> per-component "Environment
-  Variables" -> edit each of the three secret values listed above. Saving
-  triggers a redeploy that re-encrypts the new plaintext.
-- **Spec file + doctl** (preferred, matches the rest of this runbook):
-  edit `.do/app.yaml`, replace the three encrypted `EV[...]` values with
-  the new plaintext (App Platform re-encrypts on save), then push:
+- **DO web console** (RECOMMENDED): App -> Settings -> per-component
+  "Environment Variables" -> edit each of the three secret values listed
+  above. Saving triggers a redeploy that re-encrypts the new plaintext.
+  The plaintext only ever sits in the browser form field; nothing hits
+  the local filesystem.
+- **Spec file + doctl** (only if you must script it): edit `.do/app.yaml`,
+  replace the three encrypted `EV[...]` values with the new plaintext
+  (App Platform re-encrypts on save), push, then **immediately** overwrite
+  the file with the re-encrypted spec from step 9 below.
 
   ```bash
   doctl apps update <APP_ID> --spec .do/app.yaml
   ```
+
+  > **Footgun.** The committed `.do/app.yaml` briefly contains plaintext
+  > `DATABASE_URL` / `REDIS_URL` on disk between edit and the next git
+  > checkout. Do not commit / push the file in that state, do not
+  > screenshot it, and proceed to step 9 to fetch the re-encrypted spec
+  > before doing anything else.
 
   Per `reference_do_spec_sync.md`, this MUST be a direct `doctl` push;
   the `digitalocean/app_action/deploy@v2` GH Action silently prefers

--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -8,12 +8,11 @@ PFV dataset today. Mostly waiting on dump + import.
 
 ## Pre-flight checklist
 
-- [ ] Terraform applied; droplet reachable via `ssh root@<public_ipv4>`.
+- [ ] TFC apply on `FlamaCorp/pfv` succeeded; droplet reachable via
+      `ssh root@<public_ipv4>` (fetch the IP from TFC outputs or
+      `terraform -chdir=infra/terraform output -raw droplet_public_ipv4`).
 - [ ] Ansible playbook applied; `mysql --version` and `redis-cli ping` work
       on the droplet.
-- [ ] App Platform's outbound VPC routing reaches the droplet's private IP.
-      Sanity check from a worker / ad-hoc droplet inside the VPC:
-      `mysql -h <droplet_private_ipv4> -u pfv_app -p -e 'SELECT 1'`.
 - [ ] Latest weekly DO backup of the managed DB exists. As an extra belt:
       take a fresh mysqldump from the managed DB endpoint (see step 4) before
       the cutover starts.
@@ -21,6 +20,12 @@ PFV dataset today. Mostly waiting on dump + import.
 - [ ] App Platform spec file checked out and ready to edit (per
       `reference_do_spec_sync.md`: deploy via direct `doctl apps update`,
       not the GitHub deploy action).
+
+> **Note on private-IP reachability.** App Platform cannot reach the droplet's
+> 10.42.x.x address until Step 0 below attaches the app to the VPC. Don't try
+> to verify that before Step 0. To verify the *droplet side* end-to-end
+> earlier, spin up a one-shot droplet inside the VPC and run
+> `mysql -h <droplet_private_ipv4> -u pfv_app -p -e 'SELECT 1'` from there.
 
 ## Cutover
 

--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -1,0 +1,196 @@
+# Migration runbook: managed MySQL + Redis -> self-hosted droplet
+
+Source of truth for moving prod data from DO Managed MySQL + Managed Redis to
+the new `pfv-data-01` droplet provisioned by `infra/terraform`.
+
+Plan window: pick a quiet hour. Total downtime: ~10–20 min for the size of the
+PFV dataset today. Mostly waiting on dump + import.
+
+## Pre-flight checklist
+
+- [ ] Terraform applied; droplet reachable via `ssh root@<public_ipv4>`.
+- [ ] Ansible playbook applied; `mysql --version` and `redis-cli ping` work
+      on the droplet.
+- [ ] App Platform's outbound VPC routing reaches the droplet's private IP.
+      Sanity check from a worker / ad-hoc droplet inside the VPC:
+      `mysql -h <droplet_private_ipv4> -u pfv_app -p -e 'SELECT 1'`.
+- [ ] Latest weekly DO backup of the managed DB exists. As an extra belt:
+      take a fresh mysqldump from the managed DB endpoint (see step 4) before
+      the cutover starts.
+- [ ] `doctl` configured and authenticated locally.
+- [ ] App Platform spec file checked out and ready to edit (per
+      `reference_do_spec_sync.md`: deploy via direct `doctl apps update`,
+      not the GitHub deploy action).
+
+## Cutover
+
+### 1. Snapshot the managed DB (belt-and-suspenders)
+
+DO control panel -> Databases -> pfv mysql cluster -> Backups -> "Create
+backup". Wait until it shows up green. Or via API:
+
+```bash
+doctl databases backups list <db-cluster-id>
+```
+
+Skip this if the most recent automated backup is fresh enough for your
+comfort.
+
+### 2. Quiesce the app
+
+Take the App Platform service offline so no writes happen during the dump:
+
+```bash
+# Scale backend to 0 instances. Adjust component name as needed.
+doctl apps update <app-id> --spec <path-to-spec-with-instance-count-zero>
+# Or use the UI: App -> Components -> backend -> Settings -> 0 instances.
+```
+
+Confirm `/health` returns "service unavailable" (or the route 502s) before
+moving on.
+
+### 3. Dump from managed MySQL
+
+From a workstation or one-shot droplet that has network access to the managed
+DB:
+
+```bash
+mysqldump \
+  --single-transaction \
+  --routines \
+  --triggers \
+  --quick \
+  --hex-blob \
+  --set-gtid-purged=OFF \
+  -h <managed-host> \
+  -P <managed-port> \
+  -u doadmin -p \
+  --ssl-mode=REQUIRED \
+  pfv2 | gzip > pfv2_$(date +%Y%m%d-%H%M%S).sql.gz
+```
+
+(`--set-gtid-purged=OFF` keeps the dump portable; the new droplet isn't a
+GTID replica.)
+
+### 4. Import into the droplet
+
+Copy the dump up:
+
+```bash
+scp pfv2_*.sql.gz root@<droplet_public_ipv4>:/var/backups/mysql/migration/
+```
+
+On the droplet:
+
+```bash
+gunzip -c /var/backups/mysql/migration/pfv2_*.sql.gz | mysql pfv2
+```
+
+(Root creds are in `/root/.my.cnf` thanks to the mysql role.)
+
+### 5. Verify
+
+```bash
+mysql pfv2 -e 'SHOW TABLES'
+mysql pfv2 -e 'SELECT COUNT(*) FROM users'
+mysql pfv2 -e 'SELECT COUNT(*) FROM transactions'
+mysql pfv2 -e 'SELECT COUNT(*) FROM accounts'
+```
+
+Counts should match the managed DB. If you can pre-record managed-side
+counts in step 3, do so and diff here.
+
+### 6. Update App Platform secrets
+
+Edit the App Platform spec file directly and push with `doctl` (the
+`digitalocean/app_action/deploy` GH Action silently prefers `app_name` over
+the spec; see `reference_do_spec_sync.md`):
+
+```yaml
+envs:
+  - key: DATABASE_URL
+    scope: RUN_TIME
+    type: SECRET
+    value: mysql+aiomysql://pfv_app:<password>@<droplet_private_ipv4>:3306/pfv2
+  - key: REDIS_URL
+    scope: RUN_TIME
+    type: SECRET
+    value: redis://default:<password>@<droplet_private_ipv4>:6379/0
+```
+
+Push:
+
+```bash
+doctl apps update <app-id> --spec .do/app.yaml
+```
+
+### 7. Bring the app up
+
+Scale instances back to 1+:
+
+```bash
+# Same spec, instance_count restored to >=1.
+doctl apps update <app-id> --spec .do/app.yaml
+```
+
+Watch the deploy:
+
+```bash
+doctl apps logs <app-id> --type RUN --follow
+```
+
+Wait for `/api/v1/health` and `/api/v1/ready` to go green.
+
+### 8. Smoke test (manual)
+
+- [ ] Log in.
+- [ ] Open the dashboard. Charts render.
+- [ ] Create a transaction.
+- [ ] Run a CSV import.
+- [ ] Hit the rate-limited endpoint a few times rapidly. Expect 429 after
+      threshold (confirms Redis rate-limit storage works).
+- [ ] Check `/var/log/mysql/slow.log` on the droplet for any unexpected
+      slow queries during the smoke test.
+
+### 9. Decommission grace period
+
+Keep the managed DB and Redis running for 24h with no writes. If anything
+goes wrong you can flip `DATABASE_URL`/`REDIS_URL` back and redeploy.
+
+After 24h of clean operation:
+
+```bash
+doctl databases delete <mysql-cluster-id>
+doctl databases delete <redis-cluster-id>
+```
+
+## Rollback
+
+If smoke tests fail or production behaves badly:
+
+1. Revert the App Platform spec change (replace `DATABASE_URL` and
+   `REDIS_URL` with the managed endpoints).
+2. `doctl apps update <app-id> --spec .do/app.yaml` to redeploy with the
+   prior config.
+3. Investigate the droplet path before retrying. Common causes:
+   - VPC peering not actually attached (check the droplet is in the VPC
+     used by App Platform).
+   - MySQL `bind-address` left at `127.0.0.1` (check
+     `/etc/mysql/mysql.conf.d/pfv.cnf`).
+   - ufw blocking the connection (check `ufw status verbose`).
+   - Firewall rule missing (`doctl compute firewall list`).
+   - Wrong password on `pfv_app` (check `/root/.my.cnf` and the secret).
+
+## Posture notes
+
+- MySQL listens on `0.0.0.0`. MySQL 8 only accepts a single `bind-address`,
+  so we rely on the DO Cloud Firewall + host ufw to restrict to VPC. Both
+  layers must allow 3306 from the VPC CIDR for App Platform to connect.
+- Redis is bound to `127.0.0.1 <private_ipv4>` and `requirepass` is set.
+  Auth + VPC + protected-mode all required.
+- No TLS on either service. Traffic stays inside DO's VPC; revisit if we
+  add a second region or move to a multi-tenant network.
+- Backups: nightly logical dump in `/var/backups/mysql/` (7-day retention)
+  plus DO weekly droplet snapshots. To restore: copy a `.sql.gz` off the
+  droplet, `gunzip -c <file> | mysql pfv2`. Or restore the snapshot from the
+  DO console and re-point DNS / spec at the new droplet.

--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -24,6 +24,46 @@ PFV dataset today. Mostly waiting on dump + import.
 
 ## Cutover
 
+### 0. Attach App Platform to the new VPC
+
+App Platform components live in their own DO-managed VPC by default and can't
+reach the droplet's private IP until the app is explicitly attached to the
+VPC the droplet sits in. Per
+[DO's enable-VPC docs](https://docs.digitalocean.com/products/app-platform/how-to/enable-vpc/),
+this is a top-level `vpc:` block on the app spec.
+
+1. Get the VPC UUID:
+
+   ```bash
+   terraform -chdir=infra/terraform output -raw vpc_id
+   ```
+
+2. Edit `.do/app.yaml`, uncomment the top-level `vpc:` block, paste the UUID:
+
+   ```yaml
+   vpc:
+     id: <vpc-uuid-from-step-1>
+   ```
+
+3. Push the spec via `doctl` (NOT the GitHub deploy action — per
+   `reference_do_spec_sync.md`, `digitalocean/app_action/deploy@v2` silently
+   prefers `app_name` over `app_spec_location`, so the spec file never reaches
+   prod via that path):
+
+   ```bash
+   doctl apps update <APP_ID> --spec .do/app.yaml
+   ```
+
+4. Wait for the deploy to finish, then verify the VPC is attached:
+
+   ```bash
+   doctl apps get <APP_ID>
+   ```
+
+   The output should include `vpc.id = <vpc-uuid>`. If the field is empty,
+   the spec didn't take — re-run the `update` and watch the response, do not
+   proceed to "Quiesce the app" until VPC attachment is confirmed.
+
 ### 1. Snapshot the managed DB (belt-and-suspenders)
 
 DO control panel -> Databases -> pfv mysql cluster -> Backups -> "Create
@@ -80,13 +120,12 @@ Copy the dump up:
 scp pfv2_*.sql.gz root@<droplet_public_ipv4>:/var/backups/mysql/migration/
 ```
 
-On the droplet:
+On the droplet (run as root via `sudo` — root@localhost uses Ubuntu's
+default socket-auth plugin, so no password is needed):
 
 ```bash
-gunzip -c /var/backups/mysql/migration/pfv2_*.sql.gz | mysql pfv2
+sudo bash -c 'gunzip -c /var/backups/mysql/migration/pfv2_*.sql.gz | mysql pfv2'
 ```
-
-(Root creds are in `/root/.my.cnf` thanks to the mysql role.)
 
 ### 5. Verify
 
@@ -102,27 +141,48 @@ counts in step 3, do so and diff here.
 
 ### 6. Update App Platform secrets
 
-Edit the App Platform spec file directly and push with `doctl` (the
-`digitalocean/app_action/deploy` GH Action silently prefers `app_name` over
-the spec; see `reference_do_spec_sync.md`):
+App Platform stores secrets per-component and does NOT auto-inherit them
+across components. The `pfv` spec has THREE secret values that must all be
+updated atomically to point at the droplet:
 
-```yaml
-envs:
-  - key: DATABASE_URL
-    scope: RUN_TIME
-    type: SECRET
-    value: mysql+aiomysql://pfv_app:<password>@<droplet_private_ipv4>:3306/pfv2
-  - key: REDIS_URL
-    scope: RUN_TIME
-    type: SECRET
-    value: redis://default:<password>@<droplet_private_ipv4>:6379/0
-```
+| Component | Secret | New value |
+|---|---|---|
+| `services.backend.envs[DATABASE_URL]` | `DATABASE_URL` | `mysql+aiomysql://pfv_app:<PASSWORD>@<DROPLET_PRIVATE_IPV4>:3306/pfv2` |
+| `services.backend.envs[REDIS_URL]` | `REDIS_URL` | `redis://:<REDIS_PASSWORD>@<DROPLET_PRIVATE_IPV4>:6379/0` |
+| `jobs.migrate.envs[DATABASE_URL]` | `DATABASE_URL` | (same as backend's `DATABASE_URL` above) |
 
-Push:
+**WARNING:** if you only update the backend service's `DATABASE_URL` but
+leave the migrate pre-deploy job pointing at the old managed cluster,
+future deploys will run Alembic against the OLD database while the app
+serves from the NEW one. State diverges silently and you will not notice
+until something breaks.
+
+Two ways to apply (pick one):
+
+- **DO web console:** App -> Settings -> per-component "Environment
+  Variables" -> edit each of the three secret values listed above. Saving
+  triggers a redeploy that re-encrypts the new plaintext.
+- **Spec file + doctl** (preferred, matches the rest of this runbook):
+  edit `.do/app.yaml`, replace the three encrypted `EV[...]` values with
+  the new plaintext (App Platform re-encrypts on save), then push:
+
+  ```bash
+  doctl apps update <APP_ID> --spec .do/app.yaml
+  ```
+
+  Per `reference_do_spec_sync.md`, this MUST be a direct `doctl` push;
+  the `digitalocean/app_action/deploy@v2` GH Action silently prefers
+  `app_name` over `app_spec_location` and will not push the file.
+
+The `EV[...]` form for each secret can be retrieved from the live spec
+afterwards:
 
 ```bash
-doctl apps update <app-id> --spec .do/app.yaml
+doctl apps spec get <APP_ID> --format yaml
 ```
+
+Copy the freshly-encrypted blocks back into `.do/app.yaml` so the
+committed spec stays authoritative for future deploys.
 
 ### 7. Bring the app up
 
@@ -179,7 +239,10 @@ If smoke tests fail or production behaves badly:
      `/etc/mysql/mysql.conf.d/pfv.cnf`).
    - ufw blocking the connection (check `ufw status verbose`).
    - Firewall rule missing (`doctl compute firewall list`).
-   - Wrong password on `pfv_app` (check `/root/.my.cnf` and the secret).
+   - Wrong password on `pfv_app` (compare the App Platform secret value
+     with what was set in `infra/ansible/inventory.yml` /
+     `mysql_app_password`; root@localhost is socket-auth, no password to
+     check there).
 
 ## Posture notes
 

--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -212,12 +212,73 @@ Wait for `/api/v1/health` and `/api/v1/ready` to go green.
 - [ ] Check `/var/log/mysql/slow.log` on the droplet for any unexpected
       slow queries during the smoke test.
 
-### 9. Decommission grace period
+### 9. Persist the live spec to `.do/app.yaml` (REQUIRED before next deploy)
+
+> **Why this step exists.** The GitHub Actions deploy workflow at
+> `.github/workflows/deploy.yml` pushes the committed `.do/app.yaml` as
+> the authoritative spec on every merge to `main`. After the cutover
+> above, the **live** spec on App Platform has the correct `vpc.id` and
+> the new encrypted `EV[...]` secret blobs for `DATABASE_URL` (backend
+> and migrate job) and `REDIS_URL`. The **committed** file does not.
+> If you skip this step, the next normal deploy reverts the live spec
+> back to the committed file, dropping VPC attachment and / or pointing
+> secrets at whatever was there before.
+
+This gate runs after smoke tests pass and BEFORE you decommission the
+managed databases (so you can roll back if you find a problem in the
+diff).
+
+#### 9a. Fetch the live spec
+
+```bash
+doctl apps spec get <APP_ID> --format yaml > /tmp/live-app.yaml
+```
+
+#### 9b. Diff against the committed file
+
+```bash
+diff -u .do/app.yaml /tmp/live-app.yaml | less
+```
+
+The diff should show exactly:
+
+- `vpc:` block at the top level with the real VPC UUID (uncommented).
+- `services.backend.envs[DATABASE_URL]` — new `EV[...]` blob.
+- `services.backend.envs[REDIS_URL]` — new `EV[...]` blob.
+- `jobs.migrate.envs[DATABASE_URL]` — new `EV[...]` blob.
+
+Anything else (instance counts, regions, env-var values you didn't
+touch) MUST match. If something else differs, investigate before
+proceeding — the live spec may have drifted from its source-of-truth.
+
+#### 9c. Update the committed file
+
+Copy the verified differences from `/tmp/live-app.yaml` into
+`.do/app.yaml`. Keep the existing comments / structure intact; only
+swap the four target sections (vpc + three EV blobs).
+
+#### 9d. Commit and push
+
+```bash
+git checkout -b chore/post-cutover-spec-persist
+git add .do/app.yaml
+git diff --staged                       # final read-through
+git commit -m "chore(infra): persist post-cutover app spec (vpc + 3 EV secrets)"
+git push -u origin chore/post-cutover-spec-persist
+gh pr create --title "chore(infra): persist post-cutover app spec" --body "Reflects the live App Platform state after the managed-to-droplet cutover. Required before any subsequent main deploy or the GH Actions workflow will revert vpc.id and rotate secrets back to pre-cutover values."
+```
+
+Merge that PR before any other change lands on `main`. Until it's
+merged, **do NOT** trigger a deploy via merge-to-main: it will overwrite
+the live spec.
+
+### 10. Decommission grace period
 
 Keep the managed DB and Redis running for 24h with no writes. If anything
-goes wrong you can flip `DATABASE_URL`/`REDIS_URL` back and redeploy.
+goes wrong you can flip `DATABASE_URL`/`REDIS_URL` back and redeploy
+(rollback section below).
 
-After 24h of clean operation:
+After 24h of clean operation AND step 9 has merged:
 
 ```bash
 doctl databases delete <mysql-cluster-id>

--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -233,12 +233,31 @@ committed spec stays authoritative for future deploys.
 
 ### 7. Bring the app up
 
-Scale instances back to 1+:
+> **CRITICAL.** This step MUST mirror the path you chose in step 6. If
+> you took the console path in step 6, the local `.do/app.yaml` still
+> contains the OLD `EV[...]` blobs (encrypted to the managed-DB / managed-
+> Redis URLs). Pushing that file here via `doctl apps update --spec`
+> reverts the live secrets and silently re-points the app at the old
+> managed services.
 
-```bash
-# Same spec, instance_count restored to >=1.
-doctl apps update <app-id> --spec .do/app.yaml
-```
+Pick the matching path:
+
+- **Console path (matches step 6 console option, RECOMMENDED):** in the DO
+  web console, App -> Components -> `backend` -> Settings -> Resize -> set
+  instance count back to its prior value (1+). Save. App Platform
+  redeploys with the new (droplet-pointing) secrets already in place.
+  Do NOT push local `.do/app.yaml` from this machine.
+
+- **CLI path (only if step 6 used `doctl apps update --spec`):** push local
+  `.do/app.yaml` ONLY after step 9 below has already replaced the three
+  `EV[...]` blobs locally with the freshly-encrypted forms. If step 9
+  hasn't happened yet, scale back up by editing the live spec instead:
+
+  ```bash
+  doctl apps spec get <APP_ID> --format yaml > /tmp/live-app.yaml
+  # In /tmp/live-app.yaml: bump services.backend.instance_count back to 1+.
+  doctl apps update <APP_ID> --spec /tmp/live-app.yaml
+  ```
 
 Watch the deploy:
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,126 @@
+# pfv infra
+
+Self-hosted MySQL + Redis on a single DigitalOcean droplet, replacing the DO
+Managed MySQL + Managed Redis pair (~$30/mo) with one `s-1vcpu-1gb` droplet
+(~$6/mo + ~$1.20/mo for backups).
+
+This folder owns the cloud and the box. App Platform spec lives elsewhere.
+
+## What's here
+
+- `terraform/` — DO VPC, droplet, cloud firewall, project attachment.
+- `ansible/` — Ubuntu 24.04 bootstrap: hardening, MySQL, Redis, nightly backups.
+- `MIGRATION.md` — runbook for moving data off the managed services.
+
+## Architecture
+
+```
+                     ┌────────────────────────────┐
+                     │  DO App Platform (ams)     │
+                     │   pfv backend / frontend   │
+                     └──────────────┬─────────────┘
+                                    │ VPC peering
+                                    ▼
+              VPC 10.42.0.0/24 ┌────────────────────────────┐
+                               │  pfv-data-01 (s-1vcpu-1gb) │
+                               │   - MySQL 8 (3306)         │
+                               │   - Redis  (6379)          │
+                               │   - ufw + fail2ban         │
+                               │   - nightly mysqldump      │
+                               └────────────────────────────┘
+                                    ▲
+                                    │ SSH (key auth) — public IPv4
+                                    │
+                                  operator
+```
+
+DO Cloud Firewall: SSH 22 from any IPv4, MySQL 3306 + Redis 6379 from VPC CIDR
+only. ICMP from VPC. ufw on the host repeats the same restrictions.
+
+## Prerequisites
+
+- A DO API token with read/write scope. Set `TF_VAR_do_token` or fill
+  `terraform.tfvars`.
+- An SSH key already registered in DO (Settings -> Security). Note its name.
+- A DO project named `pfv` (or change `project_name`). Projects must be
+  created from the UI or `doctl` first; we don't manage them in Terraform.
+- Local tooling: `terraform >= 1.5`, `ansible >= 2.16`, `doctl` (optional but
+  handy for sanity checks).
+
+## Step-by-step
+
+### 1. Provision (Terraform)
+
+```bash
+cd infra/terraform
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars   # fill do_token + ssh_key_name
+terraform init
+terraform plan
+terraform apply
+```
+
+Note the outputs:
+
+```bash
+terraform output droplet_public_ipv4
+terraform output droplet_private_ipv4
+terraform output vpc_id
+```
+
+State file (`terraform.tfstate`) is local and gitignored. If multiple operators
+need to run this, switch to a DO Spaces backend before sharing.
+
+### 2. Configure (Ansible)
+
+```bash
+cd ../ansible
+cp inventory.yml.example inventory.yml
+$EDITOR inventory.yml
+# Fill in:
+#   ansible_host       = $(terraform -chdir=../terraform output -raw droplet_public_ipv4)
+#   private_ipv4       = $(terraform -chdir=../terraform output -raw droplet_private_ipv4)
+#   mysql_app_password = <generated>
+#   mysql_root_password = <generated>
+#   redis_password     = <generated>
+
+ansible-galaxy collection install -r requirements.yml
+ansible-playbook playbooks/site.yml
+```
+
+Recommended: `ansible-vault encrypt_string` the three passwords or move them
+into a vault-encrypted vars file. `inventory.yml` is gitignored to keep
+plain-text creds out of the repo even by accident.
+
+### 3. Wire App Platform
+
+Update App Platform secrets (separate PR / runbook step):
+
+```
+DATABASE_URL=mysql+aiomysql://pfv_app:<password>@<droplet_private_ipv4>:3306/pfv2
+REDIS_URL=redis://default:<password>@<droplet_private_ipv4>:6379/0
+```
+
+See `MIGRATION.md` for the full data-move runbook (including rollback).
+
+## Day-2
+
+- **Inspect droplet metrics**: DO control panel -> Droplets -> pfv-data-01 ->
+  Graphs. CPU, memory, disk, and network are graphed for free.
+- **Watch backups**: `ls -lh /var/backups/mysql/` on the droplet. Logs at
+  `/var/log/mysql-backup.log`.
+- **Apply OS updates**: unattended-upgrades runs daily; reboots are manual.
+  `sudo apt update && sudo apt upgrade && sudo reboot` during a quiet window.
+- **Rotate creds**: re-run the playbook with new vault values; restart
+  services as the handlers fire.
+
+## Teardown
+
+```bash
+cd infra/terraform
+terraform destroy
+```
+
+Warning: this destroys the droplet and its data. Pull a final `mysqldump`
+first (see `MIGRATION.md`) and verify weekly snapshots are also gone if you
+intend a clean break.

--- a/infra/README.md
+++ b/infra/README.md
@@ -78,11 +78,16 @@ cd ../ansible
 cp inventory.yml.example inventory.yml
 $EDITOR inventory.yml
 # Fill in:
-#   ansible_host       = $(terraform -chdir=../terraform output -raw droplet_public_ipv4)
-#   private_ipv4       = $(terraform -chdir=../terraform output -raw droplet_private_ipv4)
-#   mysql_app_password = <generated>
-#   mysql_root_password = <generated>
-#   redis_password     = <generated>
+#   ansible_host          = $(terraform -chdir=../terraform output -raw droplet_public_ipv4)
+#   private_ipv4          = $(terraform -chdir=../terraform output -raw droplet_private_ipv4)
+#   mysql_app_password    = <generated>
+#   mysql_backup_password = <generated>
+#   redis_password        = <generated>
+#
+# Note: we intentionally do NOT manage a password for root@localhost.
+# Ubuntu MySQL ships with auth_socket on root, and we keep that — local
+# maintenance is `sudo mysql`. Cron mysqldump uses the dedicated
+# mysql_backup user via /root/.my.cnf.
 
 ansible-galaxy collection install -r requirements.yml
 ansible-playbook playbooks/site.yml

--- a/infra/README.md
+++ b/infra/README.md
@@ -49,27 +49,35 @@ only. ICMP from VPC. ufw on the host repeats the same restrictions.
 
 ## Step-by-step
 
-### 1. Provision (Terraform)
+### 1. Provision (Terraform Cloud)
+
+State and runs live in Terraform Cloud, workspace `FlamaCorp/pfv`, VCS-driven
+against this repo with the working directory and trigger paths both scoped to
+`infra/terraform/`. Workflow:
+
+1. Open a PR that touches `infra/terraform/**`. TFC posts a speculative plan
+   on the run page.
+2. Merge to `main`. TFC starts an apply run. Apply method is **manual confirm**
+   on the TFC UI for now (flip to auto-apply after a few clean cycles).
+
+The workspace expects two variables to be set ahead of time:
+
+- `do_token` — sensitive, the DO API token (scoped per `infra/README.md`).
+- `ssh_key_name` — plaintext, the name of an SSH key already registered in DO.
+
+After the apply succeeds, fetch the outputs from TFC (Workspace -> Outputs)
+or via the CLI once `terraform login` is configured locally:
 
 ```bash
-cd infra/terraform
-cp terraform.tfvars.example terraform.tfvars
-$EDITOR terraform.tfvars   # fill do_token + ssh_key_name
-terraform init
-terraform plan
-terraform apply
+terraform -chdir=infra/terraform output droplet_public_ipv4
+terraform -chdir=infra/terraform output droplet_private_ipv4
+terraform -chdir=infra/terraform output -raw vpc_id
 ```
 
-Note the outputs:
-
-```bash
-terraform output droplet_public_ipv4
-terraform output droplet_private_ipv4
-terraform output vpc_id
-```
-
-State file (`terraform.tfstate`) is local and gitignored. If multiple operators
-need to run this, switch to a DO Spaces backend before sharing.
+Local-CLI runs against the same workspace work too; `terraform login` once,
+then `terraform plan` reaches the remote state. `terraform.tfvars` is for
+local runs only and stays gitignored. The `.terraform.lock.hcl` IS committed
+so TFC and laptops resolve identical provider versions.
 
 ### 2. Configure (Ansible)
 

--- a/infra/ansible/.gitignore
+++ b/infra/ansible/.gitignore
@@ -1,0 +1,4 @@
+inventory.yml
+collections/
+*.retry
+.vault_pass

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,12 @@
+[defaults]
+inventory = ./inventory.yml
+host_key_checking = False
+forks = 5
+stdout_callback = yaml
+roles_path = ./roles
+collections_paths = ./collections
+retry_files_enabled = False
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -4,7 +4,7 @@ host_key_checking = False
 forks = 5
 stdout_callback = yaml
 roles_path = ./roles
-collections_paths = ./collections
+collections_path = ./collections
 retry_files_enabled = False
 
 [ssh_connection]

--- a/infra/ansible/inventory.yml.example
+++ b/infra/ansible/inventory.yml.example
@@ -15,6 +15,10 @@ all:
     mysql_app_user: pfv_app
     # Generate a strong password and (recommended) store via ansible-vault.
     mysql_app_password: REPLACE_OR_USE_VAULT
-    mysql_root_password: REPLACE_OR_USE_VAULT
+    # Backup user used by nightly mysqldump cron and the migration runbook.
+    # root@localhost is intentionally left on Ubuntu's default socket-auth
+    # plugin (access via `sudo mysql`); we don't manage its password here.
+    mysql_backup_user: pfv_backup
+    mysql_backup_password: REPLACE_OR_USE_VAULT
     # Generate a strong password and (recommended) store via ansible-vault.
     redis_password: REPLACE_OR_USE_VAULT

--- a/infra/ansible/inventory.yml.example
+++ b/infra/ansible/inventory.yml.example
@@ -1,0 +1,20 @@
+# Copy to inventory.yml and fill from `terraform output`. inventory.yml is gitignored.
+all:
+  hosts:
+    pfv-data-01:
+      # Public IP for bootstrap. Switch to private when you have a jumpbox or
+      # are running Ansible from inside the VPC (e.g., a doctl one-shot droplet).
+      ansible_host: REPLACE_PUBLIC_IPV4
+      ansible_user: root
+      ansible_python_interpreter: /usr/bin/python3
+      # Made available to roles for binding MySQL/Redis to the VPC interface.
+      private_ipv4: REPLACE_PRIVATE_IPV4
+  vars:
+    vpc_ip_range: 10.42.0.0/24
+    mysql_app_db: pfv2
+    mysql_app_user: pfv_app
+    # Generate a strong password and (recommended) store via ansible-vault.
+    mysql_app_password: REPLACE_OR_USE_VAULT
+    mysql_root_password: REPLACE_OR_USE_VAULT
+    # Generate a strong password and (recommended) store via ansible-vault.
+    redis_password: REPLACE_OR_USE_VAULT

--- a/infra/ansible/playbooks/site.yml
+++ b/infra/ansible/playbooks/site.yml
@@ -1,0 +1,9 @@
+- name: Provision pfv data droplet (MySQL + Redis)
+  hosts: all
+  become: true
+  gather_facts: true
+  roles:
+    - common
+    - mysql
+    - redis
+    - backups

--- a/infra/ansible/requirements.yml
+++ b/infra/ansible/requirements.yml
@@ -1,0 +1,7 @@
+collections:
+  - name: community.mysql
+    version: ">=3.10.0"
+  - name: community.general
+    version: ">=8.0.0"
+  - name: ansible.posix
+    version: ">=1.5.0"

--- a/infra/ansible/roles/backups/defaults/main.yml
+++ b/infra/ansible/roles/backups/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mysql_backup_dir: /var/backups/mysql
+mysql_backup_retention_days: 7
+mysql_backup_cron_hour: "2"
+mysql_backup_cron_minute: "0"

--- a/infra/ansible/roles/backups/tasks/main.yml
+++ b/infra/ansible/roles/backups/tasks/main.yml
@@ -7,6 +7,17 @@
     group: root
     mode: "0750"
 
+# Pre-created so the migration runbook (infra/MIGRATION.md step 4) can
+# `scp dump.sql.gz droplet:/var/backups/mysql/migration/` without first
+# having to ssh in and mkdir the subdir by hand.
+- name: Create MySQL backup migration subdirectory
+  ansible.builtin.file:
+    path: "{{ mysql_backup_dir }}/migration"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
 - name: Install MySQL backup script
   ansible.builtin.template:
     src: mysql-backup.sh.j2

--- a/infra/ansible/roles/backups/tasks/main.yml
+++ b/infra/ansible/roles/backups/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Create MySQL backup directory
+  ansible.builtin.file:
+    path: "{{ mysql_backup_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Install MySQL backup script
+  ansible.builtin.template:
+    src: mysql-backup.sh.j2
+    dest: /usr/local/bin/mysql-backup.sh
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Schedule daily MySQL backup cron
+  ansible.builtin.cron:
+    name: "mysql daily backup"
+    user: root
+    hour: "{{ mysql_backup_cron_hour }}"
+    minute: "{{ mysql_backup_cron_minute }}"
+    job: "/usr/local/bin/mysql-backup.sh >> /var/log/mysql-backup.log 2>&1"
+    state: present

--- a/infra/ansible/roles/backups/templates/mysql-backup.sh.j2
+++ b/infra/ansible/roles/backups/templates/mysql-backup.sh.j2
@@ -1,5 +1,8 @@
 #!/bin/bash
-# pfv MySQL nightly logical backup. Credentials read from /root/.my.cnf.
+# pfv MySQL nightly logical backup. Credentials read from /root/.my.cnf,
+# which is templated with the dedicated `mysql_backup` user (NOT root).
+# root@localhost stays on Ubuntu's default socket-auth plugin and is for
+# ad-hoc maintenance via `sudo mysql` only.
 set -euo pipefail
 
 BACKUP_DIR={{ mysql_backup_dir }}

--- a/infra/ansible/roles/backups/templates/mysql-backup.sh.j2
+++ b/infra/ansible/roles/backups/templates/mysql-backup.sh.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+# pfv MySQL nightly logical backup. Credentials read from /root/.my.cnf.
+set -euo pipefail
+
+BACKUP_DIR={{ mysql_backup_dir }}
+DB={{ mysql_app_db }}
+DATE=$(date +%Y%m%d-%H%M%S)
+DUMP="${BACKUP_DIR}/${DB}_${DATE}.sql.gz"
+
+mkdir -p "${BACKUP_DIR}"
+
+mysqldump \
+  --single-transaction \
+  --routines \
+  --triggers \
+  --quick \
+  --hex-blob \
+  "${DB}" | gzip > "${DUMP}"
+
+# Retention: keep last {{ mysql_backup_retention_days }} daily backups.
+find "${BACKUP_DIR}" -name "${DB}_*.sql.gz" -mtime +{{ mysql_backup_retention_days }} -delete

--- a/infra/ansible/roles/common/defaults/main.yml
+++ b/infra/ansible/roles/common/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# CIDR allowed to reach MySQL/Redis through ufw. Override per-host in inventory.
+vpc_ip_range: 10.42.0.0/24
+
+# Swap file size. Tiny droplets benefit a lot from a small swap so MySQL+Redis
+# don't OOM-kill each other under transient pressure.
+swap_file_path: /swapfile
+swap_file_size_mb: 1024
+
+# Timezone. UTC keeps logs/cron predictable across regions.
+system_timezone: UTC

--- a/infra/ansible/roles/common/handlers/main.yml
+++ b/infra/ansible/roles/common/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart fail2ban
+  ansible.builtin.service:
+    name: fail2ban
+    state: restarted
+
+- name: Reload ufw
+  community.general.ufw:
+    state: reloaded

--- a/infra/ansible/roles/common/tasks/main.yml
+++ b/infra/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,157 @@
+---
+- name: Update apt cache and upgrade packages
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: safe
+    cache_valid_time: 3600
+
+- name: Install baseline packages
+  ansible.builtin.apt:
+    name:
+      - python3-pymysql       # required by community.mysql modules
+      - ufw
+      - fail2ban
+      - unattended-upgrades
+      - apt-listchanges
+      - curl
+      - htop
+      - vim
+    state: present
+
+- name: Set system timezone
+  community.general.timezone:
+    name: "{{ system_timezone }}"
+
+# --- Unattended upgrades ---------------------------------------------------
+# Minimal "yes please apply security updates" config. We don't auto-reboot;
+# a reboot could disrupt MySQL replication or in-flight transactions.
+- name: Enable unattended-upgrades (auto)
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    content: |
+      APT::Periodic::Update-Package-Lists "1";
+      APT::Periodic::Unattended-Upgrade "1";
+      APT::Periodic::AutocleanInterval "7";
+    owner: root
+    group: root
+    mode: "0644"
+
+# --- ufw -------------------------------------------------------------------
+# DO Cloud Firewall already restricts inbound traffic at the network edge.
+# ufw is defence in depth on the host itself.
+- name: Allow OpenSSH through ufw
+  community.general.ufw:
+    rule: allow
+    name: OpenSSH
+
+- name: Allow MySQL from VPC through ufw
+  community.general.ufw:
+    rule: allow
+    src: "{{ vpc_ip_range }}"
+    port: "3306"
+    proto: tcp
+
+- name: Allow Redis from VPC through ufw
+  community.general.ufw:
+    rule: allow
+    src: "{{ vpc_ip_range }}"
+    port: "6379"
+    proto: tcp
+
+- name: Set default ufw policies (deny incoming, allow outgoing)
+  community.general.ufw:
+    direction: "{{ item.direction }}"
+    policy: "{{ item.policy }}"
+  loop:
+    - { direction: incoming, policy: deny }
+    - { direction: outgoing, policy: allow }
+
+- name: Enable ufw
+  community.general.ufw:
+    state: enabled
+    logging: "on"
+
+# --- fail2ban --------------------------------------------------------------
+- name: Configure fail2ban for sshd (jail.local)
+  ansible.builtin.copy:
+    dest: /etc/fail2ban/jail.local
+    content: |
+      [DEFAULT]
+      bantime = 1h
+      findtime = 10m
+      maxretry = 5
+
+      [sshd]
+      enabled = true
+      port = ssh
+      logpath = %(sshd_log)s
+      backend = %(sshd_backend)s
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart fail2ban
+
+- name: Ensure fail2ban is started and enabled
+  ansible.builtin.service:
+    name: fail2ban
+    state: started
+    enabled: true
+
+# --- Swap (1GB) ------------------------------------------------------------
+# s-1vcpu-1gb has only 1GB RAM. Even a small swap keeps the OOM-killer at bay
+# while MySQL warms its buffer pool.
+- name: Check if swap file already exists
+  ansible.builtin.stat:
+    path: "{{ swap_file_path }}"
+  register: swap_file_stat
+
+- name: Allocate swap file
+  ansible.builtin.command: "fallocate -l {{ swap_file_size_mb }}M {{ swap_file_path }}"
+  when: not swap_file_stat.stat.exists
+  changed_when: true
+
+- name: Set swap file permissions
+  ansible.builtin.file:
+    path: "{{ swap_file_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Format swap file
+  ansible.builtin.command: "mkswap {{ swap_file_path }}"
+  when: not swap_file_stat.stat.exists
+  changed_when: true
+
+- name: Enable swap file
+  ansible.builtin.command: "swapon {{ swap_file_path }}"
+  when: not swap_file_stat.stat.exists
+  changed_when: true
+
+- name: Persist swap in /etc/fstab
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    line: "{{ swap_file_path }} none swap sw 0 0"
+    state: present
+
+- name: Tune swappiness (low — favour RAM)
+  ansible.posix.sysctl:
+    name: vm.swappiness
+    value: "10"
+    sysctl_set: true
+    state: present
+    reload: true
+
+# --- MOTD ------------------------------------------------------------------
+- name: Drop a descriptive /etc/motd
+  ansible.builtin.copy:
+    dest: /etc/motd
+    content: |
+      ============================================================
+       pfv data droplet
+       Role: MySQL + Redis (single node, VPC-only data plane)
+       Managed by: Terraform (provisioning) + Ansible (config)
+       Backups: weekly DO snapshots + nightly mysqldump (/var/backups/mysql)
+      ============================================================
+    owner: root
+    group: root
+    mode: "0644"

--- a/infra/ansible/roles/mysql/defaults/main.yml
+++ b/infra/ansible/roles/mysql/defaults/main.yml
@@ -3,7 +3,13 @@
 mysql_app_db: pfv2
 mysql_app_user: pfv_app
 mysql_app_password: CHANGE_ME
-mysql_root_password: CHANGE_ME
+
+# Dedicated user for nightly mysqldump and the migration runbook.
+# root@localhost stays on Ubuntu's default socket-auth plugin; we don't
+# manage a password for it. Backup user has the minimum privilege set
+# `mysqldump --single-transaction --routines --triggers` needs.
+mysql_backup_user: pfv_backup
+mysql_backup_password: CHANGE_ME
 
 # Tuned for s-1vcpu-1gb. Leaves headroom for the OS and Redis (200MB cap).
 mysql_max_connections: 50

--- a/infra/ansible/roles/mysql/defaults/main.yml
+++ b/infra/ansible/roles/mysql/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Override these in inventory.yml; vault-encrypt the passwords for real use.
+mysql_app_db: pfv2
+mysql_app_user: pfv_app
+mysql_app_password: CHANGE_ME
+mysql_root_password: CHANGE_ME
+
+# Tuned for s-1vcpu-1gb. Leaves headroom for the OS and Redis (200MB cap).
+mysql_max_connections: 50
+mysql_innodb_buffer_pool_size: 384M
+mysql_innodb_log_file_size: 64M

--- a/infra/ansible/roles/mysql/handlers/main.yml
+++ b/infra/ansible/roles/mysql/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart mysql
+  ansible.builtin.service:
+    name: mysql
+    state: restarted

--- a/infra/ansible/roles/mysql/tasks/main.yml
+++ b/infra/ansible/roles/mysql/tasks/main.yml
@@ -12,19 +12,27 @@
     state: started
     enabled: true
 
-# Ubuntu 24.04 ships MySQL 8 with auth_socket on root@localhost. We switch to
-# a real password so cron-backed mysqldump (and recovery sessions) can work.
-- name: Set root password (auth_socket -> mysql_native_password)
-  community.mysql.mysql_user:
-    name: root
-    host: localhost
-    password: "{{ mysql_root_password }}"
-    plugin: mysql_native_password
-    login_unix_socket: /var/run/mysqld/mysqld.sock
-    state: present
-    update_password: on_create
+# Ubuntu 24.04 ships MySQL 8 with auth_socket on root@localhost — we keep that
+# default. Local maintenance is done via `sudo mysql` (the socket plugin
+# authenticates by uid, no password needed). We deliberately do NOT manage a
+# password for root@localhost here: the `mysql_user ... update_password:
+# on_create` form only sets the password when the user is first created, and
+# root already exists from the apt package install. Re-running this play with
+# a rotated `mysql_root_password` would silently rewrite /root/.my.cnf to a
+# password MySQL never accepted, breaking subsequent tasks and cron dumps.
+# Cron dumps use the dedicated `mysql_backup` user below.
 
-- name: Drop /root/.my.cnf so root tools work non-interactively
+- name: Create backup user (read-everything for mysqldump --single-transaction)
+  community.mysql.mysql_user:
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+    name: "{{ mysql_backup_user }}"
+    password: "{{ mysql_backup_password }}"
+    host: localhost
+    priv: "*.*:SELECT,LOCK TABLES,SHOW VIEW,EVENT,TRIGGER,RELOAD,PROCESS,REPLICATION CLIENT"
+    plugin: mysql_native_password
+    state: present
+
+- name: Drop /root/.my.cnf so cron mysqldump runs non-interactively
   ansible.builtin.template:
     src: root.my.cnf.j2
     dest: /root/.my.cnf

--- a/infra/ansible/roles/mysql/tasks/main.yml
+++ b/infra/ansible/roles/mysql/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+- name: Install MySQL server
+  ansible.builtin.apt:
+    name:
+      - mysql-server
+      - python3-pymysql
+    state: present
+
+- name: Ensure MySQL is started and enabled
+  ansible.builtin.service:
+    name: mysql
+    state: started
+    enabled: true
+
+# Ubuntu 24.04 ships MySQL 8 with auth_socket on root@localhost. We switch to
+# a real password so cron-backed mysqldump (and recovery sessions) can work.
+- name: Set root password (auth_socket -> mysql_native_password)
+  community.mysql.mysql_user:
+    name: root
+    host: localhost
+    password: "{{ mysql_root_password }}"
+    plugin: mysql_native_password
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+    state: present
+    update_password: on_create
+
+- name: Drop /root/.my.cnf so root tools work non-interactively
+  ansible.builtin.template:
+    src: root.my.cnf.j2
+    dest: /root/.my.cnf
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Remove anonymous MySQL users
+  community.mysql.mysql_user:
+    name: ""
+    host_all: true
+    state: absent
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+
+- name: Remove MySQL test database
+  community.mysql.mysql_db:
+    name: test
+    state: absent
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+
+- name: Create application database
+  community.mysql.mysql_db:
+    name: "{{ mysql_app_db }}"
+    state: present
+    encoding: utf8mb4
+    collation: utf8mb4_0900_ai_ci
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+
+- name: Create application MySQL user (host=%)
+  community.mysql.mysql_user:
+    name: "{{ mysql_app_user }}"
+    password: "{{ mysql_app_password }}"
+    host: "%"
+    priv: "{{ mysql_app_db }}.*:ALL"
+    plugin: mysql_native_password
+    state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+
+- name: Drop pfv MySQL config override
+  ansible.builtin.template:
+    src: my.cnf.j2
+    dest: /etc/mysql/mysql.conf.d/pfv.cnf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart mysql

--- a/infra/ansible/roles/mysql/templates/my.cnf.j2
+++ b/infra/ansible/roles/mysql/templates/my.cnf.j2
@@ -1,0 +1,19 @@
+{# Custom overrides loaded from /etc/mysql/mysql.conf.d/. The Ubuntu MySQL #}
+{# package's main config includes this directory by default. #}
+{# bind-address = 0.0.0.0 because MySQL 8 only honours one bind-address; #}
+{# the DO Cloud Firewall + ufw together enforce VPC-only access. #}
+[mysqld]
+bind-address = 0.0.0.0
+default-authentication-plugin = mysql_native_password
+
+max_connections = {{ mysql_max_connections }}
+innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}
+innodb_log_file_size = {{ mysql_innodb_log_file_size }}
+
+character-set-server = utf8mb4
+collation-server = utf8mb4_0900_ai_ci
+
+# Slow query log helps catch regressions early on a small box.
+slow_query_log = 1
+slow_query_log_file = /var/log/mysql/slow.log
+long_query_time = 2

--- a/infra/ansible/roles/mysql/templates/root.my.cnf.j2
+++ b/infra/ansible/roles/mysql/templates/root.my.cnf.j2
@@ -1,0 +1,8 @@
+{# /root/.my.cnf — lets root run mysql/mysqldump non-interactively. #}
+[client]
+user=root
+password={{ mysql_root_password }}
+
+[mysqldump]
+user=root
+password={{ mysql_root_password }}

--- a/infra/ansible/roles/mysql/templates/root.my.cnf.j2
+++ b/infra/ansible/roles/mysql/templates/root.my.cnf.j2
@@ -1,8 +1,11 @@
-{# /root/.my.cnf — lets root run mysql/mysqldump non-interactively. #}
+{# /root/.my.cnf — credentials for cron-backed mysqldump.
+   Uses the dedicated `mysql_backup` user (see roles/mysql/tasks/main.yml),
+   not root. root@localhost stays on the default socket-auth plugin and is
+   accessed via `sudo mysql` for ad-hoc maintenance. #}
 [client]
-user=root
-password={{ mysql_root_password }}
+user = {{ mysql_backup_user }}
+password = "{{ mysql_backup_password }}"
 
 [mysqldump]
-user=root
-password={{ mysql_root_password }}
+user = {{ mysql_backup_user }}
+password = "{{ mysql_backup_password }}"

--- a/infra/ansible/roles/redis/defaults/main.yml
+++ b/infra/ansible/roles/redis/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# Override in inventory.yml; vault-encrypt for real use.
+redis_password: CHANGE_ME
+
+# 200MB cap leaves the rest of RAM to MySQL + OS. Rate-limit + session-cache
+# workloads fit easily here.
+redis_maxmemory: 200mb
+redis_maxmemory_policy: allkeys-lru

--- a/infra/ansible/roles/redis/handlers/main.yml
+++ b/infra/ansible/roles/redis/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart redis
+  ansible.builtin.service:
+    name: redis-server
+    state: restarted

--- a/infra/ansible/roles/redis/tasks/main.yml
+++ b/infra/ansible/roles/redis/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Install Redis
+  ansible.builtin.apt:
+    name: redis-server
+    state: present
+
+- name: Ensure /etc/redis/conf.d exists
+  ansible.builtin.file:
+    path: /etc/redis/conf.d
+    state: directory
+    owner: redis
+    group: redis
+    mode: "0750"
+
+- name: Drop pfv Redis config override
+  ansible.builtin.template:
+    src: redis.conf.j2
+    dest: /etc/redis/conf.d/pfv.conf
+    owner: redis
+    group: redis
+    mode: "0640"
+  notify: Restart redis
+
+# Make sure the main /etc/redis/redis.conf actually pulls in our override.
+# The Ubuntu 24.04 redis-server package supports `include` directives.
+- name: Ensure main redis.conf includes our override
+  ansible.builtin.lineinfile:
+    path: /etc/redis/redis.conf
+    line: "include /etc/redis/conf.d/pfv.conf"
+    state: present
+    insertafter: EOF
+  notify: Restart redis
+
+- name: Ensure Redis is started and enabled
+  ansible.builtin.service:
+    name: redis-server
+    state: started
+    enabled: true

--- a/infra/ansible/roles/redis/templates/redis.conf.j2
+++ b/infra/ansible/roles/redis/templates/redis.conf.j2
@@ -1,0 +1,10 @@
+{# Drop-in override loaded from /etc/redis/redis.conf via include. #}
+{# We don't rewrite the whole config; this file overrides only what matters. #}
+bind 127.0.0.1 {{ private_ipv4 }}
+protected-mode yes
+requirepass {{ redis_password }}
+maxmemory {{ redis_maxmemory }}
+maxmemory-policy {{ redis_maxmemory_policy }}
+# Persistence off: PFV uses Redis only for ephemeral data (rate limits, sessions).
+appendonly no
+save ""

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,13 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+crash.log
+crash.*.log
+terraform.tfvars
+*.auto.tfvars
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,5 +1,5 @@
 .terraform/
-.terraform.lock.hcl
+# .terraform.lock.hcl is committed (TFC needs it for reproducible runs).
 *.tfstate
 *.tfstate.*
 *.tfstate.backup

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.85.0"
+  constraints = "~> 2.40"
+  hashes = [
+    "h1:LlizM8KECueBKyZZWtdU4S+FRi3GthxyskdaXX7ZzXc=",
+    "zh:10c8ed96911d7d2a4986a0216cf820ebcb92c4e6766e8ec837edf3c19b9ccff7",
+    "zh:2e789b8b44dd7f4b88e29ed3e448835df8b0c33957d9ddf6423b2d7c3a904ae5",
+    "zh:55346c35eb1ecf37ce0592f9d78db8bbe4bf023050103ee749c8e9e61dfdc50b",
+    "zh:5fb86602def4615e03fc1a01804f02d426b9d02925f3fc7d2c46decd9db381fc",
+    "zh:634740674ed73bbdba6ca02c429b0c4d5f40147aa85b45a1b77b9c43695e4331",
+    "zh:691bba8e07d8e52db5d6b75fbd2a3cb372ac746315b08ede4d6ccbe961572a5f",
+    "zh:7c7d00c5ba40798be07c6245fa80f648a6dda24872bab53245fb0a6fcc44bba2",
+    "zh:8a917a56a21bdb64271a22ecb7d4e7ec13488c110daecb2d772c7c9c52696493",
+    "zh:8b7c4920dd2dbf5d4214177e1c161b0d040aac235c409f3e1a935f23958eebe6",
+    "zh:9e0e22b6818872934a792538651cd5390c7d53e2c4898e20054564860ac1a9b9",
+    "zh:cfb26b9876ff5132d475d173c6fbd9c6530a32b935cfdd7dfdff9d0eff12253b",
+    "zh:d1c631ba672279aa9deb12a6384e719a4a48ed10b999f2ca2162f03f8550e2a4",
+    "zh:dc28c34566c0e938c20a523156c03950c03d458847589137d2395cafbd3d6788",
+    "zh:e17d8f1f987e7b4f358090afe98224d1460d5216498b7feb51e8b07250e5445a",
+    "zh:e5fac1a597cc1944e0f074482588eee56f74a13e37f215633a210660fa194294",
+    "zh:eb8a99fe9328258a51adf1e258a39353622431e13f4c17c21bd84c5f58946280",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,80 @@
+# pfv terraform: DO data droplet
+
+Terraform Cloud workspace `FlamaCorp/pfv` managing the DigitalOcean
+infrastructure for the self-hosted MySQL + Redis pair behind `pfv`. State
+and runs live in TFC; this directory holds the configuration.
+
+## Resources managed
+
+| Resource | Purpose |
+|---|---|
+| `digitalocean_vpc` | Dedicated `10.42.0.0/24` VPC in region `ams3` |
+| `digitalocean_droplet` | `pfv-data-01`: `s-1vcpu-1gb` Ubuntu 24.04, hosts MySQL 8 + Redis |
+| `digitalocean_firewall` | SSH 22 from anywhere; MySQL 3306 / Redis 6379 / ICMP from the VPC only |
+| `digitalocean_project_resources` | Attaches the droplet to the existing DO `pfv` project |
+
+## Workspace variables
+
+Set in TFC (Workspace -> Variables); never committed.
+
+| Name | Kind | Sensitive | Description |
+|---|---|---|---|
+| `do_token` | Terraform | yes | Scoped DO API token: droplets / vpcs / firewalls / projects RW, ssh\_keys R |
+| `ssh_key_name` | Terraform | no | Name of an SSH key already registered in DO |
+
+Defaults for `region`, `droplet_size`, `droplet_image`, `project_name`,
+and `vpc_ip_range` live in `variables.tf` and rarely need overriding.
+
+## Outputs
+
+Read from TFC -> Workspace -> Outputs after apply.
+
+- `droplet_public_ipv4`: SSH bootstrap target
+- `droplet_private_ipv4`: for `DATABASE_URL` / `REDIS_URL` in `.do/app.yaml`
+- `vpc_id`: for App Platform's top-level `vpc:` block
+- `vpc_ip_range`: VPC CIDR (echoed for Ansible inventory)
+- `droplet_id`: numeric ID
+
+## Workflow
+
+- **Speculative plan**: every PR touching `infra/terraform/**` gets a TFC
+  plan posted as a status check on the PR.
+- **Apply**: triggered automatically on merge to `main`, gated on
+  **manual confirm** in the TFC UI. Auto-apply is intentionally off so
+  no infra change ever lands without an operator clicking through.
+- **Local CLI**: `terraform login` once, then
+  `terraform -chdir=infra/terraform plan` reaches the same remote state.
+
+## Module layout
+
+```
+.
+├── main.tf            cloud{} (TFC), provider, module wiring, project attachment
+├── variables.tf
+├── outputs.tf
+└── modules/
+    ├── vpc/           digitalocean_vpc
+    ├── droplet/       digitalocean_droplet (backups + monitoring on by default)
+    └── firewall/      digitalocean_firewall (defence-in-depth pair with host ufw)
+```
+
+Each child module ships its own `versions.tf` with the
+`digitalocean/digitalocean ~> 2.40` provider pin so `terraform init`
+resolves the right namespace inside the module.
+
+## Cost
+
+| Line | Monthly |
+|---|---|
+| `s-1vcpu-1gb` droplet | ~$6.00 |
+| DO weekly snapshots (~20% of droplet) | ~$1.20 |
+| VPC + firewall + project attachment | $0 |
+| **Total** | **~$7.20** |
+
+Replaces ~$30/mo of DO Managed MySQL + Managed Redis.
+
+## See also
+
+- `../README.md`: overall infra workflow + day-2 operations
+- `../MIGRATION.md`: managed -> droplet data-cutover runbook
+- `../ansible/`: Ubuntu 24.04 bootstrap that runs after `terraform apply`

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,6 +1,18 @@
 terraform {
   required_version = ">= 1.5.0"
 
+  # State + plan/apply runs live in Terraform Cloud (FlamaCorp/pfv).
+  # The workspace is VCS-driven against this repo with the working directory
+  # scoped to infra/terraform/ and trigger paths the same. Set workspace
+  # variables `do_token` (sensitive) and `ssh_key_name` in TFC; everything
+  # else has sensible defaults in variables.tf.
+  cloud {
+    organization = "FlamaCorp"
+    workspaces {
+      name = "pfv"
+    }
+  }
+
   required_providers {
     digitalocean = {
       source = "digitalocean/digitalocean"
@@ -9,9 +21,6 @@ terraform {
       version = "~> 2.40"
     }
   }
-
-  # State stored locally for now under this directory (gitignored).
-  # Switch to a DO Spaces backend once we have multiple operators or CI.
 }
 
 provider "digitalocean" {

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,72 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      # Pinned to 2.40+ to ensure project_resources, vpc, droplet backups,
+      # and monitoring fields are all stable. Bump deliberately, not accidentally.
+      version = "~> 2.40"
+    }
+  }
+
+  # State stored locally for now under this directory (gitignored).
+  # Switch to a DO Spaces backend once we have multiple operators or CI.
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+# Look up the SSH key already configured in DO by name. We never manage SSH keys
+# from Terraform here; treating them as data keeps human-rotated keys out of state.
+data "digitalocean_ssh_key" "primary" {
+  name = var.ssh_key_name
+}
+
+# Look up an existing project to attach resources to. Projects are an org-level
+# concept; we don't want Terraform owning them.
+data "digitalocean_project" "pfv" {
+  name = var.project_name
+}
+
+module "vpc" {
+  source   = "./modules/vpc"
+  name     = "${var.project_name}-vpc"
+  region   = var.region
+  ip_range = var.vpc_ip_range
+}
+
+module "data_droplet" {
+  source = "./modules/droplet"
+
+  name     = "${var.project_name}-data-01"
+  region   = var.region
+  size     = var.droplet_size
+  image    = var.droplet_image
+  vpc_uuid = module.vpc.id
+
+  ssh_key_id = data.digitalocean_ssh_key.primary.id
+
+  # backups=true is intentionally default-on: this droplet is the only copy of
+  # production data outside the nightly mysqldump cron, so weekly DO snapshots
+  # are cheap insurance.
+  enable_backups    = true
+  enable_monitoring = true
+
+  tags = ["pfv", "data", "managed-by-terraform"]
+}
+
+# Attach the droplet to the existing DO project for cost/visibility grouping.
+resource "digitalocean_project_resources" "pfv" {
+  project   = data.digitalocean_project.pfv.id
+  resources = [module.data_droplet.urn]
+}
+
+module "firewall" {
+  source = "./modules/firewall"
+
+  name         = "${var.project_name}-data-fw"
+  droplet_ids  = [module.data_droplet.id]
+  vpc_ip_range = var.vpc_ip_range
+}

--- a/infra/terraform/modules/droplet/main.tf
+++ b/infra/terraform/modules/droplet/main.tf
@@ -1,0 +1,15 @@
+resource "digitalocean_droplet" "this" {
+  name     = var.name
+  region   = var.region
+  size     = var.size
+  image    = var.image
+  vpc_uuid = var.vpc_uuid
+
+  ssh_keys = [var.ssh_key_id]
+
+  backups    = var.enable_backups
+  monitoring = var.enable_monitoring
+  ipv6       = false
+
+  tags = var.tags
+}

--- a/infra/terraform/modules/droplet/outputs.tf
+++ b/infra/terraform/modules/droplet/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "Numeric droplet ID."
+  value       = digitalocean_droplet.this.id
+}
+
+output "urn" {
+  description = "DO URN (used to attach the droplet to a project)."
+  value       = digitalocean_droplet.this.urn
+}
+
+output "public_ipv4" {
+  description = "Public IPv4 of the droplet."
+  value       = digitalocean_droplet.this.ipv4_address
+}
+
+output "private_ipv4" {
+  description = "Private (VPC) IPv4 of the droplet."
+  value       = digitalocean_droplet.this.ipv4_address_private
+}

--- a/infra/terraform/modules/droplet/variables.tf
+++ b/infra/terraform/modules/droplet/variables.tf
@@ -1,0 +1,47 @@
+variable "name" {
+  description = "Droplet name."
+  type        = string
+}
+
+variable "region" {
+  description = "DO region slug."
+  type        = string
+}
+
+variable "size" {
+  description = "Droplet size slug."
+  type        = string
+}
+
+variable "image" {
+  description = "Droplet base image slug."
+  type        = string
+}
+
+variable "vpc_uuid" {
+  description = "VPC UUID to attach the droplet to."
+  type        = string
+}
+
+variable "ssh_key_id" {
+  description = "DO SSH key fingerprint or numeric ID."
+  type        = string
+}
+
+variable "enable_backups" {
+  description = "Enable DO weekly backups (~20% droplet cost; cheap insurance for a single-droplet data tier)."
+  type        = bool
+  default     = true
+}
+
+variable "enable_monitoring" {
+  description = "Enable DO droplet metrics agent (free)."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "DO tags to apply to the droplet."
+  type        = list(string)
+  default     = []
+}

--- a/infra/terraform/modules/droplet/versions.tf
+++ b/infra/terraform/modules/droplet/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.40"
+    }
+  }
+}

--- a/infra/terraform/modules/firewall/main.tf
+++ b/infra/terraform/modules/firewall/main.tf
@@ -1,0 +1,52 @@
+# Cloud firewall sits in front of the droplet. We pair this with ufw on the
+# droplet itself (defence in depth). MySQL/Redis are VPC-only here; SSH is open
+# to the world but protected by key-only auth + fail2ban inside the droplet.
+resource "digitalocean_firewall" "this" {
+  name        = var.name
+  droplet_ids = var.droplet_ids
+
+  # Inbound: SSH from anywhere (key auth + fail2ban; tighten later if needed).
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Inbound: MySQL — VPC only.
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "3306"
+    source_addresses = [var.vpc_ip_range]
+  }
+
+  # Inbound: Redis — VPC only.
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "6379"
+    source_addresses = [var.vpc_ip_range]
+  }
+
+  # Inbound: ICMP — VPC only (ping diagnostics from App Platform side).
+  inbound_rule {
+    protocol         = "icmp"
+    source_addresses = [var.vpc_ip_range]
+  }
+
+  # Outbound: open. The droplet needs to reach apt mirrors, NTP, and DO metrics.
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}

--- a/infra/terraform/modules/firewall/outputs.tf
+++ b/infra/terraform/modules/firewall/outputs.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "Firewall UUID."
+  value       = digitalocean_firewall.this.id
+}

--- a/infra/terraform/modules/firewall/variables.tf
+++ b/infra/terraform/modules/firewall/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  description = "Firewall name."
+  type        = string
+}
+
+variable "droplet_ids" {
+  description = "Droplet IDs to attach the firewall to."
+  type        = list(number)
+}
+
+variable "vpc_ip_range" {
+  description = "VPC CIDR allowed for MySQL/Redis/ICMP inbound."
+  type        = string
+}

--- a/infra/terraform/modules/firewall/versions.tf
+++ b/infra/terraform/modules/firewall/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.40"
+    }
+  }
+}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,0 +1,5 @@
+resource "digitalocean_vpc" "this" {
+  name     = var.name
+  region   = var.region
+  ip_range = var.ip_range
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  description = "VPC UUID."
+  value       = digitalocean_vpc.this.id
+}
+
+output "ip_range" {
+  description = "VPC CIDR (echoed from input)."
+  value       = digitalocean_vpc.this.ip_range
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  description = "VPC name."
+  type        = string
+}
+
+variable "region" {
+  description = "DO region slug."
+  type        = string
+}
+
+variable "ip_range" {
+  description = "CIDR for the VPC."
+  type        = string
+}

--- a/infra/terraform/modules/vpc/versions.tf
+++ b/infra/terraform/modules/vpc/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.40"
+    }
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "droplet_public_ipv4" {
+  description = "Public IPv4 of the data droplet (for SSH bootstrap)."
+  value       = module.data_droplet.public_ipv4
+}
+
+output "droplet_private_ipv4" {
+  description = "Private IPv4 of the data droplet (for App Platform DATABASE_URL/REDIS_URL)."
+  value       = module.data_droplet.private_ipv4
+}
+
+output "droplet_id" {
+  description = "Numeric ID of the data droplet."
+  value       = module.data_droplet.id
+}
+
+output "vpc_id" {
+  description = "UUID of the VPC."
+  value       = module.vpc.id
+}
+
+output "vpc_ip_range" {
+  description = "CIDR of the VPC (echoed for convenience in Ansible inventory generation)."
+  value       = module.vpc.ip_range
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,8 +1,12 @@
-# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
-do_token     = "dop_v1_REPLACE_ME"
-ssh_key_name = "your-ssh-key-name-in-do"
+# Reference only. Production runs happen in Terraform Cloud (FlamaCorp/pfv);
+# variables are set as workspace variables there. Use this file ONLY for
+# local-CLI runs (e.g., `terraform login` then `terraform plan` from a
+# laptop), and `terraform.tfvars` stays gitignored regardless.
+#
+# do_token     = "dop_v1_REPLACE_ME"
+# ssh_key_name = "your-ssh-key-name-in-do"
 
-# Optional overrides:
+# Optional overrides (defaults live in variables.tf):
 # region        = "ams3"
 # droplet_size  = "s-1vcpu-1gb"
 # project_name  = "pfv"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
+do_token     = "dop_v1_REPLACE_ME"
+ssh_key_name = "your-ssh-key-name-in-do"
+
+# Optional overrides:
+# region        = "ams3"
+# droplet_size  = "s-1vcpu-1gb"
+# project_name  = "pfv"
+# vpc_ip_range  = "10.42.0.0/24"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,40 @@
+variable "do_token" {
+  description = "DigitalOcean API token (set via TF_VAR_do_token env var or terraform.tfvars)"
+  type        = string
+  sensitive   = true
+}
+
+variable "region" {
+  description = "DigitalOcean region slug. Match your App Platform region (ams for Europe)."
+  type        = string
+  default     = "ams3"
+}
+
+variable "droplet_size" {
+  description = "Droplet size slug. s-1vcpu-1gb is the $6/mo entry tier and is enough for MySQL+Redis on a personal-finance-app workload."
+  type        = string
+  default     = "s-1vcpu-1gb"
+}
+
+variable "droplet_image" {
+  description = "Droplet base image slug."
+  type        = string
+  default     = "ubuntu-24-04-x64"
+}
+
+variable "ssh_key_name" {
+  description = "Name of an SSH key already registered in DO (Account -> Settings -> Security)."
+  type        = string
+}
+
+variable "project_name" {
+  description = "DO project name (must already exist) and resource name prefix."
+  type        = string
+  default     = "pfv"
+}
+
+variable "vpc_ip_range" {
+  description = "CIDR for the VPC. /24 is plenty for one droplet plus the App Platform attachment."
+  type        = string
+  default     = "10.42.0.0/24"
+}


### PR DESCRIPTION
## Summary

Replaces DO Managed MySQL + Managed Redis (~$30/mo) with a single \`s-1vcpu-1gb\` Ubuntu 24.04 droplet running both services in a VPC (~$6/mo + ~$1.20/mo for backups).

### Layout

- \`infra/terraform/\`: VPC + droplet + cloud firewall + project attachment. Local state, gitignored. Provider pinned to \`digitalocean/digitalocean ~> 2.40\`.
- \`infra/ansible/\`: Ubuntu 24.04 bootstrap. Roles \`common\`, \`mysql\`, \`redis\`, \`backups\`. Real \`inventory.yml\` is gitignored.
- \`infra/README.md\` + \`infra/MIGRATION.md\`: setup walkthrough and prod cutover runbook.

### Network posture

- DO Cloud Firewall: SSH 22 from any IPv4 (key auth + fail2ban behind), MySQL 3306 + Redis 6379 + ICMP from VPC CIDR only.
- ufw on the host duplicates the same rules (defense in depth).
- MySQL listens on \`0.0.0.0\` (MySQL 8 only honours one bind-address); both firewalls enforce VPC-only.
- Redis bound to \`127.0.0.1 + private_ipv4\` with \`requirepass\` and \`protected-mode yes\`.
- No TLS — VPC traffic is private. Documented in MIGRATION.md.

### Backups

- DO weekly droplet snapshots (Terraform-managed).
- Nightly \`mysqldump\` cron at 02:00 UTC -> \`/var/backups/mysql/\` with 7-day retention.

### Validation

- \`terraform validate\` passes.
- \`terraform fmt -recursive\` is clean (no diff on second run).
- All Ansible YAML loads without syntax errors locally.
- Runtime ansible-playbook validation deferred to first real run (no controller in PATH).

### Out of scope

- App Platform env-var wiring (DATABASE_URL/REDIS_URL); follow-up PR with the \`.do/app.yaml\` change.
- Move to DO Spaces backend for Terraform state — fine local-only for now.

### Decisions made beyond spec

- Each Terraform module ships a \`versions.tf\` with its own \`required_providers\` block. Without it, child modules implicitly request \`hashicorp/digitalocean\` (the wrong namespace) and \`terraform init\` fails. Confirmed via \`terraform validate\`.
- Added \`ansible.posix\` to \`requirements.yml\` for the \`sysctl\` task that tunes \`vm.swappiness\`.
- Added a \`/root/.my.cnf\` template so the backup script + recovery sessions work without prompting for a password (mode 0600).
- Added \`fail2ban\` jail.local config explicitly (sshd jail with bantime 1h).
- Added \`infra/ansible/.gitignore\` to keep \`inventory.yml\`, \`collections/\`, and any \`.vault_pass\` out of the repo.