### PR TITLE
feat(transfers): manually mark rows as transfer during import (architect-extension)

### DIFF
--- a/backend/app/schemas/import_schemas.py
+++ b/backend/app/schemas/import_schemas.py
@@ -76,9 +76,12 @@ class ImportConfirmRow(BaseModel):
     skip: bool = False
 
     # Spec §3.2 confirm-row action mapping
-    action: Literal["create", "pair_with_existing", "drop_as_duplicate"] = "create"
+    action: Literal[
+        "create", "pair_with_existing", "drop_as_duplicate", "create_transfer_pair"
+    ] = "create"
     pair_with_transaction_id: int | None = None      # required iff action == "pair_with_existing"
     duplicate_of_transaction_id: int | None = None   # required iff action == "drop_as_duplicate"
+    partner_account_id: int | None = None            # required iff action == "create_transfer_pair"
     transfer_category_id: int | None = None
     recategorize: bool = True
 

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -428,6 +428,89 @@ async def execute_import(
                         )
                     action_taken = "drop_as_duplicate"
 
+                elif row.action == "create_transfer_pair":
+                    # First-import case: partner side not yet in DB. Create
+                    # BOTH legs (CSV leg + synthetic partner) and link them
+                    # atomically inside this row's savepoint.
+                    if row.partner_account_id is None:
+                        raise ValidationError(
+                            "partner_account_id required when "
+                            "action='create_transfer_pair'"
+                        )
+
+                    # Validate partner: same org, different from import
+                    # account, same currency.
+                    partner_account = await db.scalar(
+                        select(Account).where(
+                            Account.id == row.partner_account_id,
+                            Account.org_id == org_id,
+                        )
+                    )
+                    if partner_account is None:
+                        raise NotFoundError("Partner account")
+                    if partner_account.id == body.account_id:
+                        raise ValidationError(
+                            "Partner account must differ from import account"
+                        )
+                    if partner_account.currency != destination_account.currency:
+                        raise ValidationError(
+                            "Partner account currency must match import "
+                            "account currency"
+                        )
+
+                    # CSV leg — same shape as the plain create branch.
+                    csv_body = TransactionCreate(
+                        account_id=body.account_id,
+                        category_id=category_id,
+                        description=row.description,
+                        amount=row.amount,
+                        type=row.type,
+                        date=row.date,
+                    )
+                    csv_leg = await _create_transaction_no_commit(
+                        db, org_id, csv_body, is_imported=True
+                    )
+
+                    # Synthetic partner leg — opposite type, same magnitude
+                    # / date / description / status. is_imported=False
+                    # because the partner row was synthesized by us, not
+                    # parsed from a bank export.
+                    partner_type = "income" if row.type == "expense" else "expense"
+                    partner_body = TransactionCreate(
+                        account_id=row.partner_account_id,
+                        category_id=category_id,
+                        description=row.description,
+                        amount=row.amount,
+                        type=partner_type,
+                        date=row.date,
+                    )
+                    partner_leg = await _create_transaction_no_commit(
+                        db, org_id, partner_body, is_imported=False
+                    )
+
+                    # Determine which leg is expense / income for _link_pair.
+                    if csv_leg.type == TransactionType.EXPENSE:
+                        expense_tx, income_tx = csv_leg, partner_leg
+                    else:
+                        expense_tx, income_tx = partner_leg, csv_leg
+
+                    # _link_pair's currency invariant requires .account
+                    # loaded on both legs.
+                    await db.refresh(csv_leg, attribute_names=["account"])
+                    await db.refresh(partner_leg, attribute_names=["account"])
+
+                    await _link_pair(
+                        db,
+                        expense_tx=expense_tx,
+                        income_tx=income_tx,
+                        recategorize=row.recategorize,
+                        transfer_category_id=row.transfer_category_id,
+                    )
+                    paired_pair_ids.append((csv_leg.id, partner_leg.id))
+                    # Bind for post-savepoint telemetry.
+                    new_tx = csv_leg
+                    action_taken = "create_transfer_pair"
+
         except (ConflictError, ValidationError, NotFoundError) as exc:
             # Domain failures: row-level error, batch continues.
             errors.append(
@@ -475,6 +558,18 @@ async def execute_import(
                 duplicate_of_transaction_id=row.duplicate_of_transaction_id,
                 account_id=body.account_id,
                 amount=str(row.amount),  # spec §6.1: amount as string
+            )
+        elif action_taken == "create_transfer_pair":
+            # Counts as ONE CSV row (we created two legs but only one was in
+            # the CSV — the partner is synthetic).
+            paired_count += 1
+            await logger.ainfo(
+                "transfers.linked",
+                org_id=org_id,
+                expense_id=expense_tx.id,
+                income_id=income_tx.id,
+                source="import_create_pair",
+                recategorized=row.recategorize,
             )
 
         # ── Best-effort learning from the user's category choice ───────────

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -33,6 +33,7 @@ from app.services.transaction_service import (
     _load_opts,
     find_duplicate_of_linked_leg,
     find_match_candidates,
+    get_account_for_update,
 )
 from app.services.category_rules_service import (
     bump_shared_vote,
@@ -457,6 +458,19 @@ async def execute_import(
                             "Partner account currency must match import "
                             "account currency"
                         )
+
+                    # Acquire account locks in sorted-ID order to prevent
+                    # deadlock with concurrent imports running in the
+                    # opposite direction (import A→B vs import B→A). The
+                    # subsequent _create_transaction_no_commit calls will
+                    # re-acquire the same locks inside this transaction;
+                    # MySQL treats SELECT FOR UPDATE on an already-locked
+                    # row by the same txn as a no-op.
+                    first_id, second_id = sorted(
+                        [body.account_id, row.partner_account_id]
+                    )
+                    await get_account_for_update(db, first_id, org_id)
+                    await get_account_for_update(db, second_id, org_id)
 
                     # CSV leg — same shape as the plain create branch.
                     csv_body = TransactionCreate(

--- a/backend/tests/services/test_import_execute_with_rules.py
+++ b/backend/tests/services/test_import_execute_with_rules.py
@@ -387,3 +387,63 @@ async def test_default_category_fallthrough_records_miss(
     assert agg["miss_count"] == 1
     assert agg["learned_count"] == 0  # user didn't pick → no learn
     assert agg["source_split"]["default"] == 1
+
+
+async def test_create_transfer_pair_does_not_learn(
+    db_session: AsyncSession,
+) -> None:
+    """Smart-rules learning must not fire for action='create_transfer_pair'
+    rows. The CSV leg gets linked_transaction_id set by _link_pair, so it's
+    a transfer leg post-link; learn_from_choice must NEVER be called for
+    these rows. Mirrors test_transfer_row_does_not_learn for the new action.
+    """
+    seed = await _seed(db_session, share=False)
+    # Need a partner account in a different account from the import target.
+    other_acct = Account(
+        org_id=seed["org_id"], account_type_id=seed["account_type_id"],
+        name="Savings", balance=Decimal("0"), currency="EUR",
+    )
+    db_session.add(other_acct)
+    await db_session.flush()
+    src_acct = (await db_session.execute(
+        select(Account).where(Account.id == seed["account_id"])
+    )).scalar_one()
+    src_acct.currency = "EUR"
+    transfer_cat = Category(
+        org_id=seed["org_id"], name="Transfer", slug="transfer",
+        is_system=True, type=CategoryType.BOTH,
+    )
+    db_session.add(transfer_cat)
+    await db_session.commit()
+
+    body = ImportConfirmRequest(
+        account_id=seed["account_id"],
+        default_category_id=transfer_cat.id,
+        rows=[ImportConfirmRow(
+            row_number=1, date=datetime.date(2026, 5, 1),
+            description="POS LIDL *9999",  # would normally learn → "LIDL"
+            amount=Decimal("12.50"), type="expense",
+            category_id=transfer_cat.id,
+            action="create_transfer_pair",
+            partner_account_id=other_acct.id,
+            recategorize=False,
+            # Echo a suggestion so we'd see learning fire if it ran.
+            suggested_category_id=seed["groceries_id"],
+            suggestion_source="shared_dictionary",
+        )],
+    )
+
+    with patch(
+        "app.services.import_service.learn_from_choice",
+        new=AsyncMock(),
+    ) as learn_spy:
+        await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    # learn_from_choice must NEVER be called for create_transfer_pair rows.
+    learn_spy.assert_not_called()
+
+    # And no CategoryRule was written for the LIDL token.
+    rules = (await db_session.execute(select(CategoryRule))).scalars().all()
+    assert rules == []

--- a/backend/tests/services/test_import_service_transfers.py
+++ b/backend/tests/services/test_import_service_transfers.py
@@ -1005,3 +1005,91 @@ async def test_confirm_create_transfer_pair_increments_paired_count(
         + result.error_count
     )
     assert total == len(body.rows)
+
+
+async def test_create_transfer_pair_locks_accounts_in_sorted_order(
+    db_session: AsyncSession,
+    monkeypatch,
+) -> None:
+    """Sanity check: account locks for create_transfer_pair are acquired in
+    sorted-ID order BEFORE either _create_transaction_no_commit call.
+    Mirrors the pattern in convert_and_create_leg's lock-ordering test
+    (PR-#118 review fix — deadlock prevention).
+    """
+    seed = await _seed_two_accounts(db_session)
+    # src_id < dst_id by insertion order; verify and capture both for the
+    # sorted-ID assertion below.
+    src_id = seed["src_id"]
+    dst_id = seed["dst_id"]
+    assert src_id < dst_id
+
+    real_get_account = import_service.get_account_for_update
+    real_create = import_service._create_transaction_no_commit
+    call_log: list[tuple[str, int]] = []
+
+    async def spy_get_account(db, account_id, org_id):
+        call_log.append(("lock_account", account_id))
+        return await real_get_account(db, account_id, org_id)
+
+    async def spy_create(db, org_id, body, *, is_imported=False):
+        call_log.append(("create_no_commit", body.account_id))
+        return await real_create(db, org_id, body, is_imported=is_imported)
+
+    monkeypatch.setattr(
+        import_service, "get_account_for_update", spy_get_account,
+    )
+    monkeypatch.setattr(
+        import_service, "_create_transaction_no_commit", spy_create,
+    )
+
+    when = datetime.date(2026, 5, 1)
+    body = ImportConfirmRequest(
+        account_id=src_id,
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="TO SAVINGS", amount=Decimal("80"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="create_transfer_pair",
+            partner_account_id=dst_id,
+            recategorize=False,
+        )],
+    )
+
+    result = await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+    assert result.paired_count == 1
+    assert result.error_count == 0
+
+    # The account-lock calls (entries with op="lock_account") must come
+    # BEFORE any "create_no_commit" call, AND in sorted-ID order
+    # (lo then hi).
+    lock_entries = [c for c in call_log if c[0] == "lock_account"]
+    create_entries = [c for c in call_log if c[0] == "create_no_commit"]
+    assert len(lock_entries) >= 2, (
+        f"Expected >=2 account locks, got: {call_log}"
+    )
+    assert len(create_entries) >= 2, (
+        f"Expected 2 transaction creates, got: {call_log}"
+    )
+
+    # First two locks are the sorted account-id pair.
+    first_two_lock_ids = [c[1] for c in lock_entries[:2]]
+    assert first_two_lock_ids == sorted(first_two_lock_ids), (
+        f"Account locks must be sorted-ID order; got {first_two_lock_ids}"
+    )
+    assert first_two_lock_ids == [src_id, dst_id]
+
+    # Both account-locks happen BEFORE any create_no_commit.
+    first_create_idx = next(
+        i for i, c in enumerate(call_log) if c[0] == "create_no_commit"
+    )
+    pre_create_locks = [
+        i for i, c in enumerate(call_log[:first_create_idx])
+        if c[0] == "lock_account"
+    ]
+    assert len(pre_create_locks) >= 2, (
+        f"Both account locks must precede the first create; got {call_log}"
+    )

--- a/backend/tests/services/test_import_service_transfers.py
+++ b/backend/tests/services/test_import_service_transfers.py
@@ -769,3 +769,239 @@ async def test_confirm_pair_with_existing_rejects_pending_partner(
         )
     )).scalars().all()
     assert new_legs == []
+
+
+# ── IMM (import-mark-manual) create_transfer_pair branch ─────────────────────
+
+
+async def test_confirm_create_transfer_pair_creates_both_legs_and_links(
+    db_session: AsyncSession,
+) -> None:
+    """action='create_transfer_pair' creates the CSV leg + a synthetic
+    partner leg on partner_account_id and links them. Counts once toward
+    paired_count; transfers.linked emitted with source='import_create_pair'.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="TO SAVINGS", amount=Decimal("80"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="create_transfer_pair",
+            partner_account_id=seed["dst_id"],
+            recategorize=False,
+        )],
+    )
+
+    with patch.object(
+        import_service.logger, "ainfo", new_callable=AsyncMock,
+    ) as spy:
+        result = await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    assert result.imported_count == 0
+    assert result.paired_count == 1
+    assert result.dropped_duplicate_count == 0
+    assert result.error_count == 0
+
+    # Two transactions exist: one expense on src, one income on dst, both
+    # linked to each other, equal amounts, same date.
+    csv_leg = (await db_session.execute(
+        select(Transaction).where(
+            Transaction.account_id == seed["src_id"],
+        )
+    )).scalar_one()
+    partner_leg = (await db_session.execute(
+        select(Transaction).where(
+            Transaction.account_id == seed["dst_id"],
+        )
+    )).scalar_one()
+    assert csv_leg.type == TransactionType.EXPENSE
+    assert partner_leg.type == TransactionType.INCOME
+    assert csv_leg.amount == partner_leg.amount == Decimal("80")
+    assert csv_leg.date == partner_leg.date == when
+    assert csv_leg.linked_transaction_id == partner_leg.id
+    assert partner_leg.linked_transaction_id == csv_leg.id
+    # CSV leg flagged is_imported; synthetic partner is not.
+    assert csv_leg.is_imported is True
+    assert partner_leg.is_imported is False
+
+    linked_calls = [
+        c for c in spy.call_args_list
+        if c.args and c.args[0] == "transfers.linked"
+    ]
+    assert len(linked_calls) == 1
+    assert linked_calls[0].kwargs["source"] == "import_create_pair"
+    assert linked_calls[0].kwargs["recategorized"] is False
+
+
+async def test_confirm_create_transfer_pair_atomicity_rollback(
+    db_session: AsyncSession,
+) -> None:
+    """If _link_pair raises after both creates, BOTH legs roll back. The DB
+    must contain zero transactions afterward.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="TO SAVINGS", amount=Decimal("80"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="create_transfer_pair",
+            partner_account_id=seed["dst_id"],
+        )],
+    )
+
+    with patch(
+        "app.services.import_service._link_pair",
+        new=AsyncMock(side_effect=RuntimeError("simulated link failure")),
+    ):
+        result = await import_service.execute_import(
+            db_session, org_id=seed["org_id"], body=body,
+        )
+
+    # Surfaces as a row error.
+    assert result.paired_count == 0
+    assert result.imported_count == 0
+    assert result.error_count == 1
+    assert "simulated link failure" in result.errors[0].error
+
+    # Zero transactions in the DB — both legs were savepoint-rolled back.
+    all_tx = (await db_session.execute(select(Transaction))).scalars().all()
+    assert all_tx == []
+
+
+async def test_confirm_create_transfer_pair_validates_currency_mismatch(
+    db_session: AsyncSession,
+) -> None:
+    """Partner account with a different currency → row error, no rows
+    created (savepoint rollback).
+    """
+    seed = await _seed_two_accounts(db_session)
+    # Flip dst's currency to USD (src stays EUR).
+    dst = (await db_session.execute(
+        select(Account).where(Account.id == seed["dst_id"])
+    )).scalar_one()
+    dst.currency = "USD"
+    await db_session.commit()
+
+    when = datetime.date(2026, 5, 1)
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="TO SAVINGS", amount=Decimal("50"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="create_transfer_pair",
+            partner_account_id=seed["dst_id"],
+        )],
+    )
+
+    result = await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+    assert result.paired_count == 0
+    assert result.imported_count == 0
+    assert result.error_count == 1
+    assert "currency" in result.errors[0].error.lower()
+
+    # No transactions created.
+    all_tx = (await db_session.execute(select(Transaction))).scalars().all()
+    assert all_tx == []
+
+
+async def test_confirm_create_transfer_pair_validates_same_account(
+    db_session: AsyncSession,
+) -> None:
+    """partner_account_id == import account → row error, no rows created."""
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[ImportConfirmRow(
+            row_number=1, date=when,
+            description="SELF TRANSFER", amount=Decimal("30"),
+            type="expense",
+            category_id=seed["transfer_cat_id"],
+            action="create_transfer_pair",
+            partner_account_id=seed["src_id"],  # same as import account
+        )],
+    )
+
+    result = await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+    assert result.paired_count == 0
+    assert result.imported_count == 0
+    assert result.error_count == 1
+    assert "differ" in result.errors[0].error.lower()
+    all_tx = (await db_session.execute(select(Transaction))).scalars().all()
+    assert all_tx == []
+
+
+async def test_confirm_create_transfer_pair_increments_paired_count(
+    db_session: AsyncSession,
+) -> None:
+    """Mixed batch: 2 plain creates + 1 create_transfer_pair → imported=2,
+    paired=1. Confirms the new branch contributes to paired_count, not
+    imported_count.
+    """
+    seed = await _seed_two_accounts(db_session)
+    when = datetime.date(2026, 5, 1)
+    body = ImportConfirmRequest(
+        account_id=seed["src_id"],
+        default_category_id=seed["transfer_cat_id"],
+        rows=[
+            ImportConfirmRow(
+                row_number=1, date=when,
+                description="POS COFFEE A", amount=Decimal("3.50"),
+                type="expense",
+                category_id=seed["transfer_cat_id"],
+                action="create",
+            ),
+            ImportConfirmRow(
+                row_number=2, date=when,
+                description="POS COFFEE B", amount=Decimal("4.50"),
+                type="expense",
+                category_id=seed["transfer_cat_id"],
+                action="create",
+            ),
+            ImportConfirmRow(
+                row_number=3, date=when,
+                description="TO SAVINGS", amount=Decimal("100"),
+                type="expense",
+                category_id=seed["transfer_cat_id"],
+                action="create_transfer_pair",
+                partner_account_id=seed["dst_id"],
+            ),
+        ],
+    )
+
+    result = await import_service.execute_import(
+        db_session, org_id=seed["org_id"], body=body,
+    )
+    assert result.imported_count == 2
+    assert result.paired_count == 1
+    assert result.dropped_duplicate_count == 0
+    assert result.skipped_count == 0
+    assert result.error_count == 0
+    total = (
+        result.imported_count + result.paired_count
+        + result.dropped_duplicate_count + result.skipped_count
+        + result.error_count
+    )
+    assert total == len(body.rows)

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -645,7 +645,8 @@ function ImportPageContent() {
                                   data-testid={`mark-transfer-pill-${previewRow.row_number}`}
                                 >
                                   <span>
-                                    Will create transfer to{" "}
+                                    Will create transfer{" "}
+                                    {previewRow.type === "expense" ? "to" : "from"}{" "}
                                     {accountsById.get(ui.markTransferDestAccountId)?.name ??
                                       "account"}
                                   </span>
@@ -864,6 +865,7 @@ function ImportPageContent() {
               rowDate={markTransferModalRow.date}
               rowType={markTransferModalRow.type}
               importAccountId={preview.account_id}
+              importAccountName={currentImportAccount.name}
               importAccountCurrency={currentImportAccount.currency}
               accounts={accounts ?? []}
               initialDestAccountId={

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -505,11 +505,16 @@ function ImportPageContent() {
                   if (!rowState) return null;
 
                   // Apply Review pairings filter — when ON, only render rows
-                  // with a transfer detector match (Detector 1 or Detector 2).
+                  // with a transfer detector match (Detector 1 or Detector 2)
+                  // OR a manual "Mark as transfer..." selection in the
+                  // per-row UI state.
+                  const manualMarkDestId =
+                    transferUi[previewRow.row_number]?.markTransferDestAccountId ?? null;
                   if (
                     reviewPairingsOnly &&
                     previewRow.transfer_match_action === "none" &&
-                    !previewRow.is_duplicate_of_linked_leg
+                    !previewRow.is_duplicate_of_linked_leg &&
+                    manualMarkDestId === null
                   ) {
                     return null;
                   }

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -8,6 +8,7 @@ import { apiFetch, extractErrorMessage } from "@/lib/api";
 import AppShell from "@/components/AppShell";
 import CategorySelect from "@/components/ui/CategorySelect";
 import Spinner from "@/components/ui/Spinner";
+import ImportMarkAsTransferModal from "@/components/transactions/ImportMarkAsTransferModal";
 import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import type {
   Account,
@@ -28,6 +29,9 @@ type TransferUiState = {
   pairAccepted: boolean;
   selectedCandidateId: number | null;
   dropAccepted: boolean;
+  // Manual "Mark as transfer..." choice for un-flagged rows. When set, the
+  // row will be confirmed as create_transfer_pair with this as partner.
+  markTransferDestAccountId: number | null;
 };
 
 /**
@@ -83,6 +87,21 @@ function buildConfirmRow(
       ...rowState,
       action: "pair_with_existing",
       pair_with_transaction_id: partnerId,
+      duplicate_of_transaction_id: null,
+      transfer_category_id: null,
+      recategorize: true,
+    };
+  }
+
+  // Manual "Mark as transfer..." — the user flagged an un-detected row
+  // and picked a destination account. Backend creates the CSV leg + a
+  // synthetic partner leg on the chosen account, atomically.
+  if (ui.markTransferDestAccountId !== null) {
+    return {
+      ...rowState,
+      action: "create_transfer_pair",
+      partner_account_id: ui.markTransferDestAccountId,
+      pair_with_transaction_id: null,
       duplicate_of_transaction_id: null,
       transfer_category_id: null,
       recategorize: true,
@@ -206,6 +225,7 @@ function ImportPageContent() {
           pairAccepted: r.transfer_match_action === "pair_with",
           selectedCandidateId: null,
           dropAccepted: r.is_duplicate_of_linked_leg, // default Drop
+          markTransferDestAccountId: null,
         };
       });
       setTransferUi(ui);
@@ -232,6 +252,7 @@ function ImportPageContent() {
       pairAccepted: false,
       selectedCandidateId: null,
       dropAccepted: false,
+      markTransferDestAccountId: null,
     };
     const payloadRows = rowStates.map((rs) => {
       const pv = previewByRow.get(rs.row_number);
@@ -273,9 +294,13 @@ function ImportPageContent() {
         pairAccepted: false,
         selectedCandidateId: null,
         dropAccepted: false,
+        markTransferDestAccountId: null,
       }), ...patch },
     }));
   }, []);
+
+  // Modal state — when set, opens ImportMarkAsTransferModal for that row.
+  const [markTransferModalRow, setMarkTransferModalRow] = useState<ImportPreviewRow | null>(null);
 
   const activeRows = rowStates.filter((r) => !r.skip);
   const skipCount = rowStates.filter((r) => r.skip).length;
@@ -358,15 +383,30 @@ function ImportPageContent() {
 
       {/* ── Step 2: Preview ─────────────────────────────────────────────── */}
       {step === "preview" && preview && categories && categories.length > 0 && (() => {
-        // Hide the Transfer column entirely when no row in this preview has
-        // any transfer state. Avoids a column of empty cells confusing users
-        // who report "the Transfer column is empty / checkbox missing".
+        // Account selected at upload time. Drives the eligible-for-manual-mark
+        // check (need at least one OTHER same-currency account).
+        const currentImportAccount = accounts?.find((a) => a.id === preview.account_id);
+        const eligibleForManualMark =
+          !!currentImportAccount &&
+          (accounts?.filter(
+            (a) =>
+              a.id !== preview.account_id &&
+              a.currency === currentImportAccount.currency &&
+              a.is_active,
+          ).length ?? 0) > 0;
+
+        // Lookup map for rendering "Will create transfer to <name>" pill.
+        const accountsById = new Map((accounts ?? []).map((a) => [a.id, a]));
+
+        // Show the Transfer column when ANY row has a detector hit OR when
+        // manual marking is possible (so even on a no-detector-hit import the
+        // column appears with per-row "Mark as transfer..." buttons).
         const hasAnyTransferState =
           preview.auto_paired_count +
             preview.suggested_pair_count +
             preview.multi_candidate_count +
             preview.duplicate_of_linked_count >
-          0;
+            0 || eligibleForManualMark;
         return (
         <div className="space-y-4">
           {/* Summary bar */}
@@ -486,6 +526,7 @@ function ImportPageContent() {
                     pairAccepted: false,
                     selectedCandidateId: null,
                     dropAccepted: false,
+                    markTransferDestAccountId: null,
                   };
 
                   // Pill rendering driven by detector outputs. Detector 1
@@ -591,6 +632,44 @@ function ImportPageContent() {
                               >
                                 {pill.text}
                               </button>
+                            ) : previewRow.transfer_match_action === "none" &&
+                              !previewRow.is_duplicate_of_linked_leg ? (
+                              ui.markTransferDestAccountId !== null ? (
+                                <span
+                                  className="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2.5 py-1 text-xs font-medium text-accent"
+                                  data-testid={`mark-transfer-pill-${previewRow.row_number}`}
+                                >
+                                  <span>
+                                    Will create transfer to{" "}
+                                    {accountsById.get(ui.markTransferDestAccountId)?.name ??
+                                      "account"}
+                                  </span>
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      updateTransferUi(previewRow.row_number, {
+                                        markTransferDestAccountId: null,
+                                      })
+                                    }
+                                    aria-label="Clear mark as transfer"
+                                    className="ml-1 rounded text-accent hover:text-accent-hover"
+                                    data-testid={`mark-transfer-clear-${previewRow.row_number}`}
+                                  >
+                                    x
+                                  </button>
+                                </span>
+                              ) : eligibleForManualMark ? (
+                                <button
+                                  type="button"
+                                  onClick={() => setMarkTransferModalRow(previewRow)}
+                                  className="text-xs text-text-muted underline-offset-2 hover:text-accent hover:underline"
+                                  data-testid={`mark-transfer-button-${previewRow.row_number}`}
+                                >
+                                  Mark as transfer...
+                                </button>
+                              ) : (
+                                <span className="text-text-muted">—</span>
+                              )
                             ) : (
                               <span className="text-text-muted">—</span>
                             )}
@@ -770,6 +849,30 @@ function ImportPageContent() {
                 : `Import ${activeRows.length} transaction${activeRows.length === 1 ? "" : "s"}`}
             </button>
           </div>
+
+          {/* Mark-as-transfer modal (manual flag for un-detected rows). */}
+          {markTransferModalRow && currentImportAccount && (
+            <ImportMarkAsTransferModal
+              rowNumber={markTransferModalRow.row_number}
+              rowDescription={markTransferModalRow.description}
+              rowAmount={markTransferModalRow.amount}
+              rowDate={markTransferModalRow.date}
+              rowType={markTransferModalRow.type}
+              importAccountId={preview.account_id}
+              importAccountCurrency={currentImportAccount.currency}
+              accounts={accounts ?? []}
+              initialDestAccountId={
+                transferUi[markTransferModalRow.row_number]?.markTransferDestAccountId ?? null
+              }
+              onConfirm={(destAccountId) => {
+                updateTransferUi(markTransferModalRow.row_number, {
+                  markTransferDestAccountId: destAccountId,
+                });
+                setMarkTransferModalRow(null);
+              }}
+              onCancel={() => setMarkTransferModalRow(null)}
+            />
+          )}
         </div>
         );
       })()}

--- a/frontend/components/transactions/ImportMarkAsTransferModal.tsx
+++ b/frontend/components/transactions/ImportMarkAsTransferModal.tsx
@@ -12,6 +12,7 @@ interface Props {
   rowDate: string;
   rowType: "income" | "expense";
   importAccountId: number;
+  importAccountName: string;
   importAccountCurrency: string;
   accounts: Account[];
   initialDestAccountId: number | null;
@@ -32,6 +33,7 @@ export default function ImportMarkAsTransferModal({
   rowDate,
   rowType,
   importAccountId,
+  importAccountName,
   importAccountCurrency,
   accounts,
   initialDestAccountId,
@@ -92,9 +94,23 @@ export default function ImportMarkAsTransferModal({
     return () => document.removeEventListener("keydown", handleKey);
   }, [onCancel]);
 
+  const selectedAccount = useMemo(
+    () =>
+      destAccountId === ""
+        ? null
+        : eligibleAccounts.find((a) => a.id === Number(destAccountId)) ?? null,
+    [destAccountId, eligibleAccounts],
+  );
+
+  const directionPreview = selectedAccount
+    ? rowType === "expense"
+      ? `${importAccountName} → ${selectedAccount.name}`
+      : `${selectedAccount.name} → ${importAccountName}`
+    : null;
+
   function handleSubmit() {
     if (destAccountId === "") {
-      setErrorMsg("Pick a destination account.");
+      setErrorMsg("Pick an account.");
       return;
     }
     onConfirm(Number(destAccountId));
@@ -135,7 +151,7 @@ export default function ImportMarkAsTransferModal({
 
         <div className="mb-4">
           <label className={label} htmlFor={`import-mark-transfer-dest-${rowNumber}`}>
-            Destination account
+            Other account
           </label>
           <select
             id={`import-mark-transfer-dest-${rowNumber}`}
@@ -156,6 +172,14 @@ export default function ImportMarkAsTransferModal({
           {eligibleAccounts.length === 0 && (
             <p className="mt-2 text-xs text-text-muted">
               No other same-currency account available.
+            </p>
+          )}
+          {directionPreview && (
+            <p
+              className="mt-2 text-xs text-text-muted"
+              data-testid={`import-mark-transfer-direction-${rowNumber}`}
+            >
+              Direction: {directionPreview}
             </p>
           )}
         </div>

--- a/frontend/components/transactions/ImportMarkAsTransferModal.tsx
+++ b/frontend/components/transactions/ImportMarkAsTransferModal.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { btnPrimary, btnSecondary, card, error as errorCls, input, label } from "@/lib/styles";
+import type { Account } from "@/lib/types";
+
+interface Props {
+  rowNumber: number;
+  rowDescription: string;
+  rowAmount: number;
+  rowDate: string;
+  rowType: "income" | "expense";
+  importAccountId: number;
+  importAccountCurrency: string;
+  accounts: Account[];
+  initialDestAccountId: number | null;
+  onConfirm: (destAccountId: number) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Modal shown on the /import preview when a user clicks "Mark as transfer..."
+ * on a row that has no detector hit. Stores the user's destination-account
+ * choice in parent state; the actual create_transfer_pair payload is built at
+ * confirm time. Does not call the backend.
+ */
+export default function ImportMarkAsTransferModal({
+  rowNumber,
+  rowDescription,
+  rowAmount,
+  rowDate,
+  rowType,
+  importAccountId,
+  importAccountCurrency,
+  accounts,
+  initialDestAccountId,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [destAccountId, setDestAccountId] = useState<number | "">(
+    initialDestAccountId ?? "",
+  );
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const eligibleAccounts = useMemo(
+    () =>
+      accounts.filter(
+        (a) =>
+          a.id !== importAccountId &&
+          a.currency === importAccountCurrency &&
+          a.is_active,
+      ),
+    [accounts, importAccountId, importAccountCurrency],
+  );
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    cancelRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onCancel]);
+
+  function handleSubmit() {
+    if (destAccountId === "") {
+      setErrorMsg("Pick a destination account.");
+      return;
+    }
+    onConfirm(Number(destAccountId));
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="import-mark-transfer-title"
+        className={`${card} w-full max-w-md p-6 shadow-xl`}
+        data-testid={`import-mark-transfer-modal-${rowNumber}`}
+      >
+        <h2
+          id="import-mark-transfer-title"
+          className="mb-4 text-lg font-semibold text-text-primary"
+        >
+          Mark as transfer
+        </h2>
+
+        <div className="mb-4 space-y-1 text-sm text-text-primary">
+          <div>
+            <span className="font-medium">Date:</span> {rowDate}
+          </div>
+          <div>
+            <span className="font-medium">Amount:</span>{" "}
+            <span className={rowType === "income" ? "text-success" : "text-danger"}>
+              {rowType === "income" ? "+" : "-"}
+              {Number(rowAmount).toFixed(2)} {importAccountCurrency}
+            </span>
+          </div>
+          <div className="truncate">
+            <span className="font-medium">Description:</span> {rowDescription}
+          </div>
+        </div>
+
+        <div className="mb-4">
+          <label className={label} htmlFor={`import-mark-transfer-dest-${rowNumber}`}>
+            Destination account
+          </label>
+          <select
+            id={`import-mark-transfer-dest-${rowNumber}`}
+            value={destAccountId}
+            onChange={(e) =>
+              setDestAccountId(e.target.value === "" ? "" : Number(e.target.value))
+            }
+            className={input}
+            data-testid={`import-mark-transfer-dest-select-${rowNumber}`}
+          >
+            <option value="">Select account...</option>
+            {eligibleAccounts.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name} ({a.currency})
+              </option>
+            ))}
+          </select>
+          {eligibleAccounts.length === 0 && (
+            <p className="mt-2 text-xs text-text-muted">
+              No other same-currency account available.
+            </p>
+          )}
+        </div>
+
+        {errorMsg && (
+          <div role="alert" className={`${errorCls} mb-4`}>
+            {errorMsg}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className={btnSecondary}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={destAccountId === ""}
+            className={btnPrimary}
+            data-testid={`import-mark-transfer-confirm-${rowNumber}`}
+          >
+            Mark as transfer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -213,9 +213,10 @@ export interface ImportConfirmRow {
   category_id: number | null;
   skip: boolean;
   // Spec §3.2 confirm-row action mapping
-  action?: "create" | "pair_with_existing" | "drop_as_duplicate";
+  action?: "create" | "pair_with_existing" | "drop_as_duplicate" | "create_transfer_pair";
   pair_with_transaction_id?: number | null;
   duplicate_of_transaction_id?: number | null;
+  partner_account_id?: number | null;
   transfer_category_id?: number | null;
   recategorize?: boolean;
   // Echoed from preview for accept-vs-override smart-rules detection

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -708,4 +708,74 @@ describe("ImportPage transfer pill column", () => {
       screen.getByText(/1 dropped as duplicate of existing transfer leg/i),
     ).toBeInTheDocument();
   });
+
+  it("Review pairings only filter includes manually marked rows", async () => {
+    // Two same-currency accounts so the manual "Mark as transfer" path is
+    // eligible. Three plain rows, none with a detector flag set — without
+    // the fix, toggling the filter would hide all rows.
+    const SAVINGS = {
+      ...ACCOUNT,
+      id: 2,
+      name: "Savings",
+      is_default: false,
+    };
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([ACCOUNT, SAVINGS]);
+      if (url === "/api/v1/categories")
+        return Promise.resolve([CATEGORY_EXP, CATEGORY_INC]);
+      if (url === "/api/v1/import/preview")
+        return Promise.resolve(
+          basePreview([
+            baseRow({ row_number: 1, description: "Plain row 1" }),
+            baseRow({ row_number: 2, description: "Plain row 2" }),
+            baseRow({ row_number: 3, description: "Plain row 3" }),
+          ]),
+        );
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ImportPage />
+      </SWRConfig>,
+    );
+    const uploadButton = await screen.findByRole("button", {
+      name: /upload & preview/i,
+    });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["x"], "test.csv", { type: "text/csv" })] },
+    });
+    fireEvent.click(uploadButton);
+    await screen.findByText("test.csv");
+
+    // All three rows visible initially.
+    expect(screen.getByText("Plain row 1")).toBeInTheDocument();
+    expect(screen.getByText("Plain row 2")).toBeInTheDocument();
+    expect(screen.getByText("Plain row 3")).toBeInTheDocument();
+
+    // Manually mark row 2 as a transfer to Savings.
+    fireEvent.click(screen.getByTestId("mark-transfer-button-2"));
+    const destSelect = (await screen.findByTestId(
+      "import-mark-transfer-dest-select-2",
+    )) as HTMLSelectElement;
+    fireEvent.change(destSelect, { target: { value: "2" } });
+    fireEvent.click(screen.getByTestId("import-mark-transfer-confirm-2"));
+    await waitFor(() => {
+      expect(screen.getByTestId("mark-transfer-pill-2")).toBeInTheDocument();
+    });
+
+    // Toggle "Review pairings only" ON.
+    const toggle = screen.getByTestId("review-pairings-toggle") as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(toggle.checked).toBe(true);
+
+    // Only the manually-marked row 2 stays visible. Rows 1 and 3 are
+    // hidden because they have no detector flag and no manual mark.
+    expect(screen.queryByText("Plain row 1")).toBeNull();
+    expect(screen.getByText("Plain row 2")).toBeInTheDocument();
+    expect(screen.queryByText("Plain row 3")).toBeNull();
+  });
 });

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
 
 import ImportPage from "@/app/import/page";
 import { apiFetch } from "@/lib/api";
@@ -513,6 +514,167 @@ describe("ImportPage transfer pill column", () => {
 
     // Pill is rendered for the matched row.
     expect(screen.getByTestId("transfer-pill-2")).toBeInTheDocument();
+  });
+
+  it("Mark as transfer button visible only on rows without detector flags when eligible accounts exist", async () => {
+    const SAVINGS = {
+      ...ACCOUNT,
+      id: 2,
+      name: "Savings",
+      is_default: false,
+    };
+
+    // Two same-currency accounts (Checking + Savings) so manual mark is eligible.
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([ACCOUNT, SAVINGS]);
+      if (url === "/api/v1/categories")
+        return Promise.resolve([CATEGORY_EXP, CATEGORY_INC]);
+      if (url === "/api/v1/import/preview")
+        return Promise.resolve(
+          basePreview([
+            // Plain (un-flagged) row → should show Mark button.
+            baseRow({ row_number: 1, description: "Plain row 1" }),
+            // Detector-flagged row → should NOT show Mark button.
+            baseRow({
+              row_number: 2,
+              description: "Pair row",
+              transfer_match_action: "pair_with",
+              transfer_match_confidence: "same_day",
+              pair_with_transaction_id: 99,
+              transfer_candidates: [
+                {
+                  id: 99,
+                  date: "2026-05-01",
+                  description: "Counter leg",
+                  amount: 50,
+                  account_id: 2,
+                  account_name: "Savings",
+                  date_diff_days: 0,
+                  confidence: "same_day",
+                },
+              ],
+            }),
+          ]),
+        );
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ImportPage />
+      </SWRConfig>,
+    );
+    const uploadButton = await screen.findByRole("button", {
+      name: /upload & preview/i,
+    });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["x"], "test.csv", { type: "text/csv" })] },
+    });
+    fireEvent.click(uploadButton);
+    await screen.findByText("test.csv");
+
+    // Plain un-flagged row gets the Mark button.
+    expect(screen.getByTestId("mark-transfer-button-1")).toBeInTheDocument();
+
+    // The detector-flagged row should NOT get a Mark button (it gets a pill instead).
+    expect(screen.queryByTestId("mark-transfer-button-2")).toBeNull();
+    expect(screen.getByTestId("transfer-pill-2")).toBeInTheDocument();
+  });
+
+  it("Confirm payload sets create_transfer_pair when user marks a row", async () => {
+    const SAVINGS = {
+      ...ACCOUNT,
+      id: 2,
+      name: "Savings",
+      is_default: false,
+    };
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([ACCOUNT, SAVINGS]);
+      if (url === "/api/v1/categories")
+        return Promise.resolve([CATEGORY_EXP, CATEGORY_INC]);
+      if (url === "/api/v1/import/preview")
+        return Promise.resolve(
+          basePreview([
+            baseRow({ row_number: 1, description: "Plain row" }),
+          ]),
+        );
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ImportPage />
+      </SWRConfig>,
+    );
+    const uploadButton = await screen.findByRole("button", {
+      name: /upload & preview/i,
+    });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["x"], "test.csv", { type: "text/csv" })] },
+    });
+    fireEvent.click(uploadButton);
+    await screen.findByText("test.csv");
+
+    // Click the Mark as transfer button.
+    fireEvent.click(screen.getByTestId("mark-transfer-button-1"));
+
+    // Modal opens. Pick destination account = Savings (id=2).
+    const destSelect = (await screen.findByTestId(
+      "import-mark-transfer-dest-select-1",
+    )) as HTMLSelectElement;
+    fireEvent.change(destSelect, { target: { value: "2" } });
+
+    // Confirm modal.
+    fireEvent.click(screen.getByTestId("import-mark-transfer-confirm-1"));
+
+    // Confirmation pill replaces the button.
+    await waitFor(() => {
+      expect(screen.getByTestId("mark-transfer-pill-1")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("mark-transfer-pill-1")).toHaveTextContent(
+      /Will create transfer to Savings/i,
+    );
+
+    // Provide default category so confirm is enabled.
+    const selects = document.querySelectorAll("select");
+    const defaultCatSelect = selects[selects.length - 1] as HTMLSelectElement;
+    fireEvent.change(defaultCatSelect, { target: { value: "5" } });
+
+    apiFetchMock.mockResolvedValueOnce({
+      imported_count: 1,
+      paired_count: 1,
+      dropped_duplicate_count: 0,
+      skipped_count: 0,
+      error_count: 0,
+      errors: [],
+    } as never);
+
+    const confirmBtn = screen.getByRole("button", { name: /import 1 transaction/i });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const confirmCall = apiFetchMock.mock.calls.find(
+        ([url]) => url === "/api/v1/import/confirm",
+      );
+      expect(confirmCall).toBeDefined();
+    });
+
+    const confirmCall = apiFetchMock.mock.calls.find(
+      ([url]) => url === "/api/v1/import/confirm",
+    )!;
+    const body = JSON.parse((confirmCall[1] as RequestInit).body as string);
+
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].action).toBe("create_transfer_pair");
+    expect(body.rows[0].partner_account_id).toBe(2);
+    expect(body.rows[0].pair_with_transaction_id).toBeNull();
+    expect(body.rows[0].duplicate_of_transaction_id).toBeNull();
+    expect(body.rows[0].recategorize).toBe(true);
   });
 
   it("results page surfaces paired_count and dropped_duplicate_count", async () => {

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -778,4 +778,75 @@ describe("ImportPage transfer pill column", () => {
     expect(screen.getByText("Plain row 2")).toBeInTheDocument();
     expect(screen.queryByText("Plain row 3")).toBeNull();
   });
+
+  it("Manual transfer mark uses 'from' wording for income rows", async () => {
+    const SAVINGS = {
+      ...ACCOUNT,
+      id: 2,
+      name: "Savings",
+      is_default: false,
+    };
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([ACCOUNT, SAVINGS]);
+      if (url === "/api/v1/categories")
+        return Promise.resolve([CATEGORY_EXP, CATEGORY_INC]);
+      if (url === "/api/v1/import/preview")
+        return Promise.resolve(
+          basePreview([
+            baseRow({
+              row_number: 1,
+              description: "Salary deposit",
+              type: "income",
+              amount: 1000,
+            }),
+          ]),
+        );
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ImportPage />
+      </SWRConfig>,
+    );
+    const uploadButton = await screen.findByRole("button", {
+      name: /upload & preview/i,
+    });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["x"], "test.csv", { type: "text/csv" })] },
+    });
+    fireEvent.click(uploadButton);
+    await screen.findByText("test.csv");
+
+    // Open modal for the income row.
+    fireEvent.click(screen.getByTestId("mark-transfer-button-1"));
+
+    // Modal label is "Other account", not "Destination account".
+    expect(await screen.findByText("Other account")).toBeInTheDocument();
+    expect(screen.queryByText("Destination account")).toBeNull();
+
+    // Pick Savings as the other account.
+    const destSelect = (await screen.findByTestId(
+      "import-mark-transfer-dest-select-1",
+    )) as HTMLSelectElement;
+    fireEvent.change(destSelect, { target: { value: "2" } });
+
+    // Direction preview shows "other -> import" for income rows.
+    const direction = screen.getByTestId("import-mark-transfer-direction-1");
+    expect(direction).toHaveTextContent(/Savings\s*→\s*Checking/);
+
+    // Confirm modal.
+    fireEvent.click(screen.getByTestId("import-mark-transfer-confirm-1"));
+
+    // Pill uses "from" wording for income rows (NOT "to").
+    await waitFor(() => {
+      expect(screen.getByTestId("mark-transfer-pill-1")).toBeInTheDocument();
+    });
+    const pill = screen.getByTestId("mark-transfer-pill-1");
+    expect(pill).toHaveTextContent(/Will create transfer from Savings/i);
+    expect(pill).not.toHaveTextContent(/Will create transfer to Savings/i);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the design gap the architect flagged on the import flow: the existing strict matcher (Detector 2) only fires when **both legs already exist** in the DB on different accounts. For the most common onboarding path — first import, partner side not yet in PFV — every transfer row landed as a plain transaction with no escape hatch on the preview page. Manual flagging existed only post-import on `/transactions`, which is unbearable for hundreds of rows.

