### PR TITLE
feat(L1.7): SSO users set-initial-password UX

### DIFF
--- a/backend/alembic/versions/031_add_password_set_stepup_token.py
+++ b/backend/alembic/versions/031_add_password_set_stepup_token.py
@@ -1,0 +1,42 @@
+"""add password_set and step-up token columns to users (L1.7).
+
+Adds three columns:
+
+- `password_set` (bool, default True) — flips False on Google SSO user
+  creation so the change-password endpoint can branch on first set.
+  Existing rows default to True (they all signed up via password).
+- `stepup_token` (varchar 128, nullable) — single-use, short-lived
+  token issued by the SSO step-up callback and consumed by the email
+  change endpoint as an alternative to `current_password`.
+- `stepup_token_expires_at` (datetime, nullable) — hard 5-minute
+  expiry checked when the email-change handler validates the token.
+
+Revision ID: 031_password_set_stepup
+Revises: 030_audit_events
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "031_password_set_stepup"
+down_revision = "030_audit_events"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("password_set", sa.Boolean(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "users",
+        sa.Column("stepup_token", sa.String(128), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("stepup_token_expires_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "stepup_token_expires_at")
+    op.drop_column("users", "stepup_token")
+    op.drop_column("users", "password_set")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -64,6 +64,23 @@ class User(Base):
     sessions_invalidated_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # False for users created via Google SSO who have not yet set a real
+    # password (the SSO flow stores a random `secrets.token_urlsafe(32)`
+    # hash they cannot use). Once a user calls POST /me/password the flag
+    # flips True permanently and the standard "current password required"
+    # check kicks in. Default True so every existing row stays on the
+    # normal change-password path.
+    password_set: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
+    # Single-use, 5-minute step-up token issued by the SSO step-up
+    # callback (POST /api/v1/auth/sso-stepup/initiate → callback). The
+    # email-change endpoint accepts it as an alternative to the current
+    # password when `password_set` is False so SSO users can still
+    # rotate their email without ever having a password to type. Token
+    # is consumed (set to None) on first use; expiry is hard.
+    stepup_token: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    stepup_token_expires_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
     mfa_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     totp_secret: Mapped[str | None] = mapped_column(String(256), nullable=True)
     recovery_codes: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1119,18 +1119,20 @@ async def sso_stepup_callback(
     state: str,
     db: AsyncSession = Depends(get_db),
     oauth_state: str | None = Cookie(default=None),
-    current_user: User = Depends(get_current_user),
 ):
     """Finalize a Google step-up. Issues a 5-minute single-use token.
 
-    The signed-in user is required (the redirect happens in-browser, so
-    the access-token cookie/header is still present). We verify:
-      - state cookie matches the URL `state`
-      - state is shaped `stepup:{user_id}:{nonce}` and `user_id`
-        matches the signed-in user (no cross-account stitching)
+    Browser-driven redirect from Google: no Authorization header is
+    present, so this endpoint cannot use `get_current_user`. Identity
+    is bound through the state-cookie + state-string round trip
+    (same pattern as the SSO login `google_callback`):
+
+      - state cookie matches the URL `state` (CSRF)
+      - state is shaped `stepup:{user_id}:{nonce}`; `user_id` is the
+        target user (looked up directly from the DB)
       - the Google account that completed the consent has the same
-        verified email as the signed-in user (no swapping accounts at
-        the consent screen)
+        verified email as that user (no swapping accounts at the
+        consent screen)
 
     On success, writes a random 32-byte token + 5min expiry onto the
     `users` row and redirects back to /settings with the token in the
