### PR TITLE
feat(docs): scaffold public /docs route for in-app user manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,11 @@ mysql_data/
 .playwright-mcp/
 .cursor/
 .mcp.json
-# docs/ is intentionally kept out of the repo until we start a real user-
-# facing documentation / manual effort. Design decision records and
-# planning artifacts live in ~/.claude/projects/<slug>/specs/ (local).
-# When a dedicated docs effort starts, remove or scope this line.
-docs/
+# Top-level docs/ is intentionally kept out of the repo: design decision
+# records and planning artifacts live in ~/.claude/projects/<slug>/specs/
+# (local). The user-facing /docs page lives at frontend/app/docs/ which
+# this rule explicitly does not ignore (leading slash anchors the match).
+/docs/
 
 # Local test fixtures and scratch
 mock/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ cp .env.example .env    # First time only
 
 - App: http://localhost
 - API: http://localhost/api/
-- API docs: http://localhost/docs
+- API docs (Swagger): http://localhost/api/docs
+- In-app user manual: http://localhost/docs
 
 ## Common Commands
 
@@ -95,6 +96,6 @@ frontend/
 - **Auth on every endpoint** — use `get_current_user` dependency. Only /health, /ready, /api/v1/auth/login, /api/v1/auth/register, /api/v1/auth/refresh are public.
 - **Enum values** — SQLAlchemy enums use `values_callable=lambda x: [e.value for e in x]` to store lowercase values in MySQL
 - **Frontend has two Dockerfiles** — `Dockerfile.dev` for local dev (hot reload with volume mounts), `Dockerfile` for production (multi-stage standalone build, ~slim image)
-- **nginx is the single entry point** — backend and frontend only expose ports internally. `/api/*` routes to FastAPI, everything else to Next.js. `/docs` and `/openapi.json` are proxied directly.
+- **nginx is the single entry point** — backend and frontend only expose ports internally. `/api/*` routes to FastAPI, everything else to Next.js. FastAPI's Swagger UI is served at `/api/docs` (with `/api/openapi.json`) so `/docs` is free for the public in-app user manual served by Next.js.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,8 +373,8 @@ doctl apps create-deployment <app-id>
 
 ## API Documentation
 
-- **Swagger UI:** http://localhost/docs (development)
-- **OpenAPI spec:** http://localhost/openapi.json
+- **Swagger UI:** http://localhost/api/docs (development)
+- **OpenAPI spec:** http://localhost/api/openapi.json
 
 All API routes are prefixed with `/api/v1/`. The API is organized by resource:
 
@@ -406,7 +406,7 @@ cd frontend && npx tsc --noEmit
 ### Backend (manual)
 
 No automated test suite yet. Test via:
-- Swagger UI at http://localhost/docs
+- Swagger UI at http://localhost/api/docs
 - Browser testing of full flows
 - API calls via `curl` or httpie
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full architecture breakdown, envi
 
 ## API Documentation
 
