### PR TITLE
docs(infra): clarify VCS-driven Terraform workflow

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -2,10 +2,13 @@ terraform {
   required_version = ">= 1.5.0"
 
   # State + plan/apply runs live in Terraform Cloud (FlamaCorp/pfv).
-  # The workspace is VCS-driven against this repo with the working directory
-  # scoped to infra/terraform/ and trigger paths the same. Set workspace
-  # variables `do_token` (sensitive) and `ssh_key_name` in TFC; everything
-  # else has sensible defaults in variables.tf.
+  # The workspace is VCS-driven against this repo via the HCP Terraform
+  # GitHub App, with working directory scoped to infra/terraform/ and
+  # trigger pattern infra/terraform/** . Speculative plans fire on PR;
+  # merges to main create runs that wait for manual Confirm & Apply in
+  # the TFC UI (auto-apply is intentionally off). Set workspace variables
+  # `do_token` (sensitive) and `ssh_key_name` in TFC; everything else
+  # has sensible defaults in variables.tf.
   cloud {
     organization = "FlamaCorp"
     workspaces {


### PR DESCRIPTION
## Summary
Comment-only edit to `infra/terraform/main.tf` documenting the now-active VCS-driven workflow (HCP Terraform GitHub App, speculative plans on PR, manual approval on merge).

## Changes
- Updated the inline comment above the `cloud {}` block to reflect the actual mechanics now that the workspace is wired.

## Why this PR exists
End-to-end test of the new TFC VCS integration. Expected behavior on this PR:
- HCP Terraform speculative plan fires automatically against `infra/terraform/**` trigger pattern.
- Plan summary appears as a check on this PR.
- Plan should show 0 to add / 0 to change / 0 to destroy (purely a comment change).

If speculative plan does not appear, the trigger configuration needs another pass.