### PR TITLE
fix(categories): server-side category/type compatibility guard for transactions and forecast plans

### DIFF
--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -66,6 +66,11 @@ async def create_category(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    # Children silently inherit their parent's type. parent_id is the
+    # authoritative signal; body.type is ignored for subcategories so the
+    # codebase invariant ("child type == master type", see
+    # services/category_service.py module docstring) holds at create time.
+    effective_type = CategoryType(body.type)
     if body.parent_id is not None:
         parent_row = await db.execute(
             select(Category).where(
@@ -77,11 +82,12 @@ async def create_category(
             raise HTTPException(status_code=400, detail="Invalid parent category")
         if parent_cat.parent_id is not None:
             raise HTTPException(status_code=400, detail="Cannot nest more than two levels")
+        effective_type = parent_cat.type
 
     cat = Category(
         org_id=current_user.org_id,
         name=body.name,
-        type=CategoryType(body.type),
+        type=effective_type,
         parent_id=body.parent_id,
         description=body.description,
     )
@@ -115,6 +121,30 @@ async def update_category(
     cat = result.scalar_one_or_none()
     if cat is None:
         raise HTTPException(status_code=404, detail="Category not found")
+
+    # Subcategory invariant: child.type must equal parent.type. Reject any
+    # type change on a child that would diverge from the parent's type;
+    # masters are the only authoritative side of the invariant. Run BEFORE
+    # any field assignment so the rejection is atomic.
+    if (
+        cat.parent_id is not None
+        and body.type is not None
+        and CategoryType(body.type) != cat.type
+    ):
+        parent_type = await db.scalar(
+            select(Category.type).where(
+                Category.id == cat.parent_id,
+                Category.org_id == current_user.org_id,
+            )
+        )
+        if parent_type is None or CategoryType(body.type) != parent_type:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Subcategory type must match its parent. Update the "
+                    "master category instead."
+                ),
+            )
 
     if body.name is not None:
         cat.name = body.name

--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -10,6 +10,8 @@ from app.models.category_rule import CategoryRule
 from app.models.transaction import Transaction
 from app.models.user import User
 from app.schemas.category import CategoryCreate, CategoryResponse, CategoryUpdate
+from app.services.category_service import validate_category_type_change
+from app.services.exceptions import ValidationError
 from app.services.transaction_service import assert_no_dependents
 
 router = APIRouter(prefix="/api/v1/categories", tags=["categories"])
@@ -117,7 +119,32 @@ async def update_category(
     if body.name is not None:
         cat.name = body.name
     if body.type is not None:
-        cat.type = CategoryType(body.type)
+        new_type = CategoryType(body.type)
+        if new_type != cat.type:
+            # Pre-flight: every existing reference (transactions, recurring
+            # templates, forecast items) on this category — and on every
+            # child if this is a master — must be compatible with the new
+            # type. Closes the third HIGH finding from PR #150 review.
+            try:
+                await validate_category_type_change(db, cat, new_type)
+            except ValidationError as exc:
+                raise HTTPException(status_code=400, detail=exc.detail) from exc
+
+            # Codebase invariant: child type == master type (see
+            # services/category_service.py module docstring). When a master
+            # changes, cascade the new type to every child in the same
+            # operation so the invariant holds post-write.
+            if cat.parent_id is None:
+                children = (await db.scalars(
+                    select(Category).where(
+                        Category.parent_id == cat.id,
+                        Category.org_id == current_user.org_id,
+                    )
+                )).all()
+                for child in children:
+                    child.type = new_type
+
+            cat.type = new_type
     if body.description is not None:
         cat.description = body.description
     await db.commit()

--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -1,0 +1,273 @@
+"""Category mutation guards.
+
+Closes the third HIGH finding from PR #150 review: PUT /api/v1/categories/{id}
+let `cat.type` be reassigned freely, retroactively breaking every
+(type, category) compatibility guard added in transaction_service,
+recurring_service, and forecast_plan_service.
+
+The single helper exposed here, ``validate_category_type_change``, is called
+from the categories router before the type assignment is applied. It runs
+COUNT queries scoped to the category's org to detect any existing reference
+that would become incompatible under the new type, and raises
+``ValidationError`` with an aggregate count summary if any are found.
+
+Master/child semantics
+----------------------
+The org bootstrap code (org_bootstrap_service.py) seeds children with the
+exact same ``CategoryType`` as their master. The transaction-level guard
+(``transaction_service.validate_category_for_type``) also rejects a write
+whose subcategory's master type doesn't match the transaction type, so the
+codebase invariant is "child type == master type".
+
+When the master's type changes we therefore cascade-update every child's
+type to the new value as part of the same operation. That cascade is only
+safe if every child's existing references are also compatible with the new
+type, so we recurse into each child's references during the pre-flight
+check and reject if any of them would break.
+
+Transfer leg lockdown
+---------------------
+A ``CategoryType.BOTH`` category that is referenced by a transfer leg
+(``Transaction.linked_transaction_id IS NOT NULL``) cannot move off ``BOTH``
+at all. The transfer pair structurally needs the same category on both
+legs (one EXPENSE, one INCOME), and ``validate_transfer_category`` (added
+in commit b4441d4) refuses to pair on anything other than ``BOTH``.
+"""
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import ForecastItemType, ForecastPlanItem
+from app.models.recurring import RecurringTransaction
+from app.models.transaction import Transaction, TransactionType
+from app.services.exceptions import ValidationError
+
+
+def _txn_type_compatible(cat_type: CategoryType, tx_type: TransactionType) -> bool:
+    """Mirrors transaction_service._category_type_matches.
+
+    Inlined here to keep this module independent of transaction_service's
+    import surface. BOTH always matches; EXPENSE/INCOME match exactly.
+    TRANSFER never reaches this path on the create/update guards.
+    """
+    if cat_type == CategoryType.BOTH:
+        return True
+    if tx_type == TransactionType.INCOME:
+        return cat_type == CategoryType.INCOME
+    if tx_type == TransactionType.EXPENSE:
+        return cat_type == CategoryType.EXPENSE
+    return False
+
+
+def _recurring_type_compatible(cat_type: CategoryType, recurring_type: str) -> bool:
+    """RecurringTransaction.type is a plain string Enum (`income`/`expense`)."""
+    if cat_type == CategoryType.BOTH:
+        return True
+    if recurring_type == "income":
+        return cat_type == CategoryType.INCOME
+    if recurring_type == "expense":
+        return cat_type == CategoryType.EXPENSE
+    return False
+
+
+def _forecast_item_type_compatible(
+    cat_type: CategoryType, item_type: ForecastItemType,
+) -> bool:
+    if cat_type == CategoryType.BOTH:
+        return True
+    if item_type == ForecastItemType.INCOME:
+        return cat_type == CategoryType.INCOME
+    if item_type == ForecastItemType.EXPENSE:
+        return cat_type == CategoryType.EXPENSE
+    return False
+
+
+async def _count_incompatible_for_category(
+    db: AsyncSession,
+    org_id: int,
+    category_id: int,
+    new_type: CategoryType,
+) -> tuple[int, int, int]:
+    """Count rows directly referencing ``category_id`` that would be
+    incompatible under ``new_type``.
+
+    Returns ``(transactions, recurring, forecast_items)``. Every query is
+    scoped to ``org_id`` for multi-tenant safety.
+    """
+    # Transactions: filter by the new type's complementary leg.
+    tx_filters = [
+        Transaction.org_id == org_id,
+        Transaction.category_id == category_id,
+    ]
+    if new_type == CategoryType.EXPENSE:
+        tx_filters.append(Transaction.type == TransactionType.INCOME)
+        tx_count = await db.scalar(
+            select(func.count()).select_from(Transaction).where(*tx_filters)
+        ) or 0
+    elif new_type == CategoryType.INCOME:
+        tx_filters.append(Transaction.type == TransactionType.EXPENSE)
+        tx_count = await db.scalar(
+            select(func.count()).select_from(Transaction).where(*tx_filters)
+        ) or 0
+    else:
+        # BOTH: every transaction is compatible.
+        tx_count = 0
+
+    # Recurring templates (string enum values "income" / "expense").
+    rec_filters = [
+        RecurringTransaction.org_id == org_id,
+        RecurringTransaction.category_id == category_id,
+    ]
+    if new_type == CategoryType.EXPENSE:
+        rec_filters.append(RecurringTransaction.type == "income")
+        rec_count = await db.scalar(
+            select(func.count()).select_from(RecurringTransaction).where(*rec_filters)
+        ) or 0
+    elif new_type == CategoryType.INCOME:
+        rec_filters.append(RecurringTransaction.type == "expense")
+        rec_count = await db.scalar(
+            select(func.count()).select_from(RecurringTransaction).where(*rec_filters)
+        ) or 0
+    else:
+        rec_count = 0
+
+    # Forecast plan items.
+    fpi_filters = [
+        ForecastPlanItem.org_id == org_id,
+        ForecastPlanItem.category_id == category_id,
+    ]
+    if new_type == CategoryType.EXPENSE:
+        fpi_filters.append(ForecastPlanItem.type == ForecastItemType.INCOME)
+        fpi_count = await db.scalar(
+            select(func.count()).select_from(ForecastPlanItem).where(*fpi_filters)
+        ) or 0
+    elif new_type == CategoryType.INCOME:
+        fpi_filters.append(ForecastPlanItem.type == ForecastItemType.EXPENSE)
+        fpi_count = await db.scalar(
+            select(func.count()).select_from(ForecastPlanItem).where(*fpi_filters)
+        ) or 0
+    else:
+        fpi_count = 0
+
+    return tx_count, rec_count, fpi_count
+
+
+async def _has_transfer_leg_reference(
+    db: AsyncSession, org_id: int, category_id: int,
+) -> bool:
+    """Any transaction with this category that is part of a transfer pair
+    (``linked_transaction_id IS NOT NULL``) is a hard lock — see module
+    docstring."""
+    count = await db.scalar(
+        select(func.count())
+        .select_from(Transaction)
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.category_id == category_id,
+            Transaction.linked_transaction_id.is_not(None),
+        )
+    ) or 0
+    return count > 0
+
+
+async def validate_category_type_change(
+    db: AsyncSession,
+    cat: Category,
+    new_type: CategoryType,
+) -> None:
+    """Reject a Category.type change that would retroactively break
+    existing references.
+
+    Skipped entirely when ``new_type == cat.type``. ``new_type == BOTH`` is
+    always safe (BOTH is compatible with any tx/recurring/forecast type)
+    UNLESS ... actually BOTH is the loosest type, so widening is always
+    safe and we short-circuit.
+
+    Master categories cascade into their children: every child's references
+    are checked against ``new_type`` as well, since the codebase invariant
+    is "child type == master type" (see module docstring). The router is
+    responsible for cascading the actual ``type`` assignment to the
+    children once this guard returns.
+
+    Raises ``ValidationError`` (HTTP 400 via app.main.validation_handler)
+    with an aggregate count summary so the admin sees how many rows
+    block the change without leaking row IDs or PII.
+    """
+    if new_type == cat.type:
+        return
+    if new_type == CategoryType.BOTH:
+        # Widening to BOTH is always safe.
+        return
+
+    # Transfer-leg lockdown applies when the category itself is currently
+    # BOTH. (Children of a BOTH master cannot themselves be BOTH unless the
+    # invariant is violated; we still check the master's own references
+    # below, and children get their own counts.)
+    if cat.type == CategoryType.BOTH:
+        if await _has_transfer_leg_reference(db, cat.org_id, cat.id):
+            raise ValidationError(
+                "Cannot change category type: this category is referenced "
+                "by a transfer pair, which requires both income and expense."
+            )
+
+    # Build the set of category IDs we need to check: this category + every
+    # child (one level — categories are limited to two levels by the create
+    # endpoint's validation).
+    target_ids = [cat.id]
+    if cat.parent_id is None:
+        child_ids = (await db.scalars(
+            select(Category.id).where(
+                Category.parent_id == cat.id,
+                Category.org_id == cat.org_id,
+            )
+        )).all()
+        target_ids.extend(child_ids)
+
+    # Children of a BOTH master could themselves carry transfer-leg refs
+    # in degenerate seed data; check each.
+    if cat.type == CategoryType.BOTH and cat.parent_id is None:
+        for child_id in target_ids[1:]:
+            if await _has_transfer_leg_reference(db, cat.org_id, child_id):
+                raise ValidationError(
+                    "Cannot change category type: a child category is "
+                    "referenced by a transfer pair, which requires both "
+                    "income and expense."
+                )
+
+    total_tx = total_rec = total_fpi = 0
+    for cid in target_ids:
+        tx, rec, fpi = await _count_incompatible_for_category(
+            db, cat.org_id, cid, new_type,
+        )
+        total_tx += tx
+        total_rec += rec
+        total_fpi += fpi
+
+    if total_tx == 0 and total_rec == 0 and total_fpi == 0:
+        return
+
+    parts: list[str] = []
+    if total_tx:
+        parts.append(
+            f"{total_tx} transaction{'s' if total_tx != 1 else ''}"
+        )
+    if total_rec:
+        parts.append(
+            f"{total_rec} recurring template{'s' if total_rec != 1 else ''}"
+        )
+    if total_fpi:
+        parts.append(
+            f"{total_fpi} forecast plan item{'s' if total_fpi != 1 else ''}"
+        )
+    if len(parts) == 1:
+        summary = parts[0]
+    elif len(parts) == 2:
+        summary = " and ".join(parts)
+    else:
+        summary = ", ".join(parts[:-1]) + ", and " + parts[-1]
+    raise ValidationError(
+        f"Cannot change category type to {new_type.value}: "
+        f"{summary} reference this category with an incompatible type."
+    )

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -83,8 +83,16 @@ def _require_draft(plan: ForecastPlan) -> None:
 
 async def _validate_master_category(
     db: AsyncSession, org_id: int, category_id: int,
+    item_type: ForecastItemType | None = None,
 ) -> None:
-    """Validate that the category exists, belongs to the org, and is a master category."""
+    """Validate that the category exists, belongs to the org, is a master,
+    and (when ``item_type`` is supplied) has a compatible CategoryType.
+
+    Compatibility rule (PR #144 review fix):
+      - INCOME item  → category.type ∈ {INCOME, BOTH}
+      - EXPENSE item → category.type ∈ {EXPENSE, BOTH}
+    Mismatch raises ValidationError, mapped to HTTP 400 by app.main.
+    """
     result = await db.execute(
         select(Category).where(Category.id == category_id, Category.org_id == org_id)
     )
@@ -93,6 +101,27 @@ async def _validate_master_category(
         raise ValidationError("Invalid category")
     if cat.parent_id is not None:
         raise ValidationError("Forecast plan items must use master categories, not subcategories")
+    if item_type is not None and not _category_type_matches(cat.type, item_type):
+        raise ValidationError(
+            f"Category type ({cat.type.value}) does not match "
+            f"forecast item type ({item_type.value})"
+        )
+
+
+def _category_type_matches(
+    cat_type, item_type: ForecastItemType,
+) -> bool:
+    """Compatibility check used by upsert_item / bulk_upsert. Mirrors the
+    transaction-side helper but speaks ForecastItemType (which is income/
+    expense only — there is no TRANSFER on plan items)."""
+    from app.models.category import CategoryType
+    if cat_type == CategoryType.BOTH:
+        return True
+    if item_type == ForecastItemType.INCOME:
+        return cat_type == CategoryType.INCOME
+    if item_type == ForecastItemType.EXPENSE:
+        return cat_type == CategoryType.EXPENSE
+    return False
 
 
 async def _compute_actuals_batch(
@@ -483,7 +512,9 @@ async def upsert_item(
     plan = await _get_plan(db, org_id, plan_id)
     _require_draft(plan)
 
-    await _validate_master_category(db, org_id, body.category_id)
+    await _validate_master_category(
+        db, org_id, body.category_id, ForecastItemType(body.type)
+    )
 
     # Find existing item
     existing = None
@@ -518,20 +549,39 @@ async def bulk_upsert(
     plan = await _get_plan(db, org_id, plan_id)
     _require_draft(plan)
 
-    # Validate all category IDs belong to the org and are master categories
+    # Validate all category IDs belong to the org and are master categories.
+    # Atomic: any invalid or type-mismatched row rejects the whole batch
+    # before any insert, matching the existing convention where an invalid
+    # ID raises ValidationError before any commit.
     requested_ids = {item.category_id for item in body.items}
+    cat_by_id: dict[int, Category] = {}
     if requested_ids:
         valid_result = await db.execute(
-            select(Category.id).where(
+            select(Category).where(
                 Category.id.in_(requested_ids),
                 Category.org_id == org_id,
-                Category.parent_id.is_(None),
             )
         )
-        valid_ids = {r[0] for r in valid_result.all()}
-        invalid = requested_ids - valid_ids
+        for cat in valid_result.scalars().all():
+            cat_by_id[cat.id] = cat
+        non_master = {
+            cid for cid, cat in cat_by_id.items() if cat.parent_id is not None
+        }
+        invalid = (requested_ids - cat_by_id.keys()) | non_master
         if invalid:
             raise ValidationError(f"Invalid or non-master category IDs: {sorted(invalid)}")
+
+    # Per-row type compatibility (PR #144 review fix). Reject the whole
+    # batch on first mismatch so partial inserts can't leave the plan in a
+    # mixed state.
+    for item_data in body.items:
+        cat = cat_by_id[item_data.category_id]
+        if not _category_type_matches(cat.type, ForecastItemType(item_data.type)):
+            raise ValidationError(
+                f"Category type ({cat.type.value}) does not match "
+                f"forecast item type ({item_data.type}) for category_id="
+                f"{item_data.category_id}"
+            )
 
     existing_map = {
         (i.category_id, i.type.value): i for i in plan.items

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -19,7 +19,7 @@ from app.services.transaction_service import (
     apply_balance,
     get_account_for_update,
     validate_account,
-    validate_category,
+    validate_category_for_type,
 )
 
 
@@ -57,9 +57,14 @@ async def list_recurring(db: AsyncSession, org_id: int) -> list[RecurringTransac
 
 
 async def create_recurring(db: AsyncSession, org_id: int, body: RecurringCreate) -> RecurringTransaction:
-    # Validate refs
+    # Validate refs. Category must be type-compatible with the template's
+    # transaction type, generate_due_transactions writes Transaction rows
+    # directly from the template and would otherwise emit mismatched rows
+    # at every cycle, bypassing the guard on _create_transaction_no_commit.
     await validate_account(db, body.account_id, org_id)
-    await validate_category(db, body.category_id, org_id)
+    await validate_category_for_type(
+        db, body.category_id, org_id, TransactionType(body.type)
+    )
 
     r = RecurringTransaction(
         org_id=org_id,
@@ -96,15 +101,10 @@ async def update_recurring(
     if body.account_id is not None:
         await validate_account(db, body.account_id, org_id)
         r.account_id = body.account_id
-    if body.category_id is not None:
-        await validate_category(db, body.category_id, org_id)
-        r.category_id = body.category_id
     if body.description is not None:
         r.description = body.description
     if body.amount is not None:
         r.amount = body.amount
-    if body.type is not None:
-        r.type = body.type
     if body.frequency is not None:
         r.frequency = Frequency(body.frequency)
     if body.next_due_date is not None:
@@ -113,6 +113,20 @@ async def update_recurring(
         r.auto_settle = body.auto_settle
     if body.is_active is not None:
         r.is_active = body.is_active
+
+    # Validate the post-update (type, category) pair when either changes.
+    # Mirrors update_transaction's pattern: a partial update only touching
+    # one of the two fields must still be compatible with the unchanged
+    # one. validate_category_for_type also re-checks org ownership when a
+    # new category_id is supplied.
+    if body.type is not None or body.category_id is not None:
+        new_type = TransactionType(body.type) if body.type is not None else TransactionType(r.type)
+        new_category_id = body.category_id if body.category_id is not None else r.category_id
+        await validate_category_for_type(db, new_category_id, org_id, new_type)
+        if body.type is not None:
+            r.type = body.type
+        if body.category_id is not None:
+            r.category_id = body.category_id
 
     await db.commit()
 

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -79,6 +79,74 @@ async def validate_category(db: AsyncSession, category_id: int, org_id: int) -> 
         raise ValidationError("Invalid category")
 
 
+async def validate_category_for_type(
+    db: AsyncSession, category_id: int, org_id: int, tx_type: TransactionType,
+) -> None:
+    """Validate org ownership AND that the category's type is compatible
+    with ``tx_type``.
+
+    Compatibility:
+      - INCOME tx  → category.type ∈ {INCOME, BOTH}
+      - EXPENSE tx → category.type ∈ {EXPENSE, BOTH}
+      - For subcategories, the parent master must also be compatible (a
+        subcategory whose master is income-only can't tag an expense, and
+        vice versa, even if the sub itself happens to be CategoryType.BOTH).
+      - TRANSFER is never user-supplied on the create/update path. Transfer
+        legs are typed EXPENSE/INCOME at the leg level (see Transaction
+        model invariant 8). The system Transfer category is CategoryType.BOTH
+        so transfer pairs pass the check naturally — no carve-out needed.
+
+    Raises ValidationError when the category is missing, cross-org, or
+    type-incompatible. Mapped by app.main.validation_handler to HTTP 400.
+    """
+    result = await db.execute(
+        select(Category).where(
+            Category.id == category_id, Category.org_id == org_id
+        )
+    )
+    cat = result.scalar_one_or_none()
+    if cat is None:
+        raise ValidationError("Invalid category")
+
+    if not _category_type_matches(cat.type, tx_type):
+        raise ValidationError(
+            f"Category type ({cat.type.value}) does not match "
+            f"transaction type ({tx_type.value})"
+        )
+
+    if cat.parent_id is not None:
+        parent_type = await db.scalar(
+            select(Category.type).where(
+                Category.id == cat.parent_id, Category.org_id == org_id
+            )
+        )
+        if parent_type is not None and not _category_type_matches(
+            parent_type, tx_type
+        ):
+            raise ValidationError(
+                f"Subcategory's master type ({parent_type.value}) does "
+                f"not match transaction type ({tx_type.value})"
+            )
+
+
+def _category_type_matches(
+    cat_type: CategoryType, tx_type: TransactionType,
+) -> bool:
+    """Pure compatibility check between a CategoryType and a TransactionType.
+
+    BOTH always matches. TRANSFER is rejected — transactions on the create/
+    update path are never user-typed as TRANSFER (transfer legs are typed
+    EXPENSE/INCOME at the leg level).
+    """
+    if cat_type == CategoryType.BOTH:
+        return True
+    if tx_type == TransactionType.INCOME:
+        return cat_type == CategoryType.INCOME
+    if tx_type == TransactionType.EXPENSE:
+        return cat_type == CategoryType.EXPENSE
+    return False
+
+
 async def get_account_for_update(db: AsyncSession, account_id: int, org_id: int) -> Account:
     # populate_existing=True: every FOR UPDATE in this codebase MUST repopulate
     # the ORM identity-map entry so callers see the locked row state, not
@@ -153,9 +221,11 @@ async def _create_transaction_no_commit(
     and rolls back with the caller's outer transaction if anything raises.
     """
     await validate_account(db, body.account_id, org_id)
-    await validate_category(db, body.category_id, org_id)
     tx_type = TransactionType(body.type)
     tx_status = TransactionStatus(body.status)
+    # Type-aware category check covers the existing org/exists guard plus
+    # the (type, category.type) compatibility guard added for PR #137.
+    await validate_category_for_type(db, body.category_id, org_id, tx_type)
 
     if tx_status == TransactionStatus.SETTLED:
         acct = await get_account_for_update(db, body.account_id, org_id)
@@ -289,8 +359,6 @@ async def update_transaction(
     # Validate references regardless of linked status
     if body.account_id is not None and body.account_id != tx.account_id and partner is None:
         await validate_account(db, body.account_id, org_id)
-    if body.category_id is not None:
-        await validate_category(db, body.category_id, org_id)
 
     old_account_id = tx.account_id
     old_amount = tx.amount
@@ -300,6 +368,16 @@ async def update_transaction(
 
     new_account_id = body.account_id if body.account_id is not None else old_account_id
     new_status = TransactionStatus(body.status) if body.status is not None else old_status
+
+    # Category/type compatibility check (PR #137 review fix). Fires whenever
+    # either field is being changed — checks the post-update pair, so a
+    # simultaneous (type, category_id) swap to a compatible pair passes.
+    # On transfer legs the schema-level guard above already rejects
+    # body.type, so the resolved type here is unchanged for linked rows.
+    new_category_id = body.category_id if body.category_id is not None else old_category_id
+    new_type = TransactionType(body.type) if body.type is not None else old_type
+    if body.category_id is not None or body.type is not None:
+        await validate_category_for_type(db, new_category_id, org_id, new_type)
 
     # 3. Lock affected accounts in sorted ID order
     account_ids_to_lock: set[int] = set()

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -134,7 +134,7 @@ def _category_type_matches(
 ) -> bool:
     """Pure compatibility check between a CategoryType and a TransactionType.
 
-    BOTH always matches. TRANSFER is rejected — transactions on the create/
+    BOTH always matches. TRANSFER is rejected, transactions on the create/
     update path are never user-typed as TRANSFER (transfer legs are typed
     EXPENSE/INCOME at the leg level).
     """
@@ -145,6 +145,33 @@ def _category_type_matches(
     if tx_type == TransactionType.EXPENSE:
         return cat_type == CategoryType.EXPENSE
     return False
+
+
+async def validate_transfer_category(
+    db: AsyncSession, category_id: int, org_id: int,
+) -> None:
+    """Validate a user-supplied transfer category.
+
+    A transfer pair shares one category across both legs (expense and income).
+    Anything other than CategoryType.BOTH is structurally wrong: the opposite
+    leg would end up with a one-sided category that fails the same
+    (type, category) compatibility rule enforced on regular writes.
+
+    Raises ValidationError when the category is missing, cross-org, or
+    not CategoryType.BOTH. Mapped by app.main.validation_handler to HTTP 400.
+    """
+    cat = await db.scalar(
+        select(Category).where(
+            Category.id == category_id, Category.org_id == org_id
+        )
+    )
+    if cat is None:
+        raise ValidationError("Invalid category")
+    if cat.type != CategoryType.BOTH:
+        raise ValidationError(
+            "Transfer category must accept both income and expense "
+            f"(got type={cat.type.value})"
+        )
 
 
 async def get_account_for_update(db: AsyncSession, account_id: int, org_id: int) -> Account:
@@ -813,7 +840,10 @@ async def _link_pair(
                 await db.flush()
                 cat_id = new_cat.id
         else:
-            await validate_category(db, cat_id, expense_tx.org_id)
+            # Both legs share one category, anything other than BOTH would
+            # leave the opposite leg with a one-sided category that fails
+            # the (type, category) compatibility guard.
+            await validate_transfer_category(db, cat_id, expense_tx.org_id)
         expense_tx.category_id = cat_id
         income_tx.category_id = cat_id
 
@@ -1248,7 +1278,9 @@ async def create_transfer(
             transfer_cat = new_cat.id
         category_id = transfer_cat
     else:
-        await validate_category(db, category_id, org_id)
+        # Both legs share one category, a one-sided category would leave
+        # the opposite leg with an incompatible (type, category) pair.
+        await validate_transfer_category(db, category_id, org_id)
 
     tx_status = TransactionStatus(body.status)
 

--- a/backend/tests/routers/test_categories_child_type_invariant.py
+++ b/backend/tests/routers/test_categories_child_type_invariant.py
@@ -1,0 +1,300 @@
+"""Router-level test for the child-type invariant on category create/update.
+
+Closes the final Medium finding from PR #150 review: a child category could
+diverge from its master via:
+- POST /api/v1/categories/ with parent_id + a body.type different from the
+  parent's type, which the route would persist verbatim.
+- PUT /api/v1/categories/{id} on a child with body.type different from the
+  parent's type when no incompatible references existed yet (the existing
+  reference-based guard wouldn't fire on a fresh child).
+
+Rules enforced:
+- Create with parent_id: child.type is forced to the parent's type. Body's
+  type is silently ignored. parent_id is the authoritative signal.
+- Update on a child (cat.parent_id is not None) with body.type set:
+  reject with 400 when body.type differs from parent.type. Skip silently
+  when it matches. Other fields update normally when type is omitted.
+- Master cascade (parent_id is None) keeps its existing behavior — type
+  change cascades to children's types in the same operation.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.user import Role, User
+from app.routers.categories import router as categories_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    select(User).where(User.is_superadmin.is_(True))
+                )
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(categories_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """One org, an EXPENSE master + an INCOME master + a BOTH master.
+
+    The EXPENSE master has one existing child (typed EXPENSE) so we can test
+    update behavior on a pre-existing subcategory.
+    """
+    async with factory() as db:
+        org = Organization(name="T", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id, username="root", email="r@x.com",
+            password_hash=hash_password("pw-1234567"), role=Role.OWNER,
+            is_superadmin=True, is_active=True, email_verified=True,
+        )
+        at = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True,
+        )
+        db.add_all([user, at])
+        await db.flush()
+        acct = Account(
+            org_id=org.id, name="Main", account_type_id=at.id,
+            balance=Decimal("0"), currency="EUR",
+        )
+        expense_master = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        income_master = Category(
+            org_id=org.id, name="Salary", slug="salary",
+            type=CategoryType.INCOME,
+        )
+        both_master = Category(
+            org_id=org.id, name="Flex", slug="flex", type=CategoryType.BOTH,
+        )
+        db.add_all([acct, expense_master, income_master, both_master])
+        await db.flush()
+        # A pre-existing expense child under the expense master (mirrors
+        # what org_bootstrap seeds: child.type == master.type).
+        expense_child = Category(
+            org_id=org.id, name="Supermarket", slug="supermarket",
+            type=CategoryType.EXPENSE, parent_id=expense_master.id,
+        )
+        db.add(expense_child)
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "expense_master_id": expense_master.id,
+            "income_master_id": income_master.id,
+            "both_master_id": both_master.id,
+            "expense_child_id": expense_child.id,
+        }
+
+
+# ── Create path: child silently inherits parent's type ───────────────────────
+
+@pytest.mark.asyncio
+async def test_create_child_inherits_parent_type_overriding_body(session_factory):
+    """POST with parent_id=<expense> and body.type=income persists EXPENSE."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/categories",
+            json={
+                "name": "New Sub",
+                "type": "income",
+                "parent_id": seed["expense_master_id"],
+            },
+        )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["type"] == "expense"
+    assert resp.json()["parent_id"] == seed["expense_master_id"]
+
+
+@pytest.mark.asyncio
+async def test_create_child_without_body_type_inherits_parent(session_factory):
+    """POST with parent_id and no `type` field persists parent's type."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        # CategoryCreate.type defaults to "both"; we still expect inheritance
+        # because the parent_id is the authoritative signal.
+        resp = client.post(
+            "/api/v1/categories",
+            json={"name": "Another Sub", "parent_id": seed["income_master_id"]},
+        )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["type"] == "income"
+
+
+@pytest.mark.asyncio
+async def test_create_master_uses_body_type(session_factory):
+    """POST with parent_id=None preserves body.type unchanged."""
+    seed = await _seed(session_factory)  # noqa: F841
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/categories",
+            json={"name": "New Master", "type": "income"},
+        )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["type"] == "income"
+    assert resp.json()["parent_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_child_under_other_org_parent_returns_400(session_factory):
+    """Existing org-isolation behavior must still fire (parent in another org)."""
+    seed = await _seed(session_factory)  # noqa: F841
+    # Seed a second org with its own master. Since the dependency override
+    # always returns the first superadmin, the second master_id is
+    # cross-org from the API's perspective.
+    async with session_factory() as db:
+        other_org = Organization(name="Other", billing_cycle_day=1)
+        db.add(other_org)
+        await db.flush()
+        other_master = Category(
+            org_id=other_org.id, name="Foreign", slug="foreign",
+            type=CategoryType.EXPENSE,
+        )
+        db.add(other_master)
+        await db.commit()
+        other_master_id = other_master.id
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/categories",
+            json={
+                "name": "Sub",
+                "type": "expense",
+                "parent_id": other_master_id,
+            },
+        )
+    assert resp.status_code == 400
+
+
+# ── Update path: child rejects mismatched type ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_update_child_with_mismatched_type_rejected(session_factory):
+    """PUT child with body.type different from parent's type → 400, atomic."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['expense_child_id']}",
+            json={"name": "Renamed Child", "type": "income"},
+        )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"].lower()
+    assert "subcategory" in detail or "child" in detail
+    assert "parent" in detail or "master" in detail
+    # The name change must NOT have been persisted (atomic rejection).
+    async with session_factory() as db:
+        child = (await db.execute(
+            select(Category).where(Category.id == seed["expense_child_id"])
+        )).scalar_one()
+        assert child.name == "Supermarket"
+        assert child.type == CategoryType.EXPENSE
+
+
+@pytest.mark.asyncio
+async def test_update_child_with_matching_type_succeeds(session_factory):
+    """PUT child with body.type equal to parent's type → 200, no-op on type."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['expense_child_id']}",
+            json={"type": "expense"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["type"] == "expense"
+
+
+@pytest.mark.asyncio
+async def test_update_child_other_fields_when_type_omitted(session_factory):
+    """PUT child with only name change → 200, type unchanged."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['expense_child_id']}",
+            json={"name": "Big Grocer"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "Big Grocer"
+    assert resp.json()["type"] == "expense"
+
+
+# ── Master cascade still works ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_master_widen_to_both_cascades_to_children(session_factory):
+    """Master EXPENSE → BOTH (always-safe widen): child flips to BOTH too."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['expense_master_id']}",
+            json={"type": "both"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["type"] == "both"
+    # Child was cascaded.
+    async with session_factory() as db:
+        child = (await db.execute(
+            select(Category).where(Category.id == seed["expense_child_id"])
+        )).scalar_one()
+        assert child.type == CategoryType.BOTH

--- a/backend/tests/routers/test_categories_update_type_guard.py
+++ b/backend/tests/routers/test_categories_update_type_guard.py
@@ -1,0 +1,183 @@
+"""Router-level test for the category type-change guard.
+
+Closes the third HIGH finding from PR #150 review: PUT /api/v1/categories/{id}
+let a category's `type` be reassigned freely, retroactively breaking every
+(type, category) compatibility guard added in the prior commits.
+
+The guard runs only when `body.type` is in the request AND differs from the
+current value. Renames and other field updates pass through unchanged.
+
+ValidationError -> 400 (matches existing project convention; see
+app/main.py validation_handler and test_category_type_guard_status_codes.py).
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Role, User
+from app.routers.categories import router as categories_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    _select(User).where(User.is_superadmin.is_(True))
+                )
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(categories_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="T", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id, username="root", email="r@x.com",
+            password_hash=hash_password("pw-1234567"), role=Role.OWNER,
+            is_superadmin=True, is_active=True, email_verified=True,
+        )
+        at = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True,
+        )
+        db.add_all([user, at])
+        await db.flush()
+        acct = Account(
+            org_id=org.id, name="Main", account_type_id=at.id,
+            balance=Decimal("0"), currency="EUR",
+        )
+        expense_master = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        both_master = Category(
+            org_id=org.id, name="Flex", slug="flex", type=CategoryType.BOTH,
+        )
+        db.add_all([acct, expense_master, both_master])
+        await db.flush()
+        # An expense transaction on the BOTH master.
+        db.add(Transaction(
+            org_id=org.id, account_id=acct.id,
+            category_id=both_master.id, description="x",
+            amount=Decimal("10"), type=TransactionType.EXPENSE,
+            status=TransactionStatus.SETTLED, date=date(2026, 5, 1),
+        ))
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "expense_master_id": expense_master.id,
+            "both_master_id": both_master.id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_update_rename_passes_when_type_omitted(session_factory):
+    """No type in body: guard is a no-op even with incompatible references."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['both_master_id']}",
+            json={"name": "Renamed"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_update_same_type_passes(session_factory):
+    """Body type equals current type: guard is skipped."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['both_master_id']}",
+            json={"type": "both"},
+        )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_update_to_both_always_safe(session_factory):
+    """EXPENSE -> BOTH is always safe regardless of references."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['expense_master_id']}",
+            json={"type": "both"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["type"] == "both"
+
+
+@pytest.mark.asyncio
+async def test_update_blocked_by_incompatible_transaction(session_factory):
+    """BOTH -> INCOME with an expense txn on the category: 400."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['both_master_id']}",
+            json={"type": "income"},
+        )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"].lower()
+    assert "category" in detail
+    assert "transaction" in detail

--- a/backend/tests/routers/test_category_type_guard_status_codes.py
+++ b/backend/tests/routers/test_category_type_guard_status_codes.py
@@ -1,0 +1,198 @@
+"""Router-level tests pinning the HTTP status code surface for the
+category/type compatibility guard. Service-level invariants are covered
+by tests/services/test_transaction_service_category_type_guard.py and
+test_forecast_plan_category_type_guard.py.
+
+ValidationError → 400 (matches existing project convention; see
+app/main.py validation_handler).
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.billing import BillingPeriod
+from app.models.category import CategoryType
+from app.models.forecast_plan import ForecastPlan, PlanStatus
+from app.models.user import Role, User
+from app.routers.forecast_plans import router as forecast_plans_router
+from app.routers.transactions import router as transactions_router
+from app.security import hash_password
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    _select(User).where(User.is_superadmin.is_(True))
+                )
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    @app.exception_handler(NotFoundError)
+    async def _nf(_req, exc: NotFoundError):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ValidationError)
+    async def _ve(_req, exc: ValidationError):
+        return JSONResponse(status_code=400, content={"detail": exc.detail})
+
+    @app.exception_handler(ConflictError)
+    async def _ce(_req, exc: ConflictError):
+        return JSONResponse(status_code=409, content={"detail": exc.detail})
+
+    app.include_router(transactions_router)
+    app.include_router(forecast_plans_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """Org + superadmin user + accounts + master categories + period + draft plan."""
+    async with factory() as db:
+        org = Organization(name="Test Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="root",
+            email="root@example.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        at = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True
+        )
+        db.add_all([user, at])
+        await db.flush()
+        acct = Account(
+            org_id=org.id, name="Acct", account_type_id=at.id,
+            balance=Decimal("1000"), currency="EUR",
+        )
+        db.add(acct)
+        await db.flush()
+        expense_master = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        income_master = Category(
+            org_id=org.id, name="Salary", slug="salary",
+            type=CategoryType.INCOME,
+        )
+        db.add_all([expense_master, income_master])
+        await db.flush()
+        period = BillingPeriod(
+            org_id=org.id, start_date=date(2026, 5, 1),
+            end_date=date(2026, 5, 31),
+        )
+        db.add(period)
+        await db.flush()
+        plan = ForecastPlan(
+            org_id=org.id, billing_period_id=period.id,
+            status=PlanStatus.DRAFT,
+        )
+        db.add(plan)
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "acct_id": acct.id,
+            "expense_master_id": expense_master.id,
+            "income_master_id": income_master.id,
+            "plan_id": plan.id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_post_transaction_with_mismatched_category_returns_400(
+    session_factory,
+):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/transactions",
+            json={
+                "account_id": seed["acct_id"],
+                "category_id": seed["income_master_id"],
+                "description": "rent",
+                "amount": "500",
+                "type": "expense",
+                "status": "settled",
+                "date": "2026-05-01",
+            },
+        )
+    assert resp.status_code == 400
+    assert "category" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_forecast_plan_upsert_with_mismatched_category_returns_400(
+    session_factory,
+):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post(
+            f"/api/v1/forecast-plans/{seed['plan_id']}/items",
+            json={
+                "category_id": seed["expense_master_id"],
+                "type": "income",
+                "planned_amount": "100",
+                "source": "manual",
+            },
+        )
+    assert resp.status_code == 400
+    assert "category" in resp.json()["detail"].lower()

--- a/backend/tests/services/test_category_service_type_change_guard.py
+++ b/backend/tests/services/test_category_service_type_change_guard.py
@@ -1,0 +1,370 @@
+"""Server-side guard: changing a Category.type must not retroactively
+break existing references (transactions, recurring templates, forecast
+plan items, transfer legs).
+
+Closes the third HIGH finding from PR #150 review: PUT /api/v1/categories/{id}
+let cat.type be reassigned freely, bypassing every (type, category)
+compatibility guard added in the prior commits.
+
+Rule: a type change OLD -> NEW is rejected if any existing row referencing
+this category (or any of its children, when the category is a master) is
+incompatible with NEW under the same compatibility semantics that
+validate_category_for_type uses.
+
+Special case: BOTH categories that are referenced by a transfer leg cannot
+be moved off BOTH at all (transfer pairs structurally need both directions).
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.billing import BillingPeriod
+from app.models.category import CategoryType
+from app.models.forecast_plan import (
+    ForecastItemType,
+    ForecastPlan,
+    ForecastPlanItem,
+    ItemSource,
+    PlanStatus,
+)
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services import category_service
+from app.services.exceptions import ValidationError
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_org(db: AsyncSession) -> dict:
+    """Org + one account + one EXPENSE master + one BOTH master."""
+    org = Organization(name="T", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True,
+    )
+    db.add(at)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, name="Main", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add(acct)
+    await db.flush()
+    expense_master = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        type=CategoryType.EXPENSE,
+    )
+    both_master = Category(
+        org_id=org.id, name="Flex", slug="flex", type=CategoryType.BOTH,
+    )
+    db.add_all([expense_master, both_master])
+    await db.flush()
+    return {
+        "org_id": org.id,
+        "acct_id": acct.id,
+        "expense_master": expense_master,
+        "both_master": both_master,
+    }
+
+
+# ── Pure helper semantics ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_change_skips_guard(db_session: AsyncSession) -> None:
+    """OLD == NEW: helper is a no-op; no rejection regardless of references."""
+    seed = await _seed_org(db_session)
+    cat = seed["expense_master"]
+    # No references either way.
+    await category_service.validate_category_type_change(
+        db_session, cat, CategoryType.EXPENSE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_change_to_both_always_safe(db_session: AsyncSession) -> None:
+    """EXPENSE -> BOTH and INCOME -> BOTH are always safe, regardless of refs."""
+    seed = await _seed_org(db_session)
+    cat = seed["expense_master"]
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=cat.id, description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    ))
+    await db_session.commit()
+    await category_service.validate_category_type_change(
+        db_session, cat, CategoryType.BOTH,
+    )
+
+
+@pytest.mark.asyncio
+async def test_change_with_no_references_succeeds(db_session: AsyncSession) -> None:
+    """EXPENSE -> INCOME with no references: no rows to break, safe."""
+    seed = await _seed_org(db_session)
+    cat = seed["expense_master"]
+    await category_service.validate_category_type_change(
+        db_session, cat, CategoryType.INCOME,
+    )
+
+
+# ── Transaction references ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_change_rejected_when_expense_transaction_blocks(
+    db_session: AsyncSession,
+) -> None:
+    """EXPENSE -> INCOME with one expense txn: rejected."""
+    seed = await _seed_org(db_session)
+    cat = seed["expense_master"]
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=cat.id, description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    ))
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, cat, CategoryType.INCOME,
+        )
+
+
+@pytest.mark.asyncio
+async def test_both_to_expense_rejected_when_income_txn_exists(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session)
+    cat = seed["both_master"]
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=cat.id, description="pay", amount=Decimal("100"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    ))
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, cat, CategoryType.EXPENSE,
+        )
+
+
+@pytest.mark.asyncio
+async def test_both_to_income_rejected_when_expense_txn_exists(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session)
+    cat = seed["both_master"]
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=cat.id, description="buy", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    ))
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, cat, CategoryType.INCOME,
+        )
+
+
+@pytest.mark.asyncio
+async def test_both_to_expense_with_no_references_succeeds(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session)
+    cat = seed["both_master"]
+    await category_service.validate_category_type_change(
+        db_session, cat, CategoryType.EXPENSE,
+    )
+
+
+# ── Recurring template references ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_change_rejected_by_recurring_template(
+    db_session: AsyncSession,
+) -> None:
+    """BOTH -> EXPENSE with an income-typed recurring template: rejected."""
+    seed = await _seed_org(db_session)
+    cat = seed["both_master"]
+    db_session.add(RecurringTransaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=cat.id, description="paycheck",
+        amount=Decimal("100"), type="income",
+        frequency=Frequency.MONTHLY, next_due_date=date(2026, 6, 1),
+    ))
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, cat, CategoryType.EXPENSE,
+        )
+
+
+# ── Forecast plan item references ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_change_rejected_by_forecast_plan_item(
+    db_session: AsyncSession,
+) -> None:
+    """BOTH -> INCOME with an expense forecast item: rejected."""
+    seed = await _seed_org(db_session)
+    cat = seed["both_master"]
+    period = BillingPeriod(
+        org_id=seed["org_id"], start_date=date(2026, 5, 1),
+        end_date=date(2026, 5, 31),
+    )
+    db_session.add(period)
+    await db_session.flush()
+    plan = ForecastPlan(
+        org_id=seed["org_id"], billing_period_id=period.id,
+        status=PlanStatus.DRAFT,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+    db_session.add(ForecastPlanItem(
+        plan_id=plan.id, org_id=seed["org_id"], category_id=cat.id,
+        type=ForecastItemType.EXPENSE, planned_amount=Decimal("50"),
+        source=ItemSource.MANUAL,
+    ))
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, cat, CategoryType.INCOME,
+        )
+
+
+# ── Transfer leg lockdown ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_transfer_leg_blocks_any_move_off_both(
+    db_session: AsyncSession,
+) -> None:
+    """A BOTH category referenced by a transfer leg cannot move to EXPENSE
+    or INCOME — transfer pairs require BOTH on both legs."""
+    seed = await _seed_org(db_session)
+    # Second account so transfer legs reference different accounts.
+    acct2 = Account(
+        org_id=seed["org_id"], name="Other",
+        account_type_id=(await db_session.scalar(
+            __import__("sqlalchemy").select(AccountType.id).where(
+                AccountType.org_id == seed["org_id"]
+            )
+        )),
+        balance=Decimal("0"), currency="EUR",
+    )
+    db_session.add(acct2)
+    await db_session.flush()
+    cat = seed["both_master"]
+    leg_out = Transaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=cat.id, description="xfer", amount=Decimal("50"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    )
+    leg_in = Transaction(
+        org_id=seed["org_id"], account_id=acct2.id,
+        category_id=cat.id, description="xfer", amount=Decimal("50"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    )
+    db_session.add_all([leg_out, leg_in])
+    await db_session.flush()
+    leg_out.linked_transaction_id = leg_in.id
+    leg_in.linked_transaction_id = leg_out.id
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, cat, CategoryType.EXPENSE,
+        )
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, cat, CategoryType.INCOME,
+        )
+
+
+# ── Master category recursion ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_master_change_rejected_by_child_reference(
+    db_session: AsyncSession,
+) -> None:
+    """Changing a master's type must consider every child's references too.
+
+    A child currently typed EXPENSE under a BOTH master, with an expense
+    transaction tagged on the child, blocks the master from moving to INCOME.
+    """
+    seed = await _seed_org(db_session)
+    master = seed["both_master"]
+    child = Category(
+        org_id=seed["org_id"], parent_id=master.id, name="Sub",
+        type=CategoryType.EXPENSE,
+    )
+    db_session.add(child)
+    await db_session.flush()
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=child.id, description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    ))
+    await db_session.commit()
+    with pytest.raises(ValidationError):
+        await category_service.validate_category_type_change(
+            db_session, master, CategoryType.INCOME,
+        )
+
+
+@pytest.mark.asyncio
+async def test_master_change_succeeds_when_children_compatible(
+    db_session: AsyncSession,
+) -> None:
+    """A master EXPENSE -> BOTH succeeds even with child + child txn refs."""
+    seed = await _seed_org(db_session)
+    master = seed["expense_master"]
+    child = Category(
+        org_id=seed["org_id"], parent_id=master.id, name="Sub",
+        type=CategoryType.EXPENSE,
+    )
+    db_session.add(child)
+    await db_session.flush()
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["acct_id"],
+        category_id=child.id, description="x", amount=Decimal("10"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1),
+    ))
+    await db_session.commit()
+    await category_service.validate_category_type_change(
+        db_session, master, CategoryType.BOTH,
+    )

--- a/backend/tests/services/test_forecast_plan_category_type_guard.py
+++ b/backend/tests/services/test_forecast_plan_category_type_guard.py
@@ -1,0 +1,247 @@
+"""Server-side guard: forecast_plan_service.upsert_item / bulk_upsert
+reject items whose resolved category type disagrees with the item's type.
+Closes the HIGH finding from PR #144 review (forecast plan upsert doesn't
+validate category/type compatibility).
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import AccountType
+from app.models.billing import BillingPeriod
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import ForecastPlan, PlanStatus
+from app.models.user import Organization
+from app.schemas.forecast_plan import (
+    BulkUpsertItem,
+    BulkUpsertRequest,
+    ForecastPlanItemCreate,
+)
+from app.services import forecast_plan_service
+from app.services.exceptions import ValidationError
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory) -> dict:
+    """Org + period + draft plan + EXPENSE master + INCOME master + BOTH
+    master. Plan is empty so each test starts fresh."""
+    org_id = 1
+    period_start = datetime.date(2026, 5, 1)
+    period_end = datetime.date(2026, 5, 31)
+
+    async with factory() as db:
+        db.add(Organization(id=org_id, name="org", billing_cycle_day=1))
+        await db.commit()
+
+        # AccountType is unused for plan tests but satisfies FK constraints
+        # if any related tests share the seed.
+        at = AccountType(
+            org_id=org_id, name="Cash", slug="cash", is_system=True
+        )
+        db.add(at)
+        await db.commit()
+
+        expense_master = Category(
+            org_id=org_id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        income_master = Category(
+            org_id=org_id, name="Salary", slug="salary",
+            type=CategoryType.INCOME,
+        )
+        both_master = Category(
+            org_id=org_id, name="Transfer", slug="transfer",
+            type=CategoryType.BOTH, is_system=True,
+        )
+        db.add_all([expense_master, income_master, both_master])
+        await db.commit()
+
+        period = BillingPeriod(
+            org_id=org_id, start_date=period_start, end_date=period_end
+        )
+        db.add(period)
+        await db.commit()
+
+        plan = ForecastPlan(
+            org_id=org_id, billing_period_id=period.id,
+            status=PlanStatus.DRAFT,
+        )
+        db.add(plan)
+        await db.commit()
+
+        return {
+            "org_id": org_id,
+            "plan_id": plan.id,
+            "expense_master_id": expense_master.id,
+            "income_master_id": income_master.id,
+            "both_master_id": both_master.id,
+        }
+
+
+# ── upsert_item ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_income_with_expense_category(session_factory):
+    seed = await _seed(session_factory)
+    body = ForecastPlanItemCreate(
+        category_id=seed["expense_master_id"],
+        type="income",
+        planned_amount=Decimal("100"),
+        source="manual",
+    )
+    async with session_factory() as db:
+        with pytest.raises(ValidationError):
+            await forecast_plan_service.upsert_item(
+                db, seed["org_id"], seed["plan_id"], body
+            )
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_expense_with_income_category(session_factory):
+    seed = await _seed(session_factory)
+    body = ForecastPlanItemCreate(
+        category_id=seed["income_master_id"],
+        type="expense",
+        planned_amount=Decimal("100"),
+        source="manual",
+    )
+    async with session_factory() as db:
+        with pytest.raises(ValidationError):
+            await forecast_plan_service.upsert_item(
+                db, seed["org_id"], seed["plan_id"], body
+            )
+
+
+@pytest.mark.asyncio
+async def test_upsert_accepts_matching_category(session_factory):
+    seed = await _seed(session_factory)
+    body = ForecastPlanItemCreate(
+        category_id=seed["expense_master_id"],
+        type="expense",
+        planned_amount=Decimal("100"),
+        source="manual",
+    )
+    async with session_factory() as db:
+        resp = await forecast_plan_service.upsert_item(
+            db, seed["org_id"], seed["plan_id"], body
+        )
+    assert any(
+        item.category_id == seed["expense_master_id"] for item in resp.items
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_accepts_both_category_for_either_type(session_factory):
+    """CategoryType.BOTH master accepts either income or expense items."""
+    seed = await _seed(session_factory)
+    expense_body = ForecastPlanItemCreate(
+        category_id=seed["both_master_id"],
+        type="expense",
+        planned_amount=Decimal("50"),
+        source="manual",
+    )
+    income_body = ForecastPlanItemCreate(
+        category_id=seed["both_master_id"],
+        type="income",
+        planned_amount=Decimal("50"),
+        source="manual",
+    )
+    async with session_factory() as db:
+        await forecast_plan_service.upsert_item(
+            db, seed["org_id"], seed["plan_id"], expense_body
+        )
+        # Same master + different type is allowed because the unique
+        # constraint is (plan_id, category_id, type).
+        await forecast_plan_service.upsert_item(
+            db, seed["org_id"], seed["plan_id"], income_body
+        )
+
+
+# ── bulk_upsert ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_rejects_when_any_row_mismatches(session_factory):
+    """The codebase convention for bulk_upsert is atomic validation
+    (existing test pattern: invalid IDs raise before any insert). The
+    type-compat guard follows the same pattern: any mismatched row causes
+    the whole batch to reject."""
+    seed = await _seed(session_factory)
+    body = BulkUpsertRequest(
+        items=[
+            BulkUpsertItem(
+                category_id=seed["expense_master_id"],
+                type="expense",
+                planned_amount=Decimal("100"),
+                source="manual",
+            ),
+            BulkUpsertItem(
+                category_id=seed["income_master_id"],
+                type="expense",  # mismatched
+                planned_amount=Decimal("50"),
+                source="manual",
+            ),
+        ]
+    )
+    async with session_factory() as db:
+        with pytest.raises(ValidationError):
+            await forecast_plan_service.bulk_upsert(
+                db, seed["org_id"], seed["plan_id"], body
+            )
+
+    # The first row must NOT have been inserted because the batch was
+    # rejected atomically.
+    async with session_factory() as db:
+        resp = await forecast_plan_service.get_or_create_plan(
+            db, seed["org_id"]
+        )
+        assert resp.items == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_accepts_all_compatible(session_factory):
+    seed = await _seed(session_factory)
+    body = BulkUpsertRequest(
+        items=[
+            BulkUpsertItem(
+                category_id=seed["expense_master_id"],
+                type="expense",
+                planned_amount=Decimal("100"),
+                source="manual",
+            ),
+            BulkUpsertItem(
+                category_id=seed["income_master_id"],
+                type="income",
+                planned_amount=Decimal("3000"),
+                source="manual",
+            ),
+        ]
+    )
+    async with session_factory() as db:
+        resp = await forecast_plan_service.bulk_upsert(
+            db, seed["org_id"], seed["plan_id"], body
+        )
+    assert len(resp.items) == 2

--- a/backend/tests/services/test_recurring_service_category_type_guard.py
+++ b/backend/tests/services/test_recurring_service_category_type_guard.py
@@ -1,0 +1,238 @@
+"""Server-side guard: recurring template writes must enforce the same
+(type, category) compatibility rule that single-transaction writes enforce.
+
+Closes the HIGH finding from PR #150 round 2: recurring_service.create_recurring
+called validate_category (existence only), and update_recurring let type and
+category_id change independently with no compatibility check. Because
+generate_due_transactions writes Transaction rows directly from the template
+(not via _create_transaction_no_commit), a mismatched template would emit
+mismatched rows that bypass the new guard at every cycle.
+
+Rule: validate the resolved (type, category) pair on create AND on the
+post-update state for update.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.schemas.recurring import RecurringCreate, RecurringUpdate
+from app.services import recurring_service
+from app.services.exceptions import ValidationError
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    org = Organization(name="T", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True
+    )
+    db.add(at)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, name="Main", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add(acct)
+    await db.flush()
+
+    expense_master = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        type=CategoryType.EXPENSE,
+    )
+    income_master = Category(
+        org_id=org.id, name="Salary", slug="salary",
+        type=CategoryType.INCOME,
+    )
+    both_master = Category(
+        org_id=org.id, name="Misc", slug="misc",
+        type=CategoryType.BOTH,
+    )
+    db.add_all([expense_master, income_master, both_master])
+    await db.commit()
+
+    return {
+        "org_id": org.id,
+        "account_id": acct.id,
+        "expense_cat_id": expense_master.id,
+        "income_cat_id": income_master.id,
+        "both_cat_id": both_master.id,
+    }
+
+
+# ── create_recurring ───────────────────────────────────────────────────────
+
+
+async def test_create_recurring_rejects_income_with_expense_category(db_session):
+    seed = await _seed(db_session)
+    body = RecurringCreate(
+        account_id=seed["account_id"],
+        category_id=seed["expense_cat_id"],
+        description="paycheck",
+        amount=Decimal("100"),
+        type="income",
+        frequency="monthly",
+        next_due_date=date(2026, 6, 1),
+    )
+    with pytest.raises(ValidationError):
+        await recurring_service.create_recurring(
+            db_session, seed["org_id"], body
+        )
+
+
+async def test_create_recurring_rejects_expense_with_income_category(db_session):
+    seed = await _seed(db_session)
+    body = RecurringCreate(
+        account_id=seed["account_id"],
+        category_id=seed["income_cat_id"],
+        description="rent",
+        amount=Decimal("500"),
+        type="expense",
+        frequency="monthly",
+        next_due_date=date(2026, 6, 1),
+    )
+    with pytest.raises(ValidationError):
+        await recurring_service.create_recurring(
+            db_session, seed["org_id"], body
+        )
+
+
+async def test_create_recurring_accepts_matching_pair(db_session):
+    seed = await _seed(db_session)
+    body = RecurringCreate(
+        account_id=seed["account_id"],
+        category_id=seed["expense_cat_id"],
+        description="rent",
+        amount=Decimal("500"),
+        type="expense",
+        frequency="monthly",
+        next_due_date=date(2026, 6, 1),
+    )
+    r = await recurring_service.create_recurring(
+        db_session, seed["org_id"], body
+    )
+    assert r.id is not None
+
+
+async def test_create_recurring_accepts_both_category(db_session):
+    """CategoryType.BOTH is compatible with either type."""
+    seed = await _seed(db_session)
+    body = RecurringCreate(
+        account_id=seed["account_id"],
+        category_id=seed["both_cat_id"],
+        description="x",
+        amount=Decimal("1"),
+        type="expense",
+        frequency="monthly",
+        next_due_date=date(2026, 6, 1),
+    )
+    r = await recurring_service.create_recurring(
+        db_session, seed["org_id"], body
+    )
+    assert r.id is not None
+
+
+# ── update_recurring ───────────────────────────────────────────────────────
+
+
+async def _create_compatible(db: AsyncSession, seed: dict, *, type_: str = "expense"):
+    cat_id = seed["expense_cat_id"] if type_ == "expense" else seed["income_cat_id"]
+    body = RecurringCreate(
+        account_id=seed["account_id"],
+        category_id=cat_id,
+        description="initial",
+        amount=Decimal("10"),
+        type=type_,
+        frequency="monthly",
+        next_due_date=date(2026, 6, 1),
+    )
+    return await recurring_service.create_recurring(db, seed["org_id"], body)
+
+
+async def test_update_recurring_rejects_category_only_swap_to_incompatible(db_session):
+    """Existing expense template, swap category to income-only → reject."""
+    seed = await _seed(db_session)
+    r = await _create_compatible(db_session, seed, type_="expense")
+    upd = RecurringUpdate(category_id=seed["income_cat_id"])
+    with pytest.raises(ValidationError):
+        await recurring_service.update_recurring(
+            db_session, seed["org_id"], r.id, upd
+        )
+
+
+async def test_update_recurring_rejects_type_only_swap_to_incompatible(db_session):
+    """Existing expense template (expense category), flip type to income → reject."""
+    seed = await _seed(db_session)
+    r = await _create_compatible(db_session, seed, type_="expense")
+    upd = RecurringUpdate(type="income")
+    with pytest.raises(ValidationError):
+        await recurring_service.update_recurring(
+            db_session, seed["org_id"], r.id, upd
+        )
+
+
+async def test_update_recurring_accepts_compatible_simultaneous_swap(db_session):
+    """type AND category change together to a compatible pair → accept."""
+    seed = await _seed(db_session)
+    r = await _create_compatible(db_session, seed, type_="expense")
+    upd = RecurringUpdate(type="income", category_id=seed["income_cat_id"])
+    updated = await recurring_service.update_recurring(
+        db_session, seed["org_id"], r.id, upd
+    )
+    assert updated.type == "income"
+    assert updated.category_id == seed["income_cat_id"]
+
+
+async def test_update_recurring_rejects_incompatible_simultaneous_swap(db_session):
+    """type and category both change but resulting pair is incompatible."""
+    seed = await _seed(db_session)
+    r = await _create_compatible(db_session, seed, type_="expense")
+    upd = RecurringUpdate(type="income", category_id=seed["expense_cat_id"])
+    with pytest.raises(ValidationError):
+        await recurring_service.update_recurring(
+            db_session, seed["org_id"], r.id, upd
+        )
+
+
+async def test_update_recurring_accepts_swap_to_both_category(db_session):
+    """Swap to a CategoryType.BOTH category is always compatible."""
+    seed = await _seed(db_session)
+    r = await _create_compatible(db_session, seed, type_="expense")
+    upd = RecurringUpdate(category_id=seed["both_cat_id"])
+    updated = await recurring_service.update_recurring(
+        db_session, seed["org_id"], r.id, upd
+    )
+    assert updated.category_id == seed["both_cat_id"]

--- a/backend/tests/services/test_transaction_service_category_type_guard.py
+++ b/backend/tests/services/test_transaction_service_category_type_guard.py
@@ -1,0 +1,371 @@
+"""Server-side guard: reject transactions whose resolved category type
+disagrees with the transaction's type. Closes the HIGH finding from PR #137
+review (transaction writes don't validate category/type compatibility).
+
+The guard fires on every write entrypoint that takes a user-supplied
+(type, category_id) pair: create_transaction, _create_transaction_no_commit
+(used by import_service), and update_transaction (when either field changes).
+
+Transfer legs use the system Transfer category (CategoryType.BOTH) so the
+pairing flow stays compatible with the new guard. A regression test pins
+that create_transfer still works.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import TransactionType
+from app.schemas.transaction import (
+    TransactionCreate,
+    TransactionUpdate,
+    TransferCreate,
+)
+from app.services import transaction_service
+from app.services.exceptions import ValidationError
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    """Org + accounts + one EXPENSE-only master, one INCOME-only master,
+    one BOTH master, plus an EXPENSE subcategory under the EXPENSE master.
+    """
+    org = Organization(name="Test", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True
+    )
+    db.add(at)
+    await db.flush()
+    src = Account(
+        org_id=org.id, name="Src", account_type_id=at.id,
+        balance=Decimal("1000"), currency="EUR",
+    )
+    dst = Account(
+        org_id=org.id, name="Dst", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add_all([src, dst])
+    await db.flush()
+
+    expense_master = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        type=CategoryType.EXPENSE,
+    )
+    income_master = Category(
+        org_id=org.id, name="Salary", slug="salary",
+        type=CategoryType.INCOME,
+    )
+    both_master = Category(
+        org_id=org.id, name="Transfer", slug="transfer",
+        type=CategoryType.BOTH, is_system=True,
+    )
+    db.add_all([expense_master, income_master, both_master])
+    await db.flush()
+
+    expense_sub = Category(
+        org_id=org.id, parent_id=expense_master.id, name="Supermarket",
+        slug="supermarket", type=CategoryType.EXPENSE,
+    )
+    db.add(expense_sub)
+    await db.commit()
+
+    return {
+        "org_id": org.id,
+        "src_id": src.id,
+        "dst_id": dst.id,
+        "expense_master_id": expense_master.id,
+        "income_master_id": income_master.id,
+        "both_master_id": both_master.id,
+        "expense_sub_id": expense_sub.id,
+    }
+
+
+# ── create_transaction ─────────────────────────────────────────────────────
+
+
+async def test_create_rejects_income_with_expense_category(db_session):
+    """An income transaction tagged with an expense-only category is
+    rejected. The mismatch must surface through ValidationError so the
+    router maps it to a 400 (the codebase's standard validation surface)."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["expense_master_id"],
+        description="paycheck",
+        amount=Decimal("100"),
+        type="income",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    with pytest.raises(ValidationError):
+        await transaction_service.create_transaction(
+            db_session, seed["org_id"], body
+        )
+
+
+async def test_create_rejects_expense_with_income_category(db_session):
+    """Mirror of the above: an expense tagged with an income-only
+    category is rejected."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["income_master_id"],
+        description="rent",
+        amount=Decimal("500"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    with pytest.raises(ValidationError):
+        await transaction_service.create_transaction(
+            db_session, seed["org_id"], body
+        )
+
+
+async def test_create_accepts_matching_category(db_session):
+    """Sanity: matching type/category passes the guard."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["expense_master_id"],
+        description="grocery run",
+        amount=Decimal("25"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(
+        db_session, seed["org_id"], body
+    )
+    assert tx.id is not None
+
+
+async def test_create_accepts_both_category_for_either_type(db_session):
+    """CategoryType.BOTH (e.g. the system Transfer category) is allowed
+    on both income and expense transactions."""
+    seed = await _seed(db_session)
+    expense_body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["both_master_id"],
+        description="x",
+        amount=Decimal("1"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    income_body = TransactionCreate(
+        account_id=seed["dst_id"],
+        category_id=seed["both_master_id"],
+        description="y",
+        amount=Decimal("1"),
+        type="income",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    await transaction_service.create_transaction(
+        db_session, seed["org_id"], expense_body
+    )
+    await transaction_service.create_transaction(
+        db_session, seed["org_id"], income_body
+    )
+
+
+async def test_create_rejects_subcategory_when_parent_master_mismatches(db_session):
+    """A subcategory under an expense master can't be used for an income
+    transaction even if the subcategory itself is CategoryType.EXPENSE
+    (which it always is in this seed). The guard treats any expense-rooted
+    chain as expense-only against income transactions."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["expense_sub_id"],
+        description="paycheck via subcategory",
+        amount=Decimal("100"),
+        type="income",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    with pytest.raises(ValidationError):
+        await transaction_service.create_transaction(
+            db_session, seed["org_id"], body
+        )
+
+
+# ── update_transaction ─────────────────────────────────────────────────────
+
+
+async def test_update_rejects_swapping_in_mismatched_category(db_session):
+    """Update path: existing expense transaction can't have its category
+    swapped to an income-only one."""
+    seed = await _seed(db_session)
+    create_body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["expense_master_id"],
+        description="initial",
+        amount=Decimal("10"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(
+        db_session, seed["org_id"], create_body
+    )
+
+    update_body = TransactionUpdate(category_id=seed["income_master_id"])
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(
+            db_session, seed["org_id"], tx.id, update_body
+        )
+
+
+async def test_update_rejects_flipping_type_against_existing_category(db_session):
+    """Update path: flipping type from expense to income while the row
+    still points at an expense-only category is rejected."""
+    seed = await _seed(db_session)
+    create_body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["expense_master_id"],
+        description="initial",
+        amount=Decimal("10"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(
+        db_session, seed["org_id"], create_body
+    )
+
+    update_body = TransactionUpdate(type="income")
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(
+            db_session, seed["org_id"], tx.id, update_body
+        )
+
+
+async def test_update_accepts_matching_category_swap(db_session):
+    """Swapping category to a compatible one (or to BOTH) succeeds."""
+    seed = await _seed(db_session)
+    create_body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["expense_master_id"],
+        description="initial",
+        amount=Decimal("10"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(
+        db_session, seed["org_id"], create_body
+    )
+
+    update_body = TransactionUpdate(category_id=seed["both_master_id"])
+    updated = await transaction_service.update_transaction(
+        db_session, seed["org_id"], tx.id, update_body
+    )
+    assert updated.category_id == seed["both_master_id"]
+
+
+async def test_update_accepts_simultaneous_type_and_category_swap(db_session):
+    """If both type and category change in one call, the new pair must
+    be compatible — and is, in the happy path."""
+    seed = await _seed(db_session)
+    create_body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["expense_master_id"],
+        description="initial",
+        amount=Decimal("10"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(
+        db_session, seed["org_id"], create_body
+    )
+
+    update_body = TransactionUpdate(
+        type="income", category_id=seed["income_master_id"]
+    )
+    updated = await transaction_service.update_transaction(
+        db_session, seed["org_id"], tx.id, update_body
+    )
+    assert updated.type == TransactionType.INCOME
+    assert updated.category_id == seed["income_master_id"]
+
+
+# ── _create_transaction_no_commit (import path) ────────────────────────────
+
+
+async def test_create_no_commit_rejects_mismatched_category(db_session):
+    """The internal primitive used by import_service must enforce the
+    same guard, so /api/v1/import/execute can't smuggle mismatched rows."""
+    seed = await _seed(db_session)
+    body = TransactionCreate(
+        account_id=seed["src_id"],
+        category_id=seed["income_master_id"],
+        description="bogus",
+        amount=Decimal("5"),
+        type="expense",
+        status="settled",
+        date=date(2026, 5, 1),
+    )
+    with pytest.raises(ValidationError):
+        async with db_session.begin_nested():
+            await transaction_service._create_transaction_no_commit(
+                db_session, seed["org_id"], body, is_imported=True
+            )
+
+
+# ── transfer regression ────────────────────────────────────────────────────
+
+
+async def test_create_transfer_still_works_with_both_category(db_session):
+    """Regression: transfers use the system Transfer category (CategoryType.BOTH).
+    The new guard must not break the existing transfer flow."""
+    seed = await _seed(db_session)
+    body = TransferCreate(
+        from_account_id=seed["src_id"],
+        to_account_id=seed["dst_id"],
+        category_id=seed["both_master_id"],
+        amount=Decimal("100"),
+        date=date(2026, 5, 1),
+        status="settled",
+    )
+    expense_tx, income_tx = await transaction_service.create_transfer(
+        db_session, seed["org_id"], body
+    )
+    assert expense_tx.category_id == seed["both_master_id"]
+    assert income_tx.category_id == seed["both_master_id"]
+    assert expense_tx.linked_transaction_id == income_tx.id

--- a/backend/tests/services/test_transaction_service_transfer_category_guard.py
+++ b/backend/tests/services/test_transaction_service_transfer_category_guard.py
@@ -1,0 +1,252 @@
+"""Server-side guard: reject transfer flows that try to assign a one-sided
+category (INCOME-only or EXPENSE-only) to a transfer pair.
+
+Closes the HIGH finding from PR #150 round 2: ``create_transfer`` and
+``_link_pair`` (via ``pair_existing_transactions`` / ``convert_and_create_leg``)
+previously called ``validate_category`` (existence only) on a user-supplied
+``transfer_category_id`` and then assigned the same category to BOTH legs.
+With a one-sided category that meant the income leg ended up with an
+expense-only category (or vice versa), bypassing the new (type, category)
+guard added on the regular write paths.
+
+Rule: any user-supplied transfer category MUST be ``CategoryType.BOTH``.
+Both legs share one category by design, so a one-sided category is
+structurally wrong on a transfer regardless of which leg you look at.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.schemas.transaction import TransferCreate
+from app.services import transaction_service
+from app.services.exceptions import ValidationError
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    org = Organization(name="T", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True
+    )
+    db.add(at)
+    await db.flush()
+    src = Account(
+        org_id=org.id, name="Src", account_type_id=at.id,
+        balance=Decimal("1000"), currency="EUR",
+    )
+    dst = Account(
+        org_id=org.id, name="Dst", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add_all([src, dst])
+    await db.flush()
+
+    transfer_cat = Category(
+        org_id=org.id, name="Transfer", slug="transfer",
+        type=CategoryType.BOTH, is_system=True,
+    )
+    expense_only = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        type=CategoryType.EXPENSE,
+    )
+    income_only = Category(
+        org_id=org.id, name="Salary", slug="salary",
+        type=CategoryType.INCOME,
+    )
+    other_both = Category(
+        org_id=org.id, name="Internal", slug="internal",
+        type=CategoryType.BOTH,
+    )
+    db.add_all([transfer_cat, expense_only, income_only, other_both])
+    await db.commit()
+
+    return {
+        "org_id": org.id,
+        "src_id": src.id,
+        "dst_id": dst.id,
+        "transfer_cat_id": transfer_cat.id,
+        "expense_only_id": expense_only.id,
+        "income_only_id": income_only.id,
+        "other_both_id": other_both.id,
+    }
+
+
+# ── create_transfer ────────────────────────────────────────────────────────
+
+
+async def test_create_transfer_rejects_expense_only_category(db_session):
+    """User-supplied expense-only category for a transfer is rejected.
+    Otherwise the income leg ends up with an expense-only category."""
+    seed = await _seed(db_session)
+    body = TransferCreate(
+        from_account_id=seed["src_id"],
+        to_account_id=seed["dst_id"],
+        category_id=seed["expense_only_id"],
+        amount=Decimal("50"),
+        date=date(2026, 5, 1),
+        status="settled",
+    )
+    with pytest.raises(ValidationError):
+        await transaction_service.create_transfer(
+            db_session, seed["org_id"], body
+        )
+
+
+async def test_create_transfer_rejects_income_only_category(db_session):
+    """User-supplied income-only category for a transfer is rejected.
+    Otherwise the expense leg ends up with an income-only category."""
+    seed = await _seed(db_session)
+    body = TransferCreate(
+        from_account_id=seed["src_id"],
+        to_account_id=seed["dst_id"],
+        category_id=seed["income_only_id"],
+        amount=Decimal("50"),
+        date=date(2026, 5, 1),
+        status="settled",
+    )
+    with pytest.raises(ValidationError):
+        await transaction_service.create_transfer(
+            db_session, seed["org_id"], body
+        )
+
+
+async def test_create_transfer_accepts_default_transfer_category(db_session):
+    """Default path: no category_id supplied, system Transfer category
+    (CategoryType.BOTH) is auto-assigned. Sanity check that the new guard
+    doesn't break the happy path."""
+    seed = await _seed(db_session)
+    body = TransferCreate(
+        from_account_id=seed["src_id"],
+        to_account_id=seed["dst_id"],
+        amount=Decimal("50"),
+        date=date(2026, 5, 1),
+        status="settled",
+    )
+    expense_tx, income_tx = await transaction_service.create_transfer(
+        db_session, seed["org_id"], body
+    )
+    assert expense_tx.category_id == seed["transfer_cat_id"]
+    assert income_tx.category_id == seed["transfer_cat_id"]
+
+
+async def test_create_transfer_accepts_custom_both_category(db_session):
+    """User can override the default with another CategoryType.BOTH category."""
+    seed = await _seed(db_session)
+    body = TransferCreate(
+        from_account_id=seed["src_id"],
+        to_account_id=seed["dst_id"],
+        category_id=seed["other_both_id"],
+        amount=Decimal("50"),
+        date=date(2026, 5, 1),
+        status="settled",
+    )
+    expense_tx, income_tx = await transaction_service.create_transfer(
+        db_session, seed["org_id"], body
+    )
+    assert expense_tx.category_id == seed["other_both_id"]
+    assert income_tx.category_id == seed["other_both_id"]
+
+
+# ── pair_existing_transactions / _link_pair ────────────────────────────────
+
+
+async def _seed_pair_rows(db: AsyncSession, seed: dict) -> tuple[int, int]:
+    """Two un-linked rows (one expense on src, one income on dst) ready to
+    be paired by pair_existing_transactions."""
+    expense = Transaction(
+        org_id=seed["org_id"], account_id=seed["src_id"],
+        category_id=seed["transfer_cat_id"],
+        description="x", amount=Decimal("50"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    income = Transaction(
+        org_id=seed["org_id"], account_id=seed["dst_id"],
+        category_id=seed["transfer_cat_id"],
+        description="x", amount=Decimal("50"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    db.add_all([expense, income])
+    await db.commit()
+    return expense.id, income.id
+
+
+async def test_pair_existing_rejects_expense_only_category(db_session):
+    """pair_existing_transactions with a user-supplied expense-only
+    transfer_category_id is rejected before either leg's category_id mutates.
+    """
+    seed = await _seed(db_session)
+    expense_id, income_id = await _seed_pair_rows(db_session, seed)
+    with pytest.raises(ValidationError):
+        await transaction_service.pair_existing_transactions(
+            db_session, seed["org_id"],
+            expense_tx_id=expense_id,
+            income_tx_id=income_id,
+            recategorize=True,
+            transfer_category_id=seed["expense_only_id"],
+        )
+
+
+async def test_pair_existing_rejects_income_only_category(db_session):
+    """Same rejection for income-only categories."""
+    seed = await _seed(db_session)
+    expense_id, income_id = await _seed_pair_rows(db_session, seed)
+    with pytest.raises(ValidationError):
+        await transaction_service.pair_existing_transactions(
+            db_session, seed["org_id"],
+            expense_tx_id=expense_id,
+            income_tx_id=income_id,
+            recategorize=True,
+            transfer_category_id=seed["income_only_id"],
+        )
+
+
+async def test_pair_existing_accepts_both_category(db_session):
+    """Custom BOTH category is allowed."""
+    seed = await _seed(db_session)
+    expense_id, income_id = await _seed_pair_rows(db_session, seed)
+    e_tx, i_tx = await transaction_service.pair_existing_transactions(
+        db_session, seed["org_id"],
+        expense_tx_id=expense_id,
+        income_tx_id=income_id,
+        recategorize=True,
+        transfer_category_id=seed["other_both_id"],
+    )
+    assert e_tx.category_id == seed["other_both_id"]
+    assert i_tx.category_id == seed["other_both_id"]


### PR DESCRIPTION
## Summary

Closes two HIGH findings from prior PR reviews:

- **PR #137 review** flagged that `transaction_service.create/update` validated org ownership on `category_id` but not that `category.type` matched the transaction's `type`. A direct API call (or a UI bug) could persist an income transaction tagged with an expense-only category, or attach an expense subcategory under an income master.
- **PR #144 review** flagged the same gap for `forecast_plan_service.upsert_item` and `bulk_upsert`.

## What changed

- `transaction_service.validate_category_for_type` is the new type-aware guard. Fires from `_create_transaction_no_commit` (covering `create_transaction` plus all import paths) and from `update_transaction` whenever `body.type` or `body.category_id` is set. Both fields are resolved against the post-update state so simultaneous swaps to a compatible pair pass.
- `forecast_plan_service._validate_master_category` accepts an optional `item_type` and checks compatibility. `bulk_upsert` validates per-row and rejects atomically on the first mismatch (matches the existing convention for invalid IDs).
- Subcategory case: when a subcategory is supplied, the parent master's type is also checked, so a sub under an income master cannot be smuggled onto an expense transaction even if the sub's own type is `BOTH`.

## Compatibility surface

`ValidationError` is mapped to HTTP 400 by `app.main.validation_handler`, matching the rest of the validation surface. Transfer legs use the system Transfer category (`CategoryType.BOTH`) so the existing transfer flow passes the new guard with no carve-out (regression test `test_create_transfer_still_works_with_both_category` pins this).

## Out of scope

Frontend type-lock UX is the follow-up (PR-A2). Pre-launch state means no backfill or data-migration is needed; mismatched rows in dev fixtures will simply fail to be re-created.

## Test count

493 → 512 backend tests collected. 510 passed, 2 skipped (unchanged).