-Swagger UI is available at http://localhost/docs when running locally.
+Swagger UI is available at http://localhost/api/docs when running locally.
 
 | Resource | Prefix | Description |
 |----------|--------|-------------|

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,8 +81,12 @@ _is_dev = app_settings.app_env == "development"
 app = FastAPI(
     title=app_settings.app_name,
     lifespan=lifespan,
-    docs_url="/docs" if _is_dev else None,
-    openapi_url="/openapi.json" if _is_dev else None,
+    # Swagger UI moved under /api/ so the frontend can own /docs as the
+    # public in-app user manual. The browser path is /api/docs (proxied
+    # by nginx through the existing /api/* rule); FastAPI serves
+    # /api/docs and /api/openapi.json directly.
+    docs_url="/api/docs" if _is_dev else None,
+    openapi_url="/api/openapi.json" if _is_dev else None,
     redoc_url=None,
 )
 

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -1,0 +1,259 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import BackLink from "@/components/ui/BackLink";
+import { pageSocialMeta, siteName } from "@/lib/site";
+
+const description =
+  "Rough user manual for The Better Decision: core concepts, common workflows, and admin tasks.";
+
+export const metadata: Metadata = {
+  title: "Docs",
+  description,
+  alternates: {
+    canonical: "/docs",
+  },
+  ...pageSocialMeta({
+    title: `Docs · ${siteName}`,
+    description,
+    path: "/docs",
+  }),
+};
+
+const sections = [
+  { id: "overview", label: "Overview" },
+  { id: "core-concepts", label: "Core concepts" },
+  { id: "common-workflows", label: "Common workflows" },
+  { id: "admin-workflows", label: "Admin workflows" },
+  { id: "system-health", label: "System health" },
+  { id: "whats-next", label: "What's next" },
+];
+
+export default function DocsPage() {
+  return (
+    <div className="relative min-h-screen px-4 py-12">
+      <ThemeToggle className="absolute right-6 top-6" />
+      <article className="mx-auto max-w-2xl">
+        <header className="mb-10">
+          <BackLink />
+          <h1 className="mt-6 font-display text-3xl font-semibold text-text-primary">
+            Docs
+          </h1>
+          <p className="mt-2 text-sm text-text-muted">
+            A short, in-app manual. Rough scaffolding, will grow over
+            time.
+          </p>
+          <nav
+            aria-label="On this page"
+            className="mt-6 rounded-lg border border-border bg-surface p-4"
+          >
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-text-muted">
+              On this page
+            </p>
+            <ul className="grid gap-1.5 text-sm sm:grid-cols-2">
+              {sections.map((s) => (
+                <li key={s.id}>
+                  <a
+                    href={`#${s.id}`}
+                    className="text-text-secondary hover:text-text-primary"
+                  >
+                    {s.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </header>
+
+        <div className="space-y-8 text-text-primary [&_h2]:font-display [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mb-3 [&_h2]:mt-8 [&_h3]:font-display [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mb-2 [&_h3]:mt-6 [&_p]:text-sm [&_p]:leading-relaxed [&_p]:text-text-secondary [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-sm [&_ul]:leading-relaxed [&_ul]:text-text-secondary [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:text-sm [&_ol]:leading-relaxed [&_ol]:text-text-secondary [&_li]:mt-1">
+          <section>
+            <h2 id="overview">What is The Better Decision</h2>
+            <p>
+              The Better Decision (codename pfv) is a personal finance
+              app for households and individuals. It tracks accounts,
+              transactions, budgets, and forecasts, all scoped to your
+              organization. Categories are the backbone of the model:
+              budgets and forecasts ride on top of them, and most
+              reporting is grouped by category. The app is pre-launch,
+              so copy may be rough and some flows are still evolving.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="core-concepts">Core concepts</h2>
+            <ul>
+              <li>
+                <strong>Organizations.</strong> Every user belongs to an
+                organization. All data (accounts, transactions,
+                categories, plans) is scoped to that organization.
+              </li>
+              <li>
+                <strong>Members and roles.</strong> Within an org, users
+                are owner, admin, or member. There is also a platform
+                superadmin role for operators of the service.
+              </li>
+              <li>
+                <strong>Accounts.</strong> Bank accounts, credit cards,
+                cash, savings. Each account has a type and a balance
+                derived from its transactions.
+              </li>
+              <li>
+                <strong>Categories.</strong> Hierarchical: master
+                categories group related subcategories. Each category
+                has a type (income, expense, or both) which constrains
+                where it can be used.
+              </li>
+              <li>
+                <strong>Transactions.</strong> Every transaction has a
+                purchase date and a settled date. The settled date
+                determines which billing period the transaction belongs
+                to, which matters for credit cards where the purchase
+                and the statement fall in different months.
+              </li>
+              <li>
+                <strong>Recurring transactions.</strong> Templates that
+                fire on a cadence (monthly, weekly, biweekly, and so
+                on) and generate transactions automatically.
+              </li>
+              <li>
+                <strong>Forecasts and budgets.</strong> Budgets are the
+                current-period control surface. Forecast plans are
+                forward-looking projections per category, used by the
+                dashboard to show what the period is on track for.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 id="common-workflows">Common workflows</h2>
+
+            <h3>Importing a CSV</h3>
+            <p>
+              From the Import page, upload a CSV from your bank. The
+              app parses the file, suggests categories where it can
+              (auto-categorization), and shows a preview before
+              anything is written. Confirm the preview to commit the
+              rows as transactions.
+            </p>
+
+            <h3>Editing a transaction inline</h3>
+            <p>
+              On the Transactions page, click a row to expand the
+              inline editor. You can change the amount, dates,
+              category, and notes without leaving the list.
+            </p>
+
+            <h3>Promoting a transaction to recurring</h3>
+            <p>
+              When editing a transaction, the inline row exposes a
+              "Promote to recurring" action that turns the transaction
+              into a recurring template, so the same charge generates
+              automatically next period.
+            </p>
+
+            <h3>Marking transactions as a transfer pair</h3>
+            <p>
+              When money moves between two of your own accounts, you
+              can either record the pair from the start (Add transfer)
+              or convert an existing transaction by selecting its
+              counterparty. The pair is then excluded from
+              category-level spending so transfers do not double-count.
+            </p>
+
+            <h3>Setting up a forecast plan</h3>
+            <p>
+              From the Forecast Plans page, create a plan for the
+              current or upcoming period. Categories pull from past
+              activity and recurring templates as starting points;
+              edit the per-category amount to match your expectation
+              and save.
+            </p>
+
+            <h3>Reviewing the dashboard verdict</h3>
+            <p>
+              The dashboard summarizes the period with an On Track
+              verdict that anchors on what has actually settled, not
+              just what is projected. The projection is shown
+              alongside as informational context.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="admin-workflows">Admin workflows</h2>
+            <ul>
+              <li>
+                <strong>Renaming the org.</strong> Owners can rename
+                the organization from Settings. Names are unique
+                case-insensitively across the platform, and the change
+                is captured in the audit log.
+              </li>
+              <li>
+                <strong>Inviting members.</strong> Owners and admins
+                can invite people by email. Invitees receive a link,
+                set up an account, and join the org with the role
+                chosen at invite time.
+              </li>
+              <li>
+                <strong>Managing roles and permissions.</strong>{" "}
+                Superadmins can review and edit platform roles and the
+                permissions attached to each, from the Admin area.
+              </li>
+              <li>
+                <strong>Viewing the audit log.</strong> Superadmins can
+                browse the audit log to see security and admin events
+                (logins, role changes, org renames, deletions).
+              </li>
+              <li>
+                <strong>Toggling org settings.</strong> Settings holds
+                org-level preferences (billing cycle, defaults) that
+                influence how periods are computed and how new
+                transactions are filed.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 id="system-health">System health</h2>
+            <p>
+              When something feels off (slow loads, missing data,
+              dashboard not updating), superadmins can check the Admin
+              dashboard's System health card. It reports the live
+              status of the database and Redis, including latency.
+              Failures there usually explain whatever the rest of the
+              app is doing.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="whats-next">What's next, known gaps</h2>
+            <p>
+              This page is rough scaffolding, not a finished manual.
+              Expect more depth here over time, with screenshots,
+              edge-case notes, and better cross-linking. Areas that
+              are intentionally light right now:
+            </p>
+            <ul>
+              <li>Reporting beyond the dashboard summary.</li>
+              <li>
+                A side-by-side comparison page for budgets and
+                forecasts.
+              </li>
+              <li>Onboarding for first-time users.</li>
+            </ul>
+          </section>
+        </div>
+
+        <footer className="mt-12 border-t border-border pt-6 text-xs text-text-muted">
+          See also:{" "}
+          <Link href="/privacy" className="underline hover:text-text-primary">
+            Privacy
+          </Link>{" "}
+          ·{" "}
+          <Link href="/terms" className="underline hover:text-text-primary">
+            Terms
+          </Link>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -286,6 +286,16 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <div className="lg:hidden" />
           <div className="flex items-center gap-3">
             <TrialBanner user={user} />
+            <Link
+              href="/docs"
+              className="rounded-md p-2 text-text-muted transition-colors hover:text-text-primary"
+              aria-label="Docs"
+              title="Docs"
+            >
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
+              </svg>
+            </Link>
             <ThemeToggle />
           </div>
         </header>

--- a/frontend/components/landing/LandingFooter.tsx
+++ b/frontend/components/landing/LandingFooter.tsx
@@ -9,15 +9,15 @@ export default function LandingFooter() {
           © <CurrentYear /> The Better Decision
         </div>
         <div className="flex flex-wrap items-center gap-5">
+          <Link href="/docs" className="hover:text-text-primary">
+            Docs
+          </Link>
           <Link href="/privacy" className="hover:text-text-primary">
             Privacy
           </Link>
           <Link href="/terms" className="hover:text-text-primary">
             Terms
           </Link>
-          {/* Help link intentionally omitted until roadmap L5.3 ships a
-              /help page. Visitors with questions can use the contact
-              email below in the meantime. */}
           <a
             href="mailto:hello@thebetterdecision.com"
             className="hover:text-text-primary"

--- a/frontend/components/landing/TopNav.tsx
+++ b/frontend/components/landing/TopNav.tsx
@@ -12,6 +12,12 @@ export default function TopNav() {
       </Link>
       <div className="flex items-center gap-4">
         <Link
+          href="/docs"
+          className="text-sm text-text-muted transition-colors hover:text-text-primary"
+        >
+          Docs
+        </Link>
+        <Link
           href="/login"
           className="text-sm text-text-muted transition-colors hover:text-text-primary"
         >

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -67,24 +67,10 @@ server {
         proxy_set_header X-Request-Id $request_id_final;
     }
 
-    # API docs (FastAPI disables these outside development)
-    location = /docs {
-        proxy_pass http://backend/docs;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Request-Id $request_id_final;
-    }
-
-    location = /openapi.json {
-        proxy_pass http://backend/openapi.json;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Request-Id $request_id_final;
-    }
+    # /docs is the public in-app user manual served by Next.js (falls
+    # through to the catch-all below). FastAPI's Swagger UI now lives
+    # under /api/docs and /api/openapi.json, which the /api/ rule
+    # already proxies to the backend.
 
     # Everything else goes to Next.js
     location / {

--- a/pfv
+++ b/pfv
@@ -36,7 +36,7 @@ cmd_start() {
   echo "Ready (migrations run automatically on backend startup):"
   echo "  App:      http://localhost"
   echo "  API:      http://localhost/api/"
-  echo "  API docs: http://localhost/docs"
+  echo "  API docs: http://localhost/api/docs"
 }
 
 cmd_stop() {


### PR DESCRIPTION
## Summary

- New public route at `/docs` in the Next.js frontend serving a rough in-app user manual (overview, core concepts, common workflows, admin workflows, system health, what's next). Reachable without logging in. Visual style matches the existing public-page pattern (Privacy, Terms): no `AppShell`, `BackLink` plus `ThemeToggle` in the corner, no new design primitives.
- FastAPI's Swagger UI moved from `/docs` to `/api/docs` (and `/openapi.json` to `/api/openapi.json`) so the frontend can own `/docs`. Production already disables both endpoints; the move only affects dev. nginx `location /docs` and `location /openapi.json` blocks are removed because the `/api/` rule already proxies the new paths and `/docs` falls through to the Next.js catch-all.
- Landing page `TopNav` and `LandingFooter` get a `Docs` link. Authenticated `AppShell` header gets a small Docs icon next to the theme toggle, so logged-in users can pop the manual open at any time.

## Notes

- Content is intentionally rough (about 760 words, plain JSX, no MDX). It is scaffolding to iterate on.
- `.gitignore` was tightened from `docs/` to `/docs/` so the new `frontend/app/docs/` source tree is tracked while the top-level `docs/` ignore (planning artifacts) stays in place.
- Root `CLAUDE.md` updated to reflect the new Swagger URL and the new in-app manual URL.