### PR TITLE
fix(roles+forecast): explicit description clear, manual-only public source, honest provenance label

### DIFF
--- a/backend/app/routers/admin_roles.py
+++ b/backend/app/routers/admin_roles.py
@@ -187,12 +187,18 @@ async def update_role(
             ),
         )
 
+    # Distinguish "description omitted" from "description explicitly null"
+    # so the user can clear the field by sending `{"description": null}`.
+    # Pydantic's model_fields_set tracks which keys were present in the
+    # request body even when their value is None (PR #142 #3).
+    description_provided = "description" in body.model_fields_set
     try:
         item = await role_service.update_role(
             db,
             role_id=role_id,
             name=body.name,
             description=body.description,
+            clear_description=description_provided and body.description is None,
             permissions=body.permissions,
         )
     except NotFoundError:
@@ -209,10 +215,13 @@ async def update_role(
         )
     await db.commit()
 
+    # Treat any field present in the request body as "changed" — including
+    # `description: null` (clear). Without model_fields_set this would miss
+    # the explicit-clear case.
     changed_fields = [
         f
         for f in ("name", "description", "permissions")
-        if getattr(body, f) is not None
+        if f in body.model_fields_set
     ]
     # Capture the permission delta for the audit row. Keys are not
     # sensitive (the catalog is exposed via /admin/permissions to any

--- a/backend/app/schemas/forecast_plan.py
+++ b/backend/app/schemas/forecast_plan.py
@@ -6,10 +6,15 @@ from pydantic import BaseModel, Field
 
 
 class ForecastPlanItemCreate(BaseModel):
+    """Public-write shape for a forecast plan item.
+
+    ``source`` is intentionally NOT a field — the server pins every public
+    write to ``ItemSource.MANUAL`` (PR #144 #2). Only internal pipelines
+    (populate, refresh, copy) write RECURRING / HISTORY rows.
+    """
     category_id: int
     type: Literal["income", "expense"]
     planned_amount: Decimal = Field(gt=0)
-    source: Literal["manual", "recurring", "history"] = "manual"
 
 
 class ForecastPlanItemUpdate(BaseModel):
@@ -47,10 +52,13 @@ class ForecastPlanResponse(BaseModel):
 
 
 class BulkUpsertItem(BaseModel):
+    """Single row in a bulk public write.
+
+    ``source`` is server-controlled and pinned to MANUAL (PR #144 #2).
+    """
     category_id: int
     type: Literal["income", "expense"]
     planned_amount: Decimal = Field(gt=0)
-    source: Literal["manual", "recurring", "history"] = "manual"
 
 
 class BulkUpsertRequest(BaseModel):

