### PR TITLE
feat(orgs): owner-rename their org with case-insensitive uniqueness and audit trail

### DIFF
--- a/backend/alembic/versions/034_unique_org_name.py
+++ b/backend/alembic/versions/034_unique_org_name.py
@@ -1,0 +1,114 @@
+"""Case-insensitive UNIQUE on organizations.name (Track D org-rename).
+
+Revision ID: 034_unique_org_name
+Revises: 033_roles
+Create Date: 2026-05-07
+
+Backstory:
+    Track D introduces an OWNER-only "rename my org" endpoint
+    (PATCH /api/v1/orgs/{org_id}/rename). Two orgs with the same
+    canonical name are confusing for cross-tenant features (admin
+    surfaces, audit logs, support tickets), so the architect locked
+    in a DB-level uniqueness guarantee on the name's lower-cased,
+    accent-sensitive form. The router does a friendly preflight 409;
+    this constraint is the backstop that survives any race.
+
+MySQL strategy:
+    Add a STORED generated column ``name_normalized`` that mirrors
+    ``LOWER(name)`` with collation ``utf8mb4_0900_as_cs``. The
+    generated column is what carries the UNIQUE constraint. Accent-
+    sensitive collation distinguishes "Cafe" from "Café" (the spec's
+    decision: no surprising deduplication of distinct trade names).
+
+SQLite strategy:
+    SQLite supports virtual generated columns but stored generated
+    columns can be platform-flaky on older SQLite builds, and the
+    unit-test fixtures use ``aiosqlite`` so we keep it simple: a
+    plain UNIQUE INDEX on ``LOWER(name)``. SQLite's LOWER() is
+    binary on non-ASCII, which actually mirrors the MySQL accent-
+    sensitive behaviour (accents are preserved, only ASCII case is
+    folded), so the same dedupe semantics hold for tests.
+
+Defensive precheck:
+    Both dialects scan for any existing duplicate (case-insensitive)
+    org names before applying the constraint. Pre-launch the only
+    seeded data is the local dev DB, but the migration is cheap to
+    keep idempotent, and a future re-run on a clobbered dataset
+    would bail with a useful error rather than crashing on the DDL.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "034_unique_org_name"
+down_revision = "033_roles"
+branch_labels = None
+depends_on = None
+
+
+def _check_no_duplicates(bind) -> None:
+    """Bail with a clear error if duplicate (case-insensitive) org
+    names already exist. Pre-launch insurance: the DDL would fail
+    anyway, but this surfaces the offending rows up front so an
+    operator can fix them in one pass.
+    """
+    rows = bind.execute(sa.text(
+        "SELECT LOWER(name) AS norm, COUNT(*) AS n "
+        "FROM organizations "
+        "GROUP BY LOWER(name) "
+        "HAVING n > 1"
+    )).all()
+    if rows:
+        offenders = ", ".join(f"{r.norm!r} (x{r.n})" for r in rows)
+        raise RuntimeError(
+            "Cannot apply UNIQUE on organizations.name (case-insensitive): "
+            f"duplicates already exist: {offenders}. "
+            "Resolve the duplicates and re-run the migration."
+        )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _check_no_duplicates(bind)
+
+    if bind.dialect.name == "mysql":
+        # Generated column carries the constraint. The expression
+        # LOWER(name) is deterministic and the column is STORED so
+        # the index is point-lookup cheap.
+        op.execute(
+            "ALTER TABLE organizations "
+            "ADD COLUMN name_normalized VARCHAR(200) "
+            "GENERATED ALWAYS AS (LOWER(name)) STORED "
+            "COLLATE utf8mb4_0900_as_cs"
+        )
+        op.create_unique_constraint(
+            "uq_organizations_name_normalized",
+            "organizations",
+            ["name_normalized"],
+        )
+    else:
+        # SQLite (test) and any other dialect: plain UNIQUE INDEX on
+        # the expression. SQLite supports indexed expressions since
+        # 3.9.0 (2015) — well below our floor.
+        op.execute(
+            "CREATE UNIQUE INDEX uq_organizations_name_normalized "
+            "ON organizations (LOWER(name))"
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        op.drop_constraint(
+            "uq_organizations_name_normalized",
+            "organizations",
+            type_="unique",
+        )
+        op.drop_column("organizations", "name_normalized")
+    else:
+        op.drop_index(
+            "uq_organizations_name_normalized",
+            table_name="organizations",
+        )

--- a/backend/alembic/versions/034_unique_org_name.py
+++ b/backend/alembic/versions/034_unique_org_name.py
@@ -49,22 +49,33 @@ depends_on = None
 
 
 def _check_no_duplicates(bind) -> None:
-    """Bail with a clear error if duplicate (case-insensitive) org
-    names already exist. Pre-launch insurance: the DDL would fail
-    anyway, but this surfaces the offending rows up front so an
-    operator can fix them in one pass.
+    """Bail with a clear error if duplicate (case-insensitive,
+    accent-sensitive) org names already exist. Pre-launch insurance:
+    the DDL would fail anyway, but this surfaces the offending rows
+    up front so an operator can fix them in one pass.
+
+    The actual UNIQUE on MySQL is over ``LOWER(name)`` collated as
+    ``utf8mb4_0900_as_cs`` — case-insensitive, accent-sensitive. The
+    base ``organizations.name`` column inherits the table's default
+    collation (typically ``utf8mb4_0900_ai_ci``, accent-insensitive),
+    so a pure ``GROUP BY LOWER(name)`` SQL precheck would falsely flag
+    "Cafe" and "Café" as duplicates and block a valid upgrade. Pull
+    rows out and group in Python with ``str.lower()`` (accent-
+    preserving) to mirror the constraint exactly.
     """
