### PR TITLE
fix(audit): durable org-delete + sweep snapshots, outcome 422, SQLite-portable migrations

### DIFF
--- a/backend/alembic/versions/030_add_audit_events.py
+++ b/backend/alembic/versions/030_add_audit_events.py
@@ -14,9 +14,10 @@ which is the opposite of what an audit log is for). Snapshot
 columns (actor_email, target_org_name) preserve the human-readable
 identity at event time.
 
-created_at uses DATETIME(6) with NOW(6) default to give microsecond
-precision — events from the same admin click can land within the
-same second, and we still want a stable order in the UI.
+created_at uses sa.func.now() so Alembic emits the dialect-correct
+default (CURRENT_TIMESTAMP on SQLite, NOW() on MySQL). Order ties
+between same-second events fall back to id DESC in the read path,
+which is good enough for the admin UI.
 """
 from __future__ import annotations
 
@@ -55,7 +56,7 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             sa.DateTime(timezone=False),
-            server_default=sa.text("CURRENT_TIMESTAMP(6)"),
+            server_default=sa.func.now(),
             nullable=False,
         ),
         sa.ForeignKeyConstraint(

--- a/backend/alembic/versions/033_add_roles_and_role_permissions.py
+++ b/backend/alembic/versions/033_add_roles_and_role_permissions.py
@@ -83,13 +83,13 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             sa.DateTime(timezone=False),
-            server_default=sa.text("CURRENT_TIMESTAMP(6)"),
+            server_default=sa.func.now(),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
             sa.DateTime(timezone=False),
-            server_default=sa.text("CURRENT_TIMESTAMP(6)"),
+            server_default=sa.func.now(),
             nullable=False,
         ),
         sa.UniqueConstraint("slug", name="uq_roles_slug"),

--- a/backend/app/routers/admin_audit.py
+++ b/backend/app/routers/admin_audit.py
@@ -11,6 +11,7 @@ log captures are the same events the structlog stream emits.
 from __future__ import annotations
 
 import datetime
+from typing import Literal
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,7 +34,10 @@ async def list_audit_events(
     actor_user_id: int | None = Query(default=None, ge=1),
     target_org_id: int | None = Query(default=None, ge=1),
     event_type: str | None = Query(default=None, max_length=80),
-    outcome: str | None = Query(default=None, max_length=16),
+    # Typed Literal so a typo (?outcome=failuer) returns 422 from
+    # FastAPI's request validation rather than silently dropping the
+    # filter and returning the unfiltered list.
+    outcome: Literal["success", "failure"] | None = Query(default=None),
     from_dt: datetime.datetime | None = Query(default=None),
     to_dt: datetime.datetime | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -40,6 +40,15 @@ logger = structlog.stdlib.get_logger()
 router = APIRouter(prefix="/api/v1/admin/orgs", tags=["admin-orgs"])
 
 
+# Cap on the number of per-row entries embedded in the
+# `admin.feature_override.expired_swept` audit detail. 50 is a
+# reasonable ceiling for a JSON column and keeps the audit row
+# readable in the admin UI; over the cap, the audit row carries
+# `truncated_count` and `counts_by_feature` so the aggregate signal
+# survives even if individual rows fall off.
+_SWEEP_AUDIT_ENTRY_CAP = 50
+
+
 def _request_id() -> str | None:
     """Pull the per-request id bound by RequestContextMiddleware (L4.9)."""
     return structlog.contextvars.get_contextvars().get("request_id")
@@ -149,8 +158,58 @@ async def delete_org(
             detail="confirm_name does not match organization name",
         )
 
+    # Snapshot the org's identifying fields BEFORE the delete so the
+    # durable audit row carries answers to "what was deleted" even
+    # after the FK ON DELETE SET NULL cascade nulls target_org_id.
+    # Bounded — counts not member lists, no PII beyond what the audit
+    # table already accepts.
+    org_snapshot = {
+        "org_id": org_id,
+        "org_name": detail["name"],
+        "created_at": detail.get("created_at"),
+        "billing_cycle_day": detail.get("billing_cycle_day"),
+        "member_count_at_delete": len(detail.get("members") or []),
+        "subscription": detail.get("subscription"),
+        "deleted_by_user_id": current_user.id,
+        "deleted_by_email": current_user.email,
+    }
+
     try:
+        # 1) Stage the success audit row FIRST so the FK
+        #    (target_org_id → organizations.id) still resolves at
+        #    INSERT time — the org row is still present.
+        # 2) Run delete_org_cascade. The cascade includes the org row
+        #    DELETE; the FK is ON DELETE SET NULL, so the audit row's
+        #    target_org_id is nulled by the DB at the same time.
+        # 3) Update the audit row's `detail` with the deleted_rows
+        #    counts and commit. All atomic — audit row exists iff
+        #    delete succeeded.
+        # Snapshot in `detail.snapshot` preserves the org's identity
+        # after the cascade nulls target_org_id, which is the whole
+        # point of writing this row before the delete.
+        audit_row = audit_service.add_audit_event_to_session(
+            db,
+            event_type="admin.org.delete",
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=detail["name"],
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail={"snapshot": org_snapshot},
+        )
+        # Flush so the audit row is INSERTed with the FK still
+        # satisfiable (org row still present), before the cascade
+        # tears the org away.
+        await db.flush()
         counts = await admin_orgs_service.delete_org_cascade(db, org_id=org_id)
+        # Reassign the JSON detail (SQLAlchemy doesn't track in-place
+        # dict mutation on JSON columns by default).
+        audit_row.detail = {
+            "snapshot": org_snapshot,
+            "deleted_rows_by_table": counts,
+        }
         await db.commit()
     except Exception as e:  # noqa: BLE001 — translate to generic 500 + log.
         await db.rollback()
@@ -164,9 +223,9 @@ async def delete_org(
             error_type=type(e).__name__,
         )
         # Independent-session audit write — the business txn has been
-        # rolled back, but the failure must still appear in the audit
-        # log. That's the whole point of opening a fresh session for
-        # the audit row.
+        # rolled back (taking the staged success row with it), but the
+        # failure must still appear in the audit log. That's the whole
+        # point of opening a fresh session for the audit row.
         await audit_service.record_audit_event(
             session_factory,
             event_type="admin.org.delete.failed",
@@ -177,7 +236,11 @@ async def delete_org(
             request_id=_request_id(),
             ip_address=get_client_ip(request),
             outcome="failure",
-            detail={"error": str(e), "error_type": type(e).__name__},
+            detail={
+                "snapshot": org_snapshot,
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -191,18 +254,6 @@ async def delete_org(
         target_org_id=org_id,
         target_org_name=detail["name"],
         deleted_rows_by_table=counts,
-    )
-    await audit_service.record_audit_event(
-        session_factory,
-        event_type="admin.org.delete",
-        actor_user_id=current_user.id,
-        actor_email=current_user.email,
-        target_org_id=org_id,
-        target_org_name=detail["name"],
-        request_id=_request_id(),
-        ip_address=get_client_ip(request),
-        outcome="success",
-        detail={"deleted_rows_by_table": counts},
     )
     return {"deleted": counts}
 
@@ -243,14 +294,51 @@ async def sweep_expired_feature_overrides(
     """Delete every ``org_feature_overrides`` row whose ``expires_at``
     is in the past. Idempotent (returns ``deleted_count: 0`` when nothing
     matches). Audit row is always written.
