### PR TITLE
fix(forecast-plans): dropdown, current-period pending, refresh-from-sources

### DIFF
--- a/backend/app/routers/forecast_plans.py
+++ b/backend/app/routers/forecast_plans.py
@@ -48,6 +48,18 @@ async def populate_plan(
     return await svc.populate_from_sources(db, current_user.org_id, period_start=period_start)
 
 
+@router.post("/refresh-from-sources", response_model=ForecastPlanResponse)
+async def refresh_from_sources_plan(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    period_start: datetime.date | None = Query(default=None),
+):
+    """Drop auto-generated items (source=recurring|history) and re-run
+    populate. Manual items are preserved. Use this to pick up newly
+    added recurring templates or transactions after the initial populate."""
+    return await svc.refresh_from_sources(db, current_user.org_id, period_start=period_start)
+
+
 @router.post("/{plan_id}/items", response_model=ForecastPlanResponse, status_code=201)
 async def add_item(
     plan_id: int,

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -9,7 +9,7 @@ import datetime
 from decimal import Decimal
 
 from dateutil.relativedelta import relativedelta
-from sqlalchemy import func, literal_column, select, text
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -336,17 +336,29 @@ async def populate_from_sources(
         db.add(item)
         existing_keys.add(key)
 
-    # ── From 3-month historical monthly averages ──
-    # Aggregate subcategories into master before averaging
+    # ── From 3-month historical monthly averages + current-period activity ──
+    # Two scopes:
+    #   - History (3 months prior to current period): SETTLED only. Pending
+    #     transactions from months ago shouldn't drive averages — if they
+    #     never settled, treating them as real history would inflate the
+    #     suggestion.
+    #   - Current period: SETTLED OR PENDING. The user's already-imported
+    #     bills for the period being planned are real expectations and
+    #     should feed the suggestion immediately, not after they settle.
+    # Each contributing month counts as one slot in the average; current
+    # period acts as one additional month.
+    #
+    # Month bucketing happens in Python (not SQL date_format) so the
+    # query stays portable between MySQL and SQLite (test fixtures run
+    # in-memory SQLite).
     three_months_ago = p_start - relativedelta(months=3)
 
-    # Subquery: sum per category per type per month
-    monthly_sub = (
+    hist_q = (
         select(
             Transaction.category_id,
             Transaction.type,
-            func.date_format(Transaction.date, "%Y-%m").label("month"),
-            func.sum(Transaction.amount).label("monthly_total"),
+            Transaction.date,
+            Transaction.amount,
         )
         .where(
             Transaction.org_id == org_id,
@@ -354,30 +366,58 @@ async def populate_from_sources(
             Transaction.date >= three_months_ago,
             Transaction.date < p_start,
             Transaction.type.in_(["income", "expense"]),
-        )
-        .group_by(Transaction.category_id, Transaction.type, text("month"))
-        .subquery()
-    )
-
-    hist_result = await db.execute(
-        select(
-            monthly_sub.c.category_id,
-            monthly_sub.c.type,
-            monthly_sub.c.month,
-            monthly_sub.c.monthly_total,
+            reportable_transaction_filter(),
         )
     )
+    hist_result = await db.execute(hist_q)
 
     # Roll up to master category, then compute monthly averages
     # Structure: {(master_id, type): {month: total}}
     master_monthly: dict[tuple[int, str], dict[str, Decimal]] = {}
-    for cat_id, tx_type_raw, month, monthly_total in hist_result.all():
+    for cat_id, tx_type_raw, tx_date, amount in hist_result.all():
         tx_type = tx_type_raw.value if hasattr(tx_type_raw, "value") else str(tx_type_raw)
         master_id = cat_to_master.get(cat_id, cat_id)
         key = (master_id, tx_type)
+        month = f"{tx_date.year:04d}-{tx_date.month:02d}"
         if key not in master_monthly:
             master_monthly[key] = {}
-        master_monthly[key][month] = master_monthly[key].get(month, Decimal("0")) + Decimal(str(monthly_total))
+        master_monthly[key][month] = master_monthly[key].get(month, Decimal("0")) + Decimal(str(amount))
+
+    # Current-period scope: SETTLED OR PENDING. Treated as one additional
+    # month slot in the rolling average so already-imported bills for the
+    # period being planned surface in the suggestion right away.
+    current_q = (
+        select(
+            Transaction.category_id,
+            Transaction.type,
+            func.coalesce(func.sum(Transaction.amount), 0).label("total"),
+        )
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.status.in_(
+                [TransactionStatus.SETTLED, TransactionStatus.PENDING]
+            ),
+            Transaction.date >= p_start,
+            Transaction.date <= p_end,
+            Transaction.type.in_(["income", "expense"]),
+            reportable_transaction_filter(),
+        )
+        .group_by(Transaction.category_id, Transaction.type)
+    )
+    current_result = await db.execute(current_q)
+    current_period_label = "__current__"
+    for cat_id, tx_type_raw, total in current_result.all():
+        tx_type = tx_type_raw.value if hasattr(tx_type_raw, "value") else str(tx_type_raw)
+        master_id = cat_to_master.get(cat_id, cat_id)
+        key = (master_id, tx_type)
+        amt = Decimal(str(total))
+        if amt <= 0:
+            continue
+        if key not in master_monthly:
+            master_monthly[key] = {}
+        master_monthly[key][current_period_label] = master_monthly[key].get(
+            current_period_label, Decimal("0")
+        ) + amt
 
     for key, months in master_monthly.items():
         if key in existing_keys:
@@ -401,6 +441,34 @@ async def populate_from_sources(
     await db.commit()
     await db.refresh(plan, ["billing_period", "items"])
     return await _build_response(db, org_id, plan)
+
+
+async def refresh_from_sources(
+    db: AsyncSession, org_id: int, period_start: datetime.date | None = None,
+) -> ForecastPlanResponse:
+    """Replace auto-generated plan items, preserving manual edits.
+
+    Drops every item whose source is RECURRING or HISTORY (the populate
+    output) and re-runs ``populate_from_sources`` against fresh data.
+    Items with source=MANUAL stay untouched — that flag is set whenever
+    the user adds an item by hand or edits an auto-generated one, so the
+    rule is "user-touched stays, never-touched gets refreshed".
+    """
+    period = await resolve_period(db, org_id, period_start)
+    plan = await _get_or_create_plan_row(db, org_id, period.id)
+    _require_draft(plan)
+    await db.refresh(plan, ["billing_period", "items"])
+
+    for item in list(plan.items):
+        if item.source != ItemSource.MANUAL:
+            await db.delete(item)
+    await db.flush()
+    await db.refresh(plan, ["billing_period", "items"])
+
+    # Re-run populate against the cleared slate. populate handles its own
+    # commit; we ride on its commit so the deletes and inserts land
+    # together.
+    return await populate_from_sources(db, org_id, period_start=period_start)
 
 
 async def upsert_item(

--- a/backend/tests/services/test_forecast_plan_populate.py
+++ b/backend/tests/services/test_forecast_plan_populate.py
@@ -1,0 +1,528 @@
+"""Tests for forecast_plan_service.populate_from_sources and
+refresh_from_sources — pins:
+
+1. Recurring INCOME templates feed populate symmetrically with EXPENSE.
+2. Historical query is SETTLED-only and excludes the current period.
+3. Current-period query counts SETTLED + PENDING and acts as one extra
+   month slot in the rolling average.
+4. refresh_from_sources drops auto-generated items (recurring|history)
+   and preserves user-edited (manual) items, then re-runs populate.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.billing import BillingPeriod
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import (
+    ForecastItemType,
+    ForecastPlan,
+    ForecastPlanItem,
+    ItemSource,
+    PlanStatus,
+)
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization
+from app.services import forecast_plan_service
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory: async_sessionmaker[AsyncSession]) -> dict:
+    """Org with one open billing period (May 2026) + master Groceries +
+    master Salary + an account."""
+    org_id = 1
+    may_start = datetime.date(2026, 5, 1)
+    may_end = datetime.date(2026, 5, 31)
+
+    async with factory() as db:
+        db.add(Organization(id=org_id, name="org", billing_cycle_day=1))
+        await db.commit()
+
+        at = AccountType(org_id=org_id, name="Cash", slug="cash", is_system=True)
+        db.add(at)
+        await db.commit()
+
+        acc = Account(
+            org_id=org_id, account_type_id=at.id, name="Wallet",
+            balance=Decimal("0"),
+        )
+        db.add(acc)
+        await db.commit()
+
+        groceries = Category(
+            org_id=org_id, name="Groceries",
+            slug="groceries", type=CategoryType.EXPENSE,
+        )
+        salary = Category(
+            org_id=org_id, name="Salary",
+            slug="salary", type=CategoryType.INCOME,
+        )
+        db.add_all([groceries, salary])
+        await db.commit()
+
+        period = BillingPeriod(
+            org_id=org_id, start_date=may_start, end_date=may_end,
+        )
+        db.add(period)
+        await db.commit()
+
+        return {
+            "org_id": org_id,
+            "account_id": acc.id,
+            "groceries_id": groceries.id,
+            "salary_id": salary.id,
+            "may_start": may_start,
+            "may_end": may_end,
+            "period_id": period.id,
+        }
+
+
+# ── Bug 2: recurring INCOME flows into populate ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recurring_income_populates_plan(session_factory):
+    """A monthly recurring INCOME template due in the period must show up
+    as a plan item with source=recurring. Symmetric with EXPENSE."""
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        # Monthly salary; due May 25
+        db.add(RecurringTransaction(
+            org_id=seed["org_id"],
+            account_id=seed["account_id"],
+            category_id=seed["salary_id"],
+            description="Salary",
+            amount=Decimal("3000"),
+            type="income",
+            frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date(2026, 5, 25),
+            auto_settle=False,
+            is_active=True,
+        ))
+        # Monthly grocery bill; due May 5
+        db.add(RecurringTransaction(
+            org_id=seed["org_id"],
+            account_id=seed["account_id"],
+            category_id=seed["groceries_id"],
+            description="Weekly grocery",
+            amount=Decimal("400"),
+            type="expense",
+            frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date(2026, 5, 5),
+            auto_settle=False,
+            is_active=True,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.populate_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    by_key = {(it.category_id, it.type): it for it in resp.items}
+    inc = by_key.get((seed["salary_id"], "income"))
+    exp = by_key.get((seed["groceries_id"], "expense"))
+
+    assert inc is not None, "recurring income should populate a plan item"
+    assert inc.planned_amount == Decimal("3000")
+    assert inc.source == "recurring"
+
+    assert exp is not None, "recurring expense should populate a plan item"
+    assert exp.planned_amount == Decimal("400")
+    assert exp.source == "recurring"
+
+
+# ── Bug 3: current-period pending counts; history pending does not ──────────
+
+
+def _tx(*, org_id, account_id, category_id, amount, date, settled_date,
+        status, type_, linked_transaction_id=None) -> Transaction:
+    return Transaction(
+        org_id=org_id, account_id=account_id, category_id=category_id,
+        description="t", amount=Decimal(str(amount)), type=type_,
+        status=status, date=date, settled_date=settled_date,
+        linked_transaction_id=linked_transaction_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_period_pending_counts_history_pending_excluded(session_factory):
+    """Pending in the current period adds a slot to the average; pending
+    in history months is ignored."""
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        # History settled — Feb 2026 expense $100
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=100,
+            date=datetime.date(2026, 2, 10),
+            settled_date=datetime.date(2026, 2, 10),
+            status=TransactionStatus.SETTLED, type_=TransactionType.EXPENSE,
+        ))
+        # History settled — Mar 2026 expense $200
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=200,
+            date=datetime.date(2026, 3, 10),
+            settled_date=datetime.date(2026, 3, 10),
+            status=TransactionStatus.SETTLED, type_=TransactionType.EXPENSE,
+        ))
+        # History PENDING — Apr 2026 expense $9999 — must be ignored
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=9999,
+            date=datetime.date(2026, 4, 10),
+            settled_date=None,
+            status=TransactionStatus.PENDING, type_=TransactionType.EXPENSE,
+        ))
+        # Current period PENDING — May 2026 expense $300 — counts
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=300,
+            date=datetime.date(2026, 5, 5),
+            settled_date=None,
+            status=TransactionStatus.PENDING, type_=TransactionType.EXPENSE,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.populate_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    # Two history months ($100, $200) + current period ($300, pending) = 3 slots
+    # Average = (100 + 200 + 300) / 3 = 200.00
+    items = [
+        i for i in resp.items
+        if i.category_id == seed["groceries_id"] and i.type == "expense"
+    ]
+    assert len(items) == 1
+    assert items[0].source == "history"
+    assert items[0].planned_amount == Decimal("200.00")
+
+
+@pytest.mark.asyncio
+async def test_history_settled_only(session_factory):
+    """Two history months, no current-period activity. History pending
+    must not count even when current-period scope is empty."""
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        # Feb 2026 settled $200, Mar 2026 settled $400
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=200,
+            date=datetime.date(2026, 2, 10),
+            settled_date=datetime.date(2026, 2, 10),
+            status=TransactionStatus.SETTLED, type_=TransactionType.EXPENSE,
+        ))
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=400,
+            date=datetime.date(2026, 3, 10),
+            settled_date=datetime.date(2026, 3, 10),
+            status=TransactionStatus.SETTLED, type_=TransactionType.EXPENSE,
+        ))
+        # Apr pending — must NOT factor in
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=9999,
+            date=datetime.date(2026, 4, 15),
+            settled_date=None,
+            status=TransactionStatus.PENDING, type_=TransactionType.EXPENSE,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.populate_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    items = [
+        i for i in resp.items
+        if i.category_id == seed["groceries_id"] and i.type == "expense"
+    ]
+    assert len(items) == 1
+    # Average of only the two settled months = (200 + 400) / 2 = 300
+    assert items[0].planned_amount == Decimal("300.00")
+
+
+@pytest.mark.asyncio
+async def test_current_period_excludes_transfer_legs(session_factory):
+    """A pending transfer leg (linked_transaction_id != NULL) in the
+    current period must not feed the suggestion — same rule as actuals."""
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        # One settled history month so the threshold of 2 slots is met
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=100,
+            date=datetime.date(2026, 3, 10),
+            settled_date=datetime.date(2026, 3, 10),
+            status=TransactionStatus.SETTLED, type_=TransactionType.EXPENSE,
+        ))
+        # Transfer pair in May — both halves linked, must be excluded
+        a = _tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=500,
+            date=datetime.date(2026, 5, 10),
+            settled_date=None,
+            status=TransactionStatus.PENDING, type_=TransactionType.EXPENSE,
+        )
+        db.add(a)
+        await db.commit()
+        b = _tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=500,
+            date=datetime.date(2026, 5, 10),
+            settled_date=None,
+            status=TransactionStatus.PENDING, type_=TransactionType.INCOME,
+            linked_transaction_id=a.id,
+        )
+        db.add(b)
+        await db.commit()
+        a.linked_transaction_id = b.id
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.populate_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    # Only one history month + zero current-period reportable activity =
+    # only one slot, below the len < 2 threshold; nothing should populate
+    # for groceries.
+    items = [
+        i for i in resp.items
+        if i.category_id == seed["groceries_id"] and i.type == "expense"
+    ]
+    assert items == []
+
+
+# ── Bug 5: refresh_from_sources preserves manual, replaces auto ─────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_replaces_auto_generated_preserves_manual(session_factory):
+    """A plan with one MANUAL item, one RECURRING item, one HISTORY item.
+    After refresh: MANUAL stays, RECURRING + HISTORY are replaced by
+    fresh populate output."""
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        plan = ForecastPlan(
+            org_id=seed["org_id"], billing_period_id=seed["period_id"],
+            status=PlanStatus.DRAFT,
+        )
+        db.add(plan)
+        await db.commit()
+
+        # Manual user-entered item — must survive
+        db.add(ForecastPlanItem(
+            plan_id=plan.id, org_id=seed["org_id"],
+            category_id=seed["groceries_id"],
+            type=ForecastItemType.EXPENSE,
+            planned_amount=Decimal("777"),
+            source=ItemSource.MANUAL,
+        ))
+        # Auto-generated stale items — must be dropped
+        db.add(ForecastPlanItem(
+            plan_id=plan.id, org_id=seed["org_id"],
+            category_id=seed["salary_id"],
+            type=ForecastItemType.INCOME,
+            planned_amount=Decimal("1"),
+            source=ItemSource.RECURRING,
+        ))
+        await db.commit()
+
+        # Add a fresh recurring template that should appear after refresh
+        # (different category to avoid colliding with the manual groceries item)
+        utilities = Category(
+            org_id=seed["org_id"], name="Utilities",
+            slug="utilities", type=CategoryType.EXPENSE,
+        )
+        db.add(utilities)
+        await db.commit()
+        utilities_id = utilities.id
+
+        db.add(RecurringTransaction(
+            org_id=seed["org_id"],
+            account_id=seed["account_id"],
+            category_id=utilities_id,
+            description="Power",
+            amount=Decimal("80"),
+            type="expense",
+            frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date(2026, 5, 15),
+            auto_settle=False,
+            is_active=True,
+        ))
+        # Fresh recurring income with new amount — replaces the stale $1 item
+        db.add(RecurringTransaction(
+            org_id=seed["org_id"],
+            account_id=seed["account_id"],
+            category_id=seed["salary_id"],
+            description="Salary",
+            amount=Decimal("3500"),
+            type="income",
+            frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date(2026, 5, 25),
+            auto_settle=False,
+            is_active=True,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.refresh_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    by_key = {(it.category_id, it.type): it for it in resp.items}
+
+    manual_item = by_key.get((seed["groceries_id"], "expense"))
+    assert manual_item is not None, "manual item must survive refresh"
+    assert manual_item.planned_amount == Decimal("777")
+    assert manual_item.source == "manual"
+
+    refreshed_inc = by_key.get((seed["salary_id"], "income"))
+    assert refreshed_inc is not None
+    assert refreshed_inc.planned_amount == Decimal("3500")
+    assert refreshed_inc.source == "recurring"
+
+    new_utilities = by_key.get((utilities_id, "expense"))
+    assert new_utilities is not None
+    assert new_utilities.planned_amount == Decimal("80")
+    assert new_utilities.source == "recurring"
+
+    # No leftover stale RECURRING/HISTORY items beyond what populate now
+    # generates — confirm no item with source=recurring|history that
+    # doesn't match the fresh templates
+    stale_residue = [
+        i for i in resp.items
+        if i.source in ("recurring", "history")
+        and i.category_id not in {seed["salary_id"], utilities_id}
+    ]
+    assert stale_residue == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_when_no_plan_items_yet(session_factory):
+    """Refresh on an empty plan is equivalent to populate — no items to
+    delete, populate runs and inserts whatever sources produce."""
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        db.add(RecurringTransaction(
+            org_id=seed["org_id"],
+            account_id=seed["account_id"],
+            category_id=seed["salary_id"],
+            description="Salary",
+            amount=Decimal("3000"),
+            type="income",
+            frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date(2026, 5, 25),
+            auto_settle=False,
+            is_active=True,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.refresh_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    items = [
+        i for i in resp.items
+        if i.category_id == seed["salary_id"] and i.type == "income"
+    ]
+    assert len(items) == 1
+    assert items[0].planned_amount == Decimal("3000")
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_duplicate_manual_items(session_factory):
+    """If a manual item already exists for a category, populate's
+    additive logic must skip the (cat, type) key — the manual item
+    stays, no duplicate row."""
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        plan = ForecastPlan(
+            org_id=seed["org_id"], billing_period_id=seed["period_id"],
+            status=PlanStatus.DRAFT,
+        )
+        db.add(plan)
+        await db.commit()
+        # Manual income item; user set $5000 by hand
+        db.add(ForecastPlanItem(
+            plan_id=plan.id, org_id=seed["org_id"],
+            category_id=seed["salary_id"],
+            type=ForecastItemType.INCOME,
+            planned_amount=Decimal("5000"),
+            source=ItemSource.MANUAL,
+        ))
+        await db.commit()
+
+        # Active recurring of $3000 for the same (category, type)
+        db.add(RecurringTransaction(
+            org_id=seed["org_id"],
+            account_id=seed["account_id"],
+            category_id=seed["salary_id"],
+            description="Salary",
+            amount=Decimal("3000"),
+            type="income",
+            frequency=Frequency.MONTHLY,
+            next_due_date=datetime.date(2026, 5, 25),
+            auto_settle=False,
+            is_active=True,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.refresh_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    items = [
+        i for i in resp.items
+        if i.category_id == seed["salary_id"] and i.type == "income"
+    ]
+    assert len(items) == 1, "manual item must not be duplicated by recurring"
+    assert items[0].planned_amount == Decimal("5000")
+    assert items[0].source == "manual"

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import CategorySelect from "@/components/ui/CategorySelect";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { formatAmount } from "@/lib/format";
@@ -134,18 +135,36 @@ export default function ForecastPlansPage() {
     }
   }, [loading, user, loadPlan, periodStart]);
 
-  // Available categories for add form
-  const masterCategories = categories.filter((c) => c.parent_id === null);
-  const existingKeys = new Set(
-    (plan?.items ?? []).map((i) => `${i.category_id}-${i.type}`)
-  );
-  const availableForType = masterCategories.filter(
-    (c) =>
-      !existingKeys.has(`${c.id}-${formType}`) &&
-      (formType === "expense"
-        ? c.type === "expense" || c.type === "both"
-        : c.type === "income" || c.type === "both")
-  );
+  // Categories already used in the plan for the currently-selected
+  // type. Plan items always reference master categories, but the
+  // dropdown lets the user pick subcategories too (we roll up to master
+  // on submit), so a master being "already added" must also disable
+  // all of its children. Greying out keeps the option visible so the
+  // user sees why a previously available choice can no longer be
+  // picked, instead of having the row silently vanish.
+  const disabledForType = useMemo(() => {
+    const usedMasters = new Set<number>();
+    for (const i of plan?.items ?? []) {
+      if (i.type === formType) usedMasters.add(i.category_id);
+    }
+    const ids = new Set<number>(usedMasters);
+    for (const c of categories) {
+      if (c.parent_id !== null && usedMasters.has(c.parent_id)) {
+        ids.add(c.id);
+      }
+    }
+    return ids;
+  }, [plan?.items, formType, categories]);
+
+  // Resolve a selected category to its master (parent if it's a sub,
+  // itself if it's already a master). Forecast plans store master ids,
+  // but the dropdown lets the user pick subs for ergonomics.
+  const resolveMasterId = (catId: number | ""): number | "" => {
+    if (catId === "") return "";
+    const cat = categories.find((c) => c.id === catId);
+    if (!cat) return "";
+    return cat.parent_id ?? cat.id;
+  };
 
   // Filtered items
   const items = (plan?.items ?? []).filter(
@@ -169,17 +188,43 @@ export default function ForecastPlansPage() {
     }
   }
 
+  async function handleRefreshFromSources() {
+    setConfirmAction({
+      title: "Refresh from sources",
+      message:
+        "This replaces auto-generated rows (recurring templates, history averages) with fresh data. Lines you added or edited yourself stay untouched.",
+      variant: "warning",
+      action: async () => {
+        setError("");
+        try {
+          const p = await apiFetch<ForecastPlan>(
+            `/api/v1/forecast-plans/refresh-from-sources?period_start=${periodStart}`,
+            { method: "POST" }
+          );
+          setPlan(p);
+        } catch (err) {
+          setError(extractErrorMessage(err));
+        }
+      },
+    });
+  }
+
   async function handleAddItem(e: FormEvent) {
     e.preventDefault();
     if (!plan) return;
     setError("");
+    const masterId = resolveMasterId(formCategoryId);
+    if (masterId === "") {
+      setError("Please pick a category");
+      return;
+    }
     try {
       const p = await apiFetch<ForecastPlan>(
         `/api/v1/forecast-plans/${plan.id}/items`,
         {
           method: "POST",
           body: JSON.stringify({
-            category_id: formCategoryId,
+            category_id: masterId,
             type: formType,
             planned_amount: formAmount,
           }),
@@ -321,6 +366,15 @@ export default function ForecastPlansPage() {
             <button onClick={handlePopulate} className={btnPrimary}>
               Auto-populate
             </button>
+            {hasItems && (
+              <button
+                onClick={handleRefreshFromSources}
+                className={btnPrimary}
+                title="Drop auto-generated rows and re-run populate. Manual edits are preserved."
+              >
+                Refresh from sources
+              </button>
+            )}
             <button
               onClick={() => setShowForm(!showForm)}
               className={btnPrimary}
@@ -472,24 +526,21 @@ export default function ForecastPlansPage() {
               <label htmlFor="fp-cat" className={label}>
                 Category
               </label>
-              <select
+              <CategorySelect
                 id="fp-cat"
-                required
+                categories={categories}
                 value={formCategoryId}
-                onChange={(e) =>
-                  setFormCategoryId(
-                    e.target.value === "" ? "" : Number(e.target.value)
-                  )
-                }
+                onChange={(id) => setFormCategoryId(id)}
+                filterType={formType}
+                disabledIds={disabledForType}
                 className={input}
-              >
-                <option value="">Select category</option>
-                {availableForType.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
+                aria-label="Plan item category"
+                onCategoryCreated={(cat) => {
+                  setCategories((prev) =>
+                    prev.some((c) => c.id === cat.id) ? prev : [...prev, cat],
+                  );
+                }}
+              />
             </div>
             <div className="w-full sm:w-40">
               <label htmlFor="fp-amount" className={label}>

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -31,9 +31,22 @@ interface Props {
   className?: string;
   "aria-label"?: string;
   onCategoryCreated?: (cat: Category) => void;
+  /**
+   * Category IDs that should still appear in the dropdown but render as
+   * disabled (greyed-out, non-selectable, with an "(already added)"
+   * hint). Used by callers that enforce one-row-per-category, so a
+   * previously available choice doesn't silently vanish after it's
+   * picked — the user can see why the option is no longer selectable.
+   */
+  disabledIds?: ReadonlySet<number> | number[];
 }
 
-export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel, onCategoryCreated }: Props) {
+export default function CategorySelect({ id, categories, value, onChange, filterType, typeFilter, className = "", "aria-label": ariaLabel, onCategoryCreated, disabledIds }: Props) {
+  const disabledSet = useMemo(() => {
+    if (!disabledIds) return null;
+    return disabledIds instanceof Set ? disabledIds : new Set(disabledIds);
+  }, [disabledIds]);
+  const isDisabled = (id: number) => (disabledSet ? disabledSet.has(id) : false);
   // Normalize uppercase `typeFilter` (transfers callers) to internal lowercase
   // so it joins the existing filterType machinery without divergent code paths.
   const effectiveFilterType = filterType ?? (typeFilter === "INCOME" ? "income" : typeFilter === "EXPENSE" ? "expense" : undefined);
@@ -77,8 +90,12 @@ export default function CategorySelect({ id, categories, value, onChange, filter
     .filter(Boolean) as Category[];
   const nonRecent = filtered.filter((c) => !recentIds.includes(c.id));
 
-  // Build ordered flat list for keyboard nav
-  const flatList: Category[] = [...recentItems, ...nonRecent];
+  // Build ordered flat list for keyboard nav.
+  // Disabled categories are skipped — Enter on an "already added" row
+  // is a no-op, so we don't waste an arrow stop on it.
+  const flatList: Category[] = [...recentItems, ...nonRecent].filter(
+    (c) => !isDisabled(c.id),
+  );
 
   useEffect(() => {
     if (!open || showAddModal) return;
@@ -92,6 +109,7 @@ export default function CategorySelect({ id, categories, value, onChange, filter
   useEffect(() => { setHighlightIdx(-1); }, [query, open]);
 
   function handleSelect(cat: Category) {
+    if (isDisabled(cat.id)) return;
     onChange(cat.id);
     saveRecent(cat.id);
     setQuery("");
@@ -144,8 +162,6 @@ export default function CategorySelect({ id, categories, value, onChange, filter
   const activeDescendant = highlightIdx >= 0 && highlightIdx < flatList.length
     ? `${id}-opt-${flatList[highlightIdx].id}` : undefined;
 
-  let itemIdx = recentItems.length;
-
   return (
     <div ref={ref} className="relative">
       <input
@@ -174,37 +190,81 @@ export default function CategorySelect({ id, categories, value, onChange, filter
           {recentItems.length > 0 && (
             <>
               <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Recent</div>
-              {recentItems.map((cat, i) => (
-                <button key={cat.id} type="button" data-cat-item onClick={() => handleSelect(cat)}
-                  id={`${id}-opt-${cat.id}`}
-                  className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${highlightIdx === i ? "bg-accent-dim text-accent" : "text-text-primary hover:bg-surface-raised"}`}
-                  role="option" aria-selected={cat.id === value}>
-                  <span>{cat.name}</span>
-                  <span className="text-xs text-text-muted">{cat.parent_name}</span>
-                </button>
-              ))}
+              {recentItems.map((cat) => {
+                const disabled = isDisabled(cat.id);
+                const navIdx = flatList.indexOf(cat);
+                const highlighted = !disabled && navIdx >= 0 && highlightIdx === navIdx;
+                return (
+                  <button
+                    key={cat.id}
+                    type="button"
+                    data-cat-item
+                    onClick={() => handleSelect(cat)}
+                    id={`${id}-opt-${cat.id}`}
+                    disabled={disabled}
+                    aria-disabled={disabled}
+                    className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${
+                      disabled
+                        ? "cursor-not-allowed text-text-muted opacity-60"
+                        : highlighted
+                          ? "bg-accent-dim text-accent"
+                          : "text-text-primary hover:bg-surface-raised"
+                    }`}
+                    role="option"
+                    aria-selected={cat.id === value}
+                  >
+                    <span>
+                      {cat.name}
+                      {disabled && (
+                        <span className="ml-1.5 text-[11px] italic text-text-muted">(already added)</span>
+                      )}
+                    </span>
+                    <span className="text-xs text-text-muted">{cat.parent_name}</span>
+                  </button>
+                );
+              })}
               <div className="border-t border-border-subtle" />
             </>
           )}
 
-          {grouped.map((group) => {
-            const startIdx = itemIdx;
-            itemIdx += group.items.length;
-            return (
-              <div key={group.label}>
-                <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">{group.label}</div>
-                {group.items.map((cat, i) => (
-                  <button key={cat.id} type="button" data-cat-item onClick={() => handleSelect(cat)}
+          {grouped.map((group) => (
+            <div key={group.label}>
+              <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">{group.label}</div>
+              {group.items.map((cat) => {
+                const disabled = isDisabled(cat.id);
+                const navIdx = flatList.indexOf(cat);
+                const highlighted = !disabled && navIdx >= 0 && highlightIdx === navIdx;
+                return (
+                  <button
+                    key={cat.id}
+                    type="button"
+                    data-cat-item
+                    onClick={() => handleSelect(cat)}
                     id={`${id}-opt-${cat.id}`}
-                    className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${highlightIdx === startIdx + i ? "bg-accent-dim text-accent" : "text-text-primary hover:bg-surface-raised"}`}
-                    role="option" aria-selected={cat.id === value}>
-                    <span>{cat.name}</span>
+                    disabled={disabled}
+                    aria-disabled={disabled}
+                    className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${
+                      disabled
+                        ? "cursor-not-allowed text-text-muted opacity-60"
+                        : highlighted
+                          ? "bg-accent-dim text-accent"
+                          : "text-text-primary hover:bg-surface-raised"
+                    }`}
+                    role="option"
+                    aria-selected={cat.id === value}
+                  >
+                    <span>
+                      {cat.name}
+                      {disabled && (
+                        <span className="ml-1.5 text-[11px] italic text-text-muted">(already added)</span>
+                      )}
+                    </span>
                     {cat.description && <span className="ml-2 truncate text-xs text-text-muted">{cat.description}</span>}
                   </button>
-                ))}
-              </div>
-            );
-          })}
+                );
+              })}
+            </div>
+          ))}
 
           {filtered.length === 0 && (
             <div className="px-3 py-4 text-center text-sm text-text-muted">No categories match</div>

--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -1,0 +1,352 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import ForecastPlansPage from "@/app/forecast-plans/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/forecast-plans",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+// recharts pulls in window.matchMedia and friends; stub the bits the test
+// surfaces touch.
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+}));
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+// Master + sub categories of both types so we can prove the dropdown
+// shows masters AND subs that match the selected type.
+const CATEGORIES = [
+  // Income side
+  {
+    id: 10, name: "Salary", type: "income", parent_id: null,
+    parent_name: null, description: null, slug: "salary",
+    is_system: false, transaction_count: 0,
+  },
+  {
+    id: 11, name: "Bonus", type: "income", parent_id: 10,
+    parent_name: "Salary", description: null, slug: "bonus",
+    is_system: false, transaction_count: 0,
+  },
+  {
+    id: 12, name: "Side gigs", type: "income", parent_id: null,
+    parent_name: null, description: null, slug: "side-gigs",
+    is_system: false, transaction_count: 0,
+  },
+  // Expense side
+  {
+    id: 20, name: "Groceries", type: "expense", parent_id: null,
+    parent_name: null, description: null, slug: "groceries",
+    is_system: false, transaction_count: 0,
+  },
+  {
+    id: 21, name: "Supermarket", type: "expense", parent_id: 20,
+    parent_name: "Groceries", description: null, slug: "supermarket",
+    is_system: false, transaction_count: 0,
+  },
+];
+
+const PERIOD = {
+  id: 1, start_date: "2026-05-01", end_date: null,
+};
+
+function makePlan(items: Array<{
+  id?: number; category_id: number; category_name?: string;
+  type: "income" | "expense"; planned_amount: number;
+  source?: "manual" | "recurring" | "history";
+  parent_id?: number | null; actual_amount?: number; variance?: number;
+}> = []) {
+  return {
+    id: 100,
+    billing_period_id: PERIOD.id,
+    period_start: PERIOD.start_date,
+    period_end: null,
+    status: "draft" as const,
+    total_planned_income: 0,
+    total_planned_expense: 0,
+    total_actual_income: 0,
+    total_actual_expense: 0,
+    items: items.map((it, idx) => ({
+      id: it.id ?? idx + 1,
+      plan_id: 100,
+      category_id: it.category_id,
+      category_name: it.category_name ?? "Cat",
+      parent_id: it.parent_id ?? null,
+      type: it.type,
+      planned_amount: it.planned_amount,
+      source: it.source ?? "manual",
+      actual_amount: it.actual_amount ?? 0,
+      variance: it.variance ?? 0,
+    })),
+  };
+}
+
+function setupAuth() {
+  (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    user: USER, loading: false, login: vi.fn(), logout: vi.fn(),
+    refresh: vi.fn(),
+  });
+}
+
+function mockInitialFetches(plan: ReturnType<typeof makePlan>) {
+  // ensure-future-periods POST happens first, then categories + periods,
+  // then GET /forecast-plans?period_start=...
+  (apiFetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (path: string, init?: RequestInit) => {
+      if (path.startsWith("/api/v1/settings/billing-periods/ensure-future")) {
+        return Promise.resolve([]);
+      }
+      if (path === "/api/v1/categories") {
+        return Promise.resolve(CATEGORIES);
+      }
+      if (path === "/api/v1/settings/billing-periods") {
+        return Promise.resolve([PERIOD]);
+      }
+      if (path.startsWith("/api/v1/forecast-plans?")) {
+        return Promise.resolve(plan);
+      }
+      if (path.startsWith("/api/v1/forecast-plans/refresh-from-sources")) {
+        return Promise.resolve(plan);
+      }
+      // populate is exercised in a separate test
+      if (path.includes("/populate")) {
+        return Promise.resolve(plan);
+      }
+      // default — return whatever was requested as empty plan-like
+      void init;
+      return Promise.resolve(plan);
+    },
+  );
+}
+
+describe("ForecastPlansPage — dropdown + refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    setupAuth();
+  });
+
+  it("Bug 1: income type shows master AND sub categories in the dropdown", async () => {
+    mockInitialFetches(makePlan());
+
+    render(<ForecastPlansPage />);
+
+    // Wait for the page to render the Auto-populate header button,
+    // which means the initial fetches have settled.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Auto-populate" }),
+      ).toBeTruthy();
+    });
+
+    // Open the add form
+    fireEvent.click(screen.getByRole("button", { name: /\+ Add Item/ }));
+
+    // Switch type to income
+    const typeSelect = screen.getByLabelText("Type") as HTMLSelectElement;
+    fireEvent.change(typeSelect, { target: { value: "income" } });
+
+    // Open the CategorySelect dropdown
+    const combobox = screen.getByRole("combobox", {
+      name: /Plan item category/i,
+    });
+    fireEvent.focus(combobox);
+
+    // Both master "Salary" and sub "Bonus" must be present
+    const listbox = await screen.findByRole("listbox");
+    expect(within(listbox).getByText("Salary")).toBeTruthy();
+    expect(within(listbox).getByText("Bonus")).toBeTruthy();
+    expect(within(listbox).getByText("Side gigs")).toBeTruthy();
+    // Expense-only categories must NOT be present
+    expect(within(listbox).queryByText("Groceries")).toBeNull();
+    expect(within(listbox).queryByText("Supermarket")).toBeNull();
+  });
+
+  it("Bug 4: a category already in the plan renders as disabled with '(already added)'", async () => {
+    // Plan has "Side gigs" (master, no children) already added as income
+    mockInitialFetches(
+      makePlan([
+        {
+          category_id: 12,
+          category_name: "Side gigs",
+          type: "income",
+          planned_amount: 500,
+          source: "manual",
+        },
+      ]),
+    );
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ Add Item/ })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ Add Item/ }));
+    const typeSelect = screen.getByLabelText("Type") as HTMLSelectElement;
+    fireEvent.change(typeSelect, { target: { value: "income" } });
+
+    const combobox = screen.getByRole("combobox", {
+      name: /Plan item category/i,
+    });
+    fireEvent.focus(combobox);
+
+    const listbox = await screen.findByRole("listbox");
+
+    // The Side gigs option still appears in the dropdown and carries the
+    // "(already added)" hint instead of vanishing.
+    const options = within(listbox).getAllByRole("option");
+    const sideGigsButton = options.find((b) =>
+      (b.textContent ?? "").includes("Side gigs"),
+    ) as HTMLButtonElement | undefined;
+    expect(sideGigsButton).toBeTruthy();
+    expect(sideGigsButton!.textContent).toContain("(already added)");
+
+    // The button is disabled (cannot be selected)
+    expect(sideGigsButton!.disabled).toBe(true);
+    expect(sideGigsButton!.getAttribute("aria-disabled")).toBe("true");
+
+    // Click it — the dropdown stays open and no selection happens.
+    fireEvent.click(sideGigsButton!);
+    expect(screen.queryByRole("listbox")).toBeTruthy();
+  });
+
+  it("Bug 4: subcategory of an already-added master is disabled too", async () => {
+    // Plan has Salary master already added as income.
+    // Bonus is a child of Salary; picking Bonus would roll up to Salary,
+    // which is a no-op against the existing item — so Bonus should be
+    // shown as disabled too.
+    mockInitialFetches(
+      makePlan([
+        {
+          category_id: 10,
+          category_name: "Salary",
+          type: "income",
+          planned_amount: 3000,
+          source: "manual",
+        },
+      ]),
+    );
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ Add Item/ })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /\+ Add Item/ }));
+    const typeSelect = screen.getByLabelText("Type") as HTMLSelectElement;
+    fireEvent.change(typeSelect, { target: { value: "income" } });
+
+    const combobox = screen.getByRole("combobox", {
+      name: /Plan item category/i,
+    });
+    fireEvent.focus(combobox);
+
+    const listbox = await screen.findByRole("listbox");
+    const options = within(listbox).getAllByRole("option");
+    const bonusButton = options.find((b) =>
+      (b.textContent ?? "").includes("Bonus"),
+    ) as HTMLButtonElement | undefined;
+    expect(bonusButton).toBeTruthy();
+    expect(bonusButton!.disabled).toBe(true);
+    expect(bonusButton!.textContent).toContain("(already added)");
+  });
+
+  it("Bug 5: Refresh from sources renders a confirm modal with the locked copy", async () => {
+    mockInitialFetches(
+      makePlan([
+        {
+          category_id: 20,
+          category_name: "Groceries",
+          type: "expense",
+          planned_amount: 500,
+          source: "recurring",
+        },
+      ]),
+    );
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Refresh from sources")).toBeTruthy();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh from sources" }),
+    );
+
+    // Confirm modal copy — title rendered as the dialog heading
+    expect(screen.getByText("Refresh from sources", { selector: "h3" }))
+      .toBeTruthy();
+    expect(
+      screen.getByText(
+        /This replaces auto-generated rows .*recurring templates, history averages.* with fresh data\. Lines you added or edited yourself stay untouched\./,
+      ),
+    ).toBeTruthy();
+
+    // Confirm fires the refresh endpoint
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm$/ }));
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "/api/v1/forecast-plans/refresh-from-sources?period_start=",
+        ),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  it("Bug 5: Refresh button is hidden on an empty draft plan", async () => {
+    mockInitialFetches(makePlan());
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Auto-populate" }),
+      ).toBeTruthy();
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Refresh from sources" }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes 5 user-reported behaviors on the Forecast Plans page.

## Changes per bug

**Bug 1: Income dropdown only showed master categories.**
Replaced the native `<select>` with the shared `CategorySelect` using `filterType={formType}`. Income (and expense) now show master + sub categories; selecting a sub rolls up to its master before submit so the master-only invariant stays intact server-side. Inline "Add category" comes along for free.

**Bug 2: Recurring INCOME ignored by auto-populate.**
The recurring loop was already correct; coverage was missing. Added `test_recurring_income_populates_plan` to pin the symmetric behavior.

**Bug 3: Auto-populate ignored current-period PENDING.**
Split `populate_from_sources` history aggregation into two scopes:
- History (3 months prior): SETTLED only, now also excludes transfer legs via `reportable_transaction_filter`.
- Current period: SETTLED OR PENDING, treated as one extra month slot in the rolling average.

Month bucketing moved to Python so the query is portable between MySQL and SQLite (test fixture). Pinned by `test_current_period_pending_counts_history_pending_excluded`, `test_history_settled_only`, `test_current_period_excludes_transfer_legs`.

**Bug 4: Used categories vanished from the dropdown after add.**
Added `disabledIds` prop to `CategorySelect`. Categories already in the plan render as greyed-out options with an "(already added)" hint. Picking a sub of an already-added master is also disabled (would roll up to the same master). Keyboard nav skips disabled rows. Pinned by `Bug 4: a category already in the plan renders as disabled with '(already added)'` and `Bug 4: subcategory of an already-added master is disabled too`.

**Bug 5: Re-running auto-populate didn't pick up new transactions.**
Added `refresh_from_sources(db, org_id, period_start)` service, `POST /api/v1/forecast-plans/refresh-from-sources` endpoint, and a "Refresh from sources" button next to Auto-populate (visible only when the draft has items). Drops items where `source IN (recurring, history)` and re-runs populate; manual items survive. No schema migration needed: the existing `source` enum on `forecast_plan_items` already encodes the auto vs manual distinction (`source=MANUAL` is set when a user adds a row by hand or edits an auto-generated one). Confirm modal copy is customer-facing and uses the locked phrasing.

## Test counts
- Backend: 420 passed, 2 skipped (was 413 before this branch — 7 new in `test_forecast_plan_populate.py`).
- Frontend: 171 passed (was 166 — 5 new in `tests/app/forecast-plans-page.test.tsx`).

## Files touched
- `backend/app/services/forecast_plan_service.py`
- `backend/app/routers/forecast_plans.py`
- `backend/tests/services/test_forecast_plan_populate.py` (new)
- `frontend/app/forecast-plans/page.tsx`
- `frontend/components/ui/CategorySelect.tsx`
- `frontend/tests/app/forecast-plans-page.test.tsx` (new)

No migration. Org-scoping unchanged (every query keeps the `org_id` filter; new endpoint goes through `get_current_user`).

## Follow-ups (not in this PR)
- `upsert_item` and `bulk_upsert` accept user-supplied `source` values. The refresh logic relies on `source=MANUAL` faithfully marking user-touched rows, so a future cleanup should pin `source` server-side on direct API writes (populate would be the only path that ever sets `recurring|history`). Not exploitable across orgs, just sloppier than ideal.