@@ -1142,8 +1144,9 @@ async def sso_stepup_callback(
     if not oauth_state or oauth_state != state:
         raise HTTPException(status_code=400, detail="Invalid OAuth state — possible CSRF")
 
-    # Bind state to the signed-in user. Anyone who steals a state value
-    # from another tab cannot redeem it on a different session.
+    # State binds the redemption to a specific user_id chosen at
+    # initiate time. Without an Authorization header here, the state
+    # cookie + state string round trip is the identity proof.
     parts = state.split(":")
     if len(parts) != 3 or parts[0] != "stepup":
         raise HTTPException(status_code=400, detail="Malformed step-up state")
@@ -1151,8 +1154,12 @@ async def sso_stepup_callback(
         state_user_id = int(parts[1])
     except ValueError:
         raise HTTPException(status_code=400, detail="Malformed step-up state")
-    if state_user_id != current_user.id:
-        raise HTTPException(status_code=400, detail="Step-up state does not match this session")
+
+    user = await db.get(User, state_user_id)
+    if user is None:
+        # Treat a missing user as a bad state rather than 404, so we
+        # don't leak which user_ids exist.
+        raise HTTPException(status_code=400, detail="Invalid state")
 
     # Exchange code → tokens → userinfo, identical shape to /google/callback
     try:
@@ -1187,16 +1194,16 @@ async def sso_stepup_callback(
         raw = google_user.get("email_verified", False)
     if not bool(raw):
         raise HTTPException(status_code=400, detail="Google has not verified this email")
-    if not google_email or google_email != current_user.email.strip().lower():
+    if not google_email or google_email != user.email.strip().lower():
         # The user must complete the step-up with the same Google
         # identity attached to this account. Otherwise this would let
-        # an attacker who hijacked the session swap the email by
-        # consenting on their own Google account.
+        # an attacker who initiated step-up for someone else's user_id
+        # swap the email by consenting on their own Google account.
         raise HTTPException(status_code=400, detail="Google account does not match the signed-in user")
 
     token = secrets.token_urlsafe(32)
-    current_user.stepup_token = token
-    current_user.stepup_token_expires_at = datetime.now(timezone.utc) + timedelta(
+    user.stepup_token = token
+    user.stepup_token_expires_at = datetime.now(timezone.utc) + timedelta(
         seconds=STEPUP_TOKEN_TTL_SECONDS
     )
     await db.commit()

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -94,6 +94,7 @@ def _user_response(user: User, org: Organization, sub: Subscription | None = Non
         is_superadmin=user.is_superadmin,
         is_active=user.is_active,
         mfa_enabled=user.mfa_enabled,
+        password_set=user.password_set,
         subscription_status=sub.status.value if sub else None,
         subscription_plan=plan.slug if plan else None,
         trial_end=sub.trial_end.isoformat() if sub and sub.trial_end else None,
@@ -1004,6 +1005,12 @@ async def google_callback(
             email_verified=True,  # guaranteed by the verified_email guard
             role=Role.OWNER,
             is_superadmin=is_first_user,
+            # SSO users get a random unguessable hash they cannot use to
+            # sign in with. Flag the row so the change-password endpoint
+            # accepts a first-time set without `current_password` and so
+            # the email-change endpoint takes the step-up path. Flips
+            # back to True the moment they set a real password.
+            password_set=False,
         )
         db.add(user)
         await db.commit()
@@ -1047,4 +1054,156 @@ async def google_callback(
         max_age=7 * 24 * 60 * 60,
         path="/api/v1/auth/refresh",
     )
+    return resp
+
+
+# ── SSO Step-Up (L1.7) ──────────────────────────────────────────────────────
+#
+# SSO users without a password (`password_set=False`) cannot satisfy the
+# email-change re-auth gate the password branch enforces. Rather than
+# silently swap email on the session (which would convert any session
+# compromise to permanent account takeover, since email is the recovery
+# channel), we require a fresh round-trip through Google: the user clicks
+# "Verify with Google", we redirect them to Google's consent screen, and
+# the callback writes a 5-minute single-use token onto their `users` row.
+# The PUT /users/me handler then accepts that token in place of
+# `current_password` for the email-change branch.
+#
+# Cookie path is scoped to /api/v1/auth/sso-stepup so it never collides
+# with the main Google login `oauth_state` cookie at /api/v1/auth/google.
+
+STEPUP_TOKEN_TTL_SECONDS = 5 * 60
+
+
+@router.post("/sso-stepup/initiate")
+async def sso_stepup_initiate(
+    response: Response,
+    current_user: User = Depends(get_current_user),
+):
+    """Begin a Google step-up flow for the signed-in user.
+
+    Returns the Google consent URL the frontend should navigate to.
+    The state cookie embeds the `current_user.id` so the callback can
+    verify the same user finished the round-trip and reject any state
+    coming back to a different session.
+    """
+    _validate_google_config()
+
+    nonce = secrets.token_urlsafe(32)
+    state = f"stepup:{current_user.id}:{nonce}"
+    response.set_cookie(
+        key="oauth_state",
+        value=state,
+        httponly=True,
+        secure=app_settings.cookie_secure,
+        samesite="lax",
+        max_age=600,  # 10 minutes
+        path="/api/v1/auth/sso-stepup",
+    )
+
+    params = {
+        "client_id": app_settings.google_client_id,
+        "redirect_uri": f"{app_settings.app_url}/api/v1/auth/sso-stepup/callback",
+        "response_type": "code",
+        "scope": "openid email profile",
+        "access_type": "online",
+        "prompt": "select_account",
+        "state": state,
+    }
+    return {"redirect_url": f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}"}
+
+
+@router.get("/sso-stepup/callback")
+async def sso_stepup_callback(
+    code: str,
+    state: str,
+    db: AsyncSession = Depends(get_db),
+    oauth_state: str | None = Cookie(default=None),
+    current_user: User = Depends(get_current_user),
+):
+    """Finalize a Google step-up. Issues a 5-minute single-use token.
+
+    The signed-in user is required (the redirect happens in-browser, so
+    the access-token cookie/header is still present). We verify:
+      - state cookie matches the URL `state`
+      - state is shaped `stepup:{user_id}:{nonce}` and `user_id`
+        matches the signed-in user (no cross-account stitching)
+      - the Google account that completed the consent has the same
+        verified email as the signed-in user (no swapping accounts at
+        the consent screen)
+
+    On success, writes a random 32-byte token + 5min expiry onto the
+    `users` row and redirects back to /settings with the token in the
+    URL fragment. Like the SSO login flow, fragments stay client-side
+    (not sent to servers, not in access logs).
+    """
+    _validate_google_config()
+
+    if not oauth_state or oauth_state != state:
+        raise HTTPException(status_code=400, detail="Invalid OAuth state — possible CSRF")
+
+    # Bind state to the signed-in user. Anyone who steals a state value
+    # from another tab cannot redeem it on a different session.
+    parts = state.split(":")
+    if len(parts) != 3 or parts[0] != "stepup":
+        raise HTTPException(status_code=400, detail="Malformed step-up state")
+    try:
+        state_user_id = int(parts[1])
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Malformed step-up state")
+    if state_user_id != current_user.id:
+        raise HTTPException(status_code=400, detail="Step-up state does not match this session")
+
+    # Exchange code → tokens → userinfo, identical shape to /google/callback
+    try:
+        async with httpx.AsyncClient(timeout=GOOGLE_OAUTH_TIMEOUT) as client:
+            token_resp = await client.post(
+                "https://oauth2.googleapis.com/token",
+                data={
+                    "code": code,
+                    "client_id": app_settings.google_client_id,
+                    "client_secret": app_settings.google_client_secret,
+                    "redirect_uri": f"{app_settings.app_url}/api/v1/auth/sso-stepup/callback",
+                    "grant_type": "authorization_code",
+                },
+            )
+            if token_resp.status_code != 200:
+                raise HTTPException(status_code=400, detail="Failed to exchange Google auth code")
+            tokens = token_resp.json()
+
+            userinfo_resp = await client.get(
+                "https://www.googleapis.com/oauth2/v2/userinfo",
+                headers={"Authorization": f"Bearer {tokens['access_token']}"},
+            )
+            if userinfo_resp.status_code != 200:
+                raise HTTPException(status_code=400, detail="Failed to get Google user info")
+            google_user = userinfo_resp.json()
+    except httpx.HTTPError:
+        raise HTTPException(status_code=502, detail="Failed to communicate with Google")
+
+    google_email = (google_user.get("email") or "").strip().lower()
+    raw = google_user.get("verified_email")
+    if raw is None:
+        raw = google_user.get("email_verified", False)
+    if not bool(raw):
+        raise HTTPException(status_code=400, detail="Google has not verified this email")
+    if not google_email or google_email != current_user.email.strip().lower():
+        # The user must complete the step-up with the same Google
+        # identity attached to this account. Otherwise this would let
+        # an attacker who hijacked the session swap the email by
+        # consenting on their own Google account.
+        raise HTTPException(status_code=400, detail="Google account does not match the signed-in user")
+
+    token = secrets.token_urlsafe(32)
+    current_user.stepup_token = token
+    current_user.stepup_token_expires_at = datetime.now(timezone.utc) + timedelta(
+        seconds=STEPUP_TOKEN_TTL_SECONDS
+    )
+    await db.commit()
+
+    resp = RedirectResponse(
+        url=f"{app_settings.app_url}/settings#stepup_token={token}",
+        status_code=302,
+    )
+    resp.delete_cookie("oauth_state", path="/api/v1/auth/sso-stepup")
     return resp

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,4 +1,5 @@
 import re
+import secrets
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
@@ -20,6 +21,16 @@ from app.services.email_service import send_verification_email
 
 _USERNAME_RE = re.compile(USERNAME_PATTERN)
 
+
+def _aware(dt: datetime) -> datetime:
+    """Treat naive datetimes as UTC. The `users` step-up expiry column
+    is plain `DateTime` (naive) for cross-DB compatibility, but every
+    write goes through `datetime.now(timezone.utc)` so the underlying
+    instant is always UTC. This helper makes the comparison safe even
+    if a future migration flips the column to `DateTime(timezone=True)`.
+    """
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
 
 
@@ -40,6 +51,7 @@ def _user_response(user: User) -> UserResponse:
         is_superadmin=user.is_superadmin,
         is_active=user.is_active,
         mfa_enabled=user.mfa_enabled,
+        password_set=user.password_set,
     )
 
 
@@ -84,13 +96,41 @@ async def update_profile(
         # Closes S-P1-2: without re-auth, a session-only compromise could
         # swap the recovery channel to an attacker-controlled inbox and
         # convert a transient hijack into persistent account takeover.
-        if not body.current_password or not verify_password(
-            body.current_password, current_user.password_hash
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Current password is required and must be correct to change email",
+        # Two acceptable proofs of presence:
+        #   - normal users (`password_set=True`) supply `current_password`
+        #   - SSO users who never set a password (`password_set=False`)
+        #     instead supply a fresh `stepup_token` that the SSO step-up
+        #     callback wrote on their row (5min hard expiry, single-use).
+        if current_user.password_set:
+            if not body.current_password or not verify_password(
+                body.current_password, current_user.password_hash
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Current password is required and must be correct to change email",
+                )
+        else:
+            now_check = datetime.now(timezone.utc)
+            stored = current_user.stepup_token
+            expires_at = current_user.stepup_token_expires_at
+            # Compare in a constant-time manner; reject missing/expired
+            # tokens with the same generic 400 the password branch
+            # returns to avoid leaking which check failed.
+            valid = (
+                bool(body.stepup_token)
+                and stored is not None
+                and expires_at is not None
+                and _aware(expires_at) > now_check
+                and secrets.compare_digest(body.stepup_token, stored)
             )
+            if not valid:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Step-up verification with Google is required to change email",
+                )
+            # Consume the token so it cannot be replayed.
+            current_user.stepup_token = None
+            current_user.stepup_token_expires_at = None
         existing = await db.execute(
             select(User).where(User.email == body.email)
         )
@@ -140,14 +180,26 @@ async def change_password(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    if not verify_password(body.current_password, current_user.password_hash):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Current password is incorrect",
-        )
+    # Two paths through this handler:
+    #   - `password_set=True` (default for every classic register flow):
+    #     require a valid `current_password`. Existing behavior.
+    #   - `password_set=False` (Google SSO user setting a real password
+    #     for the first time): skip the current-password check; any
+    #     supplied value is ignored. After the write `password_set`
+    #     flips True permanently so subsequent rotations land in the
+    #     standard branch above.
+    if current_user.password_set:
+        if not body.current_password or not verify_password(
+            body.current_password, current_user.password_hash
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is incorrect",
+            )
 
     now = datetime.now(timezone.utc)
     current_user.password_hash = hash_password(body.new_password)
+    current_user.password_set = True
     current_user.password_changed_at = now
     current_user.sessions_invalidated_at = now
     await db.commit()

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -59,6 +59,11 @@ class UserResponse(BaseModel):
     is_superadmin: bool
     is_active: bool
     mfa_enabled: bool = False
+    # False for SSO-created users who have not yet set a password. The
+    # frontend uses this to flip the Change Password card into "Set a
+    # Password" mode and to show the "Verify with Google" button on the
+    # email-change form.
+    password_set: bool = True
     subscription_status: str | None = None
     subscription_plan: str | None = None
     trial_end: str | None = None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -21,6 +21,11 @@ class ProfileUpdate(BaseModel):
     # email without re-auth is a takeover-persistence vector when a
     # session is compromised.
     current_password: str | None = Field(default=None, max_length=128)
+    # Alternative to `current_password` for SSO users who have not yet
+    # set one (`password_set=False`). The token is issued by the
+    # /api/v1/auth/sso-stepup/initiate → callback flow, lives 5 minutes,
+    # and is consumed (cleared on `users`) on first successful use.
+    stepup_token: str | None = Field(default=None, max_length=128)
 
     @field_validator("avatar_url")
     @classmethod
@@ -31,5 +36,10 @@ class ProfileUpdate(BaseModel):
 
 
 class PasswordChange(BaseModel):
-    current_password: str = Field(max_length=128)
+    # Optional at the schema layer — the handler enforces the rule
+    # conditionally. When the caller has `password_set=True` the handler
+    # requires a valid `current_password`. When `password_set=False`
+    # (Google SSO user setting a password for the first time) the
+    # `current_password` field is ignored entirely.
+    current_password: str | None = Field(default=None, max_length=128)
     new_password: str = Field(min_length=8, max_length=128)

--- a/backend/tests/routers/test_users_password_set.py
+++ b/backend/tests/routers/test_users_password_set.py
@@ -1,0 +1,298 @@
+"""L1.7 — set-initial-password and SSO step-up email change.
+
+Pins the password_set flag end-to-end:
+  - Google SSO new-user creation marks the row `password_set=False`.
+  - POST /users/me/password skips the current-password check on first
+    set, flips the flag True, and rotates `sessions_invalidated_at` +
+    `password_changed_at`.
+  - Once `password_set=True`, supplying no `current_password` is
+    rejected (regression guard).
+  - PUT /users/me email change accepts a valid step-up token in place
+    of `current_password` only while the token is unexpired and matches.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.users import router as users_router
+from app.security import hash_password, verify_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory, user_id: int):
+    """Wire FastAPI overrides so that `get_current_user` returns a User
+    bound to the SAME AsyncSession the handler will use. Otherwise the
+    handler's mutations on `current_user` go to a detached instance and
+    `db.commit()` persists nothing — masking real bugs."""
+    from fastapi import Depends as _Depends
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    # Depends on `get_db` so FastAPI's per-request dependency cache
+    # hands the same AsyncSession to this override and to the route.
+    async def override_current_user(
+        db: AsyncSession = _Depends(get_db),
+    ) -> User:
+        user = await db.get(User, user_id)
+        assert user is not None
+        await db.refresh(user, ["organization"])
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(users_router)
+    return app
+
+
+async def _seed_user(
+    session_factory,
+    *,
+    password_set: bool = True,
+    stepup_token: str | None = None,
+    stepup_expires_at: datetime | None = None,
+) -> int:
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@acme.io",
+            password_hash=hash_password("starting-password"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+            password_set=password_set,
+            stepup_token=stepup_token,
+            stepup_token_expires_at=stepup_expires_at,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+# ── SSO new-user creation ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sso_user_create_sets_password_set_false(session_factory):
+    """Google-SSO-created users land with password_set=False (covers
+    the new-user branch in auth.py:google_callback)."""
+    async with session_factory() as db:
+        org = Organization(name="SSO Org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        # Mirrors the constructor used in auth.py google_callback.
+        user = User(
+            org_id=org.id,
+            username="sso-user",
+            email="sso@example.com",
+            password_hash=hash_password("random-google-fill"),
+            email_verified=True,
+            role=Role.OWNER,
+            password_set=False,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        assert user.password_set is False
+
+
+# ── change_password handler — first-time set ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_initial_password_skips_current_password_check(session_factory):
+    user_id = await _seed_user(session_factory, password_set=False)
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        # Note: no current_password in body.
+        res = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "brand-new-password"},
+        )
+    assert res.status_code == 204, res.text
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.password_set is True
+        assert verify_password("brand-new-password", user.password_hash)
+
+
+@pytest.mark.asyncio
+async def test_initial_password_updates_password_changed_at_and_sessions_invalidated_at(
+    session_factory,
+):
+    user_id = await _seed_user(session_factory, password_set=False)
+    before = datetime.now(timezone.utc)
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "brand-new-password"},
+        )
+    assert res.status_code == 204, res.text
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        # Both fields are written via datetime.now(timezone.utc) but
+        # may persist as naive depending on the driver. Treat both as UTC.
+        def _aware(dt):
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        assert user.password_changed_at is not None
+        assert user.sessions_invalidated_at is not None
+        assert _aware(user.password_changed_at) >= before
+        assert _aware(user.sessions_invalidated_at) >= before
+
+
+@pytest.mark.asyncio
+async def test_initial_password_path_rejected_after_first_set(session_factory):
+    """After password_set flips True, the standard branch must enforce
+    the current_password check. Posting only `new_password` should 400
+    instead of silently rotating the password again."""
+    user_id = await _seed_user(session_factory, password_set=False)
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        first = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "first-set-password"},
+        )
+        assert first.status_code == 204
+
+        # Second call has no current_password — must be rejected now.
+        second = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "second-set-password"},
+        )
+    assert second.status_code == 400, second.text
+
+
+@pytest.mark.asyncio
+async def test_password_set_true_still_requires_current_password(session_factory):
+    """Regression guard for users created via classic register flow."""
+    user_id = await _seed_user(session_factory, password_set=True)
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "another-password"},
+        )
+    assert res.status_code == 400, res.text
+
+
+# ── email change — step-up token branch ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_email_change_requires_stepup_token_when_password_not_set(session_factory):
+    user_id = await _seed_user(session_factory, password_set=False)
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        res = client.put(
+            "/api/v1/users/me",
+            json={"email": "new@acme.io"},
+        )
+    assert res.status_code == 400, res.text
+    assert "step-up" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_email_change_accepts_valid_stepup_token(session_factory):
+    token = "valid-stepup-token-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        stepup_expires_at=datetime.now(timezone.utc) + timedelta(minutes=4),
+    )
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        res = client.put(
+            "/api/v1/users/me",
+            json={"email": "new@acme.io", "stepup_token": token},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["email"] == "new@acme.io"
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        # Token must be consumed on use (no replay).
+        assert user.stepup_token is None
+        assert user.stepup_token_expires_at is None
+        assert user.email == "new@acme.io"
+        # Email change still invalidates sessions.
+        assert user.sessions_invalidated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_email_change_rejects_expired_stepup_token(session_factory):
+    token = "expired-token-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        # 1 second in the past.
+        stepup_expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        res = client.put(
+            "/api/v1/users/me",
+            json={"email": "new@acme.io", "stepup_token": token},
+        )
+    assert res.status_code == 400, res.text
+
+    # And the email must NOT have changed.
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.email == "alice@acme.io"

--- a/backend/tests/routers/test_users_password_set.py
+++ b/backend/tests/routers/test_users_password_set.py
@@ -296,3 +296,41 @@ async def test_email_change_rejects_expired_stepup_token(session_factory):
         user = await db.get(User, user_id)
         assert user is not None
         assert user.email == "alice@acme.io"
+
+
+@pytest.mark.asyncio
+async def test_email_change_rejects_replay_of_consumed_stepup_token(session_factory):
+    """Step-up tokens are single-use. The first PUT consumes the token
+    (clears the row), so a second PUT replaying the same token must
+    400 — even if it would otherwise still be inside the 5-min window.
+    Pins the security-critical no-replay invariant."""
+    token = "single-use-token-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        stepup_expires_at=datetime.now(timezone.utc) + timedelta(minutes=4),
+    )
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        first = client.put(
+            "/api/v1/users/me",
+            json={"email": "first@acme.io", "stepup_token": token},
+        )
+        assert first.status_code == 200, first.text
+
+        # Replay the same token: server already cleared it, so the
+        # token-match branch in PUT /users/me must fail.
+        replay = client.put(
+            "/api/v1/users/me",
+            json={"email": "second@acme.io", "stepup_token": token},
+        )
+    assert replay.status_code == 400, replay.text
+
+    # And the second email must NOT have been written.
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.email == "first@acme.io"
+        assert user.stepup_token is None
+        assert user.stepup_token_expires_at is None

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -5,7 +5,7 @@ import { FormEvent, useEffect, useState } from "react";
 import SettingsLayout from "@/components/SettingsLayout";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { input, label, btnPrimary, card, cardTitle, error as errorCls, success as successCls } from "@/lib/styles";
+import { input, label, btnPrimary, btnSecondary, card, cardTitle, error as errorCls, success as successCls } from "@/lib/styles";
 import type { User } from "@/lib/types";
 
 export default function SettingsProfilePage() {
@@ -21,6 +21,15 @@ export default function SettingsProfilePage() {
   // the /me/password endpoint's re-auth requirement and closes the
   // email-change account-takeover chain (S-P1-2).
   const [currentPassword, setCurrentPassword] = useState("");
+  // SSO users (`password_set=false`) cannot type a current password.
+  // They re-authenticate via Google: clicking "Verify with Google"
+  // POSTs /api/v1/auth/sso-stepup/initiate, the browser navigates to
+  // Google, and the callback redirects back to this page with the
+  // token in the URL fragment. We read it on mount, clear the hash
+  // so it never lingers in browser history, and pass it to the
+  // backend in place of `current_password`.
+  const [stepupToken, setStepupToken] = useState("");
+  const [stepupBusy, setStepupBusy] = useState(false);
 
   useEffect(() => {
     if (user) {
@@ -32,11 +41,40 @@ export default function SettingsProfilePage() {
     }
   }, [user]);
 
+  // Pull `#stepup_token=…` off the URL on mount and immediately
+  // strip it from history. Fragments are never sent to the server,
+  // so this is the safe channel the backend redirects to.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash;
+    if (hash.startsWith("#stepup_token=")) {
+      const token = hash.slice("#stepup_token=".length);
+      if (token) setStepupToken(token);
+      window.history.replaceState(null, "", window.location.pathname + window.location.search);
+    }
+  }, []);
+
   const [profileMsg, setProfileMsg] = useState("");
   const [profileErr, setProfileErr] = useState("");
   const [savingProfile, setSavingProfile] = useState(false);
 
   const emailChanging = email !== (user?.email ?? "");
+  const passwordSet = user?.password_set ?? true;
+
+  async function handleVerifyWithGoogle() {
+    setProfileErr(""); setStepupBusy(true);
+    try {
+      const data = await apiFetch<{ redirect_url: string }>(
+        "/api/v1/auth/sso-stepup/initiate",
+        { method: "POST" },
+      );
+      // Full navigation, not router.push — Google must own the next page.
+      window.location.href = data.redirect_url;
+    } catch (err) {
+      setProfileErr(extractErrorMessage(err));
+      setStepupBusy(false);
+    }
+  }
 
   async function handleProfileSubmit(e: FormEvent) {
     e.preventDefault();
@@ -59,13 +97,23 @@ export default function SettingsProfilePage() {
       }
 
       if ("email" in payload) {
-        if (!currentPassword) {
-          setProfileErr(
-            "Enter your current password to change your email. If you signed in with Google and never set one, reset your password first.",
-          );
-          return;
+        if (user?.password_set === false) {
+          if (!stepupToken) {
+            setProfileErr(
+              "Verify with Google before changing your email. Click 'Verify with Google' below.",
+            );
+            return;
+          }
+          payload.stepup_token = stepupToken;
+        } else {
+          if (!currentPassword) {
+            setProfileErr(
+              "Enter your current password to change your email.",
+            );
+            return;
+          }
+          payload.current_password = currentPassword;
         }
-        payload.current_password = currentPassword;
       }
 
       await apiFetch<User>("/api/v1/users/me", {
@@ -74,6 +122,7 @@ export default function SettingsProfilePage() {
       });
       await refreshMe();
       setCurrentPassword("");
+      setStepupToken("");
       // Nudge the user toward the next step — changing email logs every
       // session out and leaves email_verified=false until they click
       // the new verification link.
@@ -133,7 +182,7 @@ export default function SettingsProfilePage() {
               <label htmlFor="profile-email" className={label}>Email</label>
               <input id="profile-email" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} className={input} />
             </div>
-            {emailChanging && (
+            {emailChanging && passwordSet && (
               <div>
                 <label htmlFor="profile-current-password" className={label}>
                   Current password <span className="text-xs text-text-muted">(required to change email)</span>
@@ -148,12 +197,40 @@ export default function SettingsProfilePage() {
                   className={input}
                 />
                 <p className="mt-1 text-xs text-text-muted">
-                  Signed in with Google and never set a password?{" "}
-                  <Link href="/forgot-password" className="text-accent hover:underline">
-                    Reset it first
-                  </Link>
-                  , then come back to change your email.
+                  Prefer not to type your password? You can{" "}
+                  <Link href="/settings/security" className="text-accent hover:underline">
+                    change it
+                  </Link>{" "}
+                  any time from the Security settings.
                 </p>
+              </div>
+            )}
+            {emailChanging && !passwordSet && (
+              <div className="rounded-lg border border-border p-4 space-y-3">
+                <p className="text-sm text-text-primary font-medium">
+                  Verify with Google to change your email
+                </p>
+                <p className="text-xs text-text-muted">
+                  Your account was created with Google and has no password yet. Verify with Google now to confirm this change, or{" "}
+                  <Link href="/settings/security" className="text-accent hover:underline">
+                    set a password first
+                  </Link>{" "}
+                  in Security settings.
+                </p>
+                {stepupToken ? (
+                  <p className="text-xs text-success">
+                    Google verified. Click Save Changes to update your email.
+                  </p>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleVerifyWithGoogle}
+                    disabled={stepupBusy}
+                    className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                  >
+                    {stepupBusy ? "Redirecting..." : "Verify with Google"}
+                  </button>
+                )}
               </div>
             )}
             <div>

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -31,17 +31,33 @@ export default function SecurityPage() {
   const [pwdErr, setPwdErr] = useState("");
   const [savingPwd, setSavingPwd] = useState(false);
 
+  // SSO users (Google) start with `password_set=false`. The first time
+  // they POST /me/password the backend skips the current-password
+  // check and the flag flips true, so on the next render this branch
+  // collapses back to the standard Change Password UI.
+  const passwordSet = user?.password_set ?? true;
+
   async function handlePasswordSubmit(e: FormEvent) {
     e.preventDefault();
     setPwdMsg(""); setPwdErr("");
     if (newPassword !== confirmPassword) { setPwdErr("New passwords do not match"); return; }
     setSavingPwd(true);
     try {
+      const payload: { new_password: string; current_password?: string } = {
+        new_password: newPassword,
+      };
+      if (passwordSet) {
+        payload.current_password = currentPassword;
+      }
       await apiFetch("/api/v1/users/me/password", {
         method: "POST",
-        body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+        body: JSON.stringify(payload),
       });
-      setPwdMsg("Password changed. Signing in with new credentials...");
+      setPwdMsg(
+        passwordSet
+          ? "Password changed. Signing in with new credentials..."
+          : "Password set. Signing in with new credentials...",
+      );
       try {
         await login(user!.username, newPassword);
       } catch (loginErr) {
@@ -53,8 +69,15 @@ export default function SecurityPage() {
           throw loginErr;
         }
       }
+      // Refresh the user so `password_set` flips and the card
+      // re-renders in standard mode after a first-time set.
+      await refreshMe();
       setCurrentPassword(""); setNewPassword(""); setConfirmPassword("");
-      setPwdMsg("Password changed successfully");
+      setPwdMsg(
+        passwordSet
+          ? "Password changed successfully"
+          : "Password set. You can now sign in with your email and password.",
+      );
     } catch (err) { setPwdErr(extractErrorMessage(err)); }
     finally { setSavingPwd(false); }
   }
@@ -205,14 +228,21 @@ export default function SecurityPage() {
       <div className="max-w-lg space-y-6">
         {/* ── Change Password ──────────────────────────────────────────── */}
         <div className={`${card} p-6`}>
-          <h2 className={`mb-5 ${cardTitle}`}>Change Password</h2>
+          <h2 className={`mb-5 ${cardTitle}`}>{passwordSet ? "Change Password" : "Set a Password"}</h2>
+          {!passwordSet && (
+            <p className="mb-4 text-sm text-text-muted">
+              Your account was created with Google. Set a password to also sign in with your email address.
+            </p>
+          )}
           <form onSubmit={handlePasswordSubmit} className="space-y-4">
             {pwdMsg && <div className={successCls}>{pwdMsg}</div>}
             {pwdErr && <div className={errorCls}>{pwdErr}</div>}
-            <div>
-              <label htmlFor="pwd-current" className={label}>Current Password</label>
-              <input id="pwd-current" type="password" required value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className={input} autoComplete="current-password" />
-            </div>
+            {passwordSet && (
+              <div>
+                <label htmlFor="pwd-current" className={label}>Current Password</label>
+                <input id="pwd-current" type="password" required value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className={input} autoComplete="current-password" />
+              </div>
+            )}
             <div>
               <label htmlFor="pwd-new" className={label}>New Password</label>
               <input id="pwd-new" type="password" required minLength={8} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className={input} autoComplete="new-password" />
@@ -222,7 +252,9 @@ export default function SecurityPage() {
               <input id="pwd-confirm" type="password" required value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className={input} autoComplete="new-password" />
             </div>
             <button type="submit" disabled={savingPwd} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
-              {savingPwd ? "Changing..." : "Change Password"}
+              {savingPwd
+                ? (passwordSet ? "Changing..." : "Setting...")
+                : (passwordSet ? "Change Password" : "Set Password")}
             </button>
           </form>
         </div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -14,6 +14,11 @@ export interface User {
   is_superadmin: boolean;
   is_active: boolean;
   mfa_enabled: boolean;
+  // False for Google SSO users who have not yet set a real password.
+  // The Settings UI flips Change Password into "Set a Password" mode and
+  // swaps the email-change re-auth from "current password" to a Google
+  // step-up flow when this is false.
+  password_set: boolean;
   subscription_status: SubscriptionStatus | null;
   subscription_plan: string | null;
   trial_end: string | null;

--- a/frontend/tests/app/settings-security-password-set.test.tsx
+++ b/frontend/tests/app/settings-security-password-set.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import SecurityPage from "@/app/settings/security/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth, MfaRequiredError } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/settings/security",
+}));
+
+function makeUser(passwordSet: boolean) {
+  return {
+    id: 1,
+    username: "alice",
+    email: "alice@acme.io",
+    first_name: null,
+    last_name: null,
+    phone: null,
+    avatar_url: null,
+    email_verified: true,
+    role: "owner" as const,
+    org_id: 1,
+    org_name: "Acme",
+    billing_cycle_day: 1,
+    is_superadmin: false,
+    is_active: true,
+    mfa_enabled: false,
+    password_set: passwordSet,
+    subscription_status: null,
+    subscription_plan: null,
+    trial_end: null,
+  };
+}
+
+function mockUser(passwordSet: boolean) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: makeUser(passwordSet) as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
+
+describe("Security page — Set a Password / Change Password gate", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    // Default: every read endpoint returns empty so the MFA/session
+    // sub-cards mount cleanly without coupling to this test.
+    vi.mocked(apiFetch).mockResolvedValue([] as never);
+  });
+
+  it("renders 'Set a Password' card when password_set is false", async () => {
+    mockUser(false);
+    render(<SecurityPage />);
+    expect(
+      await screen.findByRole("heading", { name: /Set a Password/i }),
+    ).toBeInTheDocument();
+    // The current-password input is intentionally hidden in this branch.
+    expect(screen.queryByLabelText(/Current Password/i)).not.toBeInTheDocument();
+    // Helper copy explains *why* there is no current password field.
+    expect(
+      screen.getByText(/created with Google/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Change Password' card when password_set is true", async () => {
+    mockUser(true);
+    render(<SecurityPage />);
+    expect(
+      await screen.findByRole("heading", { name: /Change Password/i }),
+    ).toBeInTheDocument();
+    // Standard branch keeps the current-password input.
+    expect(screen.getByLabelText(/Current Password/i)).toBeInTheDocument();
+  });
+
+  it("submits new_password only (no current_password) when password_set is false", async () => {
+    mockUser(false);
+    render(<SecurityPage />);
+    fireEvent.change(screen.getByLabelText(/^New Password$/i), {
+      target: { value: "fresh-password-1" },
+    });
+    fireEvent.change(screen.getByLabelText(/Confirm New Password/i), {
+      target: { value: "fresh-password-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Set Password/i }));
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith(
+        "/api/v1/users/me/password",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ new_password: "fresh-password-1" }),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `password_set` flag on `users` (default true; false on Google SSO create). Single change-password endpoint branches on it: SSO users skip the current-password check on first set, then `password_set` flips true.
- Email change for SSO users requires step-up via Google: `POST /api/v1/auth/sso-stepup/initiate` returns a redirect; the callback writes a 5-minute single-use `stepup_token` consumed by the email change endpoint as an alternative to `current_password`.
- Settings UI mirrors the gate: "Set a Password" card and "Verify with Google" button when `password_set` is false.

Migration 031 chains to 029 today; if PR #(L4.7) lands first, this rebases to chain 030 → 031.