### PR TITLE
fix(transfers): responsive UI fixes for /transactions actions and /import Transfer column

### DIFF
--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -357,7 +357,17 @@ function ImportPageContent() {
       )}
 
       {/* ── Step 2: Preview ─────────────────────────────────────────────── */}
-      {step === "preview" && preview && categories && categories.length > 0 && (
+      {step === "preview" && preview && categories && categories.length > 0 && (() => {
+        // Hide the Transfer column entirely when no row in this preview has
+        // any transfer state. Avoids a column of empty cells confusing users
+        // who report "the Transfer column is empty / checkbox missing".
+        const hasAnyTransferState =
+          preview.auto_paired_count +
+            preview.suggested_pair_count +
+            preview.multi_candidate_count +
+            preview.duplicate_of_linked_count >
+          0;
+        return (
         <div className="space-y-4">
           {/* Summary bar */}
           <div className={card}>
@@ -444,7 +454,9 @@ function ImportPageContent() {
                   <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-text-muted">Amount</th>
                   <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-text-muted">Type</th>
                   <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-text-muted">Category</th>
-                  <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-text-muted">Transfer</th>
+                  {hasAnyTransferState && (
+                    <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-text-muted">Transfer</th>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -504,7 +516,8 @@ function ImportPageContent() {
                   }
 
                   // Determine table column count for panel-row colspan.
-                  const COL_COUNT = 7;
+                  // Tracks whether the Transfer column is rendered.
+                  const COL_COUNT = hasAnyTransferState ? 7 : 6;
 
                   return (
                     <Fragment key={previewRow.row_number}>
@@ -564,21 +577,25 @@ function ImportPageContent() {
                             </div>
                           )}
                         </td>
-                        <td className="px-4 py-2">
-                          {pill && (
-                            <button
-                              type="button"
-                              onClick={() =>
-                                updateTransferUi(previewRow.row_number, { panelOpen: !ui.panelOpen })
-                              }
-                              className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${pill.classes}`}
-                              aria-expanded={ui.panelOpen}
-                              data-testid={`transfer-pill-${previewRow.row_number}`}
-                            >
-                              {pill.text}
-                            </button>
-                          )}
-                        </td>
+                        {hasAnyTransferState && (
+                          <td className="px-4 py-2">
+                            {pill ? (
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  updateTransferUi(previewRow.row_number, { panelOpen: !ui.panelOpen })
+                                }
+                                className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${pill.classes}`}
+                                aria-expanded={ui.panelOpen}
+                                data-testid={`transfer-pill-${previewRow.row_number}`}
+                              >
+                                {pill.text}
+                              </button>
+                            ) : (
+                              <span className="text-text-muted">—</span>
+                            )}
+                          </td>
+                        )}
                       </tr>
 
                       {pill && ui.panelOpen && (
@@ -754,7 +771,8 @@ function ImportPageContent() {
             </button>
           </div>
         </div>
-      )}
+        );
+      })()}
 
       {/* ── Step 3: Results ─────────────────────────────────────────────── */}
       {step === "results" && results && (

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -760,13 +760,13 @@ function TransactionsPageContent() {
                   { field: "account_name" as const, label: "Account", span: "col-span-2", align: "" },
                   { field: "category_name" as const, label: "Category", span: "col-span-1", align: "" },
                   { field: "status" as const, label: "Status", span: "col-span-1", align: "text-center" },
-                  { field: "amount" as const, label: "Amount", span: "col-span-2", align: "text-right" },
+                  { field: "amount" as const, label: "Amount", span: "col-span-1", align: "text-right" },
                 ]).map((col) => (
                   <button key={col.field} onClick={() => toggleSort(col.field)} className={`${col.span} ${col.align} hover:text-text-primary transition-colors`}>
                     {col.label}{sortField === col.field ? (sortDir === "asc" ? " ↑" : " ↓") : ""}
                   </button>
                 ))}
-                <span className="col-span-1" />
+                <span className="col-span-2" />
               </div>
             </div>
             {(() => {
@@ -827,26 +827,26 @@ function TransactionsPageContent() {
                                 <option value="pending">Pending</option>
                               </select>
                             </span>
-                            <span className="col-span-2 flex gap-1 min-w-0">
+                            <span className="col-span-1 flex gap-1 min-w-0">
                               {editPartner ? (
                                 <span
                                   aria-label="Type"
                                   title="Type is fixed for transfer legs."
-                                  className={`text-[11px] !w-14 shrink-0 inline-flex items-center justify-center rounded border border-border bg-surface px-1 text-text-muted`}
+                                  className={`text-[11px] !w-10 shrink-0 inline-flex items-center justify-center rounded border border-border bg-surface px-1 text-text-muted`}
                                 >
                                   {editType === "expense" ? "-" : "+"}
                                 </span>
                               ) : (
-                                <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-[11px] !w-14 shrink-0 ${input}`}>
+                                <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-[11px] !w-10 shrink-0 ${input}`}>
                                   <option value="expense">-</option>
                                   <option value="income">+</option>
                                 </select>
                               )}
                               <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm flex-1 min-w-0 ${input}`} />
                             </span>
-                            <span className="col-span-1 flex justify-end gap-2">
-                              <button onClick={handleSaveEdit} className="text-xs text-accent hover:text-accent-hover">Save</button>
-                              <button onClick={closeEdit} className="text-xs text-text-muted hover:text-text-secondary">Cancel</button>
+                            <span className="col-span-2 flex flex-wrap justify-end gap-x-2 gap-y-1">
+                              <button onClick={handleSaveEdit} className="whitespace-nowrap text-xs text-accent hover:text-accent-hover">Save</button>
+                              <button onClick={closeEdit} className="whitespace-nowrap text-xs text-text-muted hover:text-text-secondary">Cancel</button>
                             </span>
                           </div>
                         </div>
@@ -888,18 +888,18 @@ function TransactionsPageContent() {
                               </button>
                             )}
                           </span>
-                          <span className={`col-span-2 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
+                          <span className={`col-span-1 text-right text-sm font-medium tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
                             {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
                           </span>
-                          <span className="col-span-1 flex justify-end gap-2">
-                            <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} disabled={bulkDeleting} className="text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Edit</button>
+                          <span className="col-span-2 flex flex-wrap justify-end gap-x-2 gap-y-1">
+                            <button onClick={() => startEdit(tx)} aria-label={`Edit: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Edit</button>
                             {!isTransfer && (
-                              <button onClick={() => setMarkModalSource(tx)} aria-label={`Mark as transfer: ${tx.description}`} disabled={bulkDeleting} className="text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Mark as transfer…</button>
+                              <button onClick={() => setMarkModalSource(tx)} aria-label={`Mark as transfer: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Mark transfer</button>
                             )}
                             {isTransfer && (
-                              <button onClick={() => openUnpairModal(tx)} aria-label={`Unlink transfer: ${tx.description}`} disabled={bulkDeleting} className="text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Unlink</button>
+                              <button onClick={() => openUnpairModal(tx)} aria-label={`Unlink transfer: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-accent disabled:opacity-40 disabled:cursor-not-allowed">Unlink</button>
                             )}
-                            <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} disabled={bulkDeleting} className="text-xs text-text-muted hover:text-danger disabled:opacity-40 disabled:cursor-not-allowed">Delete</button>
+                            <button onClick={() => setConfirmDeleteId(tx.id)} aria-label={`Delete: ${tx.description}`} disabled={bulkDeleting} className="whitespace-nowrap text-xs text-text-muted hover:text-danger disabled:opacity-40 disabled:cursor-not-allowed">Delete</button>
                           </span>
                         </div>
                       );

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -464,6 +464,57 @@ describe("ImportPage transfer pill column", () => {
     expect(body.rows[2].pair_with_transaction_id).toBeNull();
   });
 
+  it("hides the Transfer column header when no row has any transfer state", async () => {
+    // All rows are plain (no detector hits, no duplicate-of-linked).
+    const preview = basePreview([
+      baseRow({ row_number: 1, description: "Plain row 1" }),
+      baseRow({ row_number: 2, description: "Plain row 2" }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    // Body is rendered.
+    expect(screen.getByText("Plain row 1")).toBeInTheDocument();
+
+    // Transfer header should NOT be present when there is no transfer state at all.
+    const transferHeader = screen.queryByRole("columnheader", { name: /^Transfer$/i });
+    expect(transferHeader).toBeNull();
+  });
+
+  it("shows the Transfer column header when at least one row has transfer state", async () => {
+    const preview = basePreview([
+      baseRow({ row_number: 1, description: "Plain row" }),
+      baseRow({
+        row_number: 2,
+        description: "Pair row",
+        transfer_match_action: "pair_with",
+        transfer_match_confidence: "same_day",
+        pair_with_transaction_id: 99,
+        transfer_candidates: [
+          {
+            id: 99,
+            date: "2026-05-01",
+            description: "Counter leg",
+            amount: 50,
+            account_id: 2,
+            account_name: "Savings",
+            date_diff_days: 0,
+            confidence: "same_day",
+          },
+        ],
+      }),
+    ]);
+
+    await renderAndPreview(preview);
+
+    // Transfer header is present.
+    const transferHeader = screen.getByRole("columnheader", { name: /^Transfer$/i });
+    expect(transferHeader).toBeInTheDocument();
+
+    // Pill is rendered for the matched row.
+    expect(screen.getByTestId("transfer-pill-2")).toBeInTheDocument();
+  });
+
   it("results page surfaces paired_count and dropped_duplicate_count", async () => {
     const preview = basePreview([baseRow({ row_number: 1 })]);
 

--- a/frontend/tests/app/transactions-page.test.tsx
+++ b/frontend/tests/app/transactions-page.test.tsx
@@ -256,6 +256,41 @@ describe("TransactionsPage — transfer wiring (Task D7)", () => {
     expect(body.description).toBe("Linked out edited");
   });
 
+  it("Per-row action column renders all actions on a single un-linked row (responsive layout)", async () => {
+    // Smoke test for the responsive action-column fix: the Edit, Mark transfer,
+    // and Delete buttons must all render on the desktop grid for an un-linked
+    // row, with their full aria-labels intact.
+    const tx = makeTx({
+      id: 50, account_id: ACCT_A.id, account_name: ACCT_A.name,
+      type: "expense", amount: 30, description: "Solo tx",
+      linked_transaction_id: null,
+    });
+    setupApiFetch([tx]);
+
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Solo tx");
+
+    // All three expected actions must be reachable by aria-label. (Mobile and
+    // desktop layouts each render one button, hence findAll.)
+    await waitFor(() => {
+      expect(
+        screen.queryAllByRole("button", { name: /^Edit: Solo tx$/i }).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(
+      screen.getAllByRole("button", { name: /Mark as transfer: Solo tx/i }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("button", { name: /Delete: Solo tx/i }).length,
+    ).toBeGreaterThan(0);
+
+    // Linked-row "Unlink" must NOT appear on an un-linked row.
+    expect(
+      screen.queryByRole("button", { name: /Unlink transfer: Solo tx/i }),
+    ).toBeNull();
+  });
+
   it("Per-row Mark as transfer button shown on un-linked rows only", async () => {
     const linked = makeTx({
       id: 20, account_id: ACCT_A.id, account_name: ACCT_A.name,


### PR DESCRIPTION
## Summary

Two responsive-layout regressions from the recent transfers feature (PR-D, PR-E).

### /import — Transfer column appears empty for most rows
The Transfer column was always rendered, but the pill is only emitted for rows where the detector matched (a small minority in a typical import). The result: most rows showed an empty Transfer cell, which users read as "the column is broken / the checkbox is missing."

Fix: hide the column entirely when no row in the preview has any transfer state (`auto_paired_count + suggested_pair_count + multi_candidate_count + duplicate_of_linked_count === 0`). When at least one row does have transfer state, the column renders normally and non-matching rows show a `—` placeholder so the cell is no longer ambiguously blank. The panel-row colspan tracks the new column count.

### /transactions — action column overflowed
The desktop grid's action column was `col-span-1` (1/12 of the row, ~80px on a typical viewport) but contained three text buttons: Edit, Mark as transfer..., and Delete. The buttons spilled out of their cell and into the amount column.

Fix:
- Action column widened from `col-span-1` to `col-span-2`. Amount column tightened from `col-span-2` to `col-span-1` (tabular numbers, fits comfortably). Total still 12.
- Action button row uses `flex-wrap` with `gap-x-2 gap-y-1` so buttons stack onto a second line on tighter viewports instead of overflowing.
- Each button is `whitespace-nowrap` to keep individual labels intact.
- Visible label shortened from "Mark as transfer..." to "Mark transfer". The full `aria-label` ("Mark as transfer: <description>") is preserved, so existing accessibility tests still pass.
- Edit row's amount + Save/Cancel cells adjusted to match the new column spans.

## Tests

- `frontend/tests/app/import-page.test.tsx`: 2 new cases — Transfer header hidden when no row has transfer state, header present + pill renders when at least one row has it.
- `frontend/tests/app/transactions-page.test.tsx`: 1 new case — all per-row actions (Edit, Mark transfer, Delete) reachable on a single un-linked row.
- Full frontend suite: 93/93 pass. `npm run build` succeeds.