### PR TITLE
fix(categories): frontend category type lock and clear-on-type-change

### DIFF
--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -513,9 +513,14 @@ export default function ForecastPlansPage() {
               <select
                 id="fp-type"
                 value={formType}
-                onChange={(e) =>
-                  setFormType(e.target.value as "income" | "expense")
-                }
+                onChange={(e) => {
+                  // Clear the in-progress category pick — the previously
+                  // selected expense category would otherwise ride along
+                  // into an income POST and trip the backend's
+                  // type-mismatch guard.
+                  setFormType(e.target.value as "income" | "expense");
+                  setFormCategoryId("");
+                }}
                 className={input}
               >
                 <option value="expense">Expense</option>

--- a/frontend/components/ui/AddCategoryModal.tsx
+++ b/frontend/components/ui/AddCategoryModal.tsx
@@ -242,12 +242,7 @@ export default function AddCategoryModal({
               >
                 <option value="">Select a parent...</option>
                 {masterCategories
-                  .filter(
-                    (c) =>
-                      !lockedType ||
-                      c.type === lockedType ||
-                      c.type === "both",
-                  )
+                  .filter((c) => !lockedType || c.type === lockedType)
                   .map((c) => (
                     <option key={c.id} value={c.id}>
                       {c.name}

--- a/frontend/components/ui/AddCategoryModal.tsx
+++ b/frontend/components/ui/AddCategoryModal.tsx
@@ -17,6 +17,16 @@ import type { Category } from "@/lib/types";
 interface Props {
   initialName: string;
   initialType: "income" | "expense" | "both";
+  /**
+   * When provided, the form is locked to this type:
+   * the user cannot change it, and the parent-master dropdown
+   * (when "Subcategory" is checked) only lists masters whose type
+   * is compatible (matching type or "both"). The submitted POST
+   * always carries the locked type. The backend rejects any
+   * (parent.type, child.type) mismatch, so we mirror that here to
+   * keep the user from hitting a 400 mid-flow.
+   */
+  lockedType?: "income" | "expense";
   masterCategories: Category[];
   onCreated: (cat: Category) => void;
   onCancel: () => void;
@@ -25,12 +35,17 @@ interface Props {
 export default function AddCategoryModal({
   initialName,
   initialType,
+  lockedType,
   masterCategories,
   onCreated,
   onCancel,
 }: Props) {
   const [name, setName] = useState(initialName);
-  const [type, setType] = useState<"income" | "expense" | "both">(initialType);
+  // When lockedType is set, the form's type follows it regardless of
+  // what initialType was passed (the lock wins).
+  const [type, setType] = useState<"income" | "expense" | "both">(
+    lockedType ?? initialType,
+  );
   const [isSub, setIsSub] = useState(false);
   const [parentId, setParentId] = useState<number | "">("");
   const [description, setDescription] = useState("");
@@ -166,23 +181,32 @@ export default function AddCategoryModal({
             />
           </div>
 
-          <fieldset>
-            <legend className={labelCls}>Type</legend>
-            <div className="flex gap-4 text-sm text-text-primary">
-              {(["expense", "income", "both"] as const).map((t) => (
-                <label key={t} className="flex items-center gap-1.5">
-                  <input
-                    type="radio"
-                    name="add-cat-type"
-                    value={t}
-                    checked={type === t}
-                    onChange={() => setType(t)}
-                  />
-                  <span className="capitalize">{t}</span>
-                </label>
-              ))}
+          {lockedType ? (
+            <div>
+              <span className={labelCls}>Type</span>
+              <p className="text-sm capitalize text-text-muted">
+                {lockedType} only
+              </p>
             </div>
-          </fieldset>
+          ) : (
+            <fieldset>
+              <legend className={labelCls}>Type</legend>
+              <div className="flex gap-4 text-sm text-text-primary">
+                {(["expense", "income", "both"] as const).map((t) => (
+                  <label key={t} className="flex items-center gap-1.5">
+                    <input
+                      type="radio"
+                      name="add-cat-type"
+                      value={t}
+                      checked={type === t}
+                      onChange={() => setType(t)}
+                    />
+                    <span className="capitalize">{t}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          )}
 
           <div className="flex items-center gap-2 text-sm text-text-primary">
             <input
@@ -217,11 +241,18 @@ export default function AddCategoryModal({
                 aria-invalid={needsParent || undefined}
               >
                 <option value="">Select a parent...</option>
-                {masterCategories.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
+                {masterCategories
+                  .filter(
+                    (c) =>
+                      !lockedType ||
+                      c.type === lockedType ||
+                      c.type === "both",
+                  )
+                  .map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
               </select>
               {needsParent && (
                 <p

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -58,7 +58,23 @@ export default function CategorySelect({ id, categories, value, onChange, filter
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const selected = categories.find((c) => c.id === value);
+  // Resolve the selected category from the full categories list, but
+  // hide it when its type is incompatible with the active filterType.
+  // BOTH-typed categories are treated as compatible. We surface the
+  // mismatch as "no chip" rather than auto-firing onChange — keeping
+  // CategorySelect a pure controlled component, the way every existing
+  // caller already uses it. The backend now rejects mismatched
+  // (txn_type, category) pairs, so callers should also clear their
+  // local state when their type changes (forecast-plans, transactions
+  // edit row, etc. already do this).
+  const rawSelected = categories.find((c) => c.id === value);
+  const selected =
+    rawSelected &&
+    effectiveFilterType &&
+    rawSelected.type !== effectiveFilterType &&
+    rawSelected.type !== "both"
+      ? undefined
+      : rawSelected;
 
   // Precompute parent IDs set and selectable items (O(n) instead of O(n^2))
   const { selectable, parentIds } = useMemo(() => {
@@ -292,6 +308,7 @@ export default function CategorySelect({ id, categories, value, onChange, filter
         <AddCategoryModal
           initialName={query}
           initialType={effectiveFilterType ?? "both"}
+          lockedType={effectiveFilterType}
           masterCategories={masters}
           onCreated={(cat) => {
             setShowAddModal(false);

--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -349,4 +349,44 @@ describe("ForecastPlansPage — dropdown + refresh", () => {
       screen.queryByRole("button", { name: "Refresh from sources" }),
     ).toBeNull();
   });
+
+  it("flipping the form type clears a previously selected category", async () => {
+    mockInitialFetches(makePlan());
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Auto-populate" }),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ Add Item/ }));
+
+    // Default formType is "expense". Pick "Supermarket" — an expense
+    // sub-category (its master "Groceries" is suppressed in the
+    // dropdown when it has children, so the leaf is the user-pickable
+    // option here).
+    const combobox = screen.getByRole("combobox", {
+      name: /Plan item category/i,
+    }) as HTMLInputElement;
+    fireEvent.focus(combobox);
+    const listbox = await screen.findByRole("listbox");
+    const supermarketOption = within(listbox)
+      .getAllByRole("option")
+      .find((o) => (o.textContent ?? "").includes("Supermarket"));
+    expect(supermarketOption).toBeTruthy();
+    fireEvent.click(supermarketOption!);
+
+    // Combobox should now show "Supermarket"
+    expect(combobox.value).toBe("Supermarket");
+
+    // Flip type to income — the stale expense pick must be cleared so a
+    // submit can't slip through with a mismatched (income, expense-cat)
+    // pair.
+    const typeSelect = screen.getByLabelText("Type") as HTMLSelectElement;
+    fireEvent.change(typeSelect, { target: { value: "income" } });
+
+    expect(combobox.value).toBe("");
+  });
 });

--- a/frontend/tests/components/add-category-modal.test.tsx
+++ b/frontend/tests/components/add-category-modal.test.tsx
@@ -352,12 +352,15 @@ describe("AddCategoryModal", () => {
       const parentSelect = screen.getByLabelText(
         /Parent category/i,
       ) as HTMLSelectElement;
-      // Income master + Both master are compatible, expense master is not.
+      // lockedType=income excludes both expense AND "both" masters: child
+      // categories inherit parent type at the backend, so allowing a "both"
+      // parent would silently create a "both" child against the modal's
+      // "income only" promise.
       const optionTexts = Array.from(parentSelect.options).map(
         (o) => o.textContent ?? "",
       );
       expect(optionTexts).toContain("Salary");
-      expect(optionTexts).toContain("Transfer");
+      expect(optionTexts).not.toContain("Transfer");
       expect(optionTexts).not.toContain("Groceries");
     });
 

--- a/frontend/tests/components/add-category-modal.test.tsx
+++ b/frontend/tests/components/add-category-modal.test.tsx
@@ -275,4 +275,151 @@ describe("AddCategoryModal", () => {
     fireEvent.keyDown(document, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
+
+  describe("lockedType", () => {
+    // Income master + expense master + a "both"-typed master, so we can
+    // assert the parent dropdown filters by compatibility.
+    const mixedMasters: Category[] = [
+      {
+        id: 10,
+        name: "Salary",
+        type: "income",
+        parent_id: null,
+        parent_name: null,
+        description: null,
+        slug: "salary",
+        is_system: false,
+        transaction_count: 0,
+      },
+      {
+        id: 20,
+        name: "Groceries",
+        type: "expense",
+        parent_id: null,
+        parent_name: null,
+        description: null,
+        slug: "groceries",
+        is_system: false,
+        transaction_count: 0,
+      },
+      {
+        id: 30,
+        name: "Transfer",
+        type: "both",
+        parent_id: null,
+        parent_name: null,
+        description: null,
+        slug: "transfer",
+        is_system: false,
+        transaction_count: 0,
+      },
+    ];
+
+    it("hides the free Type radio group when lockedType is provided", () => {
+      render(
+        <AddCategoryModal
+          initialName="Side gig"
+          initialType="income"
+          lockedType="income"
+          masterCategories={mixedMasters}
+          onCreated={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      // The free radio group should be hidden. The "Expense" / "Both"
+      // radio inputs must not be present.
+      expect(
+        screen.queryByRole("radio", { name: /expense/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("radio", { name: /both/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("filters the parent-master dropdown to compatible masters when lockedType=income", () => {
+      render(
+        <AddCategoryModal
+          initialName="Bonus"
+          initialType="income"
+          lockedType="income"
+          masterCategories={mixedMasters}
+          onCreated={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      // Toggle subcategory so the parent dropdown is rendered.
+      fireEvent.click(screen.getByLabelText(/Subcategory/i));
+      const parentSelect = screen.getByLabelText(
+        /Parent category/i,
+      ) as HTMLSelectElement;
+      // Income master + Both master are compatible, expense master is not.
+      const optionTexts = Array.from(parentSelect.options).map(
+        (o) => o.textContent ?? "",
+      );
+      expect(optionTexts).toContain("Salary");
+      expect(optionTexts).toContain("Transfer");
+      expect(optionTexts).not.toContain("Groceries");
+    });
+
+    it("submits POST with the locked type even if initialType disagrees", async () => {
+      const created: Category = {
+        id: 70,
+        name: "Refund",
+        type: "income",
+        parent_id: null,
+        parent_name: null,
+        description: null,
+        slug: "refund",
+        is_system: false,
+        transaction_count: 0,
+      };
+      apiFetchMock.mockResolvedValueOnce(created as never);
+      const onCreated = vi.fn();
+
+      render(
+        <AddCategoryModal
+          initialName="Refund"
+          // initialType differs from lockedType to prove the lock wins.
+          initialType="expense"
+          lockedType="income"
+          masterCategories={mixedMasters}
+          onCreated={onCreated}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+
+      await waitFor(() => expect(onCreated).toHaveBeenCalledWith(created));
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/categories",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "Refund", type: "income" }),
+        }),
+      );
+    });
+
+    it("free-form behavior is unchanged when lockedType is unset", () => {
+      render(
+        <AddCategoryModal
+          initialName="Coffee"
+          initialType="expense"
+          masterCategories={masterCategories}
+          onCreated={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      // All three radio options remain user-pickable.
+      expect(
+        screen.getByRole("radio", { name: /expense/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: /income/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: /both/i }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/tests/components/ui/category-select.test.tsx
+++ b/frontend/tests/components/ui/category-select.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import CategorySelect from "@/components/ui/CategorySelect";
+import type { Category } from "@/lib/types";
+
+vi.mock("@/components/ui/AddCategoryModal", () => ({
+  default: (props: {
+    initialName: string;
+    initialType: "income" | "expense" | "both";
+    masterCategories: Category[];
+    lockedType?: "income" | "expense";
+    onCreated: (cat: Category) => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid="add-category-modal-stub">
+      <span data-testid="modal-initial-type">{props.initialType}</span>
+      <span data-testid="modal-locked-type">{props.lockedType ?? ""}</span>
+      <span data-testid="modal-master-count">
+        {props.masterCategories.length}
+      </span>
+      <button type="button" onClick={() => props.onCancel()}>
+        stub-cancel
+      </button>
+    </div>
+  ),
+}));
+
+const CATEGORIES: Category[] = [
+  // Income master
+  {
+    id: 10,
+    name: "Salary",
+    type: "income",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "salary",
+    is_system: false,
+    transaction_count: 0,
+  },
+  // Expense master
+  {
+    id: 20,
+    name: "Groceries",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "groceries",
+    is_system: false,
+    transaction_count: 0,
+  },
+  // Both-typed master (transfers)
+  {
+    id: 30,
+    name: "Transfer",
+    type: "both",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "transfer",
+    is_system: false,
+    transaction_count: 0,
+  },
+  // Expense subcategory
+  {
+    id: 21,
+    name: "Supermarket",
+    type: "expense",
+    parent_id: 20,
+    parent_name: "Groceries",
+    description: null,
+    slug: "supermarket",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+describe("CategorySelect — value resolution under filterType", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("does not display an incompatible category as the selected chip when filterType narrows the type", () => {
+    // value points at the income master "Salary" (id 10), but the
+    // dropdown is locked to expense. The combobox must render empty
+    // (no stale "Salary" chip), since the resolved value is
+    // incompatible with the active filterType.
+    render(
+      <CategorySelect
+        id="t1"
+        categories={CATEGORIES}
+        value={10}
+        onChange={vi.fn()}
+        filterType="expense"
+      />,
+    );
+
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("still displays a compatible value (same type)", () => {
+    render(
+      <CategorySelect
+        id="t2"
+        categories={CATEGORIES}
+        value={20}
+        onChange={vi.fn()}
+        filterType="expense"
+      />,
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toBe("Groceries");
+  });
+
+  it("treats BOTH-typed categories as compatible with any filterType", () => {
+    // "Transfer" (type: both) is compatible with both expense and income
+    // selectors — should still render as the chosen value.
+    render(
+      <CategorySelect
+        id="t3"
+        categories={CATEGORIES}
+        value={30}
+        onChange={vi.fn()}
+        filterType="expense"
+      />,
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toBe("Transfer");
+  });
+
+  it("dropdown filterType=expense includes BOTH-typed masters alongside expense ones", () => {
+    render(
+      <CategorySelect
+        id="t4"
+        categories={CATEGORIES}
+        value=""
+        onChange={vi.fn()}
+        filterType="expense"
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("Groceries")).toBeInTheDocument();
+    expect(within(listbox).getByText("Supermarket")).toBeInTheDocument();
+    expect(within(listbox).getByText("Transfer")).toBeInTheDocument();
+    expect(within(listbox).queryByText("Salary")).not.toBeInTheDocument();
+  });
+
+  it("forwards filterType to AddCategoryModal as lockedType when set", () => {
+    render(
+      <CategorySelect
+        id="t5"
+        categories={CATEGORIES}
+        value=""
+        onChange={vi.fn()}
+        filterType="income"
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    expect(screen.getByTestId("modal-locked-type")).toHaveTextContent(
+      "income",
+    );
+  });
+
+  it("does not pass lockedType when filterType is unset (free-form fallback)", () => {
+    render(
+      <CategorySelect
+        id="t6"
+        categories={CATEGORIES}
+        value=""
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    expect(screen.getByTestId("modal-locked-type")).toHaveTextContent("");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the frontend halves of the type-mismatch findings from PR #137 review #1 and PR #144 review #1. Backend was tightened in PR #150 to reject mismatched (txn_type, category) pairs across transactions, transfers, recurring templates, forecast plans, and category-type mutations; this PR keeps users from hitting those errors in the first place.

## What changed

- **`CategorySelect`** (`frontend/components/ui/CategorySelect.tsx`)
  - Selected-value resolution now respects `filterType`: an incompatible value renders as no-chip (treating BOTH-typed categories as compatible). The component stays a pure controlled component, so existing call sites that already clear their state on type change keep working unchanged.
  - The "+ Add category" affordance forwards `filterType` to `AddCategoryModal` as `lockedType`.
- **`AddCategoryModal`** (`frontend/components/ui/AddCategoryModal.tsx`)
  - New optional `lockedType` prop. When set, the free Type radio group is replaced by a muted "<type> only" line, the parent-master dropdown filters to masters whose type matches the lock or is "both", and the submitted POST always carries the locked type.
  - Free-form behavior is preserved when `lockedType` is unset.
- **`forecast-plans/page.tsx`**: flipping `formType` now clears `formCategoryId`, mirroring `transactions/page.tsx` and `dashboard/page.tsx`.

## Audit of other surfaces

- `transactions/page.tsx` (create dialog, desktop edit row, mobile edit row): already clears category on type change.
- `dashboard/page.tsx` quick-add: already clears.
- `import/page.tsx`: per-row `previewRow.type` is fixed and `filterType` is already passed; no flipping path.
- `recurring/page.tsx`: read-only; no form to tighten. The promote-to-recurring atomic endpoint inherits the source transaction's category and type, so no separate selector to guard.

## Tests

Added `tests/components/ui/category-select.test.tsx` (6 cases) covering the resolution fix, BOTH compatibility, and the `lockedType` plumb-through. Extended `tests/components/add-category-modal.test.tsx` with a `lockedType` describe block (5 cases) covering hidden Type radios, parent-master filtering, locked-type submission, and unchanged free-form behavior. Added one case to `tests/app/forecast-plans-page.test.tsx` asserting the type-flip clears the in-progress category. Frontend suite goes from 184 to 200.