### PR TITLE
fix(l3-1): per-org reset lock — close the concurrent-reset race

### DIFF
--- a/backend/alembic/versions/029_add_org_data_reset_locks.py
+++ b/backend/alembic/versions/029_add_org_data_reset_locks.py
@@ -1,0 +1,44 @@
+"""Add org_data_reset_locks table — per-org guard against concurrent resets.
+
+Revision ID: 029_reset_locks
+Revises: 028_plan_features
+Create Date: 2026-05-06
+
+PR #134 follow-up: the reset endpoint commits per batch to avoid wedging
+MySQL; without a server-side lock, two concurrent reset submissions can
+interleave and (because account_types / categories have no DB-level
+uniqueness on system slugs) duplicate the seeded defaults.
+
+This table provides a single-row-per-org exclusive lease. The endpoint
+acquires it before starting reset (rejecting with 409 if already held)
+and releases it in finally. A staleness window (30 min) guards against
+locks left orphaned by a crashed worker.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "029_reset_locks"
+down_revision = "028_plan_features"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_data_reset_locks",
+        sa.Column("org_id", sa.Integer, primary_key=True),
+        sa.Column("acquired_by_user_id", sa.Integer, nullable=False),
+        sa.Column("acquired_at", sa.DateTime, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["org_id"], ["organizations.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["acquired_by_user_id"], ["users.id"], ondelete="CASCADE",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("org_data_reset_locks")

--- a/backend/alembic/versions/029_add_org_data_reset_locks.py
+++ b/backend/alembic/versions/029_add_org_data_reset_locks.py
@@ -31,6 +31,12 @@ def upgrade() -> None:
         sa.Column("org_id", sa.Integer, primary_key=True),
         sa.Column("acquired_by_user_id", sa.Integer, nullable=False),
         sa.Column("acquired_at", sa.DateTime, nullable=False),
+        # Per-acquire lease token. The release path requires WHERE
+        # token = :acquired_token so a stale-takeover can't be
+        # accidentally released by the original (long-stalled) caller
+        # — that would otherwise reopen the concurrent-reset window
+        # this whole table exists to close.
+        sa.Column("lease_token", sa.String(36), nullable=False),
         sa.ForeignKeyConstraint(
             ["org_id"], ["organizations.id"], ondelete="CASCADE",
         ),

--- a/backend/app/_time.py
+++ b/backend/app/_time.py
@@ -1,0 +1,25 @@
+"""Tiny time utilities — single home for the naive-UTC convention.
+
+The repo's existing ``DateTime`` columns are declared without
+timezone info (the SQLAlchemy default), and historical code used
+``datetime.utcnow()`` to build matching naive-UTC values. Python
+3.12 deprecated ``utcnow()`` because it returns a *naive* datetime
+representing UTC, which is easy to confuse with local time.
+
+``utcnow_naive()`` here computes ``datetime.now(timezone.utc)`` and
+strips tzinfo at the boundary. Same wire result as ``utcnow()``,
+no deprecation warning, and the function name records that the
+result is intentionally naive.
+
+A future repo-wide sweep can change the columns to
+``DateTime(timezone=True)`` and remove the ``.replace(tzinfo=None)``
+call site by site. For now this is the drop-in replacement.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utcnow_naive() -> datetime:
+    """Naive-UTC ``datetime`` matching the repo's column convention."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from app.models.invitation import Invitation
 from app.models.category_rule import CategoryRule, RuleSource
 from app.models.merchant_dictionary import MerchantDictionaryEntry
 from app.models.feature_override import OrgFeatureOverride  # noqa: F401
+from app.models.org_data_reset_lock import OrgDataResetLock  # noqa: F401
 
 __all__ = [
     "Base",
@@ -44,4 +45,5 @@ __all__ = [
     "RuleSource",
     "MerchantDictionaryEntry",
     "OrgFeatureOverride",
+    "OrgDataResetLock",
 ]

--- a/backend/app/models/org_data_reset_lock.py
+++ b/backend/app/models/org_data_reset_lock.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Integer, DateTime, ForeignKey
+from sqlalchemy import Integer, DateTime, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -35,3 +35,9 @@ class OrgDataResetLock(Base):
         nullable=False,
     )
     acquired_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    # UUID4 hex string. Generated fresh on every acquire (whether
+    # an INSERT into an empty row or a stale-takeover UPDATE). The
+    # release path fences on `WHERE org_id = :id AND lease_token =
+    # :token`, so the original caller of a since-stale-taken-over
+    # lock cannot accidentally delete the successor's fresh lease.
+    lease_token: Mapped[str] = mapped_column(String(36), nullable=False)

--- a/backend/app/models/org_data_reset_lock.py
+++ b/backend/app/models/org_data_reset_lock.py
@@ -1,0 +1,37 @@
+"""Per-org exclusive lease for in-flight org-data resets.
+
+A single row per org while a reset is running. The endpoint
+(``routers/org_data.py``) acquires the lock before calling
+``reset_org_data`` and releases it in ``finally``; a stale-lock TTL
+in the service layer auto-recovers from crashed workers.
+
+Without this guard, two concurrent reset POSTs could interleave —
+because the seed-defaults logic relies on app-level idempotence
+(no DB-level UNIQUE on system slugs), an interleave window can
+duplicate the post-wipe defaults. Logged as residual risk on
+PR #134; this table closes it.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Integer, DateTime, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class OrgDataResetLock(Base):
+    __tablename__ = "org_data_reset_locks"
+
+    org_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    acquired_by_user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    acquired_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -13,6 +13,7 @@ message client-side, full detail server-side.
 """
 
 from datetime import datetime
+from app._time import utcnow_naive
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
@@ -170,7 +171,7 @@ async def _override_to_response(row: OrgFeatureOverride, db: AsyncSession) -> di
     email = None
     if row.set_by is not None:
         email = await db.scalar(select(User.email).where(User.id == row.set_by))
-    is_expired = row.expires_at is not None and row.expires_at <= datetime.utcnow()
+    is_expired = row.expires_at is not None and row.expires_at <= utcnow_naive()
     return {
         "feature_key": row.feature_key,
         "value": row.value,
@@ -232,7 +233,7 @@ async def set_feature_override(
             else:
                 existing.value = body.value
                 existing.set_by = user.id
-                existing.set_at = datetime.utcnow()
+                existing.set_at = utcnow_naive()
                 existing.expires_at = body.expires_at
                 existing.note = body.note
                 row = existing
@@ -351,7 +352,7 @@ async def get_feature_state(
         .outerjoin(User, User.id == OrgFeatureOverride.set_by)
         .where(OrgFeatureOverride.org_id == org_id)
     )
-    now = datetime.utcnow()
+    now = utcnow_naive()
     overrides_by_key: dict[str, dict] = {}
     for row, email in rows.all():
         if row.feature_key not in ALL_FEATURE_KEYS:

--- a/backend/app/routers/org_data.py
+++ b/backend/app/routers/org_data.py
@@ -11,7 +11,7 @@ from app.auth.org_permissions import require_org_owner
 from app.database import get_db
 from app.models.user import Organization, User
 from app.schemas.org_data import OrgDataResetRequest, OrgDataResetResponse
-from app.services import org_data_service
+from app.services import org_data_service, org_reset_lock_service
 
 logger = structlog.stdlib.get_logger()
 
@@ -46,6 +46,29 @@ async def reset_org_data(
             detail="confirm_phrase does not match required value",
         )
 
+    # Server-side concurrency guard: take the per-org reset lock
+    # before doing anything destructive. Two simultaneous reset POSTs
+    # could otherwise interleave through the per-batch commits and
+    # the app-level idempotent seed; the seed has no DB-level UNIQUE
+    # on (org_id, slug, is_system) so the interleave window can
+    # duplicate defaults. Released in `finally` so a 500 still frees
+    # the lock; stale locks self-recover after LOCK_TTL_MINUTES in
+    # case a worker crashed mid-reset.
+    acquired = await org_reset_lock_service.acquire_reset_lock(
+        db, org_id=org_id, user_id=actor_user_id,
+    )
+    if not acquired:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "reset_already_running",
+                "message": (
+                    "Another reset is already running for this organization. "
+                    "Please wait a moment and try again."
+                ),
+            },
+        )
+
     # ``reset_org_data`` commits per batch internally so locks release
     # between chunks. We do NOT issue an outer commit here — there's
     # nothing pending. On exception, rollback whatever was uncommitted
@@ -66,10 +89,15 @@ async def reset_org_data(
             error=str(e),
             error_type=type(e).__name__,
         )
+        # Release the lock before raising so a retry isn't blocked.
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to reset organization data",
         )
+
+    # Success path: release the lock so subsequent resets can run.
+    await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
 
     await logger.ainfo(
         "org.data.reset",

--- a/backend/app/routers/org_data.py
+++ b/backend/app/routers/org_data.py
@@ -54,10 +54,10 @@ async def reset_org_data(
     # duplicate defaults. Released in `finally` so a 500 still frees
     # the lock; stale locks self-recover after LOCK_TTL_MINUTES in
     # case a worker crashed mid-reset.
-    acquired = await org_reset_lock_service.acquire_reset_lock(
+    lease_token = await org_reset_lock_service.acquire_reset_lock(
         db, org_id=org_id, user_id=actor_user_id,
     )
-    if not acquired:
+    if lease_token is None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
@@ -90,14 +90,14 @@ async def reset_org_data(
             error_type=type(e).__name__,
         )
         # Release the lock before raising so a retry isn't blocked.
-        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=lease_token)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to reset organization data",
         )
 
     # Success path: release the lock so subsequent resets can run.
-    await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+    await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=lease_token)
 
     await logger.ainfo(
         "org.data.reset",

--- a/backend/app/services/invitation_service.py
+++ b/backend/app/services/invitation_service.py
@@ -18,6 +18,7 @@ isolation:
 from __future__ import annotations
 
 import datetime
+from app._time import utcnow_naive
 
 from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
@@ -54,7 +55,7 @@ async def _clear_expired_open_invites(
 ) -> None:
     """Null `open_email` on expired pending rows for this (org, email)
     so the unique slot is free for a fresh invite."""
-    now = datetime.datetime.utcnow()
+    now = utcnow_naive()
     await db.execute(
         update(Invitation)
         .where(
@@ -109,7 +110,7 @@ async def create_invitation(
     if pending is not None:
         raise ConflictError("This email is already invited")
 
-    now = datetime.datetime.utcnow()
+    now = utcnow_naive()
     inv = Invitation(
         org_id=org_id,
         email=norm,
@@ -141,7 +142,7 @@ async def list_pending_invitations(
     """Pending = not accepted, not revoked, not expired. Lazy expiry —
     rows past `expires_at` are filtered out here even if `open_email` is
     still set."""
-    now = datetime.datetime.utcnow()
+    now = utcnow_naive()
     result = await db.execute(
         select(Invitation)
         .where(
@@ -170,7 +171,7 @@ async def revoke_invitation(
     if inv.accepted_at is not None or inv.revoked_at is not None:
         # Already terminal — keep idempotent and return as-is.
         return inv
-    inv.revoked_at = datetime.datetime.utcnow()
+    inv.revoked_at = utcnow_naive()
     inv.open_email = None
     await db.flush()
     return inv
@@ -199,7 +200,7 @@ async def _resolve_pending(
     if inv.email != token_email:
         # Token reused against a row whose email was changed — refuse.
         raise InvitationUnavailable()
-    now = datetime.datetime.utcnow()
+    now = utcnow_naive()
     if inv.accepted_at is not None or inv.revoked_at is not None or inv.expires_at <= now:
         raise InvitationUnavailable()
     return inv
@@ -263,7 +264,7 @@ async def accept_invitation(
         or _normalize_email(str(payload.get("email", ""))) != inv.email
     ):
         raise InvitationUnavailable()
-    now = datetime.datetime.utcnow()
+    now = utcnow_naive()
     if inv.accepted_at is not None or inv.revoked_at is not None or inv.expires_at <= now:
         raise InvitationUnavailable()
 
@@ -395,6 +396,6 @@ async def remove_member(
             raise ConflictError("Cannot remove the last owner of the organization")
 
     target.is_active = False
-    target.sessions_invalidated_at = datetime.datetime.utcnow()
+    target.sessions_invalidated_at = utcnow_naive()
     await db.flush()
     return target

--- a/backend/app/services/org_reset_lock_service.py
+++ b/backend/app/services/org_reset_lock_service.py
@@ -30,28 +30,14 @@ Contract:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 from sqlalchemy import delete, insert, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app._time import utcnow_naive
 from app.models.org_data_reset_lock import OrgDataResetLock
-
-
-def _utcnow_naive() -> datetime:
-    """Return a naive-UTC datetime suitable for the existing
-    ``org_data_reset_locks.acquired_at`` column (declared as the
-    repo's standard naive ``DateTime``).
-
-    Equivalent to the Python <3.12 ``_utcnow_naive()`` semantics
-    but built from the timezone-aware ``datetime.now(timezone.utc)``
-    so it doesn't trigger the 3.12 deprecation warning. Stripping
-    tzinfo at the boundary keeps this drop-in compatible with the
-    naive-UTC column type — no migration churn for this PR. A
-    repo-wide tz sweep is tracked in TECHNICAL DEBT.
-    """
-    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 # How long a lock is considered fresh. After this window an in-flight
 # acquire can override the existing lock — recovery path for workers
@@ -81,7 +67,7 @@ async def acquire_reset_lock(
     by the new caller (with a new lease token). This keeps a crashed
     worker from blocking future resets indefinitely.
     """
-    now = _utcnow_naive()
+    now = utcnow_naive()
     cutoff = now - timedelta(minutes=LOCK_TTL_MINUTES)
     new_token = uuid.uuid4().hex  # 32-char hex; fits in String(36).
 
@@ -150,7 +136,7 @@ async def is_reset_locked(db: AsyncSession, *, org_id: int) -> bool:
     """Diagnostic helper for tests + admin debugging. Returns True if
     a fresh (non-stale) lock exists for ``org_id``.
     """
-    cutoff = _utcnow_naive() - timedelta(minutes=LOCK_TTL_MINUTES)
+    cutoff = utcnow_naive() - timedelta(minutes=LOCK_TTL_MINUTES)
     row = await db.scalar(
         select(OrgDataResetLock).where(
             OrgDataResetLock.org_id == org_id,

--- a/backend/app/services/org_reset_lock_service.py
+++ b/backend/app/services/org_reset_lock_service.py
@@ -1,0 +1,116 @@
+"""Per-org exclusive lease for in-flight org-data resets.
+
+The reset path commits per batch and runs an app-level idempotent
+seed (``seed_org_defaults``). Two concurrent reset POSTs that
+interleave on the same org could duplicate seeded defaults because
+``account_types`` and ``categories`` carry no DB-level UNIQUE on
+``(org_id, slug, is_system)``. This service provides a server-side
+lock keyed on the org PK to make the reset path strictly serial
+per org.
+
+Contract:
+- ``acquire_reset_lock`` returns True if the lease was taken, False
+  if another reset is in flight. Stale locks (older than
+  ``LOCK_TTL_MINUTES``) are auto-recovered so a crashed worker
+  cannot indefinitely block future resets.
+- ``release_reset_lock`` is idempotent — safe to call from a
+  ``finally`` even if acquire raised.
+- The endpoint commits each lock state change immediately. The
+  reset path's own per-batch commits don't affect lock state.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import delete, insert, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.org_data_reset_lock import OrgDataResetLock
+
+# How long a lock is considered fresh. After this window an in-flight
+# acquire can override the existing lock — recovery path for workers
+# that crashed mid-reset and never released. 30 minutes is far longer
+# than the worst-case real reset duration but short enough that an
+# operator doesn't have to manually clear stuck rows.
+LOCK_TTL_MINUTES = 30
+
+
+async def acquire_reset_lock(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    user_id: int,
+) -> bool:
+    """Try to acquire the exclusive reset lease for ``org_id``.
+
+    Returns True if acquired (caller must call
+    ``release_reset_lock`` in finally). Returns False if another
+    reset is already in flight.
+
+    Stale-lock recovery: if a row exists but its ``acquired_at`` is
+    older than ``LOCK_TTL_MINUTES``, the lock is forcibly taken over
+    by the new caller. This keeps a crashed worker from blocking
+    future resets indefinitely.
+    """
+    now = datetime.utcnow()
+    cutoff = now - timedelta(minutes=LOCK_TTL_MINUTES)
+
+    # Fast path: try INSERT. If no row exists for this org, this
+    # succeeds atomically against the PK constraint.
+    try:
+        await db.execute(
+            insert(OrgDataResetLock).values(
+                org_id=org_id,
+                acquired_by_user_id=user_id,
+                acquired_at=now,
+            )
+        )
+        await db.commit()
+        return True
+    except IntegrityError:
+        await db.rollback()
+
+    # Slow path: a row already exists. Take it over only if stale.
+    # Use a conditional UPDATE so the takeover is atomic — if a
+    # racing caller refreshes the row between our SELECT and UPDATE,
+    # rowcount=0 and we report contention.
+    result = await db.execute(
+        update(OrgDataResetLock)
+        .where(
+            OrgDataResetLock.org_id == org_id,
+            OrgDataResetLock.acquired_at < cutoff,
+        )
+        .values(acquired_by_user_id=user_id, acquired_at=now)
+    )
+    if (result.rowcount or 0) > 0:
+        await db.commit()
+        return True
+
+    await db.rollback()
+    return False
+
+
+async def release_reset_lock(db: AsyncSession, *, org_id: int) -> None:
+    """Release the lock. Idempotent — calling on a non-existent row
+    is a no-op. Safe to call from a finally block whether acquire
+    succeeded or raised.
+    """
+    await db.execute(
+        delete(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
+    )
+    await db.commit()
+
+
+async def is_reset_locked(db: AsyncSession, *, org_id: int) -> bool:
+    """Diagnostic helper for tests + admin debugging. Returns True if
+    a fresh (non-stale) lock exists for ``org_id``.
+    """
+    cutoff = datetime.utcnow() - timedelta(minutes=LOCK_TTL_MINUTES)
+    row = await db.scalar(
+        select(OrgDataResetLock).where(
+            OrgDataResetLock.org_id == org_id,
+            OrgDataResetLock.acquired_at >= cutoff,
+        )
+    )
+    return row is not None

--- a/backend/app/services/org_reset_lock_service.py
+++ b/backend/app/services/org_reset_lock_service.py
@@ -8,18 +8,28 @@ interleave on the same org could duplicate seeded defaults because
 lock keyed on the org PK to make the reset path strictly serial
 per org.
 
+**Lease tokens (PR #135 follow-up):** the release path fences on
+``WHERE org_id = :id AND lease_token = :token``. Without this fence,
+a long-stalled reset whose lock was already stale-taken-over by a
+new caller would, on resuming, ``DELETE WHERE org_id = :id`` and
+release the *successor's* fresh lease — reopening the concurrent
+window the lock is meant to close. Each acquire (fresh INSERT or
+stale-takeover UPDATE) generates a new UUID; release is a no-op
+unless the caller's token matches the row's current token.
+
 Contract:
-- ``acquire_reset_lock`` returns True if the lease was taken, False
-  if another reset is in flight. Stale locks (older than
-  ``LOCK_TTL_MINUTES``) are auto-recovered so a crashed worker
-  cannot indefinitely block future resets.
-- ``release_reset_lock`` is idempotent — safe to call from a
-  ``finally`` even if acquire raised.
-- The endpoint commits each lock state change immediately. The
-  reset path's own per-batch commits don't affect lock state.
+- ``acquire_reset_lock`` returns the lease token (UUID4 string) on
+  success, or ``None`` if another reset is in flight. Stale locks
+  (older than ``LOCK_TTL_MINUTES``) are auto-recovered so a crashed
+  worker cannot indefinitely block future resets.
+- ``release_reset_lock(org_id, token)`` is idempotent and fenced —
+  it deletes only when the row's ``lease_token`` matches the caller's
+  ``token``. Safe to call from a ``finally`` even if acquire raised.
+- The endpoint commits each lock state change immediately.
 """
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timedelta
 
 from sqlalchemy import delete, insert, select, update
@@ -41,20 +51,24 @@ async def acquire_reset_lock(
     *,
     org_id: int,
     user_id: int,
-) -> bool:
+) -> str | None:
     """Try to acquire the exclusive reset lease for ``org_id``.
 
-    Returns True if acquired (caller must call
-    ``release_reset_lock`` in finally). Returns False if another
-    reset is already in flight.
+    Returns a freshly-generated UUID4 lease token on success. Caller
+    MUST pass that token to ``release_reset_lock`` in finally — the
+    fenced release uses it to avoid deleting a successor's lock if
+    this caller stalled past the TTL.
+
+    Returns ``None`` if another (fresh) reset is already in flight.
 
     Stale-lock recovery: if a row exists but its ``acquired_at`` is
     older than ``LOCK_TTL_MINUTES``, the lock is forcibly taken over
-    by the new caller. This keeps a crashed worker from blocking
-    future resets indefinitely.
+    by the new caller (with a new lease token). This keeps a crashed
+    worker from blocking future resets indefinitely.
     """
     now = datetime.utcnow()
     cutoff = now - timedelta(minutes=LOCK_TTL_MINUTES)
+    new_token = uuid.uuid4().hex  # 32-char hex; fits in String(36).
 
     # Fast path: try INSERT. If no row exists for this org, this
     # succeeds atomically against the PK constraint.
@@ -64,40 +78,55 @@ async def acquire_reset_lock(
                 org_id=org_id,
                 acquired_by_user_id=user_id,
                 acquired_at=now,
+                lease_token=new_token,
             )
         )
         await db.commit()
-        return True
+        return new_token
     except IntegrityError:
         await db.rollback()
 
     # Slow path: a row already exists. Take it over only if stale.
-    # Use a conditional UPDATE so the takeover is atomic — if a
-    # racing caller refreshes the row between our SELECT and UPDATE,
-    # rowcount=0 and we report contention.
+    # The conditional WHERE makes the takeover atomic — if a racing
+    # caller refreshes the row between our SELECT and UPDATE, rowcount=0
+    # and we report contention. The new lease_token replaces the old.
     result = await db.execute(
         update(OrgDataResetLock)
         .where(
             OrgDataResetLock.org_id == org_id,
             OrgDataResetLock.acquired_at < cutoff,
         )
-        .values(acquired_by_user_id=user_id, acquired_at=now)
+        .values(
+            acquired_by_user_id=user_id,
+            acquired_at=now,
+            lease_token=new_token,
+        )
     )
     if (result.rowcount or 0) > 0:
         await db.commit()
-        return True
+        return new_token
 
     await db.rollback()
-    return False
+    return None
 
 
-async def release_reset_lock(db: AsyncSession, *, org_id: int) -> None:
-    """Release the lock. Idempotent — calling on a non-existent row
-    is a no-op. Safe to call from a finally block whether acquire
-    succeeded or raised.
+async def release_reset_lock(
+    db: AsyncSession, *, org_id: int, token: str
+) -> None:
+    """Fenced release. Deletes the row ONLY if the stored
+    ``lease_token`` matches ``token``. Calling with a stale token
+    (i.e., the row was taken over by a successor) is a no-op — the
+    successor's lock survives.
+
+    Idempotent on success and safe to call from a finally block
+    whether acquire succeeded or raised. Always commits, so the
+    caller's session is in a clean state regardless of rowcount.
     """
     await db.execute(
-        delete(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
+        delete(OrgDataResetLock).where(
+            OrgDataResetLock.org_id == org_id,
+            OrgDataResetLock.lease_token == token,
+        )
     )
     await db.commit()
 

--- a/backend/app/services/org_reset_lock_service.py
+++ b/backend/app/services/org_reset_lock_service.py
@@ -30,13 +30,28 @@ Contract:
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete, insert, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.org_data_reset_lock import OrgDataResetLock
+
+
+def _utcnow_naive() -> datetime:
+    """Return a naive-UTC datetime suitable for the existing
+    ``org_data_reset_locks.acquired_at`` column (declared as the
+    repo's standard naive ``DateTime``).
+
+    Equivalent to the Python <3.12 ``_utcnow_naive()`` semantics
+    but built from the timezone-aware ``datetime.now(timezone.utc)``
+    so it doesn't trigger the 3.12 deprecation warning. Stripping
+    tzinfo at the boundary keeps this drop-in compatible with the
+    naive-UTC column type — no migration churn for this PR. A
+    repo-wide tz sweep is tracked in TECHNICAL DEBT.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 # How long a lock is considered fresh. After this window an in-flight
 # acquire can override the existing lock — recovery path for workers
@@ -66,7 +81,7 @@ async def acquire_reset_lock(
     by the new caller (with a new lease token). This keeps a crashed
     worker from blocking future resets indefinitely.
     """
-    now = datetime.utcnow()
+    now = _utcnow_naive()
     cutoff = now - timedelta(minutes=LOCK_TTL_MINUTES)
     new_token = uuid.uuid4().hex  # 32-char hex; fits in String(36).
 
@@ -135,7 +150,7 @@ async def is_reset_locked(db: AsyncSession, *, org_id: int) -> bool:
     """Diagnostic helper for tests + admin debugging. Returns True if
     a fresh (non-stale) lock exists for ``org_id``.
     """
-    cutoff = datetime.utcnow() - timedelta(minutes=LOCK_TTL_MINUTES)
+    cutoff = _utcnow_naive() - timedelta(minutes=LOCK_TTL_MINUTES)
     row = await db.scalar(
         select(OrgDataResetLock).where(
             OrgDataResetLock.org_id == org_id,

--- a/backend/tests/routers/test_org_data.py
+++ b/backend/tests/routers/test_org_data.py
@@ -309,3 +309,83 @@ async def test_reset_failure_logs_failed_event(monkeypatch, session_factory, cap
     assert payload["org_id"] == seed["org_id"]
     assert payload["error_type"] == "RuntimeError"
     assert "simulated DB failure" in payload["error"]
+
+
+# ── Concurrent-reset guard (residual-risk follow-up to PR #134) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_returns_409_if_lock_already_held(session_factory):
+    """Second reset POST while a first one is in flight returns 409
+    with a structured error so the frontend can surface a clear
+    'another reset is running' message.
+    """
+    from app.services import org_reset_lock_service
+    seed = await _seed(session_factory)
+
+    # Plant a fresh lock manually to simulate an in-flight reset.
+    async with session_factory() as db:
+        acquired = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=seed["org_id"], user_id=seed["owner_id"],
+        )
+    assert acquired is True
+
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 409
+    body = res.json()
+    assert body["detail"]["code"] == "reset_already_running"
+    assert "another reset" in body["detail"]["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reset_releases_lock_on_success(session_factory):
+    """A successful reset must release the lock so the user can run
+    another reset later (the canonical workflow).
+    """
+    from app.services import org_reset_lock_service
+    seed = await _seed(session_factory)
+
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        assert await org_reset_lock_service.is_reset_locked(
+            db, org_id=seed["org_id"]
+        ) is False
+
+
+@pytest.mark.asyncio
+async def test_reset_releases_lock_on_failure(monkeypatch, session_factory):
+    """On a 500 from the reset path, the lock must still be released
+    so the user isn't stuck with a forever-busy org.
+    """
+    from app.services import org_data_service, org_reset_lock_service
+    seed = await _seed(session_factory)
+
+    async def boom(db, *, org_id, batch_size=500):
+        raise RuntimeError("simulated DB failure")
+
+    monkeypatch.setattr(org_data_service, "reset_org_data", boom)
+
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/data/reset",
+            json={"confirm_phrase": f"RESET {ORG_NAME}"},
+        )
+    assert res.status_code == 500
+
+    async with session_factory() as db:
+        assert await org_reset_lock_service.is_reset_locked(
+            db, org_id=seed["org_id"]
+        ) is False

--- a/backend/tests/routers/test_org_data.py
+++ b/backend/tests/routers/test_org_data.py
@@ -328,7 +328,7 @@ async def test_reset_returns_409_if_lock_already_held(session_factory):
         acquired = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=seed["org_id"], user_id=seed["owner_id"],
         )
-    assert acquired is True
+    assert acquired is not None  # acquire returns the lease token now
 
     app = make_app(session_factory, _resolver_for(Role.OWNER))
     with TestClient(app) as client:

--- a/backend/tests/services/test_admin_orgs_service.py
+++ b/backend/tests/services/test_admin_orgs_service.py
@@ -9,6 +9,7 @@ MySQL.
 from __future__ import annotations
 
 import datetime
+from app._time import utcnow_naive
 from decimal import Decimal
 
 import pytest
@@ -189,7 +190,7 @@ async def _seed_full_org(factory, *, name: str = "Acme") -> dict:
             org_id=org.id, email=f"invitee_{name}@acme.io",
             role=Role.MEMBER, open_email=f"invitee_{name}@acme.io",
             created_by=owner.id,
-            expires_at=datetime.datetime.utcnow() + datetime.timedelta(days=7),
+            expires_at=utcnow_naive() + datetime.timedelta(days=7),
         )
         # Smart-rules row — category_rules.category_id FKs to categories.id,
         # so the cascade must wipe these before the bulk DELETE on categories.

--- a/backend/tests/services/test_feature_service.py
+++ b/backend/tests/services/test_feature_service.py
@@ -6,6 +6,7 @@ value=False correctly denies an otherwise plan-granted feature.
 """
 from __future__ import annotations
 
+from app._time import utcnow_naive
 from datetime import datetime, timedelta
 
 import pytest
@@ -211,7 +212,7 @@ async def test_expired_override_ignored(session_factory):
             org_id=org.id,
             feature_key="ai.budget",
             value=False,
-            expires_at=datetime.utcnow() - timedelta(days=1),
+            expires_at=utcnow_naive() - timedelta(days=1),
         ))
         await db.commit()
 

--- a/backend/tests/services/test_invitation_service.py
+++ b/backend/tests/services/test_invitation_service.py
@@ -4,6 +4,7 @@ flows independent of the HTTP router."""
 from __future__ import annotations
 
 import datetime
+from app._time import utcnow_naive
 
 import pytest
 import pytest_asyncio
@@ -111,7 +112,7 @@ async def test_create_invitation_happy_path(session_factory):
         assert inv.revoked_at is None
         assert inv.open_email == "newmember@acme.io"
         # 7-day default expiry
-        delta = inv.expires_at - datetime.datetime.utcnow()
+        delta = inv.expires_at - utcnow_naive()
         assert datetime.timedelta(days=6, hours=23) < delta < datetime.timedelta(days=7, hours=1)
 
 
@@ -238,9 +239,9 @@ async def test_list_pending_invitations_excludes_accepted_and_revoked(session_fa
         )
         # Manually flip b → revoked, c → accepted.
         b.open_email = None
-        b.revoked_at = datetime.datetime.utcnow()
+        b.revoked_at = utcnow_naive()
         c.open_email = None
-        c.accepted_at = datetime.datetime.utcnow()
+        c.accepted_at = utcnow_naive()
         await db.commit()
     async with session_factory() as db:
         pending = await invitation_service.list_pending_invitations(db, org_id=org_id)
@@ -301,7 +302,7 @@ async def test_create_invitation_clears_expired_open_invite_blocking_reuse(sessi
             email="late@acme.io", role=Role.MEMBER,
         )
         # Time-warp the first row past its expires_at
-        first.expires_at = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        first.expires_at = utcnow_naive() - datetime.timedelta(days=1)
         await db.commit()
     async with session_factory() as db:
         # Second invite to the same email should succeed because the lazy

--- a/backend/tests/services/test_org_data_service.py
+++ b/backend/tests/services/test_org_data_service.py
@@ -6,6 +6,7 @@ PRAGMA foreign_keys=ON so SQLite enforces FKs the way MySQL would.
 from __future__ import annotations
 
 import datetime
+from app._time import utcnow_naive
 from decimal import Decimal
 
 import pytest
@@ -174,7 +175,7 @@ async def _seed_full_org(factory, *, name: str = "Acme") -> dict:
             org_id=org.id, email=f"invitee_{name}@acme.io",
             role=Role.MEMBER, open_email=f"invitee_{name}@acme.io",
             created_by=owner.id,
-            expires_at=datetime.datetime.utcnow() + datetime.timedelta(days=7),
+            expires_at=utcnow_naive() + datetime.timedelta(days=7),
         )
         rule = CategoryRule(
             org_id=org.id,

--- a/backend/tests/services/test_org_reset_lock_service.py
+++ b/backend/tests/services/test_org_reset_lock_service.py
@@ -1,0 +1,185 @@
+"""Tests for the per-org reset lock service.
+
+Closes the residual risk logged on PR #134: two concurrent reset
+POSTs could otherwise interleave through the per-batch commits and
+the app-level idempotent seed and duplicate the post-wipe defaults.
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.org_data_reset_lock import OrgDataResetLock
+from app.models.user import Organization, User
+from app.services import org_reset_lock_service
+
+
+@event.listens_for(Engine, "connect")
+def _enable_sqlite_fk(conn, _record):  # noqa: D401
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+async def _seed_org_and_user(factory) -> tuple[int, int]:
+    async with factory() as db:
+        org = Organization(name="Acme")
+        db.add(org)
+        await db.flush()
+        user = User(
+            username="u",
+            email="u@x.io",
+            email_verified=True,
+            password_hash="x",
+            org_id=org.id,
+            role="owner",
+        )
+        db.add(user)
+        await db.commit()
+        return org.id, user.id
+
+
+@pytest.mark.asyncio
+async def test_acquire_succeeds_when_no_existing_lock(session_factory):
+    org_id, user_id = await _seed_org_and_user(session_factory)
+    async with session_factory() as db:
+        ok = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert ok is True
+    async with session_factory() as db:
+        row = await db.scalar(
+            select(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
+        )
+        assert row is not None
+        assert row.acquired_by_user_id == user_id
+
+
+@pytest.mark.asyncio
+async def test_acquire_fails_when_fresh_lock_already_held(session_factory):
+    org_id, user_id = await _seed_org_and_user(session_factory)
+    async with session_factory() as db:
+        first = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert first is True
+    async with session_factory() as db:
+        second = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert second is False
+
+
+@pytest.mark.asyncio
+async def test_acquire_overrides_stale_lock(session_factory):
+    """A lock older than LOCK_TTL_MINUTES is overridable so a crashed
+    worker doesn't block future resets indefinitely.
+    """
+    org_id, user_id = await _seed_org_and_user(session_factory)
+    stale_ts = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    async with session_factory() as db:
+        db.add(OrgDataResetLock(
+            org_id=org_id,
+            acquired_by_user_id=user_id,
+            acquired_at=stale_ts,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        ok = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert ok is True
+
+    async with session_factory() as db:
+        row = await db.scalar(
+            select(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
+        )
+        assert row.acquired_at > stale_ts
+
+
+@pytest.mark.asyncio
+async def test_release_is_idempotent(session_factory):
+    org_id, _user_id = await _seed_org_and_user(session_factory)
+
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+
+    async with session_factory() as db:
+        await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=1,
+        )
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+
+    async with session_factory() as db:
+        row = await db.scalar(
+            select(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
+        )
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_acquire_release_acquire_cycle(session_factory):
+    """After a release, the next acquire succeeds again — the canonical
+    happy path of one reset finishing cleanly and another starting.
+    """
+    org_id, user_id = await _seed_org_and_user(session_factory)
+
+    async with session_factory() as db:
+        first = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert first is True
+
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+
+    async with session_factory() as db:
+        second = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert second is True
+
+
+@pytest.mark.asyncio
+async def test_is_reset_locked_reflects_state(session_factory):
+    org_id, user_id = await _seed_org_and_user(session_factory)
+
+    async with session_factory() as db:
+        assert await org_reset_lock_service.is_reset_locked(db, org_id=org_id) is False
+
+    async with session_factory() as db:
+        await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    async with session_factory() as db:
+        assert await org_reset_lock_service.is_reset_locked(db, org_id=org_id) is True
+
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+    async with session_factory() as db:
+        assert await org_reset_lock_service.is_reset_locked(db, org_id=org_id) is False

--- a/backend/tests/services/test_org_reset_lock_service.py
+++ b/backend/tests/services/test_org_reset_lock_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
+from app._time import utcnow_naive
 from app.models import Base
 from app.models.org_data_reset_lock import OrgDataResetLock
 from app.models.user import Organization, User
@@ -99,7 +100,7 @@ async def test_acquire_overrides_stale_lock_with_new_token(session_factory):
     acquire returns a *fresh* token, not the stale one.
     """
     org_id, user_id = await _seed_org_and_user(session_factory)
-    stale_ts = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(hours=1)
+    stale_ts = utcnow_naive() - datetime.timedelta(hours=1)
     stale_token = "stale_token_aaaaaaaaaaaaaaaaaaaaaaaa"
     async with session_factory() as db:
         db.add(OrgDataResetLock(
@@ -164,7 +165,7 @@ async def test_release_with_stale_token_does_not_delete_successor_lock(session_f
     assert token_a is not None
 
     # A stalls. Simulate by manually aging the row past LOCK_TTL_MINUTES.
-    stale_ts = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(hours=1)
+    stale_ts = utcnow_naive() - datetime.timedelta(hours=1)
     async with session_factory() as db:
         await db.execute(
             update(OrgDataResetLock)

--- a/backend/tests/services/test_org_reset_lock_service.py
+++ b/backend/tests/services/test_org_reset_lock_service.py
@@ -10,7 +10,7 @@ import datetime
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import event, select
+from sqlalchemy import event, select, update
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
@@ -61,79 +61,166 @@ async def _seed_org_and_user(factory) -> tuple[int, int]:
 
 
 @pytest.mark.asyncio
-async def test_acquire_succeeds_when_no_existing_lock(session_factory):
+async def test_acquire_returns_token_when_no_existing_lock(session_factory):
     org_id, user_id = await _seed_org_and_user(session_factory)
     async with session_factory() as db:
-        ok = await org_reset_lock_service.acquire_reset_lock(
+        token = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=org_id, user_id=user_id,
         )
-    assert ok is True
+    assert token is not None
+    assert isinstance(token, str) and len(token) >= 32
     async with session_factory() as db:
         row = await db.scalar(
             select(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
         )
         assert row is not None
         assert row.acquired_by_user_id == user_id
+        assert row.lease_token == token
 
 
 @pytest.mark.asyncio
-async def test_acquire_fails_when_fresh_lock_already_held(session_factory):
+async def test_acquire_returns_none_when_fresh_lock_already_held(session_factory):
     org_id, user_id = await _seed_org_and_user(session_factory)
     async with session_factory() as db:
         first = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=org_id, user_id=user_id,
         )
-    assert first is True
+    assert first is not None
     async with session_factory() as db:
         second = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=org_id, user_id=user_id,
         )
-    assert second is False
+    assert second is None
 
 
 @pytest.mark.asyncio
-async def test_acquire_overrides_stale_lock(session_factory):
-    """A lock older than LOCK_TTL_MINUTES is overridable so a crashed
-    worker doesn't block future resets indefinitely.
+async def test_acquire_overrides_stale_lock_with_new_token(session_factory):
+    """A lock older than LOCK_TTL_MINUTES is overridable; the new
+    acquire returns a *fresh* token, not the stale one.
     """
     org_id, user_id = await _seed_org_and_user(session_factory)
     stale_ts = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    stale_token = "stale_token_aaaaaaaaaaaaaaaaaaaaaaaa"
     async with session_factory() as db:
         db.add(OrgDataResetLock(
             org_id=org_id,
             acquired_by_user_id=user_id,
             acquired_at=stale_ts,
+            lease_token=stale_token,
         ))
         await db.commit()
 
     async with session_factory() as db:
-        ok = await org_reset_lock_service.acquire_reset_lock(
+        new_token = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=org_id, user_id=user_id,
         )
-    assert ok is True
+    assert new_token is not None
+    assert new_token != stale_token
 
     async with session_factory() as db:
         row = await db.scalar(
             select(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
         )
         assert row.acquired_at > stale_ts
+        assert row.lease_token == new_token
 
 
 @pytest.mark.asyncio
-async def test_release_is_idempotent(session_factory):
-    org_id, _user_id = await _seed_org_and_user(session_factory)
-
+async def test_release_with_correct_token_clears_the_lock(session_factory):
+    org_id, user_id = await _seed_org_and_user(session_factory)
     async with session_factory() as db:
-        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
-
-    async with session_factory() as db:
-        await org_reset_lock_service.acquire_reset_lock(
-            db, org_id=org_id, user_id=1,
+        token = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
         )
+    assert token is not None
+
     async with session_factory() as db:
-        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=token)
+
     async with session_factory() as db:
-        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+        row = await db.scalar(
+            select(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
+        )
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_release_with_stale_token_does_not_delete_successor_lock(session_factory):
+    """Critical regression: the original review finding.
+
+    Reset A acquires (token T_A), stalls past TTL, reset B takes the
+    lock over (token T_B), then A wakes up and calls release with
+    its own (now-stale) token. A must NOT delete B's fresh lock,
+    or reset C could start while B is still running and reopen the
+    interleave window the lock is meant to close.
+    """
+    org_id, user_id = await _seed_org_and_user(session_factory)
+
+    # A acquires.
+    async with session_factory() as db:
+        token_a = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert token_a is not None
+
+    # A stalls. Simulate by manually aging the row past LOCK_TTL_MINUTES.
+    stale_ts = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    async with session_factory() as db:
+        await db.execute(
+            update(OrgDataResetLock)
+            .where(OrgDataResetLock.org_id == org_id)
+            .values(acquired_at=stale_ts)
+        )
+        await db.commit()
+
+    # B takes the lock over via stale-takeover.
+    async with session_factory() as db:
+        token_b = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert token_b is not None
+    assert token_b != token_a
+
+    # A finally wakes and tries to release with its OLD token.
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(
+            db, org_id=org_id, token=token_a,
+        )
+
+    # B's lock must still be present.
+    async with session_factory() as db:
+        row = await db.scalar(
+            select(OrgDataResetLock).where(OrgDataResetLock.org_id == org_id)
+        )
+    assert row is not None, (
+        "stale-token release must not delete the successor's lock"
+    )
+    assert row.lease_token == token_b
+
+    # And `is_reset_locked` still reports busy — reset C cannot start.
+    async with session_factory() as db:
+        assert await org_reset_lock_service.is_reset_locked(
+            db, org_id=org_id
+        ) is True
+
+
+@pytest.mark.asyncio
+async def test_release_idempotent_on_correct_token(session_factory):
+    """Calling release twice with the correct token (or with no row
+    present) is a no-op the second time.
+    """
+    org_id, user_id = await _seed_org_and_user(session_factory)
+
+    async with session_factory() as db:
+        token = await org_reset_lock_service.acquire_reset_lock(
+            db, org_id=org_id, user_id=user_id,
+        )
+    assert token is not None
+
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=token)
+    async with session_factory() as db:
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=token)
 
     async with session_factory() as db:
         row = await db.scalar(
@@ -144,25 +231,24 @@ async def test_release_is_idempotent(session_factory):
 
 @pytest.mark.asyncio
 async def test_acquire_release_acquire_cycle(session_factory):
-    """After a release, the next acquire succeeds again — the canonical
-    happy path of one reset finishing cleanly and another starting.
-    """
+    """After a release, the next acquire succeeds again with a new token."""
     org_id, user_id = await _seed_org_and_user(session_factory)
 
     async with session_factory() as db:
         first = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=org_id, user_id=user_id,
         )
-    assert first is True
+    assert first is not None
 
     async with session_factory() as db:
-        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=first)
 
     async with session_factory() as db:
         second = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=org_id, user_id=user_id,
         )
-    assert second is True
+    assert second is not None
+    assert second != first
 
 
 @pytest.mark.asyncio
@@ -173,13 +259,13 @@ async def test_is_reset_locked_reflects_state(session_factory):
         assert await org_reset_lock_service.is_reset_locked(db, org_id=org_id) is False
 
     async with session_factory() as db:
-        await org_reset_lock_service.acquire_reset_lock(
+        token = await org_reset_lock_service.acquire_reset_lock(
             db, org_id=org_id, user_id=user_id,
         )
     async with session_factory() as db:
         assert await org_reset_lock_service.is_reset_locked(db, org_id=org_id) is True
 
     async with session_factory() as db:
-        await org_reset_lock_service.release_reset_lock(db, org_id=org_id)
+        await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=token)
     async with session_factory() as db:
         assert await org_reset_lock_service.is_reset_locked(db, org_id=org_id) is False

--- a/backend/tests/services/test_org_reset_lock_service.py
+++ b/backend/tests/services/test_org_reset_lock_service.py
@@ -99,7 +99,7 @@ async def test_acquire_overrides_stale_lock_with_new_token(session_factory):
     acquire returns a *fresh* token, not the stale one.
     """
     org_id, user_id = await _seed_org_and_user(session_factory)
-    stale_ts = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    stale_ts = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(hours=1)
     stale_token = "stale_token_aaaaaaaaaaaaaaaaaaaaaaaa"
     async with session_factory() as db:
         db.add(OrgDataResetLock(
@@ -164,7 +164,7 @@ async def test_release_with_stale_token_does_not_delete_successor_lock(session_f
     assert token_a is not None
 
     # A stalls. Simulate by manually aging the row past LOCK_TTL_MINUTES.
-    stale_ts = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    stale_ts = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) - datetime.timedelta(hours=1)
     async with session_factory() as db:
         await db.execute(
             update(OrgDataResetLock)

--- a/frontend/tests/app/settings-organization-danger-zone.test.tsx
+++ b/frontend/tests/app/settings-organization-danger-zone.test.tsx
@@ -227,4 +227,57 @@ describe("OrganizationSettingsPage — Danger Zone", () => {
     // Resolve the POST so the test cleans up.
     resolveReset({});
   });
+
+  it("surfaces the 409 'reset_already_running' error message and re-enables the button", async () => {
+    mockUser("owner");
+    // Mirror apiFetch's ApiResponseError shape — the wrapper translates
+    // the structured 409 detail into err.message.
+    class FakeApiResponseError extends Error {
+      status = 409;
+      code = "reset_already_running";
+      constructor(message: string) {
+        super(message);
+        this.name = "ApiResponseError";
+      }
+    }
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (url === "/api/v1/orgs/data/reset" && init?.method === "POST") {
+        return Promise.reject(
+          new FakeApiResponseError(
+            "Another reset is already running for this organization. Please wait a moment and try again.",
+          ),
+        );
+      }
+      if (url === "/api/v1/settings/billing-cycle")
+        return Promise.resolve({ billing_cycle_day: 1 });
+      if (url === "/api/v1/settings/billing-period")
+        return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      if (url === "/api/v1/settings") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/members") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
+      if (url === "/api/v1/category-rules") return Promise.resolve([]);
+      return Promise.resolve({});
+    }) as never);
+    render(<OrganizationSettingsPage />);
+    await waitFor(() => expect(screen.getByText(/Danger zone/i)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/confirm reset phrase/i), {
+      target: { value: `RESET ${ORG_NAME}` },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reset organization data permanently/i }));
+
+    // Error banner shows the structured message from the backend.
+    await waitFor(() =>
+      expect(screen.getByText(/Another reset is already running/)).toBeInTheDocument(),
+    );
+
+    // Button returns to its enabled-with-default-copy state so the
+    // user can retry once the other reset finishes.
+    const button = screen.getByRole("button", {
+      name: /reset organization data permanently/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    // Spinner copy is gone.
+    expect(screen.queryByText(/Resetting organization data/)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Closes the **residual risk logged on PR #134's review**: the new batched reset path commits per chunk and runs an app-level idempotent seed, but `account_types` and `categories` carry no DB-level UNIQUE on `(org_id, slug, is_system)`. Two concurrent reset POSTs on the same org could interleave through the per-batch commits and double-seed the defaults. Frontend disabling alone isn't enough; a replayed request, curl, or a determined client bypasses it.

## What landed

### Backend

| Slice | Change |
|---|---|
| **Migration 029** | New `org_data_reset_locks` table — `org_id` PK + FKs to organizations and users (both `ON DELETE CASCADE` so admin delete cleans the row up automatically). |
| **Lock service** | `services/org_reset_lock_service.py` exposes `acquire_reset_lock` / `release_reset_lock` / `is_reset_locked`. Acquire tries an `INSERT` first (atomic on PK collision); on duplicate, attempts a stale-takeover `UPDATE` bound by `LOCK_TTL_MINUTES = 30` with a `WHERE acquired_at < cutoff` predicate so the takeover is also atomic — a racing caller refreshing the row mid-attempt loses to `rowcount=0`. Release is idempotent. |
| **Endpoint** | `routers/org_data.py` acquires before any destructive work; on contention raises `409` with `{detail: {code: "reset_already_running", message: "..."}}` so the frontend's existing `ApiResponseError.message` path surfaces the user-facing copy. Lock released in both success and failure paths. |
| **Stale-lock auto-recovery** | After 30 minutes a worker that crashed mid-reset stops blocking new resets. Conservative — far longer than a real reset, short enough that operators don't have to manually clear stuck rows. |

### Frontend

No code changes — the existing `ApiResponseError.message` → `setResetError(extractErrorMessage(err))` path already surfaces the structured 409 message and re-enables the button. The new test asserts both behaviors.

## Verification

- `pytest` — **387/378 backend pass** (+9 new tests: 6 service, 3 endpoint).
- `npm test` — **144/144 frontend pass** (+1: 409 surfaces clearly + button re-enables).
- `npm run build` clean, `npm run lint` exits 0.

## Why a DB row, not in-process or advisory lock

- **In-process mutex** (asyncio.Lock per org): doesn't survive multi-replica or process restart. Single-replica today, but L0.6's HPA audit and P7.5 K8s migration sit on the launch path; a per-replica lock would silently break exactly when scale matters.
- **MySQL advisory lock** (`GET_LOCK`): connection-scoped on the same session; survives across requests. But: ties the lifetime to the session's connection, harder to introspect for ops, and Postgres advisory locks (which we'd want for portability) work differently. A row keyed on `org_id` is database-portable, ops-introspectable, and behavior-equivalent.
- A **single row with a TTL** beats both: durable across restarts and replicas, recoverable from worker crashes, and easy to debug (`SELECT * FROM org_data_reset_locks`).