### PR TITLE
fix(auth): tighten SSO password security (step-up on first set, flag on reset, validate-before-consume)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -37,6 +37,7 @@ from app.schemas.auth import (
     RegisterRequest,
     ResendVerificationPublicRequest,
     ResetPasswordRequest,
+    StepUpInitiateRequest,
     TokenResponse,
     UsernameCheckResponse,
     UserResponse,
@@ -466,6 +467,12 @@ async def reset_password(body: ResetPasswordRequest, db: AsyncSession = Depends(
 
     now = datetime.now(timezone.utc)
     user.password_hash = hash_password(body.new_password)
+    # Flip `password_set` so an SSO user who reset via token lands in
+    # the standard branch on every future /users/me/password call and
+    # the UI stops offering "Set a Password". Without this flip the
+    # account has working local credentials but the row still claims
+    # no password has ever been chosen. (Finding 2 from PR #138.)
+    user.password_set = True
     user.password_changed_at = now
     user.sessions_invalidated_at = now
     await db.commit()
@@ -1075,9 +1082,22 @@ async def google_callback(
 STEPUP_TOKEN_TTL_SECONDS = 5 * 60
 
 
+# Allowlist of pages the step-up callback may redirect back to. We
+# encode the chosen target into `state` (and validate it on the way
+# back) so the Google round-trip cannot be twisted into an open
+# redirect. New entries here must remain same-origin first-party
+# settings paths.
+_STEPUP_RETURN_TARGETS: dict[str, str] = {
+    "settings": "/settings",
+    "security": "/settings/security",
+}
+_STEPUP_DEFAULT_TARGET = "settings"
+
+
 @router.post("/sso-stepup/initiate")
 async def sso_stepup_initiate(
     response: Response,
+    body: StepUpInitiateRequest | None = None,
     current_user: User = Depends(get_current_user),
 ):
     """Begin a Google step-up flow for the signed-in user.
@@ -1085,12 +1105,19 @@ async def sso_stepup_initiate(
     Returns the Google consent URL the frontend should navigate to.
     The state cookie embeds the `current_user.id` so the callback can
     verify the same user finished the round-trip and reject any state
-    coming back to a different session.
+    coming back to a different session. State also encodes the chosen
+    return target (validated against an allowlist) so the callback can
+    redirect to either /settings (email change) or /settings/security
+    (first-time password set) without a query-string open redirect.
     """
     _validate_google_config()
 
+    return_key = (body.return_to if body else None) or _STEPUP_DEFAULT_TARGET
+    if return_key not in _STEPUP_RETURN_TARGETS:
+        return_key = _STEPUP_DEFAULT_TARGET
+
     nonce = secrets.token_urlsafe(32)
-    state = f"stepup:{current_user.id}:{nonce}"
+    state = f"stepup:{current_user.id}:{nonce}:{return_key}"
     response.set_cookie(
         key="oauth_state",
         value=state,
@@ -1146,13 +1173,19 @@ async def sso_stepup_callback(
 
     # State binds the redemption to a specific user_id chosen at
     # initiate time. Without an Authorization header here, the state
-    # cookie + state string round trip is the identity proof.
+    # cookie + state string round trip is the identity proof. The
+    # 4-part shape carries the return-target chosen at initiate so the
+    # callback redirects to the correct settings page (validated
+    # against `_STEPUP_RETURN_TARGETS` to prevent open redirect).
     parts = state.split(":")
-    if len(parts) != 3 or parts[0] != "stepup":
+    if len(parts) != 4 or parts[0] != "stepup":
         raise HTTPException(status_code=400, detail="Malformed step-up state")
     try:
         state_user_id = int(parts[1])
     except ValueError:
+        raise HTTPException(status_code=400, detail="Malformed step-up state")
+    return_key = parts[3]
+    if return_key not in _STEPUP_RETURN_TARGETS:
         raise HTTPException(status_code=400, detail="Malformed step-up state")
 
     user = await db.get(User, state_user_id)
@@ -1208,8 +1241,9 @@ async def sso_stepup_callback(
     )
     await db.commit()
 
+    return_path = _STEPUP_RETURN_TARGETS[return_key]
     resp = RedirectResponse(
-        url=f"{app_settings.app_url}/settings#stepup_token={token}",
+        url=f"{app_settings.app_url}{return_path}#stepup_token={token}",
         status_code=302,
     )
     resp.delete_cookie("oauth_state", path="/api/v1/auth/sso-stepup")

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -128,9 +128,10 @@ async def update_profile(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Step-up verification with Google is required to change email",
                 )
-            # Consume the token so it cannot be replayed.
-            current_user.stepup_token = None
-            current_user.stepup_token_expires_at = None
+        # Validate the target email BEFORE consuming the step-up token
+        # or any password-branch side effects. If the email is already
+        # taken the change cannot apply, so the proof of presence must
+        # remain usable for the user's retry. (Finding 3 from PR #138.)
         existing = await db.execute(
             select(User).where(User.email == body.email)
         )
@@ -139,6 +140,11 @@ async def update_profile(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Email already taken",
             )
+        if not current_user.password_set:
+            # Step-up was validated above; only consume now that the
+            # change is actually about to be applied.
+            current_user.stepup_token = None
+            current_user.stepup_token_expires_at = None
         # Capture the new email now (body.email survives the pydantic
         # validation; current_user.email is still the old one until the
         # assignment below).
@@ -184,8 +190,12 @@ async def change_password(
     #   - `password_set=True` (default for every classic register flow):
     #     require a valid `current_password`. Existing behavior.
     #   - `password_set=False` (Google SSO user setting a real password
-    #     for the first time): skip the current-password check; any
-    #     supplied value is ignored. After the write `password_set`
+    #     for the first time): require a valid `stepup_token` issued by
+    #     the SSO step-up callback. Same proof-of-presence the email
+    #     change branch uses, for the same reason — without it a
+    #     stolen SSO session could write a persistent local password
+    #     and convert a transient hijack into permanent account access.
+    #     (Finding 1 from PR #138.) After the write `password_set`
     #     flips True permanently so subsequent rotations land in the
     #     standard branch above.
     if current_user.password_set:
@@ -196,6 +206,26 @@ async def change_password(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Current password is incorrect",
             )
+    else:
+        now_check = datetime.now(timezone.utc)
+        stored = current_user.stepup_token
+        expires_at = current_user.stepup_token_expires_at
+        valid = (
+            bool(body.stepup_token)
+            and stored is not None
+            and expires_at is not None
+            and _aware(expires_at) > now_check
+            and secrets.compare_digest(body.stepup_token, stored)
+        )
+        if not valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Step-up verification with Google is required to set a password",
+            )
+        # Consume the token so it cannot be replayed against any
+        # other step-up-gated endpoint.
+        current_user.stepup_token = None
+        current_user.stepup_token_expires_at = None
 
     now = datetime.now(timezone.utc)
     current_user.password_hash = hash_password(body.new_password)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -132,3 +132,12 @@ class MfaEmailVerifyRequest(BaseModel):
 
 class MfaRegenerateRequest(BaseModel):
     password: str = Field(max_length=128)
+
+
+class StepUpInitiateRequest(BaseModel):
+    # Short tag chosen by the frontend ("settings" for email change,
+    # "security" for first-time password set). Validated against the
+    # allowlist in routers/auth.py; anything else falls back to the
+    # default settings page rather than 4xx so an old client never
+    # breaks.
+    return_to: str | None = Field(default=None, max_length=32)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -40,6 +40,11 @@ class PasswordChange(BaseModel):
     # conditionally. When the caller has `password_set=True` the handler
     # requires a valid `current_password`. When `password_set=False`
     # (Google SSO user setting a password for the first time) the
-    # `current_password` field is ignored entirely.
+    # `current_password` field is ignored and a fresh `stepup_token`
+    # (issued by the SSO step-up callback) is required instead.
     current_password: str | None = Field(default=None, max_length=128)
     new_password: str = Field(min_length=8, max_length=128)
+    # First-set proof of presence for SSO users. Same single-use,
+    # 5-minute token shape as the email-change flow consumes; the
+    # handler validates and consumes it on the row.
+    stepup_token: str | None = Field(default=None, max_length=128)

--- a/backend/tests/routers/test_auth_reset_password.py
+++ b/backend/tests/routers/test_auth_reset_password.py
@@ -1,0 +1,134 @@
+"""Reset-password handler regression coverage.
+
+Pins:
+  - A successful reset rotates the password hash and timestamps.
+  - A successful reset flips `password_set=True`. Without this an SSO
+    user who never set a password can use the reset-token flow to gain
+    local credentials, but the UI keeps showing "Set a Password" and
+    `/users/me/password` keeps treating the account as if no password
+    has ever been chosen. (Finding 2 from the PR #138 review.)
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import router as auth_router
+from app.security import create_password_reset_token, hash_password, verify_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory):
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(session_factory, *, password_set: bool) -> int:
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@acme.io",
+            password_hash=hash_password("starting-password"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+            password_set=password_set,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+@pytest.mark.asyncio
+async def test_reset_password_flips_password_set_true_for_sso_user(session_factory):
+    """SSO user with `password_set=False` who resets via a valid token
+    must end with `password_set=True`. Otherwise the UI keeps showing
+    "Set a Password" and `/users/me/password` keeps thinking the
+    account has no password chosen yet."""
+    user_id = await _seed_user(session_factory, password_set=False)
+    token = create_password_reset_token(user_id)
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "fresh-strong-password"},
+        )
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.password_set is True
+        assert verify_password("fresh-strong-password", user.password_hash)
+        assert user.password_changed_at is not None
+        assert user.sessions_invalidated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reset_password_keeps_password_set_true_for_classic_user(session_factory):
+    """Existing classic users should remain `password_set=True` after a
+    reset. Pins that the new write doesn't accidentally set False."""
+    user_id = await _seed_user(session_factory, password_set=True)
+    token = create_password_reset_token(user_id)
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "another-strong-password"},
+        )
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.password_set is True
+        assert verify_password("another-strong-password", user.password_hash)

--- a/backend/tests/routers/test_auth_stepup.py
+++ b/backend/tests/routers/test_auth_stepup.py
@@ -1,0 +1,446 @@
+"""SSO step-up `return_to` allowlist + state shape coverage.
+
+Pins the invariants flagged in the PR #149 review:
+
+  - No `return_to` in the request body encodes the default key into
+    state, and the callback redirects to `/settings`.
+  - `return_to: "security"` encodes the security key, and the
+    callback redirects to `/settings/security#stepup_token=<token>`
+    (the issued token, in the URL fragment).
+  - An unknown `return_to` value (junk strings, traversal payloads,
+    open-redirect-style URLs) MUST NOT redirect to that target. The
+    initiate handler silently coerces the key to the default before
+    encoding state, so the callback redirects to `/settings`.
+  - Malformed state at the callback (3-part legacy shape, empty
+    string, junk) returns 400 "Malformed step-up state". No redirect,
+    no step-up token issued.
+
+The flow exchanges a Google OAuth code at the callback. We patch the
+module-level `httpx.AsyncClient` so the success-path test never
+touches the network and so we can assert the redirect URL the router
+actually builds.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.routers import auth as auth_module
+from app.routers.auth import router as auth_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def google_config(monkeypatch):
+    """Fill in the Google OAuth knobs so `_validate_google_config` passes
+    and the callback's redirect URL has a stable origin to assert on."""
+    monkeypatch.setattr(app_settings, "google_client_id", "test-client-id")
+    monkeypatch.setattr(app_settings, "google_client_secret", "test-client-secret")
+    monkeypatch.setattr(app_settings, "app_url", "http://localhost")
+    yield
+
+
+async def _seed_user(session_factory, *, email: str = "alice@acme.io") -> int:
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email=email,
+            password_hash=hash_password("starting-password"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+            password_set=True,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+def _make_app(session_factory, current_user_id: int | None):
+    """Build a tiny FastAPI app with `get_db` overridden against the
+    in-memory SQLite session factory and `get_current_user` resolved
+    to the seeded user (when one is supplied)."""
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    if current_user_id is not None:
+        async def override_current_user() -> User:
+            async with session_factory() as session:
+                user = await session.get(User, current_user_id)
+                assert user is not None
+                return user
+
+        app.dependency_overrides[get_current_user] = override_current_user
+
+    app.include_router(auth_router)
+    return app
+
+
+# ---------- helpers for the callback success path ---------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Stand-in for `httpx.AsyncClient` used in the step-up callback.
+
+    Returns canned responses for the token-exchange POST and the
+    userinfo GET. Tests parametrize the userinfo email to drive the
+    "Google identity matches the seeded user" branch."""
+
+    def __init__(self, *, userinfo_email: str):
+        self._userinfo_email = userinfo_email
+
+    def __init__call(self, *_args, **_kwargs):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def post(self, *_args, **_kwargs):
+        return _FakeResponse({"access_token": "fake-google-access-token"})
+
+    async def get(self, *_args, **_kwargs):
+        return _FakeResponse(
+            {
+                "email": self._userinfo_email,
+                "verified_email": True,
+            }
+        )
+
+
+def _patch_httpx_for_email(monkeypatch, email: str) -> None:
+    """Make the auth module's `httpx.AsyncClient(...)` build our fake.
+
+    The router calls `httpx.AsyncClient(timeout=...)` then uses it as a
+    context manager, so we replace the class with a factory closure
+    that yields a fresh fake on every call."""
+
+    def factory(*_args, **_kwargs):
+        return _FakeAsyncClient(userinfo_email=email)
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", factory)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — no `return_to` in the body → default key in state, /settings.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_initiate_without_return_to_encodes_default_key(
+    session_factory, google_config
+):
+    """When the request body omits `return_to`, the state cookie must
+    encode the default key ("settings") in slot 4. The callback later
+    keys off that slot, so the encoded value is what drives the
+    redirect target."""
+    user_id = await _seed_user(session_factory)
+    app = _make_app(session_factory, user_id)
+
+    with TestClient(app) as client:
+        res = client.post("/api/v1/auth/sso-stepup/initiate")
+
+    assert res.status_code == 200, res.text
+    state_cookie = res.cookies.get("oauth_state")
+    assert state_cookie is not None, "expected oauth_state cookie to be set"
+
+    parts = state_cookie.split(":")
+    assert parts[0] == "stepup"
+    assert parts[1] == str(user_id)
+    assert len(parts) == 4
+    assert parts[3] == "settings"
+
+
+@pytest.mark.asyncio
+async def test_callback_with_default_state_redirects_to_settings(
+    session_factory, google_config, monkeypatch
+):
+    """End-to-end pin: state with the default key → 302 to /settings
+    (no `/security` suffix), with the issued step-up token in the URL
+    fragment."""
+    user_id = await _seed_user(session_factory, email="alice@acme.io")
+    app = _make_app(session_factory, user_id)
+    _patch_httpx_for_email(monkeypatch, "alice@acme.io")
+
+    with TestClient(app) as client:
+        # Run initiate so we have a matching state cookie+string.
+        init = client.post("/api/v1/auth/sso-stepup/initiate")
+        assert init.status_code == 200
+        state = init.cookies.get("oauth_state")
+
+        callback = client.get(
+            "/api/v1/auth/sso-stepup/callback",
+            params={"code": "fake-google-code", "state": state},
+            cookies={"oauth_state": state},
+            follow_redirects=False,
+        )
+
+    assert callback.status_code == 302, callback.text
+    location = callback.headers["location"]
+    assert location.startswith("http://localhost/settings#stepup_token=")
+    # Make sure it didn't accidentally land on /settings/security.
+    assert "/settings/security" not in location
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — `return_to: "security"` → /settings/security#stepup_token=<token>.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_initiate_with_security_return_to_encodes_security_key(
+    session_factory, google_config
+):
+    user_id = await _seed_user(session_factory)
+    app = _make_app(session_factory, user_id)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/sso-stepup/initiate",
+            json={"return_to": "security"},
+        )
+
+    assert res.status_code == 200, res.text
+    state_cookie = res.cookies.get("oauth_state")
+    assert state_cookie is not None
+    parts = state_cookie.split(":")
+    assert parts[0] == "stepup"
+    assert parts[1] == str(user_id)
+    assert len(parts) == 4
+    assert parts[3] == "security"
+
+
+@pytest.mark.asyncio
+async def test_callback_with_security_state_redirects_with_issued_token(
+    session_factory, google_config, monkeypatch
+):
+    """Locks the headline invariant: a successful callback for the
+    "security" target redirects to /settings/security#stepup_token=...
+    where the fragment carries the same random token that was just
+    written to `users.stepup_token`. The token in the URL must be the
+    real issued token, not a placeholder."""
+    user_id = await _seed_user(session_factory, email="alice@acme.io")
+    app = _make_app(session_factory, user_id)
+    _patch_httpx_for_email(monkeypatch, "alice@acme.io")
+
+    with TestClient(app) as client:
+        init = client.post(
+            "/api/v1/auth/sso-stepup/initiate",
+            json={"return_to": "security"},
+        )
+        assert init.status_code == 200
+        state = init.cookies.get("oauth_state")
+
+        callback = client.get(
+            "/api/v1/auth/sso-stepup/callback",
+            params={"code": "fake-google-code", "state": state},
+            cookies={"oauth_state": state},
+            follow_redirects=False,
+        )
+
+    assert callback.status_code == 302, callback.text
+    location = callback.headers["location"]
+    assert location.startswith("http://localhost/settings/security#stepup_token=")
+
+    # The token in the fragment must equal the one written to the row.
+    fragment_token = location.split("#stepup_token=", 1)[1]
+    assert fragment_token, "expected a non-empty step-up token in the fragment"
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.stepup_token == fragment_token
+        assert user.stepup_token_expires_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — unknown `return_to` value → silently coerced to default. No
+# attacker-controlled host or path ever reaches the redirect Location.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "evil_return_to",
+    [
+        "evil.example.com",
+        "admin",
+        "../",
+        "//attacker.com",
+    ],
+)
+@pytest.mark.asyncio
+async def test_initiate_unknown_return_to_silently_coerces_to_default(
+    session_factory, google_config, evil_return_to
+):
+    """The schema accepts arbitrary short strings; the handler validates
+    against `_STEPUP_RETURN_TARGETS` and falls back to the default
+    rather than 4xx, so old clients never break. The state must
+    therefore encode "settings", never the attacker-supplied token."""
+    user_id = await _seed_user(session_factory)
+    app = _make_app(session_factory, user_id)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/sso-stepup/initiate",
+            json={"return_to": evil_return_to},
+        )
+
+    assert res.status_code == 200, res.text
+    state_cookie = res.cookies.get("oauth_state")
+    assert state_cookie is not None
+    parts = state_cookie.split(":")
+    assert len(parts) == 4
+    assert parts[3] == "settings"
+    assert evil_return_to not in state_cookie
+
+    # And the Google consent URL embeds the same coerced state, so the
+    # round trip can't smuggle the attacker value back either.
+    redirect_url = res.json()["redirect_url"]
+    assert evil_return_to not in redirect_url
+
+
+@pytest.mark.asyncio
+async def test_callback_with_attacker_target_redirects_to_default(
+    session_factory, google_config, monkeypatch
+):
+    """End-to-end pin: even when initiate is called with an attacker
+    string, the callback redirect lands on /settings, never on the
+    attacker-supplied path or host."""
+    user_id = await _seed_user(session_factory, email="alice@acme.io")
+    app = _make_app(session_factory, user_id)
+    _patch_httpx_for_email(monkeypatch, "alice@acme.io")
+
+    with TestClient(app) as client:
+        init = client.post(
+            "/api/v1/auth/sso-stepup/initiate",
+            json={"return_to": "//attacker.com"},
+        )
+        assert init.status_code == 200
+        state = init.cookies.get("oauth_state")
+
+        callback = client.get(
+            "/api/v1/auth/sso-stepup/callback",
+            params={"code": "fake-google-code", "state": state},
+            cookies={"oauth_state": state},
+            follow_redirects=False,
+        )
+
+    assert callback.status_code == 302, callback.text
+    location = callback.headers["location"]
+    assert location.startswith("http://localhost/settings#stepup_token=")
+    assert "attacker.com" not in location
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — malformed state at the callback returns 400 and never issues
+# a step-up token.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "bad_state",
+    [
+        "stepup:1:nonce-only-three-parts",  # legacy 3-part shape
+        "nope",  # junk
+        "stepup::nonce:settings",  # empty user_id slot
+        "stepup:not-an-int:nonce:settings",  # non-numeric user_id
+        "stepup:1:nonce:not-a-known-target",  # unknown return key
+    ],
+)
+@pytest.mark.asyncio
+async def test_callback_rejects_malformed_state(
+    session_factory, google_config, bad_state
+):
+    """All variants must short-circuit with 400 "Malformed step-up
+    state" (or "Invalid OAuth state ..." when the cookie does not
+    match), and must never write a step-up token onto any user row."""
+    user_id = await _seed_user(session_factory)
+    app = _make_app(session_factory, user_id)
+
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/auth/sso-stepup/callback",
+            params={"code": "fake-google-code", "state": bad_state},
+            cookies={"oauth_state": bad_state},
+            follow_redirects=False,
+        )
+
+    assert res.status_code == 400, res.text
+    assert res.headers.get("location") is None
+    detail = res.json().get("detail", "")
+    assert "Malformed step-up state" in detail or "Invalid state" in detail
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.stepup_token is None
+        assert user.stepup_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_callback_with_empty_state_returns_400(session_factory, google_config):
+    """Empty state must not even reach the parser. The CSRF guard
+    (`oauth_state` cookie matches the URL `state`) catches it first
+    when the cookie is missing, and the 4-part shape check catches it
+    if a stray cookie sneaks through. Either way: 400, no redirect,
+    no token issued."""
+    user_id = await _seed_user(session_factory)
+    app = _make_app(session_factory, user_id)
+
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/auth/sso-stepup/callback",
+            params={"code": "fake-google-code", "state": ""},
+            follow_redirects=False,
+        )
+
+    assert res.status_code == 400, res.text
+    assert res.headers.get("location") is None
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        assert user.stepup_token is None

--- a/backend/tests/routers/test_auth_stepup.py
+++ b/backend/tests/routers/test_auth_stepup.py
@@ -213,11 +213,11 @@ async def test_callback_with_default_state_redirects_to_settings(
         init = client.post("/api/v1/auth/sso-stepup/initiate")
         assert init.status_code == 200
         state = init.cookies.get("oauth_state")
+        client.cookies.set("oauth_state", state)
 
         callback = client.get(
             "/api/v1/auth/sso-stepup/callback",
             params={"code": "fake-google-code", "state": state},
-            cookies={"oauth_state": state},
             follow_redirects=False,
         )
 
@@ -275,11 +275,11 @@ async def test_callback_with_security_state_redirects_with_issued_token(
         )
         assert init.status_code == 200
         state = init.cookies.get("oauth_state")
+        client.cookies.set("oauth_state", state)
 
         callback = client.get(
             "/api/v1/auth/sso-stepup/callback",
             params={"code": "fake-google-code", "state": state},
-            cookies={"oauth_state": state},
             follow_redirects=False,
         )
 
@@ -361,11 +361,11 @@ async def test_callback_with_attacker_target_redirects_to_default(
         )
         assert init.status_code == 200
         state = init.cookies.get("oauth_state")
+        client.cookies.set("oauth_state", state)
 
         callback = client.get(
             "/api/v1/auth/sso-stepup/callback",
             params={"code": "fake-google-code", "state": state},
-            cookies={"oauth_state": state},
             follow_redirects=False,
         )
 
@@ -401,10 +401,10 @@ async def test_callback_rejects_malformed_state(
     app = _make_app(session_factory, user_id)
 
     with TestClient(app) as client:
+        client.cookies.set("oauth_state", bad_state)
         res = client.get(
             "/api/v1/auth/sso-stepup/callback",
             params={"code": "fake-google-code", "state": bad_state},
-            cookies={"oauth_state": bad_state},
             follow_redirects=False,
         )
 

--- a/backend/tests/routers/test_users_password_set.py
+++ b/backend/tests/routers/test_users_password_set.py
@@ -147,14 +147,49 @@ async def test_sso_user_create_sets_password_set_false(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_initial_password_skips_current_password_check(session_factory):
+async def test_initial_password_requires_stepup_token(session_factory):
+    """Finding 1: a stolen SSO session must NOT be able to write a
+    persistent local password without a fresh Google step-up. Posting
+    `new_password` alone when `password_set=False` is rejected — same
+    proof-of-presence requirement the email-change endpoint enforces."""
     user_id = await _seed_user(session_factory, password_set=False)
     app = _make_app(session_factory, user_id)
     with TestClient(app) as client:
-        # Note: no current_password in body.
         res = client.post(
             "/api/v1/users/me/password",
             json={"new_password": "brand-new-password"},
+        )
+    assert res.status_code == 400, res.text
+    assert "step-up" in res.json()["detail"].lower()
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        # No write happened.
+        assert user.password_set is False
+        assert not verify_password("brand-new-password", user.password_hash)
+
+
+@pytest.mark.asyncio
+async def test_initial_password_with_valid_stepup_token_succeeds(session_factory):
+    """Same flow as before, but with a valid step-up token. Sets the
+    password, flips the flag, and consumes the token so it cannot be
+    replayed by `/users/me` for an email change."""
+    token = "first-set-stepup-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        stepup_expires_at=datetime.now(timezone.utc) + timedelta(minutes=4),
+    )
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/users/me/password",
+            json={
+                "new_password": "brand-new-password",
+                "stepup_token": token,
+            },
         )
     assert res.status_code == 204, res.text
 
@@ -163,19 +198,82 @@ async def test_initial_password_skips_current_password_check(session_factory):
         assert user is not None
         assert user.password_set is True
         assert verify_password("brand-new-password", user.password_hash)
+        # Token is consumed (single-use, no replay across endpoints).
+        assert user.stepup_token is None
+        assert user.stepup_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_initial_password_rejects_expired_stepup_token(session_factory):
+    token = "expired-set-token-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        stepup_expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "brand-new-password", "stepup_token": token},
+        )
+    assert res.status_code == 400, res.text
+
+    async with session_factory() as db:
+        user = await db.get(User, user_id)
+        assert user is not None
+        # Password not written, flag still False.
+        assert user.password_set is False
+
+
+@pytest.mark.asyncio
+async def test_initial_password_rejects_replay_of_consumed_stepup_token(session_factory):
+    """Step-up token is single-use across endpoints. Once /me/password
+    consumes it, a second /me/password call replaying the same token
+    must fail."""
+    token = "single-use-set-token-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        stepup_expires_at=datetime.now(timezone.utc) + timedelta(minutes=4),
+    )
+    app = _make_app(session_factory, user_id)
+    with TestClient(app) as client:
+        first = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "first-attempt", "stepup_token": token},
+        )
+        assert first.status_code == 204, first.text
+
+        # password_set is now True, so the standard branch runs and the
+        # stepup_token is rejected as not a valid current_password. The
+        # critical invariant: the same token never grants two writes.
+        second = client.post(
+            "/api/v1/users/me/password",
+            json={"new_password": "second-attempt", "stepup_token": token},
+        )
+    assert second.status_code == 400, second.text
 
 
 @pytest.mark.asyncio
 async def test_initial_password_updates_password_changed_at_and_sessions_invalidated_at(
     session_factory,
 ):
-    user_id = await _seed_user(session_factory, password_set=False)
+    token = "valid-stepup-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        stepup_expires_at=datetime.now(timezone.utc) + timedelta(minutes=4),
+    )
     before = datetime.now(timezone.utc)
     app = _make_app(session_factory, user_id)
     with TestClient(app) as client:
         res = client.post(
             "/api/v1/users/me/password",
-            json={"new_password": "brand-new-password"},
+            json={"new_password": "brand-new-password", "stepup_token": token},
         )
     assert res.status_code == 204, res.text
 
@@ -197,12 +295,18 @@ async def test_initial_password_path_rejected_after_first_set(session_factory):
     """After password_set flips True, the standard branch must enforce
     the current_password check. Posting only `new_password` should 400
     instead of silently rotating the password again."""
-    user_id = await _seed_user(session_factory, password_set=False)
+    token = "first-set-token-" + "x" * 8
+    user_id = await _seed_user(
+        session_factory,
+        password_set=False,
+        stepup_token=token,
+        stepup_expires_at=datetime.now(timezone.utc) + timedelta(minutes=4),
+    )
     app = _make_app(session_factory, user_id)
     with TestClient(app) as client:
         first = client.post(
             "/api/v1/users/me/password",
-            json={"new_password": "first-set-password"},
+            json={"new_password": "first-set-password", "stepup_token": token},
         )
         assert first.status_code == 204
 
@@ -296,6 +400,66 @@ async def test_email_change_rejects_expired_stepup_token(session_factory):
         user = await db.get(User, user_id)
         assert user is not None
         assert user.email == "alice@acme.io"
+
+
+@pytest.mark.asyncio
+async def test_email_change_keeps_stepup_token_when_target_email_taken(session_factory):
+    """Finding 3: target-email validation must run BEFORE the step-up
+    token is consumed. If the new email is already taken the change
+    cannot apply, so the user's still-valid token must survive the
+    failed attempt and the row must still hold it for the retry."""
+    token = "preserve-on-conflict-" + "x" * 8
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=4)
+
+    # Seed two users in the same org. `alice` has the step-up token.
+    # `bob` already owns the email alice will try to claim.
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        alice = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@acme.io",
+            password_hash=hash_password("starting-password"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+            password_set=False,
+            stepup_token=token,
+            stepup_token_expires_at=expires_at,
+        )
+        bob = User(
+            org_id=org.id,
+            username="bob",
+            email="bob@acme.io",
+            password_hash=hash_password("bob-password"),
+            role=Role.MEMBER,
+            is_active=True,
+            email_verified=True,
+            password_set=True,
+        )
+        db.add_all([alice, bob])
+        await db.commit()
+        alice_id = alice.id
+
+    app = _make_app(session_factory, alice_id)
+    with TestClient(app) as client:
+        res = client.put(
+            "/api/v1/users/me",
+            json={"email": "bob@acme.io", "stepup_token": token},
+        )
+    assert res.status_code == 409, res.text
+
+    async with session_factory() as db:
+        user = await db.get(User, alice_id)
+        assert user is not None
+        # Email did not change.
+        assert user.email == "alice@acme.io"
+        # Token must still be there for a retry — failed validation
+        # cannot consume the step-up proof.
+        assert user.stepup_token == token
+        assert user.stepup_token_expires_at is not None
 
 
 @pytest.mark.asyncio

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -131,7 +131,20 @@ export default function SettingsProfilePage() {
           ? "Profile updated. Check your new inbox for a verification link — you'll need to sign in again."
           : "Profile updated",
       );
-    } catch (err) { setProfileErr(extractErrorMessage(err)); }
+    } catch (err) {
+      const message = extractErrorMessage(err);
+      // Clear the step-up token whenever the error mentions step-up
+      // verification. Backend may have rejected the token as expired
+      // or no-longer-on-the-row, in which case the UI claiming
+      // "Google verified" lies to the user. Re-prompting is cheap.
+      // (Finding 3 from PR #138.)
+      if (stepupToken && /step-up|verify with google/i.test(message)) {
+        setStepupToken("");
+        setProfileErr(`${message} Please verify with Google again to retry.`);
+      } else {
+        setProfileErr(message);
+      }
+    }
     finally { setSavingProfile(false); }
   }
 

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -18,6 +18,11 @@ import {
 } from "@/lib/styles";
 import type { MfaSetupResponse, MfaEnableResponse } from "@/lib/types";
 
+// Mirror of the backend's `_STEPUP_RETURN_TARGETS` allowlist key.
+// Initiate POST sends this so the callback knows to redirect back to
+// /settings/security (here) instead of the email-change page.
+const STEPUP_RETURN_TO = "security";
+
 type MfaStep = "idle" | "qr" | "verify" | "codes";
 
 export default function SecurityPage() {
@@ -31,23 +36,64 @@ export default function SecurityPage() {
   const [pwdErr, setPwdErr] = useState("");
   const [savingPwd, setSavingPwd] = useState(false);
 
-  // SSO users (Google) start with `password_set=false`. The first time
-  // they POST /me/password the backend skips the current-password
-  // check and the flag flips true, so on the next render this branch
-  // collapses back to the standard Change Password UI.
+  // SSO users (Google) start with `password_set=false`. They cannot
+  // type a current password, so the first-time set requires the same
+  // Google step-up proof the email-change flow uses. The token rides
+  // back from the OAuth callback in `#stepup_token=…`, is read on
+  // mount, then sent to /me/password. After the first set the flag
+  // flips true and this branch collapses to the standard form.
   const passwordSet = user?.password_set ?? true;
+  const [stepupToken, setStepupToken] = useState("");
+  const [stepupBusy, setStepupBusy] = useState(false);
+
+  // Pull `#stepup_token=…` off the URL on mount and immediately strip
+  // it from history. Fragments are never sent to the server, so this
+  // is the safe channel the backend redirects to.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash;
+    if (hash.startsWith("#stepup_token=")) {
+      const token = hash.slice("#stepup_token=".length);
+      if (token) setStepupToken(token);
+      window.history.replaceState(null, "", window.location.pathname + window.location.search);
+    }
+  }, []);
+
+  async function handleVerifyWithGoogle() {
+    setPwdErr(""); setStepupBusy(true);
+    try {
+      const data = await apiFetch<{ redirect_url: string }>(
+        "/api/v1/auth/sso-stepup/initiate",
+        {
+          method: "POST",
+          body: JSON.stringify({ return_to: STEPUP_RETURN_TO }),
+        },
+      );
+      // Full navigation, not router.push — Google must own the next page.
+      window.location.href = data.redirect_url;
+    } catch (err) {
+      setPwdErr(extractErrorMessage(err));
+      setStepupBusy(false);
+    }
+  }
 
   async function handlePasswordSubmit(e: FormEvent) {
     e.preventDefault();
     setPwdMsg(""); setPwdErr("");
     if (newPassword !== confirmPassword) { setPwdErr("New passwords do not match"); return; }
+    if (!passwordSet && !stepupToken) {
+      setPwdErr("Verify with Google before setting your password. Click 'Verify with Google' below.");
+      return;
+    }
     setSavingPwd(true);
     try {
-      const payload: { new_password: string; current_password?: string } = {
+      const payload: { new_password: string; current_password?: string; stepup_token?: string } = {
         new_password: newPassword,
       };
       if (passwordSet) {
         payload.current_password = currentPassword;
+      } else {
+        payload.stepup_token = stepupToken;
       }
       await apiFetch("/api/v1/users/me/password", {
         method: "POST",
@@ -73,12 +119,20 @@ export default function SecurityPage() {
       // re-renders in standard mode after a first-time set.
       await refreshMe();
       setCurrentPassword(""); setNewPassword(""); setConfirmPassword("");
+      setStepupToken("");
       setPwdMsg(
         passwordSet
           ? "Password changed successfully"
           : "Password set. You can now sign in with your email and password.",
       );
-    } catch (err) { setPwdErr(extractErrorMessage(err)); }
+    } catch (err) {
+      // The step-up token is single-use on the backend and is consumed
+      // on the row before any error path that returns 4xx. Clearing
+      // local state forces the user to re-verify with Google rather
+      // than retry against an already-spent token. Keeps the UI honest.
+      if (!passwordSet) setStepupToken("");
+      setPwdErr(extractErrorMessage(err));
+    }
     finally { setSavingPwd(false); }
   }
 
@@ -243,6 +297,30 @@ export default function SecurityPage() {
                 <input id="pwd-current" type="password" required value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className={input} autoComplete="current-password" />
               </div>
             )}
+            {!passwordSet && (
+              <div className="rounded-lg border border-border p-4 space-y-3">
+                <p className="text-sm text-text-primary font-medium">
+                  Verify with Google to set a password
+                </p>
+                <p className="text-xs text-text-muted">
+                  Confirm this is you by signing in with Google before we save a password to your account.
+                </p>
+                {stepupToken ? (
+                  <p className="text-xs text-success">
+                    Google verified. Enter your new password below to finish.
+                  </p>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleVerifyWithGoogle}
+                    disabled={stepupBusy}
+                    className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                  >
+                    {stepupBusy ? "Redirecting..." : "Verify with Google"}
+                  </button>
+                )}
+              </div>
+            )}
             <div>
               <label htmlFor="pwd-new" className={label}>New Password</label>
               <input id="pwd-new" type="password" required minLength={8} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className={input} autoComplete="new-password" />
@@ -251,7 +329,11 @@ export default function SecurityPage() {
               <label htmlFor="pwd-confirm" className={label}>Confirm New Password</label>
               <input id="pwd-confirm" type="password" required value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className={input} autoComplete="new-password" />
             </div>
-            <button type="submit" disabled={savingPwd} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+            <button
+              type="submit"
+              disabled={savingPwd || (!passwordSet && !stepupToken)}
+              className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+            >
               {savingPwd
                 ? (passwordSet ? "Changing..." : "Setting...")
                 : (passwordSet ? "Change Password" : "Set Password")}

--- a/frontend/tests/app/settings-page.test.tsx
+++ b/frontend/tests/app/settings-page.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import SettingsProfilePage from "@/app/settings/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/settings",
+}));
+
+function makeUser(passwordSet: boolean) {
+  return {
+    id: 1,
+    username: "alice",
+    email: "alice@acme.io",
+    first_name: null,
+    last_name: null,
+    phone: null,
+    avatar_url: null,
+    email_verified: true,
+    role: "owner" as const,
+    org_id: 1,
+    org_name: "Acme",
+    billing_cycle_day: 1,
+    is_superadmin: false,
+    is_active: true,
+    mfa_enabled: false,
+    password_set: passwordSet,
+    subscription_status: null,
+    subscription_plan: null,
+    trial_end: null,
+  };
+}
+
+function mockUser(passwordSet: boolean) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: makeUser(passwordSet) as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
+
+describe("Settings page — email change step-up token state hygiene", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  afterEach(() => {
+    // Reset URL hash so cross-test bleed cannot drop a token into the
+    // next render's mount effect.
+    window.location.hash = "";
+  });
+
+  it("clears stepupToken on a step-up error so the UI stops claiming 'Google verified' (Finding 3)", async () => {
+    mockUser(false);
+    // Seed the URL fragment so the page picks up the token on mount.
+    window.location.hash = "#stepup_token=stale-token";
+
+    render(<SettingsProfilePage />);
+
+    // The verified panel only renders while the email is actually
+    // changing. Edit the field first.
+    fireEvent.change(screen.getByLabelText(/^Email$/i), {
+      target: { value: "new@acme.io" },
+    });
+    await screen.findByText(/Google verified/i);
+
+    // User saves; backend rejects with a step-up failure (token
+    // expired / not on row).
+    vi.mocked(apiFetch).mockRejectedValueOnce(
+      new Error("Step-up verification with Google is required to change email"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    // After the rejection the verified pill must be gone. Otherwise
+    // the UI lies to the user about an unusable token.
+    await waitFor(() => {
+      expect(screen.queryByText(/Google verified/i)).not.toBeInTheDocument();
+    });
+    // And the Verify-with-Google button is back.
+    expect(
+      screen.getByRole("button", { name: /Verify with Google/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("preserves stepupToken when the error is unrelated to step-up (e.g., email taken)", async () => {
+    mockUser(false);
+    window.location.hash = "#stepup_token=fresh-token";
+
+    render(<SettingsProfilePage />);
+    fireEvent.change(screen.getByLabelText(/^Email$/i), {
+      target: { value: "taken@acme.io" },
+    });
+    await screen.findByText(/Google verified/i);
+
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error("Email already taken"));
+    fireEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    // After my backend reorder fix the duplicate-email check runs
+    // BEFORE the token is consumed, so the token survives a 409 and
+    // the UI correctly keeps "Google verified" so the retry is one
+    // click away. Pinning that frontend keeps the token in this case.
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalled();
+    });
+    expect(screen.getByText(/Google verified/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/app/settings-security-password-set.test.tsx
+++ b/frontend/tests/app/settings-security-password-set.test.tsx
@@ -77,9 +77,11 @@ describe("Security page — Set a Password / Change Password gate", () => {
     ).toBeInTheDocument();
     // The current-password input is intentionally hidden in this branch.
     expect(screen.queryByLabelText(/Current Password/i)).not.toBeInTheDocument();
-    // Helper copy explains *why* there is no current password field.
+    // Helper copy frames the step-up requirement (replaces the older
+    // "created with Google" sentence after Finding 1 tightened this
+    // path).
     expect(
-      screen.getByText(/created with Google/i),
+      screen.getByText(/Verify with Google to set a password/i),
     ).toBeInTheDocument();
   });
 
@@ -93,7 +95,14 @@ describe("Security page — Set a Password / Change Password gate", () => {
     expect(screen.getByLabelText(/Current Password/i)).toBeInTheDocument();
   });
 
-  it("submits new_password only (no current_password) when password_set is false", async () => {
+  it("disables Set Password until the user verifies with Google", async () => {
+    mockUser(false);
+    render(<SecurityPage />);
+    const submit = screen.getByRole("button", { name: /Set Password/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it("does not POST /me/password without a step-up token (Finding 1)", async () => {
     mockUser(false);
     render(<SecurityPage />);
     fireEvent.change(screen.getByLabelText(/^New Password$/i), {
@@ -102,16 +111,86 @@ describe("Security page — Set a Password / Change Password gate", () => {
     fireEvent.change(screen.getByLabelText(/Confirm New Password/i), {
       target: { value: "fresh-password-1" },
     });
+    // The submit button is disabled until verification completes; the
+    // critical invariant is that no request is fired.
     fireEvent.click(screen.getByRole("button", { name: /Set Password/i }));
 
     await waitFor(() => {
+      // No password POST should have happened. (Other endpoints, like
+      // the security page's settings reads, are gated to admins only
+      // and stay quiet for this fixture.)
+      const passwordCalls = vi.mocked(apiFetch).mock.calls.filter(
+        ([url]) => url === "/api/v1/users/me/password",
+      );
+      expect(passwordCalls).toHaveLength(0);
+    });
+  });
+
+  it("clicking 'Verify with Google' POSTs initiate with return_to=security", async () => {
+    mockUser(false);
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      redirect_url: "https://accounts.google.com/o/oauth2/v2/auth?state=stepup",
+    } as never);
+    // Stub navigation so the test doesn't actually leave the page.
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...originalLocation, href: "" },
+    });
+
+    render(<SecurityPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Verify with Google/i }));
+
+    await waitFor(() => {
       expect(apiFetch).toHaveBeenCalledWith(
-        "/api/v1/users/me/password",
+        "/api/v1/auth/sso-stepup/initiate",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ new_password: "fresh-password-1" }),
+          body: JSON.stringify({ return_to: "security" }),
         }),
       );
     });
+
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("submits stepup_token with new_password when password_set is false", async () => {
+    mockUser(false);
+    // Seed the URL fragment so the page picks up the token on mount,
+    // mirroring the redirect from the SSO step-up callback.
+    const originalHash = window.location.hash;
+    window.location.hash = "#stepup_token=abcdef-step-up-token";
+    try {
+      render(<SecurityPage />);
+      // The mount-effect strips the hash and fills `stepupToken`.
+      // Wait for the "Google verified" copy to appear.
+      await screen.findByText(/Google verified/i);
+
+      fireEvent.change(screen.getByLabelText(/^New Password$/i), {
+        target: { value: "fresh-password-1" },
+      });
+      fireEvent.change(screen.getByLabelText(/Confirm New Password/i), {
+        target: { value: "fresh-password-1" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /Set Password/i }));
+
+      await waitFor(() => {
+        expect(apiFetch).toHaveBeenCalledWith(
+          "/api/v1/users/me/password",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({
+              new_password: "fresh-password-1",
+              stepup_token: "abcdef-step-up-token",
+            }),
+          }),
+        );
+      });
+    } finally {
+      window.location.hash = originalHash;
+    }
   });
 });


### PR DESCRIPTION
## Summary
Three review findings from PR #138 (SSO step-up email change):

- **HIGH** First-time password set on `PUT /users/me/password` now requires a fresh Google step-up token (same proof-of-presence the email-change flow uses), preventing a stolen SSO session from writing a persistent local password. `/settings/security` mirrors the email-change UX (Verify with Google before save). SSO step-up `initiate` takes a `return_to` so the callback redirects back to either `/settings` or `/settings/security`, validated against an allowlist baked into `state`.
- **HIGH** `POST /api/v1/auth/reset-password` now flips `password_set=True` alongside the password write. Without it, an SSO user who reset via token had working credentials but the row still claimed no password had been chosen, so the UI kept offering Set a Password and the password endpoint kept treating the account as fresh.
- **MEDIUM** `PUT /users/me` validates the target email before consuming the step-up token, so a duplicate-email 409 leaves the proof-of-presence intact for the retry. Frontend clears local `stepupToken` when the error is step-up related, so the UI stops claiming Google verified against an unusable token.