### PR TITLE
chore(plans): drop legacy ai_*_enabled columns and dual-read shim (CLEANUP-029)

### DIFF
--- a/backend/alembic/versions/028_plan_features_and_org_overrides.py
+++ b/backend/alembic/versions/028_plan_features_and_org_overrides.py
@@ -8,7 +8,7 @@ L4.11 — adds:
   * plans.features JSON NOT NULL DEFAULT (JSON_OBJECT())
     Backfilled from legacy ai_budget_enabled / ai_forecast_enabled /
     ai_smart_plan_enabled columns. ai.autocategorize defaults False.
-    Legacy columns survive for one release as rollback ballast (CLEANUP-029).
+    Legacy columns dropped in migration 032.
 
   * org_feature_overrides table — single-current per-org boolean overrides
     keyed on UNIQUE(org_id, feature_key).

--- a/backend/alembic/versions/032_drop_legacy_plan_ai_columns.py
+++ b/backend/alembic/versions/032_drop_legacy_plan_ai_columns.py
@@ -1,0 +1,84 @@
+"""Drop legacy plans.ai_*_enabled columns (CLEANUP-029).
+
+Revision ID: 032_drop_legacy_plan_ai
+Revises: 031_password_set_stepup
+Create Date: 2026-05-07
+
+L4.11 follow-up. Migration 028 added plans.features (JSON) and backfilled
+it from the three legacy boolean columns; PlanResponse derived the legacy
+booleans from features for one release. Now that the JSON column is the
+single source of truth, drop the columns and the dual-read shim.
+
+Downgrade re-adds the columns and backfills from features JSON so a
+rollback is non-lossy.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
+
+revision = "032_drop_legacy_plan_ai"
+down_revision = "031_password_set_stepup"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("plans", "ai_budget_enabled")
+    op.drop_column("plans", "ai_forecast_enabled")
+    op.drop_column("plans", "ai_smart_plan_enabled")
+
+
+def downgrade() -> None:
+    # Re-add as nullable=False with server_default="0" so existing rows
+    # accept the new column; we then backfill from features JSON.
+    op.add_column(
+        "plans",
+        sa.Column(
+            "ai_budget_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "plans",
+        sa.Column(
+            "ai_forecast_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "plans",
+        sa.Column(
+            "ai_smart_plan_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+    plans_t = table(
+        "plans",
+        column("id", sa.Integer),
+        column("ai_budget_enabled", sa.Boolean),
+        column("ai_forecast_enabled", sa.Boolean),
+        column("ai_smart_plan_enabled", sa.Boolean),
+        column("features", sa.JSON),
+    )
+    conn = op.get_bind()
+    rows = conn.execute(sa.select(plans_t.c.id, plans_t.c.features)).fetchall()
+    for row in rows:
+        features = row.features or {}
+        conn.execute(
+            plans_t.update()
+            .where(plans_t.c.id == row.id)
+            .values(
+                ai_budget_enabled=bool(features.get("ai.budget", False)),
+                ai_forecast_enabled=bool(features.get("ai.forecast", False)),
+                ai_smart_plan_enabled=bool(features.get("ai.smart_plan", False)),
+            )
+        )

--- a/backend/app/routers/subscriptions.py
+++ b/backend/app/routers/subscriptions.py
@@ -22,7 +22,7 @@ def _sub_response(sub, plan) -> dict:
     return {
         "id": sub.id,
         "org_id": sub.org_id,
-        # PlanResponse handles features + CLEANUP-029 derived ai_*_enabled fields.
+        # PlanResponse canonicalizes features for the wire shape.
         "plan": PlanResponse.model_validate(plan).model_dump(),
         "status": sub.status.value,
         "billing_interval": sub.billing_interval.value,

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, computed_field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator
 
 from app.auth.feature_catalog import PlanFeatures
 
@@ -28,24 +28,6 @@ class PlanResponse(BaseModel):
         # drifts (manual SQL, partial migration), the wire shape stays
         # canonical so consumers don't break.
         return PlanFeatures.model_validate(v or {}).model_dump(by_alias=True)
-
-    # CLEANUP-029: remove the three computed fields below when migration
-    # 029 ships. Frontend `Plan` type and `/settings/billing/page.tsx`
-    # tier-descriptor logic also migrate to read `features` directly.
-    @computed_field  # type: ignore[misc]
-    @property
-    def ai_budget_enabled(self) -> bool:
-        return self.features.get("ai.budget", False)
-
-    @computed_field  # type: ignore[misc]
-    @property
-    def ai_forecast_enabled(self) -> bool:
-        return self.features.get("ai.forecast", False)
-
-    @computed_field  # type: ignore[misc]
-    @property
-    def ai_smart_plan_enabled(self) -> bool:
-        return self.features.get("ai.smart_plan", False)
 
 
 class PlanCreate(BaseModel):

--- a/backend/tests/schemas/test_plan_response.py
+++ b/backend/tests/schemas/test_plan_response.py
@@ -1,34 +1,12 @@
-"""Compatibility-shim contract for L4.11.
+"""PlanResponse / PlanCreate / PlanUpdate validation contract.
 
-Verifies PlanResponse.features is canonical and the three legacy
-ai_*_enabled fields derive from it. This is the most-likely-to-regress
-contract during the shim window.
+Verifies features canonicalization on read, and that legacy ai_* keys
+on write are rejected by extra="forbid".
 """
 import pytest
 from pydantic import ValidationError
 
 from app.schemas.subscription import PlanCreate, PlanResponse, PlanUpdate
