### PR TITLE
fix(ci): skip semantic-release for infra-scoped commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,6 +12,7 @@
           { "scope": "test", "release": false },
           { "scope": "tests", "release": false },
           { "scope": "dev", "release": false },
+          { "scope": "infra", "release": false },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },


### PR DESCRIPTION
## Summary

PR #116 cut **v0.26.0** even though it shipped no app behavior (just the self-hosted MySQL + Redis droplet — Terraform + Ansible + docs). Releases version the user-facing app, not the infra hosting it.

## What triggered v0.26.0

1. The merge commit `feat(infra): self-hosted MySQL + Redis droplet (...)` matched `commit-analyzer`'s `{ "type": "feat", "release": "minor" }` rule.
2. The release workflow's `paths:` filter includes `.do/**`, and PR #116 added a doc-only commented-out `vpc:` block to `.do/app.yaml`, so the workflow fired.

Both factors had to align — but the existing config has no rule that says "infra-scoped commits don't ship to users".

## Fix

One-line addition to `.releaserc.json`'s `releaseRules`, mirroring the existing `ci`/`deps`/`test` pattern:

```json
{ "scope": "infra", "release": false }
```

Any commit with scope `infra` (regardless of `feat:`/`fix:`/`docs:` prefix or which file paths the workflow matched) is now a no-release commit.

## Why not also tighten `release.yml`'s `paths:` filter?

Because this rule fires later in the chain (commit-analyzer's release decision). Even when the workflow runs on `.do/**` changes, it'll see no release-worthy commits and exit cleanly. Leaving the workflow filter alone keeps the door open for *future* `.do/app.yaml` edits that aren't `infra`-scoped (e.g., a `feat(deploy):` env var change for the live app) to still produce a release.

## Going forward

Use `infra` scope for any Terraform / Ansible / cloud-config change. Examples:

- `feat(infra): switch from droplet backups to weekly snapshots` → no release
- `fix(infra): correct ansible.cfg INI key` → no release
- `feat(backend): add transaction reconciliation API` → patch/minor release as before

## Risk

CI config only. No app or infra runtime impact.