### PR TITLE
feat(dashboard): consolidate account tiles + forecast into one row

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import OnTrackTile from "@/components/dashboard/OnTrackTile";
 import AccountMonthEndForecast, {
   type AccountMonthEndForecastResponse,
 } from "@/components/dashboard/AccountMonthEndForecast";
+import AccountTile from "@/components/dashboard/AccountTile";
 import type { Account, BillingPeriod, Budget, Category, Transaction } from "@/lib/types";
 
 interface ForecastPlanItem {
@@ -703,64 +704,55 @@ export default function DashboardPage() {
             isFuturePeriod={isFutureSelectedPeriod}
           />
 
-          {/* ═══ ROW 2: Accounts — single row, primary slightly bigger ═══ */}
-          {accountsWithBalance.length > 0 && (() => {
+          {/* ═══ ROW 2: Accounts sidebar + Forecast card, side-by-side ═══
+              Tiles are compact identity/status/navigation; the Forecast
+              card is the numeric authority for Balance + EOMF. Stacks
+              vertically below `lg`. */}
+          {(() => {
+            // Non-primary accounts sort alphabetically by name (locale-
+            // aware, case-insensitive). Stable across transactions: a
+            // coffee purchase can't reshuffle the sidebar the way a
+            // balance-desc sort would.
             const defaultAcct = accountsWithBalance.find((a) => a.is_default);
-            // Non-primary accounts sort alphabetically by name (locale-aware,
-            // case-insensitive). Stable across transactions: a coffee
-            // purchase can't reshuffle the strip the way a balance-desc
-            // sort would. Predictable position is the point.
             const others = accountsWithBalance
               .filter((a) => !a.is_default)
               .slice()
-              .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+              .sort((a, b) =>
+                a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+              );
+            const orderedAccounts = defaultAcct
+              ? [defaultAcct, ...others]
+              : others;
+
             return (
-              <div className="grid grid-cols-1 gap-3 sm:flex sm:gap-3 sm:overflow-x-auto sm:pb-1">
-                {/* Primary account — wider */}
-                {defaultAcct && (
-                  <div className={`${card} px-5 py-3 sm:shrink-0 sm:min-w-[220px]`}>
-                    <div className="flex items-center gap-2">
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-primary">{defaultAcct.name}</p>
-                      <span className="rounded border border-border px-1.5 py-0.5 text-[9px] font-semibold text-text-secondary">PRIMARY</span>
-                    </div>
-                    <p className="mt-1 text-xl font-semibold tabular-nums text-text-primary">{formatAmount(defaultAcct.balance)} <span className="text-xs text-text-muted">{defaultAcct.currency}</span></p>
-                    {pendingByAccount[defaultAcct.id] !== undefined && pendingByAccount[defaultAcct.id] !== 0 && (
-                      <p className="text-[10px] tabular-nums text-text-muted">Pending: {formatAmount(Math.abs(pendingByAccount[defaultAcct.id]))}</p>
-                    )}
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+                {accountsWithBalance.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    {orderedAccounts.map((acct) => (
+                      <AccountTile
+                        key={acct.id}
+                        account={acct}
+                        hasPending={(pendingByAccount[acct.id] ?? 0) !== 0}
+                      />
+                    ))}
                   </div>
                 )}
-                {/* Other accounts */}
-                {others.map((acct) => {
-                  const pending = pendingByAccount[acct.id] || 0;
-                  const isCreditCard = acct.account_type_slug === "credit_card";
-                  return (
-                    <div key={acct.id} className={`${card} px-4 py-3 sm:shrink-0 sm:min-w-[150px]`}>
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted truncate">{acct.name}</p>
-                      <p className="mt-1 text-base font-semibold tabular-nums text-text-primary">{formatAmount(acct.balance)}</p>
-                      {isCreditCard && pending !== 0 && (
-                        <p className="text-[10px] tabular-nums text-danger">Pending: {formatAmount(Math.abs(pending))}</p>
-                      )}
-                    </div>
-                  );
-                })}
+                <AccountMonthEndForecast
+                  forecast={accountMonthEndForecast}
+                  isCurrentPeriod={isCurrentSelectedPeriod}
+                  hasAnyAccounts={activeAccounts.length > 0}
+                  hasError={accountMonthEndForecastError}
+                  onJumpToCurrent={() => {
+                    const idx = periods.findIndex((p) => p.end_date === null);
+                    if (idx >= 0) {
+                      setPeriodIdx(idx);
+                      setChartFilter(null);
+                    }
+                  }}
+                />
               </div>
             );
           })()}
-
-          {/* ═══ ROW 2.5: Account month-end forecast ═══ */}
-          <AccountMonthEndForecast
-            forecast={accountMonthEndForecast}
-            isCurrentPeriod={isCurrentSelectedPeriod}
-            hasAnyAccounts={activeAccounts.length > 0}
-            hasError={accountMonthEndForecastError}
-            onJumpToCurrent={() => {
-              const idx = periods.findIndex((p) => p.end_date === null);
-              if (idx >= 0) {
-                setPeriodIdx(idx);
-                setChartFilter(null);
-              }
-            }}
-          />
 
           {/* ═══ ROW 3: Three equal charts ═══ */}
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -971,9 +971,14 @@ export default function DashboardPage() {
                           }}
                           aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
                           aria-pressed={tx.status === "settled"}
-                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}
+                          className="inline-flex min-h-[44px] items-center"
                         >
-                          {tx.status}
+                          {/* Outer button carries the WCAG 2.5.8
+                              touch-target hit area; inner span keeps
+                              the lean visual that matches /transactions. */}
+                          <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                            {tx.status}
+                          </span>
                         </button>
                       )}
                     </div>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -13,13 +13,12 @@ import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, pa
 
 
 import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveContainer } from "recharts";
-import { Check, Clock } from "lucide-react";
 import CategorySelect from "@/components/ui/CategorySelect";
 import OnTrackTile from "@/components/dashboard/OnTrackTile";
 import AccountMonthEndForecast, {
   type AccountMonthEndForecastResponse,
 } from "@/components/dashboard/AccountMonthEndForecast";
-import AccountTile from "@/components/dashboard/AccountTile";
+import AccountTilesCard from "@/components/dashboard/AccountTile";
 import type { Account, BillingPeriod, Budget, Category, Transaction } from "@/lib/types";
 
 interface ForecastPlanItem {
@@ -705,9 +704,11 @@ export default function DashboardPage() {
           />
 
           {/* ═══ ROW 2: Accounts sidebar + Forecast card, side-by-side ═══
-              Tiles are compact identity/status/navigation; the Forecast
-              card is the numeric authority for Balance + EOMF. Stacks
-              vertically below `lg`. */}
+              Tiles share ONE card with internal divider rows; the
+              Forecast card on the right is the numeric authority for
+              Balance + EOMF. 1fr/3fr split — forecast dominates.
+              items-start so each card sits at its natural height
+              (mismatch is intentional). Stacks vertically below `lg`. */}
           {(() => {
             // Non-primary accounts sort alphabetically by name (locale-
             // aware, case-insensitive). Stable across transactions: a
@@ -725,18 +726,11 @@ export default function DashboardPage() {
               : others;
 
             return (
-              <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
-                {accountsWithBalance.length > 0 && (
-                  <div className="flex flex-col gap-2">
-                    {orderedAccounts.map((acct) => (
-                      <AccountTile
-                        key={acct.id}
-                        account={acct}
-                        hasPending={(pendingByAccount[acct.id] ?? 0) !== 0}
-                      />
-                    ))}
-                  </div>
-                )}
+              <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,3fr)]">
+                <AccountTilesCard
+                  accounts={orderedAccounts}
+                  pendingByAccount={pendingByAccount}
+                />
                 <AccountMonthEndForecast
                   forecast={accountMonthEndForecast}
                   isCurrentPeriod={isCurrentSelectedPeriod}
@@ -975,16 +969,11 @@ export default function DashboardPage() {
                               setError(extractErrorMessage(err));
                             }
                           }}
-                          aria-label={`Settled status for ${tx.description}`}
+                          aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
                           aria-pressed={tx.status === "settled"}
-                          className={`inline-flex min-h-[44px] items-center gap-1 rounded px-2 text-xs font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}
                         >
-                          {tx.status === "settled" ? (
-                            <Check className="h-3.5 w-3.5" aria-hidden="true" />
-                          ) : (
-                            <Clock className="h-3.5 w-3.5" aria-hidden="true" />
-                          )}
-                          <span>{tx.status}</span>
+                          {tx.status}
                         </button>
                       )}
                     </div>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1010,13 +1010,19 @@ function TransactionsPageContent() {
                               <button
                                 onClick={() => handleToggleStatus(tx)}
                                 aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
-                                className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                                  tx.status === "settled"
-                                    ? "bg-success-dim text-success"
-                                    : "bg-surface-overlay text-text-muted"
-                                }`}
+                                className="inline-flex min-h-[44px] items-center justify-center"
                               >
-                                {tx.status}
+                                {/* Outer button = WCAG 2.5.8 hit area;
+                                    inner span = lean pill visual. */}
+                                <span
+                                  className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                                    tx.status === "settled"
+                                      ? "bg-success-dim text-success"
+                                      : "bg-surface-overlay text-text-muted"
+                                  }`}
+                                >
+                                  {tx.status}
+                                </span>
                               </button>
                             )}
                           </span>
@@ -1228,13 +1234,19 @@ function TransactionsPageContent() {
                               <button
                                 onClick={() => handleToggleStatus(tx)}
                                 aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
-                                className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                                  tx.status === "settled"
-                                    ? "bg-success-dim text-success"
-                                    : "bg-surface-overlay text-text-muted"
-                                }`}
+                                className="ml-auto inline-flex min-h-[44px] items-center justify-center"
                               >
-                                {tx.status}
+                                {/* Outer button = WCAG 2.5.8 hit area;
+                                    inner span = lean pill visual. */}
+                                <span
+                                  className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                                    tx.status === "settled"
+                                      ? "bg-success-dim text-success"
+                                      : "bg-surface-overlay text-text-muted"
+                                  }`}
+                                >
+                                  {tx.status}
+                                </span>
                               </button>
                             )}
                           </div>

--- a/frontend/components/dashboard/AccountMonthEndForecast.tsx
+++ b/frontend/components/dashboard/AccountMonthEndForecast.tsx
@@ -116,9 +116,13 @@ export default function AccountMonthEndForecast({
           the hero replaces both. */}
       {totals.length > 0 && (
         <div className="mb-4 space-y-1">
-          <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+          {/* h2 (not p) so the page outline (h1, h2, h2 ...) stays
+              consistent with the loading / error / non-current-period
+              branches that render <h2>Forecast</h2>. Visual styling
+              matches the eyebrow tokens unchanged. */}
+          <h2 className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
             Expected month-end balance
-          </p>
+          </h2>
           <div className="space-y-0.5">
             {totals.map((t) => (
               <p

--- a/frontend/components/dashboard/AccountMonthEndForecast.tsx
+++ b/frontend/components/dashboard/AccountMonthEndForecast.tsx
@@ -137,16 +137,15 @@ export default function AccountMonthEndForecast({
       )}
 
       <div className="overflow-hidden rounded-md border border-border-subtle">
-        {/* Three left-aligned columns. Account narrowest (anchors the
-            row by name); Balance medium; End of month forecast widest
-            because the pending subtext (e.g. "Includes -€425.29
-            pending") sits underneath and shouldn't wrap awkwardly.
-            User direction overrides the spec's "tabular and right
-            aligned" — left-aligned reads as a list, not a ledger. */}
+        {/* Account left-aligned (the row anchor); Balance and End of
+            month forecast right-aligned per the spec's "currency
+            values stay tabular and right-aligned" rule. The pending
+            subtext under EOMF inherits right alignment from its
+            parent column wrapper. */}
         <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,3fr)] items-center gap-x-4 border-b border-border-subtle bg-surface-overlay px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
           <span>Account</span>
-          <span>Balance</span>
-          <span>End of month forecast</span>
+          <span className="text-right">Balance</span>
+          <span className="text-right">End of month forecast</span>
         </div>
         <div className="divide-y divide-border-subtle">
           {rows.map((row) => {
@@ -170,11 +169,11 @@ export default function AccountMonthEndForecast({
                     )}
                   </p>
                 </div>
-                <p className="text-sm tabular-nums text-text-secondary">
+                <p className="text-right text-sm tabular-nums text-text-secondary">
                   {formatAmount(row.balance)}{" "}
                   <span className="text-[10px] text-text-muted">{row.currency}</span>
                 </p>
-                <div>
+                <div className="text-right">
                   <p className="text-sm font-medium tabular-nums text-text-primary">
                     {formatAmount(row.expected_month_end_balance)}
                   </p>

--- a/frontend/components/dashboard/AccountMonthEndForecast.tsx
+++ b/frontend/components/dashboard/AccountMonthEndForecast.tsx
@@ -109,13 +109,11 @@ export default function AccountMonthEndForecast({
 
   return (
     <section className={`${card} p-5`} data-testid="account-month-end-forecast">
-      <header className={`mb-3 ${cardHeader}`}>
-        <h2 className={cardTitle}>Forecast</h2>
-        <p className="mt-1 text-xs text-text-muted">
-          Current balance plus pending items in this period.
-        </p>
-      </header>
-
+      {/* Header consolidated: the eyebrow already names the card
+          ("Expected month-end balance"), so the explicit "Forecast"
+          card title and the duplicate "Includes pending items"
+          supporting line are dropped. A single descriptive line under
+          the hero replaces both. */}
       {totals.length > 0 && (
         <div className="mb-4 space-y-1">
           <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
@@ -132,7 +130,9 @@ export default function AccountMonthEndForecast({
               </p>
             ))}
           </div>
-          <p className="text-xs text-text-muted">Includes pending items in this period.</p>
+          <p className="text-xs text-text-muted">
+            Current balance plus pending items in this period.
+          </p>
         </div>
       )}
 

--- a/frontend/components/dashboard/AccountTile.tsx
+++ b/frontend/components/dashboard/AccountTile.tsx
@@ -70,8 +70,12 @@ export function AccountTileRow({ account, hasPending }: AccountTileRowProps) {
           {hasPending && (
             <>
               <span aria-hidden="true">·</span>
+              {/* Neutral pending treatment using semantic tokens (raw
+                  palette colors are forbidden). Matches the lean
+                  pending pill style on /transactions; avoids competing
+                  with the gold accent on the Quick Add button. */}
               <span
-                className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-500"
+                className="rounded bg-surface-overlay px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-text-muted"
                 aria-label="Has pending transactions"
               >
                 Pending

--- a/frontend/components/dashboard/AccountTile.tsx
+++ b/frontend/components/dashboard/AccountTile.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { card } from "@/lib/styles";
+import { formatAmount } from "@/lib/format";
+import type { Account } from "@/lib/types";
+
+export interface AccountTileProps {
+  account: Account;
+  hasPending: boolean;
+}
+
+// Compact identity/status/navigation tile for the dashboard accounts
+// sidebar. The Forecast card is the numeric authority for Balance and
+// expected month-end; this tile shows account name, type, status
+// badges, and a click-through to /accounts. Balance is included as
+// MUTED secondary text only — the Forecast card carries the primary
+// number so the row doesn't read as redundant.
+export default function AccountTile({ account, hasPending }: AccountTileProps) {
+  const typeLabel = account.account_type_name ?? null;
+
+  return (
+    <Link
+      href="/accounts"
+      data-testid="account-tile"
+      data-account-id={account.id}
+      className={`${card} flex items-center justify-between gap-3 px-3 py-2.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent`}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="truncate text-sm font-medium text-text-primary">
+            {account.name}
+          </p>
+          {account.is_default && (
+            <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-text-secondary">
+              Primary
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-[11px] text-text-muted">
+          {typeLabel && <span className="truncate">{typeLabel}</span>}
+          {typeLabel && <span aria-hidden="true">·</span>}
+          <span className="uppercase tracking-wider">{account.currency}</span>
+          {hasPending && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span
+                className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-500"
+                aria-label="Has pending transactions"
+              >
+                Pending
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+      <p
+        className="shrink-0 text-[11px] tabular-nums text-text-muted"
+        aria-label="Current balance, secondary"
+      >
+        {formatAmount(account.balance)}
+      </p>
+    </Link>
+  );
+}

--- a/frontend/components/dashboard/AccountTile.tsx
+++ b/frontend/components/dashboard/AccountTile.tsx
@@ -5,18 +5,44 @@ import { card } from "@/lib/styles";
 import { formatAmount } from "@/lib/format";
 import type { Account } from "@/lib/types";
 
-export interface AccountTileProps {
+export interface AccountTilesCardProps {
+  accounts: Account[];
+  pendingByAccount: Record<number, number>;
+}
+
+// Compact identity/status/navigation column for the dashboard. ONE
+// shared card with internal divider rows, mirroring the Forecast card
+// idiom on the right side of the row. Each row is a click-through to
+// /accounts. The Forecast card is the numeric authority; the muted
+// balance hint here is secondary text only, NOT the primary visual
+// anchor of the row.
+export default function AccountTilesCard({
+  accounts,
+  pendingByAccount,
+}: AccountTilesCardProps) {
+  if (accounts.length === 0) return null;
+
+  return (
+    <section className={`${card} overflow-hidden`} data-testid="account-tiles-card">
+      <div className="divide-y divide-border-subtle">
+        {accounts.map((account) => (
+          <AccountTileRow
+            key={account.id}
+            account={account}
+            hasPending={(pendingByAccount[account.id] ?? 0) !== 0}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export interface AccountTileRowProps {
   account: Account;
   hasPending: boolean;
 }
 
-// Compact identity/status/navigation tile for the dashboard accounts
-// sidebar. The Forecast card is the numeric authority for Balance and
-// expected month-end; this tile shows account name, type, status
-// badges, and a click-through to /accounts. Balance is included as
-// MUTED secondary text only — the Forecast card carries the primary
-// number so the row doesn't read as redundant.
-export default function AccountTile({ account, hasPending }: AccountTileProps) {
+export function AccountTileRow({ account, hasPending }: AccountTileRowProps) {
   const typeLabel = account.account_type_name ?? null;
 
   return (
@@ -24,7 +50,7 @@ export default function AccountTile({ account, hasPending }: AccountTileProps) {
       href="/accounts"
       data-testid="account-tile"
       data-account-id={account.id}
-      className={`${card} flex items-center justify-between gap-3 px-3 py-2.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent`}
+      className="flex items-center justify-between gap-3 px-3 py-2.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
     >
       <div className="min-w-0">
         <div className="flex items-center gap-2">

--- a/frontend/components/dashboard/OnTrackTile.tsx
+++ b/frontend/components/dashboard/OnTrackTile.tsx
@@ -120,11 +120,11 @@ export default function OnTrackTile({
   if (isPastPeriod && !hasPlan) {
     return (
       <section
-        className={`${card} p-6 md:p-8`}
+        className={`${card} p-4 md:p-6`}
         data-testid="on-track-tile"
         aria-label="No plan was set for this period"
       >
-        <header className="mb-6 flex items-center justify-between">
+        <header className="mb-4 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
             Forecast
           </span>
@@ -138,14 +138,14 @@ export default function OnTrackTile({
   // Future period: prompt to plan ahead.
   if (isFuturePeriod) {
     return (
-      <section className={`${card} p-6 md:p-8`} data-testid="on-track-tile" aria-label="Plan ahead">
-        <header className="mb-6 flex items-center justify-between">
+      <section className={`${card} p-4 md:p-6`} data-testid="on-track-tile" aria-label="Plan ahead">
+        <header className="mb-4 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
             Forecast
           </span>
           <span className="text-xs text-text-secondary">Future period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <Stat
             label="Planned spending"
             value={hasPlan ? formatAmount(plannedExpense) : "—"}
@@ -170,17 +170,17 @@ export default function OnTrackTile({
   if (!hasPlan) {
     return (
       <section
-        className={`${card} p-6 md:p-8`}
+        className={`${card} p-4 md:p-6`}
         data-testid="on-track-tile"
         aria-label="No plan for this period"
       >
-        <header className="mb-6 flex items-center justify-between">
+        <header className="mb-4 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
             Forecast
           </span>
           <span className="text-xs text-text-secondary">This period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <Stat label="Planned spending" value={formatAmount(0)} sublabel="not yet planned" muted />
           <Stat label="Spent so far" value="—" muted />
         </div>
@@ -200,17 +200,17 @@ export default function OnTrackTile({
   if (projectionFailed) {
     return (
       <section
-        className={`${card} p-6 md:p-8`}
+        className={`${card} p-4 md:p-6`}
         data-testid="on-track-tile"
         aria-label="Projection unavailable"
       >
-        <header className="mb-6 flex items-center justify-between">
+        <header className="mb-4 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
             Forecast
           </span>
           <span className="text-xs text-text-secondary">This period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
           <Stat label="Spent so far" value="—" muted />
         </div>
@@ -234,17 +234,17 @@ export default function OnTrackTile({
   if (!projection) {
     return (
       <section
-        className={`${card} p-6 md:p-8`}
+        className={`${card} p-4 md:p-6`}
         data-testid="on-track-tile"
         aria-label="Loading projection"
       >
-        <header className="mb-6 flex items-center justify-between">
+        <header className="mb-4 flex items-center justify-between">
           <span className="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted">
             Forecast
           </span>
           <span className="text-xs text-text-secondary">This period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
           <Stat label="Spent so far" value="…" muted />
         </div>
@@ -261,8 +261,8 @@ export default function OnTrackTile({
     const verdict = computeVerdict(pct);
 
     return (
-      <section className={`${card} p-6 md:p-8`} data-testid="on-track-tile" aria-label={PAST_LABELS[verdict]}>
-        <header className="mb-6 flex items-center justify-between gap-2">
+      <section className={`${card} p-4 md:p-6`} data-testid="on-track-tile" aria-label={PAST_LABELS[verdict]}>
+        <header className="mb-4 flex items-center justify-between gap-2">
           <h2
             className={`flex items-center gap-2 text-2xl font-semibold uppercase tabular-nums md:text-3xl ${VERDICT_COLOR[verdict]}`}
           >
@@ -271,8 +271,13 @@ export default function OnTrackTile({
           </h2>
           <span className="text-xs text-text-secondary">Past period</span>
         </header>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Stat
+            label="Planned spending"
+            value={formatAmount(plannedExpense)}
+            sublabel="full month"
+            muted
+          />
           <Stat label="Final spent" value={formatAmount(executedExpense)} sublabel="final" />
         </div>
         <DetailsLink />
@@ -287,7 +292,7 @@ export default function OnTrackTile({
   const verdict = computeVerdict(pct);
 
   return (
-    <section className={`${card} p-6 md:p-8`} data-testid="on-track-tile" aria-label={CURRENT_LABELS[verdict]}>
+    <section className={`${card} p-4 md:p-6`} data-testid="on-track-tile" aria-label={CURRENT_LABELS[verdict]}>
       <header className="mb-6 flex items-center justify-between gap-2">
         <h2
           className={`flex items-center gap-2 text-2xl font-semibold uppercase tabular-nums md:text-3xl ${VERDICT_COLOR[verdict]}`}
@@ -297,9 +302,21 @@ export default function OnTrackTile({
         </h2>
         <span className="text-xs text-text-secondary">This period</span>
       </header>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-        <Stat label="Planned spending" value={formatAmount(plannedExpense)} sublabel="full month" />
-        <Stat label="Spent so far" value={formatAmount(executedExpense)} sublabel="actual today" />
+      {/* Metric hierarchy: Spent so far is the primary visual anchor
+          (the daily-glance number); Planned and Expected are muted
+          secondary baselines/projections. */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Stat
+          label="Planned spending"
+          value={formatAmount(plannedExpense)}
+          sublabel="full month"
+          muted
+        />
+        <Stat
+          label="Spent so far"
+          value={formatAmount(executedExpense)}
+          sublabel="actual today"
+        />
         <Stat
           label="Expected spending"
           value={formatAmount(forecastExpense)}

--- a/frontend/components/dashboard/OnTrackTile.tsx
+++ b/frontend/components/dashboard/OnTrackTile.tsx
@@ -293,7 +293,7 @@ export default function OnTrackTile({
 
   return (
     <section className={`${card} p-4 md:p-6`} data-testid="on-track-tile" aria-label={CURRENT_LABELS[verdict]}>
-      <header className="mb-6 flex items-center justify-between gap-2">
+      <header className="mb-4 flex items-center justify-between gap-2">
         <h2
           className={`flex items-center gap-2 text-2xl font-semibold uppercase tabular-nums md:text-3xl ${VERDICT_COLOR[verdict]}`}
         >

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -148,7 +148,7 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
     // status-toggle button has the destination-aware aria-label set in
     // PR #132.
     await waitFor(
-      () => expect(screen.getByLabelText(/Settled status for Coffee/)).toBeInTheDocument(),
+      () => expect(screen.getByLabelText(/Mark as pending/)).toBeInTheDocument(),
       { timeout: 3000 },
     );
 
@@ -160,7 +160,7 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
     // pending — strip totals would silently go stale. The fix wires
     // loadPendingTransactions() into the toggle handler regardless
     // of the visible page index.
-    fireEvent.click(screen.getByLabelText(/Settled status for Coffee/));
+    fireEvent.click(screen.getByLabelText(/Mark as pending/));
 
     await waitFor(() => expect(toggleCallSeen).toBe(true));
     // Critical assertion: pending endpoint was re-called AFTER the

--- a/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
+++ b/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
@@ -93,14 +93,18 @@ const TWO_CURRENCIES: AccountMonthEndForecastResponse = {
 };
 
 describe("AccountMonthEndForecast — current period", () => {
-  it("does not render a redundant 'Forecast' card title; eyebrow + hero anchor the card", () => {
+  it("renders the eyebrow as the card's h2 (page outline preserved); no redundant 'Forecast' title", () => {
     render(
       <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
     );
-    // Header consolidated: no <h2>Forecast</h2> title at the top of
-    // the card. The "Expected month-end balance" eyebrow already
-    // names what the card is about.
-    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+    // Header consolidated: the explicit "Forecast" h2 title is gone,
+    // but the page outline must stay consistent with the loading /
+    // error / non-current-period branches that DO render an h2.
+    // The "Expected month-end balance" eyebrow now carries the h2
+    // role with the same eyebrow visual.
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveTextContent(/^Expected month-end balance$/i);
+    expect(heading.textContent).not.toMatch(/^Forecast$/);
     expect(
       screen.getByText(/Current balance plus pending items in this period\./),
     ).toBeInTheDocument();

--- a/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
+++ b/frontend/tests/components/dashboard/account-month-end-forecast.test.tsx
@@ -93,17 +93,20 @@ const TWO_CURRENCIES: AccountMonthEndForecastResponse = {
 };
 
 describe("AccountMonthEndForecast — current period", () => {
-  it("renders title 'Forecast' and the prescribed subtext", () => {
+  it("does not render a redundant 'Forecast' card title; eyebrow + hero anchor the card", () => {
     render(
       <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
     );
-    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(/^Forecast$/);
+    // Header consolidated: no <h2>Forecast</h2> title at the top of
+    // the card. The "Expected month-end balance" eyebrow already
+    // names what the card is about.
+    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
     expect(
       screen.getByText(/Current balance plus pending items in this period\./),
     ).toBeInTheDocument();
   });
 
-  it("renders the expected month-end balance per currency", () => {
+  it("renders the expected month-end balance per currency with a single descriptive line", () => {
     render(
       <AccountMonthEndForecast {...defaults({ forecast: TWO_ACCOUNTS_EUR })} />,
     );
@@ -111,10 +114,14 @@ describe("AccountMonthEndForecast — current period", () => {
     expect(screen.getByText(/expected month-end balance/i)).toBeInTheDocument();
     // EUR aggregate value
     expect(screen.getByText(/5,850\.00/)).toBeInTheDocument();
-    // Subtext under the headline number
+    // The single descriptive line under the hero replaces the old
+    // duplicate "Includes pending items in this period." sentence.
     expect(
-      screen.getByText(/Includes pending items in this period\./),
+      screen.getByText(/Current balance plus pending items in this period\./),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/^Includes pending items in this period\.$/),
+    ).not.toBeInTheDocument();
   });
 
   it("renders Account / Balance / End of month forecast columns", () => {

--- a/frontend/tests/components/dashboard/account-tile.test.tsx
+++ b/frontend/tests/components/dashboard/account-tile.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+
+import AccountTile from "@/components/dashboard/AccountTile";
+import type { Account } from "@/lib/types";
+
+const PRIMARY_CHECKING: Account = {
+  id: 1,
+  name: "Checking",
+  account_type_id: 10,
+  account_type_name: "Checking",
+  account_type_slug: "checking",
+  balance: 1000 as unknown as number,
+  currency: "EUR",
+  is_active: true,
+  close_day: null,
+  is_default: true,
+};
+
+const SECONDARY_SAVINGS: Account = {
+  id: 2,
+  name: "Savings",
+  account_type_id: 11,
+  account_type_name: "Savings",
+  account_type_slug: "savings",
+  balance: 5000 as unknown as number,
+  currency: "EUR",
+  is_active: true,
+  close_day: null,
+  is_default: false,
+};
+
+describe("AccountTile — identity/status/navigation surface", () => {
+  it("renders account name and account-type label", () => {
+    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    // Both the account name and the account-type label are "Checking",
+    // so we expect two matches: name (medium-emphasis) + type (muted
+    // subtext).
+    expect(screen.getAllByText(/^Checking$/)).toHaveLength(2);
+  });
+
+  it("renders the currency code", () => {
+    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    expect(screen.getByText(/^EUR$/)).toBeInTheDocument();
+  });
+
+  it("shows the Primary badge on the default account, not on others", () => {
+    const { rerender } = render(
+      <AccountTile account={PRIMARY_CHECKING} hasPending={false} />,
+    );
+    expect(screen.getByText(/^Primary$/i)).toBeInTheDocument();
+
+    rerender(<AccountTile account={SECONDARY_SAVINGS} hasPending={false} />);
+    expect(screen.queryByText(/^Primary$/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a Pending badge only when hasPending is true", () => {
+    const { rerender } = render(
+      <AccountTile account={PRIMARY_CHECKING} hasPending={false} />,
+    );
+    expect(screen.queryByText(/^Pending$/i)).not.toBeInTheDocument();
+
+    rerender(<AccountTile account={PRIMARY_CHECKING} hasPending={true} />);
+    expect(screen.getByText(/^Pending$/i)).toBeInTheDocument();
+  });
+
+  it("renders as a link to /accounts (click-through navigation)", () => {
+    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    const link = screen.getByTestId("account-tile");
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/accounts");
+  });
+
+  it("balance text is muted (forecast card is the numeric authority, tile is secondary)", () => {
+    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    // 1,000.00 appears, but as small muted secondary text — not the
+    // primary visual anchor of the tile.
+    const balance = screen.getByText(/1,000\.00/);
+    expect(balance.className).toMatch(/text-text-muted/);
+    // Crucially, the tile does NOT render the old large balance number
+    // styled as the primary content (text-xl + tabular-nums + text-text-primary).
+    expect(balance.className).not.toMatch(/text-xl/);
+    expect(balance.className).not.toMatch(/font-semibold/);
+  });
+});

--- a/frontend/tests/components/dashboard/account-tile.test.tsx
+++ b/frontend/tests/components/dashboard/account-tile.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 
-import AccountTile from "@/components/dashboard/AccountTile";
+import AccountTilesCard, {
+  AccountTileRow,
+} from "@/components/dashboard/AccountTile";
 import type { Account } from "@/lib/types";
 
 const PRIMARY_CHECKING: Account = {
@@ -29,9 +31,9 @@ const SECONDARY_SAVINGS: Account = {
   is_default: false,
 };
 
-describe("AccountTile — identity/status/navigation surface", () => {
+describe("AccountTileRow — identity/status/navigation surface", () => {
   it("renders account name and account-type label", () => {
-    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
     // Both the account name and the account-type label are "Checking",
     // so we expect two matches: name (medium-emphasis) + type (muted
     // subtext).
@@ -39,39 +41,39 @@ describe("AccountTile — identity/status/navigation surface", () => {
   });
 
   it("renders the currency code", () => {
-    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
     expect(screen.getByText(/^EUR$/)).toBeInTheDocument();
   });
 
   it("shows the Primary badge on the default account, not on others", () => {
     const { rerender } = render(
-      <AccountTile account={PRIMARY_CHECKING} hasPending={false} />,
+      <AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />,
     );
     expect(screen.getByText(/^Primary$/i)).toBeInTheDocument();
 
-    rerender(<AccountTile account={SECONDARY_SAVINGS} hasPending={false} />);
+    rerender(<AccountTileRow account={SECONDARY_SAVINGS} hasPending={false} />);
     expect(screen.queryByText(/^Primary$/i)).not.toBeInTheDocument();
   });
 
   it("shows a Pending badge only when hasPending is true", () => {
     const { rerender } = render(
-      <AccountTile account={PRIMARY_CHECKING} hasPending={false} />,
+      <AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />,
     );
     expect(screen.queryByText(/^Pending$/i)).not.toBeInTheDocument();
 
-    rerender(<AccountTile account={PRIMARY_CHECKING} hasPending={true} />);
+    rerender(<AccountTileRow account={PRIMARY_CHECKING} hasPending={true} />);
     expect(screen.getByText(/^Pending$/i)).toBeInTheDocument();
   });
 
   it("renders as a link to /accounts (click-through navigation)", () => {
-    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
     const link = screen.getByTestId("account-tile");
     expect(link.tagName).toBe("A");
     expect(link).toHaveAttribute("href", "/accounts");
   });
 
   it("balance text is muted (forecast card is the numeric authority, tile is secondary)", () => {
-    render(<AccountTile account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
     // 1,000.00 appears, but as small muted secondary text — not the
     // primary visual anchor of the tile.
     const balance = screen.getByText(/1,000\.00/);
@@ -80,5 +82,44 @@ describe("AccountTile — identity/status/navigation surface", () => {
     // styled as the primary content (text-xl + tabular-nums + text-text-primary).
     expect(balance.className).not.toMatch(/text-xl/);
     expect(balance.className).not.toMatch(/font-semibold/);
+  });
+});
+
+describe("AccountTilesCard — unified card with internal divider rows", () => {
+  it("wraps multiple account rows in a single card with divide-y rows (mirrors Forecast card idiom)", () => {
+    render(
+      <AccountTilesCard
+        accounts={[PRIMARY_CHECKING, SECONDARY_SAVINGS]}
+        pendingByAccount={{}}
+      />,
+    );
+    const outerCard = screen.getByTestId("account-tiles-card");
+    expect(outerCard).toBeInTheDocument();
+    // Inner rows live inside the same card and use a divide-y
+    // container (NOT a flex/grid stack of standalone card siblings).
+    expect(outerCard.querySelector(".divide-y")).not.toBeNull();
+    expect(screen.getAllByTestId("account-tile")).toHaveLength(2);
+  });
+
+  it("renders nothing when accounts is empty", () => {
+    const { container } = render(
+      <AccountTilesCard accounts={[]} pendingByAccount={{}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("forwards pending state per account to the rows", () => {
+    render(
+      <AccountTilesCard
+        accounts={[PRIMARY_CHECKING, SECONDARY_SAVINGS]}
+        pendingByAccount={{
+          [PRIMARY_CHECKING.id]: -50,
+          [SECONDARY_SAVINGS.id]: 0,
+        }}
+      />,
+    );
+    // Exactly one Pending badge — only PRIMARY_CHECKING has a non-zero
+    // pending delta.
+    expect(screen.getAllByText(/^Pending$/i)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

User-requested follow-up to PR #166. The new Forecast card had horizontal slack on desktop while the row of small account tiles above it duplicated the Balance column. Consolidate both into a single row: tiles stack as a vertical sidebar next to the Forecast card, which now claims the wider column.

Tiles redesigned: dropped the prominent balance number. Each tile is now a compact identity/status/navigation surface (account name, account-type label, Primary/Pending badges, currency code) with click-through to `/accounts`. Forecast card is the numeric authority for Balance and expected month-end; a small muted balance hint stays on each tile as secondary text. Layout uses `minmax(0,1fr)_minmax(0,2fr)` on `lg+`, single column below for mobile + tablet.

6 new component tests for the tile shape; 238 frontend tests pass; TypeScript clean on production code.