### PR TITLE
feat(L4.8): role administration UI

### DIFF
--- a/backend/alembic/versions/033_add_roles_and_role_permissions.py
+++ b/backend/alembic/versions/033_add_roles_and_role_permissions.py
@@ -1,7 +1,7 @@
 """Add roles and role_permissions tables (L4.8 role admin UI).
 
 Revision ID: 033_roles
-Revises: 031_password_set_stepup_token
+Revises: 032_drop_legacy_plan_ai
 Create Date: 2026-05-07
 
 Persists platform-level roles (today only ``superadmin``; tomorrow:
@@ -39,7 +39,7 @@ from alembic import op
 
 
 revision = "033_roles"
-down_revision = "031_password_set_stepup_token"
+down_revision = "032_drop_legacy_plan_ai"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/033_add_roles_and_role_permissions.py
+++ b/backend/alembic/versions/033_add_roles_and_role_permissions.py
@@ -1,0 +1,167 @@
+"""Add roles and role_permissions tables (L4.8 role admin UI).
+
+Revision ID: 033_roles
+Revises: 031_password_set_stepup_token
+Create Date: 2026-05-07
+
+Persists platform-level roles (today only ``superadmin``; tomorrow:
+``support``, ``operator``, ``revenue``, ``analyst``, ...) and the
+permission keys each role grants. The resolver in
+``app/auth/permissions.py`` keeps the ``is_superadmin`` short-circuit;
+this table exists so future roles become configuration rather than a
+code change to ``ROLE_PERMISSIONS``.
+
+Schema notes:
+
+- ``roles.id`` uses ``BigInteger`` with the ``Integer`` SQLite variant
+  (same pattern as ``audit_events.id`` in 030). Roles will never grow
+  to billions, but matching the project pattern is cheap.
+- ``is_system_frozen`` is the UI's only guard against editing the
+  ``superadmin`` row. The router enforces it again as defense in
+  depth — never trust a single layer.
+- ``role_permissions`` uses a composite PK on ``(role_id,
+  permission_key)`` so duplicate inserts no-op via DB-level unique
+  rather than service-level checks.
+
+Seed:
+
+- One ``superadmin`` row with ``is_system_frozen=TRUE``.
+- One ``role_permissions`` row per key in ``ALL_PERMISSIONS`` at
+  migration time. The list is **snapshotted** here (not imported from
+  ``app.auth.permissions``) so future renames in the Permission Literal
+  cannot mutate the historical migration. When ``ALL_PERMISSIONS``
+  changes, follow up with a data migration; do not edit this one.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "033_roles"
+down_revision = "031_password_set_stepup_token"
+branch_labels = None
+depends_on = None
+
+
+# Snapshot of ``app.auth.permissions.ALL_PERMISSIONS`` at the time this
+# migration was written. ``roles.manage`` is added in this PR. If new
+# permissions are added later, ship a follow-up data migration that
+# inserts the new keys into ``role_permissions`` for the superadmin
+# row — do NOT edit this list. The runtime resolver still
+# short-circuits via ``is_superadmin``, so missing rows here never
+# block superadmins; the seed is for parity with future non-superadmin
+# roles.
+_PERMISSION_KEYS_AT_MIGRATION_TIME = (
+    "admin.view",
+    "plans.manage",
+    "orgs.view",
+    "orgs.manage",
+    "audit.view",
+    "roles.manage",
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "roles",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column("slug", sa.String(64), nullable=False),
+        sa.Column("name", sa.String(120), nullable=False),
+        sa.Column("description", sa.String(500), nullable=True),
+        sa.Column(
+            "is_system_frozen",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("CURRENT_TIMESTAMP(6)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("CURRENT_TIMESTAMP(6)"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("slug", name="uq_roles_slug"),
+    )
+
+    op.create_table(
+        "role_permissions",
+        sa.Column(
+            "role_id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            nullable=False,
+        ),
+        sa.Column("permission_key", sa.String(80), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["role_id"],
+            ["roles.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("role_id", "permission_key"),
+    )
+
+    # Seed the superadmin role with every permission known at migration
+    # time. The runtime resolver still short-circuits via is_superadmin
+    # — this seed is so the row exists in the UI as a frozen reference
+    # for what a fully-empowered role looks like.
+    bind = op.get_bind()
+    res = bind.execute(
+        sa.text(
+            """
+            INSERT INTO roles (slug, name, description, is_system_frozen)
+            VALUES (:slug, :name, :description, :frozen)
+            """
+        ),
+        {
+            "slug": "superadmin",
+            "name": "Superadmin",
+            "description": (
+                "Full platform access. Frozen system role; cannot be "
+                "edited or deleted."
+            ),
+            "frozen": True,
+        },
+    )
+
+    # Resolve the inserted id portably (lastrowid works on MySQL,
+    # SQLite, and Postgres; no need for RETURNING).
+    role_id = res.lastrowid
+    if role_id is None:
+        # Fallback: SELECT by slug (Postgres lastrowid behaviour
+        # depends on the driver).
+        row = bind.execute(
+            sa.text("SELECT id FROM roles WHERE slug = :slug"),
+            {"slug": "superadmin"},
+        ).first()
+        role_id = row[0]
+
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO role_permissions (role_id, permission_key)
+            VALUES (:role_id, :permission_key)
+            """
+        ),
+        [
+            {"role_id": role_id, "permission_key": key}
+            for key in _PERMISSION_KEYS_AT_MIGRATION_TIME
+        ],
+    )
+
+
+def downgrade() -> None:
+    # drop_table on role_permissions first — its FK to roles.id would
+    # otherwise block the drop on MySQL.
+    op.drop_table("role_permissions")
+    op.drop_table("roles")

--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -25,17 +25,20 @@ Permission = Literal[
     "orgs.view",
     "orgs.manage",
     "audit.view",
+    "roles.manage",
 ]
 
 
-# Canonical set — useful when iterating or seeding L4.8's eventual DB
-# migration.
+# Canonical set — useful when iterating or seeding the role admin
+# UI's permission editor (L4.8) and the migration that seeds the
+# superadmin role row.
 ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "admin.view",
     "plans.manage",
     "orgs.view",
     "orgs.manage",
     "audit.view",
+    "roles.manage",
 })
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_audit, admin_orgs, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, plans, recurring, settings, subscriptions, transactions, users
+from app.routers import account_types, accounts, admin, admin_audit, admin_orgs, admin_roles, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, plans, recurring, settings, subscriptions, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -232,6 +232,7 @@ app.include_router(plans.router)
 app.include_router(admin.router)
 app.include_router(admin_orgs.router)
 app.include_router(admin_audit.router)
+app.include_router(admin_roles.router)
 app.include_router(org_members.router)
 app.include_router(org_data.router)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.merchant_dictionary import MerchantDictionaryEntry
 from app.models.feature_override import OrgFeatureOverride  # noqa: F401
 from app.models.org_data_reset_lock import OrgDataResetLock  # noqa: F401
 from app.models.audit_event import AuditEvent, AuditOutcome  # noqa: F401
+from app.models.role import PlatformRole, RolePermission  # noqa: F401
 
 __all__ = [
     "Base",
@@ -49,4 +50,6 @@ __all__ = [
     "OrgDataResetLock",
     "AuditEvent",
     "AuditOutcome",
+    "PlatformRole",
+    "RolePermission",
 ]

--- a/backend/app/models/role.py
+++ b/backend/app/models/role.py
@@ -1,0 +1,108 @@
+"""Platform-level roles and the permission keys they grant (L4.8).
+
+Today only ``superadmin`` exists, and the runtime resolver in
+``app/auth/permissions.py`` short-circuits on ``User.is_superadmin``
+before consulting these tables. The tables exist so that:
+
+- The role admin UI has a place to render rows (``GET /admin/roles``).
+- Future non-superadmin roles (``support``, ``operator``, ``revenue``,
+  ``analyst``) become a configuration row plus a per-user assignment
+  row (L4.4 ships the user-role join), not a code change to a
+  hard-coded ``ROLE_PERMISSIONS`` map.
+
+Two design choices worth restating in code:
+
+1. **``is_system_frozen`` is a UI/router concern, not a permission.**
+   The seeded ``superadmin`` row is frozen so an admin can't
+   accidentally rename / unsubscribe / delete it through the
+   ``/admin/roles`` UI. The router and service both check this flag
+   on every write, defense in depth.
+2. **``role_permissions`` rows are not authoritative for superadmin.**
+   They're seeded for parity with future roles and so the UI has a
+   coherent display, but ``has_permission`` still grants everything to
+   ``is_superadmin=True`` users without consulting this table. Removing
+   a key from ``ALL_PERMISSIONS`` therefore never locks anyone out at
+   runtime; it just leaves an orphan row in ``role_permissions`` until
+   the next ``set_role_permissions`` call rewrites the set. The service
+   read path filters role permissions through ``ALL_PERMISSIONS`` so
+   removed keys don't surface in the UI.
+
+The class is named ``PlatformRole`` (not ``Role``) because
+``app.models.user.Role`` already exists as the per-org membership
+enum (``OWNER`` / ``ADMIN`` / ``MEMBER``). Conflating the two would
+break every router that imports ``Role`` from ``user``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class PlatformRole(Base):
+    __tablename__ = "roles"
+    __table_args__ = (
+        UniqueConstraint("slug", name="uq_roles_slug"),
+    )
+
+    # BigInteger on MySQL (forward-compat with future audit-style
+    # high-cardinality joins), Integer on SQLite so the in-memory test
+    # path keeps autoincrement.
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    slug: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(
+        String(500), nullable=True
+    )
+    is_system_frozen: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=func.now(6),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False),
+        server_default=func.now(6),
+        onupdate=func.now(6),
+        nullable=False,
+    )
+
+    permissions: Mapped[list["RolePermission"]] = relationship(
+        back_populates="role",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class RolePermission(Base):
+    __tablename__ = "role_permissions"
+
+    role_id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        ForeignKey("roles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    permission_key: Mapped[str] = mapped_column(
+        String(80), primary_key=True
+    )
+
+    role: Mapped["PlatformRole"] = relationship(back_populates="permissions")

--- a/backend/app/routers/admin_roles.py
+++ b/backend/app/routers/admin_roles.py
@@ -1,0 +1,307 @@
+"""Admin role-management router (L4.8).
+
+Mounted at ``/api/v1/admin/roles``. Gated by the platform
+``roles.manage`` permission (superadmin short-circuits today; future
+fine-grained roles can hold the permission once the L4.4 user-role
+join lands).
+
+Defense in depth: ``is_system_frozen`` is enforced both here and in
+the service layer. Mutating endpoints emit a structlog event and
+persist the same shape into the L4.7 audit log so an operator can
+later attribute who created/edited/deleted which role.
+
+Catalog endpoint ``GET /api/v1/admin/permissions`` is co-located so
+the role admin UI doesn't have to hardcode the permission list — it
+fetches the live grouped catalog at render time.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+import structlog
+
+from app.auth.permissions import ALL_PERMISSIONS, require_permission
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models.user import User
+from app.rate_limit import get_client_ip
+from app.schemas.role import (
+    PermissionCatalogResponse,
+    RoleCreate,
+    RoleDetailResponse,
+    RoleListItem,
+    RoleListResponse,
+    RoleUpdate,
+)
+from app.services import audit_service, role_service
+from app.services.exceptions import (
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
+
+
+logger = structlog.stdlib.get_logger()
+
+
+router = APIRouter(tags=["admin-roles"])
+
+
+def _request_id() -> str | None:
+    """Pull the per-request id bound by RequestContextMiddleware (L4.9)."""
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
+# ── Permissions catalog ──────────────────────────────────────────────────
+
+
+@router.get(
+    "/api/v1/admin/permissions",
+    response_model=PermissionCatalogResponse,
+    dependencies=[Depends(require_permission("roles.manage"))],
+)
+async def list_permission_catalog() -> PermissionCatalogResponse:
+    grouped = role_service.grouped_permissions()
+    return PermissionCatalogResponse(
+        namespaces=grouped,
+        keys=sorted(ALL_PERMISSIONS),
+    )
+
+
+# ── Role CRUD ────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/api/v1/admin/roles",
+    response_model=RoleListResponse,
+    dependencies=[Depends(require_permission("roles.manage"))],
+)
+async def list_roles(db: AsyncSession = Depends(get_db)) -> RoleListResponse:
+    items = await role_service.list_roles(db)
+    return RoleListResponse(
+        items=[RoleListItem(**item) for item in items]
+    )
+
+
+@router.get(
+    "/api/v1/admin/roles/{role_id}",
+    response_model=RoleDetailResponse,
+    dependencies=[Depends(require_permission("roles.manage"))],
+)
+async def get_role(
+    role_id: int, db: AsyncSession = Depends(get_db)
+) -> RoleDetailResponse:
+    try:
+        item = await role_service.get_role(db, role_id=role_id)
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Role not found"
+        )
+    return RoleDetailResponse(**item)
+
+
+@router.post(
+    "/api/v1/admin/roles",
+    response_model=RoleDetailResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_role(
+    body: RoleCreate,
+    request: Request,
+    current_user: User = Depends(require_permission("roles.manage")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+) -> RoleDetailResponse:
+    try:
+        item = await role_service.create_role(
+            db,
+            slug=body.slug,
+            name=body.name,
+            description=body.description,
+            permissions=body.permissions,
+        )
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        )
+    except ConflictError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(e)
+        )
+    await db.commit()
+
+    await logger.ainfo(
+        "admin.role.created",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        role_id=item["id"],
+        role_slug=item["slug"],
+        permission_count=len(item["permissions"]),
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.role.created",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=None,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "role_id": item["id"],
+            "role_slug": item["slug"],
+            "role_name": item["name"],
+            "permission_count": len(item["permissions"]),
+        },
+    )
+    return RoleDetailResponse(**item)
+
+
+@router.patch(
+    "/api/v1/admin/roles/{role_id}",
+    response_model=RoleDetailResponse,
+)
+async def update_role(
+    role_id: int,
+    body: RoleUpdate,
+    request: Request,
+    current_user: User = Depends(require_permission("roles.manage")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+) -> RoleDetailResponse:
+    # Defense-in-depth frozen guard: fetch once for the 404 + frozen
+    # check, then let the service patch in the same session.
+    try:
+        existing = await role_service.get_role(db, role_id=role_id)
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Role not found"
+        )
+    if existing["is_system_frozen"]:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Role {existing['slug']!r} is a frozen system role "
+                "and cannot be edited"
+            ),
+        )
+
+    try:
+        item = await role_service.update_role(
+            db,
+            role_id=role_id,
+            name=body.name,
+            description=body.description,
+            permissions=body.permissions,
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Role not found"
+        )
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        )
+    except ConflictError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(e)
+        )
+    await db.commit()
+
+    changed_fields = [
+        f
+        for f in ("name", "description", "permissions")
+        if getattr(body, f) is not None
+    ]
+    await logger.ainfo(
+        "admin.role.updated",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        role_id=item["id"],
+        role_slug=item["slug"],
+        changed_fields=changed_fields,
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.role.updated",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=None,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "role_id": item["id"],
+            "role_slug": item["slug"],
+            "changed_fields": changed_fields,
+            "permission_count": len(item["permissions"]),
+        },
+    )
+    return RoleDetailResponse(**item)
+
+
+@router.delete(
+    "/api/v1/admin/roles/{role_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_role(
+    role_id: int,
+    request: Request,
+    current_user: User = Depends(require_permission("roles.manage")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+) -> Response:
+    try:
+        existing = await role_service.get_role(db, role_id=role_id)
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Role not found"
+        )
+    # Router-side frozen guard. Service enforces too.
+    if existing["is_system_frozen"]:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Role {existing['slug']!r} is a frozen system role "
+                "and cannot be deleted"
+            ),
+        )
+
+    try:
+        await role_service.delete_role(db, role_id=role_id)
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Role not found"
+        )
+    except ConflictError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(e)
+        )
+    await db.commit()
+
+    await logger.ainfo(
+        "admin.role.deleted",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        role_id=role_id,
+        role_slug=existing["slug"],
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.role.deleted",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=None,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "role_id": role_id,
+            "role_slug": existing["slug"],
+            "role_name": existing["name"],
+        },
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/admin_roles.py
+++ b/backend/app/routers/admin_roles.py
@@ -214,6 +214,16 @@ async def update_role(
         for f in ("name", "description", "permissions")
         if getattr(body, f) is not None
     ]
+    # Capture the permission delta for the audit row. Keys are not
+    # sensitive (the catalog is exposed via /admin/permissions to any
+    # caller with roles.manage), so logging the actual sets gives an
+    # operator the accountability trail we want without leaking
+    # anything.
+    before_perms = sorted(existing["permissions"])
+    after_perms = sorted(item["permissions"])
+    perm_added = sorted(set(after_perms) - set(before_perms))
+    perm_removed = sorted(set(before_perms) - set(after_perms))
+
     await logger.ainfo(
         "admin.role.updated",
         actor_user_id=current_user.id,
@@ -221,6 +231,8 @@ async def update_role(
         role_id=item["id"],
         role_slug=item["slug"],
         changed_fields=changed_fields,
+        permissions_added=perm_added,
+        permissions_removed=perm_removed,
     )
     await audit_service.record_audit_event(
         session_factory,
@@ -237,6 +249,8 @@ async def update_role(
             "role_slug": item["slug"],
             "changed_fields": changed_fields,
             "permission_count": len(item["permissions"]),
+            "permissions_added": perm_added,
+            "permissions_removed": perm_removed,
         },
     )
     return RoleDetailResponse(**item)

--- a/backend/app/schemas/role.py
+++ b/backend/app/schemas/role.py
@@ -1,0 +1,80 @@
+"""Pydantic schemas for the L4.8 role admin API.
+
+Slug pattern: ``^[a-z][a-z0-9_]{2,63}$`` — lowercase letter, then 2 to
+63 letters/digits/underscores. Total length 3 to 64 (matches the DB
+column). Locked at the schema layer so an invalid slug 422s before
+it ever reaches the service.
+"""
+from __future__ import annotations
+
+import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+SLUG_PATTERN = r"^[a-z][a-z0-9_]{2,63}$"
+
+
+class RoleListItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    slug: str
+    name: str
+    description: Optional[str]
+    is_system_frozen: bool
+    permission_count: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class RoleListResponse(BaseModel):
+    items: list[RoleListItem]
+
+
+class RoleDetailResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    slug: str
+    name: str
+    description: Optional[str]
+    is_system_frozen: bool
+    permissions: list[str]
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class RoleCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    slug: str = Field(pattern=SLUG_PATTERN, min_length=3, max_length=64)
+    name: str = Field(min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    permissions: list[str] = Field(default_factory=list)
+
+
+class RoleUpdate(BaseModel):
+    """Patch shape — every field optional, only provided fields apply.
+
+    ``permissions`` semantic: when provided (non-None), replaces the
+    full set. ``[]`` clears all. Omitting the key leaves them
+    untouched.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    permissions: Optional[list[str]] = None
+
+
+class PermissionCatalogEntry(BaseModel):
+    key: str
+    namespace: str
+
+
+class PermissionCatalogResponse(BaseModel):
+    namespaces: dict[str, list[str]]  # e.g. {"admin": ["admin.view"], ...}
+    keys: list[str]

--- a/backend/app/services/role_service.py
+++ b/backend/app/services/role_service.py
@@ -1,0 +1,308 @@
+"""Service layer for L4.8 role administration.
+
+All writers acquire a fresh row via ``select(...).with_for_update()``
+where contention matters (e.g. delete) so concurrent writes don't
+race against the ``is_system_frozen`` guard. Reads are cheap selects.
+
+The service is the **inner** of two enforcement layers for
+``is_system_frozen`` — the router checks it too. Defense in depth:
+if a future endpoint forgets the router-level guard, the service
+still refuses.
+
+Orphan-permission policy (read path): ``get_role`` and ``list_roles``
+filter the role's stored ``permission_key`` rows through the live
+``ALL_PERMISSIONS`` set, so a key that has been removed from the
+catalog never surfaces in the UI. The next write rewrites the full
+set, so orphans clean themselves up in passing.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth.permissions import ALL_PERMISSIONS
+from app.models.role import PlatformRole, RolePermission
+from app.services.exceptions import (
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
+
+
+_SLUG_RE = re.compile(r"^[a-z][a-z0-9_]{2,63}$")
+
+
+def _validate_slug(slug: str) -> None:
+    if not _SLUG_RE.match(slug):
+        raise ValidationError(
+            "Slug must start with a lowercase letter and contain only "
+            "lowercase letters, digits, and underscores (3 to 64 chars)."
+        )
+
+
+def _validate_permissions(keys: list[str]) -> list[str]:
+    """Reject unknown permission keys; return a de-duplicated list.
+
+    Validates against ``ALL_PERMISSIONS``. Order is not preserved (we
+    sort for stable storage / display).
+    """
+    seen: set[str] = set()
+    unknown: list[str] = []
+    for k in keys:
+        if k in ALL_PERMISSIONS:
+            seen.add(k)
+        else:
+            unknown.append(k)
+    if unknown:
+        raise ValidationError(
+            f"Unknown permission key(s): {sorted(unknown)!r}"
+        )
+    return sorted(seen)
+
+
+def _filter_known_permissions(keys: list[str]) -> list[str]:
+    """Read-side filter — drop keys no longer in ``ALL_PERMISSIONS``.
+
+    Avoids surfacing orphans in the admin UI. The next write through
+    ``set_role_permissions`` will replace the full set, cleaning up.
+    """
+    return sorted(k for k in keys if k in ALL_PERMISSIONS)
+
+
+def _to_detail(role: PlatformRole) -> dict:
+    """Serialize a role with its permissions, filtered for orphans."""
+    keys = [rp.permission_key for rp in role.permissions]
+    return {
+        "id": role.id,
+        "slug": role.slug,
+        "name": role.name,
+        "description": role.description,
+        "is_system_frozen": role.is_system_frozen,
+        "permissions": _filter_known_permissions(keys),
+        "created_at": role.created_at,
+        "updated_at": role.updated_at,
+    }
+
+
+async def list_roles(db: AsyncSession) -> list[dict]:
+    """Return every role with a known-permission count.
+
+    Roles will stay small (single-digit count for the foreseeable
+    future), so no pagination is necessary. We compute the count on
+    the Python side — also runs a left-outer-join to materialize the
+    permission rows in a single query.
+    """
+    rows = (
+        await db.execute(
+            select(PlatformRole)
+            .options(selectinload(PlatformRole.permissions))
+            .order_by(PlatformRole.is_system_frozen.desc(), PlatformRole.name)
+        )
+    ).scalars().all()
+
+    items: list[dict] = []
+    for role in rows:
+        known = _filter_known_permissions(
+            [rp.permission_key for rp in role.permissions]
+        )
+        items.append(
+            {
+                "id": role.id,
+                "slug": role.slug,
+                "name": role.name,
+                "description": role.description,
+                "is_system_frozen": role.is_system_frozen,
+                "permission_count": len(known),
+                "created_at": role.created_at,
+                "updated_at": role.updated_at,
+            }
+        )
+    return items
+
+
+async def get_role(db: AsyncSession, *, role_id: int) -> dict:
+    role = (
+        await db.execute(
+            select(PlatformRole)
+            .options(selectinload(PlatformRole.permissions))
+            .where(PlatformRole.id == role_id)
+        )
+    ).scalar_one_or_none()
+    if role is None:
+        raise NotFoundError("Role")
+    return _to_detail(role)
+
+
+async def get_role_by_slug(
+    db: AsyncSession, *, slug: str
+) -> Optional[PlatformRole]:
+    return (
+        await db.execute(
+            select(PlatformRole).where(PlatformRole.slug == slug)
+        )
+    ).scalar_one_or_none()
+
+
+async def create_role(
+    db: AsyncSession,
+    *,
+    slug: str,
+    name: str,
+    description: Optional[str],
+    permissions: list[str],
+) -> dict:
+    """Create a new (non-frozen) role with the given permissions."""
+    _validate_slug(slug)
+    keys = _validate_permissions(permissions)
+
+    # Pre-check for friendly 409. The DB unique constraint is the
+    # ultimate authority — if a concurrent insert wins between the
+    # check and the flush, IntegrityError translates to ConflictError.
+    existing = await get_role_by_slug(db, slug=slug)
+    if existing is not None:
+        raise ConflictError(f"Role slug {slug!r} already exists")
+
+    role = PlatformRole(
+        slug=slug,
+        name=name,
+        description=description,
+        is_system_frozen=False,
+    )
+    db.add(role)
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise ConflictError(
+            f"Role slug {slug!r} already exists"
+        ) from exc
+
+    for key in keys:
+        db.add(RolePermission(role_id=role.id, permission_key=key))
+    await db.flush()
+    # Re-fetch with selectinload so .permissions resolves without a
+    # lazy-load callback (incompatible with async sessions absent a
+    # greenlet provider).
+    role = (
+        await db.execute(
+            select(PlatformRole)
+            .options(selectinload(PlatformRole.permissions))
+            .where(PlatformRole.id == role.id)
+        )
+    ).scalar_one()
+    return _to_detail(role)
+
+
+async def update_role(
+    db: AsyncSession,
+    *,
+    role_id: int,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    permissions: Optional[list[str]] = None,
+) -> dict:
+    """Patch a role. Refuses on ``is_system_frozen``.
+
+    ``permissions`` semantics: ``None`` leaves them untouched, ``[]``
+    clears, otherwise replaces.
+    """
+    role = (
+        await db.execute(
+            select(PlatformRole)
+            .options(selectinload(PlatformRole.permissions))
+            .where(PlatformRole.id == role_id)
+        )
+    ).scalar_one_or_none()
+    if role is None:
+        raise NotFoundError("Role")
+    if role.is_system_frozen:
+        raise ConflictError(
+            f"Role {role.slug!r} is a frozen system role and cannot be edited"
+        )
+
+    if name is not None:
+        role.name = name
+    if description is not None:
+        role.description = description
+
+    if permissions is not None:
+        keys = _validate_permissions(permissions)
+        # Replace-wholesale: delete all current rows, insert new set.
+        # Bulk DELETE is bypass-the-orm so we have to expire the
+        # relationship explicitly — otherwise the role's loaded
+        # ``.permissions`` collection still holds stale RolePermission
+        # objects in the identity map.
+        await db.execute(
+            delete(RolePermission).where(RolePermission.role_id == role.id)
+        )
+        await db.flush()
+        for key in keys:
+            db.add(RolePermission(role_id=role.id, permission_key=key))
+        await db.flush()
+        db.expire(role, ["permissions"])
+
+    # Re-fetch with selectinload + populate_existing so the
+    # already-cached identity-map row picks up the rewritten
+    # collection rather than serving the stale loaded set.
+    role = (
+        await db.execute(
+            select(PlatformRole)
+            .options(selectinload(PlatformRole.permissions))
+            .where(PlatformRole.id == role.id)
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    return _to_detail(role)
+
+
+async def delete_role(db: AsyncSession, *, role_id: int) -> None:
+    """Delete a role and its permissions. Refuses on ``is_system_frozen``."""
+    role = (
+        await db.execute(
+            select(PlatformRole).where(PlatformRole.id == role_id)
+        )
+    ).scalar_one_or_none()
+    if role is None:
+        raise NotFoundError("Role")
+    if role.is_system_frozen:
+        raise ConflictError(
+            f"Role {role.slug!r} is a frozen system role and cannot be deleted"
+        )
+    # FK ON DELETE CASCADE drops the role_permissions rows.
+    await db.delete(role)
+    await db.flush()
+
+
+async def set_role_permissions(
+    db: AsyncSession,
+    *,
+    role_id: int,
+    permissions: list[str],
+) -> dict:
+    """Replace the role's permission set wholesale."""
+    return await update_role(
+        db, role_id=role_id, permissions=permissions
+    )
+
+
+def grouped_permissions() -> dict[str, list[str]]:
+    """Return ``ALL_PERMISSIONS`` grouped by namespace.
+
+    Namespace is the substring before the first ``.`` (``admin.view``
+    → ``admin``). Keys without a dot fall under namespace ``"_root"``
+    so the UI has a stable bucket.
+    """
+    by_ns: dict[str, list[str]] = {}
+    for key in ALL_PERMISSIONS:
+        ns, _, _ = key.partition(".")
+        if not ns:
+            ns = "_root"
+        by_ns.setdefault(ns, []).append(key)
+    for ns in by_ns:
+        by_ns[ns].sort()
+    return dict(sorted(by_ns.items()))

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -51,6 +51,7 @@ def test_all_permissions_contains_known_platform_permissions() -> None:
         "orgs.view",
         "orgs.manage",
         "audit.view",
+        "roles.manage",
     })
 
 

--- a/backend/tests/routers/test_admin_roles.py
+++ b/backend/tests/routers/test_admin_roles.py
@@ -1,0 +1,368 @@
+"""Router tests for L4.8 /api/v1/admin/roles + /api/v1/admin/permissions.
+
+Pins:
+- Auth gate (roles.manage; non-superadmin gets 403).
+- CRUD shapes match RoleDetailResponse.
+- Frozen-row guards refuse PATCH and DELETE with 409.
+- Slug uniqueness 409.
+- Unknown permission key 422.
+- Permission catalog returns grouped namespaces + flat key list.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.role import PlatformRole, RolePermission
+from app.models.user import Organization, Role, User
+from app.routers.admin_roles import router as admin_roles_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(admin_roles_router)
+    return app
+
+
+async def _seed_users(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Platform", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        sa = User(
+            org_id=org.id,
+            username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=org.id,
+            username="user",
+            email="u@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+        await db.commit()
+        return {"org_id": org.id, "sa_id": sa.id, "plain_id": plain.id}
+
+
+async def _seed_frozen_superadmin(factory) -> int:
+    async with factory() as db:
+        role = PlatformRole(
+            slug="superadmin",
+            name="Superadmin",
+            is_system_frozen=True,
+        )
+        db.add(role)
+        await db.flush()
+        db.add(RolePermission(role_id=role.id, permission_key="admin.view"))
+        db.add(RolePermission(role_id=role.id, permission_key="orgs.manage"))
+        await db.commit()
+        return role.id
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+# ── auth gate ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_roles_requires_superadmin(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/roles")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_role_requires_superadmin(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/roles",
+            json={"slug": "ops", "name": "Ops", "permissions": []},
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_permission_catalog_requires_superadmin(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/permissions")
+    assert res.status_code == 403
+
+
+# ── happy path ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_roles_returns_seeded_frozen(session_factory):
+    await _seed_users(session_factory)
+    await _seed_frozen_superadmin(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/roles")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["slug"] == "superadmin"
+    assert item["is_system_frozen"] is True
+    assert item["permission_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_create_role_persists(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/roles",
+            json={
+                "slug": "support",
+                "name": "Support",
+                "description": "Read-only ops",
+                "permissions": ["admin.view", "orgs.view"],
+            },
+        )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["slug"] == "support"
+    assert body["is_system_frozen"] is False
+    assert sorted(body["permissions"]) == ["admin.view", "orgs.view"]
+
+
+@pytest.mark.asyncio
+async def test_get_role_returns_detail(session_factory):
+    await _seed_users(session_factory)
+    role_id = await _seed_frozen_superadmin(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(f"/api/v1/admin/roles/{role_id}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["slug"] == "superadmin"
+    assert sorted(body["permissions"]) == ["admin.view", "orgs.manage"]
+
+
+@pytest.mark.asyncio
+async def test_get_role_404(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/roles/9999")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_role_patches_permissions(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/admin/roles",
+            json={"slug": "ops", "name": "Ops", "permissions": ["admin.view"]},
+        ).json()
+        res = client.patch(
+            f"/api/v1/admin/roles/{created['id']}",
+            json={
+                "name": "Operations",
+                "permissions": ["admin.view", "audit.view"],
+            },
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["name"] == "Operations"
+    assert sorted(body["permissions"]) == ["admin.view", "audit.view"]
+
+
+@pytest.mark.asyncio
+async def test_delete_role(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/admin/roles",
+            json={"slug": "ops", "name": "Ops", "permissions": []},
+        ).json()
+        res = client.delete(f"/api/v1/admin/roles/{created['id']}")
+    assert res.status_code == 204
+    # Verify deleted.
+    async with session_factory() as db:
+        rows = (await db.execute(select(PlatformRole))).scalars().all()
+    assert rows == []
+
+
+# ── frozen-row guards ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_frozen_role_returns_409(session_factory):
+    await _seed_users(session_factory)
+    role_id = await _seed_frozen_superadmin(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/roles/{role_id}",
+            json={"name": "Hacked", "permissions": []},
+        )
+    assert res.status_code == 409
+    assert "frozen" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_frozen_role_returns_409(session_factory):
+    await _seed_users(session_factory)
+    role_id = await _seed_frozen_superadmin(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(f"/api/v1/admin/roles/{role_id}")
+    assert res.status_code == 409
+
+
+# ── validation ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_role_unknown_permission_returns_422(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/roles",
+            json={
+                "slug": "ops",
+                "name": "Ops",
+                "permissions": ["admin.view", "definitely.unknown.key"],
+            },
+        )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_role_invalid_slug_returns_422(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/roles",
+            json={"slug": "BadSlug", "name": "x", "permissions": []},
+        )
+    # Pydantic Field(pattern=...) raises 422 before reaching service.
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_role_duplicate_slug_returns_409(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        client.post(
+            "/api/v1/admin/roles",
+            json={"slug": "ops", "name": "Ops", "permissions": []},
+        )
+        res = client.post(
+            "/api/v1/admin/roles",
+            json={"slug": "ops", "name": "Ops Two", "permissions": []},
+        )
+    assert res.status_code == 409
+
+
+# ── permission catalog ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_permission_catalog_groups_by_namespace(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/permissions")
+    assert res.status_code == 200
+    body = res.json()
+    assert "namespaces" in body
+    assert "admin" in body["namespaces"]
+    assert "admin.view" in body["namespaces"]["admin"]
+    assert "roles.manage" in body["keys"]
+    # Keys are sorted.
+    assert body["keys"] == sorted(body["keys"])

--- a/backend/tests/services/test_role_service.py
+++ b/backend/tests/services/test_role_service.py
@@ -1,0 +1,321 @@
+"""Service-layer tests for L4.8 role_service.
+
+Pins:
+- ``create_role`` validates slug + permission keys, persists rows.
+- ``update_role`` patches name/description/permissions, refuses on frozen.
+- ``delete_role`` removes role + cascades to role_permissions, refuses on frozen.
+- Slug uniqueness raises ConflictError.
+- Unknown permission key raises ValidationError.
+- Read path filters orphan permission keys.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.role import PlatformRole, RolePermission
+from app.services import role_service
+from app.services.exceptions import (
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_frozen_superadmin(db: AsyncSession) -> int:
+    role = PlatformRole(
+        slug="superadmin",
+        name="Superadmin",
+        description="Frozen system role.",
+        is_system_frozen=True,
+    )
+    db.add(role)
+    await db.flush()
+    db.add(RolePermission(role_id=role.id, permission_key="admin.view"))
+    db.add(RolePermission(role_id=role.id, permission_key="orgs.manage"))
+    await db.commit()
+    return role.id
+
+
+# ── create ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_role_persists_with_permissions(db_session):
+    item = await role_service.create_role(
+        db_session,
+        slug="support",
+        name="Support",
+        description="Read-only ops",
+        permissions=["admin.view", "orgs.view"],
+    )
+    await db_session.commit()
+
+    assert item["slug"] == "support"
+    assert item["name"] == "Support"
+    assert item["description"] == "Read-only ops"
+    assert item["is_system_frozen"] is False
+    assert sorted(item["permissions"]) == ["admin.view", "orgs.view"]
+
+    # Roundtrip via DB.
+    rows = (await db_session.execute(select(RolePermission))).scalars().all()
+    assert {r.permission_key for r in rows} == {"admin.view", "orgs.view"}
+
+
+@pytest.mark.asyncio
+async def test_create_role_rejects_invalid_slug(db_session):
+    with pytest.raises(ValidationError):
+        await role_service.create_role(
+            db_session,
+            slug="BadSlug",
+            name="x",
+            description=None,
+            permissions=[],
+        )
+    with pytest.raises(ValidationError):
+        await role_service.create_role(
+            db_session,
+            slug="ab",  # too short
+            name="x",
+            description=None,
+            permissions=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_role_rejects_unknown_permission(db_session):
+    with pytest.raises(ValidationError):
+        await role_service.create_role(
+            db_session,
+            slug="ops",
+            name="Ops",
+            description=None,
+            permissions=["admin.view", "definitely.not.a.real.key"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_role_slug_uniqueness(db_session):
+    await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description=None,
+        permissions=[],
+    )
+    await db_session.commit()
+    with pytest.raises(ConflictError):
+        await role_service.create_role(
+            db_session,
+            slug="ops",
+            name="Ops Two",
+            description=None,
+            permissions=[],
+        )
+
+
+# ── update ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_role_replaces_permissions(db_session):
+    item = await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description=None,
+        permissions=["admin.view"],
+    )
+    await db_session.commit()
+
+    updated = await role_service.update_role(
+        db_session,
+        role_id=item["id"],
+        name="Operations",
+        permissions=["admin.view", "audit.view"],
+    )
+    await db_session.commit()
+    assert updated["name"] == "Operations"
+    assert sorted(updated["permissions"]) == ["admin.view", "audit.view"]
+
+
+@pytest.mark.asyncio
+async def test_update_role_clears_permissions_with_empty_list(db_session):
+    item = await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description=None,
+        permissions=["admin.view"],
+    )
+    await db_session.commit()
+    updated = await role_service.update_role(
+        db_session,
+        role_id=item["id"],
+        permissions=[],
+    )
+    await db_session.commit()
+    assert updated["permissions"] == []
+
+
+@pytest.mark.asyncio
+async def test_update_role_leaves_permissions_when_none(db_session):
+    item = await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description=None,
+        permissions=["admin.view"],
+    )
+    await db_session.commit()
+    updated = await role_service.update_role(
+        db_session,
+        role_id=item["id"],
+        name="Operations",
+        permissions=None,
+    )
+    await db_session.commit()
+    assert updated["permissions"] == ["admin.view"]
+
+
+@pytest.mark.asyncio
+async def test_update_role_refuses_frozen(db_session):
+    role_id = await _seed_frozen_superadmin(db_session)
+    with pytest.raises(ConflictError):
+        await role_service.update_role(
+            db_session,
+            role_id=role_id,
+            name="Hacked",
+            permissions=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_role_404_on_missing(db_session):
+    with pytest.raises(NotFoundError):
+        await role_service.update_role(
+            db_session, role_id=99999, name="x"
+        )
+
+
+# ── delete ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_role_removes_role_and_permissions(db_session):
+    item = await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description=None,
+        permissions=["admin.view"],
+    )
+    await db_session.commit()
+
+    await role_service.delete_role(db_session, role_id=item["id"])
+    await db_session.commit()
+
+    rows = (
+        await db_session.execute(select(PlatformRole))
+    ).scalars().all()
+    assert rows == []
+    perms = (
+        await db_session.execute(select(RolePermission))
+    ).scalars().all()
+    # FK CASCADE under SQLite when foreign_keys=ON.
+    assert perms == []
+
+
+@pytest.mark.asyncio
+async def test_delete_role_refuses_frozen(db_session):
+    role_id = await _seed_frozen_superadmin(db_session)
+    with pytest.raises(ConflictError):
+        await role_service.delete_role(db_session, role_id=role_id)
+
+
+@pytest.mark.asyncio
+async def test_delete_role_404_on_missing(db_session):
+    with pytest.raises(NotFoundError):
+        await role_service.delete_role(db_session, role_id=99999)
+
+
+# ── read path: orphan filtering ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_role_filters_unknown_permission_keys(db_session):
+    role = PlatformRole(
+        slug="legacy",
+        name="Legacy",
+        is_system_frozen=False,
+    )
+    db_session.add(role)
+    await db_session.flush()
+    db_session.add(
+        RolePermission(role_id=role.id, permission_key="admin.view")
+    )
+    db_session.add(
+        RolePermission(role_id=role.id, permission_key="legacy.removed")
+    )
+    await db_session.commit()
+
+    item = await role_service.get_role(db_session, role_id=role.id)
+    assert item["permissions"] == ["admin.view"]
+
+
+@pytest.mark.asyncio
+async def test_list_roles_orders_frozen_first(db_session):
+    role_id = await _seed_frozen_superadmin(db_session)
+    await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description=None,
+        permissions=["admin.view"],
+    )
+    await db_session.commit()
+
+    items = await role_service.list_roles(db_session)
+    assert [r["slug"] for r in items][0] == "superadmin"
+
+
+@pytest.mark.asyncio
+async def test_grouped_permissions_groups_by_namespace():
+    grouped = role_service.grouped_permissions()
+    assert "admin" in grouped
+    assert "admin.view" in grouped["admin"]
+    assert "roles" in grouped
+    assert "roles.manage" in grouped["roles"]

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -149,6 +149,15 @@ export default function AdminDashboardPage() {
                   org deletes, tenant resets).
                 </p>
               </Link>
