### PR TITLE
fix(forecast-plans): show categories with only current-period activity

### DIFF
--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -422,7 +422,12 @@ async def populate_from_sources(
     for key, months in master_monthly.items():
         if key in existing_keys:
             continue
-        if len(months) < 2:  # Need at least 2 months to suggest
+        # Current-period activity is authoritative: even if there is no
+        # historical settled signal in this category, an already-imported
+        # transaction in the period being planned should drive a suggestion.
+        # Pure-history signals still need 2+ months to avoid one-off noise.
+        has_current = current_period_label in months
+        if not has_current and len(months) < 2:
             continue
         master_id, tx_type = key
         avg_amount = sum(months.values()) / len(months)

--- a/backend/tests/services/test_forecast_plan_populate.py
+++ b/backend/tests/services/test_forecast_plan_populate.py
@@ -283,6 +283,49 @@ async def test_history_settled_only(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_current_period_only_creates_plan_line_without_history(session_factory):
+    """A category with NO historical settled transactions but at least one
+    current-period transaction (settled or pending) must still produce a
+    plan line. Current-period activity is authoritative; the 2-month
+    minimum gate only applies when relying purely on history.
+
+    Regression: before this fix, populate skipped any category whose only
+    activity was in the current period, so a non-recurring one-shot like
+    a furniture purchase imported in May would not surface in auto-populate
+    even though pending was being counted into master_monthly.
+    """
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        # No historical transactions at all. One pending in current period.
+        db.add(_tx(
+            org_id=seed["org_id"], account_id=seed["account_id"],
+            category_id=seed["groceries_id"], amount=500,
+            date=datetime.date(2026, 5, 7),
+            settled_date=None,
+            status=TransactionStatus.PENDING, type_=TransactionType.EXPENSE,
+        ))
+        await db.commit()
+
+    async with session_factory() as db:
+        resp = await forecast_plan_service.populate_from_sources(
+            db, org_id=seed["org_id"], period_start=seed["may_start"],
+        )
+
+    items = [
+        i for i in resp.items
+        if i.category_id == seed["groceries_id"] and i.type == "expense"
+    ]
+    assert len(items) == 1, (
+        "current-period-only activity should create a plan line; "
+        "historical 2-month gate must not apply when current-period exists"
+    )
+    # Average over the single current-period slot equals the tx amount.
+    assert items[0].planned_amount == Decimal("500.00")
+    assert items[0].source == "history"
+
+
+@pytest.mark.asyncio
 async def test_current_period_excludes_transfer_legs(session_factory):
     """A pending transfer leg (linked_transaction_id != NULL) in the
     current period must not feed the suggestion — same rule as actuals."""


### PR DESCRIPTION
## Summary
Closes the user-reported bug that auto-populate / refresh-from-sources didn't surface categories whose only activity was non-recurring transactions in the current period (e.g., a furniture purchase imported today).

## Root cause
`forecast_plan_service.populate_from_sources` rolled current-period SETTLED+PENDING into `master_monthly` as one extra slot (PR #144), but the loop that turns `master_monthly` into plan items kept the original `if len(months) < 2: continue` gate. For a brand-new category with only current-period activity, `master_monthly[key] = {"__current__": amount}` has length 1 and was skipped.

## Fix
Skip the 2-month minimum when current-period activity exists. Pure-history signals still need 2+ months to avoid one-off month noise; current-period activity is authoritative because it represents already-imported bills for the period being planned.

## Changes
- `backend/app/services/forecast_plan_service.py`: `if not has_current and len(months) < 2: continue` replaces the unconditional gate.
- `backend/tests/services/test_forecast_plan_populate.py`: new regression `test_current_period_only_creates_plan_line_without_history` pins the fix.

## Tests
Backend: **451 passed**, 2 skipped (baseline 450, added 1 regression test). Existing tests `test_history_settled_only` (history-only requires 2+ months — still gated) and `test_current_period_pending_counts_history_pending_excluded` (history + current — averaged) both still pass.