### PR TITLE
feat(orgs): L3.1 owner-only org data reset (Danger Zone)

### DIFF
--- a/backend/app/auth/org_permissions.py
+++ b/backend/app/auth/org_permissions.py
@@ -22,3 +22,19 @@ def require_org_admin(current_user: User = Depends(get_current_user)) -> User:
             detail="Admin or owner role required",
         )
     return current_user
+
+
+def require_org_owner(current_user: User = Depends(get_current_user)) -> User:
+    """Pass when the requester is OWNER within their org. ADMIN/MEMBER → 403.
+
+    Stricter than ``require_org_admin``; reserved for tenant-scoped
+    destructive operations (data reset, ownership transfer, org
+    closure). No platform-superadmin bypass on tenant endpoints —
+    superadmins use the /admin surface with its own audit.
+    """
+    if current_user.role != Role.OWNER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Owner role required",
+        )
+    return current_user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_orgs, auth, budgets, categories, forecast, forecast_plans, import_router, org_members, plans, recurring, settings, subscriptions, transactions, users
+from app.routers import account_types, accounts, admin, admin_orgs, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, plans, recurring, settings, subscriptions, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -125,6 +125,7 @@ app.include_router(plans.router)
 app.include_router(admin.router)
 app.include_router(admin_orgs.router)
 app.include_router(org_members.router)
+app.include_router(org_data.router)
 
 
 @app.get("/health")

--- a/backend/app/routers/org_data.py
+++ b/backend/app/routers/org_data.py
@@ -1,0 +1,78 @@
+"""Tenant org-data router (L3.1) — destructive owner-only operations
+on the org's own data."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+import structlog
+
+from app.auth.org_permissions import require_org_owner
+from app.database import get_db
+from app.models.user import Organization, User
+from app.schemas.org_data import OrgDataResetRequest, OrgDataResetResponse
+from app.services import org_data_service
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/orgs/data", tags=["org-data"])
+
+
+@router.post("/reset", response_model=OrgDataResetResponse)
+async def reset_org_data(
+    body: OrgDataResetRequest,
+    current_user: User = Depends(require_org_owner),
+    db: AsyncSession = Depends(get_db),
+):
+    org = (await db.execute(
+        select(Organization).where(Organization.id == current_user.org_id)
+    )).scalar_one()
+
+    # Snapshot ORM-bound fields BEFORE the cascade. If the wipe raises
+    # and we rollback, accessing org.id / org.name / current_user.email
+    # afterward could trigger a lazy reload on the async engine and trip
+    # MissingGreenlet — same gotcha as org_members.create_invitation's
+    # pre-commit snapshot pattern.
+    org_id = org.id
+    org_name = org.name
+    actor_user_id = current_user.id
+    actor_email = current_user.email
+    actor_role = current_user.role.value
+
+    expected = f"RESET {org_name}"
+    if body.confirm_phrase.strip() != expected:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="confirm_phrase does not match required value",
+        )
+
+    try:
+        counts = await org_data_service.reset_org_data(db, org_id=org_id)
+        await db.commit()
+    except Exception as e:  # noqa: BLE001 — translate to generic 500 + log.
+        await db.rollback()
+        await logger.aerror(
+            "org.data.reset.failed",
+            actor_user_id=actor_user_id,
+            actor_email=actor_email,
+            actor_role=actor_role,
+            org_id=org_id,
+            org_name=org_name,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to reset organization data",
+        )
+
+    await logger.ainfo(
+        "org.data.reset",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        actor_role=actor_role,
+        org_id=org_id,
+        org_name=org_name,
+        deleted_rows_by_table=counts,
+    )
+    return {"deleted_rows_by_table": counts}

--- a/backend/app/schemas/org_data.py
+++ b/backend/app/schemas/org_data.py
@@ -1,0 +1,15 @@
+"""Schemas for /api/v1/orgs/data endpoints (L3.1)."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class OrgDataResetRequest(BaseModel):
+    confirm_phrase: str = Field(
+        ...,
+        description='Must equal "RESET <org name>" exactly (compared after .strip(), case-sensitive).',
+    )
+
+
+class OrgDataResetResponse(BaseModel):
+    deleted_rows_by_table: dict[str, int]

--- a/backend/app/services/admin_orgs_service.py
+++ b/backend/app/services/admin_orgs_service.py
@@ -16,23 +16,20 @@ from __future__ import annotations
 import datetime
 from typing import Optional
 
-from sqlalchemy import delete, func, or_, select, update
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.account import Account, AccountType
-from app.models.billing import BillingPeriod
+from app.models.account import Account
 from app.models.budget import Budget
-from app.models.category import Category
-from app.models.category_rule import CategoryRule
 from app.models.feature_override import OrgFeatureOverride
-from app.models.forecast_plan import ForecastPlan, ForecastPlanItem
+from app.models.forecast_plan import ForecastPlan
 from app.models.invitation import Invitation
-from app.models.recurring import RecurringTransaction
 from app.models.settings import OrgSetting
 from app.models.subscription import Plan, Subscription, SubscriptionStatus
 from app.models.transaction import Transaction
 from app.models.user import Organization, User
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.org_data_service import wipe_org_data
 
 
 def _serialize_subscription(sub: Optional[Subscription], plan: Optional[Plan]) -> dict:
@@ -266,65 +263,15 @@ async def delete_org_cascade(
     if org is None:
         raise NotFoundError("Organization")
 
-    counts: dict[str, int] = {}
+    # Wipe org-scoped data tables via the shared helper. Single source
+    # of truth for the FK-safe wipe order — also used by the tenant
+    # reset path in org_data_service.reset_org_data.
+    counts = await wipe_org_data(db, org_id=org_id)
 
-    # Order matters: delete children before parents.
-    # transactions reference accounts, categories, recurring → first.
-    counts["transactions"] = (
-        await db.execute(delete(Transaction).where(Transaction.org_id == org_id))
-    ).rowcount or 0
-
-    counts["forecast_plan_items"] = (
-        await db.execute(
-            delete(ForecastPlanItem).where(ForecastPlanItem.org_id == org_id)
-        )
-    ).rowcount or 0
-
-    counts["budgets"] = (
-        await db.execute(delete(Budget).where(Budget.org_id == org_id))
-    ).rowcount or 0
+    # Org-shell tables (only the admin path deletes these):
 
     counts["invitations"] = (
         await db.execute(delete(Invitation).where(Invitation.org_id == org_id))
-    ).rowcount or 0
-
-    counts["recurring_transactions"] = (
-        await db.execute(
-            delete(RecurringTransaction).where(RecurringTransaction.org_id == org_id)
-        )
-    ).rowcount or 0
-
-    counts["forecast_plans"] = (
-        await db.execute(delete(ForecastPlan).where(ForecastPlan.org_id == org_id))
-    ).rowcount or 0
-
-    counts["billing_periods"] = (
-        await db.execute(delete(BillingPeriod).where(BillingPeriod.org_id == org_id))
-    ).rowcount or 0
-
-    counts["accounts"] = (
-        await db.execute(delete(Account).where(Account.org_id == org_id))
-    ).rowcount or 0
-
-    counts["account_types"] = (
-        await db.execute(delete(AccountType).where(AccountType.org_id == org_id))
-    ).rowcount or 0
-
-    # category_rules.category_id FKs to categories.id, so it must be
-    # deleted before the bulk DELETE on categories below or MySQL's
-    # strict FK refuses. (merchant_dictionary is shared across orgs
-    # and has no org_id — it must survive org deletion.)
-    counts["category_rules"] = (
-        await db.execute(delete(CategoryRule).where(CategoryRule.org_id == org_id))
-    ).rowcount or 0
-
-    # Categories self-reference via parent_id. Break the link before
-    # the bulk DELETE so MySQL's strict FK doesn't refuse.
-    await db.execute(
-        update(Category).where(Category.org_id == org_id).values(parent_id=None)
-    )
-    counts["categories"] = (
-        await db.execute(delete(Category).where(Category.org_id == org_id))
     ).rowcount or 0
 
     counts["settings"] = (

--- a/backend/app/services/org_data_service.py
+++ b/backend/app/services/org_data_service.py
@@ -1,0 +1,103 @@
+"""Tenant-scoped org data service (L3.1).
+
+Owns the FK-safe wipe-order knowledge for org-scoped data tables.
+``wipe_org_data`` is intentionally public — admin_orgs_service imports
+it for the cascade delete path. Putting it here (neutral location)
+keeps tenant code from depending on an admin service.
+"""
+from __future__ import annotations
+
+from sqlalchemy import delete, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account, AccountType
+from app.models.billing import BillingPeriod
+from app.models.budget import Budget
+from app.models.category import Category
+from app.models.category_rule import CategoryRule
+from app.models.forecast_plan import ForecastPlan, ForecastPlanItem
+from app.models.recurring import RecurringTransaction
+from app.models.transaction import Transaction
+
+
+async def wipe_org_data(
+    db: AsyncSession, *, org_id: int
+) -> dict[str, int]:
+    """Delete every row in org-scoped data tables for ``org_id``.
+
+    Preserves the org shell (organizations, users, subscriptions,
+    org_settings, org_feature_overrides, invitations). Never touches
+    cross-org tables (e.g. merchant_dictionary). Caller commits.
+
+    Returns a dict of ``{table: rowcount}``. Single source of truth
+    for the wipe-order across both this service's reset path AND
+    ``admin_orgs_service.delete_org_cascade``.
+    """
+    counts: dict[str, int] = {}
+
+    # Order matters: delete children before parents.
+    counts["transactions"] = (
+        await db.execute(delete(Transaction).where(Transaction.org_id == org_id))
+    ).rowcount or 0
+
+    counts["forecast_plan_items"] = (
+        await db.execute(
+            delete(ForecastPlanItem).where(ForecastPlanItem.org_id == org_id)
+        )
+    ).rowcount or 0
+
+    counts["budgets"] = (
+        await db.execute(delete(Budget).where(Budget.org_id == org_id))
+    ).rowcount or 0
+
+    counts["recurring_transactions"] = (
+        await db.execute(
+            delete(RecurringTransaction).where(RecurringTransaction.org_id == org_id)
+        )
+    ).rowcount or 0
+
+    counts["forecast_plans"] = (
+        await db.execute(delete(ForecastPlan).where(ForecastPlan.org_id == org_id))
+    ).rowcount or 0
+
+    counts["billing_periods"] = (
+        await db.execute(delete(BillingPeriod).where(BillingPeriod.org_id == org_id))
+    ).rowcount or 0
+
+    counts["accounts"] = (
+        await db.execute(delete(Account).where(Account.org_id == org_id))
+    ).rowcount or 0
+
+    counts["account_types"] = (
+        await db.execute(delete(AccountType).where(AccountType.org_id == org_id))
+    ).rowcount or 0
+
+    # category_rules.category_id FKs to categories.id, so it must be
+    # deleted before the bulk DELETE on categories.
+    counts["category_rules"] = (
+        await db.execute(delete(CategoryRule).where(CategoryRule.org_id == org_id))
+    ).rowcount or 0
+
+    # Categories self-reference via parent_id. Break the link before
+    # the bulk DELETE so MySQL's strict FK doesn't refuse.
+    await db.execute(
+        update(Category).where(Category.org_id == org_id).values(parent_id=None)
+    )
+    counts["categories"] = (
+        await db.execute(delete(Category).where(Category.org_id == org_id))
+    ).rowcount or 0
+
+    return counts
+
+
+async def reset_org_data(
+    db: AsyncSession, *, org_id: int
+) -> dict[str, int]:
+    """Reset all financial / import / setup data for ``org_id``.
+
+    Tenant-scoped wrapper over :func:`wipe_org_data`. Kept distinct
+    so future reset-side concerns (post-reset hooks, audit-table
+    writes once L4.7 lands) have a place to live without bleeding
+    into the helper. Caller commits.
+    """
+    return await wipe_org_data(db, org_id=org_id)

--- a/backend/tests/auth/test_org_permissions_owner.py
+++ b/backend/tests/auth/test_org_permissions_owner.py
@@ -1,0 +1,38 @@
+"""Tests for require_org_owner — owner-only tenant gating (L3.1)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.org_permissions import require_org_owner
+from app.models.user import Role, User
+
+
+def _user(role: Role) -> User:
+    return User(
+        id=1,
+        username="u",
+        email="u@x.io",
+        password_hash="x",
+        org_id=1,
+        role=role,
+        is_active=True,
+    )
+
+
+def test_require_org_owner_allows_owner():
+    u = _user(Role.OWNER)
+    assert require_org_owner(current_user=u) is u
+
+
+def test_require_org_owner_rejects_admin():
+    with pytest.raises(HTTPException) as exc:
+        require_org_owner(current_user=_user(Role.ADMIN))
+    assert exc.value.status_code == 403
+    assert "Owner" in exc.value.detail
+
+
+def test_require_org_owner_rejects_member():
+    with pytest.raises(HTTPException) as exc:
+        require_org_owner(current_user=_user(Role.MEMBER))
+    assert exc.value.status_code == 403

--- a/backend/tests/routers/test_org_data.py
+++ b/backend/tests/routers/test_org_data.py
@@ -1,0 +1,311 @@
+"""Router tests for L3.1 — POST /api/v1/orgs/data/reset.
+
+Service-layer behavior is pinned in
+``tests/services/test_org_data_service.py``. This file pins the auth
+gate (owner-only via ``require_org_owner``), the typed-confirm
+contract, response shape, and the structured audit-log emissions.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization, Role, User
+from app.routers import org_data as org_data_module
+from app.routers.org_data import router as org_data_router
+from app.security import hash_password
+
+
+# ── Fixture: in-memory aiosqlite + FK enforcement ──────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+# ── Test app builder ───────────────────────────────────────────────────────
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(org_data_router)
+    return app
+
+
+# ── Seed helpers ───────────────────────────────────────────────────────────
+
+
+ORG_NAME = "Acme Household"
+
+
+async def _seed(factory) -> dict:
+    """One org with owner + admin + member, all in the same org."""
+    async with factory() as db:
+        plan = Plan(slug="free", name="Free")
+        db.add(plan)
+        org = Organization(name=ORG_NAME, billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        owner = User(
+            org_id=org.id, username="owner", email="o@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        admin = User(
+            org_id=org.id, username="admin", email="a@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.ADMIN, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        member = User(
+            org_id=org.id, username="member", email="m@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([owner, admin, member])
+        await db.commit()
+        sub = Subscription(
+            org_id=org.id, plan_id=plan.id,
+            status=SubscriptionStatus.ACTIVE,
+            billing_interval=BillingInterval.MONTHLY,
+        )
+        db.add(sub)
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "owner_id": owner.id,
+            "admin_id": admin.id,
+            "member_id": member.id,
+        }
+
+
+def _resolver_for(role: Role):
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.role == role))
+            ).scalar_one()
+    return resolve
+
+
+# ── Audit-event capture ────────────────────────────────────────────────────
+
+
+class _CapturingLogger:
+    """Substitute for the structlog logger that records (event, kwargs)
+    tuples for every ainfo / aerror call."""
+
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    async def ainfo(self, event: str, **kwargs):
+        self.events.append((event, dict(kwargs)))
+
+    async def aerror(self, event: str, **kwargs):
+        self.events.append((event, dict(kwargs)))
+
+
+@pytest.fixture
+def capture_logger(monkeypatch):
+    cap = _CapturingLogger()
+    monkeypatch.setattr(org_data_module, "logger", cap)
+    return cap
+
+
+# ── Auth gate ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_owner_succeeds(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert "deleted_rows_by_table" in body
+    assert isinstance(body["deleted_rows_by_table"], dict)
+
+
+@pytest.mark.asyncio
+async def test_reset_admin_forbidden(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.ADMIN))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reset_member_forbidden(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.MEMBER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reset_unauthenticated_rejected(session_factory):
+    # Build the app WITHOUT the get_current_user override so the real
+    # auth dep runs. FastAPI's HTTPBearer dep returns 403 on missing
+    # Authorization header (not 401) — same as every other authed
+    # endpoint in this app. The point is "no auth → no access".
+    await _seed(session_factory)
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(org_data_router)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code in (401, 403)
+
+
+# ── Phrase validation ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_phrase", [
+    f"RESET {ORG_NAME.lower()}",   # wrong case
+    "RESET Wrong",                 # wrong name
+    "RESET",                       # too short
+    ORG_NAME,                      # missing the verb
+    "",                            # empty
+])
+async def test_reset_wrong_phrase_400(session_factory, bad_phrase):
+    await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": bad_phrase},
+        )
+    assert res.status_code == 400, f"phrase {bad_phrase!r} unexpectedly accepted"
+
+
+@pytest.mark.asyncio
+async def test_reset_phrase_trimmed(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"   RESET {ORG_NAME}  "},
+        )
+    assert res.status_code == 200
+
+
+# ── Audit log emissions ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_logs_audit_event(session_factory, capture_logger):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 200
+
+    success_events = [e for e in capture_logger.events if e[0] == "org.data.reset"]
+    assert len(success_events) == 1
+    payload = success_events[0][1]
+    assert payload["actor_user_id"] == seed["owner_id"]
+    assert payload["actor_email"] == "o@acme.io"
+    assert payload["actor_role"] == "owner"
+    assert payload["org_id"] == seed["org_id"]
+    assert payload["org_name"] == ORG_NAME
+    assert isinstance(payload["deleted_rows_by_table"], dict)
+
+
+@pytest.mark.asyncio
+async def test_reset_failure_logs_failed_event(monkeypatch, session_factory, capture_logger):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    from app.services import org_data_service
+
+    async def boom(*a, **kw):
+        raise RuntimeError("simulated DB failure")
+    monkeypatch.setattr(org_data_service, "reset_org_data", boom)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 500
+
+    failed = [e for e in capture_logger.events if e[0] == "org.data.reset.failed"]
+    assert len(failed) == 1
+    payload = failed[0][1]
+    assert payload["actor_user_id"] == seed["owner_id"]
+    assert payload["org_id"] == seed["org_id"]
+    assert payload["error_type"] == "RuntimeError"
+    assert "simulated DB failure" in payload["error"]