-    rows = bind.execute(sa.text(
-        "SELECT LOWER(name) AS norm, COUNT(*) AS n "
-        "FROM organizations "
-        "GROUP BY LOWER(name) "
-        "HAVING n > 1"
-    )).all()
-    if rows:
-        offenders = ", ".join(f"{r.norm!r} (x{r.n})" for r in rows)
+    rows = bind.execute(
+        sa.text("SELECT name FROM organizations")
+    ).all()
+    groups: dict[str, int] = {}
+    for r in rows:
+        key = (r.name or "").lower()
+        groups[key] = groups.get(key, 0) + 1
+    offenders = [(k, n) for k, n in groups.items() if n > 1]
+    if offenders:
+        rendered = ", ".join(f"{k!r} (x{n})" for k, n in offenders)
         raise RuntimeError(
-            "Cannot apply UNIQUE on organizations.name (case-insensitive): "
-            f"duplicates already exist: {offenders}. "
+            "Cannot apply UNIQUE on organizations.name (case-insensitive, "
+            f"accent-sensitive): duplicates already exist: {rendered}. "
             "Resolve the duplicates and re-run the migration."
         )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_audit, admin_orgs, admin_roles, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, plans, recurring, settings, subscriptions, transactions, users
+from app.routers import account_types, accounts, admin, admin_audit, admin_orgs, admin_roles, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, orgs, plans, recurring, settings, subscriptions, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -235,6 +235,7 @@ app.include_router(admin_audit.router)
 app.include_router(admin_roles.router)
 app.include_router(org_members.router)
 app.include_router(org_data.router)
+app.include_router(orgs.router)
 
 
 @app.get("/health")