-
-
-def test_plan_response_legacy_fields_derive_from_features():
-    plan = PlanResponse(
-        id=1, name="Pro", slug="pro", description="", is_custom=False,
-        is_active=True, sort_order=1,
-        price_monthly=10, price_yearly=100,
-        max_users=None, retention_days=None,
-        features={"ai.budget": True, "ai.forecast": False, "ai.smart_plan": True, "ai.autocategorize": False},
-    )
-    payload = plan.model_dump()
-
-    # Canonical features are the source.
-    assert payload["features"]["ai.budget"] is True
-    assert payload["features"]["ai.forecast"] is False
-    assert payload["features"]["ai.smart_plan"] is True
-
-    # Legacy booleans derive from features (CLEANUP-029).
-    assert payload["ai_budget_enabled"] is True
-    assert payload["ai_forecast_enabled"] is False
-    assert payload["ai_smart_plan_enabled"] is True
 
 
 def test_plan_response_features_canonicalizes_missing_keys():
@@ -47,11 +25,35 @@ def test_plan_response_features_canonicalizes_missing_keys():
     assert out["ai.autocategorize"] is False
 
 
+def test_plan_response_features_full_payload():
+    plan = PlanResponse(
+        id=1, name="Pro", slug="pro", description="", is_custom=False,
+        is_active=True, sort_order=1,
+        price_monthly=10, price_yearly=100,
+        max_users=None, retention_days=None,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": True,
+            "ai.autocategorize": False,
+        },
+    )
+    payload = plan.model_dump()
+    assert payload["features"]["ai.budget"] is True
+    assert payload["features"]["ai.forecast"] is False
+    assert payload["features"]["ai.smart_plan"] is True
+    assert payload["features"]["ai.autocategorize"] is False
+    # Legacy ai_*_enabled keys are gone.
+    assert "ai_budget_enabled" not in payload
+    assert "ai_forecast_enabled" not in payload
+    assert "ai_smart_plan_enabled" not in payload
+
+
 def test_plan_create_rejects_legacy_ai_payload():
     with pytest.raises(ValidationError):
         PlanCreate.model_validate({
             "name": "X", "slug": "x",
-            "ai_budget_enabled": True,  # legacy field — extra="forbid" rejects
+            "ai_budget_enabled": True,  # legacy field; extra="forbid" rejects
         })
 
 

