### PR TITLE
fix(transactions): enforce SETTLED-implies-settled_date invariant

### DIFF
--- a/backend/alembic/versions/036_settled_implies_settled_date.py
+++ b/backend/alembic/versions/036_settled_implies_settled_date.py
@@ -1,0 +1,85 @@
+"""SETTLED-implies-settled_date invariant.
+
+Revision ID: 036_settled_implies_settled_date
+Revises: 035_manual_balance_adjustment
+Create Date: 2026-05-08
+
+Enforces the business invariant that any ``transactions`` row with
+``status='settled'`` must have ``settled_date IS NOT NULL``.
+
+Two changes, in order:
+
+1. Backfill any orphan rows. ``settled_date`` was added in migration 020
+   as nullable to keep that change additive. Since then, every code path
+   that flips a row to SETTLED has been updated to set ``settled_date``
+   alongside, but pre-020 rows or any path that slipped through could
+   leave a SETTLED row with a NULL ``settled_date``. The fix:
+
+       UPDATE transactions
+          SET settled_date = COALESCE(settled_date, date)
+        WHERE status = 'settled' AND settled_date IS NULL;
+
+   We use the row's purchase ``date`` (column name ``date`` on the
+   transactions table — see ``effective_period_date_expr()``) as the
+   proxy. ``date`` is the only signal we have when ``settled_date`` is
+   missing, and ``effective_period_date_expr()`` already falls back to
+   it for period bucketing. ``created_at`` is technically available too,
+   but it reflects ingestion time, not the financial event, and would
+   skew period reports.
+
+2. Add a CHECK constraint:
+
+       CHECK (status <> 'settled' OR settled_date IS NOT NULL)
+
+   MySQL 8.0 enforces CHECK constraints, and SQLite has supported them
+   since forever, so this is portable. The constraint is logically
+   equivalent to "status = 'settled' implies settled_date IS NOT NULL".
+
+The application layer also has a SQLAlchemy ``@validates`` guard on the
+Transaction model that raises ``ValidationError`` before the row hits
+the DB, so the CHECK is the second line of defense (data layer truth)
+behind the model validator (clear error messages).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "036_settled_implies_settled_date"
+down_revision = "035_manual_balance_adjustment"
+branch_labels = None
+depends_on = None
+
+
+_CHECK_NAME = "ck_transactions_settled_implies_settled_date"
+_CHECK_SQL = "status <> 'settled' OR settled_date IS NOT NULL"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Step 1: backfill orphan rows so the CHECK is satisfiable.
+    # COALESCE keeps any non-NULL settled_date untouched and only fills
+    # in the fallback for the (status='settled', settled_date IS NULL)
+    # rows the new constraint would otherwise reject.
+    bind.execute(
+        sa.text(
+            "UPDATE transactions "
+            "SET settled_date = COALESCE(settled_date, date) "
+            "WHERE status = 'settled' AND settled_date IS NULL"
+        )
+    )
+
+    # Step 2: add the CHECK constraint. Both MySQL 8.0 and SQLite
+    # support inline CHECK on tables, and Alembic's
+    # ``create_check_constraint`` handles the dialect differences.
+    op.create_check_constraint(
+        _CHECK_NAME,
+        "transactions",
+        _CHECK_SQL,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_CHECK_NAME, "transactions", type_="check")

--- a/backend/alembic/versions/036_settled_implies_settled_date.py
+++ b/backend/alembic/versions/036_settled_implies_settled_date.py
@@ -71,15 +71,18 @@ def upgrade() -> None:
         )
     )
 
-    # Step 2: add the CHECK constraint. Both MySQL 8.0 and SQLite
-    # support inline CHECK on tables, and Alembic's
-    # ``create_check_constraint`` handles the dialect differences.
-    op.create_check_constraint(
-        _CHECK_NAME,
-        "transactions",
-        _CHECK_SQL,
-    )
+    # Step 2: add the CHECK constraint via batch_alter_table. SQLite
+    # has no native ALTER TABLE ADD CONSTRAINT, so Alembic's batch mode
+    # rewrites the table to apply CHECK; MySQL 8.0 accepts the batch
+    # form via plain ALTER. Plain op.create_check_constraint raises
+    # NotImplementedError on SQLite.
+    with op.batch_alter_table("transactions") as batch_op:
+        batch_op.create_check_constraint(
+            _CHECK_NAME,
+            _CHECK_SQL,
+        )
 
 
 def downgrade() -> None:
-    op.drop_constraint(_CHECK_NAME, "transactions", type_="check")
+    with op.batch_alter_table("transactions") as batch_op:
+        batch_op.drop_constraint(_CHECK_NAME, type_="check")

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -12,9 +12,10 @@ from sqlalchemy import (
     Integer,
     Numeric,
     String,
+    event,
     func,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, Mapper, mapped_column, relationship
 
 from app.models.base import Base
 
@@ -113,3 +114,24 @@ class Transaction(Base):
     linked_transaction: Mapped[Optional["Transaction"]] = relationship(
         foreign_keys=[linked_transaction_id], remote_side="Transaction.id"
     )
+
+
+def _enforce_settled_implies_settled_date(_mapper: Mapper, _conn, target: Transaction) -> None:
+    """SETTLED-implies-settled_date invariant guard at flush time.
+
+    Mirrors the DB CHECK constraint added in migration 036, but raises
+    a clear ValueError before the row hits the database so callers see
+    a typed Python error instead of an opaque IntegrityError. Runs at
+    flush time (not on attribute assignment) so the check sees the
+    final, post-construction state of both columns and is independent
+    of kwarg ordering in ``Transaction(...)`` constructors.
+    """
+    if target.status == TransactionStatus.SETTLED and target.settled_date is None:
+        raise ValueError(
+            "Transaction with status=SETTLED must have a settled_date "
+            "(SETTLED-implies-settled_date invariant)."
+        )
+
+
+event.listen(Transaction, "before_insert", _enforce_settled_implies_settled_date)
+event.listen(Transaction, "before_update", _enforce_settled_implies_settled_date)

--- a/backend/tests/routers/test_categories_update_type_guard.py
+++ b/backend/tests/routers/test_categories_update_type_guard.py
@@ -117,6 +117,7 @@ async def _seed(factory) -> dict:
             category_id=both_master.id, description="x",
             amount=Decimal("10"), type=TransactionType.EXPENSE,
             status=TransactionStatus.SETTLED, date=date(2026, 5, 1),
+            settled_date=date(2026, 5, 1),
         ))
         await db.commit()
         return {

--- a/backend/tests/routers/test_transactions_pair_routes.py
+++ b/backend/tests/routers/test_transactions_pair_routes.py
@@ -177,6 +177,7 @@ async def _add_tx(
     linked_transaction_id: int | None = None,
 ) -> int:
     async with factory() as db:
+        on_date = on_date or date(2026, 5, 1)
         tx = Transaction(
             org_id=org_id,
             account_id=account_id,
@@ -185,7 +186,8 @@ async def _add_tx(
             amount=amount,
             type=type,
             status=status,
-            date=on_date or date(2026, 5, 1),
+            date=on_date,
+            settled_date=on_date if status == TransactionStatus.SETTLED else None,
             linked_transaction_id=linked_transaction_id,
             is_imported=False,
         )
@@ -532,6 +534,7 @@ async def _add_adjustment_tx(
 ) -> int:
     """Mirror of _add_tx that flags the row as a manual balance adjustment."""
     async with factory() as db:
+        on_date = on_date or date(2026, 5, 1)
         tx = Transaction(
             org_id=org_id,
             account_id=account_id,
@@ -540,7 +543,8 @@ async def _add_adjustment_tx(
             amount=amount,
             type=type,
             status=TransactionStatus.SETTLED,
-            date=on_date or date(2026, 5, 1),
+            date=on_date,
+            settled_date=on_date,
             is_imported=False,
             is_manual_adjustment=True,
         )

--- a/backend/tests/routers/test_transactions_promote_to_recurring.py
+++ b/backend/tests/routers/test_transactions_promote_to_recurring.py
@@ -163,6 +163,7 @@ async def _add_tx(
     recurring_id: int | None = None,
 ) -> int:
     async with factory() as db:
+        on_date = on_date or date(2026, 5, 1)
         tx = Transaction(
             org_id=org_id,
             account_id=account_id,
@@ -171,7 +172,8 @@ async def _add_tx(
             amount=amount,
             type=type,
             status=TransactionStatus.SETTLED,
-            date=on_date or date(2026, 5, 1),
+            date=on_date,
+            settled_date=on_date,
             linked_transaction_id=linked_transaction_id,
             recurring_id=recurring_id,
             is_imported=False,
@@ -317,12 +319,14 @@ async def test_promote_to_recurring_rejects_transfer_leg(session_factory):
             category_id=seed["cat_transfer_id"], description="xfer out",
             amount=Decimal("50"), type=TransactionType.EXPENSE,
             status=TransactionStatus.SETTLED, date=date(2026, 5, 1),
+            settled_date=date(2026, 5, 1),
         )
         income_leg = Transaction(
             org_id=seed["org_id"], account_id=seed["a2_id"],
             category_id=seed["cat_transfer_id"], description="xfer in",
             amount=Decimal("50"), type=TransactionType.INCOME,
             status=TransactionStatus.SETTLED, date=date(2026, 5, 1),
+            settled_date=date(2026, 5, 1),
         )
         db.add_all([expense_leg, income_leg])
         await db.flush()

--- a/backend/tests/services/test_category_service_type_change_guard.py
+++ b/backend/tests/services/test_category_service_type_change_guard.py
@@ -120,7 +120,7 @@ async def test_change_to_both_always_safe(db_session: AsyncSession) -> None:
         org_id=seed["org_id"], account_id=seed["acct_id"],
         category_id=cat.id, description="x", amount=Decimal("10"),
         type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     ))
     await db_session.commit()
     await category_service.validate_category_type_change(
@@ -151,7 +151,7 @@ async def test_change_rejected_when_expense_transaction_blocks(
         org_id=seed["org_id"], account_id=seed["acct_id"],
         category_id=cat.id, description="x", amount=Decimal("10"),
         type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     ))
     await db_session.commit()
     with pytest.raises(ValidationError):
@@ -170,7 +170,7 @@ async def test_both_to_expense_rejected_when_income_txn_exists(
         org_id=seed["org_id"], account_id=seed["acct_id"],
         category_id=cat.id, description="pay", amount=Decimal("100"),
         type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     ))
     await db_session.commit()
     with pytest.raises(ValidationError):
@@ -189,7 +189,7 @@ async def test_both_to_income_rejected_when_expense_txn_exists(
         org_id=seed["org_id"], account_id=seed["acct_id"],
         category_id=cat.id, description="buy", amount=Decimal("10"),
         type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     ))
     await db_session.commit()
     with pytest.raises(ValidationError):
@@ -290,13 +290,13 @@ async def test_transfer_leg_blocks_any_move_off_both(
         org_id=seed["org_id"], account_id=seed["acct_id"],
         category_id=cat.id, description="xfer", amount=Decimal("50"),
         type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     )
     leg_in = Transaction(
         org_id=seed["org_id"], account_id=acct2.id,
         category_id=cat.id, description="xfer", amount=Decimal("50"),
         type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     )
     db_session.add_all([leg_out, leg_in])
     await db_session.flush()
@@ -336,7 +336,7 @@ async def test_master_change_rejected_by_child_reference(
         org_id=seed["org_id"], account_id=seed["acct_id"],
         category_id=child.id, description="x", amount=Decimal("10"),
         type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     ))
     await db_session.commit()
     with pytest.raises(ValidationError):
@@ -362,7 +362,7 @@ async def test_master_change_succeeds_when_children_compatible(
         org_id=seed["org_id"], account_id=seed["acct_id"],
         category_id=child.id, description="x", amount=Decimal("10"),
         type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
-        date=date(2026, 5, 1),
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
     ))
     await db_session.commit()
     await category_service.validate_category_type_change(

--- a/backend/tests/services/test_transaction_service_list_filters.py
+++ b/backend/tests/services/test_transaction_service_list_filters.py
@@ -191,24 +191,12 @@ async def test_pending_no_settled_date_falls_back_to_date(db_session, world):
     assert [r.description for r in rows] == ["pending-null"]
 
 
-async def test_settled_no_settled_date_defensive_fallback(db_session, world):
-    """SETTLED, settled_date IS NULL, date inside -> INCLUDED.
-
-    Legacy/COALESCE defensive fallback: if a settled row predates the
-    settled_date column or was inserted without one, the period bucket
-    falls back to ``date``.
-    """
-    tx = _make_tx(
-        world, dt=date(2026, 5, 12), settled_date=None,
-        status=TransactionStatus.SETTLED, description="settled-null",
-    )
-    db_session.add(tx)
-    await db_session.flush()
-
-    rows = await transaction_service.list_transactions(
-        db_session, world["org"].id, date_from=MAY_FROM, date_to=MAY_TO,
-    )
-    assert [r.description for r in rows] == ["settled-null"]
+# ``test_settled_no_settled_date_defensive_fallback`` was removed when the
+# SETTLED-implies-settled_date invariant was added (migration 036): a SETTLED
+# row with settled_date=NULL is no longer a state the database accepts, so the
+# COALESCE fallback for that case is now unreachable by construction.
+# The COALESCE in ``effective_period_date_expr()`` still serves PENDING rows
+# without an estimate, exercised by ``test_pending_no_settled_date_falls_back_to_date``.
 
 
 async def test_sort_order_uses_effective_date(db_session, world):
@@ -217,9 +205,9 @@ async def test_sort_order_uses_effective_date(db_session, world):
     Construct rows whose ``date`` order disagrees with their effective-date
     order so the assertion fails if the ORDER BY still uses ``Transaction.date``.
     """