--- a/backend/app/routers/orgs.py
+++ b/backend/app/routers/orgs.py
@@ -1,0 +1,171 @@
+"""Tenant org-management router (Track D).
+
+Mounted at ``/api/v1/orgs``. Houses owner-scoped operations on the
+caller's own organization: rename today, more later (transfer
+ownership, etc.). Strictly distinct from:
+
+- ``/api/v1/admin/orgs`` (``admin_orgs.py``) — platform-superadmin
+  cross-tenant management.
+- ``/api/v1/orgs/data`` (``org_data.py``) — owner-only destructive
+  data reset on the caller's own org.
+- ``/api/v1/orgs/members`` (``org_members.py``) — member roster.
+
+The audit pattern follows the architect's PR-C decisions for
+org-delete: stage the success row in the request-scoped session so
+it commits atomically with the business write; record failure rows
+on an independent session so a rolled-back business txn still leaves
+a forensic trail.
+"""
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.auth.org_permissions import require_org_owner
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models.user import Organization, User
+from app.rate_limit import get_client_ip
+from app.schemas.orgs import OrgRenameRequest, OrgResponse
+from app.services import audit_service, org_service
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/orgs", tags=["orgs"])
+
+
+def _request_id() -> str | None:
+    """Pull the per-request id bound by RequestContextMiddleware (L4.9)."""
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
+@router.patch("/{org_id}/rename", response_model=OrgResponse)
+async def rename_org_endpoint(
+    org_id: int,
+    body: OrgRenameRequest,
+    request: Request,
+    current_user: User = Depends(require_org_owner),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Rename the caller's own organization.
+
+    OWNER-only. Path ``org_id`` MUST match ``current_user.org_id`` —
+    cross-tenant attempts are 403 even for the owner of some other
+    org. Same-name submissions short-circuit to a no-op (200, no
+    audit row, no DB write). Duplicate names (case-insensitive)
+    return 409 with a generic message that does not reveal the
+    conflicting org's identity.
+    """
+    if org_id != current_user.org_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot rename other organizations",
+        )
+
+    # Snapshot identity-shaping fields BEFORE any await on db that
+    # could rollback or swap the session. Lazy-loading current_user
+    # attributes after a rollback can trip MissingGreenlet on the
+    # async engine, same gotcha that bit the org-delete failure-path
+    # audit before PR #152.
+    actor_user_id = current_user.id
+    actor_email = current_user.email
+    target_org_id = org_id
+    attempted_name = body.name
+
+    try:
+        old_name, new_name = await org_service.rename_org(
+            db, org_id=target_org_id, new_name=attempted_name,
+        )
+
+        if old_name == new_name:
+            # No-op: same canonical name. No audit row, no DB write.
+            # Release the FOR UPDATE lock cleanly via rollback before
+            # re-fetching the row in the autocommit path below. The
+            # final SELECT returns the unchanged row.
+            await db.rollback()
+            org = (
+                await db.execute(
+                    select(Organization).where(Organization.id == target_org_id)
+                )
+            ).scalar_one()
+            return OrgResponse.model_validate(org)
+
+        # Stage the audit row in the request-scoped session so it
+        # commits in the same txn as the rename. The Organization
+        # row is NOT deleted here, so the FK on ``audit_events
+        # .target_org_id`` is satisfied at INSERT time and stays
+        # satisfied forever (unlike the org-delete path, which
+        # needed the audit row to survive a cascade-NULL).
+        audit_service.add_audit_event_to_session(
+            db,
+            event_type="org.rename",
+            actor_user_id=actor_user_id,
+            actor_email=actor_email,
+            target_org_id=target_org_id,
+            target_org_name=new_name,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail={"old_name": old_name, "new_name": new_name},
+        )
+
+        try:
+            await db.commit()
+        except IntegrityError:
+            # Race: another rename slipped between our preflight and
+            # commit and won the UNIQUE constraint. Translate to a
+            # generic 409 (no cross-tenant name disclosure) and let
+            # the failure-path audit fire below.
+            await db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An organization with that name already exists",
+            )
+    except HTTPException:
+        # Best-effort rollback. If the failure originated in the
+        # service preflight (404/409), the session is already
+        # otherwise clean; if it was the IntegrityError translation
+        # above, the rollback already happened. Either way, calling
+        # rollback() again is a no-op on a clean session.
+        try:
+            await db.rollback()
+        except Exception:  # noqa: BLE001 — defensive, never bubble.
+            pass
+        # Failure-path audit on an INDEPENDENT session so the row
+        # survives the business rollback. Mirrors the org-delete
+        # failure pattern. Captures the attempted name in both
+        # ``target_org_name`` and ``detail.attempted_name`` for
+        # forensic value when the rename was rejected.
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="org.rename",
+            actor_user_id=actor_user_id,
+            actor_email=actor_email,
+            target_org_id=target_org_id,
+            target_org_name=attempted_name,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={"attempted_name": attempted_name},
+        )
+        raise
+
+    await logger.ainfo(
+        "org.rename",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=target_org_id,
+        old_name=old_name,
+        new_name=new_name,
+    )
+
+    org = (
+        await db.execute(
+            select(Organization).where(Organization.id == target_org_id)
+        )
+    ).scalar_one()
+    return OrgResponse.model_validate(org)

--- a/backend/app/schemas/orgs.py
+++ b/backend/app/schemas/orgs.py
@@ -1,0 +1,51 @@
+"""Schemas for tenant-org self-management endpoints (Track D).
+
+Distinct from ``schemas/admin_orgs.py`` (the platform-superadmin
+surface). The ``rename`` endpoint here is owner-scoped to the
+current tenant; the admin surface gets a parallel rename later.
+"""
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class OrgRenameRequest(BaseModel):
+    """Body for ``PATCH /api/v1/orgs/{org_id}/rename``.
+
+    Whitespace policy:
+        - Trim leading/trailing whitespace.
+        - Collapse runs of internal whitespace to a single space.
+        - Reject control characters (\\x00-\\x1F + \\x7F).
+
+    The DB column is ``VARCHAR(200)`` but we cap user input at 80 to
+    leave room for cosmetic suffixes if needed and to keep the rename
+    UI tight. The 200-char column stays in place (no migration).
+    """
+
+    name: str = Field(..., min_length=1, max_length=80)
+
+    @field_validator("name", mode="after")
+    @classmethod
+    def _normalize(cls, v: str) -> str:
+        v = v.strip()
+        v = re.sub(r"\s+", " ", v)
+        if not v:
+            raise ValueError("Name cannot be empty after trimming whitespace")
+        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in v):
+            raise ValueError("Name cannot contain control characters")
+        return v
+
+
+class OrgResponse(BaseModel):
+    """Read shape returned by the rename endpoint. Mirrors the
+    ``Organization`` ORM row's identity-shaping fields without
+    leaking the timestamps or other internal state.
+    """
+
+    id: int
+    name: str
+    billing_cycle_day: int
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/org_service.py
+++ b/backend/app/services/org_service.py
@@ -1,0 +1,83 @@
+"""Tenant org-mutation services (Track D).
+
+Initial scope is the OWNER-only rename. The wider set of org
+self-management operations (transfer-ownership, etc.) lands in
+later tracks; keeping the module narrow until then.
+"""
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import Organization
+
+
+async def rename_org(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    new_name: str,
+) -> tuple[str, str]:
+    """Rename ``org_id`` to ``new_name``.
+
+    Returns ``(old_name, new_name)``. If the new name normalizes to
+    the same value as the old name (case-insensitive, after the
+    Pydantic-side whitespace collapse), returns ``(old_name, old_name)``
+    and does NOT mutate the row — callers MUST detect this and skip
+    both audit and commit.
+
+    Caller responsibilities:
+        - Provide a ``new_name`` already normalized by ``OrgRenameRequest``
+          (trim + whitespace collapse + control-char rejection).
+        - Commit the session after this call returns.
+        - Translate ``IntegrityError`` raised on commit to a 409
+          (the DB UNIQUE constraint on ``name_normalized`` is the
+          backstop against the friendly preflight below losing a race).
+
+    Raises:
+        HTTPException(404): organization does not exist.
+        HTTPException(409): preflight finds another org with the same
+            case-insensitive name.
+    """
+    org = (
+        await db.execute(
+            select(Organization)
+            .where(Organization.id == org_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+
+    old_name = org.name
+
+    # Same-name guard. Pydantic already collapsed whitespace, but
+    # keep the strip()/lower() defensive here so the service can be
+    # reused safely by future internal callers that bypass Pydantic.
+    if old_name.lower().strip() == new_name.lower().strip():
+        return (old_name, old_name)
+
+    # Friendly preflight. The DB UNIQUE constraint is the source of
+    # truth, but a clean 409 with a helpful message beats raising
+    # IntegrityError up to the user. The race window between this
+    # SELECT and the COMMIT is closed by the constraint.
+    duplicate = (
+        await db.execute(
+            select(Organization.id)
+            .where(Organization.id != org_id)
+            .where(Organization.name.ilike(new_name))
+        )
+    ).scalar_one_or_none()
+    if duplicate is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An organization with that name already exists",
+        )
+
+    org.name = new_name
+    return (old_name, new_name)

--- a/backend/app/services/org_service.py
+++ b/backend/app/services/org_service.py
@@ -7,7 +7,7 @@ later tracks; keeping the module narrow until then.
 from __future__ import annotations
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.user import Organization
@@ -66,18 +66,35 @@ async def rename_org(
     # truth, but a clean 409 with a helpful message beats raising
     # IntegrityError up to the user. The race window between this
     # SELECT and the COMMIT is closed by the constraint.
-    duplicate = (
+    #
+    # The actual UNIQUE on MySQL lives on a generated ``name_normalized``
+    # column with collation ``utf8mb4_0900_as_cs`` — case-insensitive
+    # but accent-sensitive. The base ``organizations.name`` column uses
+    # the table's default collation (typically ``utf8mb4_0900_ai_ci``,
+    # accent-insensitive), so SQL operators on the base column treat
+    # "Cafe" and "Café" as equal. To stay aligned with the constraint,
+    # SQL pre-filters loosely on ``LOWER(name)`` (over-accepts on
+    # MySQL: matches accent variants too) and Python filters exactly
+    # with ``str.lower()`` (preserves accents).
+    #
+    # Also avoids ``ilike(new_name)``: ``%``/``_`` would be parsed as
+    # wildcards and could falsely match unrelated names.
+    new_lower = new_name.lower()
+    candidates = (
         await db.execute(
-            select(Organization.id)
+            select(Organization.id, Organization.name)
             .where(Organization.id != org_id)
-            .where(Organization.name.ilike(new_name))
+            .where(func.lower(Organization.name) == new_lower)
         )
-    ).scalar_one_or_none()
-    if duplicate is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="An organization with that name already exists",
-        )
+    ).all()
+    for row in candidates:
+        # Python's str.lower() is accent-preserving, mirroring the
+        # accent-sensitive UNIQUE on MySQL.
+        if row.name.lower() == new_lower:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An organization with that name already exists",
+            )
 
     org.name = new_name
     return (old_name, new_name)

--- a/backend/tests/test_orgs_rename.py
+++ b/backend/tests/test_orgs_rename.py
@@ -1,0 +1,443 @@
+"""Router + service tests for Track D — PATCH /api/v1/orgs/{org_id}/rename.
+
+The endpoint is owner-scoped to the caller's own organization. These
+tests pin:
+
+- Auth gate (OWNER only; ADMIN/MEMBER → 403; unauthenticated → 401/403).
+- Cross-tenant blocking (path ``org_id`` must equal the caller's
+  own ``org_id``).
+- Validation rules (empty after trim, > 80 chars).
+- Whitespace normalization (Pydantic-side trim + collapse).
+- Case-insensitive uniqueness via the migration's UNIQUE on
+  ``LOWER(name)``.
+- Accent sensitivity (Café vs Cafe stays distinct).
+- Same-name no-op (no audit row, no DB write).
+- Audit-event emission (success on the request session,
+  failure on an independent session — survives rollback).
+
+Service-layer behavior is also covered here for the ``rename_org``
+helper since the surface is small enough to keep in one file.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.user import Organization, Role, User
+from app.routers.orgs import router as orgs_router
+from app.security import hash_password
+from app.services import org_service
+
+
+# ── Fixture: in-memory aiosqlite + FK enforcement + UNIQUE LOWER(name) ──────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        # Mirror the migration's UNIQUE INDEX on LOWER(name) so the
+        # case-insensitive constraint is exercised in tests too.
+        await conn.execute(text(
+            "CREATE UNIQUE INDEX uq_organizations_name_normalized "
+            "ON organizations (LOWER(name))"
+        ))
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+# ── Test app builder ───────────────────────────────────────────────────────
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(orgs_router)
+    return app
+
+
+# ── Seed helpers ───────────────────────────────────────────────────────────
+
+
+ORG_A_NAME = "Acme Household"
+ORG_B_NAME = "Wayne Household"
+
+
+async def _seed(factory, *, second_org_name: str | None = None) -> dict:
+    """One org with owner + admin + member, plus an optional second
+    org for cross-tenant / dup-name tests.
+    """
+    async with factory() as db:
+        org_a = Organization(name=ORG_A_NAME, billing_cycle_day=1)
+        db.add(org_a)
+        await db.commit()
+
+        owner = User(
+            org_id=org_a.id, username="owner", email="o@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        admin = User(
+            org_id=org_a.id, username="admin", email="a@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.ADMIN, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        member = User(
+            org_id=org_a.id, username="member", email="m@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([owner, admin, member])
+        await db.commit()
+
+        org_b_id = None
+        if second_org_name is not None:
+            org_b = Organization(name=second_org_name, billing_cycle_day=1)
+            db.add(org_b)
+            await db.commit()
+            org_b_id = org_b.id
+
+        return {
+            "org_a_id": org_a.id,
+            "org_b_id": org_b_id,
+            "owner_id": owner.id,
+            "admin_id": admin.id,
+            "member_id": member.id,
+        }
+
+
+def _resolver_for(role: Role):
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.role == role))
+            ).scalar_one()
+    return resolve
+
+
+async def _audit_rows(factory) -> list[AuditEvent]:
+    async with factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).order_by(AuditEvent.id.asc())
+            )
+        ).scalars().all()
+        return list(rows)
+
+
+# ── Auth gate ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_org_success_owner(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "Acme Inc"},
+        )
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["id"] == seed["org_a_id"]
+    assert body["name"] == "Acme Inc"
+    assert body["billing_cycle_day"] == 1
+
+    # DB updated.
+    async with session_factory() as db:
+        org = (await db.execute(
+            select(Organization).where(Organization.id == seed["org_a_id"])
+        )).scalar_one()
+        assert org.name == "Acme Inc"
+
+    # Success audit row written via the request session.
+    rows = await _audit_rows(session_factory)
+    success = [r for r in rows if r.event_type == "org.rename" and r.outcome == AuditOutcome.SUCCESS]
+    assert len(success) == 1
+    row = success[0]
+    assert row.actor_user_id == seed["owner_id"]
+    assert row.actor_email == "o@acme.io"
+    assert row.target_org_id == seed["org_a_id"]
+    assert row.target_org_name == "Acme Inc"
+    assert row.detail == {"old_name": ORG_A_NAME, "new_name": "Acme Inc"}
+
+
+@pytest.mark.asyncio
+async def test_rename_org_admin_forbidden(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.ADMIN))
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "Acme Inc"},
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_rename_org_member_forbidden(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.MEMBER))
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "Acme Inc"},
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_rename_org_unauthenticated(session_factory):
+    """No `get_current_user` override → real HTTPBearer dep runs and
+    rejects the missing Authorization header. FastAPI's HTTPBearer
+    returns 403 on missing creds (not 401), same behaviour every
+    other authed route exhibits in this app.
+    """
+    seed = await _seed(session_factory)
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(orgs_router)
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "Acme Inc"},
+        )
+    assert res.status_code in (401, 403)
+
+
+# ── Uniqueness ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_org_duplicate_case_insensitive(session_factory):
+    """OWNER tries to rename their org to a name another org already
+    holds (case-insensitive). Returns 409 and writes a failure-path
+    audit row via the independent session.
+    """
+    seed = await _seed(session_factory, second_org_name="Acme")
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "acme"},
+        )
+
+    assert res.status_code == 409
+    assert res.json() == {"detail": "An organization with that name already exists"}
+
+    # No success row, one failure row with attempted name.
+    rows = await _audit_rows(session_factory)
+    success = [r for r in rows if r.outcome == AuditOutcome.SUCCESS]
+    failure = [r for r in rows if r.outcome == AuditOutcome.FAILURE]
+    assert success == []
+    assert len(failure) == 1
+    fail = failure[0]
+    assert fail.event_type == "org.rename"
+    assert fail.actor_user_id == seed["owner_id"]
+    assert fail.target_org_id == seed["org_a_id"]
+    assert fail.target_org_name == "acme"
+    assert fail.detail == {"attempted_name": "acme"}
+
+    # Original org name unchanged.
+    async with session_factory() as db:
+        org = (await db.execute(
+            select(Organization).where(Organization.id == seed["org_a_id"])
+        )).scalar_one()
+        assert org.name == ORG_A_NAME
+
+
+@pytest.mark.asyncio
+async def test_rename_org_duplicate_accent_sensitive(session_factory):
+    """SQLite's LOWER() folds ASCII case but is binary on accents,
+    matching the MySQL migration's ``utf8mb4_0900_as_cs`` collation.
+    'Cafe' and 'Café' coexist.
+    """
+    seed = await _seed(session_factory, second_org_name="Cafe")
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "Café"},
+        )
+
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        org = (await db.execute(
+            select(Organization).where(Organization.id == seed["org_a_id"])
+        )).scalar_one()
+        assert org.name == "Café"
+
+
+# ── No-op ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_org_no_op_same_name(session_factory):
+    """Submitting the current name short-circuits to a 200 with the
+    unchanged row. NO audit row, NO DB write.
+    """
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": ORG_A_NAME},
+        )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["name"] == ORG_A_NAME
+
+    rows = await _audit_rows(session_factory)
+    assert rows == []  # neither success nor failure rows
+
+
+@pytest.mark.asyncio
+async def test_rename_org_no_op_only_whitespace_difference(session_factory):
+    """``"  Acme   Household  "`` collapses to ``"Acme Household"``
+    via Pydantic's normalizer, which equals the current name → no-op.
+    """
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "  Acme   Household  "},
+        )
+
+    assert res.status_code == 200
+    rows = await _audit_rows(session_factory)
+    assert rows == []
+
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_org_validation_empty_after_trim(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": "   "},
+        )
+
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_rename_org_validation_too_long(session_factory):
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+    too_long = "A" * 81
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_a_id']}/rename",
+            json={"name": too_long},
+        )
+
+    assert res.status_code == 422
+
+
+# ── Cross-tenant ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_org_cross_tenant_blocked(session_factory):
+    """OWNER of org A targets ``/api/v1/orgs/{org_b_id}/rename`` →
+    403. The owner-only role gate is satisfied, but the path id
+    doesn't match ``current_user.org_id``.
+    """
+    seed = await _seed(session_factory, second_org_name="Wayne Household")
+    app = make_app(session_factory, _resolver_for(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/orgs/{seed['org_b_id']}/rename",
+            json={"name": "Wayne Inc"},
+        )
+
+    assert res.status_code == 403
+
+
+# ── Service unit test ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rename_org_normalizes_whitespace_in_preflight(session_factory):
+    """Direct ``rename_org`` call with a whitespace-collapsed name
+    that resolves to the current name (case-insensitively) returns
+    a no-op tuple ``(old, old)`` without raising. This pins the
+    service-level guard independent of the Pydantic layer.
+    """
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        old, new = await org_service.rename_org(
+            db, org_id=seed["org_a_id"], new_name="acme household",
+        )
+        assert old == ORG_A_NAME
+        assert new == ORG_A_NAME

--- a/backend/tests/test_orgs_rename.py
+++ b/backend/tests/test_orgs_rename.py
@@ -441,3 +441,76 @@ async def test_rename_org_normalizes_whitespace_in_preflight(session_factory):
         )
         assert old == ORG_A_NAME
         assert new == ORG_A_NAME