--- a/frontend/app/settings/billing/page.tsx
+++ b/frontend/app/settings/billing/page.tsx
@@ -194,9 +194,9 @@ export default function BillingPage() {
                 <div>
                   <p className="text-[11px] font-semibold uppercase tracking-wider text-text-muted">AI Features</p>
                   <p className="text-sm font-medium text-text-primary">
-                    {currentPlan.ai_smart_plan_enabled
+                    {currentPlan.features["ai.smart_plan"]
                       ? "Full Access"
-                      : currentPlan.ai_budget_enabled
+                      : currentPlan.features["ai.budget"]
                         ? "Budget Only"
                         : "None"}
                   </p>
@@ -247,9 +247,9 @@ export default function BillingPage() {
                         {plan.retention_days ? `${plan.retention_days}-day data retention` : "Unlimited retention"}
                       </li>
                       <li>
-                        {plan.ai_smart_plan_enabled
+                        {plan.features["ai.smart_plan"]
                           ? "All AI features"
-                          : plan.ai_budget_enabled
+                          : plan.features["ai.budget"]
                             ? "AI budget suggestions"
                             : "No AI features"}
                       </li>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -262,11 +262,6 @@ export interface Plan {
   max_users: number | null;
   retention_days: number | null;
   features: PlanFeatures;
-
-  // CLEANUP-029: remove the three fields below when migration 029 ships.
-  ai_budget_enabled: boolean;
-  ai_forecast_enabled: boolean;
-  ai_smart_plan_enabled: boolean;
 }
 
 export type SubscriptionStatus = "trialing" | "active" | "past_due" | "canceled";

--- a/frontend/tests/app/system-plans-page.test.tsx
+++ b/frontend/tests/app/system-plans-page.test.tsx
@@ -52,9 +52,6 @@ const PRO_PLAN = {
     "ai.smart_plan": false,
     "ai.autocategorize": false,
   },
-  ai_budget_enabled: true,
-  ai_forecast_enabled: false,
-  ai_smart_plan_enabled: false,
 };
 
 describe("/system/plans page — Features section + Duplicate", () => {


### PR DESCRIPTION
## Summary

Follow-up to L4.11 / migration 028. Now that `plans.features` (JSON) has shipped through one release as the canonical entitlement store, drop the three legacy boolean columns (`ai_budget_enabled`, `ai_forecast_enabled`, `ai_smart_plan_enabled`) and remove the `@computed_field` dual-read shim from `PlanResponse`. Frontend tier descriptors switch to reading `plan.features` directly.

## Changes

- **Migration 032** (`032_drop_legacy_plan_ai_columns.py`): drops the three columns. Downgrade re-adds them as `NOT NULL DEFAULT 0` and backfills from `features` JSON for non-lossy rollback.
- **Backend schema** (`backend/app/schemas/subscription.py`): removes the three `@computed_field` shim properties and the `computed_field` import.
- **Backend router** (`backend/app/routers/subscriptions.py`): updates an outdated comment.
- **Backend tests**: renames `test_plan_response_shim.py` → `test_plan_response.py`, drops the legacy-derive test, adds a regression test asserting the legacy keys are no longer in the wire payload. The `extra="forbid"` rejection tests stay (they guard `PlanCreate` / `PlanUpdate` against accidental legacy payloads).
- **Frontend types** (`frontend/lib/types.ts`): drops the three legacy fields from the `Plan` interface.
- **Frontend billing page** (`frontend/app/settings/billing/page.tsx`): tier descriptors read `plan.features["ai.smart_plan"]` / `plan.features["ai.budget"]` directly.
- **Frontend test fixture** (`frontend/tests/app/system-plans-page.test.tsx`): drops the three legacy fields from `PRO_PLAN`.
- **Migration 028 docstring**: updated to point at 032 (no behavior change).

Round-trip verified locally: `alembic upgrade head` → `downgrade -1` (columns re-created and backfilled from JSON) → `upgrade head` (columns dropped again). Backend 409 passed / frontend 165 passed.