--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -523,9 +523,12 @@ async def upsert_item(
             existing = item
             break
 
+    # Public writes are always MANUAL (PR #144 #2). The schema no longer
+    # carries a source field; recurring/history are reserved for internal
+    # populate/refresh/copy paths.
     if existing:
         existing.planned_amount = body.planned_amount
-        existing.source = ItemSource(body.source)
+        existing.source = ItemSource.MANUAL
     else:
         new_item = ForecastPlanItem(
             plan_id=plan.id,
@@ -533,7 +536,7 @@ async def upsert_item(
             category_id=body.category_id,
             type=ForecastItemType(body.type),
             planned_amount=body.planned_amount,
-            source=ItemSource(body.source),
+            source=ItemSource.MANUAL,
         )
         db.add(new_item)
 
@@ -587,11 +590,12 @@ async def bulk_upsert(
         (i.category_id, i.type.value): i for i in plan.items
     }
 
+    # Public bulk writes are always MANUAL (PR #144 #2). See upsert_item.
     for item_data in body.items:
         key = (item_data.category_id, item_data.type)
         if key in existing_map:
             existing_map[key].planned_amount = item_data.planned_amount
-            existing_map[key].source = ItemSource(item_data.source)
+            existing_map[key].source = ItemSource.MANUAL
         else:
             new_item = ForecastPlanItem(
                 plan_id=plan.id,
@@ -599,7 +603,7 @@ async def bulk_upsert(
                 category_id=item_data.category_id,
                 type=ForecastItemType(item_data.type),
                 planned_amount=item_data.planned_amount,
-                source=ItemSource(item_data.source),
+                source=ItemSource.MANUAL,
             )
             db.add(new_item)
             existing_map[key] = new_item  # track to handle duplicates in same request

--- a/backend/app/services/role_service.py
+++ b/backend/app/services/role_service.py
@@ -204,9 +204,17 @@ async def update_role(
     role_id: int,
     name: Optional[str] = None,
     description: Optional[str] = None,
+    clear_description: bool = False,
     permissions: Optional[list[str]] = None,
 ) -> dict:
     """Patch a role. Refuses on ``is_system_frozen``.
+
+    ``description`` semantics (PR #142 #3): the patch shape needs to
+    distinguish "field omitted" from "field explicitly cleared to null".
+    Callers pass ``description=None`` for both omitted and explicit null,
+    so an extra ``clear_description=True`` flag tells the service to
+    write NULL to the column. Without that flag a ``None`` description
+    is treated as "leave unchanged".
 
     ``permissions`` semantics: ``None`` leaves them untouched, ``[]``
     clears, otherwise replaces.
@@ -229,6 +237,8 @@ async def update_role(
         role.name = name
     if description is not None:
         role.description = description
+    elif clear_description:
+        role.description = None
 
     if permissions is not None:
         keys = _validate_permissions(permissions)

--- a/backend/tests/routers/test_admin_roles.py
+++ b/backend/tests/routers/test_admin_roles.py
@@ -258,6 +258,49 @@ async def test_update_role_patches_permissions(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_update_role_clears_description_with_explicit_null(session_factory):
+    """PR #142 #3: PATCH with `description: null` actually clears.
+
+    Previously the service collapsed `None` into "leave unchanged"; this
+    pins that explicit null clears the stored value while omitting the
+    field still leaves it untouched.
+    """
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/admin/roles",
+            json={
+                "slug": "ops",
+                "name": "Ops",
+                "description": "Original",
+                "permissions": [],
+            },
+        ).json()
+        # PATCH without description leaves it.
+        res = client.patch(
+            f"/api/v1/admin/roles/{created['id']}",
+            json={"name": "Operations"},
+        )
+        assert res.status_code == 200
+        assert res.json()["description"] == "Original"
+        # PATCH with explicit null clears.
+        res = client.patch(
+            f"/api/v1/admin/roles/{created['id']}",
+            json={"description": None},
+        )
+        assert res.status_code == 200
+        assert res.json()["description"] is None
+        # PATCH with non-null sets.
+        res = client.patch(
+            f"/api/v1/admin/roles/{created['id']}",
+            json={"description": "New value"},
+        )
+        assert res.status_code == 200
+        assert res.json()["description"] == "New value"
+
+
+@pytest.mark.asyncio
 async def test_delete_role(session_factory):
     await _seed_users(session_factory)
     app = make_app(session_factory, _superadmin_resolver())

--- a/backend/tests/services/test_forecast_plan_category_type_guard.py
+++ b/backend/tests/services/test_forecast_plan_category_type_guard.py
@@ -110,7 +110,6 @@ async def test_upsert_rejects_income_with_expense_category(session_factory):
         category_id=seed["expense_master_id"],
         type="income",
         planned_amount=Decimal("100"),
-        source="manual",
     )
     async with session_factory() as db:
         with pytest.raises(ValidationError):
@@ -126,7 +125,6 @@ async def test_upsert_rejects_expense_with_income_category(session_factory):
         category_id=seed["income_master_id"],
         type="expense",
         planned_amount=Decimal("100"),
-        source="manual",
     )
     async with session_factory() as db:
         with pytest.raises(ValidationError):
@@ -142,7 +140,6 @@ async def test_upsert_accepts_matching_category(session_factory):
         category_id=seed["expense_master_id"],
         type="expense",
         planned_amount=Decimal("100"),
-        source="manual",
     )
     async with session_factory() as db:
         resp = await forecast_plan_service.upsert_item(
@@ -161,13 +158,11 @@ async def test_upsert_accepts_both_category_for_either_type(session_factory):
         category_id=seed["both_master_id"],
         type="expense",
         planned_amount=Decimal("50"),
-        source="manual",
     )
     income_body = ForecastPlanItemCreate(
         category_id=seed["both_master_id"],
         type="income",
         planned_amount=Decimal("50"),
-        source="manual",
     )
     async with session_factory() as db:
         await forecast_plan_service.upsert_item(
@@ -196,13 +191,11 @@ async def test_bulk_upsert_rejects_when_any_row_mismatches(session_factory):
                 category_id=seed["expense_master_id"],
                 type="expense",
                 planned_amount=Decimal("100"),
-                source="manual",
             ),
             BulkUpsertItem(
                 category_id=seed["income_master_id"],
                 type="expense",  # mismatched
                 planned_amount=Decimal("50"),
-                source="manual",
             ),
         ]
     )
@@ -230,13 +223,11 @@ async def test_bulk_upsert_accepts_all_compatible(session_factory):
                 category_id=seed["expense_master_id"],
                 type="expense",
                 planned_amount=Decimal("100"),
-                source="manual",
             ),
             BulkUpsertItem(
                 category_id=seed["income_master_id"],
                 type="income",
                 planned_amount=Decimal("3000"),
-                source="manual",
             ),
         ]
     )

--- a/backend/tests/services/test_forecast_plan_source_pinning.py
+++ b/backend/tests/services/test_forecast_plan_source_pinning.py
@@ -1,0 +1,160 @@
+"""PR #144 #2: source is now server-controlled on public writes.
+
+The reviewer flagged that ``ForecastPlanItemCreate`` and ``BulkUpsertItem``
+accepted a client-supplied ``source`` field which then made its way into the
+database. Combined with ``refresh_from_sources`` deleting every non-MANUAL
+item, a malicious or careless caller posting ``source="history"`` could
+make a manually-added line vanish on next refresh.
+
+Fix: drop ``source`` from the public write schemas and pin every public
+write path to ``ItemSource.MANUAL``. Internal pipelines (populate, refresh,
+copy) keep the right to write RECURRING / HISTORY since they're not
+reachable from a public POST body.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.billing import BillingPeriod
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import ForecastPlan, PlanStatus
+from app.models.user import Organization
+from app.schemas.forecast_plan import (
+    BulkUpsertItem,
+    BulkUpsertRequest,
+    ForecastPlanItemCreate,
+)
+from app.services import forecast_plan_service
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory) -> dict:
+    org_id = 1
+    period_start = datetime.date(2026, 5, 1)
+    period_end = datetime.date(2026, 5, 31)
+
+    async with factory() as db:
+        db.add(Organization(id=org_id, name="org", billing_cycle_day=1))
+        await db.commit()
+
+        groceries = Category(
+            org_id=org_id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        salary = Category(
+            org_id=org_id, name="Salary", slug="salary",
+            type=CategoryType.INCOME,
+        )
+        db.add_all([groceries, salary])
+        await db.commit()
+
+        period = BillingPeriod(
+            org_id=org_id, start_date=period_start, end_date=period_end
+        )
+        db.add(period)
+        await db.commit()
+
+        plan = ForecastPlan(
+            org_id=org_id, billing_period_id=period.id,
+            status=PlanStatus.DRAFT,
+        )
+        db.add(plan)
+        await db.commit()
+
+        return {
+            "org_id": org_id,
+            "plan_id": plan.id,
+            "groceries_id": groceries.id,
+            "salary_id": salary.id,
+        }
+
+
+def test_create_schema_does_not_accept_source():
+    """The schema no longer carries a ``source`` field."""
+    assert "source" not in ForecastPlanItemCreate.model_fields
+    assert "source" not in BulkUpsertItem.model_fields
+
+
+@pytest.mark.asyncio
+async def test_upsert_item_pins_source_to_manual(session_factory):
+    seed = await _seed(session_factory)
+    body = ForecastPlanItemCreate(
+        category_id=seed["groceries_id"],
+        type="expense",
+        planned_amount=Decimal("100"),
+    )
+    async with session_factory() as db:
+        resp = await forecast_plan_service.upsert_item(
+            db, seed["org_id"], seed["plan_id"], body
+        )
+    item = next(
+        i for i in resp.items if i.category_id == seed["groceries_id"]
+    )
+    assert item.source == "manual"
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_pins_source_to_manual(session_factory):
+    seed = await _seed(session_factory)
+    body = BulkUpsertRequest(items=[
+        BulkUpsertItem(
+            category_id=seed["groceries_id"],
+            type="expense",
+            planned_amount=Decimal("100"),
+        ),
+        BulkUpsertItem(
+            category_id=seed["salary_id"],
+            type="income",
+            planned_amount=Decimal("3000"),
+        ),
+    ])
+    async with session_factory() as db:
+        resp = await forecast_plan_service.bulk_upsert(
+            db, seed["org_id"], seed["plan_id"], body
+        )
+    assert all(i.source == "manual" for i in resp.items)
+
+
+@pytest.mark.asyncio
+async def test_upsert_item_silently_ignores_source_in_payload(session_factory):
+    """Even if a client somehow sends ``source`` in the JSON body (for
+    example via a stale client), Pydantic's default extra-allow drops it
+    silently and the service still pins MANUAL. Regression guard."""
+    seed = await _seed(session_factory)
+    # Build the model from a dict with an extra field; default extra="ignore".
+    body = ForecastPlanItemCreate.model_validate({
+        "category_id": seed["groceries_id"],
+        "type": "expense",
+        "planned_amount": "100",
+        "source": "history",
+    })
+    async with session_factory() as db:
+        resp = await forecast_plan_service.upsert_item(
+            db, seed["org_id"], seed["plan_id"], body
+        )
+    item = next(
+        i for i in resp.items if i.category_id == seed["groceries_id"]
+    )
+    assert item.source == "manual"

--- a/backend/tests/services/test_role_service.py
+++ b/backend/tests/services/test_role_service.py
@@ -212,6 +212,74 @@ async def test_update_role_leaves_permissions_when_none(db_session):
 
 
 @pytest.mark.asyncio
+async def test_update_role_clears_description_when_explicit_none(db_session):
+    """PR #142 #3: passing description=None must clear the stored value.
+
+    The router passes a sentinel via the schema's ``model_fields_set`` so
+    "field omitted" stays a no-op while "field explicitly null" actually
+    nulls out the column.
+    """
+    item = await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description="Original description",
+        permissions=[],
+    )
+    await db_session.commit()
+
+    updated = await role_service.update_role(
+        db_session,
+        role_id=item["id"],
+        description=None,
+        clear_description=True,
+    )
+    await db_session.commit()
+    assert updated["description"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_role_leaves_description_when_omitted(db_session):
+    """No description argument means leave stored value untouched."""
+    item = await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description="Keep me",
+        permissions=[],
+    )
+    await db_session.commit()
+
+    updated = await role_service.update_role(
+        db_session,
+        role_id=item["id"],
+        name="Operations",
+    )
+    await db_session.commit()
+    assert updated["description"] == "Keep me"
+
+
+@pytest.mark.asyncio
+async def test_update_role_sets_description_when_provided(db_session):
+    item = await role_service.create_role(
+        db_session,
+        slug="ops",
+        name="Ops",
+        description=None,
+        permissions=[],
+    )
+    await db_session.commit()
+
+    updated = await role_service.update_role(
+        db_session,
+        role_id=item["id"],
+        description="New description",
+    )
+    await db_session.commit()
+    assert updated["description"] == "New description"
+
+
+@pytest.mark.asyncio
 async def test_update_role_refuses_frozen(db_session):
     role_id = await _seed_frozen_superadmin(db_session)
     with pytest.raises(ConflictError):

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -33,10 +33,15 @@ import {
 } from "recharts";
 import type { BillingPeriod, Category, ForecastPlan, ForecastPlanItem } from "@/lib/types";
 
+// "Auto" is the honest label for source=history (PR #146 #1). populate
+// surfaces both 3-month-average rows AND current-period-only rows under
+// the same flag, so calling the bucket "Avg (3mo)" was a lie when a one-off
+// furniture purchase showed up. Matches the L3.10 import preview "Auto"
+// badge convention.
 const SOURCE_LABELS: Record<string, string> = {
   manual: "Manual",
   recurring: "Recurring",
-  history: "Avg (3mo)",
+  history: "Auto",
 };
 
 export default function ForecastPlansPage() {

--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -389,4 +389,33 @@ describe("ForecastPlansPage — dropdown + refresh", () => {
 
     expect(combobox.value).toBe("");
   });
+
+  it("PR #146 #1: source=history renders an honest 'Auto' label, not 'Avg (3mo)'", async () => {
+    // populate now also surfaces categories whose only signal is in the
+    // current period (one-off furniture purchase, etc.) but writes them
+    // with source=history. "Avg (3mo)" lied; rename to "Auto" — broader
+    // and matches the L3.10 import preview "Auto" badge.
+    mockInitialFetches(
+      makePlan([
+        {
+          category_id: 20,
+          category_name: "Groceries",
+          type: "expense",
+          planned_amount: 250,
+          source: "history",
+        },
+      ]),
+    );
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeTruthy();
+    });
+
+    // The honest label appears.
+    expect(screen.getAllByText("Auto").length).toBeGreaterThan(0);
+    // The misleading old label is gone.
+    expect(screen.queryByText("Avg (3mo)")).toBeNull();
+  });
 });


