### PR TITLE
feat(app): brand-consistent error/404/loading fallbacks (L5.7)

### DIFF
--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { btnPrimary, btnSecondary, card, cardTitle } from "@/lib/styles";
+
+// Root error boundary. Auth-neutral by design: must not import or
+// render AppShell, useAuth, or anything that assumes a session — if
+// auth itself crashes, this is the page that has to keep working.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  // Surface to the browser console in dev so the underlying stack is
+  // visible alongside the friendly UI; production noise gets filtered
+  // by the structured logger upstream.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.error("[error.tsx] caught:", error);
+    }
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className={`${card} max-w-md w-full p-6`}>
+        <h1 className={`${cardTitle} text-danger`}>Something went wrong</h1>
+        <p className="mt-3 text-sm text-text-secondary">
+          The page couldn&rsquo;t be displayed. This is on us — the team has been
+          notified. You can try again, or head back to safer ground.
+        </p>
+        {error?.digest && (
+          <p className="mt-3 text-xs font-mono text-text-muted">
+            Reference: <code>{error.digest}</code>
+          </p>
+        )}
+        <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={() => reset()}
+            className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+          >
+            Try again
+          </button>
+          <Link
+            href="/dashboard"
+            className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center`}
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -25,12 +25,11 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background p-4">
+    <main className="flex min-h-screen items-center justify-center bg-bg p-4">
       <div className={`${card} max-w-md w-full p-6`}>
         <h1 className={`${cardTitle} text-danger`}>Something went wrong</h1>
         <p className="mt-3 text-sm text-text-secondary">
-          The page couldn&rsquo;t be displayed. This is on us — the team has been
-          notified. You can try again, or head back to safer ground.
+          The page couldn&rsquo;t be displayed. You can try again, or head back to safer ground.
         </p>
         {error?.digest && (
           <p className="mt-3 text-xs font-mono text-text-muted">

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect } from "react";
+
+// True global error boundary. Renders when an error escapes app/error.tsx,
+// which only catches errors thrown below app/layout.tsx. Errors from inside
+// the root layout itself (ThemeProvider, AuthProvider, the inline theme
+// script, font loaders) bubble past app/error.tsx and end up here.
+//
+// Per Next.js docs, this file MUST own its own <html> and <body> because it
+// fully replaces the root layout when it activates. It MUST NOT import any
+// providers, hooks, or @/lib helpers that depend on layout-level setup —
+// those are exactly the things that can be on fire when this page renders.
+//
+// Inline styles only (no Tailwind class evaluation, no globals.css) so a
+// CSS pipeline failure doesn't take this page down with it.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.error("[global-error.tsx] caught:", error);
+    }
+  }, [error]);
+
+  const wrapStyle: React.CSSProperties = {
+    minHeight: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "1rem",
+    background: "#0a0a0a",
+    color: "#fafafa",
+    fontFamily:
+      "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  };
+  const cardStyle: React.CSSProperties = {
+    maxWidth: "28rem",
+    width: "100%",
+    padding: "1.5rem",
+    border: "1px solid #2a2a2a",
+    borderRadius: "0.5rem",
+    background: "#171717",
+  };
+  const headingStyle: React.CSSProperties = {
+    fontSize: "1.125rem",
+    fontWeight: 600,
+    color: "#f87171",
+    margin: 0,
+  };
+  const bodyStyle: React.CSSProperties = {
+    marginTop: "0.75rem",
+    fontSize: "0.875rem",
+    lineHeight: 1.6,
+    color: "#a3a3a3",
+  };
+  const refStyle: React.CSSProperties = {
+    marginTop: "0.75rem",
+    fontSize: "0.75rem",
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    color: "#737373",
+  };
+  const buttonRowStyle: React.CSSProperties = {
+    marginTop: "1.25rem",
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.5rem",
+  };
+  const buttonStyle: React.CSSProperties = {
+    minHeight: "44px",
+    padding: "0.5rem 1rem",
+    border: "1px solid #2a2a2a",
+    borderRadius: "0.375rem",
+    fontSize: "0.875rem",
+    fontWeight: 500,
+    background: "#262626",
+    color: "#fafafa",
+    cursor: "pointer",
+    textDecoration: "none",
+    textAlign: "center",
+  };
+
+  return (
+    <html lang="en">
+      <body style={wrapStyle}>
+        <main role="alert" style={cardStyle}>
+          <h1 style={headingStyle}>Something went wrong</h1>
+          <p style={bodyStyle}>
+            The application couldn&rsquo;t start. This is a low-level failure that bypassed the page-level error handler. You can reload, or head back to the home page.
+          </p>
+          {error?.digest && (
+            <p style={refStyle}>
+              Reference: <code>{error.digest}</code>
+            </p>
+          )}
+          <div style={buttonRowStyle}>
+            <button type="button" onClick={() => reset()} style={buttonStyle}>
+              Reload application
+            </button>
+            <a href="/" style={buttonStyle}>
+              Go to home page
+            </a>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/loading.tsx
+++ b/frontend/app/loading.tsx
@@ -8,7 +8,7 @@ export default function RootLoading() {
       role="status"
       aria-live="polite"
       aria-label="Loading"
-      className="flex min-h-screen items-center justify-center bg-background"
+      className="flex min-h-screen items-center justify-center bg-bg"
     >
       <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-accent" />
     </main>

--- a/frontend/app/loading.tsx
+++ b/frontend/app/loading.tsx
@@ -1,0 +1,16 @@
+// Root-segment loading state. Renders while a route segment streams
+// in or while async work in a Server Component is pending. Auth-
+// neutral: shows a minimal centered spinner without depending on
+// AppShell or session state.
+export default function RootLoading() {
+  return (
+    <main
+      role="status"
+      aria-live="polite"
+      aria-label="Loading"
+      className="flex min-h-screen items-center justify-center bg-background"
+    >
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-accent" />
+    </main>
+  );
+}

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { btnPrimary, btnSecondary, card, cardTitle } from "@/lib/styles";
+
+// Custom 404. Server component, auth-neutral. Cannot read auth state
+// or use hooks — those would require "use client" and break the
+// statically-rendered fallback contract that lets / and /login also
+// resolve through this page when their slugs don't match.
+export const metadata = {
+  title: "Page not found",
+  robots: { index: false, follow: false },
+};
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className={`${card} max-w-md w-full p-6 text-center`}>
+        <p className="font-display text-6xl text-text-primary">404</p>
+        <h1 className={`${cardTitle} mt-2`}>Page not found</h1>
+        <p className="mt-3 text-sm text-text-secondary">
+          The page you&rsquo;re looking for doesn&rsquo;t exist or was moved.
+        </p>
+        <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/dashboard"
+            className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center`}
+          >
+            Go to dashboard
+          </Link>
+          <Link
+            href="/"
+            className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center`}
+          >
+            Visit landing page
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -12,7 +12,7 @@ export const metadata = {
 
 export default function NotFound() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background p-4">
+    <main className="flex min-h-screen items-center justify-center bg-bg p-4">
       <div className={`${card} max-w-md w-full p-6 text-center`}>
         <p className="font-display text-6xl text-text-primary">404</p>
         <h1 className={`${cardTitle} mt-2`}>Page not found</h1>

--- a/frontend/tests/app/global-fallbacks.test.tsx
+++ b/frontend/tests/app/global-fallbacks.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import GlobalError from "@/app/error";
+import NotFound from "@/app/not-found";
+import RootLoading from "@/app/loading";
+
+// These tests pin three properties of the L5.7 framework fallbacks:
+//
+//   1. Render contract — they show their distinctive copy / role.
+//   2. Auth-neutrality — none of them import AppShell, useAuth, or
+//      any session-bearing primitive. If they did, importing them
+//      would either fail in this minimal test setup or pull in mocks.
+//   3. Reset behavior — error.tsx wires the framework-supplied reset
+//      callback to its "Try again" button.
+
+describe("GlobalError (L5.7)", () => {
+  it("renders the friendly error message and a Try again button", () => {
+    render(<GlobalError error={new Error("boom")} reset={() => {}} />);
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("invokes the reset callback when Try again is clicked", () => {
+    const reset = vi.fn();
+    render(<GlobalError error={new Error("boom")} reset={reset} />);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the error digest when present", () => {
+    const err = Object.assign(new Error("boom"), { digest: "abc123" });
+    render(<GlobalError error={err} reset={() => {}} />);
+    expect(screen.getByText(/abc123/i)).toBeInTheDocument();
+  });
+
+  it("links back to /dashboard as the safe-ground escape", () => {
+    render(<GlobalError error={new Error("boom")} reset={() => {}} />);
+    const backLink = screen.getByRole("link", { name: /back to dashboard/i });
+    expect(backLink).toHaveAttribute("href", "/dashboard");
+  });
+});
+
+describe("NotFound (L5.7)", () => {
+  it("renders the 404 marker and the page-not-found heading", () => {
+    render(<NotFound />);
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();
+  });
+
+  it("offers both dashboard and landing as escape paths", () => {
+    render(<NotFound />);
+    const dashboard = screen.getByRole("link", { name: /go to dashboard/i });
+    const landing = screen.getByRole("link", { name: /visit landing page/i });
+    expect(dashboard).toHaveAttribute("href", "/dashboard");
+    expect(landing).toHaveAttribute("href", "/");
+  });
+});
+
+describe("RootLoading (L5.7)", () => {
+  it("renders a status region with an accessible label", () => {
+    render(<RootLoading />);
+    const status = screen.getByRole("status");
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute("aria-label", "Loading");
+  });
+});

--- a/frontend/tests/app/global-fallbacks.test.tsx
+++ b/frontend/tests/app/global-fallbacks.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import GlobalError from "@/app/error";
+import GlobalErrorBoundary from "@/app/global-error";
 import NotFound from "@/app/not-found";
 import RootLoading from "@/app/loading";
 
@@ -13,11 +14,18 @@ import RootLoading from "@/app/loading";
 //   3. Reset behavior — error.tsx wires the framework-supplied reset
 //      callback to its "Try again" button.
 
-describe("GlobalError (L5.7)", () => {
+describe("GlobalError — root segment boundary (L5.7)", () => {
   it("renders the friendly error message and a Try again button", () => {
     render(<GlobalError error={new Error("boom")} reset={() => {}} />);
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("does not falsely claim the team has been notified", () => {
+    // Reporting is not wired today; copy must not promise a
+    // notification we don't actually send (PR #125 review finding).
+    render(<GlobalError error={new Error("boom")} reset={() => {}} />);
+    expect(screen.queryByText(/notified/i)).toBeNull();
   });
 
   it("invokes the reset callback when Try again is clicked", () => {
@@ -53,6 +61,40 @@ describe("NotFound (L5.7)", () => {
     const landing = screen.getByRole("link", { name: /visit landing page/i });
     expect(dashboard).toHaveAttribute("href", "/dashboard");
     expect(landing).toHaveAttribute("href", "/");
+  });
+});
+
+describe("GlobalErrorBoundary — true root fallback (L5.7)", () => {
+  // global-error.tsx replaces the root layout when it activates, so it
+  // owns its own <html>/<body>. React warns about <html> inside RTL's
+  // <div> container; suppress that one expected warning while we test
+  // the actual behavior (text + button + reset wiring).
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it("renders the global friendly error message", () => {
+    render(<GlobalErrorBoundary error={new Error("layout boom")} reset={() => {}} />);
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  it("invokes the reset callback when Reload is clicked", () => {
+    const reset = vi.fn();
+    render(<GlobalErrorBoundary error={new Error("boom")} reset={reset} />);
+    fireEvent.click(screen.getByRole("button", { name: /reload application/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers a Go-to-home-page anchor as the auth-neutral escape", () => {
+    render(<GlobalErrorBoundary error={new Error("boom")} reset={() => {}} />);
+    expect(screen.getByRole("link", { name: /go to home page/i })).toHaveAttribute(
+      "href",
+      "/",
+    );
   });
 });
 


### PR DESCRIPTION
Closes L5.7 from `project_roadmap.md` (sweep S anchor).

App Router has no `error.tsx`, `not-found.tsx`, or `loading.tsx` today — defaults to Next.js framework pages. This PR adds all three at the app root:

- **`app/error.tsx`** — global error boundary. Friendly "Something went wrong" copy, **Try again** button wired to the framework `reset` callback, `error.digest` surfaced for support correlation, escape link back to `/dashboard`.
- **`app/not-found.tsx`** — custom 404. `noindex/nofollow` metadata so search engines don't bookmark stale paths through this page. Escape links to `/dashboard` and `/` (landing).
- **`app/loading.tsx`** — minimal centered spinner with `role="status"` + `aria-label="Loading"` for screen readers.

## Auth-neutrality

Per the architect-locked constraint on this S anchor: framework fallback pages **must not** depend on `AppShell` or authenticated user state. If auth itself crashes, `error.tsx` is the page that has to keep working — same applies to 404 and loading. None of the three import `AppShell`, `useAuth`, or any session-bearing primitive; they use only auth-neutral style tokens from `@/lib/styles`.

## Tests
7 RTL tests pin: render contracts (distinctive copy + roles), the reset-callback wiring on Try-again, digest pass-through, escape-link `href`s, and the loading status region's accessible label.

Frontend: 107 → 114. Build still green; `/dashboard` and other routes still prerender as expected.