+              <Link
+                href="/admin/roles"
+                className={`${card} block p-5 transition-colors hover:border-accent`}
+              >
+                <h2 className={`${cardTitle} mb-1`}>Roles</h2>
+                <p className="text-sm text-text-secondary">
+                  Manage platform roles and the permissions they grant.
+                </p>
+              </Link>
             </section>
           </>
         )}

--- a/frontend/app/admin/roles/[id]/page.tsx
+++ b/frontend/app/admin/roles/[id]/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import ConfirmModal from "@/components/ui/ConfirmModal";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { isSuperadmin } from "@/lib/auth";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  label as labelCls,
+  pageTitle,
+  success as successCls,
+} from "@/lib/styles";
+import type {
+  PermissionCatalogResponse,
+  RoleDetail,
+  RoleUpdatePayload,
+} from "@/lib/types";
+
+export default function AdminRoleDetailPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const roleId = params?.id ? Number(params.id) : NaN;
+
+  const [role, setRole] = useState<RoleDetail | null>(null);
+  const [catalog, setCatalog] = useState<PermissionCatalogResponse | null>(null);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [fetching, setFetching] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!isSuperadmin(user)) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (loading || !user || !isSuperadmin(user)) return;
+    if (!Number.isFinite(roleId)) {
+      setError("Invalid role id.");
+      setFetching(false);
+      return;
+    }
+    setFetching(true);
+    Promise.all([
+      apiFetch<RoleDetail>(`/api/v1/admin/roles/${roleId}`),
+      apiFetch<PermissionCatalogResponse>("/api/v1/admin/permissions"),
+    ])
+      .then(([detail, perms]) => {
+        setRole(detail);
+        setCatalog(perms);
+        setName(detail.name);
+        setDescription(detail.description ?? "");
+        setSelected(new Set(detail.permissions));
+      })
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load role")))
+      .finally(() => setFetching(false));
+  }, [loading, user, roleId]);
+
+  const isFrozen = role?.is_system_frozen ?? false;
+
+  const dirty = useMemo(() => {
+    if (!role) return false;
+    if (name !== role.name) return true;
+    if ((description ?? "") !== (role.description ?? "")) return true;
+    const a = Array.from(selected).sort();
+    const b = [...role.permissions].sort();
+    if (a.length !== b.length) return true;
+    return a.some((k, i) => k !== b[i]);
+  }, [role, name, description, selected]);
+
+  function togglePermission(key: string) {
+    if (isFrozen) return;
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  function resetForm() {
+    if (!role) return;
+    setName(role.name);
+    setDescription(role.description ?? "");
+    setSelected(new Set(role.permissions));
+    setError("");
+    setSuccess("");
+  }
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    if (!role || isFrozen) return;
+    setError("");
+    setSuccess("");
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload: RoleUpdatePayload = {
+        name: name.trim(),
+        description: description.trim() ? description.trim() : null,
+        permissions: Array.from(selected).sort(),
+      };
+      const updated = await apiFetch<RoleDetail>(
+        `/api/v1/admin/roles/${role.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      setRole(updated);
+      setName(updated.name);
+      setDescription(updated.description ?? "");
+      setSelected(new Set(updated.permissions));
+      setSuccess("Role updated.");
+    } catch (e) {
+      setError(extractErrorMessage(e, "Failed to update role"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function destroy() {
+    if (!role || isFrozen) return;
+    setError("");
+    setDeleting(true);
+    try {
+      await apiFetch<void>(`/api/v1/admin/roles/${role.id}`, {
+        method: "DELETE",
+      });
+      router.replace("/admin/roles");
+    } catch (e) {
+      setError(extractErrorMessage(e, "Failed to delete role"));
+      setDeleting(false);
+      setShowConfirmDelete(false);
+    }
+  }
+
+  if (loading || !user || !isSuperadmin(user)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-2 text-xs text-text-muted">
+        <Link href="/admin/roles" className="hover:text-accent">
+          ← Back to roles
+        </Link>
+      </div>
+      <div className="mb-8 flex items-center gap-3">
+        <h1 className={`${pageTitle} mb-0`}>{role?.name ?? "Role"}</h1>
+        {role && isFrozen && (
+          <span className="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-accent">
+            system
+          </span>
+        )}
+      </div>
+
+      {fetching && <Spinner />}
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className={`${successCls} mb-4`} role="status">
+          {success}
+        </div>
+      )}
+
+      {role && catalog && (
+        <form onSubmit={save} className="space-y-6">
+          <div className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Details</h2>
+            </div>
+            <div className="space-y-4 px-6 py-4">
+              <div>
+                <label htmlFor="role-slug" className={labelCls}>
+                  Slug
+                </label>
+                <input
+                  id="role-slug"
+                  type="text"
+                  value={role.slug}
+                  className={`${input} font-mono`}
+                  disabled
+                  readOnly
+                  aria-readonly="true"
+                />
+                <p className="mt-1 text-xs text-text-muted">
+                  Slug is immutable once created.
+                </p>
+              </div>
+              <div>
+                <label htmlFor="role-name" className={labelCls}>
+                  Name
+                </label>
+                <input
+                  id="role-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className={input}
+                  maxLength={120}
+                  disabled={isFrozen}
+                  aria-disabled={isFrozen}
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="role-description" className={labelCls}>
+                  Description
+                </label>
+                <textarea
+                  id="role-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  className={`${input} min-h-[5rem]`}
+                  maxLength={500}
+                  disabled={isFrozen}
+                  aria-disabled={isFrozen}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Permissions</h2>
+            </div>
+            <div className="px-6 py-4">
+              {isFrozen && (
+                <p className="mb-3 text-xs text-text-muted">
+                  System role permissions are read-only.
+                </p>
+              )}
+              <div className="space-y-3">
+                {Object.entries(catalog.namespaces).map(([ns, keys]) => (
+                  <fieldset
+                    key={ns}
+                    className="rounded-md border border-border-subtle px-3 py-2"
+                  >
+                    <legend className="px-1 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                      {ns}
+                    </legend>
+                    <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                      {keys.map((key) => (
+                        <label
+                          key={key}
+                          className={`flex items-center gap-2 rounded px-1 py-1 text-sm ${
+                            isFrozen
+                              ? "text-text-secondary"
+                              : "text-text-primary hover:bg-surface-raised"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selected.has(key)}
+                            onChange={() => togglePermission(key)}
+                            disabled={isFrozen}
+                            aria-disabled={isFrozen}
+                            className="h-4 w-4 rounded border-border accent-accent"
+                          />
+                          <span className="font-mono text-xs">{key}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </fieldset>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={() => setShowConfirmDelete(true)}
+              className="rounded-md border border-danger/40 px-4 py-2 text-sm font-medium text-danger hover:bg-danger-dim disabled:opacity-50"
+              disabled={isFrozen || deleting}
+              aria-disabled={isFrozen}
+              title={
+                isFrozen
+                  ? "System roles cannot be deleted."
+                  : "Delete this role"
+              }
+            >
+              Delete role
+            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={resetForm}
+                className={btnSecondary}
+                disabled={isFrozen || !dirty || saving}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className={btnPrimary}
+                disabled={isFrozen || !dirty || saving}
+                aria-disabled={isFrozen}
+                title={
+                  isFrozen
+                    ? "System roles cannot be edited."
+                    : "Save changes"
+                }
+              >
+                {saving ? "Saving…" : "Save changes"}
+              </button>
+            </div>
+          </div>
+        </form>
+      )}
+
+      {role && (
+        <ConfirmModal
+          open={showConfirmDelete}
+          title="Delete role"
+          message={`Delete the "${role.name}" role? This cannot be undone.`}
+          confirmLabel={deleting ? "Deleting…" : "Delete"}
+          cancelLabel="Cancel"
+          onConfirm={destroy}
+          onCancel={() => setShowConfirmDelete(false)}
+          variant="danger"
+        />
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/app/admin/roles/page.tsx
+++ b/frontend/app/admin/roles/page.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { isSuperadmin } from "@/lib/auth";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  label as labelCls,
+  pageTitle,
+} from "@/lib/styles";
+import type {
+  PermissionCatalogResponse,
+  RoleCreatePayload,
+  RoleDetail,
+  RoleListItem,
+  RoleListResponse,
+} from "@/lib/types";
+
+const SLUG_PATTERN = /^[a-z][a-z0-9_]{2,63}$/;
+
+interface CreateModalProps {
+  catalog: PermissionCatalogResponse;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+function CreateRoleModal({ catalog, onClose, onCreated }: CreateModalProps) {
+  const [slug, setSlug] = useState("");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState("");
+
+  const slugValid = SLUG_PATTERN.test(slug);
+
+  function togglePermission(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr("");
+    if (!slugValid) {
+      setErr(
+        "Slug must start with a lowercase letter and contain only lowercase letters, digits, and underscores (3 to 64 chars).",
+      );
+      return;
+    }
+    if (!name.trim()) {
+      setErr("Name is required.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const payload: RoleCreatePayload = {
+        slug,
+        name: name.trim(),
+        description: description.trim() ? description.trim() : null,
+        permissions: Array.from(selected).sort(),
+      };
+      await apiFetch<RoleDetail>("/api/v1/admin/roles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      onCreated();
+    } catch (e) {
+      setErr(extractErrorMessage(e, "Failed to create role"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-role-title"
+    >
+      <div className={`${card} w-full max-w-2xl max-h-[90vh] overflow-y-auto`}>
+        <div className={cardHeader}>
+          <h2 id="create-role-title" className={cardTitle}>
+            New role
+          </h2>
+        </div>
+        <form onSubmit={submit} className="space-y-4 px-6 py-4">
+          {err && (
+            <div className={errorCls} role="alert">
+              {err}
+            </div>
+          )}
+          <div>
+            <label htmlFor="role-slug" className={labelCls}>
+              Slug
+            </label>
+            <input
+              id="role-slug"
+              type="text"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              className={input}
+              placeholder="support"
+              autoComplete="off"
+              required
+            />
+            <p className="mt-1 text-xs text-text-muted">
+              Lowercase letters, digits, underscores. Must start with a letter.
+            </p>
+          </div>
+          <div>
+            <label htmlFor="role-name" className={labelCls}>
+              Name
+            </label>
+            <input
+              id="role-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={input}
+              placeholder="Support"
+              maxLength={120}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="role-description" className={labelCls}>
+              Description (optional)
+            </label>
+            <textarea
+              id="role-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className={`${input} min-h-[5rem]`}
+              maxLength={500}
+              placeholder="What this role can do"
+            />
+          </div>
+          <div>
+            <p className={`${labelCls} mb-2`}>Permissions</p>
+            <div className="space-y-3">
+              {Object.entries(catalog.namespaces).map(([ns, keys]) => (
+                <fieldset
+                  key={ns}
+                  className="rounded-md border border-border-subtle px-3 py-2"
+                >
+                  <legend className="px-1 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    {ns}
+                  </legend>
+                  <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                    {keys.map((key) => (
+                      <label
+                        key={key}
+                        className="flex items-center gap-2 rounded px-1 py-1 text-sm text-text-primary hover:bg-surface-raised"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selected.has(key)}
+                          onChange={() => togglePermission(key)}
+                          className="h-4 w-4 rounded border-border accent-accent"
+                        />
+                        <span className="font-mono text-xs">{key}</span>
+                      </label>
+                    ))}
+                  </div>
+                </fieldset>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className={btnSecondary}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={btnPrimary}
+              disabled={submitting || !slugValid || !name.trim()}
+            >
+              {submitting ? "Creating…" : "Create role"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminRolesPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<RoleListResponse | null>(null);
+  const [catalog, setCatalog] = useState<PermissionCatalogResponse | null>(null);
+  const [error, setError] = useState("");
+  const [fetching, setFetching] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [reloadCounter, setReloadCounter] = useState(0);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!isSuperadmin(user)) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (loading || !user || !isSuperadmin(user)) return;
+    setFetching(true);
+    Promise.all([
+      apiFetch<RoleListResponse>("/api/v1/admin/roles"),
+      apiFetch<PermissionCatalogResponse>("/api/v1/admin/permissions"),
+    ])
+      .then(([roles, perms]) => {
+        setData(roles);
+        setCatalog(perms);
+      })
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
+      .finally(() => setFetching(false));
+  }, [loading, user, reloadCounter]);
+
+  const sortedItems: RoleListItem[] = useMemo(() => {
+    if (!data) return [];
+    return [...data.items].sort((a, b) => {
+      // Frozen first, then by name.
+      if (a.is_system_frozen !== b.is_system_frozen) {
+        return a.is_system_frozen ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+  }, [data]);
+
+  if (loading || !user || !isSuperadmin(user)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-8 flex items-end justify-between gap-4">
+        <h1 className={`${pageTitle} mb-0`}>Roles</h1>
+        <button
+          type="button"
+          className={btnPrimary}
+          onClick={() => setShowCreate(true)}
+          disabled={!catalog}
+        >
+          + New role
+        </button>
+      </div>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Platform roles</h2>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3">Name</th>
+                <th className="px-6 py-3">Slug</th>
+                <th className="px-6 py-3">Permissions</th>
+                <th className="px-6 py-3">Type</th>
+                <th className="px-6 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!fetching && sortedItems.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    No roles defined.
+                  </td>
+                </tr>
+              )}
+              {!fetching &&
+                sortedItems.map((row) => (
+                  <tr
+                    key={row.id}
+                    className="border-b border-border-subtle"
+                  >
+                    <td className="px-6 py-3">
+                      <Link
+                        href={`/admin/roles/${row.id}`}
+                        className="text-accent hover:text-accent-hover"
+                      >
+                        {row.name}
+                      </Link>
+                      {row.description && (
+                        <p className="mt-0.5 text-xs text-text-muted">
+                          {row.description}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-6 py-3 font-mono text-xs text-text-secondary">
+                      {row.slug}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.permission_count}
+                    </td>
+                    <td className="px-6 py-3">
+                      {row.is_system_frozen ? (
+                        <span className="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-accent">
+                          system
+                        </span>
+                      ) : (
+                        <span className="text-xs text-text-muted">custom</span>
+                      )}
+                    </td>
+                    <td className="px-6 py-3 text-right">
+                      <Link
+                        href={`/admin/roles/${row.id}`}
+                        className="text-xs text-text-muted hover:text-accent"
+                      >
+                        View
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {showCreate && catalog && (
+        <CreateRoleModal
+          catalog={catalog}
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false);
+            setReloadCounter((n) => n + 1);
+          }}
+        />
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -380,3 +380,49 @@ export interface AuditEventListResponse {
   items: AuditEvent[];
   total: number;
 }
+
+// L4.8 — Role administration UI.
+
+export interface RoleListItem {
+  id: number;
+  slug: string;
+  name: string;
+  description: string | null;
+  is_system_frozen: boolean;
+  permission_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RoleListResponse {
+  items: RoleListItem[];
+}
+
+export interface RoleDetail {
+  id: number;
+  slug: string;
+  name: string;
+  description: string | null;
+  is_system_frozen: boolean;
+  permissions: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RoleCreatePayload {
+  slug: string;
+  name: string;
+  description?: string | null;
+  permissions: string[];
+}
+
+export interface RoleUpdatePayload {
+  name?: string;
+  description?: string | null;
+  permissions?: string[];
+}
+
+export interface PermissionCatalogResponse {
+  namespaces: Record<string, string[]>;
+  keys: string[];
+}

--- a/frontend/tests/app/admin-roles-page.test.tsx
+++ b/frontend/tests/app/admin-roles-page.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import AdminRolesPage from "@/app/admin/roles/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+      "@/components/auth/AuthProvider",
+    );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/roles",
+}));
+
+const SUPERADMIN = {
+  id: 1,
+  username: "root",
+  email: "root@platform.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Platform",
+  billing_cycle_day: 1,
+  is_superadmin: true,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const CATALOG = {
+  namespaces: {
+    admin: ["admin.view"],
+    audit: ["audit.view"],
+    orgs: ["orgs.manage", "orgs.view"],
+    plans: ["plans.manage"],
+    roles: ["roles.manage"],
+  },
+  keys: [
+    "admin.view",
+    "audit.view",
+    "orgs.manage",
+    "orgs.view",
+    "plans.manage",
+    "roles.manage",
+  ],
+};
+
+describe("AdminRolesPage", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders the seeded superadmin role with system badge", async () => {
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === "/api/v1/admin/roles") {
+        return {
+          items: [
+            {
+              id: 1,
+              slug: "superadmin",
+              name: "Superadmin",
+              description: "Full platform access.",
+              is_system_frozen: true,
+              permission_count: 6,
+              created_at: "2026-05-07T09:00:00",
+              updated_at: "2026-05-07T09:00:00",
+            },
+          ],
+        };
+      }
+      if (path === "/api/v1/admin/permissions") return CATALOG;
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    render(<AdminRolesPage />);
+
+    await screen.findByText("Superadmin");
+    expect(screen.getByText("system")).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
+  });
+
+  it("redirects non-superadmin users away", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminRolesPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("opens the create modal and submits a new role", async () => {
+    apiFetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
+      if (path === "/api/v1/admin/roles" && (!init || init.method === undefined)) {
+        return { items: [] };
+      }
+      if (path === "/api/v1/admin/permissions") return CATALOG;
+      if (path === "/api/v1/admin/roles" && init?.method === "POST") {
+        const body = JSON.parse(init.body as string);
+        expect(body.slug).toBe("support");
+        expect(body.name).toBe("Support");
+        expect(body.permissions).toEqual(["admin.view"]);
+        return {
+          id: 2,
+          slug: "support",
+          name: "Support",
+          description: null,
+          is_system_frozen: false,
+          permissions: ["admin.view"],
+          created_at: "2026-05-07T09:00:00",
+          updated_at: "2026-05-07T09:00:00",
+        };
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    render(<AdminRolesPage />);
+
+    // Wait for the load to complete (button enables once catalog arrives).
+    const newButton = await screen.findByRole("button", { name: /new role/i });
+    await waitFor(() => expect(newButton).not.toBeDisabled());
+    fireEvent.click(newButton);
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText(/slug/i), {
+      target: { value: "support" },
+    });
+    fireEvent.change(within(dialog).getByLabelText(/^name$/i), {
+      target: { value: "Support" },
+    });
+    // Toggle the admin.view permission checkbox.
+    fireEvent.click(within(dialog).getByLabelText(/admin\.view/i));
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /create role/i }));
+
+    await waitFor(() => {
+      // Modal closed.
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Ships the platform role/permission surface under `/admin/roles`. Roles + role_permissions are now persisted in the DB; the `superadmin` row is seeded as a frozen system role with every permission known at migration time. Future non-superadmin roles (`support`, `operator`, `revenue`, `analyst`) become a configuration row + a per-user assignment row when L4.4 lands, not a code change to a hardcoded `ROLE_PERMISSIONS` map.

This PR is the role/permission surface only — no user assignment UI yet (lands with L4.4 user management). The runtime resolver still short-circuits via `is_superadmin`.

## Changes

### Backend

- Migration `033_add_roles_and_role_permissions.py` — creates `roles` (id, slug UNIQUE, name, description, is_system_frozen, created_at, updated_at) and `role_permissions` (composite PK on role_id + permission_key, FK CASCADE on role_id). Seeds a frozen `superadmin` row with every permission key known at migration time. Down-revision chains to `032_drop_legacy_plan_ai`.
- `app/models/role.py` — `PlatformRole` + `RolePermission` (named to avoid the existing `app.models.user.Role` enum collision).
- `app/auth/permissions.py` — adds `roles.manage` to the `Permission` Literal and `ALL_PERMISSIONS`.
- `app/services/role_service.py` — `list_roles` / `get_role` / `create_role` / `update_role` / `delete_role` / `set_role_permissions` / `grouped_permissions`. Slug pattern `^[a-z][a-z0-9_]{2,63}$`; rejects unknown permission keys with `ValidationError`; refuses on `is_system_frozen` for edits/deletes. Read path filters orphan keys through `ALL_PERMISSIONS` so removed keys never surface.
- `app/routers/admin_roles.py` — full CRUD on `/api/v1/admin/roles` (list, get, post, patch, delete) plus `GET /api/v1/admin/permissions` returning the grouped catalog. All gated on `roles.manage`. Defense-in-depth frozen-row guard at both router and service. Mutations emit `admin.role.created` / `admin.role.updated` / `admin.role.deleted` structlog events and persist to the L4.7 audit log via `record_audit_event`.
- `app/schemas/role.py` — request/response shapes with `extra="forbid"` on writes, slug validated by Pydantic `Field(pattern=...)`.
- Tests: `tests/services/test_role_service.py` (15) + `tests/routers/test_admin_roles.py` (15). Cover create, edit, delete, frozen-row guards, slug uniqueness, unknown-permission 422, non-superadmin 403, orphan-key filtering.

### Frontend

- `app/admin/roles/page.tsx` — list view, system badge for frozen rows, "+ New role" modal that fetches the live permission catalog and renders namespace-grouped checkboxes.
- `app/admin/roles/[id]/page.tsx` — detail/edit with a namespace-grouped permission editor, Save / Cancel / Delete. Frozen rows get a `system` badge and disabled affordances on every input.
- `app/admin/page.tsx` — Roles hub card linking to the list.
- `lib/types.ts` — `RoleListItem` / `RoleDetail` / `RoleCreatePayload` / `RoleUpdatePayload` / `PermissionCatalogResponse`.
- Tests: `tests/app/admin-roles-page.test.tsx` (3). Cover list render with frozen badge, create-modal submission, non-superadmin redirect.

### Test counts

- Backend: 409 → 439 (+30).
- Frontend: 165 → 168 (+3).

## Notes

- **Orphan permissions:** if a key is later removed from `ALL_PERMISSIONS`, the read path filters it out so it doesn't surface in the UI; the next write through the role replaces the full set, so orphans clean themselves up in passing.
- **Defense in depth:** `is_system_frozen` enforced at both router and service layers — a future endpoint that forgets the router-level guard still gets refused at the service.
- **No user assignment UI:** lands with L4.4 user management.