+
+
+@pytest.mark.asyncio
+async def test_rename_org_service_preflight_is_accent_sensitive(session_factory):
+    """Service-level pin for the accent-sensitive preflight.
+
+    Regression: the original preflight used
+    ``Organization.name.ilike(new_name)``. On MySQL with the base
+    column's default ``utf8mb4_0900_ai_ci`` collation, ``ilike``
+    treats "Cafe" and "Café" as equal and would 409 a rename that
+    the actual UNIQUE on the ``utf8mb4_0900_as_cs``-collated
+    ``name_normalized`` column would happily accept.
+
+    There's a route-level test (``test_rename_org_duplicate_accent_sensitive``)
+    that exercises this path through the API on SQLite, but the SQL
+    operator behaviour differs by dialect. This test calls the
+    service directly so the intent — "accent-different names are NOT
+    duplicates" — is greppable at the comparison's site.
+    """
+    seed = await _seed(session_factory, second_org_name="Cafe")
+    async with session_factory() as db:
+        old, new = await org_service.rename_org(
+            db, org_id=seed["org_a_id"], new_name="Café",
+        )
+        assert old == ORG_A_NAME
+        assert new == "Café"
+
+
+@pytest.mark.asyncio
+async def test_rename_org_service_preflight_does_not_treat_underscore_as_wildcard(
+    session_factory,
+):
+    """Service-level pin that the preflight uses exact comparison,
+    not SQL ``LIKE`` wildcards.
+
+    Regression: ``ilike("FooXbar")`` would NOT have matched a row
+    named "Foo_bar" — wrong direction for that example. The real
+    risk with ``ilike`` is the inverse: ``ilike("Foo_bar")`` matches
+    "FooXbar" because ``_`` is the single-char wildcard. Seed an org
+    "Foo_bar", then attempt to rename to "Foo_bar" exactly while
+    another org "FooXbar" exists. The exact match should still
+    409 (collision with self-named row). The flip case — exists
+    "FooXbar", rename target "Foo_bar" — should NOT 409 because
+    the names are genuinely different.
+    """
+    seed = await _seed(session_factory, second_org_name="FooXbar")
+    async with session_factory() as db:
+        # Distinct names, distinct rows: this rename must succeed.
+        old, new = await org_service.rename_org(
+            db, org_id=seed["org_a_id"], new_name="Foo_bar",
+        )
+        assert old == ORG_A_NAME
+        assert new == "Foo_bar"
+
+
+@pytest.mark.asyncio
+async def test_rename_org_service_preflight_case_insensitive_still_blocks(
+    session_factory,
+):
+    """Companion to the accent-sensitive test: confirm the preflight
+    still raises 409 when the new name differs from another org's
+    name only by ASCII case. Belt-and-suspenders alongside the
+    route-level case-insensitive test.
+    """
+    from fastapi import HTTPException
+
+    seed = await _seed(session_factory, second_org_name="Acme")
+    async with session_factory() as db:
+        with pytest.raises(HTTPException) as exc:
+            await org_service.rename_org(
+                db, org_id=seed["org_a_id"], new_name="ACME",
+            )
+        assert exc.value.status_code == 409

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -17,6 +17,7 @@ import {
   input,
   label,
   btnPrimary,
+  btnSecondary,
   card,
   cardHeader,
   cardTitle,
@@ -26,7 +27,7 @@ import {
 import type { OrgSetting } from "@/lib/types";
 
 export default function OrganizationSettingsPage() {
-  const { user, loading } = useAuth();
+  const { user, loading, refreshMe } = useAuth();
   const router = useRouter();
 
   const [settings, setSettings] = useState<OrgSetting[]>([]);
@@ -66,6 +67,15 @@ export default function OrganizationSettingsPage() {
   const [resetPhrase, setResetPhrase] = useState("");
   const [resetting, setResetting] = useState(false);
   const [resetError, setResetError] = useState("");
+
+  // Track D — owner-only org rename. Read-only display for non-owners.
+  // Same superadmin caveat as the Danger Zone above: the backend's
+  // require_org_owner gate refuses the platform-superadmin bypass on
+  // tenant routes, so the UI mirrors that strictness exactly.
+  const [renaming, setRenaming] = useState(false);
+  const [renameDraft, setRenameDraft] = useState("");
+  const [renameSaving, setRenameSaving] = useState(false);
+  const [renameError, setRenameError] = useState("");
 
   const admin = user ? isAdmin(user) : false;
   const isOrgOwner = user?.role === "owner";
@@ -124,6 +134,55 @@ export default function OrganizationSettingsPage() {
         });
     }
   }, [admin, reload]);
