### PR TITLE
docs(privacy): disclose the short-lived oauth_state cookie

### DIFF
--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -78,9 +78,11 @@ export default function PrivacyPolicyPage() {
               </li>
               <li>
                 <strong>Cookies:</strong> an HTTP-only refresh-token cookie
-                to keep you logged in, a theme preference in local storage,
-                and a bot-management cookie set by Cloudflare. We do not use
-                analytics or advertising cookies.
+                to keep you logged in, a short-lived <code>oauth_state</code>{" "}
+                cookie issued during Google sign-in (deleted within 10 minutes
+                of the sign-in flow completing or being cancelled), a theme
+                preference in local storage, and a bot-management cookie set
+                by Cloudflare. We do not use analytics or advertising cookies.
               </li>
             </ul>
           </section>


### PR DESCRIPTION
Closes the cosmetic follow-up from the L1.4 cookie audit (`~/.claude/projects/-Users-fjorge-src-pfv/audits/2026-05-05-l1-4-cookie-audit.md` §5).

The existing privacy disclosure listed the refresh-token cookie + theme localStorage + Cloudflare bot-management cookie but omitted the `oauth_state` cookie issued during Google SSO. The cookie is short-lived and deleted by the OAuth callback (or after 10 min if the flow stalls), but the policy claim is "the cookies we set," not "the long-lived cookies we set" — truthful disclosure adds the missing line.

## Diff

Before:
> **Cookies:** an HTTP-only refresh-token cookie to keep you logged in, a theme preference in local storage, and a bot-management cookie set by Cloudflare. We do not use analytics or advertising cookies.

After:
> **Cookies:** an HTTP-only refresh-token cookie to keep you logged in, a short-lived `oauth_state` cookie issued during Google sign-in (deleted within 10 minutes of the sign-in flow completing or being cancelled), a theme preference in local storage, and a bot-management cookie set by Cloudflare. We do not use analytics or advertising cookies.

## Tests

Pure copy edit, no new tests. Frontend: 123 passing, build green, `/privacy` still prerenders as Static.

## Notes

Independent of in-flight PRs #127 (pydantic 422 redaction) and #128 (smoke-failure GH issue auto-create); they touch different files. Third and final PR of the bundle the architect approved earlier.