### PR TITLE
feat(forecasts): Dashboard simplification + per-account expected month-end balance

### DIFF
--- a/backend/app/routers/forecast.py
+++ b/backend/app/routers/forecast.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.user import User
-from app.services import forecast_service as svc
+from app.schemas.forecast import AccountBalanceForecastResponse
+from app.services import account_balance_forecast_service, forecast_service
 
 router = APIRouter(prefix="/api/v1/forecast", tags=["forecast"])
 
@@ -17,4 +18,24 @@ async def get_forecast(
     db: AsyncSession = Depends(get_db),
     period_start: datetime.date | None = Query(default=None),
 ):
-    return await svc.compute_forecast(db, current_user.org_id, period_start=period_start)
+    return await forecast_service.compute_forecast(
+        db, current_user.org_id, period_start=period_start
+    )
+
+
+@router.get("/account-balances", response_model=AccountBalanceForecastResponse)
+async def get_account_balance_forecast(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    period_start: datetime.date | None = Query(default=None),
+):
+    """Per-account expected month-end balance for a billing period.
+
+    Dashboard-only view: balance + pending delta in the period. Excludes
+    settled rows (already in stored balance) and manual adjustments
+    (settled-only today). Includes pending transfer legs because they
+    move per-account balances even though they aren't reportable.
+    """
+    return await account_balance_forecast_service.compute_account_balance_forecast(
+        db, current_user.org_id, period_start=period_start
+    )

--- a/backend/app/schemas/forecast.py
+++ b/backend/app/schemas/forecast.py
@@ -1,0 +1,38 @@
+"""Pydantic shapes for the account-balance forecast endpoint.
+
+The legacy forecast aggregate (GET /api/v1/forecast) returns an untyped
+dict and stays that way for now — it's a deeply nested rollup with a
+churning shape. The newer per-account projection has a stable contract,
+so we type it.
+"""
+
+import datetime
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AccountBalanceForecastTotal(BaseModel):
+    currency: str
+    balance: Decimal
+    pending_delta: Decimal
+    expected_month_end_balance: Decimal
+
+
+class AccountBalanceForecastRow(BaseModel):
+    account_id: int
+    account_name: str
+    currency: str
+    is_default: bool
+    account_type_slug: Optional[str] = None
+    balance: Decimal
+    pending_delta: Decimal
+    expected_month_end_balance: Decimal
+
+
+class AccountBalanceForecastResponse(BaseModel):
+    period_start: datetime.date
+    period_end: datetime.date
+    totals: list[AccountBalanceForecastTotal]
+    accounts: list[AccountBalanceForecastRow]

--- a/backend/app/services/account_balance_forecast_service.py
+++ b/backend/app/services/account_balance_forecast_service.py
@@ -1,0 +1,163 @@
+"""Per-account expected month-end balance projection.
+
+Dashboard-only view. Distinct from forecast_service.compute_forecast,
+which deals with reportable income/expense aggregates (and excludes
+transfer legs / manual adjustments). This module answers a different
+question:
+
+  "What will each account's balance be at the end of this billing period?"
+
+Account balance is the sum of all settled transactions on the account,
+including transfer legs. Pending transactions on the account haven't
+moved the stored balance yet but will. So the projection is simply:
+
+  expected_account_balance = stored_balance + sum(pending deltas in period)
+
+with sign by type (income +, expense -). Transfer legs MUST be included
+because they DO move balances per-account, even though they're not
+reportable income/expense. Manual adjustments are settled-only by design,
+but we filter them out defensively from the pending delta in case that
+ever changes.
+
+Currency totals are grouped: never sum unlike currencies.
+"""
+
+import datetime
+from decimal import Decimal
+
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account, AccountType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.services.billing_service import resolve_period
+from app.services.transaction_filters import effective_period_date_expr
+
+
+async def compute_account_balance_forecast(
+    db: AsyncSession,
+    org_id: int,
+    *,
+    period_start: datetime.date | None = None,
+) -> dict:
+    """Compute expected month-end balance per account for a billing period.
+
+    Returns the spec shape:
+
+        {
+          "period_start": "YYYY-MM-DD",
+          "period_end": "YYYY-MM-DD",
+          "totals": [{currency, balance, pending_delta, expected_month_end_balance}],
+          "accounts": [{account_id, account_name, currency, is_default,
+                        account_type_slug, balance, pending_delta,
+                        expected_month_end_balance}],
+        }
+    """
+    period = await resolve_period(db, org_id, period_start)
+
+    p_start = period.start_date
+    p_end = period.end_date or (
+        p_start + relativedelta(months=1) - datetime.timedelta(days=1)
+    )
+
+    accounts_result = await db.execute(
+        select(Account, AccountType.slug)
+        .join(AccountType, Account.account_type_id == AccountType.id)
+        .where(
+            Account.org_id == org_id,
+            Account.is_active.is_(True),
+        )
+    )
+    rows = accounts_result.all()
+
+    # Aggregate pending transactions in the selected period by account.
+    # Sign by type: income +, expense -. Include transfer legs (this is
+    # per-account balance math, not reportable). Defensively exclude
+    # manual adjustments (settled-only today).
+    eff_date = effective_period_date_expr()
+    pending_result = await db.execute(
+        select(
+            Transaction.account_id,
+            Transaction.type,
+            func.coalesce(func.sum(Transaction.amount), Decimal("0")),
+        )
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.status == TransactionStatus.PENDING,
+            Transaction.is_manual_adjustment.is_(False),
+            and_(eff_date >= p_start, eff_date <= p_end),
+        )
+        .group_by(Transaction.account_id, Transaction.type)
+    )
+
+    pending_by_account: dict[int, Decimal] = {}
+    for account_id, tx_type, total in pending_result.all():
+        delta = Decimal(str(total or 0))
+        if tx_type == TransactionType.EXPENSE:
+            delta = -delta
+        pending_by_account[account_id] = (
+            pending_by_account.get(account_id, Decimal("0")) + delta
+        )
+
+    accounts_payload: list[dict] = []
+    totals_by_currency: dict[str, dict[str, Decimal]] = {}
+
+    sorted_rows = sorted(
+        rows,
+        key=lambda r: (
+            not r[0].is_default,
+            r[0].name.casefold(),
+            r[0].id,
+        ),
+    )
+
+    for account, type_slug in sorted_rows:
+        balance = Decimal(str(account.balance))
+        delta = pending_by_account.get(account.id, Decimal("0"))
+        expected = balance + delta
+
+        accounts_payload.append(
+            {
+                "account_id": account.id,
+                "account_name": account.name,
+                "currency": account.currency,
+                "is_default": account.is_default,
+                "account_type_slug": type_slug,
+                "balance": _q(balance),
+                "pending_delta": _q(delta),
+                "expected_month_end_balance": _q(expected),
+            }
+        )
+
+        bucket = totals_by_currency.setdefault(
+            account.currency,
+            {"balance": Decimal("0"), "pending_delta": Decimal("0")},
+        )
+        bucket["balance"] += balance
+        bucket["pending_delta"] += delta
+
+    totals_payload = [
+        {
+            "currency": currency,
+            "balance": _q(b["balance"]),
+            "pending_delta": _q(b["pending_delta"]),
+            "expected_month_end_balance": _q(b["balance"] + b["pending_delta"]),
+        }
+        for currency, b in sorted(totals_by_currency.items())
+    ]
+
+    return {
+        "period_start": p_start.isoformat(),
+        "period_end": p_end.isoformat(),
+        "totals": totals_payload,
+        "accounts": accounts_payload,
+    }
+
+
+_TWOPLACES = Decimal("0.01")
+
+
+def _q(value: Decimal) -> str:
+    """Format a Decimal as a fixed 2-decimal string for JSON transport."""
+    return str(value.quantize(_TWOPLACES))

