### PR TITLE
chore: tech-debt bundle (next.config mount, expired override sweep, logger dedupe)

### DIFF
--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from app._time import utcnow_naive
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 import structlog
@@ -36,7 +36,6 @@ from app.services import admin_orgs_service, audit_service, feature_service
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 logger = structlog.stdlib.get_logger()
-log = structlog.get_logger()
 
 router = APIRouter(prefix="/api/v1/admin/orgs", tags=["admin-orgs"])
 
@@ -234,6 +233,47 @@ async def _override_to_response(row: OrgFeatureOverride, db: AsyncSession) -> di
     }
 
 
+@router.post("/feature-overrides/sweep-expired")
+async def sweep_expired_feature_overrides(
+    request: Request,
+    user: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Delete every ``org_feature_overrides`` row whose ``expires_at``
+    is in the past. Idempotent (returns ``deleted_count: 0`` when nothing
+    matches). Audit row is always written.
+    """
+    cutoff = utcnow_naive()
+    result = await db.execute(
+        delete(OrgFeatureOverride)
+        .where(OrgFeatureOverride.expires_at.is_not(None))
+        .where(OrgFeatureOverride.expires_at <= cutoff)
+    )
+    deleted_count = result.rowcount or 0
+    await db.commit()
+
+    await logger.ainfo(
+        "admin.feature_override.expired_swept",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        deleted_count=deleted_count,
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.feature_override.expired_swept",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=None,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"deleted_count": deleted_count},
+    )
+    return {"deleted_count": deleted_count}
+
+
 @router.put(
     "/{org_id}/feature-overrides/{feature_key}",
     response_model=OrgFeatureOverrideResponse,
@@ -299,7 +339,7 @@ async def set_feature_override(
             detail="Override changed concurrently; retry.",
         )
 
-    log.info(
+    await logger.ainfo(
         "admin.org.feature.set",
         target_org_id=org_id,
         feature_key=feature_key,
@@ -378,7 +418,7 @@ async def revoke_feature_override(
     await db.delete(existing)
     await db.commit()
 
-    log.info(
+    await logger.ainfo(
         "admin.org.feature.revoked",
         target_org_id=org_id,
         feature_key=feature_key,

--- a/backend/tests/routers/test_admin_feature_overrides.py
+++ b/backend/tests/routers/test_admin_feature_overrides.py
@@ -13,7 +13,7 @@ DELETE coverage lives in `test_admin_feature_overrides_delete.py`
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -25,8 +25,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.feature_override import OrgFeatureOverride
 from app.models.user import Organization, Role, User
 from app.routers.admin_orgs import router as admin_orgs_router
 from app.security import hash_password
@@ -65,8 +67,12 @@ def make_app(session_factory, current_user_resolver):
     async def override_current_user() -> User:
         return await current_user_resolver(session_factory)
 
+    def override_session_factory():
+        return session_factory
+
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
     app.include_router(admin_orgs_router)
     return app
 
@@ -131,7 +137,8 @@ def _plain_user_resolver():
 async def test_put_sets_new_override(session_factory):
     seed = await _seed(session_factory)
     app = make_app(session_factory, _superadmin_resolver())
-    with patch("app.routers.admin_orgs.log") as mock_log:
+    from app.routers import admin_orgs as admin_orgs_module
+    with patch.object(admin_orgs_module.logger, "ainfo", new_callable=AsyncMock) as mock_ainfo:
         with TestClient(app) as client:
             res = client.put(
                 f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
@@ -145,9 +152,13 @@ async def test_put_sets_new_override(session_factory):
     assert body["set_by_email"] == seed["admin_email"]
     assert body["is_expired"] is False
 
-    mock_log.info.assert_called_once()
-    args, kwargs = mock_log.info.call_args
-    assert args[0] == "admin.org.feature.set"
+    # Find the structured event among possibly-multiple ainfo calls.
+    set_calls = [
+        c for c in mock_ainfo.call_args_list
+        if c.args and c.args[0] == "admin.org.feature.set"
+    ]
+    assert len(set_calls) == 1
+    args, kwargs = set_calls[0]
     assert kwargs["target_org_id"] == seed["target_id"]
     assert kwargs["feature_key"] == "ai.budget"
     assert kwargs["old_value"] is None
@@ -171,7 +182,8 @@ async def test_put_updates_existing_override(session_factory):
         assert first.status_code == 200
         assert first.json()["value"] is True
 
-        with patch("app.routers.admin_orgs.log") as mock_log:
+        from app.routers import admin_orgs as admin_orgs_module
+        with patch.object(admin_orgs_module.logger, "ainfo", new_callable=AsyncMock) as mock_ainfo:
             second = client.put(
                 f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.forecast",
                 json={"value": False, "note": "rolled back"},
@@ -182,9 +194,12 @@ async def test_put_updates_existing_override(session_factory):
     assert body["value"] is False
     assert body["set_by_email"] == seed["admin_email"]
 
-    mock_log.info.assert_called_once()
-    args, kwargs = mock_log.info.call_args
-    assert args[0] == "admin.org.feature.set"
+    set_calls = [
+        c for c in mock_ainfo.call_args_list
+        if c.args and c.args[0] == "admin.org.feature.set"
+    ]
+    assert len(set_calls) == 1
+    args, kwargs = set_calls[0]
     assert kwargs["old_value"] is True
     assert kwargs["new_value"] is False
     assert kwargs["note_present"] is True
@@ -258,7 +273,8 @@ async def test_delete_revokes_existing_override(session_factory):
         )
         assert put_res.status_code == 200
 
-        with patch("app.routers.admin_orgs.log") as mock_log:
+        from app.routers import admin_orgs as admin_orgs_module
+        with patch.object(admin_orgs_module.logger, "ainfo", new_callable=AsyncMock) as mock_ainfo:
             del_res = client.delete(
                 f"/api/v1/admin/orgs/{seed['target_id']}/feature-overrides/ai.budget",
             )
@@ -266,9 +282,12 @@ async def test_delete_revokes_existing_override(session_factory):
     assert del_res.status_code == 204
     assert del_res.content == b""
 
-    mock_log.info.assert_called_once()
-    args, kwargs = mock_log.info.call_args
-    assert args[0] == "admin.org.feature.revoked"
+    revoked_calls = [
+        c for c in mock_ainfo.call_args_list
+        if c.args and c.args[0] == "admin.org.feature.revoked"
+    ]
+    assert len(revoked_calls) == 1
+    args, kwargs = revoked_calls[0]
     assert kwargs["target_org_id"] == seed["target_id"]
     assert kwargs["feature_key"] == "ai.budget"
     assert kwargs["old_value"] is True
@@ -385,3 +404,156 @@ async def test_put_refreshes_set_at_on_update(session_factory):
     # ISO-8601 is lexicographically ordered, so a string compare suffices,
     # but parsing is more explicit.
     assert datetime.fromisoformat(new_set_at) > past
+
+
+# ── POST /feature-overrides/sweep-expired ─────────────────────────────────
+
+
+async def _seed_overrides(factory, target_id: int, *, admin_user_id: int) -> None:
+    """Plant 4 overrides on target org: 2 expired, 1 future, 1 NULL expiry."""
+    from datetime import timedelta
+
+    from app._time import utcnow_naive
+
+    now = utcnow_naive()
+    past_1 = now - timedelta(days=1)
+    past_2 = now - timedelta(hours=1)
+    future = now + timedelta(days=7)
+    async with factory() as db:
+        db.add_all([
+            OrgFeatureOverride(
+                org_id=target_id, feature_key="ai.budget",
+                value=True, set_by=admin_user_id, expires_at=past_1,
+            ),
+            OrgFeatureOverride(
+                org_id=target_id, feature_key="ai.forecast",
+                value=True, set_by=admin_user_id, expires_at=past_2,
+            ),
+            OrgFeatureOverride(
+                org_id=target_id, feature_key="ai.smart_plan",
+                value=True, set_by=admin_user_id, expires_at=future,
+            ),
+            OrgFeatureOverride(
+                org_id=target_id, feature_key="ai.autocategorize",
+                value=True, set_by=admin_user_id, expires_at=None,
+            ),
+        ])
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_sweep_deletes_only_expired_rows(session_factory):
+    """Only rows whose expires_at is past NOW are deleted. Future-
+    and NULL-expiry rows are untouched."""
+    from sqlalchemy import select as _select
+
+    seed = await _seed(session_factory)
+    await _seed_overrides(
+        session_factory, seed["target_id"], admin_user_id=seed["admin_user_id"]
+    )
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post("/api/v1/admin/orgs/feature-overrides/sweep-expired")
+
+    assert res.status_code == 200
+    assert res.json() == {"deleted_count": 2}
+
+    async with session_factory() as db:
+        remaining_keys = sorted(
+            (
+                await db.execute(
+                    _select(OrgFeatureOverride.feature_key).where(
+                        OrgFeatureOverride.org_id == seed["target_id"]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert remaining_keys == ["ai.autocategorize", "ai.smart_plan"]
+
+
+@pytest.mark.asyncio
+async def test_sweep_writes_audit_event(session_factory):
+    """A successful sweep records exactly one
+    ``admin.feature_override.expired_swept`` audit row carrying
+    ``deleted_count`` in detail and no PII beyond the actor email."""
+    from sqlalchemy import select as _select
+
+    seed = await _seed(session_factory)
+    await _seed_overrides(
+        session_factory, seed["target_id"], admin_user_id=seed["admin_user_id"]
+    )
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post("/api/v1/admin/orgs/feature-overrides/sweep-expired")
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                _select(AuditEvent).where(
+                    AuditEvent.event_type
+                    == "admin.feature_override.expired_swept"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == AuditOutcome.SUCCESS
+    assert row.actor_user_id == seed["admin_user_id"]
+    assert row.actor_email == seed["admin_email"]
+    assert row.target_org_id is None
+    assert row.target_org_name is None
+    assert row.detail == {"deleted_count": 2}
+
+
+@pytest.mark.asyncio
+async def test_sweep_idempotent_when_nothing_expired(session_factory):
+    """No expired rows → returns deleted_count: 0, audit row still written."""
+    from sqlalchemy import select as _select
+
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post("/api/v1/admin/orgs/feature-overrides/sweep-expired")
+    assert res.status_code == 200
+    assert res.json() == {"deleted_count": 0}
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                _select(AuditEvent).where(
+                    AuditEvent.event_type
+                    == "admin.feature_override.expired_swept"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].detail == {"deleted_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_sweep_requires_orgs_manage(session_factory):
+    """A non-superadmin without orgs.manage gets 403 and nothing is deleted."""
+    from sqlalchemy import select as _select
+
+    seed = await _seed(session_factory)
+    await _seed_overrides(
+        session_factory, seed["target_id"], admin_user_id=seed["admin_user_id"]
+    )
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.post("/api/v1/admin/orgs/feature-overrides/sweep-expired")
+    assert res.status_code == 403
+
+    async with session_factory() as db:
+        count = (
+            await db.execute(
+                _select(OrgFeatureOverride).where(
+                    OrgFeatureOverride.org_id == seed["target_id"]
+                )
+            )
+        ).scalars().all()
+    # All 4 rows still present.
+    assert len(count) == 4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,10 @@ services:
       - ./frontend/lib:/app/lib
       - ./frontend/public:/app/public
       - ./frontend/tests:/app/tests
+      # next.config.ts is COPYed into the image at build time; without
+      # this explicit mount, edits require `docker compose up --build`
+      # to take effect.
+      - ./frontend/next.config.ts:/app/next.config.ts
 
   nginx:
     image: nginx:alpine

--- a/frontend/app/admin/orgs/page.tsx
+++ b/frontend/app/admin/orgs/page.tsx
@@ -4,17 +4,20 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { isSuperadmin } from "@/lib/auth";
 import {
+  btnSecondary,
   card,
   cardHeader,
   cardTitle,
   error as errorCls,
   input,
   pageTitle,
+  success as successCls,
 } from "@/lib/styles";
 
 type OrgRow = {
@@ -46,6 +49,27 @@ export default function AdminOrgsPage() {
   const [q, setQ] = useState("");
   const [offset, setOffset] = useState(0);
   const [fetching, setFetching] = useState(true);
+  const [sweepConfirmOpen, setSweepConfirmOpen] = useState(false);
+  const [sweepBusy, setSweepBusy] = useState(false);
+  const [sweepNotice, setSweepNotice] = useState("");
+
+  async function runSweep() {
+    setSweepConfirmOpen(false);
+    setSweepBusy(true);
+    setSweepNotice("");
+    setError("");
+    try {
+      const res = await apiFetch<{ deleted_count: number }>(
+        "/api/v1/admin/orgs/feature-overrides/sweep-expired",
+        { method: "POST" },
+      );
+      setSweepNotice(`Removed ${res.deleted_count} expired overrides.`);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Sweep failed"));
+    } finally {
+      setSweepBusy(false);
+    }
+  }
 
   useEffect(() => {
     if (loading) return;
@@ -82,13 +106,40 @@ export default function AdminOrgsPage() {
 
   return (
     <AppShell>
-      <h1 className={pageTitle}>Organizations</h1>
+      <div className="mb-8 flex items-center justify-between gap-4">
+        <h1 className={`${pageTitle} mb-0`}>Organizations</h1>
+        <button
+          type="button"
+          onClick={() => setSweepConfirmOpen(true)}
+          disabled={sweepBusy}
+          className={btnSecondary}
+        >
+          {sweepBusy ? "Sweeping…" : "Sweep expired overrides"}
+        </button>
+      </div>
 
       {error && (
         <div className={`${errorCls} mb-4`} role="alert">
           {error}
         </div>
       )}
+
+      {sweepNotice && (
+        <div className={`${successCls} mb-4`} role="status">
+          {sweepNotice}
+        </div>
+      )}
+
+      <ConfirmModal
+        open={sweepConfirmOpen}
+        title="Sweep expired overrides"
+        message="Permanently delete every feature override row whose expires_at is in the past. This cannot be undone."
+        confirmLabel="Sweep"
+        cancelLabel="Cancel"
+        variant="warning"
+        onConfirm={runSweep}
+        onCancel={() => setSweepConfirmOpen(false)}
+      />
 
       <div className={`${card} mb-6`}>
         <div className={cardHeader}>

--- a/frontend/tests/app/admin-orgs-page.test.tsx
+++ b/frontend/tests/app/admin-orgs-page.test.tsx
@@ -85,4 +85,29 @@ describe("AdminOrgsPage", () => {
       expect(replaceMock).toHaveBeenCalledWith("/dashboard");
     });
   });
+
+  it("sweeps expired overrides and shows the deleted count", async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      items: [], total: 0, limit: 50, offset: 0,
+    } as never);
+    apiFetchMock.mockResolvedValueOnce({ deleted_count: 3 } as never);
+
+    render(<AdminOrgsPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /sweep expired overrides/i,
+    });
+    fireEvent.click(button);
+
+    const confirm = await screen.findByRole("button", { name: /^Sweep$/ });
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/feature-overrides/sweep-expired",
+        { method: "POST" },
+      );
+    });
+    await screen.findByText("Removed 3 expired overrides.");
+  });
 });


### PR DESCRIPTION
## Summary

Three small, independent tech-debt fixes shipped in one PR.

### 1. `frontend/next.config.ts` bind-mounted in dev
`docker-compose.yml` now mounts `frontend/next.config.ts` directly so config edits propagate to the running container without a `docker compose up --build -d frontend`. Verified live: edited the host file, the container saw the change immediately.

### 2. Expired feature-override sweep (manual admin button)
- `POST /api/v1/admin/orgs/feature-overrides/sweep-expired` deletes every `org_feature_overrides` row whose `expires_at` is past `NOW()`. Idempotent. Returns `{deleted_count: N}`.
- Gated by `orgs.manage` (matches the existing PUT/DELETE override endpoints; superadmin short-circuits).
- Emits `admin.feature_override.expired_swept` audit event with `detail = {"deleted_count": N}`. No PII beyond the actor email already snapshot by the audit recorder.
- Frontend: "Sweep expired overrides" button on `/admin/orgs` with a confirm modal and inline success notice ("Removed N expired overrides.").
- Cron alternative deferred — manual button is shippable today and unblocks operators.

### 3. Logger dedupe in `admin_orgs.py`
Dropped the redundant `log = structlog.get_logger()` binding. Unified the file on the single `logger = structlog.stdlib.get_logger()` and converted the two `log.info(...)` sites to `await logger.ainfo(...)`, matching the rest of the file. Test patches updated (`patch.object(admin_orgs.logger, "ainfo", new_callable=AsyncMock)`).

## Coverage
- Backend: 413 passed, 2 skipped (added 4 sweep tests covering happy path, audit event recorded, idempotent zero-row case, permission gate).
- Frontend: 166 passed (added 1 admin-orgs-page sweep test).