### PR TITLE
docs(forecasts): explain variance, projected, auto populate, refresh from sources

### DIFF
--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -216,8 +216,10 @@ export default function DocsPage() {
               </li>
               <li>
                 <strong>Whatever you've already booked in this period</strong>,
-                used as a fallback when there is neither a recurring bill
-                nor 3 months of history.
+                blended in with the past 3 months so the suggestion reflects
+                your most recent reality. A category can be seeded from
+                current-period activity alone, even if it has no 3-month
+                history.
               </li>
             </ol>
             <p>

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -24,6 +24,7 @@ const sections = [
   { id: "overview", label: "Overview" },
   { id: "core-concepts", label: "Core concepts" },
   { id: "common-workflows", label: "Common workflows" },
+  { id: "forecasts", label: "Forecasts: planning vs projecting" },
   { id: "admin-workflows", label: "Admin workflows" },
   { id: "system-health", label: "System health" },
   { id: "whats-next", label: "What's next" },
@@ -175,6 +176,131 @@ export default function DocsPage() {
               verdict that anchors on what has actually settled, not
               just what is projected. The projection is shown
               alongside as informational context.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="forecasts">Forecasts: planning vs projecting</h2>
+            <p>
+              The Forecasts area can feel confusing at first because four
+              ideas overlap: the plan, the projection, the variance, and
+              the two buttons that fill the plan in. Here is each one in
+              the simplest words.
+            </p>
+
+            <h3>The plan is your wish list</h3>
+            <p>
+              A plan is a wish list with numbers. You write down what you
+              want to spend on each category for the period. For example,
+              "I want to spend 600 on groceries this month and 80 on
+              coffee." That is the plan. Saving the plan does not move
+              any money. It just records your intention.
+            </p>
+
+            <h3>Auto-populate fills the wish list for you</h3>
+            <p>
+              When you create a brand new plan, the wish list is empty.
+              Click <strong>Auto-populate</strong> and the app fills it
+              in for you. It looks at three things, in order, for each
+              master category:
+            </p>
+            <ol>
+              <li>
+                <strong>Recurring bills</strong> that will fire in the
+                period (rent, Netflix, salary). Their amounts are added
+                up.
+              </li>
+              <li>
+                <strong>Your last 3 months of activity</strong>, averaged.
+                Used for categories that don't have a recurring bill.
+              </li>
+              <li>
+                <strong>Whatever you've already booked in this period</strong>,
+                used as a fallback when there is neither a recurring bill
+                nor 3 months of history.
+              </li>
+            </ol>
+            <p>
+              Each row in the plan shows where its number came from: a
+              recurring template, your history (labeled "Auto"), or a
+              manual edit you made.
+            </p>
+
+            <h3>Variance: did you stick to the wish list</h3>
+            <p>
+              Variance compares your plan to what actually happened.
+            </p>
+            <ul>
+              <li>
+                You planned 600 for groceries and spent 400 so far.
+                Variance is 200 under plan, shown in green. You have
+                room to spare.
+              </li>
+              <li>
+                You planned 600 for groceries and spent 700. Variance
+                is 100 over plan, shown in red. You went past the
+                number you wrote down.
+              </li>
+              <li>
+                For income, the colors flip. Earning more than you
+                planned is good (green), earning less is amber or red.
+              </li>
+            </ul>
+
+            <h3>Projected: the app's best guess for end of month</h3>
+            <p>
+              The Projected number on the dashboard is a totally
+              different idea from the plan. The plan is what you want
+              to spend. Projected is what the app thinks will actually
+              happen by the end of the month, given everything it can
+              already see. It is the sum of:
+            </p>
+            <ul>
+              <li>
+                <strong>Settled</strong>: what has already cleared.
+              </li>
+              <li>
+                <strong>Pending</strong>: charges that have been booked
+                but not yet cleared (a card swipe waiting on the
+                statement, a manual upcoming expense you typed in).
+              </li>
+              <li>
+                <strong>Scheduled recurring</strong>: every recurring
+                bill that will fire from now until the end of the
+                period.
+              </li>
+            </ul>
+            <p>
+              <strong>
+                Projected is not Planned Income minus Planned Expenses.
+              </strong>{" "}
+              It can be higher than your plan if pending charges or
+              upcoming recurring bills are bigger than you expected, or
+              lower if life has been quiet and not many bills are
+              scheduled. Treat Projected as a heads-up, not a verdict.
+              The dashboard's On Track verdict reads from what has
+              actually settled, so a noisy projection won't alarm you
+              before any money has moved.
+            </p>
+
+            <h3>Refresh from sources: re-check after life changes</h3>
+            <p>
+              Auto-populate is for the very first fill. Refresh from
+              sources is for later. Use it when something about your
+              setup has changed since you first built the plan. Maybe
+              you added a new subscription, ended an old one, edited
+              the amount of a recurring bill, or imported new
+              transactions that should feed the average.
+            </p>
+            <p>
+              Refresh drops every row whose source is Recurring or Auto
+              (the rows the system filled in) and re-runs Auto-populate
+              against today's templates and history. Rows you typed or
+              edited yourself are kept untouched. Categories that have
+              shown up since the first populate will be added in this
+              pass too. Refresh only works while the plan is a draft.
+              Finalize the plan when you're done, and click Edit Plan
+              to revert to draft if you want to refresh again later.
             </p>
           </section>
 

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -44,6 +44,34 @@ const SOURCE_LABELS: Record<string, string> = {
   history: "Auto",
 };
 
+// Inline help copy. The /docs#forecasts section carries the long explanation;
+// these are 1-2 sentence reminders reachable from the controls themselves.
+const HELP_VARIANCE =
+  "Actual minus planned. For expenses, green when under plan and red when over. For income, the colors flip.";
+const HELP_AUTO_POPULATE =
+  "Fill the empty plan from your recurring bills, your last 3 months of activity, and what's already booked this period. Use this when you first build the plan.";
+const HELP_REFRESH =
+  "Re-run the auto-fill against today's templates and history. Drops Recurring and Auto rows, keeps anything you typed by hand. Drafts only.";
+const HELP_EDIT_PLAN =
+  "Plans go through Draft (editable) and Finalized (read-only, actuals tracked live). Edit Plan reverts the finalized plan to draft so you can change numbers or refresh.";
+const DOCS_HINT = " See /docs#forecasts for more.";
+
+// Tiny `(?)` indicator with native title tooltip. No design-system tooltip
+// primitive exists yet; native title is honest and ships now.
+function HelpIcon({ label, text }: { label: string; text: string }) {
+  return (
+    <span
+      tabIndex={0}
+      role="img"
+      aria-label={`${label} explained: ${text}`}
+      title={text + DOCS_HINT}
+      className="ml-1 cursor-help text-text-muted/70 hover:text-text-secondary"
+    >
+      (?)
+    </span>
+  );
+}
+
 export default function ForecastPlansPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
@@ -368,17 +396,25 @@ export default function ForecastPlansPage() {
                 Discard
               </button>
             )}
-            <button onClick={handlePopulate} className={btnPrimary}>
+            <button
+              onClick={handlePopulate}
+              className={btnPrimary}
+              title={HELP_AUTO_POPULATE + DOCS_HINT}
+            >
               Auto-populate
             </button>
+            <HelpIcon label="Auto-populate" text={HELP_AUTO_POPULATE} />
             {hasItems && (
-              <button
-                onClick={handleRefreshFromSources}
-                className={btnPrimary}
-                title="Drop auto-generated rows and re-run populate. Manual edits are preserved."
-              >
-                Refresh from sources
-              </button>
+              <>
+                <button
+                  onClick={handleRefreshFromSources}
+                  className={btnPrimary}
+                  title={HELP_REFRESH + DOCS_HINT}
+                >
+                  Refresh from sources
+                </button>
+                <HelpIcon label="Refresh from sources" text={HELP_REFRESH} />
+              </>
             )}
             <button
               onClick={() => setShowForm(!showForm)}
@@ -389,9 +425,16 @@ export default function ForecastPlansPage() {
           </div>
         )}
         {isActive && (
-          <button onClick={handleRevertToDraft} className={btnPrimary}>
-            Edit Plan
-          </button>
+          <>
+            <button
+              onClick={handleRevertToDraft}
+              className={btnPrimary}
+              title={HELP_EDIT_PLAN + DOCS_HINT}
+            >
+              Edit Plan
+            </button>
+            <HelpIcon label="Edit Plan" text={HELP_EDIT_PLAN} />
+          </>
         )}
       </div>
 
@@ -824,7 +867,10 @@ function ItemSection({
             <span>Category</span>
             <span className="text-right">Planned</span>
             <span className="hidden text-right md:block">Actual</span>
-            <span className="hidden text-right md:block">Variance</span>
+            <span className="hidden text-right md:block">
+              Variance
+              <HelpIcon label="Variance" text={HELP_VARIANCE} />
+            </span>
             <span className="hidden text-center md:block">Source</span>
             {!readOnly && <span className="text-right">Actions</span>}
           </div>

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -47,7 +47,7 @@ const SOURCE_LABELS: Record<string, string> = {
 // Inline help copy. The /docs#forecasts section carries the long explanation;
 // these are 1-2 sentence reminders reachable from the controls themselves.
 const HELP_VARIANCE =
-  "Actual minus planned. For expenses, green when under plan and red when over. For income, the colors flip.";
+  "Actual minus planned, per category. Negative means you spent less than planned for an expense category (good); positive means you spent more (over budget). Income variance flips: positive is good, negative is short of plan.";
 const HELP_AUTO_POPULATE =
   "Fill the empty plan from your recurring bills, your last 3 months of activity, and what's already booked this period. Use this when you first build the plan.";
 const HELP_REFRESH =
@@ -65,7 +65,7 @@ function HelpIcon({ label, text }: { label: string; text: string }) {
       role="img"
       aria-label={`${label} explained: ${text}`}
       title={text + DOCS_HINT}
-      className="ml-1 cursor-help text-text-muted/70 hover:text-text-secondary"
+      className="ml-1 cursor-help rounded-sm text-text-muted/70 hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
     >
       (?)
     </span>
@@ -425,7 +425,7 @@ export default function ForecastPlansPage() {
           </div>
         )}
         {isActive && (
-          <>
+          <div className="flex items-center gap-2">
             <button
               onClick={handleRevertToDraft}
               className={btnPrimary}
@@ -434,7 +434,7 @@ export default function ForecastPlansPage() {
               Edit Plan
             </button>
             <HelpIcon label="Edit Plan" text={HELP_EDIT_PLAN} />
-          </>
+          </div>
         )}
       </div>
 

--- a/frontend/components/dashboard/OnTrackTile.tsx
+++ b/frontend/components/dashboard/OnTrackTile.tsx
@@ -32,7 +32,7 @@ const WATCH_MAX = 1.05;
 // Tooltip copy for the dashboard stats. Plain language; the docs page
 // (/docs#forecasts) carries the longer explanation.
 const VARIANCE_HELP =
-  "Plan minus actual. Green when you're under plan, red when you're over.";
+  "Plan minus actual. Positive number means you spent less than planned (good for expense). Green when you're under plan, red when you're over.";
 const PROJECTED_HELP =
   "Best guess at end-of-month total = settled + pending + scheduled recurring. Can differ from your plan.";
 
@@ -85,14 +85,14 @@ function Stat({
   return (
     <div>
       <p className="flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
-        <span>{label}</span>
+        {label}
         {helpText && (
           <span
             tabIndex={0}
             role="img"
             aria-label={`${label} explained: ${helpText}`}
             title={`${helpText} See /docs#forecasts for more.`}
-            className="cursor-help text-text-muted/70 hover:text-text-secondary"
+            className="cursor-help rounded-sm text-text-muted/70 hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
           >
             (?)
           </span>

--- a/frontend/components/dashboard/OnTrackTile.tsx
+++ b/frontend/components/dashboard/OnTrackTile.tsx
@@ -29,6 +29,13 @@ export interface OnTrackTileProps {
 const ON_TRACK_MAX = 0.95;
 const WATCH_MAX = 1.05;
 
+// Tooltip copy for the dashboard stats. Plain language; the docs page
+// (/docs#forecasts) carries the longer explanation.
+const VARIANCE_HELP =
+  "Plan minus actual. Green when you're under plan, red when you're over.";
+const PROJECTED_HELP =
+  "Best guess at end-of-month total = settled + pending + scheduled recurring. Can differ from your plan.";
+
 type Verdict = "on-track" | "watch" | "over";
 
 function computeVerdict(pct: number): Verdict {
@@ -66,16 +73,31 @@ function Stat({
   sublabel,
   valueClass = "text-text-primary",
   muted = false,
+  helpText,
 }: {
   label: string;
   value: string;
   sublabel?: string;
   valueClass?: string;
   muted?: boolean;
+  helpText?: string;
 }) {
   return (
     <div>
-      <p className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">{label}</p>
+      <p className="flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
+        <span>{label}</span>
+        {helpText && (
+          <span
+            tabIndex={0}
+            role="img"
+            aria-label={`${label} explained: ${helpText}`}
+            title={`${helpText} See /docs#forecasts for more.`}
+            className="cursor-help text-text-muted/70 hover:text-text-secondary"
+          >
+            (?)
+          </span>
+        )}
+      </p>
       <p
         className={`mt-1 text-2xl font-semibold tabular-nums ${
           muted ? "text-text-muted" : valueClass
@@ -139,8 +161,8 @@ export default function OnTrackTile({
             muted={!hasPlan}
           />
           <Stat label="SPENT" value="—" sublabel="nothing yet" muted />
-          <Stat label="VARIANCE" value="—" muted />
-          <Stat label="PROJECTED" value="—" muted />
+          <Stat label="VARIANCE" value="—" muted helpText={VARIANCE_HELP} />
+          <Stat label="PROJECTED" value="—" muted helpText={PROJECTED_HELP} />
         </div>
         <div className="mt-6 text-sm">
           <Link
@@ -171,8 +193,8 @@ export default function OnTrackTile({
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
           <Stat label="PLAN" value={formatAmount(0)} sublabel="not yet planned" muted />
           <Stat label="SPENT SO FAR" value="—" muted />
-          <Stat label="VARIANCE" value="—" muted />
-          <Stat label="PROJECTED" value="—" muted />
+          <Stat label="VARIANCE" value="—" muted helpText={VARIANCE_HELP} />
+          <Stat label="PROJECTED" value="—" muted helpText={PROJECTED_HELP} />
         </div>
         <div className="mt-6 text-sm">
           <Link
@@ -203,8 +225,8 @@ export default function OnTrackTile({
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
           <Stat label="PLAN" value={formatAmount(plannedExpense)} sublabel="full month" />
           <Stat label="SPENT SO FAR" value="—" muted />
-          <Stat label="VARIANCE" value="—" muted />
-          <Stat label="PROJECTED" value="Unavailable" muted />
+          <Stat label="VARIANCE" value="—" muted helpText={VARIANCE_HELP} />
+          <Stat label="PROJECTED" value="Unavailable" muted helpText={PROJECTED_HELP} />
         </div>
         <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-text-muted">
           <span>Projection unavailable.</span>
@@ -239,8 +261,8 @@ export default function OnTrackTile({
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
           <Stat label="PLAN" value={formatAmount(plannedExpense)} sublabel="full month" />
           <Stat label="SPENT SO FAR" value="…" muted />
-          <Stat label="VARIANCE" value="…" muted />
-          <Stat label="PROJECTED" value="…" muted />
+          <Stat label="VARIANCE" value="…" muted helpText={VARIANCE_HELP} />
+          <Stat label="PROJECTED" value="…" muted helpText={PROJECTED_HELP} />
         </div>
       </section>
     );
@@ -280,6 +302,7 @@ export default function OnTrackTile({
             value={`${variance >= 0 ? "+" : "−"}${formatAmount(Math.abs(variance))}`}
             sublabel={varianceFavorable ? "under plan" : "over plan"}
             valueClass={varianceFavorable ? "text-accent" : "text-danger"}
+            helpText={VARIANCE_HELP}
           />
         </div>
       </section>
@@ -318,12 +341,14 @@ export default function OnTrackTile({
           value={`${variance >= 0 ? "+" : "−"}${formatAmount(Math.abs(variance))}`}
           sublabel={varianceFavorable ? "under plan" : "over plan"}
           valueClass={varianceFavorable ? "text-accent" : "text-danger"}
+          helpText={VARIANCE_HELP}
         />
         <Stat
           label="PROJECTED"
           value={formatAmount(forecastExpense)}
           sublabel="projected end-of-month"
           muted
+          helpText={PROJECTED_HELP}
         />
       </div>
     </section>


### PR DESCRIPTION
## Summary

Users (most recently me) keep getting tangled in four overlapping ideas in the Forecasts area: the plan itself, what Auto-populate seeds it with, how Variance reads, and what Projected actually computes. The most common confusion is expecting Projected to equal planned income minus planned expenses; it isn't. Projected is settled plus pending plus scheduled recurring, computed live by `forecast_service.compute_forecast`.

This PR adds a new section to the public `/docs` page, "Forecasts: planning vs projecting" (anchor `#forecasts`), that explains each idea in plain words with concrete numbers. The tone matches the existing docs page voice: short, slightly playful, no jargon.

It also wires small `(?)` help indicators with native `title` tooltips next to:

- VARIANCE and PROJECTED on the dashboard On Track tile (`frontend/components/dashboard/OnTrackTile.tsx`)
- the Variance column header on the Forecast Plans table (`frontend/app/forecast-plans/page.tsx`)
- the Auto-populate, Refresh from sources, and Edit Plan buttons on the same page

Each tooltip carries a one or two sentence reminder and points readers to `/docs#forecasts` for the longer explanation. No new tooltip primitive was added; the codebase didn't have one and a content-only PR is the wrong place to land that.