+
+  function startRename() {
+    setRenameDraft(orgName);
+    setRenameError("");
+    setRenaming(true);
+  }
+
+  function cancelRename() {
+    setRenaming(false);
+    setRenameDraft("");
+    setRenameError("");
+  }
+
+  async function handleSaveRename(e: FormEvent) {
+    e.preventDefault();
+    if (!user) return;
+    const trimmed = renameDraft.trim();
+    // Client-side guards mirror the server: empty/whitespace-only
+    // is rejected here so we don't flash a spinner only to see a 422.
+    // Same-name submissions also short-circuit; the server treats
+    // them as a no-op but there's no point in the round trip.
+    if (trimmed === "") {
+      setRenameError("Name cannot be empty");
+      return;
+    }
+    if (trimmed === orgName) {
+      cancelRename();
+      return;
+    }
+    setRenameSaving(true);
+    setRenameError("");
+    try {
+      await apiFetch(`/api/v1/orgs/${user.org_id}/rename`, {
+        method: "PATCH",
+        body: JSON.stringify({ name: trimmed }),
+      });
+      // Pull the fresh user shape so org_name updates everywhere
+      // that reads from AuthContext (sidebar, header, etc.).
+      await refreshMe();
+      setRenaming(false);
+      setRenameDraft("");
+      setSuccessMsg("Organization renamed");
+      setTimeout(() => setSuccessMsg(""), 3000);
+    } catch (err) {
+      setRenameError(extractErrorMessage(err, "Failed to rename organization"));
+    } finally {
+      setRenameSaving(false);
+    }
+  }
 
   async function handleSaveCycle(e: FormEvent) {
     e.preventDefault();
@@ -250,7 +309,74 @@ export default function OrganizationSettingsPage() {
             <h2 className={cardTitle}>Organization</h2>
           </div>
           <div className="p-6">
-            <p className="text-sm text-text-secondary">{user.org_name}</p>
+            {isOrgOwner ? (
+              renaming ? (
+                <form onSubmit={handleSaveRename} className="space-y-3">
+                  <label className={label} htmlFor="org-rename-input">
+                    New organization name
+                  </label>
+                  <input
+                    id="org-rename-input"
+                    type="text"
+                    className={input}
+                    value={renameDraft}
+                    onChange={(e) => setRenameDraft(e.target.value)}
+                    maxLength={80}
+                    autoFocus
+                    aria-invalid={renameError ? true : undefined}
+                    aria-describedby={renameError ? "org-rename-error" : undefined}
+                  />
+                  {renameError && (
+                    <p id="org-rename-error" className={errorCls}>
+                      {renameError}
+                    </p>
+                  )}
+                  <div className="flex gap-2">
+                    <button
+                      type="submit"
+                      disabled={
+                        renameSaving ||
+                        renameDraft.trim() === "" ||
+                        renameDraft.trim() === orgName
+                      }
+                      className={btnPrimary}
+                      aria-label="Save organization name"
+                    >
+                      {renameSaving ? (
+                        <span className="inline-flex items-center gap-2">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Saving...
+                        </span>
+                      ) : (
+                        "Save"
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelRename}
+                      disabled={renameSaving}
+                      className={btnSecondary}
+                      aria-label="Cancel organization rename"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <div className="flex items-center justify-between gap-4">
+                  <p className="text-sm text-text-secondary">{user.org_name}</p>
+                  <button
+                    type="button"
+                    onClick={startRename}
+                    className={btnSecondary}
+                  >
+                    Rename
+                  </button>
+                </div>
+              )
+            ) : (
+              <p className="text-sm text-text-secondary">{user.org_name}</p>
+            )}
           </div>
         </div>
 

--- a/frontend/tests/settings/organization-rename.test.tsx
+++ b/frontend/tests/settings/organization-rename.test.tsx
@@ -1,0 +1,220 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import OrganizationSettingsPage from "@/app/settings/organization/page";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { mutate } from "swr";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("swr", async () => {
+  const actual = await vi.importActual<typeof import("swr")>("swr");
+  return { ...actual, mutate: vi.fn(() => Promise.resolve()) };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => "/settings/organization",
+}));
+
+const ORG_NAME = "Acme Household";
+const ORG_ID = 42;
+
+function makeUser(role: "owner" | "admin" | "member") {
+  return {
+    id: 1, username: "u", email: "u@x.io",
+    first_name: null, last_name: null, phone: null, avatar_url: null,
+    email_verified: true,
+    role,
+    org_id: ORG_ID, org_name: ORG_NAME, billing_cycle_day: 1,
+    is_superadmin: false, is_active: true, mfa_enabled: false,
+    subscription_status: null, subscription_plan: null, trial_end: null,
+  };
+}
+
+function mockApiBaseFixtures() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period") return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings") return Promise.resolve([]);
+    if (url === "/api/v1/orgs/members") return Promise.resolve([]);
+    if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
+    if (url === "/api/v1/category-rules") return Promise.resolve([]);
+    return Promise.resolve({});
+  }) as never);
+}
+
+function mockUser(role: "owner" | "admin" | "member", refreshMe = vi.fn()) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: makeUser(role) as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe,
+  } as never);
+  return refreshMe;
+}
+
+describe("OrganizationSettingsPage — rename", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    vi.mocked(mutate).mockClear();
+    mockApiBaseFixtures();
+  });
+
+  it("renames org successfully and refreshes user", async () => {
+    const refreshMe = vi.fn().mockResolvedValue(undefined);
+    mockUser("owner", refreshMe);
+
+    // Layer the rename success on top of the base GET fixtures.
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (init?.method === "PATCH" && url === `/api/v1/orgs/${ORG_ID}/rename`) {
+        return Promise.resolve({ id: ORG_ID, name: "Acme Inc", billing_cycle_day: 1 });
+      }
+      if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+      if (url === "/api/v1/settings/billing-period") return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      if (url === "/api/v1/settings") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/members") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
+      if (url === "/api/v1/category-rules") return Promise.resolve([]);
+      return Promise.resolve({});
+    }) as never);
+
+    render(<OrganizationSettingsPage />);
+
+    // Open the edit form.
+    const renameButton = await screen.findByRole("button", { name: /^rename$/i });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByLabelText(/new organization name/i) as HTMLInputElement;
+    expect(input.value).toBe(ORG_NAME);
+
+    // Type a new name and submit.
+    fireEvent.change(input, { target: { value: "Acme Inc" } });
+    fireEvent.click(screen.getByRole("button", { name: /save organization name/i }));
+
+    await waitFor(() => {
+      const call = vi.mocked(apiFetch).mock.calls.find(
+        ([url, opts]) => url === `/api/v1/orgs/${ORG_ID}/rename` && (opts as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(call).toBeTruthy();
+      const init = call![1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual({ name: "Acme Inc" });
+    });
+
+    await waitFor(() => expect(refreshMe).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText(/organization renamed/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 409 error message on duplicate", async () => {
+    mockUser("owner");
+
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (init?.method === "PATCH" && url === `/api/v1/orgs/${ORG_ID}/rename`) {
+        return Promise.reject(
+          new ApiResponseError(409, "An organization with that name already exists"),
+        );
+      }
+      if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+      if (url === "/api/v1/settings/billing-period") return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      if (url === "/api/v1/settings") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/members") return Promise.resolve([]);
+      if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
+      if (url === "/api/v1/category-rules") return Promise.resolve([]);
+      return Promise.resolve({});
+    }) as never);
+
+    render(<OrganizationSettingsPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /^rename$/i }));
+    const input = screen.getByLabelText(/new organization name/i);
+    fireEvent.change(input, { target: { value: "Other Co" } });
+    fireEvent.click(screen.getByRole("button", { name: /save organization name/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/an organization with that name already exists/i),
+      ).toBeInTheDocument(),
+    );
+    // Form stays open so the user can correct.
+    expect(screen.getByLabelText(/new organization name/i)).toBeInTheDocument();
+  });
+
+  it("non-owner sees read-only display, no form", async () => {
+    mockUser("admin");
+    render(<OrganizationSettingsPage />);
+
+    // Org name still visible somewhere on the card.
+    await waitFor(() =>
+      expect(screen.getAllByText(ORG_NAME).length).toBeGreaterThan(0),
+    );
+    // No Rename button for non-owners.
+    expect(screen.queryByRole("button", { name: /^rename$/i })).toBeNull();
+    // No edit input either.
+    expect(screen.queryByLabelText(/new organization name/i)).toBeNull();
+  });
+
+  it("validates client-side empty input", async () => {
+    mockUser("owner");
+    render(<OrganizationSettingsPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /^rename$/i }));
+    const input = screen.getByLabelText(/new organization name/i);
+
+    // Whitespace-only input → Save button is disabled (no API call fires).
+    fireEvent.change(input, { target: { value: "   " } });
+    const saveButton = screen.getByRole("button", { name: /save organization name/i }) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+
+    // No PATCH was issued.
+    const patchCalls = vi.mocked(apiFetch).mock.calls.filter(
+      ([url, opts]) => url === `/api/v1/orgs/${ORG_ID}/rename` && (opts as RequestInit | undefined)?.method === "PATCH",
+    );
+    expect(patchCalls.length).toBe(0);
+  });
+
+  it("cancels edit returns to read-only view without API call", async () => {
+    mockUser("owner");
+    render(<OrganizationSettingsPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /^rename$/i }));
+
+    const input = screen.getByLabelText(/new organization name/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Some Draft" } });
+    fireEvent.click(screen.getByRole("button", { name: /cancel organization rename/i }));
+
+    // Form gone, original name still showing.
+    await waitFor(() =>
+      expect(screen.queryByLabelText(/new organization name/i)).toBeNull(),
+    );
+    expect(screen.getAllByText(ORG_NAME).length).toBeGreaterThan(0);
+
+    // No PATCH was issued.
+    const patchCalls = vi.mocked(apiFetch).mock.calls.filter(
+      ([url, opts]) => url === `/api/v1/orgs/${ORG_ID}/rename` && (opts as RequestInit | undefined)?.method === "PATCH",
+    );
+    expect(patchCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds an OWNER-only PATCH /api/v1/orgs/{org_id}/rename endpoint and edit-in-place UI in Settings > Organization. Names are case-insensitively unique (DB-enforced via a stored generated column on MySQL, UNIQUE INDEX on LOWER(name) for SQLite tests), accent-sensitive (Cafe and Café coexist), trimmed and whitespace-collapsed, control-char rejected. Same-name submissions short-circuit to a no-op (no audit row, no DB write). Successful renames stage their audit row in the request session so it commits atomically with the rename, while validation, 404, 409, and cross-tenant rejections record a failure-path audit row on an independent session so the forensic trail survives the business rollback. Cross-tenant attempts (the OWNER of org A targeting org B) are 403, and the 409 body never names the conflicting org. Frontend gates the form to user.role === "owner" exactly (no superadmin tenant bypass), client-side disables Save until the draft is non-empty and changed, and refreshMe() pulls the new name into AuthContext on success so the sidebar/header update without a full reload.