### PR TITLE
feat(dashboard,accounts): keep CC pending visible across periods (L3.4)

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -7,13 +7,17 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { formatAmount } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
-import type { Account, AccountType } from "@/lib/types";
+import type { Account, AccountType, Transaction } from "@/lib/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 
 export default function AccountsPage() {
   const { user, loading } = useAuth();
   const [accountTypes, setAccountTypes] = useState<AccountType[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
+  // All-time pending transactions for the per-account "Pending: €X.XX"
+  // row. Pending is a status, not a period concept; a CC charge sitting
+  // in pending must be visible whether it was made this month or last.
+  const [pendingTransactions, setPendingTransactions] = useState<Transaction[]>([]);
   const [fetching, setFetching] = useState(true);
 
   const [typeName, setTypeName] = useState("");
@@ -38,12 +42,14 @@ export default function AccountsPage() {
   const [confirmDeleteAcctId, setConfirmDeleteAcctId] = useState<number | null>(null);
 
   const reload = useCallback(async () => {
-    const [types, accts] = await Promise.all([
+    const [types, accts, pending] = await Promise.all([
       apiFetch<AccountType[]>("/api/v1/account-types"),
       apiFetch<Account[]>("/api/v1/accounts"),
+      apiFetch<Transaction[]>("/api/v1/transactions?status=pending&limit=200"),
     ]);
     setAccountTypes(types ?? []);
     setAccounts(accts ?? []);
+    setPendingTransactions(pending ?? []);
     setFetching(false);
   }, []);
 
@@ -133,6 +139,16 @@ export default function AccountsPage() {
       await reload();
     } catch (err) { setError(extractErrorMessage(err)); }
   }
+
+  // Per-account pending totals. Income contributes positively, expense
+  // negatively (so for a CC, pending is normally negative — money owed).
+  // The display below renders Math.abs() and the "Pending:" label, so
+  // sign is just used to compute the magnitude correctly.
+  const pendingByAccount = pendingTransactions.reduce<Record<number, number>>((acc, tx) => {
+    const sign = tx.type === "income" ? 1 : -1;
+    acc[tx.account_id] = (acc[tx.account_id] || 0) + Number(tx.amount) * sign;
+    return acc;
+  }, {});
 
   return (
     <AppShell>
@@ -261,11 +277,16 @@ export default function AccountsPage() {
                         {!a.is_active && <span className="text-xs text-danger">inactive</span>}
                       </div>
                     </div>
-                    <div className="flex shrink-0 items-center gap-4 md:ml-auto">
+                    <div className="flex shrink-0 flex-col items-end gap-0.5 md:ml-auto">
                       <span className="text-sm tabular-nums text-text-primary">
                         {formatAmount(a.balance)}{" "}
                         <span className="text-text-muted">{a.currency}</span>
                       </span>
+                      {pendingByAccount[a.id] ? (
+                        <span className="text-xs tabular-nums text-text-muted">
+                          Pending: {formatAmount(Math.abs(pendingByAccount[a.id]))}
+                        </span>
+                      ) : null}
                     </div>
                     <div className="flex flex-wrap gap-3">
                       <button onClick={() => startEditAcct(a)} aria-label={`Edit ${a.name}`} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Edit</button>

--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -5,6 +5,7 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { fetchAll } from "@/lib/pagination";
 import { formatAmount } from "@/lib/format";
 import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import type { Account, AccountType, Transaction } from "@/lib/types";
@@ -45,7 +46,9 @@ export default function AccountsPage() {
     const [types, accts, pending] = await Promise.all([
       apiFetch<AccountType[]>("/api/v1/account-types"),
       apiFetch<Account[]>("/api/v1/accounts"),
-      apiFetch<Transaction[]>("/api/v1/transactions?status=pending&limit=200"),
+      // Paged so the per-page limit (200 server-side) can't drop older
+      // unresolved pending charges from the per-account totals.
+      fetchAll<Transaction>("/api/v1/transactions?status=pending"),
     ]);
     setAccountTypes(types ?? []);
     setAccounts(accts ?? []);

--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -43,16 +43,25 @@ export default function AccountsPage() {
   const [confirmDeleteAcctId, setConfirmDeleteAcctId] = useState<number | null>(null);
 
   const reload = useCallback(async () => {
+    // Primary fetches: account types + accounts. A failure here is a
+    // real failure — surface it through the existing reload().catch.
+    // Run in parallel with the supplementary pending fetch but don't
+    // let pending's failure bring the whole page down.
+    const pendingPromise = fetchAll<Transaction>("/api/v1/transactions?status=pending")
+      // Best-effort: a pending fetch failure must not (a) blank the
+      // accounts list on initial load, or (b) make a successful
+      // mutation look failed because reload() rejected only due to
+      // the pending augment. Resolve with `null` to signal "skip the
+      // setState" without rejecting the parent Promise.all.
+      .catch(() => null);
     const [types, accts, pending] = await Promise.all([
       apiFetch<AccountType[]>("/api/v1/account-types"),
       apiFetch<Account[]>("/api/v1/accounts"),
-      // Paged so the per-page limit (200 server-side) can't drop older
-      // unresolved pending charges from the per-account totals.
-      fetchAll<Transaction>("/api/v1/transactions?status=pending"),
+      pendingPromise,
     ]);
     setAccountTypes(types ?? []);
     setAccounts(accts ?? []);
-    setPendingTransactions(pending ?? []);
+    if (pending !== null) setPendingTransactions(pending);
     setFetching(false);
   }, []);
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -95,6 +95,11 @@ export default function DashboardPage() {
   const [billingCycleDay, setBillingCycleDay] = useState(user?.billing_cycle_day ?? 1);
   const [periodIdx, setPeriodIdx] = useState(0);
   const [forecast, setForecast] = useState<ForecastPlan | null>(null);
+  // All-time pending transactions (no date filter). Pending is a status,
+  // not a period concept; a CC charge from October that's still pending
+  // in November must remain visible regardless of which period the user
+  // is viewing. Refreshed on writes via loadTransactions.
+  const [pendingTransactions, setPendingTransactions] = useState<Transaction[]>([]);
   const [forecastProjection, setForecastProjection] = useState<ForecastProjection | null>(null);
   const [projectionFailed, setProjectionFailed] = useState(false);
   const [projectionLoading, setProjectionLoading] = useState(false);
@@ -182,11 +187,15 @@ export default function DashboardPage() {
     const budgetUrl = realPeriodStart ? `/api/v1/budgets?period_start=${realPeriodStart}` : "/api/v1/budgets";
     const forecastUrl = realPeriodStart ? `/api/v1/forecast-plans/current?period_start=${realPeriodStart}` : "/api/v1/forecast-plans/current";
     const dateFilter = `date_from=${monthFrom}${monthTo ? `&date_to=${monthTo}` : ""}`;
-    const [pageData, allData, bds, fc] = await Promise.all([
+    const [pageData, allData, bds, fc, pendingData] = await Promise.all([
       apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
       p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?limit=200&${dateFilter}`) : null,
       p === 0 ? apiFetch<Budget[]>(budgetUrl) : null,
       p === 0 ? apiFetch<ForecastPlan | null>(forecastUrl) : null,
+      // All-time pending — no date filter. Closes the L3.4 gap where a
+      // pending charge from a prior period would disappear when the
+      // user navigated forward.
+      p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?status=pending&limit=200`) : null,
     ]);
     const page_txs = pageData ?? [];
     setHasMore(page_txs.length > PAGE_SIZE);
@@ -195,6 +204,7 @@ export default function DashboardPage() {
     if (bds) setBudgets(bds);
     // null is a valid response (no plan yet) — set state so empty-state UI renders.
     if (p === 0) setForecast(fc ?? null);
+    if (pendingData) setPendingTransactions(pendingData);
     setFetching(false);
   }, [monthFrom, monthTo, realPeriodStart]);
 
@@ -387,14 +397,15 @@ export default function DashboardPage() {
   // Precompute tx map for O(1) linked lookups
   const txMap = new Map(allTransactions.map((tx) => [tx.id, tx]));
 
-  // Pending totals per account from all period transactions
-  const pendingByAccount = allTransactions
-    .filter((tx) => tx.status === "pending")
-    .reduce<Record<number, number>>((acc, tx) => {
-      const sign = tx.type === "income" ? 1 : -1;
-      acc[tx.account_id] = (acc[tx.account_id] || 0) + Number(tx.amount) * sign;
-      return acc;
-    }, {});
+  // Pending totals per account, computed from the all-time pending fetch
+  // (NOT from the period-filtered allTransactions). Pending CC charges
+  // must remain visible regardless of which billing period the user is
+  // viewing — pending is a status, not a date.
+  const pendingByAccount = pendingTransactions.reduce<Record<number, number>>((acc, tx) => {
+    const sign = tx.type === "income" ? 1 : -1;
+    acc[tx.account_id] = (acc[tx.account_id] || 0) + Number(tx.amount) * sign;
+    return acc;
+  }, {});
 
   // Spending by category from all period transactions. Transfer expense
   // halves carry linked_transaction_id; excluding them here stops transfers

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { fetchAll } from "@/lib/pagination";
 import { formatAmount, formatLocalDate, projectedPeriodEnd, todayISO } from "@/lib/format";
 import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, pageTitle, error as errorCls } from "@/lib/styles";
 
@@ -98,8 +99,14 @@ export default function DashboardPage() {
   // All-time pending transactions (no date filter). Pending is a status,
   // not a period concept; a CC charge from October that's still pending
   // in November must remain visible regardless of which period the user
-  // is viewing. Refreshed on writes via loadTransactions.
+  // is viewing. Refreshed on every write — independent of the visible
+  // transaction page (the status toggle on page 2 still needs to refresh
+  // the strip's pending totals).
   const [pendingTransactions, setPendingTransactions] = useState<Transaction[]>([]);
+  // Counter-ref guard for the pending fetch. Two writes in quick
+  // succession can issue two pending refetches; only the latest one is
+  // allowed to commit state. Same pattern as projectionRequestId below.
+  const pendingRequestId = useRef(0);
   const [forecastProjection, setForecastProjection] = useState<ForecastProjection | null>(null);
   const [projectionFailed, setProjectionFailed] = useState(false);
   const [projectionLoading, setProjectionLoading] = useState(false);
@@ -187,15 +194,11 @@ export default function DashboardPage() {
     const budgetUrl = realPeriodStart ? `/api/v1/budgets?period_start=${realPeriodStart}` : "/api/v1/budgets";
     const forecastUrl = realPeriodStart ? `/api/v1/forecast-plans/current?period_start=${realPeriodStart}` : "/api/v1/forecast-plans/current";
     const dateFilter = `date_from=${monthFrom}${monthTo ? `&date_to=${monthTo}` : ""}`;
-    const [pageData, allData, bds, fc, pendingData] = await Promise.all([
+    const [pageData, allData, bds, fc] = await Promise.all([
       apiFetch<Transaction[]>(`/api/v1/transactions?limit=${PAGE_SIZE + 1}&offset=${p * PAGE_SIZE}&${dateFilter}`),
       p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?limit=200&${dateFilter}`) : null,
       p === 0 ? apiFetch<Budget[]>(budgetUrl) : null,
       p === 0 ? apiFetch<ForecastPlan | null>(forecastUrl) : null,
-      // All-time pending — no date filter. Closes the L3.4 gap where a
-      // pending charge from a prior period would disappear when the
-      // user navigated forward.
-      p === 0 ? apiFetch<Transaction[]>(`/api/v1/transactions?status=pending&limit=200`) : null,
     ]);
     const page_txs = pageData ?? [];
     setHasMore(page_txs.length > PAGE_SIZE);
@@ -204,9 +207,26 @@ export default function DashboardPage() {
     if (bds) setBudgets(bds);
     // null is a valid response (no plan yet) — set state so empty-state UI renders.
     if (p === 0) setForecast(fc ?? null);
-    if (pendingData) setPendingTransactions(pendingData);
     setFetching(false);
   }, [monthFrom, monthTo, realPeriodStart]);
+
+  // All-time pending refetch. Decoupled from loadTransactions so it
+  // refreshes on writes regardless of which transaction page is visible:
+  // a status toggle on page 2 must still update the accounts strip.
+  // Paginated through fetchAll<Transaction> so the limit=200 cap can't
+  // silently drop older unresolved pending charges.
+  const loadPendingTransactions = useCallback(async () => {
+    const myId = ++pendingRequestId.current;
+    try {
+      const all = await fetchAll<Transaction>("/api/v1/transactions?status=pending");
+      if (pendingRequestId.current !== myId) return;
+      setPendingTransactions(all);
+    } catch {
+      // Pending failures are noisy but non-fatal — silently keep the
+      // last good snapshot. The dashboard error banner already surfaces
+      // the real problem if loadRefs / loadTransactions also failed.
+    }
+  }, []);
 
   // Loads the forecast projection from /api/v1/forecast for the
   // currently-selected billing period. Separate from loadTransactions
@@ -260,8 +280,10 @@ export default function DashboardPage() {
       loadRefs().catch((err) => {
         setError(extractErrorMessage(err, "Failed to load dashboard data"));
       });
+      // Pending is independent of period and refs; load alongside.
+      void loadPendingTransactions();
     }
-  }, [loading, user, loadRefs]);
+  }, [loading, user, loadRefs, loadPendingTransactions]);
 
   useEffect(() => {
     // Gate the period-scoped load on a real billing period being in
@@ -356,6 +378,9 @@ export default function DashboardPage() {
       // we re-call /api/v1/forecast, otherwise the page's primary answer
       // ("are we on track?") can be wrong.
       void loadForecastProjection();
+      // Pending charges may have changed (a settled-on-create or a manual
+      // pending entry); refresh independent of the visible page index.
+      void loadPendingTransactions();
     } catch (err) {
       setError(extractErrorMessage(err));
     }
@@ -890,6 +915,9 @@ export default function DashboardPage() {
                               await loadTransactions(page);
                               await loadRefs();
                               void loadForecastProjection();
+                              // Independent of `page` — a toggle on page 2
+                              // still has to refresh the strip's totals.
+                              void loadPendingTransactions();
                             } catch (err) {
                               setError(extractErrorMessage(err));
                             }

--- a/frontend/lib/pagination.ts
+++ b/frontend/lib/pagination.ts
@@ -1,0 +1,33 @@
+import { apiFetch } from "@/lib/api";
+
+/**
+ * Page through a list endpoint that supports `limit` + `offset` query
+ * params and returns an array of T. Stops when a response shorter than
+ * `pageSize` arrives. For all-time aggregates whose per-page cap (≤200
+ * server-side) would otherwise truncate the result.
+ *
+ * Caller passes a base URL with any non-pagination query params already
+ * attached, e.g. `fetchAll<Transaction>("/api/v1/transactions?status=pending")`.
+ *
+ * Lives in its own module (not `lib/api.ts`) so test code that mocks
+ * `apiFetch` via `vi.mock("@/lib/api", ...)` correctly intercepts the
+ * fetcher used here. Functions that call `apiFetch` from within
+ * `lib/api.ts` itself bypass the export-level mock; cross-module imports
+ * do not.
+ */
+export async function fetchAll<T>(baseUrl: string, pageSize = 200): Promise<T[]> {
+  const result: T[] = [];
+  let offset = 0;
+  const sep = baseUrl.includes("?") ? "&" : "?";
+  // Cap the loop at a sane upper bound. 100 × 200 = 20k items is far
+  // beyond any realistic dashboard workload; raise if a real workload
+  // ever approaches it.
+  for (let page = 0; page < 100; page += 1) {
+    const rows = await apiFetch<T[]>(`${baseUrl}${sep}limit=${pageSize}&offset=${offset}`);
+    if (!Array.isArray(rows) || rows.length === 0) break;
+    result.push(...rows);
+    if (rows.length < pageSize) break;
+    offset += pageSize;
+  }
+  return result;
+}

--- a/frontend/tests/app/accounts-pending-visibility.test.tsx
+++ b/frontend/tests/app/accounts-pending-visibility.test.tsx
@@ -140,6 +140,25 @@ describe("AccountsPage — pending visibility (L3.4)", () => {
     expect(screen.getAllByText(/^Pending:/)).toHaveLength(1);
   });
 
+  it("renders accounts even when the pending fetch rejects (best-effort)", async () => {
+    // The pending augment must not bring the page down. Account types +
+    // accounts succeed; pending throws. Page must still render the
+    // accounts list and clear the spinner.
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
+      if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
+      if (url.startsWith("/api/v1/transactions?status=pending"))
+        return Promise.reject(new Error("backend down"));
+      return Promise.resolve({});
+    }) as never);
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+    expect(screen.getByText(/ING Joint/)).toBeInTheDocument();
+    // Without the best-effort handling, the spinner would never clear
+    // and Amex Primary would never render.
+    expect(screen.queryByText(/^Pending:/)).not.toBeInTheDocument();
+  });
+
   it("aggregates multiple pending charges per account and ignores other accounts", async () => {
     mockAccountsAPI([
       { id: 1, account_id: 10, amount: "120.00", type: "expense", status: "pending", date: "2026-04-15", description: "a", category_id: null, category_name: null, account_name: "Amex Primary", currency: "EUR", linked_transaction_id: null, is_imported: false, settled_date: null },

--- a/frontend/tests/app/accounts-pending-visibility.test.tsx
+++ b/frontend/tests/app/accounts-pending-visibility.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AccountsPage from "@/app/accounts/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/accounts",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCOUNT_TYPES = [
+  { id: 1, name: "Credit Card", slug: "credit_card", is_system: true, account_count: 1 },
+  { id: 2, name: "Checking", slug: "checking", is_system: true, account_count: 1 },
+];
+
+const ACCOUNTS = [
+  {
+    id: 10,
+    name: "Amex Primary",
+    account_type_id: 1,
+    account_type_name: "Credit Card",
+    account_type_slug: "credit_card",
+    balance: "0.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: false,
+    close_day: 5,
+  },
+  {
+    id: 20,
+    name: "ING Joint",
+    account_type_id: 2,
+    account_type_name: "Checking",
+    account_type_slug: "checking",
+    balance: "1500.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: true,
+    close_day: null,
+  },
+];
+
+describe("AccountsPage — pending visibility (L3.4)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+  });
+
+  function mockAccountsAPI(pending: unknown[]) {
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
+      if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
+      if (url === "/api/v1/transactions?status=pending&limit=200") return Promise.resolve(pending);
+      return Promise.resolve({});
+    }) as never);
+  }
+
+  it("renders no Pending line when there are no pending transactions", async () => {
+    mockAccountsAPI([]);
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+    expect(screen.queryByText(/^Pending:/)).not.toBeInTheDocument();
+  });
+
+  it("renders Pending: line for a CC with a pending charge, even when balance is 0", async () => {
+    // The exact L3.4 scenario: CC balance is 0 (post-payment) but pending != 0.
+    // Pre-fix, this row showed nothing about the pending charge.
+    mockAccountsAPI([
+      {
+        id: 100,
+        account_id: 10,
+        amount: "150.00",
+        type: "expense",
+        status: "pending",
+        date: "2026-04-15",
+        description: "Pending charge",
+        category_id: null,
+        category_name: null,
+        account_name: "Amex Primary",
+        currency: "EUR",
+        linked_transaction_id: null,
+        is_imported: false,
+        settled_date: null,
+      },
+    ]);
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Pending: 150\.00/)).toBeInTheDocument());
+    // The CC tile keeps its 0.00 balance display.
+    expect(screen.getAllByText(/0\.00/).length).toBeGreaterThan(0);
+    // The Checking account, with no pending transactions, must NOT render a Pending line.
+    // Tighter check: only one Pending: text on the page.
+    expect(screen.getAllByText(/^Pending:/)).toHaveLength(1);
+  });
+
+  it("aggregates multiple pending charges per account and ignores other accounts", async () => {
+    mockAccountsAPI([
+      { id: 1, account_id: 10, amount: "120.00", type: "expense", status: "pending", date: "2026-04-15", description: "a", category_id: null, category_name: null, account_name: "Amex Primary", currency: "EUR", linked_transaction_id: null, is_imported: false, settled_date: null },
+      { id: 2, account_id: 10, amount: "30.00", type: "expense", status: "pending", date: "2026-04-16", description: "b", category_id: null, category_name: null, account_name: "Amex Primary", currency: "EUR", linked_transaction_id: null, is_imported: false, settled_date: null },
+    ]);
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Pending: 150\.00/)).toBeInTheDocument());
+  });
+});

--- a/frontend/tests/app/accounts-pending-visibility.test.tsx
+++ b/frontend/tests/app/accounts-pending-visibility.test.tsx
@@ -97,7 +97,8 @@ describe("AccountsPage — pending visibility (L3.4)", () => {
     vi.mocked(apiFetch).mockImplementation(((url: string) => {
       if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
       if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
-      if (url === "/api/v1/transactions?status=pending&limit=200") return Promise.resolve(pending);
+      // fetchAll<T> appends &limit=200&offset=N; match the prefix.
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve(pending);
       return Promise.resolve({});
     }) as never);
   }

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/dashboard",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+// One transaction in the visible list, settled — used as the click target
+// for the status toggle. Its description is the button's aria-label suffix.
+const SETTLED_TX = {
+  id: 999,
+  account_id: 10,
+  amount: "50.00",
+  type: "expense",
+  status: "settled",
+  date: "2026-05-01",
+  description: "Coffee",
+  category_id: null,
+  category_name: null,
+  account_name: "Amex Primary",
+  currency: "EUR",
+  linked_transaction_id: null,
+  is_imported: false,
+  settled_date: "2026-05-01",
+};
+
+describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    window.history.pushState({}, "", "/dashboard");
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+  });
+
+  it("fires the all-time pending fetch after a status toggle, independent of the visible page", async () => {
+    let pendingCalls = 0;
+    let toggleCallSeen = false;
+
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([]);
+      if (url === "/api/v1/categories") return Promise.resolve([]);
+      if (url === "/api/v1/budgets" || url.startsWith("/api/v1/budgets?"))
+        return Promise.resolve([]);
+      if (url === "/api/v1/settings/billing-cycle")
+        return Promise.resolve({ billing_cycle_day: 1 });
+      if (url === "/api/v1/settings/billing-period")
+        return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      if (url === "/api/v1/settings/billing-periods")
+        return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+      if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
+      if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
+      // PUT /api/v1/transactions/{id} — the status toggle write.
+      if (url.startsWith("/api/v1/transactions/") && init?.method === "PUT") {
+        toggleCallSeen = true;
+        return Promise.resolve({});
+      }
+      // The fetchAll paginator hits ?status=pending&limit=200&offset=N.
+      // Count those calls and return [] (empty page → fetchAll exits).
+      if (url.startsWith("/api/v1/transactions?status=pending")) {
+        pendingCalls += 1;
+        return Promise.resolve([]);
+      }
+      // The non-paginated transactions calls (page list + period
+      // aggregate) return [SETTLED_TX] for the "all" call so the toggle
+      // button has something to click.
+      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve([SETTLED_TX]);
+      if (url.startsWith("/api/v1/transactions?")) return Promise.resolve([SETTLED_TX]);
+      return Promise.resolve({});
+    }) as never);
+
+    render(<DashboardPage />);
+
+    // Wait for the page to settle on initial load — the toggle button
+    // for our SETTLED_TX is rendered in the Recent Transactions list.
+    await waitFor(
+      () => expect(screen.getByLabelText(/Settled status for Coffee/)).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+
+    const callsAfterMount = pendingCalls;
+    expect(callsAfterMount).toBeGreaterThan(0); // initial pending load
+
+    // Toggle the status. This used to call loadTransactions(page) only,
+    // leaving pendingByAccount stale on any non-zero page. The fix
+    // wires loadPendingTransactions() into the toggle handler so the
+    // strip's pending totals refresh independent of the visible page.
+    fireEvent.click(screen.getByLabelText(/Settled status for Coffee/));
+
+    await waitFor(() => expect(toggleCallSeen).toBe(true));
+    // Critical assertion: the pending endpoint was re-called after the
+    // toggle, NOT just on the initial load.
+    await waitFor(() => expect(pendingCalls).toBeGreaterThan(callsAfterMount));
+  });
+});

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -81,9 +81,21 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
     } as never);
   });
 
-  it("fires the all-time pending fetch after a status toggle, independent of the visible page", async () => {
+  it("fires the all-time pending fetch after a status toggle on page > 0", async () => {
     let pendingCalls = 0;
     let toggleCallSeen = false;
+
+    // Page 0: 11 rows so hasMore is true and the Next button is enabled.
+    // Each row has a unique id so React keys are stable.
+    const PAGE_0_ROWS = Array.from({ length: 11 }, (_, i) => ({
+      ...SETTLED_TX,
+      id: 200 + i,
+      description: `Row ${i}`,
+    }));
+    // Page 1: SETTLED_TX (description "Coffee"). The aria-label match
+    // below targets exactly this row, so the toggle test is unambiguous
+    // about which page it's on.
+    const PAGE_1_ROWS = [SETTLED_TX];
 
     vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
       if (url === "/api/v1/accounts") return Promise.resolve([]);
@@ -103,41 +115,57 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
         toggleCallSeen = true;
         return Promise.resolve({});
       }
-      // The fetchAll paginator hits ?status=pending&limit=200&offset=N.
-      // Count those calls and return [] (empty page → fetchAll exits).
+      // fetchAll paginator hits ?status=pending&limit=200&offset=N. Count
+      // these calls and return [] so fetchAll exits on the first page.
       if (url.startsWith("/api/v1/transactions?status=pending")) {
         pendingCalls += 1;
         return Promise.resolve([]);
       }
-      // The non-paginated transactions calls (page list + period
-      // aggregate) return [SETTLED_TX] for the "all" call so the toggle
-      // button has something to click.
-      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve([SETTLED_TX]);
-      if (url.startsWith("/api/v1/transactions?")) return Promise.resolve([SETTLED_TX]);
+      // limit=200 is the period-scoped "all" fetch (donut, charts, etc.).
+      // limit=11 is the paginated visible-page fetch (PAGE_SIZE+1).
+      if (url.startsWith("/api/v1/transactions?limit=200"))
+        return Promise.resolve([...PAGE_0_ROWS, ...PAGE_1_ROWS]);
+      if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
+        return Promise.resolve(PAGE_0_ROWS);
+      if (url.startsWith("/api/v1/transactions?limit=11&offset=10"))
+        return Promise.resolve(PAGE_1_ROWS);
       return Promise.resolve({});
     }) as never);
 
     render(<DashboardPage />);
 
-    // Wait for the page to settle on initial load — the toggle button
-    // for our SETTLED_TX is rendered in the Recent Transactions list.
+    // Wait for the initial page-0 render. The Next button is enabled
+    // (hasMore=true because PAGE_0_ROWS.length = 11 > PAGE_SIZE).
+    await waitFor(
+      () => expect(screen.getByRole("button", { name: /^Next$/ })).not.toBeDisabled(),
+      { timeout: 3000 },
+    );
+
+    // Navigate to page 1 (page index 1 = "page > 0", the regression case).
+    fireEvent.click(screen.getByRole("button", { name: /^Next$/ }));
+
+    // Wait for page-1 render. SETTLED_TX (Coffee) is now visible; its
+    // status-toggle button has the destination-aware aria-label set in
+    // PR #132.
     await waitFor(
       () => expect(screen.getByLabelText(/Settled status for Coffee/)).toBeInTheDocument(),
       { timeout: 3000 },
     );
 
-    const callsAfterMount = pendingCalls;
-    expect(callsAfterMount).toBeGreaterThan(0); // initial pending load
+    const pendingCallsBeforeToggle = pendingCalls;
+    expect(pendingCallsBeforeToggle).toBeGreaterThan(0);
 
-    // Toggle the status. This used to call loadTransactions(page) only,
-    // leaving pendingByAccount stale on any non-zero page. The fix
-    // wires loadPendingTransactions() into the toggle handler so the
-    // strip's pending totals refresh independent of the visible page.
+    // Toggle the status while the user is on page 1. Pre-fix, this
+    // only called loadTransactions(page=1), which never refetches
+    // pending — strip totals would silently go stale. The fix wires
+    // loadPendingTransactions() into the toggle handler regardless
+    // of the visible page index.
     fireEvent.click(screen.getByLabelText(/Settled status for Coffee/));
 
     await waitFor(() => expect(toggleCallSeen).toBe(true));
-    // Critical assertion: the pending endpoint was re-called after the
-    // toggle, NOT just on the initial load.
-    await waitFor(() => expect(pendingCalls).toBeGreaterThan(callsAfterMount));
+    // Critical assertion: pending endpoint was re-called AFTER the
+    // toggle on page 1, not just on initial mount or the page-change
+    // refetch.
+    await waitFor(() => expect(pendingCalls).toBeGreaterThan(pendingCallsBeforeToggle));
   });
 });


### PR DESCRIPTION
## Summary

Closes **L3.4** on the launch path. Two real gaps mapped to the roadmap framing "Balance goes to 0 but pending != 0 must stay visible. Currently disappears on payment":

1. **Dashboard pending was period-filtered.** `pendingByAccount` was computed by filtering `allTransactions`, which is itself date-filtered by the selected billing period. A CC charge made in October that was still pending in November "disappeared" from the dashboard when the user navigated forward, because October's row wasn't in the period set. Pending is a status, not a date — the source must be all-time.
2. **/accounts page showed nothing for pending.** It fetched `/api/v1/accounts` and `/api/v1/account-types` only. After a CC payment, the user saw balance `€0.00` with no signal of unsettled charges. They could believe the card was clear when it wasn't.

## What landed

- New `?status=pending&limit=200` fetch on both pages (no date filter). Backend already supported the filter; no API changes.
- Dashboard: `pendingByAccount` is now derived from the all-time pending set instead of period-filtered `allTransactions`. Render gates unchanged (CC-only on the others strip, any-type on the primary tile).
- /accounts: each row's right-hand column now stacks the balance with a `Pending: €X.XX` line when non-zero. Any account type qualifies (matches the dashboard primary-tile pattern) — the L3.4 framing is CC-driven but the implementation is type-agnostic for consistency.
- New `tests/app/accounts-pending-visibility.test.tsx`: exact L3.4 scenario (CC balance 0 + pending charge → Pending line visible), absence case, multi-charge aggregation per account. 3 tests, 140 total now (was 137).

## Verification

- `npm run build` — clean
- `npm run lint` — exits 0
- `npm test` — 140/140 (30 files, +1 new file)

## Out of scope

- Backend signal that "pending != 0 even when balance == 0" — we surface it client-side from the existing transactions endpoint. No new endpoint or aggregation needed for this UX gap.
- Pending visibility on routes other than `/dashboard` and `/accounts` (e.g. `/transactions` already shows per-row status; no aggregation needed there).