--- a/backend/tests/services/test_account_balance_forecast_service.py
+++ b/backend/tests/services/test_account_balance_forecast_service.py
@@ -1,0 +1,474 @@
+"""Tests for account_balance_forecast_service.compute_account_balance_forecast.
+
+Pins the spec contract for /api/v1/forecast/account-balances:
+
+  expected_account_month_end_balance = stored balance + pending delta in period
+
+Settled rows are NOT added (already in stored balance — would double-count).
+Pending transfer legs ARE included (per-account balance math).
+Manual adjustments are excluded (settled-only today, defensive filter).
+Pending outside the selected period is excluded.
+Effective period date = COALESCE(settled_date, date).
+Totals are grouped by currency.
+"""
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import (
+    Account,
+    AccountType,
+    Category,
+    Organization,
+    Transaction,
+)
+from app.models.base import Base
+from app.models.billing import BillingPeriod
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.services.account_balance_forecast_service import (
+    compute_account_balance_forecast,
+)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+PERIOD_START = datetime.date(2026, 5, 1)
+PERIOD_END = datetime.date(2026, 5, 31)
+IN_PERIOD = datetime.date(2026, 5, 15)
+BEFORE_PERIOD = datetime.date(2026, 4, 20)
+AFTER_PERIOD = datetime.date(2026, 6, 5)
+
+
+async def _seed(
+    db: AsyncSession,
+    *,
+    second_currency: bool = False,
+    second_account_currency: str = "USD",
+):
+    org = Organization(name="Test", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db.add(at)
+    await db.flush()
+
+    accounts: dict[str, Account] = {}
+    accounts["primary"] = Account(
+        org_id=org.id,
+        name="Checking",
+        account_type_id=at.id,
+        balance=Decimal("1000.00"),
+        currency="EUR",
+        is_default=True,
+    )
+    accounts["secondary"] = Account(
+        org_id=org.id,
+        name="Savings",
+        account_type_id=at.id,
+        balance=Decimal("5000.00"),
+        currency="EUR",
+        is_default=False,
+    )
+    db.add_all([accounts["primary"], accounts["secondary"]])
+    await db.flush()
+
+    if second_currency:
+        accounts["usd"] = Account(
+            org_id=org.id,
+            name="USD Cash",
+            account_type_id=at.id,
+            balance=Decimal("200.00"),
+            currency=second_account_currency,
+            is_default=False,
+        )
+        db.add(accounts["usd"])
+        await db.flush()
+
+    cat_income = Category(
+        org_id=org.id, name="Salary", slug="salary", type=CategoryType.INCOME
+    )
+    cat_expense = Category(
+        org_id=org.id, name="Groceries", slug="groceries", type=CategoryType.EXPENSE
+    )
+    cat_transfer = Category(
+        org_id=org.id, name="Transfer", slug="transfer", type=CategoryType.BOTH,
+        is_system=True,
+    )
+    db.add_all([cat_income, cat_expense, cat_transfer])
+    await db.flush()
+
+    period = BillingPeriod(
+        org_id=org.id, start_date=PERIOD_START, end_date=PERIOD_END
+    )
+    db.add(period)
+    await db.flush()
+
+    return {
+        "org_id": org.id,
+        "accounts": accounts,
+        "cat_income": cat_income.id,
+        "cat_expense": cat_expense.id,
+        "cat_transfer": cat_transfer.id,
+        "period": period,
+    }
+
+
+def _new_tx(**overrides) -> Transaction:
+    """Build a Transaction with sensible defaults for these tests."""
+    defaults = dict(
+        amount=Decimal("100.00"),
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PENDING,
+        date=IN_PERIOD,
+        settled_date=None,
+        description="x",
+        is_imported=False,
+        is_manual_adjustment=False,
+    )
+    defaults.update(overrides)
+    return Transaction(**defaults)
+
+
+# ---------- Test 1: settled rows are not double-counted ----------
+
+async def test_settled_transactions_not_double_counted(db_session: AsyncSession):
+    """Account balance is authoritative. Settled rows must not be added on
+    top of stored balance; pending delta only."""
+    seed = await _seed(db_session)
+    primary = seed["accounts"]["primary"]
+
+    # Settled rows in-period — these should be ignored entirely (already in
+    # the stored balance). If the service double-counted, the expected
+    # would deviate from the stored balance.
+    db_session.add_all(
+        [
+            _new_tx(
+                org_id=seed["org_id"],
+                account_id=primary.id,
+                category_id=seed["cat_expense"],
+                amount=Decimal("250.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.SETTLED,
+                date=IN_PERIOD,
+                settled_date=IN_PERIOD,
+            ),
+            _new_tx(
+                org_id=seed["org_id"],
+                account_id=primary.id,
+                category_id=seed["cat_income"],
+                amount=Decimal("400.00"),
+                type=TransactionType.INCOME,
+                status=TransactionStatus.SETTLED,
+                date=IN_PERIOD,
+                settled_date=IN_PERIOD,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    primary_row = next(a for a in result["accounts"] if a["account_id"] == primary.id)
+    assert primary_row["balance"] == "1000.00"
+    assert primary_row["pending_delta"] == "0.00"
+    assert primary_row["expected_month_end_balance"] == "1000.00"
+
+
+# ---------- Test 2: totals grouped by currency ----------
+
+async def test_totals_grouped_by_currency(db_session: AsyncSession):
+    seed = await _seed(db_session, second_currency=True)
+    eur_primary = seed["accounts"]["primary"]
+    eur_secondary = seed["accounts"]["secondary"]
+    usd_account = seed["accounts"]["usd"]
+
+    # Pending expense on USD account
+    db_session.add(
+        _new_tx(
+            org_id=seed["org_id"],
+            account_id=usd_account.id,
+            category_id=seed["cat_expense"],
+            amount=Decimal("50.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            date=IN_PERIOD,
+        )
+    )
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    by_currency = {t["currency"]: t for t in result["totals"]}
+    assert set(by_currency.keys()) == {"EUR", "USD"}
+    assert by_currency["EUR"]["balance"] == str(
+        (Decimal(str(eur_primary.balance)) + Decimal(str(eur_secondary.balance))).quantize(Decimal("0.01"))
+    )
+    assert by_currency["EUR"]["pending_delta"] == "0.00"
+    assert by_currency["EUR"]["expected_month_end_balance"] == "6000.00"
+    assert by_currency["USD"]["balance"] == "200.00"
+    assert by_currency["USD"]["pending_delta"] == "-50.00"
+    assert by_currency["USD"]["expected_month_end_balance"] == "150.00"
+
+
+# ---------- Test 3: pending expense lowers expected balance ----------
+
+async def test_pending_expense_lowers_expected(db_session: AsyncSession):
+    seed = await _seed(db_session)
+    primary = seed["accounts"]["primary"]
+
+    db_session.add(
+        _new_tx(
+            org_id=seed["org_id"],
+            account_id=primary.id,
+            category_id=seed["cat_expense"],
+            amount=Decimal("75.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            date=IN_PERIOD,
+        )
+    )
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    row = next(a for a in result["accounts"] if a["account_id"] == primary.id)
+    assert row["pending_delta"] == "-75.00"
+    assert row["expected_month_end_balance"] == "925.00"
+
+
+# ---------- Test 4: pending income raises expected balance ----------
+
+async def test_pending_income_raises_expected(db_session: AsyncSession):
+    seed = await _seed(db_session)
+    primary = seed["accounts"]["primary"]
+
+    db_session.add(
+        _new_tx(
+            org_id=seed["org_id"],
+            account_id=primary.id,
+            category_id=seed["cat_income"],
+            amount=Decimal("250.00"),
+            type=TransactionType.INCOME,
+            status=TransactionStatus.PENDING,
+            date=IN_PERIOD,
+        )
+    )
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    row = next(a for a in result["accounts"] if a["account_id"] == primary.id)
+    assert row["pending_delta"] == "250.00"
+    assert row["expected_month_end_balance"] == "1250.00"
+
+
+# ---------- Test 5: pending transfer pair lowers source / raises destination ----------
+
+async def test_pending_transfer_pair_moves_balances(db_session: AsyncSession):
+    """Per-account math must include pending transfer legs even though they
+    aren't reportable income/expense."""
+    seed = await _seed(db_session)
+    src = seed["accounts"]["primary"]
+    dst = seed["accounts"]["secondary"]
+
+    expense_leg = _new_tx(
+        org_id=seed["org_id"],
+        account_id=src.id,
+        category_id=seed["cat_transfer"],
+        amount=Decimal("400.00"),
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PENDING,
+        date=IN_PERIOD,
+    )
+    income_leg = _new_tx(
+        org_id=seed["org_id"],
+        account_id=dst.id,
+        category_id=seed["cat_transfer"],
+        amount=Decimal("400.00"),
+        type=TransactionType.INCOME,
+        status=TransactionStatus.PENDING,
+        date=IN_PERIOD,
+    )
+    db_session.add_all([expense_leg, income_leg])
+    await db_session.flush()
+    expense_leg.linked_transaction_id = income_leg.id
+    income_leg.linked_transaction_id = expense_leg.id
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    by_id = {a["account_id"]: a for a in result["accounts"]}
+    assert by_id[src.id]["pending_delta"] == "-400.00"
+    assert by_id[src.id]["expected_month_end_balance"] == "600.00"
+    assert by_id[dst.id]["pending_delta"] == "400.00"
+    assert by_id[dst.id]["expected_month_end_balance"] == "5400.00"
+
+
+# ---------- Test 6: pending outside selected period is excluded ----------
+
+async def test_pending_outside_period_excluded(db_session: AsyncSession):
+    seed = await _seed(db_session)
+    primary = seed["accounts"]["primary"]
+
+    db_session.add_all(
+        [
+            _new_tx(
+                org_id=seed["org_id"],
+                account_id=primary.id,
+                category_id=seed["cat_expense"],
+                amount=Decimal("99.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                date=BEFORE_PERIOD,
+            ),
+            _new_tx(
+                org_id=seed["org_id"],
+                account_id=primary.id,
+                category_id=seed["cat_expense"],
+                amount=Decimal("88.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                date=AFTER_PERIOD,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    row = next(a for a in result["accounts"] if a["account_id"] == primary.id)
+    assert row["pending_delta"] == "0.00"
+    assert row["expected_month_end_balance"] == "1000.00"
+
+
+# ---------- Test 7: settled_date is preferred over date for period bucketing ----------
+
+async def test_effective_period_date_uses_settled_date_then_date(
+    db_session: AsyncSession,
+):
+    """Pending with settled_date estimate uses settled_date.
+    Pending without settled_date falls back to date."""
+    seed = await _seed(db_session)
+    primary = seed["accounts"]["primary"]
+
+    # (a) date is BEFORE period, but settled_date estimate is IN period -> include
+    # (b) date is IN period, no settled_date -> include
+    # (c) date is IN period, but settled_date is AFTER period -> exclude
+    db_session.add_all(
+        [
+            _new_tx(
+                org_id=seed["org_id"],
+                account_id=primary.id,
+                category_id=seed["cat_expense"],
+                amount=Decimal("10.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                date=BEFORE_PERIOD,
+                settled_date=IN_PERIOD,
+            ),
+            _new_tx(
+                org_id=seed["org_id"],
+                account_id=primary.id,
+                category_id=seed["cat_expense"],
+                amount=Decimal("20.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                date=IN_PERIOD,
+                settled_date=None,
+            ),
+            _new_tx(
+                org_id=seed["org_id"],
+                account_id=primary.id,
+                category_id=seed["cat_expense"],
+                amount=Decimal("40.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.PENDING,
+                date=IN_PERIOD,
+                settled_date=AFTER_PERIOD,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    row = next(a for a in result["accounts"] if a["account_id"] == primary.id)
+    # -10 (settled_date in-period) + -20 (no settled_date, date in-period) = -30
+    assert row["pending_delta"] == "-30.00"
+    assert row["expected_month_end_balance"] == "970.00"
+
+
+# ---------- Test 8: manual adjustments do not affect pending delta ----------
+
+async def test_manual_adjustments_excluded_from_pending_delta(
+    db_session: AsyncSession,
+):
+    """Manual adjustments are settled-only today, but defensively excluded
+    so a future change to allow pending manual adjustments doesn't
+    silently start landing in the dashboard projection."""
+    seed = await _seed(db_session)
+    primary = seed["accounts"]["primary"]
+
+    db_session.add(
+        _new_tx(
+            org_id=seed["org_id"],
+            account_id=primary.id,
+            category_id=seed["cat_expense"],
+            amount=Decimal("999.00"),
+            type=TransactionType.EXPENSE,
+            status=TransactionStatus.PENDING,
+            date=IN_PERIOD,
+            is_manual_adjustment=True,
+        )
+    )
+    await db_session.commit()
+
+    result = await compute_account_balance_forecast(
+        db_session, seed["org_id"], period_start=PERIOD_START
+    )
+
+    row = next(a for a in result["accounts"] if a["account_id"] == primary.id)
+    assert row["pending_delta"] == "0.00"
+    assert row["expected_month_end_balance"] == "1000.00"

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -16,6 +16,9 @@ import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveCo
 import { Check, Clock } from "lucide-react";
 import CategorySelect from "@/components/ui/CategorySelect";
 import OnTrackTile from "@/components/dashboard/OnTrackTile";
+import AccountMonthEndForecast, {
+  type AccountMonthEndForecastResponse,
+} from "@/components/dashboard/AccountMonthEndForecast";
 import type { Account, BillingPeriod, Budget, Category, Transaction } from "@/lib/types";
 
 interface ForecastPlanItem {
@@ -110,6 +113,13 @@ export default function DashboardPage() {
   const [forecastProjection, setForecastProjection] = useState<ForecastProjection | null>(null);
   const [projectionFailed, setProjectionFailed] = useState(false);
   const [projectionLoading, setProjectionLoading] = useState(false);
+  // Per-account expected month-end balance from /api/v1/forecast/account-balances.
+  // Distinct from forecastProjection above (which drives the OnTrackTile —
+  // reportable income/expense aggregates). This one is per-account balance
+  // math including pending transfer legs.
+  const [accountMonthEndForecast, setAccountMonthEndForecast] =
+    useState<AccountMonthEndForecastResponse | null>(null);
+  const accountForecastRequestId = useRef(0);
   // Monotonically-increasing request id for the projection fetch. Used
   // to discard stale responses when a newer fetch has already started
   // (e.g. period nav during an in-flight call, or two writes in quick
@@ -310,6 +320,35 @@ export default function DashboardPage() {
     }
   }, [loading, user, realPeriodStart, loadForecastProjection]);
 
+  // Per-account month-end balance forecast. Only fetch for the current
+  // selected period — past/future periods render a neutral "only
+  // available for current period" state in the component, since the
+  // stored balance is "now" and projecting it elsewhere would mislead.
+  const loadAccountMonthEndForecast = useCallback(async () => {
+    if (!realPeriodStart || !isCurrentSelectedPeriod) {
+      accountForecastRequestId.current += 1;
+      setAccountMonthEndForecast(null);
+      return;
+    }
+    const myId = ++accountForecastRequestId.current;
+    try {
+      const data = await apiFetch<AccountMonthEndForecastResponse>(
+        `/api/v1/forecast/account-balances?period_start=${realPeriodStart}`,
+      );
+      if (accountForecastRequestId.current !== myId) return;
+      setAccountMonthEndForecast(data);
+    } catch {
+      if (accountForecastRequestId.current !== myId) return;
+      setAccountMonthEndForecast(null);
+    }
+  }, [realPeriodStart, isCurrentSelectedPeriod]);
+
+  useEffect(() => {
+    if (!loading && user) {
+      void loadAccountMonthEndForecast();
+    }
+  }, [loading, user, loadAccountMonthEndForecast]);
+
   function handleTypeChange(t: "income" | "expense") {
     setFormType(t);
     setFormCategoryId("");
@@ -381,6 +420,7 @@ export default function DashboardPage() {
       // Pending charges may have changed (a settled-on-create or a manual
       // pending entry); refresh independent of the visible page index.
       void loadPendingTransactions();
+      void loadAccountMonthEndForecast();
     } catch (err) {
       setError(extractErrorMessage(err));
     }
@@ -698,6 +738,20 @@ export default function DashboardPage() {
             );
           })()}
 
+          {/* ═══ ROW 2.5: Account month-end forecast ═══ */}
+          <AccountMonthEndForecast
+            forecast={accountMonthEndForecast}
+            isCurrentPeriod={isCurrentSelectedPeriod}
+            hasAnyAccounts={activeAccounts.length > 0}
+            onJumpToCurrent={() => {
+              const idx = periods.findIndex((p) => p.end_date === null);
+              if (idx >= 0) {
+                setPeriodIdx(idx);
+                setChartFilter(null);
+              }
+            }}
+          />
+
           {/* ═══ ROW 3: Three equal charts ═══ */}
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
             {/* Spending by category (donut) */}
@@ -844,11 +898,7 @@ export default function DashboardPage() {
                               if (name) setChartFilter(chartFilter === name ? null : name);
                             }}
                           />
-                          <Bar dataKey="actual" fill="var(--color-chart-2)" radius={[4, 4, 4, 4]} animationDuration={600}>
-                            {expenseItems.slice(0, 8).map((it, i) => (
-                              <Cell key={i} fill={Number(it.actual_amount) > Number(it.planned_amount) ? "var(--color-chart-5)" : "var(--color-chart-2)"} />
-                            ))}
-                          </Bar>
+                          <Bar dataKey="actual" fill="var(--color-chart-2)" radius={[4, 4, 4, 4]} animationDuration={600} />
                         </BarChart>
                       </ResponsiveContainer>
                     </div>
@@ -867,8 +917,7 @@ export default function DashboardPage() {
               })()}
               <div className="mt-2 flex gap-3 text-[10px] text-text-muted">
                 <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-1)" }} /> Planned</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-2)" }} /> Under plan</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-5)" }} /> Over plan</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-2)" }} /> Actual</span>
               </div>
             </div>
           </div>
@@ -916,6 +965,7 @@ export default function DashboardPage() {
                               await loadTransactions(page);
                               await loadRefs();
                               void loadForecastProjection();
+                              void loadAccountMonthEndForecast();
                               // Independent of `page` — a toggle on page 2
                               // still has to refresh the strip's totals.
                               void loadPendingTransactions();

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -119,6 +119,11 @@ export default function DashboardPage() {
   // math including pending transfer legs.
   const [accountMonthEndForecast, setAccountMonthEndForecast] =
     useState<AccountMonthEndForecastResponse | null>(null);
+  // Distinguish "in flight / not yet fetched" from "load failed" so the
+  // card can render an error state instead of a loading placeholder
+  // forever on a 500.
+  const [accountMonthEndForecastError, setAccountMonthEndForecastError] =
+    useState(false);
   const accountForecastRequestId = useRef(0);
   // Monotonically-increasing request id for the projection fetch. Used
   // to discard stale responses when a newer fetch has already started
@@ -328,18 +333,22 @@ export default function DashboardPage() {
     if (!realPeriodStart || !isCurrentSelectedPeriod) {
       accountForecastRequestId.current += 1;
       setAccountMonthEndForecast(null);
+      setAccountMonthEndForecastError(false);
       return;
     }
     const myId = ++accountForecastRequestId.current;
+    setAccountMonthEndForecastError(false);
     try {
       const data = await apiFetch<AccountMonthEndForecastResponse>(
         `/api/v1/forecast/account-balances?period_start=${realPeriodStart}`,
       );
       if (accountForecastRequestId.current !== myId) return;
       setAccountMonthEndForecast(data);
+      setAccountMonthEndForecastError(false);
     } catch {
       if (accountForecastRequestId.current !== myId) return;
       setAccountMonthEndForecast(null);
+      setAccountMonthEndForecastError(true);
     }
   }, [realPeriodStart, isCurrentSelectedPeriod]);
 
@@ -743,6 +752,7 @@ export default function DashboardPage() {
             forecast={accountMonthEndForecast}
             isCurrentPeriod={isCurrentSelectedPeriod}
             hasAnyAccounts={activeAccounts.length > 0}
+            hasError={accountMonthEndForecastError}
             onJumpToCurrent={() => {
               const idx = periods.findIndex((p) => p.end_date === null);
               if (idx >= 0) {

--- a/frontend/components/dashboard/AccountMonthEndForecast.tsx
+++ b/frontend/components/dashboard/AccountMonthEndForecast.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { card, cardHeader, cardTitle } from "@/lib/styles";
+import { formatAmount } from "@/lib/format";
+
+export interface AccountMonthEndForecastTotal {
+  currency: string;
+  balance: string;
+  pending_delta: string;
+  expected_month_end_balance: string;
+}
+
+export interface AccountMonthEndForecastRow {
+  account_id: number;
+  account_name: string;
+  currency: string;
+  is_default: boolean;
+  account_type_slug: string | null;
+  balance: string;
+  pending_delta: string;
+  expected_month_end_balance: string;
+}
+
+export interface AccountMonthEndForecastResponse {
+  period_start: string;
+  period_end: string;
+  totals: AccountMonthEndForecastTotal[];
+  accounts: AccountMonthEndForecastRow[];
+}
+
+export interface AccountMonthEndForecastProps {
+  forecast: AccountMonthEndForecastResponse | null;
+  isCurrentPeriod: boolean;
+  onJumpToCurrent?: () => void;
+  hasAnyAccounts: boolean;
+}
+
+export default function AccountMonthEndForecast({
+  forecast,
+  isCurrentPeriod,
+  onJumpToCurrent,
+  hasAnyAccounts,
+}: AccountMonthEndForecastProps) {
+  // Past or future selected period: the stored balance is "now", not
+  // historical or future, so projecting it into another period would
+  // mislead. Spec mandates a small neutral state instead.
+  if (!isCurrentPeriod) {
+    return (
+      <section className={`${card} p-5`} data-testid="account-month-end-forecast">
+        <header className={`mb-2 flex items-center justify-between ${cardHeader}`}>
+          <h2 className={cardTitle}>Forecast</h2>
+        </header>
+        <p className="text-sm text-text-muted">
+          Month-end balance forecast is only available for the current period.
+        </p>
+        {onJumpToCurrent && (
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={onJumpToCurrent}
+              className="text-xs text-text-secondary underline underline-offset-2 hover:text-text-primary"
+            >
+              Today
+            </button>
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  // No accounts yet: defer to the page-level empty state. Render nothing
+  // so the dashboard's existing "No accounts yet" tile owns this surface.
+  if (!hasAnyAccounts) return null;
+
+  if (!forecast) {
+    return (
+      <section className={`${card} p-5`} data-testid="account-month-end-forecast">
+        <header className={`mb-2 flex items-center justify-between ${cardHeader}`}>
+          <h2 className={cardTitle}>Forecast</h2>
+        </header>
+        <p className="text-sm text-text-muted">Loading…</p>
+      </section>
+    );
+  }
+
+  const totals = forecast.totals;
+  const rows = forecast.accounts;
+
+  return (
+    <section className={`${card} p-5`} data-testid="account-month-end-forecast">
+      <header className={`mb-3 ${cardHeader}`}>
+        <h2 className={cardTitle}>Forecast</h2>
+        <p className="mt-1 text-xs text-text-muted">
+          Current balance plus pending items in this period.
+        </p>
+      </header>
+
+      {totals.length > 0 && (
+        <div className="mb-4 space-y-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+            Expected month-end balance
+          </p>
+          <div className="space-y-0.5">
+            {totals.map((t) => (
+              <p
+                key={t.currency}
+                className="text-2xl font-semibold tabular-nums text-text-primary"
+              >
+                {formatAmount(t.expected_month_end_balance)}{" "}
+                <span className="text-xs font-normal text-text-muted">{t.currency}</span>
+              </p>
+            ))}
+          </div>
+          <p className="text-xs text-text-muted">Includes pending items in this period.</p>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-md border border-border-subtle">
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-4 border-b border-border-subtle bg-surface-overlay px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+          <span>Account</span>
+          <span className="text-right">Balance</span>
+          <span className="text-right">End of month forecast</span>
+        </div>
+        <div className="divide-y divide-border-subtle">
+          {rows.map((row) => {
+            const pendingNum = Number(row.pending_delta);
+            const showPending = pendingNum !== 0;
+            const sign = pendingNum > 0 ? "+" : "-";
+            const pendingMagnitude = formatAmount(Math.abs(pendingNum));
+            const pendingCurrencySymbol = currencySymbol(row.currency);
+            return (
+              <div
+                key={row.account_id}
+                className="grid grid-cols-[1fr_auto_auto] items-center gap-x-4 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="flex items-center gap-2 text-sm text-text-primary">
+                    <span className="truncate">{row.account_name}</span>
+                    {row.is_default && (
+                      <span className="rounded border border-border px-1.5 py-0.5 text-[9px] font-semibold text-text-secondary">
+                        DEFAULT
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <p className="text-sm tabular-nums text-text-secondary">
+                  {formatAmount(row.balance)}{" "}
+                  <span className="text-[10px] text-text-muted">{row.currency}</span>
+                </p>
+                <div className="text-right">
+                  <p className="text-sm font-medium tabular-nums text-text-primary">
+                    {formatAmount(row.expected_month_end_balance)}
+                  </p>
+                  {showPending && (
+                    <p className="text-[10px] tabular-nums text-text-muted">
+                      Includes {sign}
+                      {pendingCurrencySymbol}
+                      {pendingMagnitude} pending
+                    </p>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// Best-effort symbol mapping. Falls back to the ISO code so unknown
+// currencies still round-trip readable copy.
+function currencySymbol(code: string): string {
+  switch (code) {
+    case "EUR":
+      return "€";
+    case "USD":
+      return "$";
+    case "GBP":
+      return "£";
+    default:
+      return `${code} `;
+  }
+}

--- a/frontend/components/dashboard/AccountMonthEndForecast.tsx
+++ b/frontend/components/dashboard/AccountMonthEndForecast.tsx
@@ -137,10 +137,16 @@ export default function AccountMonthEndForecast({
       )}
 
       <div className="overflow-hidden rounded-md border border-border-subtle">
-        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-4 border-b border-border-subtle bg-surface-overlay px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+        {/* Three left-aligned columns. Account narrowest (anchors the
+            row by name); Balance medium; End of month forecast widest
+            because the pending subtext (e.g. "Includes -€425.29
+            pending") sits underneath and shouldn't wrap awkwardly.
+            User direction overrides the spec's "tabular and right
+            aligned" — left-aligned reads as a list, not a ledger. */}
+        <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,3fr)] items-center gap-x-4 border-b border-border-subtle bg-surface-overlay px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
           <span>Account</span>
-          <span className="text-right">Balance</span>
-          <span className="text-right">End of month forecast</span>
+          <span>Balance</span>
+          <span>End of month forecast</span>
         </div>
         <div className="divide-y divide-border-subtle">
           {rows.map((row) => {
@@ -152,7 +158,7 @@ export default function AccountMonthEndForecast({
             return (
               <div
                 key={row.account_id}
-                className="grid grid-cols-[1fr_auto_auto] items-center gap-x-4 px-3 py-2"
+                className="grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,3fr)] items-center gap-x-4 px-3 py-2"
               >
                 <div className="min-w-0">
                   <p className="flex items-center gap-2 text-sm text-text-primary">
@@ -168,7 +174,7 @@ export default function AccountMonthEndForecast({
                   {formatAmount(row.balance)}{" "}
                   <span className="text-[10px] text-text-muted">{row.currency}</span>
                 </p>
-                <div className="text-right">
+                <div>
                   <p className="text-sm font-medium tabular-nums text-text-primary">
                     {formatAmount(row.expected_month_end_balance)}
                   </p>

--- a/frontend/components/dashboard/AccountMonthEndForecast.tsx
+++ b/frontend/components/dashboard/AccountMonthEndForecast.tsx
@@ -33,6 +33,11 @@ export interface AccountMonthEndForecastProps {
   isCurrentPeriod: boolean;
   onJumpToCurrent?: () => void;
   hasAnyAccounts: boolean;
+  // True when the most recent fetch attempt failed. Distinguishes "still
+  // loading" (forecast null AND no error) from "load failed" (forecast
+  // null AND error true). Without this, a 500 from the endpoint would
+  // render the same "Loading…" placeholder forever.
+  hasError?: boolean;
 }
 
 export default function AccountMonthEndForecast({
@@ -40,7 +45,14 @@ export default function AccountMonthEndForecast({
   isCurrentPeriod,
   onJumpToCurrent,
   hasAnyAccounts,
+  hasError = false,
 }: AccountMonthEndForecastProps) {
+  // No accounts: page-level empty state owns this surface; render nothing
+  // regardless of period. Runs BEFORE the period check so an empty org
+  // viewing a past/future period doesn't see a neutral month-end card it
+  // can never use.
+  if (!hasAnyAccounts) return null;
+
   // Past or future selected period: the stored balance is "now", not
   // historical or future, so projecting it into another period would
   // mislead. Spec mandates a small neutral state instead.
@@ -68,9 +80,18 @@ export default function AccountMonthEndForecast({
     );
   }
 
-  // No accounts yet: defer to the page-level empty state. Render nothing
-  // so the dashboard's existing "No accounts yet" tile owns this surface.
-  if (!hasAnyAccounts) return null;
+  if (hasError) {
+    return (
+      <section className={`${card} p-5`} data-testid="account-month-end-forecast">
+        <header className={`mb-2 flex items-center justify-between ${cardHeader}`}>
+          <h2 className={cardTitle}>Forecast</h2>
+        </header>
+        <p className="text-sm text-text-muted">
+          Couldn&apos;t load account forecast. Try again later.
+        </p>
+      </section>
+    );
+  }
 
   if (!forecast) {
     return (

--- a/frontend/components/dashboard/OnTrackTile.tsx
+++ b/frontend/components/dashboard/OnTrackTile.tsx
@@ -24,17 +24,9 @@ export interface OnTrackTileProps {
   isFuturePeriod: boolean;
 }
 
-// Verdict bands: ≤95% on track, 95-105% watch, >105% over.
-// Tunable in a follow-up; for now constants live here.
+// Verdict bands: <=95% on track, 95-105% watch, >105% over.
 const ON_TRACK_MAX = 0.95;
 const WATCH_MAX = 1.05;
-
-// Tooltip copy for the dashboard stats. Plain language; the docs page
-// (/docs#forecasts) carries the longer explanation.
-const VARIANCE_HELP =
-  "Plan minus actual. Positive number means you spent less than planned (good for expense). Green when you're under plan, red when you're over.";
-const PROJECTED_HELP =
-  "Best guess at end-of-month total = settled + pending + scheduled recurring. Can differ from your plan.";
 
 type Verdict = "on-track" | "watch" | "over";
 
@@ -73,30 +65,17 @@ function Stat({
   sublabel,
   valueClass = "text-text-primary",
   muted = false,
-  helpText,
 }: {
   label: string;
   value: string;
   sublabel?: string;
   valueClass?: string;
   muted?: boolean;
-  helpText?: string;
 }) {
   return (
     <div>
-      <p className="flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
+      <p className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
         {label}
-        {helpText && (
-          <span
-            tabIndex={0}
-            role="img"
-            aria-label={`${label} explained: ${helpText}`}
-            title={`${helpText} See /docs#forecasts for more.`}
-            className="cursor-help rounded-sm text-text-muted/70 hover:text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
-          >
-            (?)
-          </span>
-        )}
       </p>
       <p
         className={`mt-1 text-2xl font-semibold tabular-nums ${
@@ -106,6 +85,19 @@ function Stat({
         {value}
       </p>
       {sublabel && <p className="mt-1 text-xs text-text-muted">{sublabel}</p>}
+    </div>
+  );
+}
+
+function DetailsLink() {
+  return (
+    <div className="mt-6 text-sm">
+      <Link
+        href="/forecast-plans"
+        className="text-text-primary underline underline-offset-2 hover:text-text-secondary"
+      >
+        View forecast details
+      </Link>
     </div>
   );
 }
@@ -122,9 +114,9 @@ export default function OnTrackTile({
   const plannedExpense = forecastPlan ? Number(forecastPlan.total_planned_expense) : 0;
   const hasPlan = forecastPlan !== null && plannedExpense > 0;
 
-  // Past period with no plan: non-actionable, past-tense copy.
-  // Runs BEFORE the no-plan branch so a closed period without a plan
-  // doesn't render the current-period "Set one up" CTA.
+  // Past period with no plan: non-actionable, past-tense copy. Runs
+  // BEFORE the no-plan branch so a closed period without a plan doesn't
+  // render the current-period CTA.
   if (isPastPeriod && !hasPlan) {
     return (
       <section
@@ -134,7 +126,7 @@ export default function OnTrackTile({
       >
         <header className="mb-6 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
-            Plan vs Actual
+            Forecast
           </span>
           <span className="text-xs text-text-secondary">Past period</span>
         </header>
@@ -143,26 +135,24 @@ export default function OnTrackTile({
     );
   }
 
-  // Pre-period (selected period in the future): plan if drafted, suppress everything else.
+  // Future period: prompt to plan ahead.
   if (isFuturePeriod) {
     return (
       <section className={`${card} p-6 md:p-8`} data-testid="on-track-tile" aria-label="Plan ahead">
         <header className="mb-6 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
-            Plan ahead
+            Forecast
           </span>
           <span className="text-xs text-text-secondary">Future period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           <Stat
-            label="PLAN"
+            label="Planned spending"
             value={hasPlan ? formatAmount(plannedExpense) : "—"}
             sublabel={hasPlan ? "full month" : "not yet planned"}
             muted={!hasPlan}
           />
-          <Stat label="SPENT" value="—" sublabel="nothing yet" muted />
-          <Stat label="VARIANCE" value="—" muted helpText={VARIANCE_HELP} />
-          <Stat label="PROJECTED" value="—" muted helpText={PROJECTED_HELP} />
+          <Stat label="Spent so far" value="—" sublabel="nothing yet" muted />
         </div>
         <div className="mt-6 text-sm">
           <Link
@@ -176,7 +166,7 @@ export default function OnTrackTile({
     );
   }
 
-  // Current period, no plan exists. Spent so far is suppressed (no source independent of the projection call).
+  // Current period, no plan exists.
   if (!hasPlan) {
     return (
       <section
@@ -186,15 +176,13 @@ export default function OnTrackTile({
       >
         <header className="mb-6 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
-            Plan vs Projection
+            Forecast
           </span>
           <span className="text-xs text-text-secondary">This period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <Stat label="PLAN" value={formatAmount(0)} sublabel="not yet planned" muted />
-          <Stat label="SPENT SO FAR" value="—" muted />
-          <Stat label="VARIANCE" value="—" muted helpText={VARIANCE_HELP} />
-          <Stat label="PROJECTED" value="—" muted helpText={PROJECTED_HELP} />
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <Stat label="Planned spending" value={formatAmount(0)} sublabel="not yet planned" muted />
+          <Stat label="Spent so far" value="—" muted />
         </div>
         <div className="mt-6 text-sm">
           <Link
@@ -208,7 +196,7 @@ export default function OnTrackTile({
     );
   }
 
-  // Plan exists, projection call failed. Plan stays; Spent / Variance / Projected suppress.
+  // Plan exists, projection call failed.
   if (projectionFailed) {
     return (
       <section
@@ -218,18 +206,16 @@ export default function OnTrackTile({
       >
         <header className="mb-6 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
-            Plan vs Projection
+            Forecast
           </span>
           <span className="text-xs text-text-secondary">This period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <Stat label="PLAN" value={formatAmount(plannedExpense)} sublabel="full month" />
-          <Stat label="SPENT SO FAR" value="—" muted />
-          <Stat label="VARIANCE" value="—" muted helpText={VARIANCE_HELP} />
-          <Stat label="PROJECTED" value="Unavailable" muted helpText={PROJECTED_HELP} />
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
+          <Stat label="Spent so far" value="—" muted />
         </div>
         <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-text-muted">
-          <span>Projection unavailable.</span>
+          <span>Forecast unavailable.</span>
           <button
             type="button"
             onClick={onRetryProjection}
@@ -244,7 +230,7 @@ export default function OnTrackTile({
     );
   }
 
-  // Plan exists but projection hasn't loaded yet. Show plan with placeholders for the rest.
+  // Plan exists but projection hasn't loaded yet.
   if (!projection) {
     return (
       <section
@@ -254,15 +240,13 @@ export default function OnTrackTile({
       >
         <header className="mb-6 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
-            Plan vs Projection
+            Forecast
           </span>
           <span className="text-xs text-text-secondary">This period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <Stat label="PLAN" value={formatAmount(plannedExpense)} sublabel="full month" />
-          <Stat label="SPENT SO FAR" value="…" muted />
-          <Stat label="VARIANCE" value="…" muted helpText={VARIANCE_HELP} />
-          <Stat label="PROJECTED" value="…" muted helpText={PROJECTED_HELP} />
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
+          <Stat label="Spent so far" value="…" muted />
         </div>
       </section>
     );
@@ -271,13 +255,10 @@ export default function OnTrackTile({
   const executedExpense = Number(projection.executed_expense);
   const forecastExpense = Number(projection.forecast_expense);
 
-  // Past period: verdict + variance use actuals (executed_expense), not the projection.
-  // Projected column is suppressed; Final spent replaces it.
+  // Past period: verdict uses actuals (executed_expense), not the projection.
   if (isPastPeriod) {
     const pct = executedExpense / plannedExpense;
     const verdict = computeVerdict(pct);
-    const variance = plannedExpense - executedExpense;
-    const varianceFavorable = variance >= 0;
 
     return (
       <section className={`${card} p-6 md:p-8`} data-testid="on-track-tile" aria-label={PAST_LABELS[verdict]}>
@@ -290,33 +271,20 @@ export default function OnTrackTile({
           </h2>
           <span className="text-xs text-text-secondary">Past period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-          <Stat label="PLAN" value={formatAmount(plannedExpense)} sublabel="full month" />
-          <Stat
-            label="FINAL SPENT"
-            value={formatAmount(executedExpense)}
-            sublabel="final"
-          />
-          <Stat
-            label="VARIANCE"
-            value={`${variance >= 0 ? "+" : "−"}${formatAmount(Math.abs(variance))}`}
-            sublabel={varianceFavorable ? "under plan" : "over plan"}
-            valueClass={varianceFavorable ? "text-accent" : "text-danger"}
-            helpText={VARIANCE_HELP}
-          />
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
+          <Stat label="Final spent" value={formatAmount(executedExpense)} sublabel="final" />
         </div>
+        <DetailsLink />
       </section>
     );
   }
 
-  // Default current-period view: verdict + variance anchor on actual (settled)
-  // spending, NOT the projection. The projection is shown as an informational
-  // muted stat so it never alarms the user before money has actually moved.
-  // YNAB / Monarch / Copilot / Mint all behave this way.
+  // Current period: verdict anchors on actual (settled) spending. Expected
+  // spending is shown as a supporting fact, not the verdict driver. YNAB /
+  // Monarch / Copilot / Mint all behave this way.
   const pct = executedExpense / plannedExpense;
   const verdict = computeVerdict(pct);
-  const variance = plannedExpense - executedExpense;
-  const varianceFavorable = variance >= 0;
 
   return (
     <section className={`${card} p-6 md:p-8`} data-testid="on-track-tile" aria-label={CURRENT_LABELS[verdict]}>
@@ -329,28 +297,17 @@ export default function OnTrackTile({
         </h2>
         <span className="text-xs text-text-secondary">This period</span>
       </header>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-        <Stat label="PLAN" value={formatAmount(plannedExpense)} sublabel="full month" />
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
+        <Stat label="Spent so far" value={formatAmount(executedExpense)} sublabel="actual today" />
         <Stat
-          label="SPENT SO FAR"
-          value={formatAmount(executedExpense)}
-          sublabel="actual today"
-        />
-        <Stat
-          label="VARIANCE"
-          value={`${variance >= 0 ? "+" : "−"}${formatAmount(Math.abs(variance))}`}
-          sublabel={varianceFavorable ? "under plan" : "over plan"}
-          valueClass={varianceFavorable ? "text-accent" : "text-danger"}
-          helpText={VARIANCE_HELP}
-        />
-        <Stat
-          label="PROJECTED"
+          label="Expected spending"
           value={formatAmount(forecastExpense)}
-          sublabel="projected end-of-month"
+          sublabel="end of month"
           muted
-          helpText={PROJECTED_HELP}
         />
       </div>
+      <DetailsLink />
     </section>
   );
 }

--- a/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
+++ b/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
@@ -1,0 +1,211 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import AccountMonthEndForecast, {
+  type AccountMonthEndForecastResponse,
+} from "@/components/dashboard/AccountMonthEndForecast";
+
+function defaults(
+  overrides: Partial<Parameters<typeof AccountMonthEndForecast>[0]> = {},
+) {
+  return {
+    forecast: null,
+    isCurrentPeriod: true,
+    hasAnyAccounts: true,
+    onJumpToCurrent: vi.fn(),
+    ...overrides,
+  };
+}
+
+const TWO_ACCOUNTS_EUR: AccountMonthEndForecastResponse = {
+  period_start: "2026-05-01",
+  period_end: "2026-05-31",
+  totals: [
+    {
+      currency: "EUR",
+      balance: "6000.00",
+      pending_delta: "-150.00",
+      expected_month_end_balance: "5850.00",
+    },
+  ],
+  accounts: [
+    {
+      account_id: 1,
+      account_name: "Checking",
+      currency: "EUR",
+      is_default: true,
+      account_type_slug: "checking",
+      balance: "1000.00",
+      pending_delta: "-250.00",
+      expected_month_end_balance: "750.00",
+    },
+    {
+      account_id: 2,
+      account_name: "Savings",
+      currency: "EUR",
+      is_default: false,
+      account_type_slug: "savings",
+      balance: "5000.00",
+      pending_delta: "100.00",
+      expected_month_end_balance: "5100.00",
+    },
+  ],
+};
+
+const TWO_CURRENCIES: AccountMonthEndForecastResponse = {
+  period_start: "2026-05-01",
+  period_end: "2026-05-31",
+  totals: [
+    {
+      currency: "EUR",
+      balance: "1000.00",
+      pending_delta: "0.00",
+      expected_month_end_balance: "1000.00",
+    },
+    {
+      currency: "USD",
+      balance: "200.00",
+      pending_delta: "-50.00",
+      expected_month_end_balance: "150.00",
+    },
+  ],
+  accounts: [
+    {
+      account_id: 1,
+      account_name: "Checking EUR",
+      currency: "EUR",
+      is_default: true,
+      account_type_slug: "checking",
+      balance: "1000.00",
+      pending_delta: "0.00",
+      expected_month_end_balance: "1000.00",
+    },
+    {
+      account_id: 2,
+      account_name: "USD Cash",
+      currency: "USD",
+      is_default: false,
+      account_type_slug: "cash",
+      balance: "200.00",
+      pending_delta: "-50.00",
+      expected_month_end_balance: "150.00",
+    },
+  ],
+};
+
+describe("AccountMonthEndForecast — current period", () => {
+  it("renders title 'Forecast' and the prescribed subtext", () => {
+    render(
+      <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^Forecast$/);
+    expect(
+      screen.getByText(/Current balance plus pending items in this period\./),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the expected month-end balance per currency", () => {
+    render(
+      <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
+    );
+    // Top summary
+    expect(screen.getByText(/expected month-end balance/i)).toBeInTheDocument();
+    // EUR aggregate value
+    expect(screen.getByText(/5,850\.00/)).toBeInTheDocument();
+    // Subtext under the headline number
+    expect(
+      screen.getByText(/Includes pending items in this period\./),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Account / Balance / End of month forecast columns", () => {
+    render(
+      <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
+    );
+    expect(screen.getByText(/^Account$/)).toBeInTheDocument();
+    expect(screen.getByText(/^Balance$/)).toBeInTheDocument();
+    expect(screen.getByText(/^End of month forecast$/)).toBeInTheDocument();
+  });
+
+  it("default account renders with DEFAULT marker and appears first", () => {
+    render(
+      <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
+    );
+    const checking = screen.getByText("Checking");
+    const savings = screen.getByText("Savings");
+    expect(checking.compareDocumentPosition(savings) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText(/^DEFAULT$/)).toBeInTheDocument();
+  });
+
+  it("shows the pending subtext only on rows whose pending delta is non-zero", () => {
+    render(
+      <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
+    );
+    // Checking pending: -250
+    expect(screen.getByText(/Includes -€250\.00 pending/)).toBeInTheDocument();
+    // Savings pending: +100
+    expect(screen.getByText(/Includes \+€100\.00 pending/)).toBeInTheDocument();
+  });
+
+  it("renders one expected-balance row per currency without combining unlike currencies", () => {
+    render(
+      <AccountMonthEndForecast {...defaults({ forecast: TWO_CURRENCIES })} />,
+    );
+    // EUR + USD totals listed separately. The 1,000.00 value appears
+    // both as the total summary AND as the per-account row, so look up
+    // by currency code and assert both currencies are present.
+    // Each currency code appears in BOTH the total headline and the
+    // per-account row, so use getAllByText for multi-match safety.
+    expect(screen.getAllByText(/^EUR$/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/^USD$/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/1,000\.00/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/150\.00/).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("AccountMonthEndForecast — non-current periods", () => {
+  it("past period renders the neutral state and does not show columns", () => {
+    render(
+      <AccountMonthEndForecast
+        {...defaults({ forecast: TWO_ACCOUNTS_EUR, isCurrentPeriod: false })}
+      />,
+    );
+    expect(
+      screen.getByText(
+        /Month-end balance forecast is only available for the current period\./,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^End of month forecast$/)).not.toBeInTheDocument();
+  });
+
+  it("future period renders a Today action when onJumpToCurrent is provided", () => {
+    const onJump = vi.fn();
+    render(
+      <AccountMonthEndForecast
+        {...defaults({
+          forecast: TWO_ACCOUNTS_EUR,
+          isCurrentPeriod: false,
+          onJumpToCurrent: onJump,
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /today/i }));
+    expect(onJump).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AccountMonthEndForecast — empty states", () => {
+  it("renders nothing when there are no accounts (page-level empty state owns this)", () => {
+    const { container } = render(
+      <AccountMonthEndForecast {...defaults({ forecast: null, hasAnyAccounts: false })} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not show a zero-pending subtext on rows whose pending delta is exactly 0", () => {
+    render(
+      <AccountMonthEndForecast {...defaults({ forecast: TWO_CURRENCIES })} />,
+    );
+    expect(screen.queryByText(/Includes \+?€0\.00 pending/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Includes \+?\$0\.00 pending/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
+++ b/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
@@ -201,11 +201,53 @@ describe("AccountMonthEndForecast — empty states", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it("renders nothing when there are no accounts even on a non-current period", () => {
+    // Empty org viewing a past/future period must NOT see the neutral
+    // month-end card — the page-level empty state owns this surface.
+    const { container } = render(
+      <AccountMonthEndForecast
+        {...defaults({
+          forecast: null,
+          hasAnyAccounts: false,
+          isCurrentPeriod: false,
+        })}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
   it("does not show a zero-pending subtext on rows whose pending delta is exactly 0", () => {
     render(
       <AccountMonthEndForecast {...defaults({ forecast: TWO_CURRENCIES })} />,
     );
     expect(screen.queryByText(/Includes \+?€0\.00 pending/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Includes \+?\$0\.00 pending/)).not.toBeInTheDocument();
+  });
+});
+
+describe("AccountMonthEndForecast — error state", () => {
+  it("renders an explicit error message when hasError is true (not 'Loading…')", () => {
+    render(
+      <AccountMonthEndForecast
+        {...defaults({ forecast: null, hasError: true })}
+      />,
+    );
+    expect(
+      screen.getByText(/Couldn't load account forecast\. Try again later\./),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Loading…/)).not.toBeInTheDocument();
+  });
+
+  it("error state still renders nothing when there are no accounts", () => {
+    const { container } = render(
+      <AccountMonthEndForecast
+        {...defaults({
+          forecast: null,
+          hasAnyAccounts: false,
+          hasError: true,
+        })}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/tests/components/dashboard/on-track-tile.test.tsx
+++ b/frontend/tests/components/dashboard/on-track-tile.test.tsx
@@ -58,9 +58,9 @@ describe("OnTrackTile — verdict thresholds (current period, anchored on actual
 });
 
 describe("OnTrackTile — verdict ignores projection (the user-reported bug)", () => {
-  // Bug: a fully-pending month (executed=0) used to read as OVER BUDGET because
-  // the projected expense (settled + pending + remaining recurring fires)
-  // exceeded the plan. The verdict now anchors on settled spending only.
+  // Bug history: a fully-pending month (executed=0) used to read as OVER
+  // BUDGET because projected expense exceeded the plan. Verdict anchors
+  // on settled spending only — projection is supporting info.
 
   it("ON TRACK when nothing has actually been spent yet, even with projected > plan", () => {
     render(
@@ -72,11 +72,10 @@ describe("OnTrackTile — verdict ignores projection (the user-reported bug)", (
       />,
     );
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^ON TRACK/);
-    // Projected stat still shows the number, but muted (informational only).
-    const projectedLabel = screen.getByText(/^PROJECTED$/);
-    const projectedValue = projectedLabel.parentElement?.querySelectorAll("p")[1];
-    expect(projectedValue?.textContent).toMatch(/1,050/);
-    expect(projectedValue?.className).toMatch(/text-text-muted/);
+    const expectedLabel = screen.getByText(/^Expected spending$/i);
+    const expectedValue = expectedLabel.parentElement?.querySelectorAll("p")[1];
+    expect(expectedValue?.textContent).toMatch(/1,050/);
+    expect(expectedValue?.className).toMatch(/text-text-muted/);
   });
 
   it("OVER BUDGET when settled spending alone exceeds the plan", () => {
@@ -90,67 +89,10 @@ describe("OnTrackTile — verdict ignores projection (the user-reported bug)", (
     );
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^OVER BUDGET/);
   });
-
-  it("ON TRACK with projected over plan: variance is favorable, no danger color anywhere", () => {
-    const { container } = render(
-      <OnTrackTile
-        {...defaults({
-          forecastPlan: { total_planned_expense: "561.86" },
-          projection: { executed_expense: "300", forecast_expense: "900" },
-        })}
-      />,
-    );
-    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^ON TRACK/);
-    // Variance under plan, accent (favorable) color, no danger.
-    expect(screen.getByText(/under plan/i)).toBeInTheDocument();
-    expect(container.querySelector(".text-danger")).toBeNull();
-  });
-
-  it("PROJECTED stat carries 'projected end-of-month' sublabel and is muted", () => {
-    render(
-      <OnTrackTile
-        {...defaults({
-          forecastPlan: PLAN_1000,
-          projection: { executed_expense: "300", forecast_expense: "900" },
-        })}
-      />,
-    );
-    expect(screen.getByText(/projected end-of-month/i)).toBeInTheDocument();
-    const projectedLabel = screen.getByText(/^PROJECTED$/);
-    const projectedValue = projectedLabel.parentElement?.querySelectorAll("p")[1];
-    expect(projectedValue?.className).toMatch(/text-text-muted/);
-  });
 });
 
-describe("OnTrackTile — variance and column labels", () => {
-  it("renders Variance with brass + 'under plan' sublabel when projection is favorable", () => {
-    render(
-      <OnTrackTile
-        {...defaults({
-          forecastPlan: PLAN_1000,
-          projection: { executed_expense: "300", forecast_expense: "850" },
-        })}
-      />,
-    );
-    expect(screen.getByText(/^\+/)).toHaveClass("text-accent");
-    expect(screen.getByText(/under plan/i)).toBeInTheDocument();
-  });
-
-  it("renders Variance with danger + 'over plan' sublabel when actual spending is unfavorable", () => {
-    render(
-      <OnTrackTile
-        {...defaults({
-          forecastPlan: PLAN_1000,
-          projection: { executed_expense: "1200", forecast_expense: "1200" },
-        })}
-      />,
-    );
-    const variance = screen.getByText(/^−/);
-    expect(variance).toHaveClass("text-danger");
-    expect(screen.getByText(/over plan/i)).toBeInTheDocument();
-  });
-
-  it("uses 'Projected spend' (not 'end-of-period balance') and renders four columns", () => {
+describe("OnTrackTile — simplified column set", () => {
+  it("current period with plan + projection renders three plain-language columns", () => {
     render(
       <OnTrackTile
         {...defaults({
@@ -159,26 +101,53 @@ describe("OnTrackTile — variance and column labels", () => {
         })}
       />,
     );
-    expect(screen.getByText(/^PLAN$/)).toBeInTheDocument();
-    expect(screen.getByText(/^SPENT SO FAR$/)).toBeInTheDocument();
-    expect(screen.getByText(/^VARIANCE$/)).toBeInTheDocument();
-    expect(screen.getByText(/^PROJECTED$/)).toBeInTheDocument();
-    expect(screen.queryByText(/end.of.period balance/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/^Planned spending$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Spent so far$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Expected spending$/i)).toBeInTheDocument();
+  });
+
+  it("does not surface VARIANCE, source labels, or technical (?) markers", () => {
+    const { container } = render(
+      <OnTrackTile
+        {...defaults({
+          forecastPlan: PLAN_1000,
+          projection: { executed_expense: "500", forecast_expense: "950" },
+        })}
+      />,
+    );
+    expect(screen.queryByText(/^VARIANCE$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^PROJECTED$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^under plan$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^over plan$/i)).not.toBeInTheDocument();
+    expect(container.textContent).not.toContain("(?)");
+  });
+
+  it("renders a single 'View forecast details' link routing to /forecast-plans", () => {
+    render(
+      <OnTrackTile
+        {...defaults({
+          forecastPlan: PLAN_1000,
+          projection: { executed_expense: "500", forecast_expense: "950" },
+        })}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /view forecast details/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/forecast-plans");
   });
 });
 
 describe("OnTrackTile — degraded states", () => {
-  it("no-plan state: suppresses Spent so far (no source independent of projection) and shows the Set-one-up CTA", () => {
+  it("no-plan state: suppresses Spent so far and shows the Set-one-up CTA", () => {
     render(<OnTrackTile {...defaults({ forecastPlan: null, projection: null })} />);
     expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
     expect(screen.getByText(/No plan for this period\. Set one up/)).toBeInTheDocument();
-    // Spent so far renders the muted em-dash placeholder, not a number
-    const spentLabel = screen.getByText(/^SPENT SO FAR$/);
+    const spentLabel = screen.getByText(/^Spent so far$/i);
     const spentValue = spentLabel.parentElement?.querySelectorAll("p")[1];
     expect(spentValue?.textContent).toBe("—");
   });
 
-  it("projection-fail state: plan stays, Spent/Variance/Projected suppress, retry button visible", () => {
+  it("projection-fail state: plan stays, retry button visible, no verdict heading", () => {
     render(
       <OnTrackTile
         {...defaults({
@@ -189,12 +158,9 @@ describe("OnTrackTile — degraded states", () => {
       />,
     );
     expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
-    expect(screen.getByText(/Projection unavailable\./)).toBeInTheDocument();
+    expect(screen.getByText(/Forecast unavailable\./)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
-    // Plan column shows real value
-    expect(screen.getByText(/PLAN$/i)).toBeInTheDocument();
-    // Spent so far is suppressed — em-dash placeholder
-    const spentLabel = screen.getByText(/^SPENT SO FAR$/);
+    const spentLabel = screen.getByText(/^Spent so far$/i);
     const spentValue = spentLabel.parentElement?.querySelectorAll("p")[1];
     expect(spentValue?.textContent).toBe("—");
   });
@@ -214,7 +180,7 @@ describe("OnTrackTile — degraded states", () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
-  it("future period: shows Plan ahead CTA, suppresses verdict + variance + projected", () => {
+  it("future period: shows Plan ahead CTA, suppresses verdict + Expected spending", () => {
     render(
       <OnTrackTile
         {...defaults({
@@ -225,14 +191,12 @@ describe("OnTrackTile — degraded states", () => {
     );
     expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /plan ahead/i })).toBeInTheDocument();
+    expect(screen.queryByText(/^Expected spending$/i)).not.toBeInTheDocument();
   });
 });
 
 describe("OnTrackTile — past period", () => {
   it("uses executed_expense (not forecast_expense) for the verdict on closed periods", () => {
-    // executed_expense alone = 1100/1000 = 1.10 → OVER BUDGET.
-    // forecast_expense (used in current period) would be 800/1000 = 0.80 → ON TRACK.
-    // Past-period branch must NOT pick the projection.
     render(
       <OnTrackTile
         {...defaults({
@@ -275,7 +239,7 @@ describe("OnTrackTile — past period", () => {
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^ENDED ON TRACK/);
   });
 
-  it("renders FINAL SPENT column and suppresses PROJECTED column", () => {
+  it("renders Final spent, no Expected spending column", () => {
     render(
       <OnTrackTile
         {...defaults({
@@ -285,9 +249,9 @@ describe("OnTrackTile — past period", () => {
         })}
       />,
     );
-    expect(screen.getByText(/^FINAL SPENT$/)).toBeInTheDocument();
-    expect(screen.queryByText(/^PROJECTED$/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/^SPENT SO FAR$/)).not.toBeInTheDocument();
+    expect(screen.getByText(/^Final spent$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Expected spending$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Spent so far$/i)).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

PR A from the forecasts UX restructure spec (`~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-08-forecasts-ux-restructure.md`).

- Backend: new `GET /api/v1/forecast/account-balances?period_start=YYYY-MM-DD` returning per-account expected month-end balance (stored balance + pending delta in the selected period) with currency-grouped totals. Includes pending transfer legs (per-account balance math, not reportable income/expense), excludes manual adjustments defensively, buckets pending rows by `COALESCE(settled_date, date)` via the shared `effective_period_date_expr()`.
- Frontend: new compact `AccountMonthEndForecast` card on `/dashboard` showing expected month-end totals plus per-account rows with pending subtext. Past/future periods render a neutral state with a Today action.
- Frontend: `OnTrackTile` simplified to plain language (`Planned spending` / `Spent so far` / `Expected spending`); technical (?) tooltips replaced by a single `View forecast details` link to `/forecast-plans`. `Forecast by Category` legend reduced to Planned / Actual without variance interpretation. Verdict and visual chart remain first-class.

Acceptance from spec PR A:
- Balance + pending delta only, no settled double-count.
- Past/future periods do not pretend the stored balance is historical/future.
- `OnTrackTile` and `Forecast by Category` remain first-class dashboard surfaces.
- `Budget Progress` and `Spending by Category` untouched.

Backend tests: 8 new (settled-not-double-counted, currency grouping, pending expense/income, pending transfer pair, out-of-period exclusion, settled_date-vs-date bucketing, manual-adjustment exclusion). 680 backend tests pass.

Frontend tests: 10 new (`account-month-end-forecast.test.tsx`) + 18 updated (`on-track-tile.test.tsx`). 224 frontend tests pass.