### PR TITLE
chore(infra): pfv-data-01 -> s-1vcpu-2gb, MySQL tuning, backups off

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,8 +1,9 @@
 # pfv infra
 
 Self-hosted MySQL + Redis on a single DigitalOcean droplet, replacing the DO
-Managed MySQL + Managed Redis pair (~$30/mo) with one `s-1vcpu-1gb` droplet
-(~$6/mo + ~$1.20/mo for backups).
+Managed MySQL + Managed Redis pair (~$30/mo) with one `s-1vcpu-2gb` droplet
+(~$12/mo). DO backups are off; the nightly mysqldump cron is the durability
+floor.
 
 This folder owns the cloud and the box. App Platform spec lives elsewhere.
 
@@ -22,7 +23,7 @@ This folder owns the cloud and the box. App Platform spec lives elsewhere.
                                     │ VPC peering
                                     ▼
               VPC 10.42.0.0/24 ┌────────────────────────────┐
-                               │  pfv-data-01 (s-1vcpu-1gb) │
+                               │  pfv-data-01 (s-1vcpu-2gb) │
                                │   - MySQL 8 (3306)         │
                                │   - Redis  (6379)          │
                                │   - ufw + fail2ban         │

--- a/infra/ansible/roles/mysql/defaults/main.yml
+++ b/infra/ansible/roles/mysql/defaults/main.yml
@@ -11,7 +11,22 @@ mysql_app_password: CHANGE_ME
 mysql_backup_user: pfv_backup
 mysql_backup_password: CHANGE_ME
 
-# Tuned for s-1vcpu-1gb. Leaves headroom for the OS and Redis (200MB cap).
-mysql_max_connections: 50
-mysql_innodb_buffer_pool_size: 384M
-mysql_innodb_log_file_size: 64M
+# Tuned for s-1vcpu-2gb shared with Redis (300M cap) + OS overhead (~250M).
+# MySQL gets ~1.4G of the 2G total. Adjust upward only if Redis stays
+# well under its cap and the OS isn't paging.
+mysql_max_connections: 100
+mysql_innodb_buffer_pool_size: 768M
+# One pool instance is the right call when the buffer pool is under ~1G;
+# multiple instances at this scale just waste RAM on per-instance overhead.
+mysql_innodb_buffer_pool_instances: 1
+mysql_innodb_log_file_size: 128M
+mysql_innodb_log_buffer_size: 16M
+# tmp_table_size and max_heap_table_size MUST stay equal — MySQL silently
+# clamps in-memory temp tables to the smaller of the two.
+mysql_tmp_table_size: 32M
+mysql_max_heap_table_size: 32M
+# DO block storage is SSD-backed; the 200/400 InnoDB defaults are HDD-era.
+# 1000/2000 lets InnoDB push more dirty pages per flush cycle, which is
+# what the L4.7 audit-log + L4.9 request-log write workload wants.
+mysql_innodb_io_capacity: 1000
+mysql_innodb_io_capacity_max: 2000

--- a/infra/ansible/roles/mysql/templates/my.cnf.j2
+++ b/infra/ansible/roles/mysql/templates/my.cnf.j2
@@ -6,9 +6,40 @@
 bind-address = 0.0.0.0
 default-authentication-plugin = mysql_native_password
 
+# DNS lookups on every TCP connect are pure overhead at our scale; auth is
+# host=% for pfv_app, no hostname-based ACLs to break.
+skip-name-resolve
+
+# --- Connections ---
 max_connections = {{ mysql_max_connections }}
+# 0 = let MySQL auto-tune. Hard-capping concurrency on a 1-vCPU box just
+# leaves cores idle when one query is blocked on I/O.
+innodb_thread_concurrency = 0
+
+# --- Buffer pool / memory ---
 innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}
+innodb_buffer_pool_instances = {{ mysql_innodb_buffer_pool_instances }}
 innodb_log_file_size = {{ mysql_innodb_log_file_size }}