+
+    Audit detail (PR-C / PR #141 #1) includes a bounded summary of the
+    rows that were deleted so ops can answer "which orgs/features lost
+    access" without reaching for structlog. ``entries`` is capped at
+    ``_SWEEP_AUDIT_ENTRY_CAP``; over the cap, ``truncated_count`` and
+    ``counts_by_feature`` carry the rest.
     """
     cutoff = utcnow_naive()
-    result = await db.execute(
-        delete(OrgFeatureOverride)
-        .where(OrgFeatureOverride.expires_at.is_not(None))
-        .where(OrgFeatureOverride.expires_at <= cutoff)
-    )
-    deleted_count = result.rowcount or 0
+    # SELECT the rows that will be deleted FIRST so we can record their
+    # identity in the audit row. Reading and deleting in the same txn
+    # guarantees the audit summary is exactly what was removed.
+    expiring_rows = (
+        await db.execute(
+            select(OrgFeatureOverride)
+            .where(OrgFeatureOverride.expires_at.is_not(None))
+            .where(OrgFeatureOverride.expires_at <= cutoff)
+            .order_by(OrgFeatureOverride.org_id, OrgFeatureOverride.feature_key)
+        )
+    ).scalars().all()
+    deleted_count = len(expiring_rows)
+
+    # Build the bounded audit detail. counts_by_feature is the
+    # truth-as-aggregate; entries is a capped sample for spot-checks.
+    counts_by_feature: dict[str, int] = {}
+    for row in expiring_rows:
+        counts_by_feature[row.feature_key] = (
+            counts_by_feature.get(row.feature_key, 0) + 1
+        )
+    entries = [
+        {
+            "org_id": row.org_id,
+            "feature_key": row.feature_key,
+            "value": row.value,
+            "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+        }
+        for row in expiring_rows[:_SWEEP_AUDIT_ENTRY_CAP]
+    ]
+    truncated_count = max(0, deleted_count - _SWEEP_AUDIT_ENTRY_CAP)
+
+    if expiring_rows:
+        await db.execute(
+            delete(OrgFeatureOverride)
+            .where(OrgFeatureOverride.expires_at.is_not(None))
+            .where(OrgFeatureOverride.expires_at <= cutoff)
+        )
     await db.commit()
 
     await logger.ainfo(
@@ -269,7 +357,12 @@ async def sweep_expired_feature_overrides(
         request_id=_request_id(),
         ip_address=get_client_ip(request),
         outcome="success",
-        detail={"deleted_count": deleted_count},
+        detail={
+            "deleted_count": deleted_count,
+            "entries": entries,
+            "truncated_count": truncated_count,
+            "counts_by_feature": counts_by_feature,
+        },
     )
     return {"deleted_count": deleted_count}
 

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -300,6 +300,14 @@ async def sweep_expired_feature_overrides(
     access" without reaching for structlog. ``entries`` is capped at
     ``_SWEEP_AUDIT_ENTRY_CAP``; over the cap, ``truncated_count`` and
     ``counts_by_feature`` carry the rest.
+
+    On the rare ``DELETE`` rowcount mismatch path (locked N rows under
+    SELECT FOR UPDATE, deleted M < N) the audit detail records
+    ``deleted_count`` and ``locked_count`` plus a ``divergence`` flag,
+    and OMITS per-row ``entries`` and ``counts_by_feature``: without
+    ``DELETE ... RETURNING`` (unsupported on MySQL) we cannot honestly
+    tell which of the locked rows our DELETE removed versus rows a
+    concurrent actor removed, so we refuse to guess.
     """
     cutoff = utcnow_naive()
     # Lock-then-delete-by-id so the audit summary describes rows this
@@ -339,7 +347,8 @@ async def sweep_expired_feature_overrides(
     }
     locked_ids = list(locked_by_id.keys())
 
-    deleted_ids: list[int] = []
+    deleted_count = 0
+    divergence = False
     if locked_ids:
         delete_result = await db.execute(
             delete(OrgFeatureOverride).where(OrgFeatureOverride.id.in_(locked_ids))
@@ -350,49 +359,64 @@ async def sweep_expired_feature_overrides(
             # ``rowcount`` of -1/None on a dialect that doesn't report
             # affected rows is treated as the all-locked-deleted case;
             # FOR UPDATE held the rows in InnoDB so this is safe.
-            deleted_ids = locked_ids
+            deleted_count = len(locked_ids)
         else:
-            # Divergence: between SELECT FOR UPDATE and DELETE, some
-            # rows disappeared (out-of-band delete, concurrent sweep
-            # without locking, or a non-InnoDB dialect). Trust the
-            # rowcount and report only the rows that actually went
-            # away under our DELETE.
+            # Divergence: rowcount disagrees with the locked snapshot.
+            # On MySQL InnoDB with SELECT FOR UPDATE this branch
+            # should never fire in practice; it's a defensive
+            # fallback for environments without row locks (e.g., the
+            # SQLite test database) and protects audit detail from
+            # claiming false row identities.
+            #
+            # We refuse to guess which of the locked rows our DELETE
+            # actually removed: without ``DELETE ... RETURNING``
+            # (which MySQL does not support) the answer is
+            # unknowable. ``deleted_count`` (the rowcount) is
+            # authoritative; ``entries`` and ``counts_by_feature``
+            # are deliberately omitted from the audit detail.
+            divergence = True
+            deleted_count = affected
             await logger.awarning(
                 "admin.feature_override.sweep.lock_delete_mismatch",
                 locked_count=len(locked_ids),
                 deleted_count=affected,
             )
-            still_present = set(
-                (
-                    await db.execute(
-                        select(OrgFeatureOverride.id).where(
-                            OrgFeatureOverride.id.in_(locked_ids)
-                        )
-                    )
-                ).scalars().all()
+
+    # Audit detail. Happy path: bounded per-row entries +
+    # counts_by_feature for ops spot-checks. Divergence path:
+    # counts only, with an explicit flag and note so a future reader
+    # of the audit table can tell why per-row identity is missing.
+    detail: dict[str, object]
+    if divergence:
+        detail = {
+            "deleted_count": deleted_count,
+            "locked_count": len(locked_ids),
+            "divergence": True,
+            "divergence_reason": "concurrent_modification",
+            "note": (
+                "Exact row identities could not be determined under "
+                "concurrent sweep activity. deleted_count is "
+                "authoritative; counts_by_feature and entries are "
+                "omitted."
+            ),
+        }
+    else:
+        counts_by_feature: dict[str, int] = {}
+        entries: list[dict] = []
+        for row_id in locked_ids:
+            snap = locked_by_id[row_id]
+            counts_by_feature[snap["feature_key"]] = (
+                counts_by_feature.get(snap["feature_key"], 0) + 1
             )
-            absent_ids = [i for i in locked_ids if i not in still_present]
-            # Cap absent_ids by the affected count so we don't audit
-            # rows another actor removed. When absent > affected,
-            # someone else won those deletes; pick the first ``affected``
-            # in the locked order to keep audit ordering stable.
-            deleted_ids = absent_ids[:affected]
-
-    deleted_count = len(deleted_ids)
-
-    # Build the bounded audit detail from rows the sweep ACTUALLY
-    # removed. counts_by_feature is the truth-as-aggregate; entries is
-    # a capped sample for spot-checks.
-    counts_by_feature: dict[str, int] = {}
-    entries: list[dict] = []
-    for row_id in deleted_ids:
-        snap = locked_by_id[row_id]
-        counts_by_feature[snap["feature_key"]] = (
-            counts_by_feature.get(snap["feature_key"], 0) + 1
-        )
-        if len(entries) < _SWEEP_AUDIT_ENTRY_CAP:
-            entries.append(snap)
-    truncated_count = max(0, deleted_count - _SWEEP_AUDIT_ENTRY_CAP)
+            if len(entries) < _SWEEP_AUDIT_ENTRY_CAP:
+                entries.append(snap)
+        truncated_count = max(0, deleted_count - _SWEEP_AUDIT_ENTRY_CAP)
+        detail = {
+            "deleted_count": deleted_count,
+            "entries": entries,
+            "truncated_count": truncated_count,
+            "counts_by_feature": counts_by_feature,
+        }
 
     await db.commit()
 
@@ -412,12 +436,7 @@ async def sweep_expired_feature_overrides(
         request_id=_request_id(),
         ip_address=get_client_ip(request),
         outcome="success",
-        detail={
-            "deleted_count": deleted_count,
-            "entries": entries,
-            "truncated_count": truncated_count,
-            "counts_by_feature": counts_by_feature,
-        },
+        detail=detail,
     )
     return {"deleted_count": deleted_count}
 

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -302,43 +302,98 @@ async def sweep_expired_feature_overrides(
     ``counts_by_feature`` carry the rest.
     """
     cutoff = utcnow_naive()
-    # SELECT the rows that will be deleted FIRST so we can record their
-    # identity in the audit row. Reading and deleting in the same txn
-    # guarantees the audit summary is exactly what was removed.
-    expiring_rows = (
+    # Lock-then-delete-by-id so the audit summary describes rows this
+    # sweep actually removed, not rows it merely observed.
+    #
+    # The previous SELECT-then-DELETE-by-predicate pattern was racy:
+    # two overlapping sweeps could each snapshot the same expired rows
+    # (predicate-equal), the first DELETE removed them, and the second
+    # DELETE matched nothing yet still audited
+    # ``deleted_count = len(snapshot)`` plus per-row entries for rows
+    # it never touched. With FOR UPDATE on InnoDB the second sweep
+    # blocks until the first commits, then locks zero rows; with
+    # DELETE-by-id and rowcount-driven counts, even a non-locking
+    # dialect (e.g. tests on SQLite) can't drift out of sync because
+    # the audit numbers come from the actual rows removed.
+    locked_rows = (
         await db.execute(
             select(OrgFeatureOverride)
             .where(OrgFeatureOverride.expires_at.is_not(None))
             .where(OrgFeatureOverride.expires_at <= cutoff)
             .order_by(OrgFeatureOverride.org_id, OrgFeatureOverride.feature_key)
+            .with_for_update()
         )
     ).scalars().all()
-    deleted_count = len(expiring_rows)
 
-    # Build the bounded audit detail. counts_by_feature is the
-    # truth-as-aggregate; entries is a capped sample for spot-checks.
-    counts_by_feature: dict[str, int] = {}
-    for row in expiring_rows:
-        counts_by_feature[row.feature_key] = (
-            counts_by_feature.get(row.feature_key, 0) + 1
-        )
-    entries = [
-        {
+    # Snapshot identity for the audit detail BEFORE the delete; after
+    # commit the in-memory rows are detached and SQLAlchemy's
+    # expire-on-commit would invalidate attribute access.
+    locked_by_id = {
+        row.id: {
             "org_id": row.org_id,
             "feature_key": row.feature_key,
             "value": row.value,
             "expires_at": row.expires_at.isoformat() if row.expires_at else None,
         }
-        for row in expiring_rows[:_SWEEP_AUDIT_ENTRY_CAP]
-    ]
+        for row in locked_rows
+    }
+    locked_ids = list(locked_by_id.keys())
+
+    deleted_ids: list[int] = []
+    if locked_ids:
+        delete_result = await db.execute(
+            delete(OrgFeatureOverride).where(OrgFeatureOverride.id.in_(locked_ids))
+        )
+        affected = delete_result.rowcount
+        if affected is None or affected == len(locked_ids):
+            # Happy path on every locking dialect we care about.
+            # ``rowcount`` of -1/None on a dialect that doesn't report
+            # affected rows is treated as the all-locked-deleted case;
+            # FOR UPDATE held the rows in InnoDB so this is safe.
+            deleted_ids = locked_ids
+        else:
+            # Divergence: between SELECT FOR UPDATE and DELETE, some
+            # rows disappeared (out-of-band delete, concurrent sweep
+            # without locking, or a non-InnoDB dialect). Trust the
+            # rowcount and report only the rows that actually went
+            # away under our DELETE.
+            await logger.awarning(
+                "admin.feature_override.sweep.lock_delete_mismatch",
+                locked_count=len(locked_ids),
+                deleted_count=affected,
+            )
+            still_present = set(
+                (
+                    await db.execute(
+                        select(OrgFeatureOverride.id).where(
+                            OrgFeatureOverride.id.in_(locked_ids)
+                        )
+                    )
+                ).scalars().all()
+            )
+            absent_ids = [i for i in locked_ids if i not in still_present]
+            # Cap absent_ids by the affected count so we don't audit
+            # rows another actor removed. When absent > affected,
+            # someone else won those deletes; pick the first ``affected``
+            # in the locked order to keep audit ordering stable.
+            deleted_ids = absent_ids[:affected]
+
+    deleted_count = len(deleted_ids)
+
+    # Build the bounded audit detail from rows the sweep ACTUALLY
+    # removed. counts_by_feature is the truth-as-aggregate; entries is
+    # a capped sample for spot-checks.
+    counts_by_feature: dict[str, int] = {}
+    entries: list[dict] = []
+    for row_id in deleted_ids:
+        snap = locked_by_id[row_id]
+        counts_by_feature[snap["feature_key"]] = (
+            counts_by_feature.get(snap["feature_key"], 0) + 1
+        )
+        if len(entries) < _SWEEP_AUDIT_ENTRY_CAP:
+            entries.append(snap)
     truncated_count = max(0, deleted_count - _SWEEP_AUDIT_ENTRY_CAP)
 
-    if expiring_rows:
-        await db.execute(
-            delete(OrgFeatureOverride)
-            .where(OrgFeatureOverride.expires_at.is_not(None))
-            .where(OrgFeatureOverride.expires_at <= cutoff)
-        )
     await db.commit()
 
     await logger.ainfo(

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -36,6 +36,31 @@ from app.models.audit_event import AuditEvent, AuditOutcome
 logger = structlog.stdlib.get_logger()
 
 
+def _build_audit_event(
+    *,
+    event_type: str,
+    actor_user_id: Optional[int],
+    actor_email: str,
+    target_org_id: Optional[int],
+    target_org_name: Optional[str],
+    request_id: Optional[str],
+    ip_address: Optional[str],
+    outcome: Literal["success", "failure"],
+    detail: Optional[dict[str, Any]] = None,
+) -> AuditEvent:
+    return AuditEvent(
+        event_type=event_type,
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=target_org_id,
+        target_org_name=target_org_name,
+        request_id=request_id,
+        ip_address=ip_address,
+        outcome=AuditOutcome(outcome),
+        detail=detail,
+    )
+
+
 async def record_audit_event(
     session_factory: async_sessionmaker[AsyncSession],
     *,
@@ -49,13 +74,26 @@ async def record_audit_event(
     outcome: Literal["success", "failure"],
     detail: Optional[dict[str, Any]] = None,
 ) -> None:
-    """Persist an audit event in its own transaction.
+    """Persist an audit event in its OWN transaction.
 
     Failures are logged via structlog and swallowed. Never raises.
+
+    Use this when the audit write must succeed regardless of the
+    business txn outcome (e.g. a failed delete still needs an audit
+    row even though the business txn rolled back).
+
+    For the inverse case — audit row should commit if-and-only-if
+    the business txn commits — use ``add_audit_event_to_session``
+    on the request-scoped session instead. That pattern is used for
+    org deletion: the audit row carries a snapshot of the org's
+    identifying fields, the FK to organizations is ON DELETE SET
+    NULL, and writing in the same txn before the delete means a
+    cascade-failure rolls back the audit row too (no orphan audit
+    rows for non-deletes).
     """
     try:
         async with session_factory() as session:
-            row = AuditEvent(
+            session.add(_build_audit_event(
                 event_type=event_type,
                 actor_user_id=actor_user_id,
                 actor_email=actor_email,
@@ -63,13 +101,17 @@ async def record_audit_event(
                 target_org_name=target_org_name,
                 request_id=request_id,
                 ip_address=ip_address,
-                outcome=AuditOutcome(outcome),
+                outcome=outcome,
                 detail=detail,
-            )
-            session.add(row)
+            ))
             await session.commit()
     except Exception as exc:  # noqa: BLE001 — defensive: never bubble.
-        await logger.aerror(
+        # Backstop: keep the swallow but escalate to WARN so an alert
+        # can be wired up later. After PR-C the org-delete success
+        # path no longer relies on this swallow (it writes in the
+        # business txn before the delete), so any audit.record.failed
+        # signal is a genuine problem worth surfacing.
+        await logger.awarning(
             "audit.record.failed",
             event_type=event_type,
             actor_user_id=actor_user_id,
@@ -78,6 +120,43 @@ async def record_audit_event(
             error=str(exc),
             error_type=type(exc).__name__,
         )
+
+
+def add_audit_event_to_session(
+    session: AsyncSession,
+    *,
+    event_type: str,
+    actor_user_id: Optional[int],
+    actor_email: str,
+    target_org_id: Optional[int],
+    target_org_name: Optional[str],
+    request_id: Optional[str],
+    ip_address: Optional[str],
+    outcome: Literal["success", "failure"],
+    detail: Optional[dict[str, Any]] = None,
+) -> AuditEvent:
+    """Stage an audit-event row on the caller's session so it commits
+    in the SAME transaction as the business write. Use for the
+    org-delete success path (the row should exist iff the delete
+    commits) and other cases where the audit row's correctness
+    depends on the business txn.
+
+    Returns the staged AuditEvent so the caller can assert on it
+    before commit if useful.
+    """
+    row = _build_audit_event(
+        event_type=event_type,
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=target_org_id,
+        target_org_name=target_org_name,
+        request_id=request_id,
+        ip_address=ip_address,
+        outcome=outcome,
+        detail=detail,
+    )
+    session.add(row)
+    return row
 
 
 async def list_audit_events(
@@ -105,13 +184,13 @@ async def list_audit_events(
     if event_type:
         where.append(AuditEvent.event_type == event_type)
     if outcome:
-        # Validate against enum so a typo can't silently match nothing.
-        try:
-            outcome_enum = AuditOutcome(outcome)
-        except ValueError:
-            outcome_enum = None
-        if outcome_enum is not None:
-            where.append(AuditEvent.outcome == outcome_enum)
+        # The HTTP route now types this as Literal["success", "failure"]
+        # so FastAPI returns 422 for typos before this branch runs.
+        # Direct service callers (and tests) still pass strings, so
+        # raise ValueError on bad input rather than silently
+        # unfiltering — that's the bug we're closing.
+        outcome_enum = AuditOutcome(outcome)
+        where.append(AuditEvent.outcome == outcome_enum)
     if from_dt is not None:
         where.append(AuditEvent.created_at >= from_dt)
     if to_dt is not None:

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -106,12 +106,14 @@ async def record_audit_event(
             ))
             await session.commit()
     except Exception as exc:  # noqa: BLE001 — defensive: never bubble.
-        # Backstop: keep the swallow but escalate to WARN so an alert
-        # can be wired up later. After PR-C the org-delete success
-        # path no longer relies on this swallow (it writes in the
-        # business txn before the delete), so any audit.record.failed
-        # signal is a genuine problem worth surfacing.
-        await logger.awarning(
+        # Kept as a backstop. Logged at ERROR so a regression in a
+        # caller that doesn't pre-snapshot (like the original
+        # org-delete path) surfaces immediately. After PR-C the
+        # org-delete success path stages its audit row in the
+        # business txn via add_audit_event_to_session, so any
+        # audit.record.failed signal here is a genuine problem
+        # worth alerting on.
+        await logger.aerror(
             "audit.record.failed",
             event_type=event_type,
             actor_user_id=actor_user_id,

--- a/backend/tests/migrations/test_sqlite_portability.py
+++ b/backend/tests/migrations/test_sqlite_portability.py
@@ -1,0 +1,54 @@
+"""Migration timestamp-default portability test.
+
+The reviewer for PRs #139 and #142 ran `alembic upgrade head` against
+SQLite (e.g. for local exploration) and migrations 030 and 033 blew
+up on `sa.text("CURRENT_TIMESTAMP(6)")` (MySQL-only literal syntax —
+SQLite parses it as a function call missing a `(` and rejects).
+
+The codebase's dominant pattern is `sa.func.now()`, which Alembic
+translates per dialect (`CURRENT_TIMESTAMP` on SQLite, `NOW()` on
+MySQL). This test grep-asserts that no migration smuggles back a
+literal `CURRENT_TIMESTAMP(...)` text default — that's the only
+portability issue we know about, and it's a one-line drift away
+from regressing.
+
+We don't claim SQLite is a supported runtime — production is MySQL.
+But migration files must compile on SQLite so reviewers and local
+exploration tools work. Migrations 008+ already use `op.add_column`
+which doesn't ALTER constraints, so the file-level ban here is the
+appropriate guard, not a full `alembic upgrade head` smoke run.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+
+# Pattern: sa.text("CURRENT_TIMESTAMP(<digits>)") — SQLite rejects the
+# parenthesised precision. Catches both single- and double-quoted
+# literals.
+_CURRENT_TIMESTAMP_PRECISION_RE = re.compile(
+    r"""sa\.text\(\s*['"]CURRENT_TIMESTAMP\(\d+\)['"]\s*\)""",
+)
+
+
+@pytest.mark.parametrize(
+    "migration_file",
+    sorted(p for p in VERSIONS_DIR.glob("*.py") if not p.name.startswith("__")),
+    ids=lambda p: p.name,
+)
+def test_no_mysql_only_current_timestamp_precision_default(migration_file):
+    """No migration may use `sa.text("CURRENT_TIMESTAMP(N)")` as a
+    server_default — it parses as MySQL-only and breaks SQLite.
+    Use `sa.func.now()` instead; it dialect-translates."""
+    src = migration_file.read_text()
+    matches = _CURRENT_TIMESTAMP_PRECISION_RE.findall(src)
+    assert not matches, (
+        f"{migration_file.name} uses MySQL-only "
+        f"`CURRENT_TIMESTAMP(N)` literal text default. Replace with "
+        f"`sa.func.now()` for dialect portability. Found: {matches!r}"
+    )

--- a/backend/tests/routers/test_admin_audit.py
+++ b/backend/tests/routers/test_admin_audit.py
@@ -178,3 +178,58 @@ async def test_get_audit_list_pagination(session_factory):
         body2 = res2.json()
         assert body2["total"] == 5
         assert len(body2["items"]) == 1
+
+
+# ── outcome filter validation (PR-C / PR #139 #3) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_invalid_outcome_returns_422(session_factory):
+    """A typo'd outcome (e.g. `failuer`) must return 422, not silently
+    skip the filter and return all events. Catches the bug where the
+    service's ``except ValueError: pass`` was swallowing typos."""
+    await _seed(session_factory)
+    await _seed_events(session_factory, 3)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit?outcome=failuer")
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_audit_list_outcome_success_filters(session_factory):
+    """The valid value `success` filters as before."""
+    await _seed(session_factory)
+    base = datetime.datetime(2026, 5, 1, 9, 0, 0)
+    async with session_factory() as db:
+        db.add_all([
+            AuditEvent(
+                event_type="admin.x.success",
+                actor_user_id=None, actor_email="a@x.io",
+                target_org_id=None, target_org_name=None,
+                request_id=None, ip_address=None,
+                outcome=AuditOutcome.SUCCESS, detail=None,
+                created_at=base,
+            ),
+            AuditEvent(
+                event_type="admin.x.failure",
+                actor_user_id=None, actor_email="a@x.io",
+                target_org_id=None, target_org_name=None,
+                request_id=None, ip_address=None,
+                outcome=AuditOutcome.FAILURE, detail=None,
+                created_at=base + datetime.timedelta(minutes=1),
+            ),
+        ])
+        await db.commit()
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/audit?outcome=success")
+        assert res.status_code == 200
+        assert res.json()["total"] == 1
+        assert res.json()["items"][0]["outcome"] == "success"
+
+        res2 = client.get("/api/v1/admin/audit?outcome=failure")
+        assert res2.status_code == 200
+        assert res2.json()["total"] == 1
+        assert res2.json()["items"][0]["outcome"] == "failure"

--- a/backend/tests/routers/test_admin_feature_overrides.py
+++ b/backend/tests/routers/test_admin_feature_overrides.py
@@ -505,7 +505,18 @@ async def test_sweep_writes_audit_event(session_factory):
     assert row.actor_email == seed["admin_email"]
     assert row.target_org_id is None
     assert row.target_org_name is None
-    assert row.detail == {"deleted_count": 2}
+    # PR-C: bounded detail with per-row entries + counts.
+    assert row.detail["deleted_count"] == 2
+    assert row.detail["truncated_count"] == 0
+    assert sorted(e["feature_key"] for e in row.detail["entries"]) == (
+        ["ai.budget", "ai.forecast"]
+    )
+    # All entries reference the seeded target org.
+    assert {e["org_id"] for e in row.detail["entries"]} == {seed["target_id"]}
+    assert row.detail["counts_by_feature"] == {
+        "ai.budget": 1,
+        "ai.forecast": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -530,7 +541,79 @@ async def test_sweep_idempotent_when_nothing_expired(session_factory):
             )
         ).scalars().all()
     assert len(rows) == 1
-    assert rows[0].detail == {"deleted_count": 0}
+    # No expirees: zero counts everywhere, empty entries list.
+    assert rows[0].detail["deleted_count"] == 0
+    assert rows[0].detail["truncated_count"] == 0
+    assert rows[0].detail["entries"] == []
+    assert rows[0].detail["counts_by_feature"] == {}
+
+
+@pytest.mark.asyncio
+async def test_sweep_truncates_audit_entries_over_cap(session_factory):
+    """When > _SWEEP_AUDIT_ENTRY_CAP rows are deleted, the audit
+    detail caps the per-row `entries` list and surfaces the rest as
+    `truncated_count` plus `counts_by_feature`.
+
+    Pre-PR-C the audit row only carried `deleted_count`, so an ops
+    person investigating a sweep could only see the total — not which
+    orgs/features lost access.
+    """
+    from datetime import timedelta
+
+    from sqlalchemy import select as _select
+
+    from app._time import utcnow_naive
+    from app.models.user import Organization
+    from app.routers.admin_orgs import _SWEEP_AUDIT_ENTRY_CAP
+
+    seed = await _seed(session_factory)
+    cap = _SWEEP_AUDIT_ENTRY_CAP
+    over_cap = cap + 5
+    past = utcnow_naive() - timedelta(hours=1)
+
+    # Need many distinct orgs because of the UNIQUE(org_id, feature_key).
+    # Plant a single expired override per fresh org, alternating between
+    # two keys so counts_by_feature is non-trivial.
+    async with session_factory() as db:
+        orgs = [
+            Organization(name=f"OrgX-{i}", billing_cycle_day=1)
+            for i in range(over_cap)
+        ]
+        db.add_all(orgs)
+        await db.commit()
+        for i, org in enumerate(orgs):
+            db.add(
+                OrgFeatureOverride(
+                    org_id=org.id,
+                    feature_key=("ai.budget" if i % 2 == 0 else "ai.forecast"),
+                    value=True,
+                    set_by=seed["admin_user_id"],
+                    expires_at=past,
+                )
+            )
+        await db.commit()
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.post("/api/v1/admin/orgs/feature-overrides/sweep-expired")
+    assert res.status_code == 200
+    assert res.json()["deleted_count"] == over_cap
+
+    async with session_factory() as db:
+        row = (
+            await db.execute(
+                _select(AuditEvent).where(
+                    AuditEvent.event_type
+                    == "admin.feature_override.expired_swept"
+                )
+            )
+        ).scalars().one()
+    assert row.detail["deleted_count"] == over_cap
+    assert len(row.detail["entries"]) == cap
+    assert row.detail["truncated_count"] == over_cap - cap
+    # Aggregate counts cover ALL deleted rows, not just the entries list.
+    total_via_counts = sum(row.detail["counts_by_feature"].values())
+    assert total_via_counts == over_cap
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_admin_feature_overrides.py
+++ b/backend/tests/routers/test_admin_feature_overrides.py
@@ -640,3 +640,156 @@ async def test_sweep_requires_orgs_manage(session_factory):
         ).scalars().all()
     # All 4 rows still present.
     assert len(count) == 4
+
+
+@pytest.mark.asyncio
+async def test_sweep_audit_count_matches_actual_deletes(session_factory):
+    """Regression: audit `deleted_count`, `entries`, and `counts_by_feature`
+    must reflect rows that were ACTUALLY removed by this sweep, not the
+    set of rows the sweep merely observed as expired.
+
+    Pre-fix the route ran SELECT-then-DELETE-by-predicate. Two
+    overlapping sweeps could both snapshot the same expired rows; the
+    first deleted them, the second deleted 0 but still audited
+    ``deleted_count = len(snapshot)``. With lock-then-delete-by-id +
+    deleted_count derived from the DELETE rowcount, the second sweep
+    audits exactly what it removed.
+
+    We simulate the race deterministically by deleting some of the
+    expired rows out-of-band BETWEEN the route's snapshot and its
+    DELETE. SQLite ignores SELECT FOR UPDATE, so this hook reliably
+    fires; on MySQL the FOR UPDATE serializes the second sweep until
+    the first commits, achieving the same invariant.
+    """
+    from datetime import timedelta
+
+    from sqlalchemy import delete as _delete
+    from sqlalchemy import select as _select
+
+    from app._time import utcnow_naive
+
+    seed = await _seed(session_factory)
+    await _seed_overrides(
+        session_factory, seed["target_id"], admin_user_id=seed["admin_user_id"]
+    )
+
+    # Hook to fire between the route's snapshot SELECT and its
+    # DELETE: delete ai.budget out-of-band so the sweep observes 2
+    # expired rows but only actually deletes 1.
+    saw_select = {"done": False}
+    real_execute = AsyncSession.execute
+
+    async def hooked_execute(self, statement, *args, **kwargs):
+        sql = str(statement).lower()
+        # Fire AFTER the snapshot SELECT, BEFORE the DELETE.
+        if (
+            not saw_select["done"]
+            and "select" in sql
+            and "org_feature_overrides" in sql
+            and "expires_at" in sql
+        ):
+            saw_select["done"] = True
+            result = await real_execute(self, statement, *args, **kwargs)
+            # Out-of-band delete via a separate session so it commits
+            # independently of the route's session.
+            async with session_factory() as side_db:
+                await side_db.execute(
+                    _delete(OrgFeatureOverride).where(
+                        OrgFeatureOverride.org_id == seed["target_id"],
+                        OrgFeatureOverride.feature_key == "ai.budget",
+                    )
+                )
+                await side_db.commit()
+            return result
+        return await real_execute(self, statement, *args, **kwargs)
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with patch.object(AsyncSession, "execute", hooked_execute):
+        with TestClient(app) as client:
+            res = client.post("/api/v1/admin/orgs/feature-overrides/sweep-expired")
+    assert res.status_code == 200
+    # Only ai.forecast survived to be deleted by the route. ai.budget
+    # was deleted out-of-band; the route's DELETE-by-id should not
+    # count it.
+    assert res.json() == {"deleted_count": 1}
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                _select(AuditEvent).where(
+                    AuditEvent.event_type
+                    == "admin.feature_override.expired_swept"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    detail = rows[0].detail
+    # Invariants the reviewer asked for: the audit row's numbers
+    # describe what was ACTUALLY deleted by this sweep, and entries
+    # match deleted_count.
+    assert detail["deleted_count"] == 1
+    assert len(detail["entries"]) == detail["deleted_count"]
+    assert sum(detail["counts_by_feature"].values()) == detail["deleted_count"]
+    assert detail["truncated_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sweep_zero_deletes_when_all_expired_rows_already_gone(session_factory):
+    """Edge: every expired row is removed out-of-band between the
+    route's snapshot and its DELETE. Sweep must audit deleted_count=0
+    with empty entries — the symmetric of the partial-overlap case.
+    """
+    from sqlalchemy import delete as _delete
+    from sqlalchemy import select as _select
+
+    seed = await _seed(session_factory)
+    await _seed_overrides(
+        session_factory, seed["target_id"], admin_user_id=seed["admin_user_id"]
+    )
+
+    saw_select = {"done": False}
+    real_execute = AsyncSession.execute
+
+    async def hooked_execute(self, statement, *args, **kwargs):
+        sql = str(statement).lower()
+        if (
+            not saw_select["done"]
+            and "select" in sql
+            and "org_feature_overrides" in sql
+            and "expires_at" in sql
+        ):
+            saw_select["done"] = True
+            result = await real_execute(self, statement, *args, **kwargs)
+            async with session_factory() as side_db:
+                await side_db.execute(
+                    _delete(OrgFeatureOverride).where(
+                        OrgFeatureOverride.org_id == seed["target_id"],
+                        OrgFeatureOverride.feature_key.in_(
+                            ["ai.budget", "ai.forecast"]
+                        ),
+                    )
+                )
+                await side_db.commit()
+            return result
+        return await real_execute(self, statement, *args, **kwargs)
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with patch.object(AsyncSession, "execute", hooked_execute):
+        with TestClient(app) as client:
+            res = client.post("/api/v1/admin/orgs/feature-overrides/sweep-expired")
+    assert res.status_code == 200
+    assert res.json() == {"deleted_count": 0}
+
+    async with session_factory() as db:
+        row = (
+            await db.execute(
+                _select(AuditEvent).where(
+                    AuditEvent.event_type
+                    == "admin.feature_override.expired_swept"
+                )
+            )
+        ).scalars().one()
+    assert row.detail["deleted_count"] == 0
+    assert row.detail["entries"] == []
+    assert row.detail["counts_by_feature"] == {}
+    assert row.detail["truncated_count"] == 0

--- a/backend/tests/routers/test_admin_feature_overrides.py
+++ b/backend/tests/routers/test_admin_feature_overrides.py
@@ -517,6 +517,10 @@ async def test_sweep_writes_audit_event(session_factory):
         "ai.budget": 1,
         "ai.forecast": 1,
     }
+    # Happy path: no divergence flag (or explicitly false). Pin the
+    # contract so a future reader can tell happy-path detail from the
+    # divergence-path detail at a glance.
+    assert not row.detail.get("divergence")
 
 
 @pytest.mark.asyncio
@@ -541,11 +545,13 @@ async def test_sweep_idempotent_when_nothing_expired(session_factory):
             )
         ).scalars().all()
     assert len(rows) == 1
-    # No expirees: zero counts everywhere, empty entries list.
+    # No expirees: zero counts everywhere, empty entries list. Happy
+    # path (nothing was locked, nothing was deleted), so no divergence.
     assert rows[0].detail["deleted_count"] == 0
     assert rows[0].detail["truncated_count"] == 0
     assert rows[0].detail["entries"] == []
     assert rows[0].detail["counts_by_feature"] == {}
+    assert not rows[0].detail.get("divergence")
 
 
 @pytest.mark.asyncio
@@ -614,6 +620,8 @@ async def test_sweep_truncates_audit_entries_over_cap(session_factory):
     # Aggregate counts cover ALL deleted rows, not just the entries list.
     total_via_counts = sum(row.detail["counts_by_feature"].values())
     assert total_via_counts == over_cap
+    # Happy path: no divergence under non-racing sweep.
+    assert not row.detail.get("divergence")
 
 
 @pytest.mark.asyncio
@@ -724,13 +732,20 @@ async def test_sweep_audit_count_matches_actual_deletes(session_factory):
         ).scalars().all()
     assert len(rows) == 1
     detail = rows[0].detail
-    # Invariants the reviewer asked for: the audit row's numbers
-    # describe what was ACTUALLY deleted by this sweep, and entries
-    # match deleted_count.
+    # Divergence path: the route locked 2 rows under SELECT FOR
+    # UPDATE (no-op on SQLite) but only deleted 1 because the other
+    # was removed out-of-band. We CANNOT honestly tell which of the
+    # two locked rows our DELETE removed without DELETE ... RETURNING
+    # (MySQL doesn't have it). The audit row records the count we
+    # know is true and explicitly flags the gap; per-row identities
+    # are omitted because asserting them would be a guess.
     assert detail["deleted_count"] == 1
-    assert len(detail["entries"]) == detail["deleted_count"]
-    assert sum(detail["counts_by_feature"].values()) == detail["deleted_count"]
-    assert detail["truncated_count"] == 0
+    assert detail["locked_count"] == 2
+    assert detail["divergence"] is True
+    assert detail["divergence_reason"] == "concurrent_modification"
+    assert "entries" not in detail
+    assert "counts_by_feature" not in detail
+    assert "truncated_count" not in detail
 
 
 @pytest.mark.asyncio
@@ -789,7 +804,13 @@ async def test_sweep_zero_deletes_when_all_expired_rows_already_gone(session_fac
                 )
             )
         ).scalars().one()
+    # Divergence: route locked 2 rows, then both were deleted
+    # out-of-band, so DELETE-by-id removed 0. Same shape as the
+    # partial-overlap case. No per-row claims.
     assert row.detail["deleted_count"] == 0
-    assert row.detail["entries"] == []
-    assert row.detail["counts_by_feature"] == {}
-    assert row.detail["truncated_count"] == 0
+    assert row.detail["locked_count"] == 2
+    assert row.detail["divergence"] is True
+    assert row.detail["divergence_reason"] == "concurrent_modification"
+    assert "entries" not in row.detail
+    assert "counts_by_feature" not in row.detail
+    assert "truncated_count" not in row.detail

--- a/backend/tests/routers/test_audit_wiring.py
+++ b/backend/tests/routers/test_audit_wiring.py
@@ -163,6 +163,108 @@ async def test_subscription_override_writes_audit(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_delete_success_persists_audit_with_snapshot(session_factory):
+    """PR-C / PR #139 #1: the org-delete success audit row must be
+    durably persisted to ``audit_events`` (it used to be lost because
+    the FK insert ran AFTER the org row was deleted, the FK violation
+    was swallowed by record_audit_event, and the success only ever
+    showed up in structlog).
+
+    Pin:
+    - row exists with outcome=SUCCESS and event_type=admin.org.delete
+    - target_org_id is NULL (FK ON DELETE SET NULL fired in the same
+      txn — the org is gone)
+    - detail.snapshot.org_id preserves the original id even after the
+      FK nulls
+    - detail.deleted_rows_by_table is populated
+    """
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.request(
+            "DELETE",
+            f"/api/v1/admin/orgs/{seed['target_id']}",
+            json={"confirm_name": seed["target_name"]},
+        )
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.delete"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1, "success audit row missing — pre-PR-C bug"
+    row = rows[0]
+    assert row.outcome == AuditOutcome.SUCCESS
+    # FK ON DELETE SET NULL fired when the org row was deleted in the
+    # SAME transaction — target_org_id is now NULL on the audit row.
+    assert row.target_org_id is None
+    # Snapshot preserves the identity that the FK just dropped.
+    assert row.detail is not None
+    snapshot = row.detail.get("snapshot")
+    assert snapshot is not None
+    assert snapshot["org_id"] == seed["target_id"]
+    assert snapshot["org_name"] == seed["target_name"]
+    assert "member_count_at_delete" in snapshot
+    assert snapshot["deleted_by_user_id"] == seed["admin_user_id"]
+    assert snapshot["deleted_by_email"] == "root@platform.io"
+    # Counts also recorded.
+    assert "deleted_rows_by_table" in row.detail
+    assert row.detail["deleted_rows_by_table"]["organizations"] == 1
+    # Snapshot survives even though target_org_id is gone — the
+    # org_name fallback column on the audit row is also still set.
+    assert row.target_org_name == seed["target_name"]
+
+
+@pytest.mark.asyncio
+async def test_delete_rollback_drops_staged_audit_row(session_factory):
+    """When delete_org_cascade raises after the success audit row has
+    been staged in the same session, the rollback must take the
+    staged audit row with it — no orphan ``admin.org.delete`` rows
+    for deletes that didn't happen.
+
+    The independent-session ``admin.org.delete.failed`` row is the
+    only audit-table evidence in the rollback case; covered by
+    test_delete_failed_writes_audit below.
+    """
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("simulated cascade failure")
+
+    with patch(
+        "app.routers.admin_orgs.admin_orgs_service.delete_org_cascade",
+        side_effect=boom,
+    ):
+        with TestClient(app) as client:
+            res = client.request(
+                "DELETE",
+                f"/api/v1/admin/orgs/{seed['target_id']}",
+                json={"confirm_name": seed["target_name"]},
+            )
+    assert res.status_code == 500
+
+    # The success row should NOT exist — the rollback dropped it.
+    async with session_factory() as db:
+        success_rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.delete",
+                    AuditEvent.outcome == AuditOutcome.SUCCESS,
+                )
+            )
+        ).scalars().all()
+    assert len(success_rows) == 0, (
+        "success audit row leaked despite rollback — pre-commit "
+        "staging didn't roll back with the business txn"
+    )
+
+
+@pytest.mark.asyncio
 async def test_delete_failed_writes_audit(session_factory):
     """Patch delete_org_cascade to raise — verify a `failure` audit
     row exists even though the business txn rolled back. This is the
@@ -201,6 +303,14 @@ async def test_delete_failed_writes_audit(session_factory):
     assert row.target_org_name == seed["target_name"]
     assert row.detail is not None
     assert row.detail.get("error_type") == "RuntimeError"
+    # PR-C also embeds the org snapshot on the failure path so
+    # ops can answer "which org failed to delete and what state was
+    # it in" without reaching back to a structlog grep.
+    snapshot = row.detail.get("snapshot")
+    assert snapshot is not None
+    assert snapshot["org_id"] == seed["target_id"]
+    assert snapshot["org_name"] == seed["target_name"]
+    assert snapshot["deleted_by_email"] == "root@platform.io"
 
     # The target org is still present — the business txn was rolled
     # back. Sanity check: the audit row survived a rollback because

--- a/backend/tests/services/test_audit_service.py
+++ b/backend/tests/services/test_audit_service.py
@@ -167,6 +167,19 @@ async def test_list_audit_events_filters_by_outcome(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_list_audit_events_invalid_outcome_raises(session_factory):
+    """Service-direct callers (and old swallow) used to silently skip
+    the filter on a typo. PR-C tightens this: the route layer types
+    the param as Literal so FastAPI rejects, and the service raises
+    ValueError so any direct caller (tests, ad-hoc scripts) sees the
+    typo loudly."""
+    await _seed_three(session_factory)
+    async with session_factory() as db:
+        with pytest.raises(ValueError):
+            await list_audit_events(db, outcome="failuer")
+
+
+@pytest.mark.asyncio
 async def test_list_audit_events_date_range(session_factory):
     await _seed_three(session_factory)
     async with session_factory() as db:

--- a/backend/tests/services/test_audit_service.py
+++ b/backend/tests/services/test_audit_service.py
@@ -108,6 +108,54 @@ async def test_record_audit_event_survives_bad_session():
     )
 
 
+@pytest.mark.asyncio
+async def test_record_audit_event_failure_logs_at_error():
+    """A backstop audit-write failure surfaces at ERROR level.
+
+    After PR-C the org-delete success path stages the audit row in
+    the business txn (see ``add_audit_event_to_session``); the
+    independent-session ``record_audit_event`` is now reserved for
+    the failure path and the sweep. Either is operationally
+    significant when it fails — a regression that pulls a caller
+    back onto this swallow needs to fire alerts, not whisper at
+    WARN. This pins the level so a future "oops" downgrade is
+    caught.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    def broken_factory():
+        raise RuntimeError("DB unreachable")
+
+    from app.services import audit_service as audit_service_module
+
+    with patch.object(
+        audit_service_module.logger, "aerror", new_callable=AsyncMock
+    ) as mock_aerror, patch.object(
+        audit_service_module.logger, "awarning", new_callable=AsyncMock
+    ) as mock_awarning:
+        await record_audit_event(
+            broken_factory,
+            event_type="admin.org.delete",
+            actor_user_id=None,
+            actor_email="root@example.io",
+            target_org_id=None,
+            target_org_name=None,
+            request_id=None,
+            ip_address=None,
+            outcome="failure",
+            detail=None,
+        )
+
+    assert mock_awarning.call_count == 0, (
+        "audit.record.failed must log at ERROR, not WARN"
+    )
+    assert mock_aerror.call_count == 1
+    args, kwargs = mock_aerror.call_args
+    assert args[0] == "audit.record.failed"
+    assert kwargs["event_type"] == "admin.org.delete"
+    assert kwargs["error_type"] == "RuntimeError"
+
+
 # ── querying ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Bundles five backend findings from review of PR #139, PR #141, and PR #142.

**PR #139 #1 (HIGH).** The org-delete success audit row was lost. The route deleted the org and committed first, then called `record_audit_event` with the now-deleted `target_org_id`; the FK insert failed and `audit_service` swallowed the error. Fix: stage the success audit row on the **same session** before the cascade. `target_org_id` already has `ON DELETE SET NULL`, so the cascade nulls it at flush time and the snapshot in `detail` (org_id, org_name, created_at, billing_cycle_day, member_count_at_delete, subscription, deleted_by_user_id, deleted_by_email) preserves identity. The failure path also gets the snapshot. The swallow in `record_audit_event` stays as a backstop but escalates to WARN.

**PR #139 #2 + PR #142 #2 (MEDIUM).** Migrations 030 and 033 used `sa.text(\"CURRENT_TIMESTAMP(6)\")` which SQLite rejects as a function-call syntax error. Replaced with `sa.func.now()` (Alembic translates per dialect, matches the dominant pattern in 020+ migrations). Added `tests/migrations/test_sqlite_portability.py` to grep-assert the ban going forward.

**PR #139 #3 (LOW).** `outcome=failuer` used to silently return all events. Typed the route param as `Literal[\"success\", \"failure\"] | None` so FastAPI returns 422; the service now raises `ValueError` on bad input instead of swallowing.

**PR #141 #1 (MEDIUM).** The override-sweep audit row only carried `deleted_count`. It now SELECTs the rows that will be deleted before the DELETE and records a bounded summary in `detail`: `entries` (capped at 50), `truncated_count`, `counts_by_feature`. Ops can answer "which orgs/features lost access" from the audit table.