### PR TITLE
fix(ui): modal focus, tokenized overlay, partial-success on edit+promote, /v-flag pattern, stale lockedType docstring

### DIFF
--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -200,7 +200,7 @@ export default function SystemPlansPage() {
                 value={formSlug}
                 onChange={(e) => setFormSlug(e.target.value)}
                 className={input}
-                pattern="[-a-z0-9]+"
+                pattern={"[a-z0-9\\-]+"}
                 required
                 disabled={!!editing}
               />

--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -200,7 +200,7 @@ export default function SystemPlansPage() {
                 value={formSlug}
                 onChange={(e) => setFormSlug(e.target.value)}
                 className={input}
-                pattern="[a-z0-9-]+"
+                pattern="[-a-z0-9]+"
                 required
                 disabled={!!editing}
               />

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -437,26 +437,42 @@ function TransactionsPageContent() {
         body: JSON.stringify(body),
       });
       if (wantsPromote) {
-        const promoted = await apiFetch<Transaction>(
-          `/api/v1/transactions/${editingId}/promote-to-recurring`,
-          {
-            method: "POST",
-            body: JSON.stringify({
-              frequency: editRecFrequency,
-              next_due_date: editRecNextDue,
-            }),
-          },
-        );
-        // Optimistically reflect the new recurring_id locally so the chip
-        // appears immediately even before loadTransactions resolves.
-        if (promoted) {
-          setTransactions((prev) =>
-            prev.map((t) =>
-              t.id === editingId
-                ? { ...t, recurring_id: promoted.recurring_id }
-                : t,
-            ),
+        // The PUT already committed the edit. If the promote step then
+        // fails, surface a partial-success message so the user knows
+        // the transaction edits stuck even though the combined action
+        // reported an error.
+        try {
+          const promoted = await apiFetch<Transaction>(
+            `/api/v1/transactions/${editingId}/promote-to-recurring`,
+            {
+              method: "POST",
+              body: JSON.stringify({
+                frequency: editRecFrequency,
+                next_due_date: editRecNextDue,
+              }),
+            },
           );
+          // Optimistically reflect the new recurring_id locally so the chip
+          // appears immediately even before loadTransactions resolves.
+          if (promoted) {
+            setTransactions((prev) =>
+              prev.map((t) =>
+                t.id === editingId
+                  ? { ...t, recurring_id: promoted.recurring_id }
+                  : t,
+              ),
+            );
+          }
+        } catch (promoteErr) {
+          const reason = extractErrorMessage(promoteErr);
+          setError(
+            `Transaction updated, but promote-to-recurring failed: ${reason}. The transaction still reflects your edits.`,
+          );
+          // Exit edit mode (the edit DID persist) and refresh so the row
+          // shows the saved values; the error banner stays visible.
+          closeEdit();
+          await loadTransactions(page);
+          return;
         }
       }
       closeEdit();

--- a/frontend/components/system/DuplicatePlanModal.tsx
+++ b/frontend/components/system/DuplicatePlanModal.tsx
@@ -70,7 +70,7 @@ export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Pr
             value={slug}
             onChange={(e) => setSlug(e.target.value)}
             className={input}
-            pattern="^[a-z0-9-]+$"
+            pattern="^[-a-z0-9]+$"
             required
           />
         </div>

--- a/frontend/components/system/DuplicatePlanModal.tsx
+++ b/frontend/components/system/DuplicatePlanModal.tsx
@@ -70,7 +70,7 @@ export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Pr
             value={slug}
             onChange={(e) => setSlug(e.target.value)}
             className={input}
-            pattern="^[-a-z0-9]+$"
+            pattern={"^[a-z0-9\\-]+$"}
             required
           />
         </div>

--- a/frontend/components/ui/AddCategoryModal.tsx
+++ b/frontend/components/ui/AddCategoryModal.tsx
@@ -21,10 +21,13 @@ interface Props {
    * When provided, the form is locked to this type:
    * the user cannot change it, and the parent-master dropdown
    * (when "Subcategory" is checked) only lists masters whose type
-   * is compatible (matching type or "both"). The submitted POST
-   * always carries the locked type. The backend rejects any
-   * (parent.type, child.type) mismatch, so we mirror that here to
-   * keep the user from hitting a 400 mid-flow.
+   * matches exactly (no "both" parents). Child categories inherit
+   * parent type at the backend, so allowing a "both" parent would
+   * silently create a "both" child against the modal's type-only
+   * promise. The submitted POST always carries the locked type.
+   * The backend rejects any (parent.type, child.type) mismatch,
+   * so we mirror that here to keep the user from hitting a 400
+   * mid-flow.
    */
   lockedType?: "income" | "expense";
   masterCategories: Category[];
@@ -61,15 +64,19 @@ export default function AddCategoryModal({
     setMounted(true);
   }, []);
 
-  // Focus + restore
+  // Focus + restore. Gated on `mounted` so it runs after the portal
+  // content actually renders. Without the gate, nameRef.current is
+  // null on first run and keyboard focus stays behind the aria-modal
+  // dialog.
   useEffect(() => {
+    if (!mounted) return;
     previousFocusRef.current = document.activeElement as HTMLElement;
     nameRef.current?.focus();
     nameRef.current?.select();
     return () => {
       previousFocusRef.current?.focus();
     };
-  }, []);
+  }, [mounted]);
 
   // Escape + focus trap
   useEffect(() => {
@@ -142,7 +149,7 @@ export default function AddCategoryModal({
   if (!mounted) return null;
 
   const modal = (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-bg/80 p-4">
       <div
         ref={dialogRef}
         role="dialog"

--- a/frontend/tests/app/transactions-promote-recurring.test.tsx
+++ b/frontend/tests/app/transactions-promote-recurring.test.tsx
@@ -205,6 +205,55 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
     expect(body.next_due_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
+  it("partial success: PUT succeeds + POST promote fails surfaces partial-success message and exits edit", async () => {
+    const tx = makeTx({ id: 75, description: "Partial save", recurring_id: null });
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+      if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+      if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+      if (url === "/api/v1/transactions/75" && method === "PUT") {
+        return { ...tx, description: "Partial save edited" } as never;
+      }
+      if (url === "/api/v1/transactions/75/promote-to-recurring" && method === "POST") {
+        throw new Error("recurring quota exceeded");
+      }
+      if (url.startsWith("/api/v1/transactions") && method === "GET") return [tx] as never;
+      return null as never;
+    });
+
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Partial save");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    fireEvent.click(screen.getAllByLabelText("Make recurring")[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /^Save$/i })[0]);
+
+    // Partial-success banner explicitly tells the user what stuck and what failed.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Transaction updated, but promote-to-recurring failed/i),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/recurring quota exceeded/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/still reflects your edits/i),
+    ).toBeInTheDocument();
+
+    // Edit mode should have exited (the PUT did persist), so no Save button visible.
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Save$/i }).length).toBe(0);
+    });
+  });
+
   it("save without ticking recurring does NOT call promote-to-recurring", async () => {
     const tx = makeTx({ id: 72, description: "No promote" });
     setupApiFetch([tx], {

--- a/frontend/tests/components/add-category-modal.test.tsx
+++ b/frontend/tests/components/add-category-modal.test.tsx
@@ -55,6 +55,25 @@ describe("AddCategoryModal", () => {
     expect(nameInput.value).toBe("Rent");
   });
 
+  it("focuses the name field on mount (after portal renders)", async () => {
+    render(
+      <AddCategoryModal
+        initialName="Rent"
+        initialType="expense"
+        masterCategories={masterCategories}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    // The modal gates rendering on `mounted`, which flips in a
+    // post-mount effect. Wait for the input to be present (proving
+    // the portal mounted), then assert it's the active element.
+    const nameInput = await screen.findByLabelText(/Name/i);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(nameInput);
+    });
+  });
+
   it("disables Add category when name is empty", () => {
     render(
       <AddCategoryModal


### PR DESCRIPTION
## Summary

Five small frontend cleanup items bundled together. Each fix is local; no architecture changes.

### 1. AddCategoryModal focus on open (PR #137 review #2)

The focus effect ran with an empty dep array on first render, but the modal returns `null` until the post-mount `setMounted(true)` flips. By that point the effect had already fired with `nameRef.current === null`, so keyboard focus stayed behind the aria-modal dialog. Gated the focus effect on `mounted`.

`frontend/components/ui/AddCategoryModal.tsx`

### 2. Tokenized overlay (PR #137 review #3)

Replaced raw `bg-black/50` with tokenized `bg-bg/80` to match `ConfirmModal` and the recent dashboard hardening pass.

`frontend/components/ui/AddCategoryModal.tsx`

Note: several other modals still use `bg-black/50` (FeatureOverridesCard, MarkAsTransferModal, ImportMarkAsTransferModal, UnpairTransferModal, ChangePlanModal, LinkAsTransferModal, admin/roles, system/DuplicatePlanModal). Out of scope for this bundle; flagged for a follow-up sweep.

### 3. Stale `lockedType` docstring (carried forward from PR #151 re-review)

The prop comment still described pre-`b1b860b` behavior ('matching type or "both"'). Updated to reflect that locked mode now allows ONLY exact same-type masters.

`frontend/components/ui/AddCategoryModal.tsx`

### 4. Partial-success on edit + promote-to-recurring (PR #147 review #1)

When the user saves an edit with "Make recurring" ticked, the page issues `PUT /transactions/{id}` followed by `POST /promote-to-recurring`. Previously, if the PUT succeeded but the POST failed, the user got a generic error and the row stayed in edit mode, with no indication that the transaction changes had already committed.

Now: on PUT-succeeds-then-POST-fails, the page surfaces an explicit "Transaction updated, but promote-to-recurring failed: <reason>. The transaction still reflects your edits." banner, exits edit mode (the edit DID persist), and refreshes the table so the row shows the saved values. No new combined backend endpoint per user direction.

`frontend/app/transactions/page.tsx`

### 5. `/v`-flag pattern attribute regex bug

Modern browsers parse the `pattern` attribute with the `/v` (UnicodeSets) flag, which rejects unescaped `-` between ranges and surfaces 'Invalid character class' in the console. Moved the hyphen to the start of the character class on both occurrences. Same semantic meaning (lowercase letters, digits, hyphens).

`frontend/app/system/plans/page.tsx`, `frontend/components/system/DuplicatePlanModal.tsx`

## Tests

Frontend suite was 200 after PR #151. Now 202 (+2: focus-on-mount regression for AddCategoryModal, partial-success path for edit+promote).