### PR TITLE
chore(ui): tokenize remaining modal overlays

### DIFF
--- a/frontend/app/admin/roles/page.tsx
+++ b/frontend/app/admin/roles/page.tsx
@@ -93,7 +93,7 @@ function CreateRoleModal({ catalog, onClose, onCreated }: CreateModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="create-role-title"

--- a/frontend/components/admin/ChangePlanModal.tsx
+++ b/frontend/components/admin/ChangePlanModal.tsx
@@ -48,7 +48,7 @@ export default function ChangePlanModal({ orgId, currentPlanSlug, onClose, onCha
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
       <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
         <h2 className="mb-4 text-lg font-semibold">Change plan</h2>
         {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}

--- a/frontend/components/admin/FeatureOverridesCard.tsx
+++ b/frontend/components/admin/FeatureOverridesCard.tsx
@@ -130,7 +130,7 @@ function FeatureOverrideEditModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
       <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
         <h2 className="mb-4 text-lg font-semibold">{FEATURE_LABELS[row.key].label}</h2>
         {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}

--- a/frontend/components/system/DuplicatePlanModal.tsx
+++ b/frontend/components/system/DuplicatePlanModal.tsx
@@ -46,7 +46,7 @@ export default function DuplicatePlanModal({ source, onClose, onDuplicated }: Pr
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
       <form onSubmit={handleSubmit} className={`${card} w-full max-w-md p-6`}>
         <h2 className="mb-4 text-lg font-semibold">Duplicate plan</h2>
         {errorMsg && <div className={`${errorCls} mb-3`}>{errorMsg}</div>}

--- a/frontend/components/transactions/ImportMarkAsTransferModal.tsx
+++ b/frontend/components/transactions/ImportMarkAsTransferModal.tsx
@@ -117,7 +117,7 @@ export default function ImportMarkAsTransferModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
       <div
         ref={dialogRef}
         role="dialog"

--- a/frontend/components/transactions/LinkAsTransferModal.tsx
+++ b/frontend/components/transactions/LinkAsTransferModal.tsx
@@ -84,7 +84,7 @@ export default function LinkAsTransferModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
       <div
         ref={dialogRef}
         role="dialog"

--- a/frontend/components/transactions/MarkAsTransferModal.tsx
+++ b/frontend/components/transactions/MarkAsTransferModal.tsx
@@ -217,7 +217,7 @@ export default function MarkAsTransferModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
       <div
         ref={dialogRef}
         role="dialog"

--- a/frontend/components/transactions/UnpairTransferModal.tsx
+++ b/frontend/components/transactions/UnpairTransferModal.tsx
@@ -102,7 +102,7 @@ export default function UnpairTransferModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4">
       <div
         ref={dialogRef}
         role="dialog"


### PR DESCRIPTION
## Summary

Completes the dashboard tokenization pass started in PR #153 by replacing the remaining raw `bg-black/50` modal backdrops with the `bg-bg/80` token. Pure mechanical substitution; no logic changes.

## Files touched

- `frontend/app/admin/roles/page.tsx`
- `frontend/components/admin/ChangePlanModal.tsx`
- `frontend/components/admin/FeatureOverridesCard.tsx`
- `frontend/components/system/DuplicatePlanModal.tsx`
- `frontend/components/transactions/ImportMarkAsTransferModal.tsx`
- `frontend/components/transactions/LinkAsTransferModal.tsx`
- `frontend/components/transactions/MarkAsTransferModal.tsx`
- `frontend/components/transactions/UnpairTransferModal.tsx`

After this PR, no `bg-black/*` classes remain in `frontend/`. All 8 sites used the same `fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4` modal backdrop pattern.

Frontend test suite: 203 passed (was 202 baseline plus one main-branch test; no delta from this change).