### PR TITLE
feat(forecast-plans): Show details toggle + finalized-plan refresh modal + docs split

### DIFF
--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -174,8 +174,18 @@ export default function DocsPage() {
             <p>
               The dashboard summarizes the period with an On Track
               verdict that anchors on what has actually settled, not
-              just what is projected. The projection is shown
-              alongside as informational context.
+              just what is projected. Below the verdict, a Forecast
+              card shows your expected month-end balance per account
+              (current balance plus pending items in the period), and
+              a Forecast by Category card highlights how planned and
+              actual compare for your top expense categories.
+            </p>
+            <p>
+              The Dashboard intentionally stays light on technical
+              detail. For variance numbers, source attribution, the
+              planned vs actual chart, and the refresh-from-sources
+              control, open the Forecast Plans page and turn on Show
+              details.
             </p>
           </section>
 
@@ -186,6 +196,16 @@ export default function DocsPage() {
               ideas overlap: the plan, the projection, the variance, and
               the two buttons that fill the plan in. Here is each one in
               the simplest words.
+            </p>
+            <p>
+              Where you see what: the Dashboard answers household
+              questions visually (are we on track, where will we end the
+              month, which accounts and categories explain that). The
+              Forecast Plans page is where you build and adjust the
+              plan itself. Forecast Plans starts in a simple view and
+              has a Show details toggle that reveals variance numbers,
+              source attribution, the planned vs actual chart, and the
+              refresh-from-sources control when you need them.
             </p>
 
             <h3>The plan is your wish list</h3>
@@ -300,9 +320,18 @@ export default function DocsPage() {
               against today's templates and history. Rows you typed or
               edited yourself are kept untouched. Categories that have
               shown up since the first populate will be added in this
-              pass too. Refresh only works while the plan is a draft.
-              Finalize the plan when you're done, and click Edit Plan
-              to revert to draft if you want to refresh again later.
+              pass too.
+            </p>
+            <p>
+              Refresh from sources is part of the details view on the
+              Forecast Plans page (turn on Show details to see it).
+              On a draft plan, Refresh runs immediately. On a finalized
+              plan, Refresh opens an Edit and refresh confirmation that
+              reverts the plan to draft, refreshes the auto-generated
+              rows, and keeps the lines you added or edited yourself.
+              If the refresh step fails after the revert, the plan is
+              left in draft and the error is shown so you can retry or
+              continue editing manually.
             </p>
           </section>
 

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -102,8 +102,39 @@ export default function ForecastPlansPage() {
     title: string;
     message: string;
     variant: "warning" | "danger";
+    confirmLabel?: string;
     action: () => void;
   } | null>(null);
+
+  // Show details toggle. Default off; persisted under
+  // forecast-plans:show-details. Initial render reads localStorage in a
+  // mount effect so server/client HTML stays identical (no hydration
+  // mismatch). Until the effect runs, treat the toggle as "off" — the
+  // simpler view — so flipping after hydration only ever reveals more.
+  const [showDetails, setShowDetails] = useState<boolean>(false);
+  const [showDetailsHydrated, setShowDetailsHydrated] = useState<boolean>(false);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem("forecast-plans:show-details");
+      if (raw === "true") setShowDetails(true);
+    } catch {
+      // localStorage unavailable (private mode etc.) — keep default off.
+    }
+    setShowDetailsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!showDetailsHydrated) return;
+    try {
+      localStorage.setItem(
+        "forecast-plans:show-details",
+        showDetails ? "true" : "false",
+      );
+    } catch {
+      // ignore
+    }
+  }, [showDetails, showDetailsHydrated]);
 
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
@@ -236,6 +267,48 @@ export default function ForecastPlansPage() {
           );
           setPlan(p);
         } catch (err) {
+          setError(extractErrorMessage(err));
+        }
+      },
+    });
+  }
+
+  // Finalized-plan refresh: revert to draft, then refresh from sources.
+  // The user explicitly chose to edit and refresh, so a partial failure
+  // (revert ok, refresh fails) MUST leave the plan in draft and surface
+  // the error — silently flipping back to active would discard the
+  // user's choice without explanation.
+  async function handleEditAndRefresh() {
+    setConfirmAction({
+      title: "Edit and refresh plan",
+      message:
+        "This will revert the plan to draft, replace auto-generated rows with fresh data, and keep lines you added or edited yourself.",
+      variant: "warning",
+      confirmLabel: "Edit and refresh",
+      action: async () => {
+        if (!plan) return;
+        setError("");
+        let revertedPlan: ForecastPlan | null = null;
+        try {
+          revertedPlan = await apiFetch<ForecastPlan>(
+            `/api/v1/forecast-plans/${plan.id}/revert`,
+            { method: "POST" },
+          );
+          setPlan(revertedPlan);
+        } catch (err) {
+          setError(extractErrorMessage(err));
+          return;
+        }
+        try {
+          const refreshed = await apiFetch<ForecastPlan>(
+            `/api/v1/forecast-plans/refresh-from-sources?period_start=${periodStart}`,
+            { method: "POST" },
+          );
+          setPlan(refreshed);
+        } catch (err) {
+          // Revert succeeded, refresh failed. Keep the draft visible
+          // and surface the error so the user can retry refresh or
+          // continue editing manually.
           setError(extractErrorMessage(err));
         }
       },
@@ -384,58 +457,102 @@ export default function ForecastPlansPage() {
   return (
     <AppShell>
       {/* Header */}
-      <div className="mb-2 flex items-center justify-between">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
         <h1 className={`${pageTitle} mb-0`}>Forecast Plans</h1>
-        {isDraft && (
-          <div className="flex items-center gap-2">
-            {hasItems && (
-              <button
-                onClick={handleDiscard}
-                className="rounded-md px-3 py-2 text-xs text-text-muted hover:text-danger"
-              >
-                Discard
-              </button>
-            )}
-            <button
-              onClick={handlePopulate}
-              className={btnPrimary}
-              title={HELP_AUTO_POPULATE + DOCS_HINT}
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Show/hide details toggle. Hides variance/source/chart/refresh
+              and the technical (?) help markers when off. */}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={showDetails}
+            aria-label={showDetails ? "Hide details" : "Show details"}
+            onClick={() => setShowDetails((v) => !v)}
+            className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          >
+            <span
+              aria-hidden="true"
+              className={`inline-block h-3 w-6 rounded-full transition-colors ${
+                showDetails ? "bg-accent" : "bg-border"
+              }`}
             >
-              Auto-populate
-            </button>
-            <HelpIcon label="Auto-populate" text={HELP_AUTO_POPULATE} />
-            {hasItems && (
-              <>
+              <span
+                className={`block h-3 w-3 rounded-full bg-surface transition-transform ${
+                  showDetails ? "translate-x-3" : "translate-x-0"
+                }`}
+              />
+            </span>
+            <span>{showDetails ? "Hide details" : "Show details"}</span>
+          </button>
+
+          {isDraft && (
+            <>
+              {hasItems && (
                 <button
-                  onClick={handleRefreshFromSources}
+                  onClick={handleDiscard}
+                  className="rounded-md px-3 py-2 text-xs text-text-muted hover:text-danger"
+                >
+                  Discard
+                </button>
+              )}
+              <button
+                onClick={handlePopulate}
+                className={btnPrimary}
+                title={
+                  showDetails ? HELP_AUTO_POPULATE + DOCS_HINT : undefined
+                }
+              >
+                Auto-populate
+              </button>
+              {showDetails && (
+                <HelpIcon label="Auto-populate" text={HELP_AUTO_POPULATE} />
+              )}
+              {showDetails && hasItems && (
+                <>
+                  <button
+                    onClick={handleRefreshFromSources}
+                    className={btnPrimary}
+                    title={HELP_REFRESH + DOCS_HINT}
+                  >
+                    Refresh from sources
+                  </button>
+                  <HelpIcon label="Refresh from sources" text={HELP_REFRESH} />
+                </>
+              )}
+              <button
+                onClick={() => setShowForm(!showForm)}
+                className={btnPrimary}
+              >
+                {showForm ? "Cancel" : "+ Add Item"}
+              </button>
+            </>
+          )}
+          {isActive && (
+            <>
+              {showDetails && (
+                <button
+                  onClick={handleEditAndRefresh}
                   className={btnPrimary}
                   title={HELP_REFRESH + DOCS_HINT}
                 >
                   Refresh from sources
                 </button>
-                <HelpIcon label="Refresh from sources" text={HELP_REFRESH} />
-              </>
-            )}
-            <button
-              onClick={() => setShowForm(!showForm)}
-              className={btnPrimary}
-            >
-              {showForm ? "Cancel" : "+ Add Item"}
-            </button>
-          </div>
-        )}
-        {isActive && (
-          <div className="flex items-center gap-2">
-            <button
-              onClick={handleRevertToDraft}
-              className={btnPrimary}
-              title={HELP_EDIT_PLAN + DOCS_HINT}
-            >
-              Edit Plan
-            </button>
-            <HelpIcon label="Edit Plan" text={HELP_EDIT_PLAN} />
-          </div>
-        )}
+              )}
+              <button
+                onClick={handleRevertToDraft}
+                className={btnPrimary}
+                title={
+                  showDetails ? HELP_EDIT_PLAN + DOCS_HINT : undefined
+                }
+              >
+                Edit Plan
+              </button>
+              {showDetails && (
+                <HelpIcon label="Edit Plan" text={HELP_EDIT_PLAN} />
+              )}
+            </>
+          )}
+        </div>
       </div>
 
       {/* Contextual guidance */}
@@ -666,7 +783,7 @@ export default function ForecastPlansPage() {
           )}
 
           {/* Planned vs Actual chart */}
-          {chartData.length > 0 && (
+          {showDetails && chartData.length > 0 && (
             <div className={`${card} p-5 overflow-hidden`}>
               <h2 className={`${cardTitle} mb-4`}>
                 Planned vs Actual (Expenses)
@@ -757,6 +874,7 @@ export default function ForecastPlansPage() {
                 title="Income"
                 items={incomeItems}
                 readOnly={isActive}
+                showDetails={showDetails}
                 editingId={editingId}
                 editAmount={editAmount}
                 onStartEdit={(item) => {
@@ -776,6 +894,7 @@ export default function ForecastPlansPage() {
                 title="Expenses"
                 items={expenseItems}
                 readOnly={isActive}
+                showDetails={showDetails}
                 editingId={editingId}
                 editAmount={editAmount}
                 onStartEdit={(item) => {
@@ -815,7 +934,7 @@ export default function ForecastPlansPage() {
         open={confirmAction !== null}
         title={confirmAction?.title ?? ""}
         message={confirmAction?.message ?? ""}
-        confirmLabel="Confirm"
+        confirmLabel={confirmAction?.confirmLabel ?? "Confirm"}
         variant={confirmAction?.variant ?? "default"}
         onConfirm={() => { confirmAction?.action(); setConfirmAction(null); }}
         onCancel={() => setConfirmAction(null)}
@@ -830,6 +949,7 @@ function ItemSection({
   title,
   items,
   readOnly,
+  showDetails,
   editingId,
   editAmount,
   onStartEdit,
@@ -841,6 +961,7 @@ function ItemSection({
   title: string;
   items: ForecastPlanItem[];
   readOnly: boolean;
+  showDetails: boolean;
   editingId: number | null;
   editAmount: string;
   onStartEdit: (item: ForecastPlanItem) => void;
@@ -849,9 +970,16 @@ function ItemSection({
   onDelete: (id: number) => void;
   setEditAmount: (v: string) => void;
 }) {
+  // When details are off, drop variance + source columns. The grid
+  // template tracks the visible column count so cells don't wrap
+  // around an invisible slot.
   const colTemplate = readOnly
-    ? "grid-cols-[1fr_100px] md:grid-cols-[1fr_100px_100px_100px_80px]"
-    : "grid-cols-[1fr_100px_100px] md:grid-cols-[1fr_100px_100px_100px_80px_100px]";
+    ? showDetails
+      ? "grid-cols-[1fr_100px] md:grid-cols-[1fr_100px_100px_100px_80px]"
+      : "grid-cols-[1fr_100px] md:grid-cols-[1fr_100px_100px]"
+    : showDetails
+      ? "grid-cols-[1fr_100px_100px] md:grid-cols-[1fr_100px_100px_100px_80px_100px]"
+      : "grid-cols-[1fr_100px_100px] md:grid-cols-[1fr_100px_100px_100px]";
 
   return (
     <div className={card}>
@@ -867,11 +995,15 @@ function ItemSection({
             <span>Category</span>
             <span className="text-right">Planned</span>
             <span className="hidden text-right md:block">Actual</span>
-            <span className="hidden text-right md:block">
-              Variance
-              <HelpIcon label="Variance" text={HELP_VARIANCE} />
-            </span>
-            <span className="hidden text-center md:block">Source</span>
+            {showDetails && (
+              <>
+                <span className="hidden text-right md:block">
+                  Variance
+                  <HelpIcon label="Variance" text={HELP_VARIANCE} />
+                </span>
+                <span className="hidden text-center md:block">Source</span>
+              </>
+            )}
             {!readOnly && <span className="text-right">Actions</span>}
           </div>
           <div className="divide-y divide-border-subtle">
@@ -908,8 +1040,12 @@ function ItemSection({
                       <span className="hidden text-right text-sm tabular-nums text-text-secondary md:block">
                         {formatAmount(item.actual_amount)}
                       </span>
-                      <span className="hidden md:block" />
-                      <span className="hidden md:block" />
+                      {showDetails && (
+                        <>
+                          <span className="hidden md:block" />
+                          <span className="hidden md:block" />
+                        </>
+                      )}
                       <div className="flex justify-end gap-2">
                         <button
                           onClick={() => onSaveEdit(item.id)}
@@ -930,17 +1066,22 @@ function ItemSection({
                       <div className="text-sm text-text-primary">
                         {item.category_name}
                         <div className="md:hidden mt-1 text-xs text-text-muted">
-                          Actual {formatAmount(item.actual_amount)} · Variance{" "}
-                          <span
-                            className={`font-medium ${
-                              isOver ? "text-danger" : "text-success"
-                            }`}
-                          >
-                            {variance > 0 ? "+" : ""}
-                            {formatAmount(variance)}
-                          </span>
-                          {" · "}
-                          {SOURCE_LABELS[item.source] ?? item.source}
+                          Actual {formatAmount(item.actual_amount)}
+                          {showDetails && (
+                            <>
+                              {" · "}Variance{" "}
+                              <span
+                                className={`font-medium ${
+                                  isOver ? "text-danger" : "text-success"
+                                }`}
+                              >
+                                {variance > 0 ? "+" : ""}
+                                {formatAmount(variance)}
+                              </span>
+                              {" · "}
+                              {SOURCE_LABELS[item.source] ?? item.source}
+                            </>
+                          )}
                         </div>
                       </div>
                       <span className="text-right text-sm tabular-nums text-text-primary">
@@ -949,17 +1090,21 @@ function ItemSection({
                       <span className="hidden text-right text-sm tabular-nums text-text-secondary md:block">
                         {formatAmount(item.actual_amount)}
                       </span>
-                      <span
-                        className={`hidden text-right text-sm tabular-nums font-medium md:block ${
-                          isOver ? "text-danger" : "text-success"
-                        }`}
-                      >
-                        {variance > 0 ? "+" : ""}
-                        {formatAmount(variance)}
-                      </span>
-                      <span className="hidden text-center text-[11px] text-text-muted md:block">
-                        {SOURCE_LABELS[item.source] ?? item.source}
-                      </span>
+                      {showDetails && (
+                        <>
+                          <span
+                            className={`hidden text-right text-sm tabular-nums font-medium md:block ${
+                              isOver ? "text-danger" : "text-success"
+                            }`}
+                          >
+                            {variance > 0 ? "+" : ""}
+                            {formatAmount(variance)}
+                          </span>
+                          <span className="hidden text-center text-[11px] text-text-muted md:block">
+                            {SOURCE_LABELS[item.source] ?? item.source}
+                          </span>
+                        </>
+                      )}
                       {!readOnly && (
                         <div className="flex justify-end gap-2">
                           <button

--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -304,6 +304,14 @@ describe("ForecastPlansPage — dropdown + refresh", () => {
 
     render(<ForecastPlansPage />);
 
+    // Refresh from sources is gated behind the Show details toggle
+    // (defaults off post-PR-B forecasts UX restructure). Flip it on
+    // before asserting the button is visible.
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /show details/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("switch", { name: /show details/i }));
+
     await waitFor(() => {
       expect(screen.getByText("Refresh from sources")).toBeTruthy();
     });
@@ -390,6 +398,243 @@ describe("ForecastPlansPage — dropdown + refresh", () => {
     expect(combobox.value).toBe("");
   });
 
+  it("Show details toggle defaults off: Variance/Source columns and Refresh-from-sources are hidden on a draft plan", async () => {
+    mockInitialFetches(
+      makePlan([
+        {
+          category_id: 20,
+          category_name: "Groceries",
+          type: "expense",
+          planned_amount: 500,
+          source: "history",
+          actual_amount: 300,
+          variance: -200,
+        },
+      ]),
+    );
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeTruthy();
+    });
+
+    // Toggle is off by default — labelled "Show details".
+    const toggle = screen.getByRole("switch", { name: /show details/i });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+
+    // Variance + Source columns hidden.
+    expect(screen.queryByText("Variance")).toBeNull();
+    expect(screen.queryByText("Source")).toBeNull();
+    // Auto label (source) is also hidden.
+    expect(screen.queryByText("Auto")).toBeNull();
+    // Refresh-from-sources hidden on draft when details off.
+    expect(
+      screen.queryByRole("button", { name: "Refresh from sources" }),
+    ).toBeNull();
+  });
+
+  it("Show details toggle persists in localStorage and rehydrates on reload", async () => {
+    mockInitialFetches(makePlan());
+
+    const { unmount } = render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /show details/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("switch", { name: /show details/i }));
+
+    // Persisted to localStorage.
+    await waitFor(() => {
+      expect(localStorage.getItem("forecast-plans:show-details")).toBe("true");
+    });
+    unmount();
+
+    // Re-render with the same localStorage state — the toggle should
+    // come back as "Hide details" (i.e. on).
+    render(<ForecastPlansPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /hide details/i })).toBeTruthy();
+    });
+  });
+
+  it("Finalized plan + details on: Refresh from sources opens 'Edit and refresh plan' modal with locked copy and confirm label", async () => {
+    const finalized = {
+      ...makePlan([
+        {
+          category_id: 20,
+          category_name: "Groceries",
+          type: "expense",
+          planned_amount: 500,
+          source: "recurring",
+          actual_amount: 200,
+          variance: -300,
+        },
+      ]),
+      status: "active" as const,
+    };
+
+    mockInitialFetches(finalized);
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /show details/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("switch", { name: /show details/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Refresh from sources" }),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh from sources" }),
+    );
+
+    // Modal renders with the spec-locked copy.
+    expect(
+      screen.getByText("Edit and refresh plan", { selector: "h3" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        /This will revert the plan to draft, replace auto-generated rows with fresh data, and keep lines you added or edited yourself\./,
+      ),
+    ).toBeTruthy();
+    // Confirm label is "Edit and refresh", not generic "Confirm".
+    expect(
+      screen.getByRole("button", { name: /^Edit and refresh$/ }),
+    ).toBeTruthy();
+  });
+
+  it("Finalized refresh confirm calls /revert then /refresh-from-sources in order", async () => {
+    const finalized = {
+      ...makePlan([
+        {
+          category_id: 20,
+          category_name: "Groceries",
+          type: "expense",
+          planned_amount: 500,
+          source: "recurring",
+          actual_amount: 200,
+          variance: -300,
+        },
+      ]),
+      status: "active" as const,
+    };
+
+    const calls: string[] = [];
+    (apiFetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (path: string) => {
+        if (path.startsWith("/api/v1/settings/billing-periods/ensure-future"))
+          return Promise.resolve([]);
+        if (path === "/api/v1/categories") return Promise.resolve(CATEGORIES);
+        if (path === "/api/v1/settings/billing-periods")
+          return Promise.resolve([PERIOD]);
+        if (path.startsWith("/api/v1/forecast-plans?"))
+          return Promise.resolve(finalized);
+        if (path.includes("/revert")) {
+          calls.push("revert");
+          return Promise.resolve({ ...finalized, status: "draft" });
+        }
+        if (path.startsWith("/api/v1/forecast-plans/refresh-from-sources")) {
+          calls.push("refresh");
+          return Promise.resolve({ ...finalized, status: "draft" });
+        }
+        return Promise.resolve(finalized);
+      },
+    );
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /show details/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("switch", { name: /show details/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Refresh from sources" }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh from sources" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Edit and refresh$/ }),
+    );
+
+    await waitFor(() => {
+      expect(calls).toEqual(["revert", "refresh"]);
+    });
+  });
+
+  it("Finalized refresh: revert ok + refresh fail leaves plan in draft and surfaces error (no silent fallback)", async () => {
+    const finalized = {
+      ...makePlan([
+        {
+          category_id: 20,
+          category_name: "Groceries",
+          type: "expense",
+          planned_amount: 500,
+          source: "recurring",
+          actual_amount: 200,
+          variance: -300,
+        },
+      ]),
+      status: "active" as const,
+    };
+    const draftCopy = { ...finalized, status: "draft" as const };
+
+    (apiFetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (path: string) => {
+        if (path.startsWith("/api/v1/settings/billing-periods/ensure-future"))
+          return Promise.resolve([]);
+        if (path === "/api/v1/categories") return Promise.resolve(CATEGORIES);
+        if (path === "/api/v1/settings/billing-periods")
+          return Promise.resolve([PERIOD]);
+        if (path.startsWith("/api/v1/forecast-plans?"))
+          return Promise.resolve(finalized);
+        if (path.includes("/revert")) return Promise.resolve(draftCopy);
+        if (path.startsWith("/api/v1/forecast-plans/refresh-from-sources"))
+          return Promise.reject(new Error("Refresh blew up"));
+        return Promise.resolve(finalized);
+      },
+    );
+
+    render(<ForecastPlansPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /show details/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("switch", { name: /show details/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Refresh from sources" }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh from sources" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Edit and refresh$/ }),
+    );
+
+    // Error surfaces. Plan remains in draft (Edit Plan disappears,
+    // Auto-populate appears since drafts can populate again).
+    await waitFor(() => {
+      expect(screen.getByText(/Refresh blew up/)).toBeTruthy();
+    });
+    expect(
+      screen.queryByRole("button", { name: /^Edit Plan$/ }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Auto-populate" }),
+    ).toBeTruthy();
+  });
+
   it("PR #146 #1: source=history renders an honest 'Auto' label, not 'Avg (3mo)'", async () => {
     // populate now also surfaces categories whose only signal is in the
     // current period (one-off furniture purchase, etc.) but writes them
@@ -408,6 +653,13 @@ describe("ForecastPlansPage — dropdown + refresh", () => {
     );
 
     render(<ForecastPlansPage />);
+
+    // Source column is gated behind Show details (off by default
+    // post-PR-B). Flip it on so the label is visible.
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /show details/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("switch", { name: /show details/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Groceries")).toBeTruthy();


### PR DESCRIPTION
## Summary

PR B from the forecasts UX restructure spec (`~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-08-forecasts-ux-restructure.md`). Bundles the docs cleanup (PR C) since PR A's review raised no copy/wording flags.

- Forecast Plans now defaults to a simpler view. A page-level `Show details` toggle (persisted as `forecast-plans:show-details` in `localStorage`, default off, keyboard-accessible via `role="switch"`) reveals variance and source columns, the planned vs actual chart, the inline `(?)` help markers, and the refresh-from-sources control.
- Refresh-from-sources moves out of the Dashboard into Forecast Plans. On a finalized plan with details on, the button opens an `Edit and refresh plan` modal with the spec-locked copy that reverts the plan to draft and then refreshes the auto-generated rows. If revert succeeds and refresh fails, the plan stays in draft and the error is surfaced (no silent fallback).
- `/docs#forecasts` updated to describe the new split: Dashboard shows visual status, expected month-end balances, and a simplified category forecast; Forecast Plans owns plan details, actuals, variance, source attribution, and refresh from sources.

7 new frontend tests cover the toggle visibility states, persistence + rehydration, the finalized refresh confirm modal copy, the call sequence (`/revert` then `/refresh-from-sources`), and the partial-failure path. All 221 frontend tests pass.