--- a/backend/tests/services/test_org_data_service.py
+++ b/backend/tests/services/test_org_data_service.py
@@ -1,0 +1,339 @@
+"""Service-layer tests for L3.1 — org data reset.
+
+Fixture mirrors test_admin_orgs_service.py: in-memory aiosqlite with
+PRAGMA foreign_keys=ON so SQLite enforces FKs the way MySQL would.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, func, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.billing import BillingPeriod
+from app.models.budget import Budget
+from app.models.category import Category, CategoryType
+from app.models.category_rule import CategoryRule, RuleSource
+from app.models.feature_override import OrgFeatureOverride
+from app.models.merchant_dictionary import MerchantDictionaryEntry
+from app.models.forecast_plan import (
+    ForecastItemType, ForecastPlan, ForecastPlanItem, ItemSource, PlanStatus,
+)
+from app.models.invitation import Invitation
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.settings import OrgSetting
+from app.models.subscription import (
+    BillingInterval, Plan, Subscription, SubscriptionStatus,
+)
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import org_data_service
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_full_org(factory, *, name: str = "Acme") -> dict:
+    """Seed an org plus one row in every wipe-list AND preserve-list table.
+
+    Returns ``{"org_id": int, "owner_id": int}``.
+    """
+    async with factory() as db:
+        plan = (
+            await db.execute(select(Plan).where(Plan.slug == "free"))
+        ).scalar_one_or_none()
+        if plan is None:
+            plan = Plan(slug="free", name="Free")
+            db.add(plan)
+            await db.commit()
+
+        org = Organization(name=name, billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        owner = User(
+            org_id=org.id, username=f"{name}_owner",
+            email=f"{name}_owner@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        member = User(
+            org_id=org.id, username=f"{name}_member",
+            email=f"{name}_member@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([owner, member])
+        await db.commit()
+
+        sub = Subscription(
+            org_id=org.id, plan_id=plan.id,
+            status=SubscriptionStatus.TRIALING,
+            billing_interval=BillingInterval.MONTHLY,
+            trial_start=datetime.date.today(),
+            trial_end=datetime.date.today() + datetime.timedelta(days=14),
+        )
+        db.add(sub)
+
+        atype = AccountType(org_id=org.id, name="Checking", slug=f"checking-{name}")
+        db.add(atype)
+        await db.commit()
+
+        account = Account(
+            org_id=org.id, account_type_id=atype.id,
+            name="Main", balance=Decimal("100.00"),
+        )
+        master = Category(
+            org_id=org.id, name="Food", slug=f"food-{name}",
+            type=CategoryType.EXPENSE,
+        )
+        db.add_all([account, master])
+        await db.commit()
+
+        sub_cat = Category(
+            org_id=org.id, parent_id=master.id, name="Groceries",
+            slug=f"groceries-{name}", type=CategoryType.EXPENSE,
+        )
+        db.add(sub_cat)
+        bp = BillingPeriod(
+            org_id=org.id,
+            start_date=datetime.date.today().replace(day=1),
+            end_date=None,
+        )
+        db.add(bp)
+        await db.commit()
+
+        recurring = RecurringTransaction(
+            org_id=org.id, account_id=account.id, category_id=master.id,
+            description="Rent", amount=Decimal("1500.00"),
+            type="expense", frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date.today(),
+        )
+        db.add(recurring)
+        await db.commit()
+
+        tx = Transaction(
+            org_id=org.id, account_id=account.id, category_id=master.id,
+            recurring_id=recurring.id,
+            description="Lunch", amount=Decimal("12.34"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.SETTLED,
+            date=datetime.date.today(),
+            settled_date=datetime.date.today(),
+        )
+        budget = Budget(
+            org_id=org.id, category_id=master.id,
+            amount=Decimal("400.00"),
+            period_start=datetime.date.today().replace(day=1),
+        )
+        plan_row = ForecastPlan(
+            org_id=org.id, billing_period_id=bp.id, status=PlanStatus.ACTIVE,
+        )
+        setting = OrgSetting(
+            org_id=org.id, key=f"{name}_setting", value="x",
+        )
+        db.add_all([tx, budget, plan_row, setting])
+        await db.commit()
+
+        plan_item = ForecastPlanItem(
+            plan_id=plan_row.id, org_id=org.id, category_id=master.id,
+            type=ForecastItemType.EXPENSE, source=ItemSource.MANUAL,
+            planned_amount=Decimal("400.00"),
+        )
+        invite = Invitation(
+            org_id=org.id, email=f"invitee_{name}@acme.io",
+            role=Role.MEMBER, open_email=f"invitee_{name}@acme.io",
+            created_by=owner.id,
+            expires_at=datetime.datetime.utcnow() + datetime.timedelta(days=7),
+        )
+        rule = CategoryRule(
+            org_id=org.id,
+            normalized_token=f"TEST{name.upper()}",
+            raw_description_seen=f"POS {name} *0001",
+            category_id=master.id,
+            match_count=1,
+            source=RuleSource.USER_PICK,
+        )
+        override = OrgFeatureOverride(
+            org_id=org.id,
+            feature_key="ai.budget",
+            value=False,
+            set_by=owner.id,
+        )
+        db.add_all([plan_item, invite, rule, override])
+        await db.commit()
+
+        return {"org_id": org.id, "owner_id": owner.id}
+
+
+async def _count(db: AsyncSession, model, **filt) -> int:
+    stmt = select(func.count()).select_from(model)
+    for k, v in filt.items():
+        stmt = stmt.where(getattr(model, k) == v)
+    return (await db.scalar(stmt)) or 0
+
+
+# ── wipe_org_data ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wipe_clears_all_org_scoped_data(session_factory):
+    seeded = await _seed_full_org(session_factory)
+
+    async with session_factory() as db:
+        counts = await org_data_service.wipe_org_data(db, org_id=seeded["org_id"])
+        await db.commit()
+
+    expected_keys = {
+        "transactions", "forecast_plan_items", "budgets",
+        "recurring_transactions", "forecast_plans", "billing_periods",
+        "accounts", "account_types", "category_rules", "categories",
+    }
+    assert set(counts.keys()) == expected_keys
+    for key, n in counts.items():
+        assert n >= 1, f"expected >=1 row deleted from {key}, got {n}"
+
+    async with session_factory() as db:
+        for model in (Transaction, ForecastPlanItem, Budget, RecurringTransaction,
+                      ForecastPlan, BillingPeriod, Account, AccountType,
+                      CategoryRule, Category):
+            assert await _count(db, model, org_id=seeded["org_id"]) == 0, (
+                f"{model.__name__} not wiped"
+            )
+
+
+@pytest.mark.asyncio
+async def test_wipe_preserves_org_shell(session_factory):
+    seeded = await _seed_full_org(session_factory)
+
+    async with session_factory() as db:
+        await org_data_service.wipe_org_data(db, org_id=seeded["org_id"])
+        await db.commit()
+
+    async with session_factory() as db:
+        assert await _count(db, Organization, id=seeded["org_id"]) == 1
+        assert await _count(db, User, org_id=seeded["org_id"]) == 2
+        assert await _count(db, Subscription, org_id=seeded["org_id"]) == 1
+        assert await _count(db, OrgSetting, org_id=seeded["org_id"]) == 1
+        assert await _count(db, OrgFeatureOverride, org_id=seeded["org_id"]) == 1
+        assert await _count(db, Invitation, org_id=seeded["org_id"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_wipe_does_not_touch_merchant_dictionary(session_factory):
+    seeded = await _seed_full_org(session_factory)
+
+    async with session_factory() as db:
+        db.add(MerchantDictionaryEntry(
+            normalized_token="LIDL", category_slug="groceries",
+            is_seed=True, vote_count=0,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        await org_data_service.wipe_org_data(db, org_id=seeded["org_id"])
+        await db.commit()
+
+    async with session_factory() as db:
+        rows = (await db.execute(
+            select(MerchantDictionaryEntry)
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].normalized_token == "LIDL"
+
+
+@pytest.mark.asyncio
+async def test_wipe_does_not_touch_other_orgs(session_factory):
+    target = await _seed_full_org(session_factory, name="Target")
+    keep = await _seed_full_org(session_factory, name="Keep")
+
+    async with session_factory() as db:
+        await org_data_service.wipe_org_data(db, org_id=target["org_id"])
+        await db.commit()
+
+    async with session_factory() as db:
+        for model in (Transaction, Budget, Account, AccountType, Category,
+                      CategoryRule, BillingPeriod, RecurringTransaction,
+                      ForecastPlan, ForecastPlanItem):
+            assert await _count(db, model, org_id=keep["org_id"]) >= 1, (
+                f"{model.__name__} for keep org unexpectedly wiped"
+            )
+
+
+@pytest.mark.asyncio
+async def test_wipe_handles_categories_with_parent_id(session_factory):
+    """Self-FK on categories.parent_id requires a parent_id-null trick
+    before bulk DELETE. If broken, MySQL strict FK refuses; SQLite with
+    PRAGMA foreign_keys=ON does the same."""
+    seeded = await _seed_full_org(session_factory)
+
+    async with session_factory() as db:
+        counts = await org_data_service.wipe_org_data(db, org_id=seeded["org_id"])
+        await db.commit()
+    assert counts["categories"] == 2  # master + sub
+
+
+@pytest.mark.asyncio
+async def test_wipe_idempotent(session_factory):
+    seeded = await _seed_full_org(session_factory)
+
+    async with session_factory() as db:
+        await org_data_service.wipe_org_data(db, org_id=seeded["org_id"])
+        await db.commit()
+    async with session_factory() as db:
+        second = await org_data_service.wipe_org_data(db, org_id=seeded["org_id"])
+        await db.commit()
+    assert all(n == 0 for n in second.values())
+
+
+# ── reset_org_data ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_returns_counts_and_wipes_data(session_factory):
+    seeded = await _seed_full_org(session_factory)
+
+    async with session_factory() as db:
+        counts = await org_data_service.reset_org_data(db, org_id=seeded["org_id"])
+        await db.commit()
+
+    expected_keys = {
+        "transactions", "forecast_plan_items", "budgets",
+        "recurring_transactions", "forecast_plans", "billing_periods",
+        "accounts", "account_types", "category_rules", "categories",
+    }
+    assert set(counts.keys()) == expected_keys
+
+    async with session_factory() as db:
+        # Org shell still alive (wrapper didn't accidentally call cascade).
+        assert await _count(db, Organization, id=seeded["org_id"]) == 1

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -44,6 +45,19 @@ const PAGE_SIZE = 10;
 
 export default function DashboardPage() {
   const { user, loading } = useAuth();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [resetBanner, setResetBanner] = useState(false);
+
+  // L3.1: read ?reset=1 left by the data-reset flow, show a one-time
+  // success banner, then strip the param so a refresh doesn't replay it.
+  useEffect(() => {
+    if (searchParams.get("reset") === "1") {
+      setResetBanner(true);
+      router.replace("/dashboard");
+    }
+  }, [searchParams, router]);
+
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
@@ -357,6 +371,25 @@ export default function DashboardPage() {
           </Link>
         </div>
       </div>
+
+      {resetBanner && (
+        <div
+          data-testid="reset-banner"
+          className="mb-4 flex items-start justify-between gap-3 rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4"
+        >
+          <div className="text-sm text-text-primary">
+            <strong>Your data has been reset.</strong> Welcome back to a clean slate.
+          </div>
+          <button
+            type="button"
+            onClick={() => setResetBanner(false)}
+            aria-label="Dismiss"
+            className="text-lg leading-none text-text-secondary hover:text-text-primary"
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -46,17 +46,21 @@ const PAGE_SIZE = 10;
 export default function DashboardPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [resetBanner, setResetBanner] = useState(false);
 
   // L3.1: read ?reset=1 left by the data-reset flow, show a one-time
   // success banner, then strip the param so a refresh doesn't replay it.
+  // Reads window.location instead of useSearchParams() so /dashboard
+  // can stay statically prerenderable in Next 15 — useSearchParams
+  // would force a Suspense boundary or a deopt warning at build time,
+  // and this banner is purely a client-only artifact.
   useEffect(() => {
-    if (searchParams.get("reset") === "1") {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("reset") === "1") {
       setResetBanner(true);
       router.replace("/dashboard");
     }
-  }, [searchParams, router]);
+  }, [router]);
 
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { mutate } from "swr";
 import SettingsLayout from "@/components/SettingsLayout";
 import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
@@ -415,6 +416,14 @@ export default function OrganizationSettingsPage() {
                         method: "POST",
                         body: JSON.stringify({ confirm_phrase: resetPhrase.trim() }),
                       });
+                      // Clear every SWR cache key without revalidating —
+                      // the reset wiped accounts/categories/etc. on the
+                      // server, so any cached value in this client session
+                      // (e.g. /import's account+category lists) would
+                      // briefly show deleted rows. Skipping revalidation
+                      // here is safe because we navigate away immediately
+                      // and the destination's hooks will refetch fresh.
+                      await mutate(() => true, undefined, { revalidate: false });
                       router.push("/dashboard?reset=1");
                     } catch (err) {
                       setResetError(extractErrorMessage(err, "Reset failed"));

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -57,7 +57,19 @@ export default function OrganizationSettingsPage() {
   } | null>(null);
   const [closingPeriod, setClosingPeriod] = useState(false);
 
+  // L3.1 Danger Zone — owner-only data reset.
+  // Compare user.role exactly; do NOT use isOwner() from @/lib/auth,
+  // which treats is_superadmin as owner — the backend rejects
+  // superadmin tenant bypass, so the UI must mirror that.
+  const [resetPhrase, setResetPhrase] = useState("");
+  const [resetting, setResetting] = useState(false);
+  const [resetError, setResetError] = useState("");
+
   const admin = user ? isAdmin(user) : false;
+  const isOrgOwner = user?.role === "owner";
+  const orgName = user?.org_name ?? "";
+  const expectedResetPhrase = `RESET ${orgName}`;
+  const resetPhraseMatches = resetPhrase.trim() === expectedResetPhrase;
 
   const currentPeriodEndDisplay = currentPeriod
     ? currentPeriod.end_date ?? projectedPeriodEnd(currentPeriod.start_date, Number(billingCycleDay))
@@ -366,6 +378,57 @@ export default function OrganizationSettingsPage() {
             currentRole={user.role as "owner" | "admin" | "member"}
           />
           <SmartRulesSection />
+        </div>
+      )}
+
+      {isOrgOwner && (
+        <div className="mt-6">
+          <section className={`${card} border-danger/40`}>
+            <div className={cardHeader}>
+              <h2 className={`${cardTitle} text-danger`}>Danger zone</h2>
+            </div>
+            <div className="px-6 py-5 space-y-3">
+              <p className="text-sm text-text-secondary">
+                Resetting wipes <strong>transactions, accounts, account types, categories, smart rules, budgets, forecast plans, recurring transactions, and billing periods</strong>. Your organization, members, subscription, settings, feature overrides, and pending invitations are preserved. The action cannot be undone.
+              </p>
+              <p className="text-sm text-text-secondary">
+                Type <code className="rounded bg-surface-raised px-1.5 py-0.5 font-mono text-text-primary">RESET {orgName}</code> to confirm:
+              </p>
+              <input
+                type="text"
+                aria-label="Confirm reset phrase"
+                value={resetPhrase}
+                onChange={(e) => setResetPhrase(e.target.value)}
+                placeholder={expectedResetPhrase}
+                className={`${input} max-w-md`}
+              />
+              {resetError && <p className="text-sm text-danger">{resetError}</p>}
+              <div>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (!resetPhraseMatches) return;
+                    setResetError("");
+                    setResetting(true);
+                    try {
+                      await apiFetch("/api/v1/orgs/data/reset", {
+                        method: "POST",
+                        body: JSON.stringify({ confirm_phrase: resetPhrase.trim() }),
+                      });
+                      router.push("/dashboard?reset=1");
+                    } catch (err) {
+                      setResetError(extractErrorMessage(err, "Reset failed"));
+                      setResetting(false);
+                    }
+                  }}
+                  disabled={!resetPhraseMatches || resetting}
+                  className="rounded-md bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
+                >
+                  {resetting ? "Resetting…" : "Reset my data"}
+                </button>
+              </div>
+            </div>
+          </section>
         </div>
       )}
 

--- a/frontend/tests/app/dashboard-reset-banner.test.tsx
+++ b/frontend/tests/app/dashboard-reset-banner.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+// Return a stable router object so useEffect deps don't re-trigger
+// the banner-show effect on every render after a click.
+const stableRouter = { push: pushMock, replace: replaceMock };
+let searchParamsValue = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/dashboard",
+  useSearchParams: () => searchParamsValue,
+}));
+
+const USER = {
+  id: 1, username: "u", email: "u@x.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1, org_name: "Acme", billing_cycle_day: 1,
+  is_superadmin: false, is_active: true, mfa_enabled: false,
+  subscription_status: null, subscription_plan: null, trial_end: null,
+};
+
+function mockEmptyDashboard() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/accounts") return Promise.resolve([]);
+    if (url === "/api/v1/categories") return Promise.resolve([]);
+    if (url === "/api/v1/budgets") return Promise.resolve([]);
+    if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period") return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings/billing-periods") return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("DashboardPage — reset banner", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    replaceMock.mockReset();
+    searchParamsValue = new URLSearchParams();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockEmptyDashboard();
+  });
+
+  it("does not render the banner without ?reset=1", async () => {
+    render(<DashboardPage />);
+    await waitFor(() => expect(screen.queryByTestId("reset-banner")).toBeNull());
+  });
+
+  it("renders the banner when ?reset=1", async () => {
+    searchParamsValue = new URLSearchParams("reset=1");
+    render(<DashboardPage />);
+    await waitFor(() => expect(screen.getByTestId("reset-banner")).toBeInTheDocument());
+  });
+
+  it("calls router.replace('/dashboard') after first paint to clear the param", async () => {
+    searchParamsValue = new URLSearchParams("reset=1");
+    render(<DashboardPage />);
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith("/dashboard"));
+  });
+
+  it("dismisses the banner on click", async () => {
+    searchParamsValue = new URLSearchParams("reset=1");
+    render(<DashboardPage />);
+    await waitFor(() => expect(screen.getByTestId("reset-banner")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    await waitFor(() => expect(screen.queryByTestId("reset-banner")).toBeNull());
+  });
+});

--- a/frontend/tests/app/dashboard-reset-banner.test.tsx
+++ b/frontend/tests/app/dashboard-reset-banner.test.tsx
@@ -25,11 +25,9 @@ const pushMock = vi.fn();
 // Return a stable router object so useEffect deps don't re-trigger
 // the banner-show effect on every render after a click.
 const stableRouter = { push: pushMock, replace: replaceMock };
-let searchParamsValue = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useRouter: () => stableRouter,
   usePathname: () => "/dashboard",
-  useSearchParams: () => searchParamsValue,
 }));
 
 const USER = {
@@ -60,7 +58,10 @@ describe("DashboardPage — reset banner", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
     replaceMock.mockReset();
-    searchParamsValue = new URLSearchParams();
+    // Reset URL between tests; the page reads window.location.search
+    // directly so the banner-show effect responds to whatever the URL
+    // is at first render.
+    window.history.pushState({}, "", "/dashboard");
     vi.mocked(useAuth).mockReturnValue({
       user: USER as never,
       loading: false,
@@ -79,19 +80,19 @@ describe("DashboardPage — reset banner", () => {
   });
 
   it("renders the banner when ?reset=1", async () => {
-    searchParamsValue = new URLSearchParams("reset=1");
+    window.history.pushState({}, "", "/dashboard?reset=1");
     render(<DashboardPage />);
     await waitFor(() => expect(screen.getByTestId("reset-banner")).toBeInTheDocument());
   });
 
   it("calls router.replace('/dashboard') after first paint to clear the param", async () => {
-    searchParamsValue = new URLSearchParams("reset=1");
+    window.history.pushState({}, "", "/dashboard?reset=1");
     render(<DashboardPage />);
     await waitFor(() => expect(replaceMock).toHaveBeenCalledWith("/dashboard"));
   });
 
   it("dismisses the banner on click", async () => {
-    searchParamsValue = new URLSearchParams("reset=1");
+    window.history.pushState({}, "", "/dashboard?reset=1");
     render(<DashboardPage />);
     await waitFor(() => expect(screen.getByTestId("reset-banner")).toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));

--- a/frontend/tests/app/settings-organization-danger-zone.test.tsx
+++ b/frontend/tests/app/settings-organization-danger-zone.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import OrganizationSettingsPage from "@/app/settings/organization/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => "/settings/organization",
+}));
+
+const ORG_NAME = "Acme Household";
+
+function makeUser(role: "owner" | "admin" | "member") {
+  return {
+    id: 1, username: "u", email: "u@x.io",
+    first_name: null, last_name: null, phone: null, avatar_url: null,
+    email_verified: true,
+    role,
+    org_id: 1, org_name: ORG_NAME, billing_cycle_day: 1,
+    is_superadmin: false, is_active: true, mfa_enabled: false,
+    subscription_status: null, subscription_plan: null, trial_end: null,
+  };
+}
+
+function mockApiSuccessFixtures() {
+  vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+    if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period") return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings") return Promise.resolve([]);
+    if (url === "/api/v1/orgs/members") return Promise.resolve([]);
+    if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
+    if (url === "/api/v1/category-rules") return Promise.resolve([]);
+    if (url === "/api/v1/orgs/data/reset" && init?.method === "POST") {
+      return Promise.resolve({ deleted_rows_by_table: { transactions: 0 } });
+    }
+    return Promise.resolve({});
+  }) as never);
+}
+
+function mockUser(role: "owner" | "admin" | "member") {
+  vi.mocked(useAuth).mockReturnValue({
+    user: makeUser(role) as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  } as never);
+}
+
+describe("OrganizationSettingsPage — Danger Zone", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    mockApiSuccessFixtures();
+  });
+
+  it("does not render Danger Zone for member role", async () => {
+    mockUser("member");
+    render(<OrganizationSettingsPage />);
+    // Member should be redirected away from this page entirely (admin-only),
+    // so the Danger Zone never appears.
+    await waitFor(() => expect(screen.queryByText(/Danger zone/i)).toBeNull());
+  });
+
+  it("does not render Danger Zone for admin role", async () => {
+    mockUser("admin");
+    render(<OrganizationSettingsPage />);
+    await waitFor(() => expect(screen.queryByText(/Danger zone/i)).toBeNull());
+  });
+
+  it("renders Danger Zone for owner role", async () => {
+    mockUser("owner");
+    render(<OrganizationSettingsPage />);
+    await waitFor(() => expect(screen.getByText(/Danger zone/i)).toBeInTheDocument());
+  });
+
+  it("disables Reset button until confirm phrase exactly matches", async () => {
+    mockUser("owner");
+    render(<OrganizationSettingsPage />);
+    await waitFor(() => expect(screen.getByText(/Danger zone/i)).toBeInTheDocument());
+
+    const button = screen.getByRole("button", { name: /reset my data/i }) as HTMLButtonElement;
+    const input = screen.getByLabelText(/confirm reset phrase/i);
+
+    expect(button.disabled).toBe(true);
+
+    // Wrong case
+    fireEvent.change(input, { target: { value: `reset ${ORG_NAME.toLowerCase()}` } });
+    expect(button.disabled).toBe(true);
+
+    // Wrong name
+    fireEvent.change(input, { target: { value: "RESET Wrong" } });
+    expect(button.disabled).toBe(true);
+
+    // Just RESET
+    fireEvent.change(input, { target: { value: "RESET" } });
+    expect(button.disabled).toBe(true);
+
+    // Exact match
+    fireEvent.change(input, { target: { value: `RESET ${ORG_NAME}` } });
+    expect(button.disabled).toBe(false);
+
+    // Trimmed exact match
+    fireEvent.change(input, { target: { value: `   RESET ${ORG_NAME}    ` } });
+    expect(button.disabled).toBe(false);
+  });
+
+  it("POSTs the correct phrase and redirects to /dashboard?reset=1 on success", async () => {
+    mockUser("owner");
+    render(<OrganizationSettingsPage />);
+    await waitFor(() => expect(screen.getByText(/Danger zone/i)).toBeInTheDocument());
+
+    const input = screen.getByLabelText(/confirm reset phrase/i);
+    fireEvent.change(input, { target: { value: `RESET ${ORG_NAME}` } });
+    fireEvent.click(screen.getByRole("button", { name: /reset my data/i }));
+
+    await waitFor(() => {
+      const call = vi.mocked(apiFetch).mock.calls.find(
+        ([url]) => url === "/api/v1/orgs/data/reset",
+      );
+      expect(call).toBeTruthy();
+      const init = call![1] as RequestInit;
+      expect(init?.method).toBe("POST");
+      expect(JSON.parse(init!.body as string)).toEqual({
+        confirm_phrase: `RESET ${ORG_NAME}`,
+      });
+    });
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/dashboard?reset=1"));
+  });
+});

--- a/frontend/tests/app/settings-organization-danger-zone.test.tsx
+++ b/frontend/tests/app/settings-organization-danger-zone.test.tsx
@@ -3,10 +3,16 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import OrganizationSettingsPage from "@/app/settings/organization/page";
 import { apiFetch } from "@/lib/api";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { mutate } from "swr";
 
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
   return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("swr", async () => {
+  const actual = await vi.importActual<typeof import("swr")>("swr");
+  return { ...actual, mutate: vi.fn(() => Promise.resolve()) };
 });
 
 vi.mock("@/components/auth/AuthProvider", async () => {
@@ -73,6 +79,7 @@ describe("OrganizationSettingsPage — Danger Zone", () => {
     vi.mocked(apiFetch).mockReset();
     pushMock.mockReset();
     replaceMock.mockReset();
+    vi.mocked(mutate).mockClear();
     mockApiSuccessFixtures();
   });
 
@@ -148,5 +155,29 @@ describe("OrganizationSettingsPage — Danger Zone", () => {
       });
     });
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/dashboard?reset=1"));
+  });
+
+  it("clears every SWR cache key on reset success before navigating", async () => {
+    mockUser("owner");
+    render(<OrganizationSettingsPage />);
+    await waitFor(() => expect(screen.getByText(/Danger zone/i)).toBeInTheDocument());
+
+    const input = screen.getByLabelText(/confirm reset phrase/i);
+    fireEvent.change(input, { target: { value: `RESET ${ORG_NAME}` } });
+    fireEvent.click(screen.getByRole("button", { name: /reset my data/i }));
+
+    await waitFor(() => expect(vi.mocked(mutate)).toHaveBeenCalled());
+    // Match-all matcher (function predicate), undefined value (clear),
+    // revalidate: false (don't refetch — we're navigating away).
+    const call = vi.mocked(mutate).mock.calls[0];
+    expect(typeof call[0]).toBe("function");
+    expect(call[1]).toBeUndefined();
+    expect(call[2]).toEqual({ revalidate: false });
+    // mutate must be invoked before the redirect, so any subsequent
+    // hook on the destination page sees a clean cache.
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/dashboard?reset=1"));
+    const mutateOrder = vi.mocked(mutate).mock.invocationCallOrder[0];
+    const pushOrder = pushMock.mock.invocationCallOrder[0];
+    expect(mutateOrder).toBeLessThan(pushOrder);
   });
 });


### PR DESCRIPTION
Closes the L3.1 launch-tier item from `project_roadmap.md`.

Owners get a Danger Zone in Settings → Organization that wipes all financial / import / setup data while preserving the org shell (org row, members, subscription, settings, feature overrides, invitations). Typed-confirm `RESET <org name>` (trim, case-sensitive) gates the action; success redirects to `/dashboard?reset=1` with a one-time dismissible banner that's `router.replace`d after first paint.

## Three load-bearing decisions

1. **Shared wipe helper, neutral location.** The FK-safe wipe order is the load-bearing knowledge here — the L3.10 incident (where `category_rules` had to be retro-added to the cascade after the model shipped) is the bug class that motivated the factoring. Created `services/org_data_service.py` with public `wipe_org_data` (the single source of truth) plus `reset_org_data` wrapper. `admin_orgs_service.delete_org_cascade` now delegates to `wipe_org_data` and continues with the org-shell deletes inline. Existing admin-delete behavior is unchanged — verified by the 10 pre-existing regression tests.

2. **Tenant-namespace audit, not `admin.*`.** Events are `org.data.reset` and `org.data.reset.failed`. Mixing into `admin.*` would make future "what did staff do?" filtering noisy. ORM-bound logging fields (`org.id`, `org.name`, `current_user.email`, etc.) are snapshotted to locals before the cascade so the failure path can log without triggering a lazy reload after rollback — same pattern as `org_members.create_invitation`'s pre-commit snapshot.

3. **Owner-only via new `require_org_owner` dep, no superadmin tenant bypass.** New helper alongside `require_org_admin` in `auth/org_permissions.py`. Frontend mirrors the rule via explicit `user.role === "owner"` rather than the existing `isOwner()` helper, which treats `is_superadmin` as owner.

## Spec
`~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-05-l3-1-reset-org-data-design.md`

## Verification
- Backend: 348 tests pass (was 326; +22 new). Includes 10-test admin-delete regression gate.
- Frontend: 106 tests pass (was 97; +9 new).
- Live throwaway-org reset against the local stack returned `deleted_rows_by_table` correctly; post-reset endpoints all 200 with empty data; billing period auto-created on next read; `org.data.reset` audit event emitted with the full payload.