### PR TITLE
feat(L4.7): superadmin audit log

### DIFF
--- a/backend/alembic/versions/030_add_audit_events.py
+++ b/backend/alembic/versions/030_add_audit_events.py
@@ -35,7 +35,7 @@ def upgrade() -> None:
         "audit_events",
         sa.Column(
             "id",
-            sa.BigInteger().with_variant(sa.BigInteger(), "mysql"),
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
             primary_key=True,
             autoincrement=True,
         ),

--- a/backend/alembic/versions/030_add_audit_events.py
+++ b/backend/alembic/versions/030_add_audit_events.py
@@ -1,0 +1,90 @@
+"""Add audit_events table — durable superadmin audit log (L4.7).
+
+Revision ID: 030_audit_events
+Revises: 029_reset_locks
+Create Date: 2026-05-06
+
+Persists the structured ``admin.org.*`` and ``org.data.*`` events
+that already stream to structlog into a durable, queryable store.
+
+Foreign keys use ON DELETE SET NULL on both actor_user_id and
+target_org_id so the audit history outlives the rows it describes
+(otherwise wiping an org would erase the record of who wiped it,
+which is the opposite of what an audit log is for). Snapshot
+columns (actor_email, target_org_name) preserve the human-readable
+identity at event time.
+
+created_at uses DATETIME(6) with NOW(6) default to give microsecond
+precision — events from the same admin click can land within the
+same second, and we still want a stable order in the UI.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "030_audit_events"
+down_revision = "029_reset_locks"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_events",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.BigInteger(), "mysql"),
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column("event_type", sa.String(80), nullable=False),
+        sa.Column("actor_user_id", sa.Integer, nullable=True),
+        sa.Column("actor_email", sa.String(255), nullable=False),
+        sa.Column("target_org_id", sa.Integer, nullable=True),
+        sa.Column("target_org_name", sa.String(200), nullable=True),
+        sa.Column("request_id", sa.String(64), nullable=True),
+        sa.Column("ip_address", sa.String(45), nullable=True),
+        sa.Column(
+            "outcome",
+            sa.Enum("success", "failure", name="auditoutcome"),
+            nullable=False,
+        ),
+        sa.Column("detail", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("CURRENT_TIMESTAMP(6)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["actor_user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_org_id"],
+            ["organizations.id"],
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index(
+        "ix_audit_events_event_type", "audit_events", ["event_type"]
+    )
+    op.create_index(
+        "ix_audit_events_actor_user_id", "audit_events", ["actor_user_id"]
+    )
+    op.create_index(
+        "ix_audit_events_target_org_id", "audit_events", ["target_org_id"]
+    )
+    op.create_index(
+        "ix_audit_events_created_at", "audit_events", ["created_at"]
+    )
+
+
+def downgrade() -> None:
+    # drop_table removes FKs and their backing indexes implicitly on
+    # MySQL — listing the indexes individually first fails because
+    # MySQL refuses to drop an index that an FK still depends on.
+    op.drop_table("audit_events")

--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -24,6 +24,7 @@ Permission = Literal[
     "plans.manage",
     "orgs.view",
     "orgs.manage",
+    "audit.view",
 ]
 
 
@@ -34,6 +35,7 @@ ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "plans.manage",
     "orgs.view",
     "orgs.manage",
+    "audit.view",
 })
 
 

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -4,11 +4,21 @@ import structlog
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.database import get_db
+from app.database import async_session, get_db
 from app.models.user import User
 from app.security import decode_token, token_cutoff
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    """Return the engine-wide session factory for callers that need
+    to open an independent transaction (audit-event recording, etc.).
+
+    Wrapped in a dependency so tests can override with an in-memory
+    factory the same way they override ``get_db``.
+    """
+    return async_session
 
 bearer_scheme = HTTPBearer()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_orgs, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, plans, recurring, settings, subscriptions, transactions, users
+from app.routers import account_types, accounts, admin, admin_audit, admin_orgs, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, plans, recurring, settings, subscriptions, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -231,6 +231,7 @@ app.include_router(subscriptions.router)
 app.include_router(plans.router)
 app.include_router(admin.router)
 app.include_router(admin_orgs.router)
+app.include_router(admin_audit.router)
 app.include_router(org_members.router)
 app.include_router(org_data.router)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -14,6 +14,7 @@ from app.models.category_rule import CategoryRule, RuleSource
 from app.models.merchant_dictionary import MerchantDictionaryEntry
 from app.models.feature_override import OrgFeatureOverride  # noqa: F401
 from app.models.org_data_reset_lock import OrgDataResetLock  # noqa: F401
+from app.models.audit_event import AuditEvent, AuditOutcome  # noqa: F401
 
 __all__ = [
     "Base",
@@ -46,4 +47,6 @@ __all__ = [
     "MerchantDictionaryEntry",
     "OrgFeatureOverride",
     "OrgDataResetLock",
+    "AuditEvent",
+    "AuditOutcome",
 ]

--- a/backend/app/models/audit_event.py
+++ b/backend/app/models/audit_event.py
@@ -1,0 +1,101 @@
+"""Durable audit log for superadmin platform actions (L4.7).
+
+The structlog ``admin.org.*`` and ``org.data.*`` events emitted by the
+admin and tenant routers stream to stdout (and from there to whatever
+log sink ops wires up). They're great for triage but they're not a
+queryable history with SLA-grade retention. This table persists the
+same events into a durable, indexable store so superadmins can answer
+"who did what to whom, and when" from the admin UI without grepping
+container logs.
+
+Two design choices worth restating in code:
+
+1. **Independent-session writes.** The recording function opens its
+   own ``AsyncSession`` from the engine-wide factory, commits, and
+   swallows exceptions after logging. An audit-write failure must
+   never poison the business transaction it describes — and a
+   business rollback (e.g. ``admin.org.delete.failed``) must still
+   produce an audit row, which only works if the audit write isn't
+   inside the rolled-back txn.
+
+2. **Survives org wipe.** ``audit_events.target_org_id`` uses
+   ``ON DELETE SET NULL`` so deleting an organization (or wiping
+   its data via the tenant reset path) leaves the audit history
+   intact. The ``target_org_name`` snapshot column preserves the
+   org name at the moment of the event, which is the only sane
+   thing to display in the UI after the org is gone. Same trick for
+   ``actor_user_id`` / ``actor_email``.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AuditOutcome(str, enum.Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+
+
+class AuditEvent(Base):
+    __tablename__ = "audit_events"
+
+    # BigInteger on MySQL (audit logs grow forever and we don't want
+    # to wedge against the 32-bit ceiling), but SQLite's autoincrement
+    # only honours INTEGER (not BIGINT) — `with_variant` keeps the
+    # in-memory test path on a real autoincrementing column.
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    event_type: Mapped[str] = mapped_column(
+        String(80), nullable=False, index=True
+    )
+    actor_user_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # Snapshot — the actor's email at event time, never resolved
+    # through the FK (which can be NULL after user deletion).
+    actor_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    target_org_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # Snapshot — same rationale as actor_email.
+    target_org_name: Mapped[Optional[str]] = mapped_column(
+        String(200), nullable=True
+    )
+    request_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    ip_address: Mapped[Optional[str]] = mapped_column(String(45), nullable=True)
+    outcome: Mapped[AuditOutcome] = mapped_column(
+        Enum(AuditOutcome, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+    )
+    detail: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=func.now(6),
+        nullable=False,
+        index=True,
+    )

--- a/backend/app/routers/admin_audit.py
+++ b/backend/app/routers/admin_audit.py
@@ -1,0 +1,57 @@
+"""Admin audit-log read API (L4.7).
+
+Mounted at ``/api/v1/admin/audit``. Gated by the platform
+``audit.view`` permission (superadmin short-circuits, fine-grained
+roles via L4.8 layer in later without touching this file).
+
+Read-only. Writes happen as a side effect inside admin and tenant
+routers via ``audit_service.record_audit_event`` so the events the
+log captures are the same events the structlog stream emits.
+"""
+from __future__ import annotations
+
+import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.permissions import require_permission
+from app.database import get_db
+from app.schemas.audit import AuditEventListResponse, AuditEventResponse
+from app.services import audit_service
+
+
+router = APIRouter(prefix="/api/v1/admin/audit", tags=["admin-audit"])
+
+
+@router.get(
+    "",
+    response_model=AuditEventListResponse,
+    dependencies=[Depends(require_permission("audit.view"))],
+)
+async def list_audit_events(
+    actor_user_id: int | None = Query(default=None, ge=1),
+    target_org_id: int | None = Query(default=None, ge=1),
+    event_type: str | None = Query(default=None, max_length=80),
+    outcome: str | None = Query(default=None, max_length=16),
+    from_dt: datetime.datetime | None = Query(default=None),
+    to_dt: datetime.datetime | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+) -> AuditEventListResponse:
+    rows, total = await audit_service.list_audit_events(
+        db,
+        actor_user_id=actor_user_id,
+        target_org_id=target_org_id,
+        event_type=event_type,
+        outcome=outcome,
+        from_dt=from_dt,
+        to_dt=to_dt,
+        limit=limit,
+        offset=offset,
+    )
+    return AuditEventListResponse(
+        items=[AuditEventResponse.model_validate(r) for r in rows],
+        total=total,
+    )

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -15,29 +15,35 @@ message client-side, full detail server-side.
 from datetime import datetime
 from app._time import utcnow_naive
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 import structlog
 
 from app.auth.feature_catalog import ALL_FEATURE_KEYS
 from app.auth.permissions import require_permission
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models.feature_override import OrgFeatureOverride
 from app.models.subscription import Plan, Subscription, SubscriptionStatus
 from app.models.user import Organization, User
+from app.rate_limit import get_client_ip
 from app.schemas.admin_orgs import OrgDeleteRequest, SubscriptionUpdateRequest
 from app.schemas.feature_override import FeatureOverrideUpsert, OrgFeatureOverrideResponse
 from app.schemas.feature_state import FeatureStateResponse
-from app.services import admin_orgs_service, feature_service
+from app.services import admin_orgs_service, audit_service, feature_service
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 logger = structlog.stdlib.get_logger()
 log = structlog.get_logger()
 
 router = APIRouter(prefix="/api/v1/admin/orgs", tags=["admin-orgs"])
+
+
+def _request_id() -> str | None:
+    """Pull the per-request id bound by RequestContextMiddleware (L4.9)."""
+    return structlog.contextvars.get_contextvars().get("request_id")
 
 
 @router.get(
@@ -68,8 +74,10 @@ async def get_org_detail(org_id: int, db: AsyncSession = Depends(get_db)):
 async def update_org_subscription(
     org_id: int,
     body: SubscriptionUpdateRequest,
+    request: Request,
     current_user: User = Depends(require_permission("orgs.manage")),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     try:
         # Look up name once for the audit event.
@@ -101,6 +109,18 @@ async def update_org_subscription(
         before=before,
         after=after,
     )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.org.subscription.override",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=org_id,
+        target_org_name=detail["name"],
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"before": before, "after": after},
+    )
     return {"before": before, "after": after}
 
 
@@ -108,8 +128,10 @@ async def update_org_subscription(
 async def delete_org(
     org_id: int,
     body: OrgDeleteRequest,
+    request: Request,
     current_user: User = Depends(require_permission("orgs.manage")),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     if org_id == current_user.org_id:
         raise HTTPException(
@@ -142,6 +164,22 @@ async def delete_org(
             error=str(e),
             error_type=type(e).__name__,
         )
+        # Independent-session audit write — the business txn has been
+        # rolled back, but the failure must still appear in the audit
+        # log. That's the whole point of opening a fresh session for
+        # the audit row.
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.org.delete.failed",
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=detail["name"],
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={"error": str(e), "error_type": type(e).__name__},
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete organization",
@@ -154,6 +192,18 @@ async def delete_org(
         target_org_id=org_id,
         target_org_name=detail["name"],
         deleted_rows_by_table=counts,
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.org.delete",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=org_id,
+        target_org_name=detail["name"],
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"deleted_rows_by_table": counts},
     )
     return {"deleted": counts}
 
@@ -192,22 +242,25 @@ async def set_feature_override(
     org_id: int,
     feature_key: str,
     body: FeatureOverrideUpsert,
+    request: Request,
     user: User = Depends(require_permission("orgs.manage")),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     try:
         _validate_feature_key(feature_key)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
-    org_exists = await db.scalar(
-        select(Organization.id).where(Organization.id == org_id)
-    )
-    if org_exists is None:
+    org_row = (
+        await db.execute(select(Organization).where(Organization.id == org_id))
+    ).scalar_one_or_none()
+    if org_row is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Organization not found",
         )
+    target_org_name = org_row.name
 
     existing = await db.scalar(
         select(OrgFeatureOverride).where(
@@ -258,6 +311,25 @@ async def set_feature_override(
         actor_email=user.email,
         note_present=body.note is not None,
     )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.org.feature.set",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=org_id,
+        target_org_name=target_org_name,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "feature_key": feature_key,
+            "old_value": old_value,
+            "new_value": body.value,
+            "old_expires_at": old_expires_at.isoformat() if old_expires_at else None,
+            "new_expires_at": body.expires_at.isoformat() if body.expires_at else None,
+            "note_present": body.note is not None,
+        },
+    )
 
     return await _override_to_response(row, db)
 
@@ -269,8 +341,10 @@ async def set_feature_override(
 async def revoke_feature_override(
     org_id: int,
     feature_key: str,
+    request: Request,
     user: User = Depends(require_permission("orgs.manage")),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     # 400 if key isn't in the catalog (matches PUT translation).
     try:
@@ -278,14 +352,15 @@ async def revoke_feature_override(
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
-    org_exists = await db.scalar(
-        select(Organization.id).where(Organization.id == org_id)
-    )
-    if org_exists is None:
+    org_row = (
+        await db.execute(select(Organization).where(Organization.id == org_id))
+    ).scalar_one_or_none()
+    if org_row is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Organization not found",
         )
+    target_org_name = org_row.name
 
     existing = await db.scalar(
         select(OrgFeatureOverride).where(
@@ -310,6 +385,18 @@ async def revoke_feature_override(
         old_value=old_value,
         actor_user_id=user.id,
         actor_email=user.email,
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.org.feature.revoked",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=org_id,
+        target_org_name=target_org_name,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"feature_key": feature_key, "old_value": old_value},
     )
     return Response(status_code=204)
 

--- a/backend/app/routers/org_data.py
+++ b/backend/app/routers/org_data.py
@@ -2,27 +2,36 @@
 on the org's own data."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 import structlog
 
 from app.auth.org_permissions import require_org_owner
 from app.database import get_db
+from app.deps import get_session_factory
 from app.models.user import Organization, User
+from app.rate_limit import get_client_ip
 from app.schemas.org_data import OrgDataResetRequest, OrgDataResetResponse
-from app.services import org_data_service, org_reset_lock_service
+from app.services import audit_service, org_data_service, org_reset_lock_service
 
 logger = structlog.stdlib.get_logger()
 
 router = APIRouter(prefix="/api/v1/orgs/data", tags=["org-data"])
 
 
+def _request_id() -> str | None:
+    """Pull the per-request id bound by RequestContextMiddleware (L4.9)."""
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
 @router.post("/reset", response_model=OrgDataResetResponse)
 async def reset_org_data(
     body: OrgDataResetRequest,
+    request: Request,
     current_user: User = Depends(require_org_owner),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     org = (await db.execute(
         select(Organization).where(Organization.id == current_user.org_id)
@@ -91,6 +100,25 @@ async def reset_org_data(
         )
         # Release the lock before raising so a retry isn't blocked.
         await org_reset_lock_service.release_reset_lock(db, org_id=org_id, token=lease_token)
+        # Independent-session audit write — survives the business
+        # rollback and a possible follow-on org wipe (target_org_id
+        # uses ON DELETE SET NULL).
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="org.data.reset.failed",
+            actor_user_id=actor_user_id,
+            actor_email=actor_email,
+            target_org_id=org_id,
+            target_org_name=org_name,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={
+                "actor_role": actor_role,
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to reset organization data",
@@ -107,5 +135,20 @@ async def reset_org_data(
         org_id=org_id,
         org_name=org_name,
         deleted_rows_by_table=counts,
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="org.data.reset",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=org_id,
+        target_org_name=org_name,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "actor_role": actor_role,
+            "deleted_rows_by_table": counts,
+        },
     )
     return {"deleted_rows_by_table": counts}

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,0 +1,28 @@
+"""Pydantic schemas for the L4.7 audit-log read API."""
+from __future__ import annotations
+
+import datetime
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AuditEventResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    event_type: str
+    actor_user_id: Optional[int]
+    actor_email: str
+    target_org_id: Optional[int]
+    target_org_name: Optional[str]
+    request_id: Optional[str]
+    ip_address: Optional[str]
+    outcome: Literal["success", "failure"]
+    detail: Optional[dict[str, Any]]
+    created_at: datetime.datetime
+
+
+class AuditEventListResponse(BaseModel):
+    items: list[AuditEventResponse]
+    total: int

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -1,0 +1,134 @@
+"""Audit-event recording and querying (L4.7).
+
+The recording path uses an **independent session** opened from the
+engine-wide ``async_sessionmaker`` so the audit write is a separate
+transaction from whatever business operation triggered it. Two
+properties this gives us:
+
+- A failed business txn (e.g. ``admin.org.delete.failed``) still
+  produces an audit row, because the audit write doesn't ride on
+  the rolled-back session.
+- A failed audit write (DB transient, FK violation, anything) never
+  surfaces back to the caller. We log the failure via structlog and
+  swallow — the structlog event the caller already emitted is the
+  fallback channel.
+
+Caller responsibilities:
+
+- Pass the ``async_sessionmaker`` (not a session). Inject via
+  ``Depends(get_session_factory)`` in routers.
+- Call **after** ``await db.commit()`` (or after the rollback path)
+  so the snapshot fields reflect the state the audit row should
+  attest to.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.audit_event import AuditEvent, AuditOutcome
+
+
+logger = structlog.stdlib.get_logger()
+
+
+async def record_audit_event(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    event_type: str,
+    actor_user_id: Optional[int],
+    actor_email: str,
+    target_org_id: Optional[int],
+    target_org_name: Optional[str],
+    request_id: Optional[str],
+    ip_address: Optional[str],
+    outcome: Literal["success", "failure"],
+    detail: Optional[dict[str, Any]] = None,
+) -> None:
+    """Persist an audit event in its own transaction.
+
+    Failures are logged via structlog and swallowed. Never raises.
+    """
+    try:
+        async with session_factory() as session:
+            row = AuditEvent(
+                event_type=event_type,
+                actor_user_id=actor_user_id,
+                actor_email=actor_email,
+                target_org_id=target_org_id,
+                target_org_name=target_org_name,
+                request_id=request_id,
+                ip_address=ip_address,
+                outcome=AuditOutcome(outcome),
+                detail=detail,
+            )
+            session.add(row)
+            await session.commit()
+    except Exception as exc:  # noqa: BLE001 — defensive: never bubble.
+        await logger.aerror(
+            "audit.record.failed",
+            event_type=event_type,
+            actor_user_id=actor_user_id,
+            target_org_id=target_org_id,
+            outcome=outcome,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+
+
+async def list_audit_events(
+    db: AsyncSession,
+    *,
+    actor_user_id: Optional[int] = None,
+    target_org_id: Optional[int] = None,
+    event_type: Optional[str] = None,
+    outcome: Optional[str] = None,
+    from_dt: Optional[datetime] = None,
+    to_dt: Optional[datetime] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[AuditEvent], int]:
+    """Return ``(rows, total)`` for the admin audit table.
+
+    Ordered by ``created_at DESC`` (then id DESC for stable sort
+    across same-timestamp events).
+    """
+    where = []
+    if actor_user_id is not None:
+        where.append(AuditEvent.actor_user_id == actor_user_id)
+    if target_org_id is not None:
+        where.append(AuditEvent.target_org_id == target_org_id)
+    if event_type:
+        where.append(AuditEvent.event_type == event_type)
+    if outcome:
+        # Validate against enum so a typo can't silently match nothing.
+        try:
+            outcome_enum = AuditOutcome(outcome)
+        except ValueError:
+            outcome_enum = None
+        if outcome_enum is not None:
+            where.append(AuditEvent.outcome == outcome_enum)
+    if from_dt is not None:
+        where.append(AuditEvent.created_at >= from_dt)
+    if to_dt is not None:
+        where.append(AuditEvent.created_at <= to_dt)
+
+    base = select(AuditEvent)
+    count_q = select(func.count()).select_from(AuditEvent)
+    for clause in where:
+        base = base.where(clause)
+        count_q = count_q.where(clause)
+
+    total = (await db.execute(count_q)).scalar_one()
+
+    rows_result = await db.execute(
+        base.order_by(AuditEvent.created_at.desc(), AuditEvent.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = list(rows_result.scalars().all())
+    return rows, total

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -50,6 +50,7 @@ def test_all_permissions_contains_known_platform_permissions() -> None:
         "plans.manage",
         "orgs.view",
         "orgs.manage",
+        "audit.view",
     })
 
 

--- a/backend/tests/routers/test_admin_audit.py
+++ b/backend/tests/routers/test_admin_audit.py
@@ -1,0 +1,180 @@
+"""Router tests for L4.7 GET /api/v1/admin/audit.
+
+Pins:
+- The auth gate (audit.view → superadmin short-circuit; non-superadmin
+  gets 403).
+- Response shape and ordering (newest first).
+- Pagination (limit/offset surface total + items correctly).
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.user import Organization, Role, User
+from app.routers.admin_audit import router as admin_audit_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_audit_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Audit Org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        sa = User(
+            org_id=org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=org.id, username="user",
+            email="u@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+        await db.commit()
+        return {"org_id": org.id, "sa_id": sa.id, "plain_id": plain.id}
+
+
+async def _seed_events(factory, n: int) -> None:
+    base = datetime.datetime(2026, 5, 1, 9, 0, 0)
+    async with factory() as db:
+        for i in range(n):
+            db.add(
+                AuditEvent(
+                    event_type=f"admin.org.event.{i}",
+                    actor_user_id=None,
+                    actor_email=f"actor-{i}@x.io",
+                    target_org_id=None,
+                    target_org_name=f"Org-{i}",
+                    request_id=f"req-{i}",
+                    ip_address="10.0.0.1",
+                    outcome=AuditOutcome.SUCCESS,
+                    detail={"i": i},
+                    created_at=base + datetime.timedelta(minutes=i),
+                )
+            )
+        await db.commit()
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_requires_superadmin(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 1)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_returns_events(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 3)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 3
+    assert len(body["items"]) == 3
+    # Newest first — index 2 is the last seeded (latest timestamp).
+    assert body["items"][0]["event_type"] == "admin.org.event.2"
+    assert body["items"][0]["outcome"] == "success"
+    assert body["items"][0]["request_id"] == "req-2"
+    assert body["items"][0]["target_org_name"] == "Org-2"
+    assert body["items"][0]["detail"] == {"i": 2}
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_pagination(session_factory):
+    await _seed(session_factory)
+    await _seed_events(session_factory, 5)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit?limit=2&offset=0")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 5
+        assert len(body["items"]) == 2
+
+        res2 = client.get("/api/v1/admin/audit?limit=2&offset=4")
+        body2 = res2.json()
+        assert body2["total"] == 5
+        assert len(body2["items"]) == 1

--- a/backend/tests/routers/test_audit_wiring.py
+++ b/backend/tests/routers/test_audit_wiring.py
@@ -1,0 +1,214 @@
+"""End-to-end audit wiring tests (L4.7).
+
+The point isn't to re-test admin behaviour (already covered in
+``test_admin_orgs.py`` / ``test_org_data.py``) — it's to prove that
+each call site we wired writes an ``audit_events`` row in addition
+to its existing structlog event. Two important paths:
+
+- A success: subscription override writes a `success` audit row.
+- A FAILURE: when the org-cascade delete blows up mid-transaction,
+  the business txn rolls back but an audit `failure` row must still
+  exist (independent-session pattern).
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization, Role, User
+from app.routers.admin_orgs import router as admin_orgs_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    def override_session_factory():
+        # Hand the test's in-memory factory to the audit recorder so
+        # it writes into the same SQLite the test reads from.
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(admin_orgs_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        plan = Plan(slug="free", name="Free")
+        db.add(plan)
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target = Organization(name="Target Inc", billing_cycle_day=1)
+        db.add_all([admin_org, target])
+        await db.commit()
+        sa = User(
+            org_id=admin_org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        db.add(sa)
+        await db.commit()
+        target_sub = Subscription(
+            org_id=target.id, plan_id=plan.id,
+            status=SubscriptionStatus.TRIALING,
+            billing_interval=BillingInterval.MONTHLY,
+            trial_end=datetime.date.today() + datetime.timedelta(days=14),
+        )
+        admin_sub = Subscription(
+            org_id=admin_org.id, plan_id=plan.id,
+            status=SubscriptionStatus.ACTIVE,
+            billing_interval=BillingInterval.MONTHLY,
+        )
+        db.add_all([target_sub, admin_sub])
+        await db.commit()
+        return {
+            "admin_user_id": sa.id,
+            "admin_org_id": admin_org.id,
+            "target_id": target.id,
+            "target_name": target.name,
+        }
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+@pytest.mark.asyncio
+async def test_subscription_override_writes_audit(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/subscription",
+            json={"status": "active"},
+        )
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.subscription.override"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == AuditOutcome.SUCCESS
+    assert row.actor_user_id == seed["admin_user_id"]
+    assert row.actor_email == "root@platform.io"
+    assert row.target_org_id == seed["target_id"]
+    assert row.target_org_name == seed["target_name"]
+    assert row.detail is not None
+    assert "before" in row.detail and "after" in row.detail
+
+
+@pytest.mark.asyncio
+async def test_delete_failed_writes_audit(session_factory):
+    """Patch delete_org_cascade to raise — verify a `failure` audit
+    row exists even though the business txn rolled back. This is the
+    whole point of writing audit on an independent session.
+    """
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("simulated cascade failure")
+
+    with patch(
+        "app.routers.admin_orgs.admin_orgs_service.delete_org_cascade",
+        side_effect=boom,
+    ):
+        with TestClient(app) as client:
+            res = client.request(
+                "DELETE",
+                f"/api/v1/admin/orgs/{seed['target_id']}",
+                json={"confirm_name": seed["target_name"]},
+            )
+    assert res.status_code == 500
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.delete.failed"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == AuditOutcome.FAILURE
+    assert row.target_org_id == seed["target_id"]
+    assert row.target_org_name == seed["target_name"]
+    assert row.detail is not None
+    assert row.detail.get("error_type") == "RuntimeError"
+
+    # The target org is still present — the business txn was rolled
+    # back. Sanity check: the audit row survived a rollback because
+    # it was written on its OWN session.
+    async with session_factory() as db:
+        target = (
+            await db.execute(
+                select(Organization).where(Organization.id == seed["target_id"])
+            )
+        ).scalar_one_or_none()
+    assert target is not None

--- a/backend/tests/services/test_audit_service.py
+++ b/backend/tests/services/test_audit_service.py
@@ -1,0 +1,204 @@
+"""Service-layer tests for L4.7 audit_service.
+
+Two properties to pin tightly:
+
+1. ``record_audit_event`` opens its OWN session through the factory
+   and commits — so an audit row exists even when the caller's session
+   was rolled back.
+2. ``record_audit_event`` NEVER raises. A broken factory must be
+   absorbed; the caller's structlog event is the fallback channel.
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.services.audit_service import list_audit_events, record_audit_event
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+# ── recording ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_audit_event_commits_independently(session_factory):
+    """Audit row is visible to a freshly-opened session — i.e. it was
+    actually committed, not just flushed inside the recorder's
+    not-yet-committed scope.
+    """
+    await record_audit_event(
+        session_factory,
+        event_type="admin.org.delete",
+        actor_user_id=None,
+        actor_email="root@example.io",
+        target_org_id=None,
+        target_org_name="Some Org",
+        request_id="abc123",
+        ip_address="10.0.0.1",
+        outcome="success",
+        detail={"k": "v"},
+    )
+
+    async with session_factory() as db:
+        rows = (await db.execute(select(AuditEvent))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.event_type == "admin.org.delete"
+    assert row.actor_email == "root@example.io"
+    assert row.target_org_name == "Some Org"
+    assert row.request_id == "abc123"
+    assert row.ip_address == "10.0.0.1"
+    assert row.outcome == AuditOutcome.SUCCESS
+    assert row.detail == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_record_audit_event_survives_bad_session():
+    """If the factory itself blows up, record_audit_event must NOT
+    raise — the structlog event the caller already emitted is the
+    backup channel and we don't want to mask the original 200/500 the
+    user sees.
+    """
+    def broken_factory():
+        raise RuntimeError("DB unreachable")
+
+    # Should not raise.
+    await record_audit_event(
+        broken_factory,
+        event_type="admin.org.delete",
+        actor_user_id=None,
+        actor_email="root@example.io",
+        target_org_id=None,
+        target_org_name=None,
+        request_id=None,
+        ip_address=None,
+        outcome="failure",
+        detail=None,
+    )
+
+
+# ── querying ────────────────────────────────────────────────────────────
+
+
+async def _seed_three(factory) -> None:
+    """Three rows: 2 success, 1 failure, spread across two timestamps."""
+    base = datetime.datetime(2026, 5, 1, 9, 0, 0)
+    async with factory() as db:
+        db.add_all([
+            AuditEvent(
+                event_type="admin.org.delete",
+                actor_user_id=None,
+                actor_email="a@x.io",
+                target_org_id=None,
+                target_org_name="A",
+                request_id="r1",
+                ip_address=None,
+                outcome=AuditOutcome.SUCCESS,
+                detail=None,
+                created_at=base,
+            ),
+            AuditEvent(
+                event_type="admin.org.delete.failed",
+                actor_user_id=None,
+                actor_email="b@x.io",
+                target_org_id=None,
+                target_org_name="B",
+                request_id="r2",
+                ip_address=None,
+                outcome=AuditOutcome.FAILURE,
+                detail=None,
+                created_at=base + datetime.timedelta(hours=1),
+            ),
+            AuditEvent(
+                event_type="admin.org.subscription.override",
+                actor_user_id=None,
+                actor_email="c@x.io",
+                target_org_id=None,
+                target_org_name="C",
+                request_id="r3",
+                ip_address=None,
+                outcome=AuditOutcome.SUCCESS,
+                detail=None,
+                created_at=base + datetime.timedelta(hours=2),
+            ),
+        ])
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_audit_events_filters_by_outcome(session_factory):
+    await _seed_three(session_factory)
+    async with session_factory() as db:
+        rows, total = await list_audit_events(db, outcome="failure")
+    assert total == 1
+    assert len(rows) == 1
+    assert rows[0].event_type == "admin.org.delete.failed"
+
+
+@pytest.mark.asyncio
+async def test_list_audit_events_date_range(session_factory):
+    await _seed_three(session_factory)
+    async with session_factory() as db:
+        rows, total = await list_audit_events(
+            db,
+            from_dt=datetime.datetime(2026, 5, 1, 9, 30, 0),
+            to_dt=datetime.datetime(2026, 5, 1, 10, 30, 0),
+        )
+    # The middle event (10:00) is the only one inside the window.
+    assert total == 1
+    assert rows[0].event_type == "admin.org.delete.failed"
+
+
+@pytest.mark.asyncio
+async def test_list_audit_events_orders_newest_first(session_factory):
+    await _seed_three(session_factory)
+    async with session_factory() as db:
+        rows, total = await list_audit_events(db)
+    assert total == 3
+    # Newest first — the 11:00 row leads.
+    assert rows[0].event_type == "admin.org.subscription.override"
+    assert rows[-1].event_type == "admin.org.delete"
+
+
+@pytest.mark.asyncio
+async def test_list_audit_events_pagination(session_factory):
+    await _seed_three(session_factory)
+    async with session_factory() as db:
+        rows, total = await list_audit_events(db, limit=2, offset=0)
+    assert total == 3
+    assert len(rows) == 2
+    async with session_factory() as db:
+        rows2, total2 = await list_audit_events(db, limit=2, offset=2)
+    assert total2 == 3
+    assert len(rows2) == 1

--- a/frontend/app/admin/audit/page.tsx
+++ b/frontend/app/admin/audit/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { isSuperadmin } from "@/lib/auth";
+import type { AuditEvent, AuditEventListResponse } from "@/lib/types";
+import {
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  pageTitle,
+} from "@/lib/styles";
+
+const PAGE_SIZE = 50;
+
+const dtFmt = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+function shortRequestId(value: string | null): string {
+  if (!value) return "";
+  return value.length > 12 ? value.slice(0, 12) : value;
+}
+
+export default function AdminAuditPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<AuditEventListResponse | null>(null);
+  const [error, setError] = useState("");
+  const [eventTypeInput, setEventTypeInput] = useState("");
+  const [outcomeInput, setOutcomeInput] = useState("");
+  const [targetOrgInput, setTargetOrgInput] = useState("");
+  const [offset, setOffset] = useState(0);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!isSuperadmin(user)) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (loading || !user || !isSuperadmin(user)) return;
+    setFetching(true);
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+    });
+    if (eventTypeInput.trim()) params.set("event_type", eventTypeInput.trim());
+    if (outcomeInput) params.set("outcome", outcomeInput);
+    const targetOrg = targetOrgInput.trim();
+    if (targetOrg && /^[1-9][0-9]*$/.test(targetOrg)) {
+      params.set("target_org_id", targetOrg);
+    }
+    apiFetch<AuditEventListResponse>(
+      `/api/v1/admin/audit?${params.toString()}`,
+    )
+      .then((d) => setData(d))
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
+      .finally(() => setFetching(false));
+  }, [loading, user, eventTypeInput, outcomeInput, targetOrgInput, offset]);
+
+  if (loading || !user || !isSuperadmin(user)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <h1 className={pageTitle}>Audit log</h1>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Recent events</h2>
+        </div>
+        <div className="grid grid-cols-1 gap-3 px-6 py-4 sm:grid-cols-3">
+          <input
+            type="search"
+            value={eventTypeInput}
+            onChange={(e) => {
+              setOffset(0);
+              setEventTypeInput(e.target.value);
+            }}
+            placeholder="Event type (exact)"
+            className={input}
+            aria-label="Filter by event type"
+          />
+          <select
+            value={outcomeInput}
+            onChange={(e) => {
+              setOffset(0);
+              setOutcomeInput(e.target.value);
+            }}
+            className={input}
+            aria-label="Filter by outcome"
+          >
+            <option value="">All outcomes</option>
+            <option value="success">Success</option>
+            <option value="failure">Failure</option>
+          </select>
+          <input
+            type="text"
+            inputMode="numeric"
+            value={targetOrgInput}
+            onChange={(e) => {
+              setOffset(0);
+              setTargetOrgInput(e.target.value);
+            }}
+            placeholder="Target org ID"
+            className={input}
+            aria-label="Filter by target org id"
+          />
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3">When</th>
+                <th className="px-6 py-3">Event type</th>
+                <th className="px-6 py-3">Actor email</th>
+                <th className="px-6 py-3">Target org</th>
+                <th className="px-6 py-3">Outcome</th>
+                <th className="px-6 py-3">Request ID</th>
+                <th className="px-6 py-3">IP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && (
+                <tr>
+                  <td
+                    colSpan={7}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!fetching && data?.items.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={7}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    No audit events match.
+                  </td>
+                </tr>
+              )}
+              {!fetching &&
+                data?.items.map((row: AuditEvent) => (
+                  <tr key={row.id} className="border-b border-border-subtle">
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {dtFmt.format(new Date(row.created_at))}
+                    </td>
+                    <td className="px-6 py-3 text-text-primary">
+                      {row.event_type}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary">
+                      {row.actor_email}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary">
+                      {row.target_org_name ?? "—"}
+                      {row.target_org_id != null && (
+                        <span className="ml-1 text-text-muted">
+                          (#{row.target_org_id})
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-6 py-3">
+                      <span
+                        className={
+                          row.outcome === "success"
+                            ? "rounded-full bg-success/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-success"
+                            : "rounded-full bg-danger/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-danger"
+                        }
+                      >
+                        {row.outcome}
+                      </span>
+                    </td>
+                    <td
+                      className="px-6 py-3 font-mono text-xs text-text-muted"
+                      title={row.request_id ?? ""}
+                    >
+                      {shortRequestId(row.request_id)}
+                    </td>
+                    <td className="px-6 py-3 font-mono text-xs text-text-muted">
+                      {row.ip_address ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+
+        {data && data.total > PAGE_SIZE && (
+          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
+            <span>
+              {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
+              {data.total}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                disabled={offset + PAGE_SIZE >= data.total}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/admin/audit/page.tsx
+++ b/frontend/app/admin/audit/page.tsx
@@ -183,7 +183,7 @@ export default function AdminAuditPage() {
                       {row.actor_email}
                     </td>
                     <td className="px-6 py-3 text-text-secondary">
-                      {row.target_org_name ?? "—"}
+                      {row.target_org_name ?? "-"}
                       {row.target_org_id != null && (
                         <span className="ml-1 text-text-muted">
                           (#{row.target_org_id})
@@ -208,7 +208,7 @@ export default function AdminAuditPage() {
                       {shortRequestId(row.request_id)}
                     </td>
                     <td className="px-6 py-3 font-mono text-xs text-text-muted">
-                      {row.ip_address ?? "—"}
+                      {row.ip_address ?? "-"}
                     </td>
                   </tr>
                 ))}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -126,6 +127,28 @@ export default function AdminDashboardPage() {
               <h2 className={`${cardTitle} mb-2`}>System health</h2>
               <HealthRow name="Database" cell={data.health.db} />
               <HealthRow name="Redis" cell={data.health.redis} />
+            </section>
+
+            <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Link
+                href="/admin/orgs"
+                className={`${card} block p-5 transition-colors hover:border-accent`}
+              >
+                <h2 className={`${cardTitle} mb-1`}>Organizations</h2>
+                <p className="text-sm text-text-secondary">
+                  Search, drill into, and manage every org on the platform.
+                </p>
+              </Link>
+              <Link
+                href="/admin/audit"
+                className={`${card} block p-5 transition-colors hover:border-accent`}
+              >
+                <h2 className={`${cardTitle} mb-1`}>Audit log</h2>
+                <p className="text-sm text-text-secondary">
+                  Persisted record of platform actions (subscription overrides,
+                  org deletes, tenant resets).
+                </p>
+              </Link>
             </section>
           </>
         )}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -97,6 +97,15 @@ const systemItems = [
     ),
   },
   {
+    href: "/admin/audit",
+    label: "Audit log",
+    icon: (
+      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2Z" />
+      </svg>
+    ),
+  },
+  {
     href: "/system/plans",
     label: "Plans",
     icon: (

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -361,3 +361,22 @@ export interface UnpairTransactionRequest {
   expense_fallback_category_id: number;
   income_fallback_category_id: number;
 }
+
+export interface AuditEvent {
+  id: number;
+  event_type: string;
+  actor_user_id: number | null;
+  actor_email: string;
+  target_org_id: number | null;
+  target_org_name: string | null;
+  request_id: string | null;
+  ip_address: string | null;
+  outcome: "success" | "failure";
+  detail: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AuditEventListResponse {
+  items: AuditEvent[];
+  total: number;
+}

--- a/frontend/tests/app/admin-page.test.tsx
+++ b/frontend/tests/app/admin-page.test.tsx
@@ -96,9 +96,12 @@ describe("/admin page", () => {
     render(<AdminDashboardPage />);
 
     expect(await screen.findByText("Admin")).toBeInTheDocument();
-    expect(screen.getByText("Organizations")).toBeInTheDocument();
+    // "Organizations" appears in both the KPI label and the quick-link
+    // card — at least one match is enough to confirm the page rendered.
+    expect(screen.getAllByText("Organizations").length).toBeGreaterThan(0);
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("System health")).toBeInTheDocument();
+    expect(screen.getByText("Audit log")).toBeInTheDocument();
     expect(screen.getByText("Database")).toBeInTheDocument();
     expect(screen.getByText("Redis")).toBeInTheDocument();
     expect(screen.getByText("timeout")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Adds `audit_events` table (migration 030) and persists existing `admin.org.*` and `org.data.*` structlog events into it via independent-session writes (failures don't kill the request, structlog stays as backup).
- New `GET /api/v1/admin/audit` gated by `audit.view` permission. New `/admin/audit` page mirrors `/admin/orgs` table pattern.
- `audit_events` deliberately excluded from `wipe_org_data` so the log survives org operations it describes.