### PR TITLE
feat(system): add /system hub index page (L5.8)

### DIFF
--- a/frontend/app/system/page.tsx
+++ b/frontend/app/system/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { card, cardTitle, pageTitle } from "@/lib/styles";
+
+type SystemSection = {
+  href: string;
+  title: string;
+  description: string;
+};
+
+// Catalog of /system/* subsections. Add a row here when a new
+// platform-admin surface lands — keeps the hub honest without
+// touching the gate logic below.
+const SECTIONS: SystemSection[] = [
+  {
+    href: "/system/plans",
+    title: "Plans",
+    description:
+      "Manage subscription plans (free, premium, custom) and per-plan feature flags. Duplicate a plan to build a custom variant for sales-negotiated deals.",
+  },
+];
+
+export default function SystemHubPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  // Client-side guard: redirect non-superadmins. The backend gates on
+  // platform permissions for every /system/* call — this just keeps a
+  // regular user from seeing a half-rendered hub before the redirect.
+  useEffect(() => {
+    if (!loading && (!user || !user.is_superadmin)) {
+      router.replace("/dashboard");
+    }
+  }, [user, loading, router]);
+
+  if (loading || !user?.is_superadmin) return null;
+
+  return (
+    <AppShell>
+      <h1 className={pageTitle}>System</h1>
+      <p className="mt-1 mb-6 text-sm text-text-secondary">
+        Platform-admin surface. Tenants and members live under{" "}
+        <Link href="/admin" className="text-accent hover:underline">/admin</Link>;
+        the surfaces below configure the platform itself.
+      </p>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {SECTIONS.map((section) => (
+          <Link key={section.href} href={section.href} className={`${card} block p-5 transition-colors hover:border-accent`}>
+            <h2 className={cardTitle}>{section.title}</h2>
+            <p className="mt-2 text-sm text-text-secondary">{section.description}</p>
+            <p className="mt-3 text-xs font-medium text-accent">Open →</p>
+          </Link>
+        ))}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/tests/app/system-hub-page.test.tsx
+++ b/frontend/tests/app/system-hub-page.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import SystemHubPage from "@/app/system/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/system",
+}));
+
+const SUPERADMIN = {
+  id: 1, username: "root", email: "root@platform.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner", org_id: 1, org_name: "Platform",
+  billing_cycle_day: 1, is_superadmin: true, is_active: true, mfa_enabled: false,
+  subscription_status: null, subscription_plan: null, trial_end: null,
+};
+
+const PLAIN_USER = { ...SUPERADMIN, id: 2, is_superadmin: false };
+
+describe("SystemHubPage (L5.8)", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+  });
+
+  it("renders subsection cards for superadmin", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    render(<SystemHubPage />);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1, name: /system/i })).toBeInTheDocument(),
+    );
+    // Plans card present and linked. The shell sidebar also has links
+    // matching /plans/ ("Forecast plans"), so locate the hub card by
+    // its exact href instead of by a regex on accessible name.
+    const allLinks = screen.getAllByRole("link");
+    const plansLink = allLinks.find((a) => a.getAttribute("href") === "/system/plans");
+    expect(plansLink).toBeDefined();
+    // Card-level heading ("Plans") is reachable inside the link element.
+    expect(plansLink!.textContent).toMatch(/plans/i);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects non-superadmin to /dashboard and renders nothing", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: PLAIN_USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    const { container } = render(<SystemHubPage />);
+    expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    // Component returns null while gated; no headings or cards rendered.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while auth is still loading", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null as never,
+      loading: true,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    const { container } = render(<SystemHubPage />);
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
Closes L5.8 from `project_roadmap.md` (sweep XS).

`/system` URL was 404 — only `/system/plans` existed. Adds a hub index page that mirrors `/admin`'s pattern: superadmin-gated, lists each platform-admin subsection as a card with description and link.

Currently catalogs only **Plans** (the one section that exists today). Future platform-admin pages add a row to the `SECTIONS` array at the top of the file; the gate logic stays untouched.

Gate matches `/system/plans` exactly: `router.replace("/dashboard")` for non-superadmin via `useEffect`, plus `return null` for the loading and gated render paths. The backend remains authoritative on every `/api/v1/admin/*` call — this is purely a UX guard so a regular user doesn't see a half-rendered hub before the redirect.

Frontend tests: 107 → 110.