This PR adds a **per-row "Mark as transfer..." affordance on the import preview** that creates BOTH legs atomically at confirm time.

### Architect-locked extension to spec §3.3

1. Existing strict matcher unchanged (still solves later imports + dedup).
2. New `ImportConfirmRow.action` value: `"create_transfer_pair"`.
3. New schema field: `partner_account_id: int | None`.
4. Backend `execute_import` adds a per-row branch that:
   - Validates: same org, different account from import account, same currency.
   - Creates the CSV leg via `_create_transaction_no_commit` (`is_imported=True`).
   - Creates the synthetic partner leg on `partner_account_id` (mirrored opposite type/amount/date, `is_imported=False`).
   - Calls `_link_pair` to tie them under the existing per-row savepoint (atomic — both rows roll back if anything fails).
   - Counts as **one** CSV row in `paired_count` (not 2).
   - Skips smart-rules learning.
5. Telemetry: `transfers.linked` event with `source="import_create_pair"` (distinct from `import_pair`).
6. Future imports of the destination account's CSV are already protected by Detector 1 (`find_duplicate_of_linked_leg`) — the synthetic partner is linked, so the bank-side duplicate gets flagged.

### Frontend

- `ImportConfirmRow` TS type extended with the new action + `partner_account_id`.
- `TransferUiState` (parallel UI state map keyed by `row_number`) gains `markTransferDestAccountId`.
- TRANSFER column now appears whenever **any row could be manually marked** (i.e., another same-currency account exists), even on a "no detector hits" import.
- For un-flagged rows in that column: `Mark as transfer...` button → opens a new lean `ImportMarkAsTransferModal` (no HTTP, just stores user choice in state) → confirmation pill `Will create transfer to <account>` with a clear button.
- `buildConfirmRow` produces the new payload after detector branches but before the `create` fallback (manual mark only takes effect when no detector handled the row).

### Tests

- Backend: 6 new (5 in `test_import_service_transfers.py`: happy path + atomicity rollback + currency mismatch + same-account validation + counter increment; 1 in `test_import_execute_with_rules.py`: smart-rules no-learn assertion).
- Frontend: 2 new in `test_import-page.test.tsx`: button visibility gating + confirm payload mapping.
- Backend baseline: 319 → **325 passed**.
- Frontend baseline: 93 → **95 passed**.

### Sizing

+857 / -6 across 8 files (4 backend including 2 test files; 4 frontend including a new modal + 1 test file).

### Out of scope (future)

- The architect's "second-layer hint" idea (heuristic-based "Possible transfer" pre-highlight when description/counterparty mentions an existing same-currency account name) — separate brainstorm. This PR strictly delivers the manual path.
- Cross-currency transfers — D-track, deferred indefinitely.

Spec: \`~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-03-transfers-between-accounts-design.md\` §3.3 + this PR's extension.