+innodb_log_buffer_size = {{ mysql_innodb_log_buffer_size }}
+tmp_table_size = {{ mysql_tmp_table_size }}
+max_heap_table_size = {{ mysql_max_heap_table_size }}
+
+# --- I/O (DO SSD) ---
+# O_DIRECT skips the OS page cache so we don't double-buffer dirty pages
+# (InnoDB's buffer pool already caches them). Standard for InnoDB on Linux.
+innodb_flush_method = O_DIRECT
+# Flush-neighbors is an HDD optimization (coalesces adjacent dirty pages
+# into one seek). On SSD it's a small write-amp tax for no payoff.
+innodb_flush_neighbors = 0
+innodb_io_capacity = {{ mysql_innodb_io_capacity }}
+innodb_io_capacity_max = {{ mysql_innodb_io_capacity_max }}
+
+# --- Durability ---
+# innodb_flush_log_at_trx_commit = 1 is the MySQL default and is the right
+# call for a finance app: every committed txn is fsynced to redo log on
+# commit. Setting 2 trades durability for ~10-20% write throughput; not
+# worth it here. innodb_doublewrite stays on (default) as torn-write
+# protection.
 
 character-set-server = utf8mb4
 collation-server = utf8mb4_0900_ai_ci

--- a/infra/ansible/roles/redis/defaults/main.yml
+++ b/infra/ansible/roles/redis/defaults/main.yml
@@ -2,7 +2,9 @@
 # Override in inventory.yml; vault-encrypt for real use.
 redis_password: CHANGE_ME
 
-# 200MB cap leaves the rest of RAM to MySQL + OS. Rate-limit + session-cache
-# workloads fit easily here.
-redis_maxmemory: 200mb
+# 300MB cap on the s-1vcpu-2gb shared box (was 200MB on s-1vcpu-1gb).
+# 50% headroom for cache growth without crowding the InnoDB buffer pool.
+# Rate-limit + session-cache workloads still fit easily; allkeys-lru means
+# any overflow evicts cold keys cleanly.
+redis_maxmemory: 300mb
 redis_maxmemory_policy: allkeys-lru

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -9,7 +9,7 @@ and runs live in TFC; this directory holds the configuration.
 | Resource | Purpose |
 |---|---|
 | `digitalocean_vpc` | Dedicated `10.42.0.0/24` VPC in region `ams3` |
-| `digitalocean_droplet` | `pfv-data-01`: `s-1vcpu-1gb` Ubuntu 24.04, hosts MySQL 8 + Redis |
+| `digitalocean_droplet` | `pfv-data-01`: `s-1vcpu-2gb` Ubuntu 24.04, hosts MySQL 8 + Redis |
 | `digitalocean_firewall` | SSH 22 from anywhere; MySQL 3306 / Redis 6379 / ICMP from the VPC only |
 | `digitalocean_project_resources` | Attaches the droplet to the existing DO `pfv` project |
 
@@ -54,7 +54,7 @@ Read from TFC -> Workspace -> Outputs after apply.
 ├── outputs.tf
 └── modules/
     ├── vpc/           digitalocean_vpc
