### PR TITLE
fix(l3-1): batched reset, post-wipe re-seed, in-flight spinner

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -124,42 +124,19 @@ async def _find_available_username(db: AsyncSession, base: str) -> str:
 
 
 async def _create_org_with_defaults(db: AsyncSession, org_name: str) -> Organization:
-    """Create an organization with system account types and categories."""
+    """Create an organization and seed system account types + categories.
+
+    Delegates the seed to ``org_bootstrap_service.seed_org_defaults`` so
+    the same logic backs both initial registration and the post-reset
+    re-seed in ``org_data_service.reset_org_data``. Idempotent on the
+    seed side; this caller path inserts a fresh org so no preexisting
+    defaults can collide.
+    """
     org = Organization(name=org_name)
     db.add(org)
     await db.flush()
-
-    for sat in SYSTEM_ACCOUNT_TYPES:
-        db.add(AccountType(org_id=org.id, name=sat["name"], slug=sat["slug"], is_system=True))
-
-    for master_def in SYSTEM_CATEGORIES:
-        master = Category(
-            org_id=org.id,
-            name=master_def["name"],
-            slug=master_def["slug"],
-            description=master_def["description"],
-            type=CategoryType(master_def["type"]),
-            is_system=True,
-        )
-        db.add(master)
-        await db.flush()
-        for child_def in master_def.get("children", []):
-            db.add(Category(
-                org_id=org.id,
-                parent_id=master.id,
-                name=child_def["name"],
-                slug=child_def["slug"],
-                description=child_def["description"],
-                type=CategoryType(master_def["type"]),
-                is_system=True,
-            ))
-
-    db.add(Category(
-        org_id=org.id, name="Transfer", slug="transfer",
-        description="Internal transfers between accounts",
-        type=CategoryType.BOTH, is_system=True,
-    ))
-
+    from app.services.org_bootstrap_service import seed_org_defaults
+    await seed_org_defaults(db, org_id=org.id)
     return org
 
 

--- a/backend/app/routers/org_data.py
+++ b/backend/app/routers/org_data.py
@@ -46,9 +46,14 @@ async def reset_org_data(
             detail="confirm_phrase does not match required value",
         )
 
+    # ``reset_org_data`` commits per batch internally so locks release
+    # between chunks. We do NOT issue an outer commit here — there's
+    # nothing pending. On exception, rollback whatever was uncommitted
+    # at the moment of failure; previously-committed batches persist
+    # and the user can re-run the reset (idempotent on both the wipe
+    # and the seed) to finish.
     try:
         counts = await org_data_service.reset_org_data(db, org_id=org_id)
