### PR TITLE
fix(dashboard): on-track verdict anchors on actual spending, not projection

### DIFF
--- a/frontend/components/dashboard/OnTrackTile.tsx
+++ b/frontend/components/dashboard/OnTrackTile.tsx
@@ -286,10 +286,13 @@ export default function OnTrackTile({
     );
   }
 
-  // Default current-period view: verdict + variance use the projection.
-  const pct = forecastExpense / plannedExpense;
+  // Default current-period view: verdict + variance anchor on actual (settled)
+  // spending, NOT the projection. The projection is shown as an informational
+  // muted stat so it never alarms the user before money has actually moved.
+  // YNAB / Monarch / Copilot / Mint all behave this way.
+  const pct = executedExpense / plannedExpense;
   const verdict = computeVerdict(pct);
-  const variance = plannedExpense - forecastExpense;
+  const variance = plannedExpense - executedExpense;
   const varianceFavorable = variance >= 0;
 
   return (
@@ -319,7 +322,8 @@ export default function OnTrackTile({
         <Stat
           label="PROJECTED"
           value={formatAmount(forecastExpense)}
-          sublabel="forecast for month"
+          sublabel="projected end-of-month"
+          muted
         />
       </div>
     </section>

--- a/frontend/tests/components/dashboard/on-track-tile.test.tsx
+++ b/frontend/tests/components/dashboard/on-track-tile.test.tsx
@@ -17,8 +17,8 @@ function defaults(overrides: Partial<Parameters<typeof OnTrackTile>[0]> = {}) {
   };
 }
 
-describe("OnTrackTile — verdict thresholds (current period)", () => {
-  it("renders ON TRACK when projected/plan <= 0.95", () => {
+describe("OnTrackTile — verdict thresholds (current period, anchored on actuals)", () => {
+  it("renders ON TRACK when executed/plan <= 0.95", () => {
     render(
       <OnTrackTile
         {...defaults({
@@ -32,28 +32,93 @@ describe("OnTrackTile — verdict thresholds (current period)", () => {
     expect(screen.getByRole("heading", { level: 2 })).not.toHaveTextContent(/OVER BUDGET/);
   });
 
-  it("renders WATCH when 0.95 < projected/plan <= 1.05", () => {
+  it("renders WATCH when 0.95 < executed/plan <= 1.05", () => {
     render(
       <OnTrackTile
         {...defaults({
           forecastPlan: PLAN_1000,
-          projection: { executed_expense: "500", forecast_expense: "1000" },
+          projection: { executed_expense: "1000", forecast_expense: "1000" },
         })}
       />,
     );
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^WATCH/);
   });
 
-  it("renders OVER BUDGET when projected/plan > 1.05", () => {
+  it("renders OVER BUDGET when executed/plan > 1.05", () => {
     render(
       <OnTrackTile
         {...defaults({
           forecastPlan: PLAN_1000,
-          projection: { executed_expense: "800", forecast_expense: "1200" },
+          projection: { executed_expense: "1200", forecast_expense: "1200" },
         })}
       />,
     );
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/OVER BUDGET/);
+  });
+});
+
+describe("OnTrackTile — verdict ignores projection (the user-reported bug)", () => {
+  // Bug: a fully-pending month (executed=0) used to read as OVER BUDGET because
+  // the projected expense (settled + pending + remaining recurring fires)
+  // exceeded the plan. The verdict now anchors on settled spending only.
+
+  it("ON TRACK when nothing has actually been spent yet, even with projected > plan", () => {
+    render(
+      <OnTrackTile
+        {...defaults({
+          forecastPlan: { total_planned_expense: "561.86" },
+          projection: { executed_expense: "0", forecast_expense: "1050" },
+        })}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^ON TRACK/);
+    // Projected stat still shows the number, but muted (informational only).
+    const projectedLabel = screen.getByText(/^PROJECTED$/);
+    const projectedValue = projectedLabel.parentElement?.querySelectorAll("p")[1];
+    expect(projectedValue?.textContent).toMatch(/1,050/);
+    expect(projectedValue?.className).toMatch(/text-text-muted/);
+  });
+
+  it("OVER BUDGET when settled spending alone exceeds the plan", () => {
+    render(
+      <OnTrackTile
+        {...defaults({
+          forecastPlan: { total_planned_expense: "561.86" },
+          projection: { executed_expense: "600", forecast_expense: "600" },
+        })}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^OVER BUDGET/);
+  });
+
+  it("ON TRACK with projected over plan: variance is favorable, no danger color anywhere", () => {
+    const { container } = render(
+      <OnTrackTile
+        {...defaults({
+          forecastPlan: { total_planned_expense: "561.86" },
+          projection: { executed_expense: "300", forecast_expense: "900" },
+        })}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^ON TRACK/);
+    // Variance under plan, accent (favorable) color, no danger.
+    expect(screen.getByText(/under plan/i)).toBeInTheDocument();
+    expect(container.querySelector(".text-danger")).toBeNull();
+  });
+
+  it("PROJECTED stat carries 'projected end-of-month' sublabel and is muted", () => {
+    render(
+      <OnTrackTile
+        {...defaults({
+          forecastPlan: PLAN_1000,
+          projection: { executed_expense: "300", forecast_expense: "900" },
+        })}
+      />,
+    );
+    expect(screen.getByText(/projected end-of-month/i)).toBeInTheDocument();
+    const projectedLabel = screen.getByText(/^PROJECTED$/);
+    const projectedValue = projectedLabel.parentElement?.querySelectorAll("p")[1];
+    expect(projectedValue?.className).toMatch(/text-text-muted/);
   });
 });
 
@@ -71,12 +136,12 @@ describe("OnTrackTile — variance and column labels", () => {
     expect(screen.getByText(/under plan/i)).toBeInTheDocument();
   });
 
-  it("renders Variance with danger + 'over plan' sublabel when projection is unfavorable", () => {
+  it("renders Variance with danger + 'over plan' sublabel when actual spending is unfavorable", () => {
     render(
       <OnTrackTile
         {...defaults({
           forecastPlan: PLAN_1000,
-          projection: { executed_expense: "800", forecast_expense: "1200" },
+          projection: { executed_expense: "1200", forecast_expense: "1200" },
         })}
       />,
     );
@@ -195,6 +260,19 @@ describe("OnTrackTile — past period", () => {
     expect(screen.queryByText(/Set one up/)).not.toBeInTheDocument();
     expect(screen.queryByText(/^This period$/)).not.toBeInTheDocument();
     expect(screen.getByText(/^Past period$/)).toBeInTheDocument();
+  });
+
+  it("renders ENDED ON TRACK when final actual spending is comfortably under plan", () => {
+    render(
+      <OnTrackTile
+        {...defaults({
+          forecastPlan: { total_planned_expense: "561.86" },
+          projection: { executed_expense: "400", forecast_expense: "400" },
+          isPastPeriod: true,
+        })}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^ENDED ON TRACK/);
   });
 
   it("renders FINAL SPENT column and suppresses PROJECTED column", () => {


### PR DESCRIPTION
## Summary

The dashboard On Track tile now computes its verdict (`ON TRACK` / `WATCH` / `OVER BUDGET`) from settled spending rather than from the projection. Before the fix, a fully-pending month (executed = 0) read as `OVER BUDGET` because the projection (settled + pending + remaining recurring fires) exceeded plan. YNAB / Monarch / Copilot / Mint all anchor the alarm on settled actuals; the projection is informational.

## Behavior change

| | Before | After |
|---|---|---|
| Verdict driver | `forecast_expense / planned` | `executed_expense / planned` |
| Variance driver | `planned - forecast_expense` | `planned - executed_expense` |
| `PROJECTED` stat | colored value, sublabel "forecast for month" | muted value, sublabel "projected end-of-month" |
| Bands | `<= 0.95` on track, `0.95 - 1.05` watch, `> 1.05` over | unchanged |

User-reported case (executed = 0, projected = 1050, plan = 561.86) now correctly renders `ON TRACK`. A separate investigation into why the backend's `forecast_expense` is roughly 2x the plan in production is deferred.

## Tests

- Updated existing band tests to assert against executed-anchored verdict.
- Added 4 new tests covering the bug case (executed = 0 / projected over plan), settled-over-plan, settled-on-target with projected over, and the muted PROJECTED treatment.
- Added one past-period `ENDED ON TRACK` case.
- Frontend suite: 184 passed (was 179 / +5 net).

## Out of scope

- The backend `compute_forecast` math, which appears to over-project in some prod data, is a separate investigation requiring a reseed and is not addressed here.
- Per-category bars / lists.
- The Forecast Plans page.