-    # tx_a: settled, date=05-15, no settled_date  -> effective 05-15
+    # tx_a: settled, date=05-15, settled_date=05-15  -> effective 05-15
     tx_a = _make_tx(
-        world, dt=date(2026, 5, 15), settled_date=None,
+        world, dt=date(2026, 5, 15), settled_date=date(2026, 5, 15),
         status=TransactionStatus.SETTLED, description="A",
     )
     # tx_b: pending, date=05-05, settled_date=05-25  -> effective 05-25

--- a/backend/tests/services/test_transaction_service_promote_to_recurring.py
+++ b/backend/tests/services/test_transaction_service_promote_to_recurring.py
@@ -101,6 +101,7 @@ async def _add_tx(
     linked_transaction_id: int | None = None,
     recurring_id: int | None = None,
 ) -> Transaction:
+    on_date = on_date or date(2026, 5, 1)
     tx = Transaction(
         org_id=org_id,
         account_id=account_id,
@@ -109,7 +110,8 @@ async def _add_tx(
         amount=amount,
         type=type,
         status=TransactionStatus.SETTLED,
-        date=on_date or date(2026, 5, 1),
+        date=on_date,
+        settled_date=on_date,
         linked_transaction_id=linked_transaction_id,
         recurring_id=recurring_id,
         is_imported=False,

--- a/backend/tests/test_settled_invariant.py
+++ b/backend/tests/test_settled_invariant.py
@@ -1,0 +1,222 @@
+"""SETTLED-implies-settled_date invariant tests.
+
+Two layers of enforcement, both exercised here:
+
+1. App-level: SQLAlchemy ``before_insert`` / ``before_update`` event
+   listener on the Transaction model raises ``ValueError`` at flush
+   time when status=SETTLED and settled_date is NULL. The event runs
+   on flush, not on attribute assignment, so it sees the final state
+   of both columns and is independent of kwarg ordering in the
+   constructor.
+
+2. DB-level: CHECK constraint
+   ``status <> 'settled' OR settled_date IS NOT NULL`` added by
+   migration 036. The app-level guard short-circuits before this
+   normally fires, but the DB layer is the source of truth (handles
+   raw-SQL writes, future code paths, etc.).
+
+These tests run against SQLite in-memory and so verify the app-level
+guard. The DB CHECK has been verified manually against MySQL 8 in the
+local stack; it's portable to SQLite (universal feature) and exercised
+implicitly by ``Base.metadata.create_all`` issuing the column-bound
+CHECK clause.
+"""
+from __future__ import annotations
+
+from datetime import date as _date
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_org_account_category(session: AsyncSession):
+    org = Organization(name="Test", billing_cycle_day=1)
+    session.add(org)
+    await session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    session.add(at)
+    await session.flush()
+    acct = Account(
+        org_id=org.id,
+        name="Main",
+        account_type_id=at.id,
+        balance=0,
+        currency="EUR",
+    )
+    cat = Category(
+        org_id=org.id,
+        name="Groceries",
+        slug="groceries",
+        type=CategoryType.EXPENSE,
+        is_system=False,
+    )
+    session.add_all([acct, cat])
+    await session.flush()
+    return org, acct, cat
+
+
+async def test_create_settled_without_settled_date_raises(db_session):
+    """Inserting a SETTLED row with settled_date=NULL must be rejected."""
+    org, acct, cat = await _seed_org_account_category(db_session)
+    tx = Transaction(
+        org_id=org.id,
+        account_id=acct.id,
+        category_id=cat.id,
+        description="bad",
+        amount=10,
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.SETTLED,
+        date=_date(2026, 5, 8),
+        settled_date=None,
+    )
+    db_session.add(tx)
+    with pytest.raises((ValueError, IntegrityError)) as exc_info:
+        await db_session.flush()
+    # Guard message is informative (covers either layer firing first).
+    assert "settled" in str(exc_info.value).lower()
+
+
+async def test_create_settled_with_settled_date_succeeds(db_session):
+    """Happy path: SETTLED + non-null settled_date is allowed."""
+    org, acct, cat = await _seed_org_account_category(db_session)
+    tx = Transaction(
+        org_id=org.id,
+        account_id=acct.id,
+        category_id=cat.id,
+        description="ok",
+        amount=10,
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.SETTLED,
+        date=_date(2026, 5, 8),
+        settled_date=_date(2026, 5, 8),
+    )
+    db_session.add(tx)
+    await db_session.flush()
+    assert tx.id is not None
+
+
+async def test_create_pending_without_settled_date_succeeds(db_session):
+    """PENDING rows are allowed to have settled_date=NULL — that's the
+    whole point of pending."""
+    org, acct, cat = await _seed_org_account_category(db_session)
+    tx = Transaction(
+        org_id=org.id,
+        account_id=acct.id,
+        category_id=cat.id,
+        description="pending",
+        amount=10,
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PENDING,
+        date=_date(2026, 5, 8),
+        settled_date=None,
+    )
+    db_session.add(tx)
+    await db_session.flush()
+    assert tx.id is not None
+    assert tx.settled_date is None
+
+
+async def test_update_clear_settled_date_on_settled_row_raises(db_session):
+    """Cannot UPDATE a SETTLED row to have settled_date=NULL."""
+    org, acct, cat = await _seed_org_account_category(db_session)
+    tx = Transaction(
+        org_id=org.id,
+        account_id=acct.id,
+        category_id=cat.id,
+        description="ok",
+        amount=10,
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.SETTLED,
+        date=_date(2026, 5, 8),
+        settled_date=_date(2026, 5, 8),
+    )
+    db_session.add(tx)
+    await db_session.flush()
+
+    tx.settled_date = None
+    with pytest.raises((ValueError, IntegrityError)) as exc_info:
+        await db_session.flush()
+    assert "settled" in str(exc_info.value).lower()
+
+
+async def test_update_status_to_settled_with_null_date_raises(db_session):
+    """Cannot UPDATE a row to status=SETTLED while settled_date is NULL."""
+    org, acct, cat = await _seed_org_account_category(db_session)
+    tx = Transaction(
+        org_id=org.id,
+        account_id=acct.id,
+        category_id=cat.id,
+        description="pending row",
+        amount=10,
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PENDING,
+        date=_date(2026, 5, 8),
+        settled_date=None,
+    )
+    db_session.add(tx)
+    await db_session.flush()
+
+    tx.status = TransactionStatus.SETTLED
+    with pytest.raises((ValueError, IntegrityError)) as exc_info:
+        await db_session.flush()
+    assert "settled" in str(exc_info.value).lower()
+
+
+async def test_pending_to_settled_with_date_succeeds(db_session):
+    """Setting both status=SETTLED and a non-null settled_date in the
+    same flush must succeed — that's the legitimate transition."""
+    org, acct, cat = await _seed_org_account_category(db_session)
+    tx = Transaction(
+        org_id=org.id,
+        account_id=acct.id,
+        category_id=cat.id,
+        description="pending row",
+        amount=10,
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PENDING,
+        date=_date(2026, 5, 8),
+        settled_date=None,
+    )
+    db_session.add(tx)
+    await db_session.flush()
+
+    tx.status = TransactionStatus.SETTLED
+    tx.settled_date = _date(2026, 5, 8)
+    await db_session.flush()
+    # Re-read to confirm persisted.
+    result = await db_session.execute(select(Transaction).where(Transaction.id == tx.id))
+    fetched = result.scalar_one()
+    assert fetched.status == TransactionStatus.SETTLED
+    assert fetched.settled_date == _date(2026, 5, 8)


### PR DESCRIPTION
## Summary

Enforces the business invariant that a `transactions` row with `status='settled'` must have `settled_date IS NOT NULL`. Previously the data layer tolerated this state, relying on every code path to set both columns together, which is a one-line drift away from regressing.

## Enforcement (belt-and-suspenders)

- **DB layer** (migration `036_settled_implies_settled_date`): backfills any orphan SETTLED rows by `COALESCE`ing `settled_date <- date` (same fallback `effective_period_date_expr()` already uses for period bucketing), then adds CHECK constraint `status <> 'settled' OR settled_date IS NOT NULL`. Portable to MySQL 8 and SQLite.
- **App layer**: `before_insert`/`before_update` SQLAlchemy event listeners on the Transaction model raise `ValueError` at flush time when the invariant is violated, so callers see a typed Python error rather than an opaque `IntegrityError`. The flush-time hook avoids the false-positive trap that per-attribute `@validates` would hit during constructor kwarg ordering.

## Orphan count

Zero in the local dev DB at time of writing. The migration's backfill is defensive against pre-`020` rows or any path that slipped through — an `UPDATE` that no-ops if no orphans exist.

## Test fixture cleanup

Several test fixtures were creating SETTLED rows without `settled_date` (relying on the un-enforced invariant). They've been updated to set both columns. One test, `test_settled_no_settled_date_defensive_fallback`, was removed because its scenario (SETTLED + NULL `settled_date`) is now unreachable by construction; the COALESCE still serves PENDING rows without an estimate and is exercised by the sibling pending-fallback test.

Test counts: backend test suite went from 668 to 668 passing (one removed, six added in `tests/test_settled_invariant.py`).