-        await db.commit()
     except Exception as e:  # noqa: BLE001 — translate to generic 500 + log.
         await db.rollback()
         await logger.aerror(

--- a/backend/app/services/org_bootstrap_service.py
+++ b/backend/app/services/org_bootstrap_service.py
@@ -1,0 +1,118 @@
+"""Idempotent seeding of system defaults for an org.
+
+Single source of truth for the post-registration "starter state":
+system account types, system master + child categories, and the
+shared Transfer system category. Used by:
+
+- ``auth.register`` (initial seed when a new org is created)
+- ``org_data_service.reset_org_data`` (re-seed after a self-service
+  reset, so the org returns to the post-registration state instead
+  of an empty shell)
+
+Called from inside an active session; flushes between rows so child
+inserts can reference parent IDs but does not commit. Caller controls
+the transaction boundary.
+"""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import AccountType, SYSTEM_ACCOUNT_TYPES
+from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
+
+
+async def seed_org_defaults(db: AsyncSession, *, org_id: int) -> dict[str, int]:
+    """Insert system account types and categories for ``org_id``.
+
+    Idempotent: existing rows with matching ``(org_id, slug, is_system=True)``
+    are left in place; only missing rows are inserted. Safe to call at
+    registration AND at reset (after a wipe).
+
+    Returns a dict with counts of newly inserted rows per table:
+    ``{"account_types": N, "categories": M}``. Caller commits.
+    """
+    counts = {"account_types": 0, "categories": 0}
+
+    # ── Account types ──────────────────────────────────────────────
+    existing_at_slugs = set(
+        (await db.scalars(
+            select(AccountType.slug).where(
+                AccountType.org_id == org_id,
+                AccountType.is_system.is_(True),
+            )
+        )).all()
+    )
+    for sat in SYSTEM_ACCOUNT_TYPES:
+        if sat["slug"] not in existing_at_slugs:
+            db.add(AccountType(
+                org_id=org_id,
+                name=sat["name"],
+                slug=sat["slug"],
+                is_system=True,
+            ))
+            counts["account_types"] += 1
+
+    # ── Categories (master + children + Transfer) ─────────────────
+    existing_cat_slugs = set(
+        (await db.scalars(
+            select(Category.slug).where(
+                Category.org_id == org_id,
+                Category.is_system.is_(True),
+            )
+        )).all()
+    )
+
+    for master_def in SYSTEM_CATEGORIES:
+        master: Category | None
+        if master_def["slug"] in existing_cat_slugs:
+            # Master already present — fetch it so children can attach.
+            master = await db.scalar(
+                select(Category).where(
+                    Category.org_id == org_id,
+                    Category.slug == master_def["slug"],
+                    Category.is_system.is_(True),
+                )
+            )
+        else:
+            master = Category(
+                org_id=org_id,
+                name=master_def["name"],
+                slug=master_def["slug"],
+                description=master_def["description"],
+                type=CategoryType(master_def["type"]),
+                is_system=True,
+            )
+            db.add(master)
+            counts["categories"] += 1
+            # Flush so master.id is populated for the children below.
+            await db.flush()
+
+        for child_def in master_def.get("children", []):
+            if child_def["slug"] in existing_cat_slugs:
+                continue
+            db.add(Category(
+                org_id=org_id,
+                parent_id=master.id if master is not None else None,
+                name=child_def["name"],
+                slug=child_def["slug"],
+                description=child_def["description"],
+                type=CategoryType(master_def["type"]),
+                is_system=True,
+            ))
+            counts["categories"] += 1
+
+    # Transfer system category (CategoryType.BOTH; no children).
+    if "transfer" not in existing_cat_slugs:
+        db.add(Category(
+            org_id=org_id,
+            name="Transfer",
+            slug="transfer",
+            description="Internal transfers between accounts",
+            type=CategoryType.BOTH,
+            is_system=True,
+        ))
+        counts["categories"] += 1
+
+    await db.flush()
+    return counts

--- a/backend/app/services/org_data_service.py
+++ b/backend/app/services/org_data_service.py
@@ -4,10 +4,23 @@ Owns the FK-safe wipe-order knowledge for org-scoped data tables.
 ``wipe_org_data`` is intentionally public — admin_orgs_service imports
 it for the cascade delete path. Putting it here (neutral location)
 keeps tenant code from depending on an admin service.
+
+Two distinct paths:
+
+- ``wipe_org_data`` (admin delete) issues unbounded ``DELETE WHERE
+  org_id = :id`` statements inside the caller's transaction. The
+  whole org is going away, so partial-state risk is moot and the
+  caller wants one commit boundary.
+- ``reset_org_data`` (self-service tenant reset) issues batched
+  ``DELETE WHERE id IN (...)`` over PK chunks with a commit between
+  each chunk. Releases locks so other traffic can interleave on a
+  single-replica MySQL instance. Accepts partial-wipe risk on
+  interruption — the operation is idempotent (re-running picks up
+  any remaining rows + re-runs the seed).
 """
 from __future__ import annotations
 
-from sqlalchemy import delete, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account, AccountType
@@ -18,6 +31,7 @@ from app.models.category_rule import CategoryRule
 from app.models.forecast_plan import ForecastPlan, ForecastPlanItem
 from app.models.recurring import RecurringTransaction
 from app.models.transaction import Transaction
+from app.services.org_bootstrap_service import seed_org_defaults
 
 
 async def wipe_org_data(
@@ -90,14 +104,126 @@ async def wipe_org_data(
     return counts
 
 
-async def reset_org_data(
-    db: AsyncSession, *, org_id: int
-) -> dict[str, int]:
-    """Reset all financial / import / setup data for ``org_id``.
+# Default chunk size for batched reset deletes. 500 rows per batch
+# is a balance between (a) keeping each transaction's lock window
+# short enough to not wedge a single-replica MySQL under load, and
+# (b) not bloating the round-trip count for typical household
+# volumes (a real customer org has dozens of accounts, hundreds to
+# low-thousands of transactions). Tunable via the ``batch_size``
+# kwarg on ``reset_org_data`` if real workloads warrant.
+RESET_BATCH_SIZE = 500
 
-    Tenant-scoped wrapper over :func:`wipe_org_data`. Kept distinct
-    so future reset-side concerns (post-reset hooks, audit-table
-    writes once L4.7 lands) have a place to live without bleeding
-    into the helper. Caller commits.
+
+async def _batch_delete_by_pk(
+    db: AsyncSession,
+    model: type,
+    org_id: int,
+    label: str,
+    batch_size: int,
+) -> int:
+    """Delete rows from ``model`` matching ``org_id`` in PK-id chunks.
+
+    Selects PKs first (cheap, indexed on ``id`` + ``org_id``), deletes
+    by ``WHERE id IN (...)``, commits, repeats. Each commit releases
+    the lock window so concurrent traffic can interleave. The select
+    finds a fresh batch each iteration (already-deleted rows fall out
+    of the result set), so no offset bookkeeping is needed.
+
+    The ``label`` argument is for caller logging only; this function
+    just returns the total deleted count.
     """
-    return await wipe_org_data(db, org_id=org_id)
+    total = 0
+    while True:
+        ids = list((await db.scalars(
+            select(model.id).where(model.org_id == org_id).limit(batch_size)
+        )).all())
+        if not ids:
+            break
+        result = await db.execute(
+            delete(model).where(model.id.in_(ids))
+        )
+        total += result.rowcount or 0
+        await db.commit()
+        if len(ids) < batch_size:
+            break
+    return total
+
+
+async def reset_org_data(
+    db: AsyncSession, *, org_id: int, batch_size: int = RESET_BATCH_SIZE
+) -> dict[str, int]:
+    """Reset all financial / import / setup data for ``org_id`` and
+    re-seed system defaults.
+
+    Distinct from :func:`wipe_org_data` (admin delete path):
+
+    - Deletes are batched by PK with a ``db.commit()`` between
+      chunks so locks release and other traffic can interleave
+      on the single-replica DO instance.
+    - After the wipe completes, calls
+      :func:`org_bootstrap_service.seed_org_defaults` to restore the
+      post-registration state: system account types, system master +
+      child categories, and the Transfer category.
+
+    Returns a dict of ``{table: rowcount}`` for the wipe plus
+    ``seeded_account_types`` and ``seeded_categories`` counts.
+
+    Caller does NOT commit afterward — this function manages its own
+    transaction boundaries (per-batch + a final commit on the seed).
+    Endpoint should rollback only if an exception escapes; committed
+    batches up to that point persist, and the user can re-run the
+    reset to finish (idempotent).
+    """
+    counts: dict[str, int] = {}
+
+    counts["transactions"] = await _batch_delete_by_pk(
+        db, Transaction, org_id, "transactions", batch_size
+    )
+    counts["forecast_plan_items"] = await _batch_delete_by_pk(
+        db, ForecastPlanItem, org_id, "forecast_plan_items", batch_size
+    )
+    counts["budgets"] = await _batch_delete_by_pk(
+        db, Budget, org_id, "budgets", batch_size
+    )
+    counts["recurring_transactions"] = await _batch_delete_by_pk(
+        db, RecurringTransaction, org_id, "recurring_transactions", batch_size
+    )
+    counts["forecast_plans"] = await _batch_delete_by_pk(
+        db, ForecastPlan, org_id, "forecast_plans", batch_size
+    )
+    counts["billing_periods"] = await _batch_delete_by_pk(
+        db, BillingPeriod, org_id, "billing_periods", batch_size
+    )
+    counts["accounts"] = await _batch_delete_by_pk(
+        db, Account, org_id, "accounts", batch_size
+    )
+    counts["account_types"] = await _batch_delete_by_pk(
+        db, AccountType, org_id, "account_types", batch_size
+    )
+    counts["category_rules"] = await _batch_delete_by_pk(
+        db, CategoryRule, org_id, "category_rules", batch_size
+    )
+
+    # Categories self-reference via parent_id. Break the link as a
+    # single UPDATE before the batched delete so MySQL's strict FK
+    # check does not refuse mid-chunk. Children are typically a small
+    # set vs the whole categories table, so the UPDATE is cheap and
+    # does not warrant batching itself.
+    await db.execute(
+        update(Category).where(Category.org_id == org_id).values(parent_id=None)
+    )
+    await db.commit()
+    counts["categories"] = await _batch_delete_by_pk(
+        db, Category, org_id, "categories", batch_size
+    )
+
+    # Re-seed the post-registration defaults. Idempotent: if the
+    # caller is retrying after a partial wipe, existing defaults are
+    # left in place. A single commit at the end caps the seed so
+    # the per-batch wipe + seed all reach a consistent state.
+    seeded = await seed_org_defaults(db, org_id=org_id)
+    counts["seeded_account_types"] = seeded["account_types"]
+    counts["seeded_categories"] = seeded["categories"]
+    await db.commit()
+
+    return counts

--- a/backend/tests/services/test_org_data_service.py
+++ b/backend/tests/services/test_org_data_service.py
@@ -324,16 +324,186 @@ async def test_reset_returns_counts_and_wipes_data(session_factory):
     seeded = await _seed_full_org(session_factory)
 
     async with session_factory() as db:
+        # reset_org_data commits per batch internally; the outer commit
+        # here is a no-op but kept for symmetry with the test pattern.
         counts = await org_data_service.reset_org_data(db, org_id=seeded["org_id"])
         await db.commit()
 
+    # The contract widened in the L3.4 follow-up: `reset_org_data` now
+    # also re-seeds system defaults after the wipe and reports those
+    # counts as `seeded_account_types` and `seeded_categories`.
     expected_keys = {
         "transactions", "forecast_plan_items", "budgets",
         "recurring_transactions", "forecast_plans", "billing_periods",
         "accounts", "account_types", "category_rules", "categories",
+        "seeded_account_types", "seeded_categories",
     }
     assert set(counts.keys()) == expected_keys
 
     async with session_factory() as db:
         # Org shell still alive (wrapper didn't accidentally call cascade).
         assert await _count(db, Organization, id=seeded["org_id"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_reseeds_system_defaults_after_wipe(session_factory):
+    """The L3.4 follow-up gap: post-reset, the org must look like a freshly
+    registered org (system account types, system master + child categories,
+    Transfer category) instead of an empty shell.
+    """
+    seeded = await _seed_full_org(session_factory)
+    org_id = seeded["org_id"]
+
+    # Pre-reset: verify the seeded org has *non-default* shape (otherwise
+    # the assertions below trivially pass on the seed alone).
+    async with session_factory() as db:
+        # The fixture inserts 1 system + 1 user account type plus 1 master
+        # + 1 child category. After reset we expect to see only system
+        # account types and system categories — the user-added ones go.
+        pre_user_at = await db.scalar(
+            select(func.count()).select_from(AccountType).where(
+                AccountType.org_id == org_id,
+                AccountType.is_system.is_(False),
+            )
+        )
+        assert pre_user_at >= 1, "fixture should seed at least one user account type"
+
+    async with session_factory() as db:
+        counts = await org_data_service.reset_org_data(db, org_id=org_id)
+
+    # The seed inserted SOMETHING — non-zero counts confirm the re-seed ran.
+    assert counts["seeded_account_types"] > 0
+    assert counts["seeded_categories"] > 0
+
+    async with session_factory() as db:
+        # After reset, only system rows survive in the per-org tables.
+        all_at = (await db.scalars(
+            select(AccountType).where(AccountType.org_id == org_id)
+        )).all()
+        assert len(all_at) > 0
+        assert all(at.is_system for at in all_at)
+
+        all_cats = (await db.scalars(
+            select(Category).where(Category.org_id == org_id)
+        )).all()
+        assert len(all_cats) > 0
+        assert all(cat.is_system for cat in all_cats)
+        # The Transfer system category specifically must be present.
+        transfer = await db.scalar(
+            select(Category).where(
+                Category.org_id == org_id,
+                Category.slug == "transfer",
+                Category.is_system.is_(True),
+            )
+        )
+        assert transfer is not None, "Transfer system category not re-seeded"
+
+
+@pytest.mark.asyncio
+async def test_seed_org_defaults_is_idempotent(session_factory):
+    """``seed_org_defaults`` is keyed by ``(org_id, slug, is_system=True)``
+    and must skip existing rows. Calling it twice without a wipe in
+    between must not duplicate, and the second call's reported counts
+    must be zero.
+    """
+    from app.services.org_bootstrap_service import seed_org_defaults
+
+    seeded = await _seed_full_org(session_factory)
+    org_id = seeded["org_id"]
+
+    # First call: ``_seed_full_org`` already inserted some system rows
+    # (matching the registration shape — see fixture). The seed should
+    # find them and only insert what's missing.
+    async with session_factory() as db:
+        first = await seed_org_defaults(db, org_id=org_id)
+        await db.commit()
+
+    async with session_factory() as db:
+        second = await seed_org_defaults(db, org_id=org_id)
+        await db.commit()
+    # Second call: nothing missing, nothing inserted.
+    assert second == {"account_types": 0, "categories": 0}
+
+    # Row counts unchanged between the two calls.
+    async with session_factory() as db:
+        at_count = await db.scalar(
+            select(func.count()).select_from(AccountType).where(AccountType.org_id == org_id)
+        )
+        cat_count = await db.scalar(
+            select(func.count()).select_from(Category).where(Category.org_id == org_id)
+        )
+    # Sanity: the first call did insert rows (or the fixture already
+    # had them all). Either way the contract is non-negative + stable.
+    assert first["account_types"] >= 0
+    assert first["categories"] >= 0
+    assert at_count >= 1
+    assert cat_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_reset_end_state_is_stable_across_repeats(session_factory):
+    """Repeated resets must leave the org in the same shape every
+    time. Each reset wipes (including system rows) and re-seeds, so
+    every reset's seed counts are non-zero — but the final row counts
+    must be identical to the first reset's final state.
+    """
+    seeded = await _seed_full_org(session_factory)
+    org_id = seeded["org_id"]
+
+    async with session_factory() as db:
+        await org_data_service.reset_org_data(db, org_id=org_id)
+
+    async with session_factory() as db:
+        first_at = await db.scalar(
+            select(func.count()).select_from(AccountType).where(AccountType.org_id == org_id)
+        )
+        first_cat = await db.scalar(
+            select(func.count()).select_from(Category).where(Category.org_id == org_id)
+        )
+
+    # Run reset two more times and confirm the row counts are stable.
+    async with session_factory() as db:
+        await org_data_service.reset_org_data(db, org_id=org_id)
+    async with session_factory() as db:
+        await org_data_service.reset_org_data(db, org_id=org_id)
+
+    async with session_factory() as db:
+        third_at = await db.scalar(
+            select(func.count()).select_from(AccountType).where(AccountType.org_id == org_id)
+        )
+        third_cat = await db.scalar(
+            select(func.count()).select_from(Category).where(Category.org_id == org_id)
+        )
+    assert third_at == first_at
+    assert third_cat == first_cat
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_still_uses_unbatched_wipe_path(session_factory):
+    """Regression: ``admin_orgs_service.delete_org_cascade`` must keep
+    using ``wipe_org_data`` (single transaction, no per-batch commit,
+    no re-seed) — NOT the new ``reset_org_data`` path. A change to the
+    self-service reset path must not bleed into the admin delete path.
+    """
+    from app.services import admin_orgs_service
+    seeded = await _seed_full_org(session_factory)
+    org_id = seeded["org_id"]
+
+    async with session_factory() as db:
+        counts = await admin_orgs_service.delete_org_cascade(db, org_id=org_id)
+        # The admin-delete contract is: caller commits. delete_org_cascade
+        # uses the unbatched wipe path expecting one commit boundary,
+        # which is exactly what this regression is asserting must NOT
+        # have changed when reset_org_data was rewritten.
+        await db.commit()
+
+    # delete_org_cascade returns its own merged dict including the
+    # wipe table counts AND the org-shell counts (org_settings,
+    # subscriptions, users, organization). Critically, it must NOT
+    # include the seed keys — admin delete does not re-seed a tomb.
+    assert "seeded_account_types" not in counts
+    assert "seeded_categories" not in counts
+
+    # The org itself is gone (admin-delete cascade ran to completion).
+    async with session_factory() as db:
+        assert await _count(db, Organization, id=org_id) == 0

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -6,6 +6,7 @@ import { mutate } from "swr";
 import SettingsLayout from "@/components/SettingsLayout";
 import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import { Loader2 } from "lucide-react";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { projectedPeriodEnd } from "@/lib/format";
@@ -433,7 +434,14 @@ export default function OrganizationSettingsPage() {
                   disabled={!resetPhraseMatches || resetting}
                   className="rounded-md bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
                 >
-                  {resetting ? "Resetting…" : "Reset my data"}
+                  {resetting ? (
+                    <span className="inline-flex items-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                      Resetting organization data...
+                    </span>
+                  ) : (
+                    "Reset organization data permanently"
+                  )}
                 </button>
               </div>
             </div>

--- a/frontend/tests/app/settings-organization-danger-zone.test.tsx
+++ b/frontend/tests/app/settings-organization-danger-zone.test.tsx
@@ -108,7 +108,7 @@ describe("OrganizationSettingsPage — Danger Zone", () => {
     render(<OrganizationSettingsPage />);
     await waitFor(() => expect(screen.getByText(/Danger zone/i)).toBeInTheDocument());
 
-    const button = screen.getByRole("button", { name: /reset my data/i }) as HTMLButtonElement;
+    const button = screen.getByRole("button", { name: /reset organization data permanently/i }) as HTMLButtonElement;
     const input = screen.getByLabelText(/confirm reset phrase/i);
 
     expect(button.disabled).toBe(true);
@@ -141,7 +141,7 @@ describe("OrganizationSettingsPage — Danger Zone", () => {
 
     const input = screen.getByLabelText(/confirm reset phrase/i);
     fireEvent.change(input, { target: { value: `RESET ${ORG_NAME}` } });
-    fireEvent.click(screen.getByRole("button", { name: /reset my data/i }));
+    fireEvent.click(screen.getByRole("button", { name: /reset organization data permanently/i }));
 
     await waitFor(() => {
       const call = vi.mocked(apiFetch).mock.calls.find(
@@ -164,7 +164,7 @@ describe("OrganizationSettingsPage — Danger Zone", () => {
 
     const input = screen.getByLabelText(/confirm reset phrase/i);
     fireEvent.change(input, { target: { value: `RESET ${ORG_NAME}` } });
-    fireEvent.click(screen.getByRole("button", { name: /reset my data/i }));
+    fireEvent.click(screen.getByRole("button", { name: /reset organization data permanently/i }));
 
     await waitFor(() => expect(vi.mocked(mutate)).toHaveBeenCalled());
     // Match-all matcher (function predicate), undefined value (clear),
@@ -179,5 +179,52 @@ describe("OrganizationSettingsPage — Danger Zone", () => {
     const mutateOrder = vi.mocked(mutate).mock.invocationCallOrder[0];
     const pushOrder = pushMock.mock.invocationCallOrder[0];
     expect(mutateOrder).toBeLessThan(pushOrder);
+  });
+
+  it("shows a spinner + 'Resetting organization data...' while the POST is in flight", async () => {
+    mockUser("owner");
+    // Hold the POST open so we can assert the in-flight UI. Wire up
+    // the same baseline fixtures the other tests use, then override
+    // /orgs/data/reset to be deferred.
+    let resolveReset!: (v: unknown) => void;
+    const resetPromise = new Promise((r) => {
+      resolveReset = r;
+    });
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (url === "/api/v1/orgs/data/reset" && init?.method === "POST")
+        return resetPromise as never;
+      if (url === "/api/v1/settings/billing-cycle")
+        return Promise.resolve({ billing_cycle_day: 1 });
+      if (url === "/api/v1/settings/billing-period")
+        return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      if (url === "/api/v1/settings") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/members") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
+      if (url === "/api/v1/category-rules") return Promise.resolve([]);
+      return Promise.resolve({});
+    }) as never);
+    render(<OrganizationSettingsPage />);
+    await waitFor(() => expect(screen.getByText(/Danger zone/i)).toBeInTheDocument());
+
+    const input = screen.getByLabelText(/confirm reset phrase/i);
+    fireEvent.change(input, { target: { value: `RESET ${ORG_NAME}` } });
+    const button = screen.getByRole("button", { name: /reset organization data permanently/i });
+    fireEvent.click(button);
+
+    // In-flight: button copy switches to "Resetting organization data..."
+    // and a spinner svg appears next to it.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /resetting organization data/i })).toBeInTheDocument(),
+    );
+    const spinningButton = screen.getByRole("button", { name: /resetting organization data/i });
+    // The spinner is a Loader2 lucide icon with the animate-spin class.
+    const spinner = spinningButton.querySelector("svg");
+    expect(spinner).not.toBeNull();
+    expect(spinner?.classList.contains("animate-spin")).toBe(true);
+    // Button is disabled while the POST is in flight.
+    expect((spinningButton as HTMLButtonElement).disabled).toBe(true);
+
+    // Resolve the POST so the test cleans up.
+    resolveReset({});
   });
 });


### PR DESCRIPTION
## Summary

Three real gaps the user found while exercising the L3.1 self-service org reset on production data. None of these were known when L3.1 shipped (PR #122) — they only surface against real volume + a real customer flow.

## What landed

### Backend

| Slice | Change |
|---|---|
| **Batched reset path** | `services/org_data_service.py` gained a `_batch_delete_by_pk` helper. `reset_org_data` is rewritten to select PKs in chunks of 500, delete by `WHERE id IN (...)`, commit between chunks. Locks release between batches; the request takes longer wall-clock but doesn't wedge the DB. **`wipe_org_data` is unchanged** — `admin_orgs_service.delete_org_cascade` still uses the unbatched single-commit path (the whole org is going away, partial-state risk is moot, and the caller wants one transaction boundary). Regression test in `test_org_data_service.py::test_admin_delete_still_uses_unbatched_wipe_path` pins this. |
| **Idempotent default seed** | New `services/org_bootstrap_service.py:seed_org_defaults(db, org_id)`. Single source of truth for system account types + categories + Transfer. Idempotent on `(org_id, slug, is_system=True)`. Used by registration (`auth._create_org_with_defaults` got replaced with a delegate call) and by reset (re-seeds after the wipe completes). |
| **Reset re-seed** | `reset_org_data` calls `seed_org_defaults` after the batched wipe. New return shape includes `seeded_account_types` and `seeded_categories` counts. Audit-log payload pinning test was updated. |
| **Endpoint** | `routers/org_data.py` no longer commits after `reset_org_data` — that function manages its own transaction boundaries. The outer rollback on exception still runs (whatever was uncommitted at the failure point); previously-committed batches persist, and the user can re-run the reset (idempotent on both wipe and seed) to finish. |

### Frontend

| Slice | Change |
|---|---|
| **Button copy** | Default: `"Reset organization data permanently"` (was `"Reset my data"`). In-flight: `"Resetting organization data..."` with a `Loader2` lucide icon (`animate-spin`) inline. |
| **Spinner regression test** | `tests/app/settings-organization-danger-zone.test.tsx` gained one case: holds the reset POST open, asserts the button label switches and the spinner svg renders with the `animate-spin` class. |

### Skipped

**Final irreversible-warning modal after typed-confirm.** Argued out: the typed-confirm pattern (`RESET <org name>`) is the established final commitment in this UX lane (AWS / GitHub / Stripe all stop there). Adding another modal is double-confirm fatigue.

## Verification

- `pytest` — **369/369 backend pass** (was 365; +4 new tests for the bootstrap service + reset behavior)
- `npm test` — **143/143 frontend pass** (was 142; +1 spinner regression test)
- `npm run build` — clean (36 routes, Turbopack)
- `npm run lint` — exits 0

## Trade-offs called out in code

- **Partial-wipe risk**: per-batch commits mean a request that fails mid-wipe leaves the org in a partially-wiped state. Acceptable because the user can re-run the reset; both wipe and seed are idempotent.
- **Batch size 500** is a launch-volume guess. Tunable via the `batch_size` kwarg on `reset_org_data` if real workloads warrant.