### PR TITLE
feat(L3.6): inline Add category from CategorySelect

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -559,7 +559,7 @@ export default function DashboardPage() {
                 {formMode === "transaction" && (
                   <div>
                     <label htmlFor="da-category" className={label}>Category</label>
-                    <CategorySelect id="da-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+                    <CategorySelect id="da-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                   </div>
                 )}
                 {formMode === "transfer" && (
@@ -571,6 +571,7 @@ export default function DashboardPage() {
                       value={formTransferCatId}
                       onChange={setFormTransferCatId}
                       className={input}
+                      onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])}
                     />
                     <p className="mt-1 text-[10px] text-text-muted">Defaults to Transfer. Override to track in budgets.</p>
                   </div>

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -132,7 +132,7 @@ function ImportPageContent() {
 
   // ── Shared data ──────────────────────────────────────────────────────────
   const { data: accounts } = useSWR<Account[]>("accounts", () => apiFetch<Account[]>("/api/v1/accounts"));
-  const { data: categories } = useSWR<Category[]>("categories", () => apiFetch<Category[]>("/api/v1/categories"));
+  const { data: categories, mutate: mutateCategories } = useSWR<Category[]>("categories", () => apiFetch<Category[]>("/api/v1/categories"));
 
   const activeAccounts = useMemo(() => accounts?.filter((a) => a.is_active) ?? [], [accounts]);
   const defaultAccount = useMemo(() => activeAccounts.find((a) => a.is_default), [activeAccounts]);
@@ -603,6 +603,9 @@ function ImportPageContent() {
                                 }
                                 filterType={previewRow.type === "income" ? "income" : "expense"}
                                 className={input + " !w-48"}
+                                onCategoryCreated={() => {
+                                  void mutateCategories();
+                                }}
                               />
                               {previewRow.suggestion_source === "org_rule" && (
                                 <span

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -600,13 +600,13 @@ function TransactionsPageContent() {
             {formMode === "transaction" && (
               <div>
                 <label htmlFor="tx-category" className={label}>Category</label>
-                <CategorySelect id="tx-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} />
+                <CategorySelect id="tx-category" categories={categories} value={formCategoryId} onChange={setFormCategoryId} filterType={formType} className={input} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
               </div>
             )}
             {formMode === "transfer" && (
               <div>
                 <label className={label}>Category (optional)</label>
-                <CategorySelect id="tx-transfer-cat" categories={categories} value={formTransferCatId} onChange={setFormTransferCatId} className={input} />
+                <CategorySelect id="tx-transfer-cat" categories={categories} value={formTransferCatId} onChange={setFormTransferCatId} className={input} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                 <p className="mt-1 text-[10px] text-text-muted">Defaults to Transfer. Override to track in budgets.</p>
               </div>
             )}
@@ -819,7 +819,7 @@ function TransactionsPageContent() {
                               </select>
                             </span>
                             <span className="col-span-1 min-w-0">
-                              <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} />
+                              <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                             </span>
                             <span className="col-span-1">
                               <select aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-[11px] ${input}`}>
@@ -957,7 +957,7 @@ function TransactionsPageContent() {
                               </div>
                               <div>
                                 <label className={label}>Category</label>
-                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} />
+                                <CategorySelect aria-label="Category" id={`edit-cat-mobile-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                               </div>
                               <div>
                                 <label className={label}>Status</label>

--- a/frontend/components/ui/AddCategoryModal.tsx
+++ b/frontend/components/ui/AddCategoryModal.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  error as errorCls,
+  input,
+  label as labelCls,
+} from "@/lib/styles";
+import type { Category } from "@/lib/types";
+
+interface Props {
+  initialName: string;
+  initialType: "income" | "expense" | "both";
+  masterCategories: Category[];
+  onCreated: (cat: Category) => void;
+  onCancel: () => void;
+}
+
+export default function AddCategoryModal({
+  initialName,
+  initialType,
+  masterCategories,
+  onCreated,
+  onCancel,
+}: Props) {
+  const [name, setName] = useState(initialName);
+  const [type, setType] = useState<"income" | "expense" | "both">(initialType);
+  const [isSub, setIsSub] = useState(false);
+  const [parentId, setParentId] = useState<number | "">("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Focus + restore
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    nameRef.current?.focus();
+    nameRef.current?.select();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  // Escape + focus trap
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !submitting) {
+        e.stopPropagation();
+        onCancel();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const visible = Array.from(focusable).filter(
+          (el) => !el.hasAttribute("disabled") && el.offsetParent !== null
+        );
+        if (visible.length === 0) return;
+        const first = visible[0];
+        const last = visible[visible.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [submitting, onCancel]);
+
+  const trimmedName = name.trim();
+  const canSubmit = trimmedName.length > 0 && trimmedName.length <= 100 && !submitting;
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setErrorText(null);
+    try {
+      const body: Record<string, unknown> = {
+        name: trimmedName,
+        type,
+      };
+      if (isSub && parentId !== "") {
+        body.parent_id = parentId;
+      }
+      const trimmedDescription = description.trim();
+      if (trimmedDescription) {
+        body.description = trimmedDescription;
+      }
+      const created = await apiFetch<Category>("/api/v1/categories", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      onCreated(created);
+    } catch (err) {
+      setErrorText(extractErrorMessage(err, "Failed to create category"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!mounted) return null;
+
+  const modal = (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-category-title"
+        className={`${card} w-full max-w-md p-6 shadow-xl`}
+      >
+        <h2
+          id="add-category-title"
+          className="mb-4 text-lg font-semibold text-text-primary"
+        >
+          New category
+        </h2>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+          className="space-y-4"
+        >
+          <div>
+            <label htmlFor="add-cat-name" className={labelCls}>
+              Name
+            </label>
+            <input
+              ref={nameRef}
+              id="add-cat-name"
+              type="text"
+              required
+              maxLength={100}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={input}
+              autoComplete="off"
+            />
+          </div>
+
+          <fieldset>
+            <legend className={labelCls}>Type</legend>
+            <div className="flex gap-4 text-sm text-text-primary">
+              {(["expense", "income", "both"] as const).map((t) => (
+                <label key={t} className="flex items-center gap-1.5">
+                  <input
+                    type="radio"
+                    name="add-cat-type"
+                    value={t}
+                    checked={type === t}
+                    onChange={() => setType(t)}
+                  />
+                  <span className="capitalize">{t}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="flex items-center gap-2 text-sm text-text-primary">
+            <input
+              id="add-cat-issub"
+              type="checkbox"
+              checked={isSub}
+              onChange={(e) => {
+                setIsSub(e.target.checked);
+                if (!e.target.checked) setParentId("");
+              }}
+            />
+            <label htmlFor="add-cat-issub">Subcategory</label>
+          </div>
+
+          {isSub && (
+            <div>
+              <label htmlFor="add-cat-parent" className={labelCls}>
+                Parent category
+              </label>
+              <select
+                id="add-cat-parent"
+                value={parentId === "" ? "" : String(parentId)}
+                onChange={(e) =>
+                  setParentId(
+                    e.target.value === "" ? "" : Number(e.target.value)
+                  )
+                }
+                className={input}
+              >
+                <option value="">Select a parent...</option>
+                {masterCategories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="add-cat-desc" className={labelCls}>
+              Description (optional)
+            </label>
+            <input
+              id="add-cat-desc"
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className={input}
+              autoComplete="off"
+            />
+          </div>
+
+          {errorText && (
+            <div role="alert" className={errorCls}>
+              {errorText}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={submitting}
+              className={btnSecondary}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className={btnPrimary}
+            >
+              {submitting ? "Adding..." : "Add category"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/frontend/components/ui/AddCategoryModal.tsx
+++ b/frontend/components/ui/AddCategoryModal.tsx
@@ -89,7 +89,12 @@ export default function AddCategoryModal({
   }, [submitting, onCancel]);
 
   const trimmedName = name.trim();
-  const canSubmit = trimmedName.length > 0 && trimmedName.length <= 100 && !submitting;
+  const needsParent = isSub && parentId === "";
+  const canSubmit =
+    trimmedName.length > 0 &&
+    trimmedName.length <= 100 &&
+    !submitting &&
+    !needsParent;
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -206,6 +211,10 @@ export default function AddCategoryModal({
                   )
                 }
                 className={input}
+                aria-describedby={
+                  needsParent ? "add-cat-parent-help" : undefined
+                }
+                aria-invalid={needsParent || undefined}
               >
                 <option value="">Select a parent...</option>
                 {masterCategories.map((c) => (
@@ -214,6 +223,14 @@ export default function AddCategoryModal({
                   </option>
                 ))}
               </select>
+              {needsParent && (
+                <p
+                  id="add-cat-parent-help"
+                  className="mt-1 text-xs text-text-muted"
+                >
+                  Pick a parent category
+                </p>
+              )}
             </div>
           )}
 

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -123,8 +123,13 @@ export default function CategorySelect({ id, categories, value, onChange, filter
     items[highlightIdx]?.scrollIntoView({ block: "nearest" });
   }, [highlightIdx]);
 
-  // Group non-recent by master for display
-  const masters = categories.filter((c) => c.parent_id === null);
+  // Group non-recent by master for display.
+  // Memoized so the `grouped` useMemo below sees a stable `masters`
+  // reference and only recomputes when the categories list itself changes.
+  const masters = useMemo(
+    () => categories.filter((c) => c.parent_id === null),
+    [categories]
+  );
   const grouped = useMemo(() => {
     const groups: { label: string; items: Category[] }[] = [];
     for (const master of masters) {

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
+import AddCategoryModal from "@/components/ui/AddCategoryModal";
 import type { Category } from "@/lib/types";
 
 const RECENT_KEY = "pfv2-recent-categories";
@@ -29,17 +30,20 @@ interface Props {
   typeFilter?: "INCOME" | "EXPENSE";
   className?: string;
   "aria-label"?: string;
+  onCategoryCreated?: (cat: Category) => void;
 }
 
-export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel }: Props) {
+export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel, onCategoryCreated }: Props) {
   // Normalize uppercase `typeFilter` (transfers callers) to internal lowercase
   // so it joins the existing filterType machinery without divergent code paths.
   const effectiveFilterType = filterType ?? (typeFilter === "INCOME" ? "income" : typeFilter === "EXPENSE" ? "expense" : undefined);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [highlightIdx, setHighlightIdx] = useState(-1);
+  const [showAddModal, setShowAddModal] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const selected = categories.find((c) => c.id === value);
 
@@ -77,13 +81,13 @@ export default function CategorySelect({ id, categories, value, onChange, filter
   const flatList: Category[] = [...recentItems, ...nonRecent];
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || showAddModal) return;
     function handleClick(e: MouseEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     }
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
+  }, [open, showAddModal]);
 
   useEffect(() => { setHighlightIdx(-1); }, [query, open]);
 
@@ -140,6 +144,7 @@ export default function CategorySelect({ id, categories, value, onChange, filter
   return (
     <div ref={ref} className="relative">
       <input
+        ref={inputRef}
         id={id}
         type="text"
         autoComplete="off"
@@ -199,7 +204,40 @@ export default function CategorySelect({ id, categories, value, onChange, filter
           {filtered.length === 0 && (
             <div className="px-3 py-4 text-center text-sm text-text-muted">No categories match</div>
           )}
+
+          <div className="sticky bottom-0 border-t border-border-subtle bg-surface">
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                // Prevent the input's blur/outside-click handler from firing
+                // before the click registers; keeps the dropdown open while
+                // the modal mounts.
+                e.preventDefault();
+              }}
+              onClick={() => setShowAddModal(true)}
+              className="flex w-full items-center px-3 py-2 text-left text-sm font-medium text-accent transition-colors hover:bg-accent-dim"
+            >
+              + Add category
+            </button>
+          </div>
         </div>
+      )}
+
+      {showAddModal && (
+        <AddCategoryModal
+          initialName={query}
+          initialType={effectiveFilterType ?? "both"}
+          masterCategories={masters}
+          onCreated={(cat) => {
+            setShowAddModal(false);
+            onCategoryCreated?.(cat);
+            handleSelect(cat);
+          }}
+          onCancel={() => {
+            setShowAddModal(false);
+            inputRef.current?.focus();
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/tests/components/add-category-modal.test.tsx
+++ b/frontend/tests/components/add-category-modal.test.tsx
@@ -1,0 +1,247 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AddCategoryModal from "@/components/ui/AddCategoryModal";
+import { apiFetch } from "@/lib/api";
+import type { Category } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const masterCategories: Category[] = [
+  {
+    id: 1,
+    name: "Housing",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "housing",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 2,
+    name: "Food",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "food",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+describe("AddCategoryModal", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("renders with the name field pre-filled from initialName", () => {
+    render(
+      <AddCategoryModal
+        initialName="Rent"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const nameInput = screen.getByLabelText(/Name/i) as HTMLInputElement;
+    expect(nameInput.value).toBe("Rent");
+  });
+
+  it("disables Add category when name is empty", () => {
+    render(
+      <AddCategoryModal
+        initialName=""
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /Add category/i })
+    ).toBeDisabled();
+  });
+
+  it("disables Add category while submitting", async () => {
+    let resolveFetch: (value: Category) => void = () => {};
+    apiFetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Category>((resolve) => {
+          resolveFetch = resolve;
+        }) as never
+    );
+
+    render(
+      <AddCategoryModal
+        initialName="Coffee"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const submit = screen.getByRole("button", { name: /Add category/i });
+    fireEvent.click(submit);
+    await waitFor(() => expect(submit).toBeDisabled());
+    expect(submit).toHaveTextContent(/Adding/i);
+
+    // Resolve to clean up.
+    resolveFetch({
+      id: 99,
+      name: "Coffee",
+      type: "expense",
+      parent_id: null,
+      parent_name: null,
+      description: null,
+      slug: "coffee",
+      is_system: false,
+      transaction_count: 0,
+    });
+    await waitFor(() => expect(apiFetchMock).toHaveBeenCalled());
+  });
+
+  it("submits POST with master category body (no parent_id)", async () => {
+    const created: Category = {
+      id: 50,
+      name: "Rent",
+      type: "expense",
+      parent_id: null,
+      parent_name: null,
+      description: null,
+      slug: "rent",
+      is_system: false,
+      transaction_count: 0,
+    };
+    apiFetchMock.mockResolvedValueOnce(created as never);
+    const onCreated = vi.fn();
+
+    render(
+      <AddCategoryModal
+        initialName="Rent"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={onCreated}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(created));
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/v1/categories",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Rent", type: "expense" }),
+      })
+    );
+  });
+
+  it("submits POST with parent_id when subcategory and parent are selected", async () => {
+    const created: Category = {
+      id: 60,
+      name: "Mortgage",
+      type: "expense",
+      parent_id: 1,
+      parent_name: "Housing",
+      description: null,
+      slug: "mortgage",
+      is_system: false,
+      transaction_count: 0,
+    };
+    apiFetchMock.mockResolvedValueOnce(created as never);
+    const onCreated = vi.fn();
+
+    render(
+      <AddCategoryModal
+        initialName="Mortgage"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={onCreated}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText(/Subcategory/i));
+    const parentSelect = screen.getByLabelText(
+      /Parent category/i
+    ) as HTMLSelectElement;
+    fireEvent.change(parentSelect, { target: { value: "1" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(created));
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/v1/categories",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "Mortgage",
+          type: "expense",
+          parent_id: 1,
+        }),
+      })
+    );
+  });
+
+  it("shows API error message via extractErrorMessage", async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error("Category already exists"));
+
+    render(
+      <AddCategoryModal
+        initialName="Rent"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Category already exists/i
+      )
+    );
+  });
+
+  it("Cancel calls onCancel without submitting", () => {
+    const onCancel = vi.fn();
+    render(
+      <AddCategoryModal
+        initialName="Rent"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("Escape key calls onCancel", () => {
+    const onCancel = vi.fn();
+    render(
+      <AddCategoryModal
+        initialName="Rent"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/add-category-modal.test.tsx
+++ b/frontend/tests/components/add-category-modal.test.tsx
@@ -230,6 +230,37 @@ describe("AddCategoryModal", () => {
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
+  it("disables Add category and shows hint when subcategory is checked but no parent picked", () => {
+    render(
+      <AddCategoryModal
+        initialName="Mortgage"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // With a name filled in but no subcategory toggle, submit is enabled.
+    const submit = screen.getByRole("button", { name: /Add category/i });
+    expect(submit).not.toBeDisabled();
+
+    // Toggling Subcategory (without picking a parent) must disable submit
+    // and surface the inline hint.
+    fireEvent.click(screen.getByLabelText(/Subcategory/i));
+    expect(submit).toBeDisabled();
+    expect(screen.getByText(/Pick a parent category/i)).toBeInTheDocument();
+
+    // Selecting a parent re-enables submit and removes the hint.
+    fireEvent.change(screen.getByLabelText(/Parent category/i), {
+      target: { value: "1" },
+    });
+    expect(submit).not.toBeDisabled();
+    expect(
+      screen.queryByText(/Pick a parent category/i)
+    ).not.toBeInTheDocument();
+  });
+
   it("Escape key calls onCancel", () => {
     const onCancel = vi.fn();
     render(

--- a/frontend/tests/components/ui/category-select-add.test.tsx
+++ b/frontend/tests/components/ui/category-select-add.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import CategorySelect from "@/components/ui/CategorySelect";
+import type { Category } from "@/lib/types";
+
+vi.mock("@/components/ui/AddCategoryModal", () => ({
+  default: (props: {
+    initialName: string;
+    initialType: "income" | "expense" | "both";
+    masterCategories: Category[];
+    onCreated: (cat: Category) => void;
+    onCancel: () => void;
+  }) => {
+    return (
+      <div data-testid="add-category-modal-stub">
+        <span data-testid="modal-initial-name">{props.initialName}</span>
+        <span data-testid="modal-initial-type">{props.initialType}</span>
+        <button
+          type="button"
+          onClick={() =>
+            props.onCreated({
+              id: 999,
+              name: "NewCat",
+              type: "expense",
+              parent_id: null,
+              parent_name: null,
+              description: null,
+              slug: "newcat",
+              is_system: false,
+              transaction_count: 0,
+            })
+          }
+        >
+          stub-created
+        </button>
+        <button type="button" onClick={() => props.onCancel()}>
+          stub-cancel
+        </button>
+      </div>
+    );
+  },
+}));
+
+const categories: Category[] = [
+  {
+    id: 1,
+    name: "Housing",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "housing",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 2,
+    name: "Groceries",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "groceries",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+function openDropdown() {
+  const input = screen.getByRole("combobox");
+  fireEvent.focus(input);
+  return input;
+}
+
+describe("CategorySelect Add category affordance", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders + Add category at the bottom of the open dropdown", () => {
+    render(
+      <CategorySelect
+        id="t1"
+        categories={categories}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+    openDropdown();
+    expect(
+      screen.getByRole("button", { name: /Add category/i })
+    ).toBeInTheDocument();
+  });
+
+  it("pre-fills modal name with current query text", () => {
+    render(
+      <CategorySelect
+        id="t2"
+        categories={categories}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+    const input = openDropdown();
+    fireEvent.change(input, { target: { value: "Rent" } });
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    expect(screen.getByTestId("modal-initial-name")).toHaveTextContent("Rent");
+  });
+
+  it("calls onCategoryCreated and selects the new category on success", () => {
+    const onChange = vi.fn();
+    const onCategoryCreated = vi.fn();
+    render(
+      <CategorySelect
+        id="t3"
+        categories={categories}
+        value=""
+        onChange={onChange}
+        onCategoryCreated={onCategoryCreated}
+      />
+    );
+    openDropdown();
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    fireEvent.click(screen.getByText("stub-created"));
+
+    expect(onCategoryCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 999, name: "NewCat" })
+    );
+    expect(onChange).toHaveBeenCalledWith(999);
+  });
+
+  it("on modal cancel, closes the modal and combobox stays open", () => {
+    render(
+      <CategorySelect
+        id="t4"
+        categories={categories}
+        value=""
+        onChange={vi.fn()}
+      />
+    );
+    openDropdown();
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    expect(screen.getByTestId("add-category-modal-stub")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("stub-cancel"));
+    expect(
+      screen.queryByTestId("add-category-modal-stub")
+    ).not.toBeInTheDocument();
+    // Dropdown still open: the Add category button is still rendered.
+    expect(
+      screen.getByRole("button", { name: /Add category/i })
+    ).toBeInTheDocument();
+  });
+
+  it("uses filterType to set initial modal type", () => {
+    render(
+      <CategorySelect
+        id="t5"
+        categories={categories}
+        value=""
+        onChange={vi.fn()}
+        filterType="income"
+      />
+    );
+    openDropdown();
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    expect(screen.getByTestId("modal-initial-type")).toHaveTextContent(
+      "income"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- New `AddCategoryModal` opens from a sticky "+ Add category" button at the bottom of the CategorySelect dropdown. The modal pre-fills its name field with whatever the user has typed in the combobox, the key onboarding win.
- Supports master and subcategory creation. Backend POST /api/v1/categories untouched.
- On success, the new category is selected immediately and parent pages refresh local state via a new `onCategoryCreated` prop on CategorySelect.