### PR TITLE
feat(dashboard): explain planned vs actual on forecast tile (L3.7)

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -561,10 +561,10 @@ export default function DashboardPage() {
                     className="absolute left-0 top-full z-20 mt-2 w-72 rounded-md border border-border bg-surface p-3 text-xs leading-relaxed text-text-secondary shadow-lg"
                   >
                     <p>
-                      <strong className="text-text-primary">Planned</strong> is what you set in your forecast plan for this period — the targets you&rsquo;re working against.
+                      <strong className="text-text-primary">Planned</strong> is what you set in your forecast plan for this period (the targets you&rsquo;re working against).
                     </p>
                     <p className="mt-2">
-                      <strong className="text-text-primary">Actual</strong> is what has already happened in this period (settled + pending transactions), computed from your data.
+                      <strong className="text-text-primary">Actual</strong> is the sum of settled transactions for this period, matched by settlement date. Pending transactions are not counted until they settle.
                     </p>
                   </div>
                 </details>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -547,7 +547,28 @@ export default function DashboardPage() {
 
             {/* Forecast */}
             <div className={`${card} p-5`}>
-              <h2 className={`mb-4 ${cardTitle}`}>Forecast</h2>
+              <div className="mb-4 flex items-center gap-2">
+                <h2 className={cardTitle}>Forecast</h2>
+                <details className="group relative">
+                  <summary
+                    aria-label="Explain forecast numbers"
+                    className="flex h-5 w-5 cursor-help items-center justify-center rounded-full border border-border text-[10px] font-semibold text-text-muted hover:border-accent hover:text-accent list-none [&::-webkit-details-marker]:hidden"
+                  >
+                    i
+                  </summary>
+                  <div
+                    role="tooltip"
+                    className="absolute left-0 top-full z-20 mt-2 w-72 rounded-md border border-border bg-surface p-3 text-xs leading-relaxed text-text-secondary shadow-lg"
+                  >
+                    <p>
+                      <strong className="text-text-primary">Planned</strong> is what you set in your forecast plan for this period — the targets you&rsquo;re working against.
+                    </p>
+                    <p className="mt-2">
+                      <strong className="text-text-primary">Actual</strong> is what has already happened in this period (settled + pending transactions), computed from your data.
+                    </p>
+                  </div>
+                </details>
+              </div>
               {forecast ? (() => {
                 const plannedIncome = Number(forecast.total_planned_income);
                 const plannedExpense = Number(forecast.total_planned_expense);

--- a/frontend/tests/app/dashboard-forecast-tooltip.test.tsx
+++ b/frontend/tests/app/dashboard-forecast-tooltip.test.tsx
@@ -83,6 +83,12 @@ describe("DashboardPage — forecast info tooltip (L3.7)", () => {
     expect(tooltip.textContent).toMatch(/planned/i);
     expect(tooltip.textContent).toMatch(/forecast plan/i);
     expect(tooltip.textContent).toMatch(/actual/i);
-    expect(tooltip.textContent).toMatch(/already happened/i);
+    // Pin the corrected financial semantic: actuals are settled-only,
+    // matched by settlement date. The earlier copy claimed "settled +
+    // pending" which contradicted backend/forecast_plan_service.py
+    // (Transaction.status == SETTLED + Transaction.settled_date filter).
+    expect(tooltip.textContent).toMatch(/settled transactions/i);
+    expect(tooltip.textContent).toMatch(/settlement date/i);
+    expect(tooltip.textContent).toMatch(/pending.*not counted/i);
   });
 });

--- a/frontend/tests/app/dashboard-forecast-tooltip.test.tsx
+++ b/frontend/tests/app/dashboard-forecast-tooltip.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/dashboard",
+}));
+
+const USER = {
+  id: 1, username: "u", email: "u@x.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1, org_name: "Acme", billing_cycle_day: 1,
+  is_superadmin: false, is_active: true, mfa_enabled: false,
+  subscription_status: null, subscription_plan: null, trial_end: null,
+};
+
+function mockEmptyDashboard() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/accounts") return Promise.resolve([]);
+    if (url === "/api/v1/categories") return Promise.resolve([]);
+    if (url === "/api/v1/budgets") return Promise.resolve([]);
+    if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period") return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings/billing-periods") return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("DashboardPage — forecast info tooltip (L3.7)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    window.history.pushState({}, "", "/dashboard");
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockEmptyDashboard();
+  });
+
+  it("renders an info disclosure next to the Forecast heading", async () => {
+    render(<DashboardPage />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/explain forecast numbers/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("includes both planned and actual explanation text in the tooltip body", async () => {
+    render(<DashboardPage />);
+    await waitFor(() =>
+      expect(screen.getByLabelText(/explain forecast numbers/i)).toBeInTheDocument(),
+    );
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip.textContent).toMatch(/planned/i);
+    expect(tooltip.textContent).toMatch(/forecast plan/i);
+    expect(tooltip.textContent).toMatch(/actual/i);
+    expect(tooltip.textContent).toMatch(/already happened/i);
+  });
+});


### PR DESCRIPTION
Closes L3.7 from `project_roadmap.md` (sweep XS).

Forecast tile shows two sets of numbers (planned + actual under it) without explaining what either means. Adds a small info disclosure next to the heading.

Native `<details>` / `<summary>` pattern, so keyboard-accessible with zero JS state. Mobile-friendly (click to open). Hover gives the cursor a `cursor-help` affordance for desktop discoverability.

Copy:
- **Planned** = what you set in your forecast plan for this period — the targets you're working against.
- **Actual** = what has already happened in this period (settled + pending transactions), computed from your data.

Frontend tests: 107 → 109. `/dashboard` still prerenders as Static.