-    ├── droplet/       digitalocean_droplet (backups + monitoring on by default)
+    ├── droplet/       digitalocean_droplet (monitoring on by default; backups off, see main.tf)
     └── firewall/      digitalocean_firewall (defence-in-depth pair with host ufw)
 ```
 
@@ -66,12 +66,14 @@ resolves the right namespace inside the module.
 
 | Line | Monthly |
 |---|---|
-| `s-1vcpu-1gb` droplet | ~$6.00 |
-| DO weekly snapshots (~20% of droplet) | ~$1.20 |
+| `s-1vcpu-2gb` droplet | ~$12.00 |
+| DO weekly snapshots | $0 (disabled — nightly mysqldump cron is the durability floor) |
 | VPC + firewall + project attachment | $0 |
-| **Total** | **~$7.20** |
+| **Total** | **~$12.00** |
 
-Replaces ~$30/mo of DO Managed MySQL + Managed Redis.
+Replaces ~$30/mo of DO Managed MySQL + Managed Redis. The 2 GB tier (vs.
+the 1 GB launch tier) gives the InnoDB buffer pool room to absorb the
+write rate from the L4.7 audit log and L4.9 enriched request logs.
 
 ## See also
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -57,10 +57,12 @@ module "data_droplet" {
 
   ssh_key_id = data.digitalocean_ssh_key.primary.id
 
-  # backups=true is intentionally default-on: this droplet is the only copy of
-  # production data outside the nightly mysqldump cron, so weekly DO snapshots
-  # are cheap insurance.
-  enable_backups    = true
+  # backups=false: the nightly mysqldump cron (see ansible/roles/backups) plus
+  # the App Platform release pin already cover the recovery scenarios we care
+  # about for a single-user finance app. Re-enable here if/when shared use
+  # changes the durability calculus. Toggling backups on/off does not affect
+  # the size variable above.
+  enable_backups    = false
   enable_monitoring = true
 
   tags = ["pfv", "data", "managed-by-terraform"]

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -8,6 +8,6 @@
 
 # Optional overrides (defaults live in variables.tf):
 # region        = "ams3"
-# droplet_size  = "s-1vcpu-1gb"
+# droplet_size  = "s-1vcpu-2gb"
 # project_name  = "pfv"
 # vpc_ip_range  = "10.42.0.0/24"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -11,9 +11,9 @@ variable "region" {
 }
 
 variable "droplet_size" {
-  description = "Droplet size slug. s-1vcpu-1gb is the $6/mo entry tier and is enough for MySQL+Redis on a personal-finance-app workload."
+  description = "Droplet size slug. s-1vcpu-2gb (~$12/mo) is the sweet spot for MySQL+Redis: gives the InnoDB buffer pool room to breathe (~768M) once the L4.7 audit-log + L4.9 enriched-request-log write rates kick in. s-1vcpu-1gb worked at launch but ran hot under sustained writes."
   type        = string
-  default     = "s-1vcpu-1gb"
+  default     = "s-1vcpu-2gb"
 }
 
 variable "droplet_image" {


### PR DESCRIPTION
## Summary

- Reconciles the Terraform IaC with the live state of `pfv-data-01` after the manual DO resize: `s-1vcpu-1gb` → `s-1vcpu-2gb`, weekly DO backups disabled.
- Re-tunes MySQL for the new 2 GB memory budget on a box shared with Valkey + OS, with extra attention to the L4.7 audit-log + L4.9 enriched-request-log write workload.
- Bumps Valkey `maxmemory` 200M → 300M to reclaim some of the freed RAM as cache headroom.

## Changes

### Terraform (`infra/terraform/`)

| File | Change |
|---|---|
| `variables.tf` | `droplet_size` default: `s-1vcpu-1gb` → `s-1vcpu-2gb` (description updated) |
| `main.tf` | `module.data_droplet.enable_backups`: `true` → `false` (rationale in inline comment) |
| `terraform.tfvars.example` | example `droplet_size` line updated |
| `README.md` | cost table + module-layout note refreshed |

The droplet child module already parameterizes `size` and `enable_backups`, so no changes there. The `region`, `image`, and other vars stay default.

### MySQL (`infra/ansible/roles/mysql/`)

`defaults/main.yml` — bumped or added the following knobs. Template `templates/my.cnf.j2` was extended to render every var plus the static SSD/Linux flags.

| Knob | Old | New | Rationale |
|---|---|---|---|
| `mysql_max_connections` | 50 | **100** | 2x headroom; the box can support it. slowapi rate-limit upstream contains DoS angle. |
| `mysql_innodb_buffer_pool_size` | 384M | **768M** | ~37% of total RAM; sweet spot for shared-host MySQL with 1.4G budget. |
| `mysql_innodb_buffer_pool_instances` | (default 8) | **1** | Multiple instances waste RAM on per-instance overhead under ~1G pool. |
| `mysql_innodb_log_file_size` | 64M | **128M** | More redo headroom for write bursts (audit log, request logs). |
| `mysql_innodb_log_buffer_size` | (default 16M) | **16M** | Now explicit. |
| `mysql_tmp_table_size` | (default 16M) | **32M** | Bigger in-memory temp tables; must equal max_heap_table_size or MySQL clamps. |
| `mysql_max_heap_table_size` | (default 16M) | **32M** | Pairs with tmp_table_size. |
| `mysql_innodb_io_capacity` | (default 200) | **1000** | DO block storage is SSD; 200 is the HDD-era default. |
| `mysql_innodb_io_capacity_max` | (default 2000) | **2000** | Explicit, paired with the above. |

Template-only (static, not parameterized — these don't vary by host):

| Directive | Value | Rationale |
|---|---|---|
| `skip-name-resolve` | on | DNS lookups on every TCP connect are pure overhead; auth uses `host=%`, no hostname ACLs. |
| `innodb_thread_concurrency` | `0` | Let MySQL auto-tune. Hard caps just leave a 1-vCPU box idle on I/O blocks. |
| `innodb_flush_method` | `O_DIRECT` | Skip OS double-buffering on Linux; standard for InnoDB. |
| `innodb_flush_neighbors` | `0` | HDD optimization; pure write-amp tax on SSD. |

**Durability — intentionally NOT touched:**

- `innodb_flush_log_at_trx_commit` stays at the MySQL default of `1` (every committed txn fsyncs to redo log). Setting `2` trades durability for write throughput; not worth it for a finance app.
- `innodb_doublewrite` stays on (default) — torn-write protection for InnoDB.

### Valkey (`infra/ansible/roles/redis/`)

| Knob | Old | New | Rationale |
|---|---|---|---|
| `redis_maxmemory` | 200mb | **300mb** | 50% headroom for cache growth without crowding MySQL's 768M pool. |
| `redis_maxmemory_policy` | allkeys-lru | allkeys-lru | Unchanged; still the right call for ephemeral rate-limit + session caches. |

Persistence (`appendonly no`, `save ""`) stays off; PFV uses Redis only for ephemeral data.

## Plan output

Terraform Cloud (`FlamaCorp/pfv`) is the authoritative state and runs are VCS-driven against this PR. A speculative plan should post on the run page. Local `terraform plan` from the worktree was not run because TFC auth is not wired here (`Failed to read organization "FlamaCorp" at host app.terraform.io`). `terraform validate` and `terraform fmt -check -recursive` both pass.

**Expected plan: 0 to add, 0 to change, 0 to destroy.** The cloud already matches what this PR is committing (resize and backup-disable were done live before the PR was opened). If TFC's speculative plan shows any drift in either direction, do NOT apply — surface it as a follow-up.

## How to apply

1. **Terraform:** merge to `main`. TFC kicks off an apply run; manual-confirm in the TFC UI. Should be a no-op apply.
2. **Ansible:** the new MySQL config + Valkey cap need to land on the live droplet. Run from a workstation with the inventory configured:

```bash
cd infra/ansible
ansible-playbook playbooks/site.yml --limit pfv-data-01
```

The site playbook runs all four roles (`common`, `mysql`, `redis`, `backups`); they're idempotent. Both the MySQL `Drop pfv MySQL config override` task and the Valkey `Drop pfv Redis config override` task notify their respective `Restart` handlers, so changed configs trigger a service restart automatically.

**Heads up: applying the new my.cnf will restart MySQL** (10–30 s of unavailability while the service comes back up and reopens InnoDB). Do this during a quiet window. Valkey's restart is faster and less impactful (cache only).

CI ansible is not yet wired (tracked in `project_infra_followups.md` follow-up A); this is a manual operator step for now.

## Verification

- `terraform fmt -check -recursive`: clean
- `terraform validate`: Success
- All ansible YAML files parse
- No secrets touched (defaults files still ship `CHANGE_ME` placeholders for the three passwords; real values stay in vault-encrypted inventory.yml)