### PR TITLE
docs: housekeeping pass — refresh to current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,15 @@ docker compose exec backend alembic revision -m "description"
 # Rebuild after dependency changes
 docker compose up --build -d backend
 docker compose up --build -d frontend
+
+# Backend tests (run inside the backend container)
+docker compose exec backend pytest tests/...
+
+# Frontend tests
+docker compose exec frontend npm test -- tests/...
+
+# TypeScript type-check
+docker compose exec frontend npx tsc --noEmit
 ```
 
 ## Seeding
@@ -96,6 +105,8 @@ frontend/
 - **Auth on every endpoint** — use `get_current_user` dependency. Only /health, /ready, /api/v1/auth/login, /api/v1/auth/register, /api/v1/auth/refresh are public.
 - **Enum values** — SQLAlchemy enums use `values_callable=lambda x: [e.value for e in x]` to store lowercase values in MySQL
 - **Frontend has two Dockerfiles** — `Dockerfile.dev` for local dev (hot reload with volume mounts), `Dockerfile` for production (multi-stage standalone build, ~slim image)
-- **nginx is the single entry point** — backend and frontend only expose ports internally. `/api/*` routes to FastAPI, everything else to Next.js. FastAPI's Swagger UI is served at `/api/docs` (with `/api/openapi.json`) so `/docs` is free for the public in-app user manual served by Next.js.
+- **nginx is the single entry point in dev** — backend and frontend only expose ports internally. `/api/*` routes to FastAPI, everything else to Next.js. FastAPI's Swagger UI is served at `/api/docs` (with `/api/openapi.json`) so `/docs` is free for the public in-app user manual served by Next.js. In production (DO App Platform) ingress takes nginx's role.
+- **Production data plane is self-hosted** — MySQL 8 and Redis run on a single dedicated DO droplet (`pfv-data-01`) in a private VPC; App Platform reaches them over the VPC's private IPv4. Runbook lives in `infra/MIGRATION.md`. Terraform is VCS-driven via TFC (workspace `FlamaCorp/pfv`), with manual Confirm & Apply on merge.
+- **Sensitive admin / org actions are audited** — org rename, org-data wipe, override sweep, role edits, etc. write to `audit_events` and surface in `/admin/audit`.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -467,13 +467,13 @@ All API routes are prefixed with `/api/v1/`. The API is organized by resource:
 | Import | `/api/v1/import` | CSV file import (preview + confirm) |
 | Settings | `/api/v1/settings` | Org settings, billing periods, billing cycle |
 | Orgs | `/api/v1/orgs` | Org rename (owner-only) and per-org actions |
-| Org members | `/api/v1/orgs/.../members` | Membership and invitations |
-| Org data | `/api/v1/org-data` | Org-data wipe / reset (audited, lock-guarded) |
+| Org members | `/api/v1/orgs/members`, `/api/v1/orgs/invitations` | Membership and invitations |
+| Org data | `/api/v1/orgs/data` | Org-data wipe / reset (audited, lock-guarded) |
 | Plans | `/api/v1/plans` | Plan catalog |
 | Subscriptions | `/api/v1/subscriptions` | Trial / subscription state |
 | Admin | `/api/v1/admin` | Superadmin dashboard |
 | Admin orgs | `/api/v1/admin/orgs` | Superadmin org management + override sweep |
-| Admin audit | `/api/v1/admin/audit-events` | Audit log (durable trail) |
+| Admin audit | `/api/v1/admin/audit` | Audit log (durable trail) |
 | Admin roles | `/api/v1/admin/roles` | Custom role + permission editing |
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,50 +94,84 @@ In production (DigitalOcean App Platform), nginx is replaced by DO's built-in in
 
 ```
 backend/app/
-├── main.py                  # App factory, lifespan, CORS, router registration
+├── main.py                  # App factory, lifespan, CORS, router registration, 422 sanitizer
 ├── config.py                # pydantic-settings — all config from env vars
 ├── database.py              # Async SQLAlchemy engine + session factory
 ├── security.py              # JWT creation/decode, bcrypt, MFA token helpers
 ├── deps.py                  # FastAPI dependencies: get_db, get_current_user
 ├── logging.py               # structlog JSON logging + health check filter
 ├── rate_limit.py            # slowapi rate limiter (shared instance)
-├── redis_client.py          # Async Redis/Valkey singleton (MFA nonce today)
+├── redis_client.py          # Async Redis singleton (MFA nonce, step-up state)
+├── middleware/              # Pure ASGI middleware (request id / context)
 ├── models/                  # SQLAlchemy ORM models
-│   ├── user.py              #   User, Organization, Role enum
+│   ├── user.py              #   User, Organization, Role enum, password_set flag
 │   ├── account.py           #   Account, AccountType
 │   ├── category.py          #   Category (hierarchical), CategoryType
-│   ├── transaction.py       #   Transaction (income/expense/transfer)
+│   ├── category_rule.py     #   Per-org auto-categorization rules
+│   ├── merchant_dictionary.py # Shared merchant -> category dictionary
+│   ├── transaction.py       #   Transaction (income/expense/transfer, settled_date)
 │   ├── recurring.py         #   RecurringTransaction templates
 │   ├── billing.py           #   BillingPeriod (org-scoped)
 │   ├── budget.py            #   Budget (per category per period)
-│   ├── forecast_plan.py     #   ForecastPlan + ForecastPlanItem
+│   ├── forecast_plan.py     #   ForecastPlan + ForecastPlanItem (with ItemSource)
+│   ├── audit_event.py       #   Durable audit log (admin + sensitive ops)
+│   ├── role.py              #   Custom roles + role_permissions
+│   ├── invitation.py        #   Org invitation tokens
+│   ├── subscription.py      #   Org subscription / trial state
+│   ├── feature_override.py  #   Per-org plan-feature overrides
+│   ├── org_data_reset_lock.py # Guard against concurrent org-data wipes
 │   └── settings.py          #   OrgSetting (key-value per org)
 ├── schemas/                 # Pydantic request/response models (mirrors models/)
 ├── routers/                 # API route handlers
-│   ├── auth.py              #   Login, register, MFA, Google SSO, password reset
+│   ├── auth.py              #   Login, register, MFA, Google SSO + step-up, password reset
 │   ├── users.py             #   Profile update, password change
 │   ├── accounts.py          #   CRUD accounts
 │   ├── account_types.py     #   CRUD account types
-│   ├── categories.py        #   CRUD categories (hierarchical)
-│   ├── transactions.py      #   CRUD transactions + transfers
+│   ├── categories.py        #   CRUD categories (hierarchical, type-locked once used)
+│   ├── transactions.py      #   CRUD transactions + transfers (settled_date period bucket)
 │   ├── recurring.py         #   CRUD recurring templates + generation
 │   ├── budgets.py           #   CRUD budgets + transfers between budgets
 │   ├── forecast.py          #   Read-only computed forecast
-│   ├── forecast_plans.py    #   CRUD editable forecast plans
+│   ├── forecast_plans.py    #   CRUD editable forecast plans (MANUAL on public writes)
 │   ├── import_router.py     #   CSV import: preview + confirm
-│   └── settings.py          #   Org settings, billing periods, billing cycle
+│   ├── settings.py          #   Org settings, billing periods, billing cycle
+│   ├── orgs.py              #   Org rename (owner-only, case-insensitive uniqueness)
+│   ├── org_members.py       #   Org membership + invitations
+│   ├── org_data.py          #   Org-data wipe / reset (audited + locked)
+│   ├── plans.py             #   Plan catalog (read)
+│   ├── subscriptions.py     #   Org subscription / trial state
+│   ├── admin.py             #   Superadmin dashboard
+│   ├── admin_orgs.py        #   Superadmin org management + override sweep
+│   ├── admin_audit.py       #   Audit log query API
+│   └── admin_roles.py       #   Custom role + permission editing
 └── services/                # Business logic (called by routers)
-    ├── billing_service.py   #   Period management, resolve_period()
-    ├── budget_service.py    #   Budget queries with spending calculations
-    ├── transaction_service.py # Shared validation helpers
-    ├── recurring_service.py #   Generate transactions from templates
-    ├── forecast_service.py  #   Compute forecast from transactions + recurring
+    ├── billing_service.py       # Period management, resolve_period()
+    ├── budget_service.py        # Budget queries with spending calculations
+    ├── transaction_service.py   # Shared validation helpers, category-type guard
+    ├── transaction_filters.py   # effective_period_date_expr() — COALESCE(settled_date, date)
+    ├── recurring_service.py     # Generate transactions from templates
+    ├── forecast_service.py      # Compute forecast from transactions + recurring
     ├── forecast_plan_service.py # Forecast plan CRUD with actual tracking
-    ├── import_parser.py     #   CSV parsing (delimiter, date, amount detection)
-    ├── import_service.py    #   Import preview + commit logic
-    ├── email_service.py     #   Mailgun (prod) / structlog (dev) email sender
-    ├── mfa_service.py       #   TOTP, QR codes, recovery codes, encryption
-    └── date_utils.py        #   Shared advance_date() for billing calculations
+    ├── category_service.py      # Category CRUD with type compatibility checks
+    ├── category_rules_service.py # Per-org auto-categorization rules
+    ├── import_parser.py         # CSV parsing (delimiter, date, amount detection)
+    ├── import_service.py        # Import preview + commit logic
+    ├── email_service.py         # Mailgun (prod) / structlog (dev) email sender
+    ├── mfa_service.py           # TOTP, QR codes, recovery codes, encryption
+    ├── audit_service.py         # Persist audit_event rows (durable admin trail)
+    ├── role_service.py          # Custom role + permission resolution
+    ├── plan_service.py          # Plan catalog
+    ├── subscription_service.py  # Trial creation, plan transitions
+    ├── feature_service.py       # Plan + per-org feature override resolution
+    ├── org_service.py           # Org rename + uniqueness checks
+    ├── org_bootstrap_service.py # First-user-becomes-superadmin bootstrap
+    ├── org_data_service.py      # Org-data wipe with snapshot + audit
+    ├── org_reset_lock_service.py # Concurrency guard for wipes
+    ├── invitation_service.py    # Org-member invitations
+    ├── admin_dashboard_service.py # Superadmin dashboard aggregates
+    ├── admin_orgs_service.py    # Superadmin org list / detail / override sweep
+    ├── exceptions.py            # Domain exception types -> HTTP mappers in main.py
+    └── date_utils.py            # Shared advance_date() for billing calculations
 ```
 
 ### Frontend (Next.js / TypeScript)
@@ -146,47 +180,66 @@ backend/app/
 frontend/
 ├── app/                     # Next.js App Router pages
 │   ├── dashboard/           #   Main dashboard with charts + summary
-│   ├── transactions/        #   Transaction list with filters
+│   ├── transactions/        #   Transaction list (period bucketed by settled_date)
 │   ├── accounts/            #   Account management
 │   ├── recurring/           #   Recurring transaction templates
 │   ├── budgets/             #   Budget management + transfers
 │   ├── forecast-plans/      #   Editable forecast plans
-│   ├── categories/          #   Category hierarchy management
+│   ├── categories/          #   Category hierarchy management (type lock once in use)
 │   ├── import/              #   CSV import wizard
 │   ├── profile/             #   User profile editing
-│   ├── settings/security/   #   Password, MFA, session lifetime
-│   ├── admin/settings/      #   Org settings, billing periods
+│   ├── settings/            #   /settings/security, /settings/billing, /settings/organization
+│   ├── admin/               #   /admin (dashboard), /admin/orgs, /admin/audit, /admin/roles, /admin/settings
 │   ├── login/               #   Login page
 │   ├── register/            #   Registration page
+│   ├── setup/               #   First-user / first-org setup
+│   ├── accept-invite/       #   Org invitation acceptance
 │   ├── mfa-verify/          #   MFA challenge during login
 │   ├── forgot-password/     #   Request password reset
 │   ├── reset-password/      #   Complete password reset
 │   ├── verify-email/        #   Email verification
-│   ├── auth/google/callback/ # Google SSO callback
+│   ├── auth/google/         #   Google SSO callback (login + step-up return)
+│   ├── system/              #   Public system / status surface
+│   ├── health/              #   Frontend health probe
 │   ├── privacy/             #   Privacy Policy (public, GDPR-compliant)
 │   └── terms/               #   Terms of Service (public)
 ├── components/
 │   ├── AppShell.tsx         #   Sidebar + header + footer layout
-│   ├── auth/AuthProvider.tsx #  Auth context, login/logout/refresh
-│   └── ui/                  #   Shared UI components
+│   ├── SettingsLayout.tsx   #   Sub-nav layout for /settings/*
+│   ├── ThemeProvider.tsx    #   Dark / light theme provider
+│   ├── auth/AuthProvider.tsx #  Auth context, login/logout/silent refresh
+│   ├── admin/               #   Admin-only widgets (orgs table, audit table, roles)
+│   ├── settings/            #   Settings sub-pages (security, billing, organization)
+│   ├── transactions/        #   List + edit row + recurring promotion
+│   ├── dashboard/           #   Dashboard tiles, charts, on-track verdict
+│   ├── landing/             #   Public marketing surface
+│   ├── system/              #   System status widgets
+│   └── ui/                  #   Shared UI primitives
 └── lib/
     ├── api.ts               #   Typed fetch wrapper with silent token refresh
     ├── types.ts             #   Shared TypeScript interfaces
-    ├── styles.ts            #   Tailwind class constants
-    ├── auth.ts              #   isAdmin() helper
+    ├── styles.ts            #   Tailwind class constants (btnPrimary, card, input, etc.)
+    ├── auth.ts              #   isAdmin() / role helpers
+    ├── feature-catalog.ts   #   Plan-feature catalog mirror (kept in sync with backend)
+    ├── format.ts            #   Currency / date formatters
     ├── logger.ts            #   Client+server structured JSON logger
-    └── validation.ts        #   Shared client-side validation rules (kept in sync with backend/app/schemas)
+    ├── pagination.ts        #   Shared list pagination helpers
+    ├── site.ts              #   Public site URL helpers (canonical, OG)
+    └── validation.ts        #   Shared client-side validation (mirrors backend/app/schemas)
 ```
 
 ### Key Design Decisions
 
 - **All config via env vars** — pydantic-settings in backend, `NEXT_PUBLIC_` prefix in frontend
 - **Stateless backend** — no in-memory state. JWT for auth, ready for horizontal scaling.
-- **Migrations auto-run on startup** in dev. In production, they run before the app starts.
+- **Migrations auto-run on startup** in dev. In production, they run as a `PRE_DEPLOY` job (App Platform) or initContainer (k8s) before the app starts.
 - **First user is superadmin** — no seed data needed for bootstrapping.
 - **Org-scoped data** — every query filters by `org_id`. Users only see their org's data.
-- **Hierarchical categories** — master categories for budgets, subcategories as transaction tags.
-- **Billing periods** — org-level month close date. `settled_date` determines which period a transaction counts against.
+- **Hierarchical categories** — master categories for budgets, subcategories as transaction tags. A category's `type` (income / expense / both) is enforced server-side on writes; once a category has been used the UI locks the type to keep historical aggregates honest.
+- **Transfer category invariant** — transfer legs require a `CategoryType.BOTH` category. The system seeds a `Transfer` master category for this; arbitrary income / expense categories on transfer legs are rejected.
+- **Billing periods** — org-level month close date. `settled_date` (or `COALESCE(settled_date, date)` for hand-keyed pending rows) determines which period a transaction counts against. The transactions list and aggregates both bucket on this effective period date.
+- **Audit trail** — sensitive admin and org actions (org rename, org-data wipe, override sweep, role edits, etc.) write a row to `audit_events` and surface in `/admin/audit`. structlog still emits the same events to stdout, but the durable trail is the table.
+- **Forecast plan source** — public writes always set `ItemSource.MANUAL`. Auto-population marks items as `RECURRING` or `HISTORY`; subsequent edits flip them to `MANUAL`. The HISTORY label surfaces as "Auto" in the UI.
 
 ---
 
@@ -194,11 +247,20 @@ frontend/
 
 ### Auth Flow
 
-1. **Login** — `POST /api/v1/auth/login` with username/email + password
-2. **MFA challenge** (if enabled) — returns `mfa_token`, user completes TOTP/recovery/email verification
+1. **Login** — `POST /api/v1/auth/login` with username/email + password, or Google SSO via `/api/v1/auth/google`
+2. **MFA challenge** (if enabled) — returns `mfa_token`, user completes TOTP / recovery / email verification
 3. **Tokens issued** — access token (15 min, in response body) + refresh token (7 day, httpOnly cookie)
 4. **Silent refresh** — frontend auto-refreshes via `POST /api/v1/auth/refresh` on 401
 5. **Absolute session lifetime** — sessions expire after a configurable max duration (default 30 days)
+
+### SSO password security
+
+Google-SSO users have `password_set=False` until they explicitly set a password. To prevent an unprompted password from being attached to a hijacked SSO session:
+
+- **First password set** requires a Google **step-up** verification. The user re-authenticates with the same Google account, the backend issues a 5-minute single-use step-up token, and only then accepts the password write.
+- **Reset password via email token** (the standard `/forgot-password` -> `/reset-password` flow) flips `password_set=True` on success, so future logins can use either Google SSO or the new password.
+- **Step-up callbacks** redirect back through a server-side allowlist of `return_to` keys. Arbitrary URLs are rejected with `400 Malformed step-up state`.
+- **Email change** also takes the step-up path and flips `password_set` back to `False` if the new email belongs to a different identity, forcing a re-set.
 
 ### MFA (Two-Factor Authentication)
 
@@ -253,7 +315,7 @@ All other endpoints require a Bearer access token via `get_current_user` depende
 | `JWT_REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token (idle timeout) |
 | `SESSION_LIFETIME_DAYS` | `30` | Absolute max session duration |
 | `COOKIE_SECURE` | `true` | Set `false` for local dev (HTTP) |
-| `REDIS_URL` | _(empty)_ | Redis/Valkey connection |
+| `REDIS_URL` | _(empty)_ | Redis connection (`redis://...`) — used for MFA nonces and SSO step-up state |
 | `MFA_ENCRYPTION_KEY` | _(empty)_ | Fernet key for TOTP secret encryption |
 | `MAILGUN_API_KEY` | _(empty)_ | Mailgun API key (emails logged if empty) |
 | `MAILGUN_DOMAIN` | _(empty)_ | Mailgun sending domain |
@@ -331,13 +393,13 @@ Migration files are in `backend/alembic/versions/` and follow sequential numberi
 
 ### DigitalOcean App Platform
 
-The app is deployed on DO App Platform (Amsterdam region) with managed MySQL and Valkey (Redis-compatible).
+The app is deployed on DO App Platform (Amsterdam region). MySQL 8 and Redis are **self-hosted** on a single dedicated DO droplet (`pfv-data-01`) in a private VPC; the App Platform components reach them over the VPC's private IPv4. Background and runbook live in `infra/README.md` and `infra/MIGRATION.md`.
 
 **GitHub Actions workflows (`.github/workflows/`):**
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `deploy.yml` | Push to `main` | Deploys to production via `digitalocean/app_action/deploy@v2` |
+| `deploy.yml` | Push to `main` | Deploys to production via `digitalocean/app_action/deploy@v2`, pushing `.do/app.yaml` as the authoritative spec |
 
 **Required GitHub repository secret:**
 
@@ -345,7 +407,7 @@ The app is deployed on DO App Platform (Amsterdam region) with managed MySQL and
 |--------|-------------|
 | `DIGITALOCEAN_ACCESS_TOKEN` | DO API token with read/write access to App Platform |
 
-**App spec:** `.do/app.yaml` defines the app structure. Secrets use placeholder values — real secrets are configured in DO console and preserved across deployments.
+**App spec:** `.do/app.yaml` is the source of truth. Secrets are committed as App Platform's encrypted `EV[...]` blobs (only readable by DO) so they survive every deploy; any secret missing from the file is removed from the live app on push. The `vpc.id` block at the top wires the app to the data-droplet's VPC and must stay populated.
 
 ### Manual Deployment
 
@@ -356,18 +418,30 @@ If you need to deploy without GitHub Actions:
 brew install doctl
 doctl auth init
 
-# Deploy current branch to the app
+# Push the spec (preferred — covers vpc, components, env, and secrets)
+doctl apps update <app-id> --spec .do/app.yaml
+
+# Or trigger a redeploy of the current spec
 doctl apps create-deployment <app-id>
 ```
 
-### Infrastructure
+### Infrastructure as code
+
+Production infra is split between App Platform (the application) and the data droplet (MySQL + Redis):
+
+- **App Platform** is described by `.do/app.yaml` and pushed via the GH Actions workflow above.
+- **Droplet, VPC, firewall, project attachment** are managed by Terraform under `infra/terraform/`. State and runs live in **HCP Terraform / Terraform Cloud** (workspace `FlamaCorp/pfv`). Workflow is VCS-driven: PRs touching `infra/terraform/**` get a speculative plan; merges to `main` create runs that require **manual Confirm & Apply** in the TFC UI. CLI `terraform plan` / `apply` is debug-only — never the routine path.
+- **Droplet bootstrap** (Ubuntu hardening, MySQL, Redis, nightly mysqldump) is managed by Ansible under `infra/ansible/`.
+
+### Infrastructure components
 
 | Component | Service | Details |
 |-----------|---------|---------|
-| Backend | DO App Service | FastAPI, basic-xxs, port 8000 |
-| Frontend | DO App Service | Next.js standalone, basic-xxs, port 3000 |
-| Database | DO Managed MySQL 8 | Single node, ams3 |
-| Cache | DO Managed Valkey 8 | Single node, ams3 |
+| Backend | DO App Service | FastAPI, `basic-xxs`, port 8000 |
+| Frontend | DO App Service | Next.js standalone, `basic-xxs`, port 3000 |
+| Database | Self-hosted MySQL 8 on `pfv-data-01` | `s-1vcpu-2gb` droplet, ams3, private VPC |
+| Cache | Self-hosted Redis on `pfv-data-01` | Same droplet, bound to private IP, `requirepass` set |
+| Backups | Nightly `mysqldump` cron on the droplet (`/var/backups/mysql/`, 7-day retention) | DO droplet snapshots are **off** at the IaC level |
 
 ---
 
@@ -380,37 +454,68 @@ All API routes are prefixed with `/api/v1/`. The API is organized by resource:
 
 | Resource | Prefix | Description |
 |----------|--------|-------------|
-| Auth | `/api/v1/auth` | Login, register, MFA, SSO, password reset |
+| Auth | `/api/v1/auth` | Login, register, MFA, Google SSO + step-up, password reset |
 | Users | `/api/v1/users` | Profile, password change |
 | Accounts | `/api/v1/accounts` | Bank accounts and balances |
 | Account Types | `/api/v1/account-types` | Checking, savings, credit card, etc. |
 | Categories | `/api/v1/categories` | Hierarchical income/expense categories |
-| Transactions | `/api/v1/transactions` | Income, expenses, transfers |
+| Transactions | `/api/v1/transactions` | Income, expenses, transfers (period bucketed by `settled_date`) |
 | Recurring | `/api/v1/recurring` | Recurring transaction templates |
 | Budgets | `/api/v1/budgets` | Per-category per-period budgets |
 | Forecast | `/api/v1/forecast` | Computed forecast (read-only) |
 | Forecast Plans | `/api/v1/forecast-plans` | Editable forecast plans |
 | Import | `/api/v1/import` | CSV file import (preview + confirm) |
-| Settings | `/api/v1/settings` | Org settings, billing periods |
+| Settings | `/api/v1/settings` | Org settings, billing periods, billing cycle |
+| Orgs | `/api/v1/orgs` | Org rename (owner-only) and per-org actions |
+| Org members | `/api/v1/orgs/.../members` | Membership and invitations |
+| Org data | `/api/v1/org-data` | Org-data wipe / reset (audited, lock-guarded) |
+| Plans | `/api/v1/plans` | Plan catalog |
+| Subscriptions | `/api/v1/subscriptions` | Trial / subscription state |
+| Admin | `/api/v1/admin` | Superadmin dashboard |
+| Admin orgs | `/api/v1/admin/orgs` | Superadmin org management + override sweep |
+| Admin audit | `/api/v1/admin/audit-events` | Audit log (durable trail) |
+| Admin roles | `/api/v1/admin/roles` | Custom role + permission editing |
 
 ---
 
 ## Testing
 
-### TypeScript Type Checking
+### Backend (pytest)
+
+The backend runs in the `backend` container; tests live in `backend/tests/` and run inside it:
 
 ```bash
+# Full suite
+docker compose exec backend pytest
+
+# A single module or test
+docker compose exec backend pytest tests/routers/test_auth.py
+docker compose exec backend pytest tests/routers/test_auth.py::test_login_happy_path
+```
+
+`requirements-dev.txt` is installed in the dev image (`INSTALL_DEV=true` build arg, set in `docker-compose.yml`). Production / CI builds keep `INSTALL_DEV=false`.
+
+### Frontend (vitest / jest)
+
+```bash
+# Full suite
+docker compose exec frontend npm test
+
+# A single test file
+docker compose exec frontend npm test -- tests/lib/api.test.ts
+```
+
+### TypeScript type checking
+
+```bash
+docker compose exec frontend npx tsc --noEmit
+# or, if you have node locally:
 cd frontend && npx tsc --noEmit
 ```
 
-### Backend (manual)
+### Manual smoke testing
 
-No automated test suite yet. Test via:
-- Swagger UI at http://localhost/api/docs
-- Browser testing of full flows
-- API calls via `curl` or httpie
-
-Adding pytest infrastructure is on the technical debt backlog.
+The Swagger UI at http://localhost/api/docs is the fastest way to poke a single endpoint by hand. Browser testing covers UI flows; `curl` or httpie cover scripted checks.
 
 ---
 
@@ -438,22 +543,22 @@ cd frontend && npx tsc --noEmit
 ./pfv rebuild
 ```
 
-### Database issues
+### Database issues (local dev)
 
 ```bash
-# Connect to MySQL
-docker compose exec mysql mysql -upfv2 -ppfv2_secret pfv2
+# Connect to MySQL (uses values from .env)
+docker compose exec mysql mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"
 
-# Reset everything (destroys all data)
+# Reset everything (destroys all data, rotates JWT secret)
 ./pfv reset
 ```
 
-### MFA locked out
+### MFA locked out (local dev)
 
 If you lose access to your authenticator and recovery codes:
 
 ```bash
-# Disable MFA directly in the database
-docker compose exec mysql mysql -upfv2 -ppfv2_secret pfv2 \
+# Disable MFA directly in the local database
+docker compose exec mysql mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" \
   -e "UPDATE users SET mfa_enabled=0, totp_secret=NULL, recovery_codes=NULL WHERE username='youruser';"
 ```

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,9 +1,5 @@
 # Product
 
-## Register
-
-product
-
 ## Users
 
 Individuals and households who plan their financial lives, not just track them. The seed user is a finance-savvy operator who currently runs a manual monthly spreadsheet (per-line-item budget + forecast across multiple accounts and a credit card). The product expands to couples and families managing shared finances through the org-scoped data model (every account, transaction, budget, and forecast belongs to an organization, not a single user).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Track income and expenses across multiple accounts, set budgets per category, fo
 | Layer | Technology |
 |-------|-----------|
 | Backend | Python 3.12, FastAPI, SQLAlchemy 2.0 (async), Alembic, Pydantic v2 |
-| Frontend | Next.js 15 (App Router), React 19, TypeScript, Tailwind CSS, Recharts |
+| Frontend | Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS, Recharts |
 | Database | MySQL 8.0 (self-hosted on a single DO droplet in production) |
 | Cache | Redis 7 (containerized in dev, self-hosted on the same droplet in production) |
 | Auth | JWT (access + refresh), bcrypt, TOTP (pyotp), Google OAuth2 (with step-up for sensitive flows) |

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Track income and expenses across multiple accounts, set budgets per category, fo
 |-------|-----------|
 | Backend | Python 3.12, FastAPI, SQLAlchemy 2.0 (async), Alembic, Pydantic v2 |
 | Frontend | Next.js 15 (App Router), React 19, TypeScript, Tailwind CSS, Recharts |
-| Database | MySQL 8.0 |
-| Cache | Redis / Valkey |
-| Auth | JWT (access + refresh), bcrypt, TOTP (pyotp), Google OAuth2 |
+| Database | MySQL 8.0 (self-hosted on a single DO droplet in production) |
+| Cache | Redis 7 (containerized in dev, self-hosted on the same droplet in production) |
+| Auth | JWT (access + refresh), bcrypt, TOTP (pyotp), Google OAuth2 (with step-up for sensitive flows) |
 | Email | Mailgun (production), structlog (development) |
 | Proxy | nginx (development), DO App Platform ingress (production) |
 
@@ -83,17 +83,20 @@ Swagger UI is available at http://localhost/api/docs when running locally.
 
 | Resource | Prefix | Description |
 |----------|--------|-------------|
-| Auth | `/api/v1/auth` | Login, register, MFA, SSO, password reset |
+| Auth | `/api/v1/auth` | Login, register, MFA, Google SSO, password reset, step-up |
 | Users | `/api/v1/users` | Profile, password change |
 | Accounts | `/api/v1/accounts` | Bank accounts and balances |
 | Categories | `/api/v1/categories` | Hierarchical income/expense categories |
-| Transactions | `/api/v1/transactions` | Income, expenses, transfers |
+| Transactions | `/api/v1/transactions` | Income, expenses, transfers (period bucketing by `settled_date`) |
 | Recurring | `/api/v1/recurring` | Recurring transaction templates |
 | Budgets | `/api/v1/budgets` | Per-category spending limits |
 | Forecast | `/api/v1/forecast` | Computed forecast (read-only) |
 | Forecast Plans | `/api/v1/forecast-plans` | Editable forecast plans |
 | Import | `/api/v1/import` | CSV import (preview + confirm) |
-| Settings | `/api/v1/settings` | Org settings, billing periods |
+| Settings | `/api/v1/settings` | Org settings, billing periods, billing cycle |
+| Orgs | `/api/v1/orgs` | Org rename and per-org actions |
+| Plans / Subscriptions | `/api/v1/plans`, `/api/v1/subscriptions` | Plan catalog and trial / subscription state |
+| Admin | `/api/v1/admin/*` | Superadmin: orgs, audit log, roles |
 
 ## Contributing
 

--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -3,6 +3,13 @@
 Source of truth for moving prod data from DO Managed MySQL + Managed Redis to
 the new `pfv-data-01` droplet provisioned by `infra/terraform`.
 
+> **Status (2026-05-07).** The cutover described here has already been
+> executed; production runs against `pfv-data-01` and the managed services
+> have been decommissioned. The runbook is kept as a reference for any
+> future managed-to-droplet move (or as the canonical writeup of the path
+> we took). Variables like `<managed-host>`, `<APP_ID>`, and the secret
+> blobs are illustrative for any next time; do not re-run the steps as-is.
+
 Plan window: pick a quiet hour. Total downtime: ~10–20 min for the size of the
 PFV dataset today. Mostly waiting on dump + import.
 
@@ -381,6 +388,8 @@ If smoke tests fail or production behaves badly:
 - No TLS on either service. Traffic stays inside DO's VPC; revisit if we
   add a second region or move to a multi-tenant network.
 - Backups: nightly logical dump in `/var/backups/mysql/` (7-day retention)
-  plus DO weekly droplet snapshots. To restore: copy a `.sql.gz` off the
-  droplet, `gunzip -c <file> | mysql pfv2`. Or restore the snapshot from the
-  DO console and re-point DNS / spec at the new droplet.
+  is the only durability floor; DO droplet snapshots are off at the IaC
+  level (`enable_backups = false` in `infra/terraform/main.tf`). To restore:
+  copy a `.sql.gz` off the droplet, `gunzip -c <file> | mysql pfv2`. If
+  snapshots are ever re-enabled, restoring from the DO console and
+  re-pointing the spec at the new droplet is the alternate recovery path.

--- a/infra/README.md
+++ b/infra/README.md
@@ -40,8 +40,10 @@ only. ICMP from VPC. ufw on the host repeats the same restrictions.
 
 ## Prerequisites
 
-- A DO API token with read/write scope. Set `TF_VAR_do_token` or fill
-  `terraform.tfvars`.
+- A DO API token with read/write scope. In normal operation it lives as the
+  `do_token` workspace variable in TFC (`FlamaCorp/pfv`); local CLI debug
+  runs against the same workspace need `TF_VAR_do_token` (or a gitignored
+  `terraform.tfvars`).
 - An SSH key already registered in DO (Settings -> Security). Note its name.
 - A DO project named `pfv` (or change `project_name`). Projects must be
   created from the UI or `doctl` first; we don't manage them in Terraform.
@@ -130,11 +132,15 @@ See `MIGRATION.md` for the full data-move runbook (including rollback).
 
 ## Teardown
 
-```bash
-cd infra/terraform
-terraform destroy
-```
+Terraform is VCS-driven via TFC; teardown follows the same path. Either:
 
-Warning: this destroys the droplet and its data. Pull a final `mysqldump`
-first (see `MIGRATION.md`) and verify weekly snapshots are also gone if you
-intend a clean break.
+- Open a PR that removes (or comments out) the droplet / VPC / firewall
+  resources in `infra/terraform/`. Merge it and run the apply via the TFC
+  UI (Confirm & Apply), same as any other infra change.
+- Or, for a one-shot destroy, queue a `Destroy plan` from the TFC
+  workspace UI and approve it. Local `terraform destroy` is debug-only.
+
+Warning: this destroys the droplet and its data. DO droplet snapshots are
+disabled at the IaC level, so the only durability floor is the nightly
+`mysqldump` on the droplet — pull a final dump (see `MIGRATION.md` for the
+command and the verify step) before queuing the destroy.


### PR DESCRIPTION
## Summary

Single-pass docs refresh against the codebase after the heavy churn of the last several weeks (cost-reduction cutover, audit log, categories integrity, SSO password tightening, org rename, role admin, forecast plan source pinning, transactions period bucketing). Edits are surgical, not a rewrite.

## Files changed

- **README.md** — Cache row drops the Redis/Valkey alias; production framing now points at the self-hosted droplet; SSO step-up mentioned in the Auth row; API table now covers orgs, plans, subscriptions, admin endpoints; transactions row notes settled_date period bucketing.
- **CONTRIBUTING.md** — Backend file tree updated to match disk (audit_event / role / invitation / subscription / feature_override / org_data_reset_lock / merchant_dictionary / category_rule models; admin / admin_orgs / admin_audit / admin_roles / orgs / org_members / org_data / plans / subscriptions routers; full set of services). Frontend tree updated to include /admin, /settings/*, /system, /health, /accept-invite, /setup, ThemeProvider, SettingsLayout, lib/feature-catalog, lib/format, lib/pagination, lib/site. Key Design Decisions adds the category type guard, transfer category invariant, audit-trail, and forecast plan source. New SSO password security subsection covers step-up on first set, return_to allowlist, and reset_password flipping password_set. Deployment section rewritten: managed MySQL/Valkey replaced by self-hosted droplet plus TFC VCS-driven Terraform; new Infrastructure as code subsection; backups row notes nightly mysqldump and disabled DO snapshots. Testing section rewritten: pytest and vitest exist now and run inside the containers. Database / MFA reset examples use .env vars instead of hardcoded pfv2_secret. API table covers orgs / org_members / org_data / plans / subscriptions / admin / admin_orgs / admin_audit / admin_roles. REDIS_URL env var description updated.
- **PRODUCT.md** — Removed the empty placeholder \"Register / product\" section.
- **infra/README.md** — Prerequisites note that the DO API token now normally lives as a TFC workspace variable; CLI tfvars is for debug runs. Teardown section rewritten to follow the VCS-driven path (PR + Confirm & Apply or queued Destroy plan) and to acknowledge that DO snapshots are off, so the nightly mysqldump is the only durability floor.
- **infra/MIGRATION.md** — Header note marks the cutover as already executed; the runbook is now reference material. Posture notes' \"DO weekly droplet snapshots\" claim corrected to match the disabled-snapshots reality.
- **CLAUDE.md** — Common Commands gains backend pytest / frontend npm test / tsc commands. nginx clarified as the dev entry point (App Platform ingress in prod). New bullets cover the self-hosted data plane (TFC workflow) and the audit_events table.

## Notes

- No new docs created. Issue templates and DESIGN.md were left alone (still accurate).
- The /docs route reference is intentionally left as-is in CONTRIBUTING and README; the parallel scaffolding PR will flip that.
- No em-dashes added in customer-facing copy (README, PRODUCT). Existing em-dashes in those files were left in place per the \"don't churn\" guideline.