### PR DESCRIPTION
Bundles three review findings.

**PR #142 #3 (MEDIUM): role description can't be cleared via null.** The detail page sends `description: null` when the textarea is wiped, but the service collapsed `None` into "leave unchanged", so the old description came back on save. The router now uses `model_fields_set` to distinguish "field omitted" from "field explicitly null" and passes a `clear_description` flag to `role_service.update_role`. Frontend already sends the right shape; no UI change needed. `changed_fields` in the audit row also now includes `description` when explicitly cleared.

**PR #144 #2 (MEDIUM): source is client-controlled on public forecast writes.** `ForecastPlanItemCreate` and `BulkUpsertItem` accepted a `source` field that flowed into the database, so a caller posting `source="history"` could plant a row that `refresh_from_sources` would later sweep along with the auto-generated set. Dropped `source` from the public-write schemas and pinned `upsert_item` / `bulk_upsert` to `ItemSource.MANUAL`. Internal pipelines (populate, refresh, copy) keep their right to write RECURRING / HISTORY. Pre-launch, no migration shim. Tests updated to remove the now-stripped `source=...` arguments.

**PR #146 #1 (LOW): current-period-only rows mislabeled as 3-month average.** The PR #146 bypass correctly creates a row when `__current__` is the only contributing slot but still tags it `source=HISTORY`. The UI mapped that to `Avg (3mo)`, which is a lie for a one-off furniture purchase. Picked Option A (label-only change): renamed the frontend label to `Auto`, matching the L3.10 import preview "Auto" badge convention. Single-line change, no backend / enum churn. Future provenance-rework can split the enum if per-source granularity becomes valuable.

Backend: 600 + 2 skipped (was 592). Frontend: 203 (was 200).