### PR TITLE
fix(roles-ui): swap isSuperadmin gate for hasPlatformPermission(roles.manage)

### DIFF
--- a/frontend/app/admin/roles/[id]/page.tsx
+++ b/frontend/app/admin/roles/[id]/page.tsx
@@ -8,7 +8,7 @@ import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { isSuperadmin } from "@/lib/auth";
+import { hasPlatformPermission } from "@/lib/auth";
 import {
   btnPrimary,
   btnSecondary,
@@ -51,13 +51,13 @@ export default function AdminRoleDetailPage() {
       router.replace("/login");
       return;
     }
-    if (!isSuperadmin(user)) {
+    if (!hasPlatformPermission(user, "roles.manage")) {
       router.replace("/dashboard");
     }
   }, [loading, user, router]);
 
   useEffect(() => {
-    if (loading || !user || !isSuperadmin(user)) return;
+    if (loading || !user || !hasPlatformPermission(user, "roles.manage")) return;
     if (!Number.isFinite(roleId)) {
       setError("Invalid role id.");
       setFetching(false);
@@ -165,7 +165,7 @@ export default function AdminRoleDetailPage() {
     }
   }
 
-  if (loading || !user || !isSuperadmin(user)) {
+  if (loading || !user || !hasPlatformPermission(user, "roles.manage")) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner />

--- a/frontend/app/admin/roles/page.tsx
+++ b/frontend/app/admin/roles/page.tsx
@@ -7,7 +7,7 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { isSuperadmin } from "@/lib/auth";
+import { hasPlatformPermission } from "@/lib/auth";
 import {
   btnPrimary,
   btnSecondary,
@@ -226,13 +226,13 @@ export default function AdminRolesPage() {
       router.replace("/login");
       return;
     }
-    if (!isSuperadmin(user)) {
+    if (!hasPlatformPermission(user, "roles.manage")) {
       router.replace("/dashboard");
     }
   }, [loading, user, router]);
 
   useEffect(() => {
-    if (loading || !user || !isSuperadmin(user)) return;
+    if (loading || !user || !hasPlatformPermission(user, "roles.manage")) return;
     setFetching(true);
     Promise.all([
       apiFetch<RoleListResponse>("/api/v1/admin/roles"),
@@ -257,7 +257,7 @@ export default function AdminRolesPage() {
     });
   }, [data]);
 
-  if (loading || !user || !isSuperadmin(user)) {
+  if (loading || !user || !hasPlatformPermission(user, "roles.manage")) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner />

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -11,3 +11,17 @@ export function isOwner(user: User): boolean {
 export function isSuperadmin(user: User): boolean {
   return user.is_superadmin;
 }
+
+// Forward-compatible platform-permission gate. Superadmin short-circuits
+// to true; otherwise check the optional permissions array. Today /me does
+// not return permissions, so non-superadmin users always resolve to false
+// (matches existing isSuperadmin behavior). The day backend /me starts
+// returning a permissions array, FE call sites pick it up automatically.
+export function hasPlatformPermission(
+  user: User | null | undefined,
+  permission: string,
+): boolean {
+  if (!user) return false;
+  if (user.is_superadmin) return true;
+  return Array.isArray(user.permissions) && user.permissions.includes(permission);
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -27,6 +27,12 @@ export interface User {
   subscription_status: SubscriptionStatus | null;
   subscription_plan: string | null;
   trial_end: string | null;
+  // Optional platform permissions array. Forward-compat: when /me starts
+  // returning effective permissions for non-superadmin platform admins,
+  // hasPlatformPermission(user, key) will pick them up without further FE
+  // changes. Today the field is undefined, so every gate degrades to the
+  // is_superadmin short-circuit (current behavior).
+  permissions?: string[];
 }
 
 export interface TokenResponse {

--- a/frontend/tests/app/admin-role-detail-page.test.tsx
+++ b/frontend/tests/app/admin-role-detail-page.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AdminRoleDetailPage from "@/app/admin/roles/[id]/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+      "@/components/auth/AuthProvider",
+    );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "1" }),
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/roles/1",
+}));
+
+const SUPERADMIN = {
+  id: 1,
+  username: "root",
+  email: "root@platform.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Platform",
+  billing_cycle_day: 1,
+  is_superadmin: true,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const ROLE_DETAIL = {
+  id: 1,
+  slug: "support",
+  name: "Support",
+  description: "Read-only operator role.",
+  is_system_frozen: false,
+  permissions: ["audit.view"],
+  created_at: "2026-05-07T09:00:00",
+  updated_at: "2026-05-07T09:00:00",
+};
+
+const CATALOG = {
+  namespaces: { audit: ["audit.view"], roles: ["roles.manage"] },
+  keys: ["audit.view", "roles.manage"],
+};
+
+describe("AdminRoleDetailPage permission gate", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === `/api/v1/admin/roles/1`) return ROLE_DETAIL;
+      if (path === "/api/v1/admin/permissions") return CATALOG;
+      throw new Error(`unexpected path: ${path}`);
+    });
+  });
+
+  it("renders the role detail for a superadmin", async () => {
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminRoleDetailPage />);
+
+    await screen.findByDisplayValue("Support");
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("redirects a non-superadmin user without roles.manage", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminRoleDetailPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("renders for a non-superadmin who carries roles.manage in permissions", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["roles.manage"],
+      } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminRoleDetailPage />);
+
+    await screen.findByDisplayValue("Support");
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+});

--- a/frontend/tests/app/admin-roles-page.test.tsx
+++ b/frontend/tests/app/admin-roles-page.test.tsx
@@ -114,7 +114,7 @@ describe("AdminRolesPage", () => {
     expect(screen.getByText("6")).toBeInTheDocument();
   });
 
-  it("redirects non-superadmin users away", async () => {
+  it("redirects non-superadmin users without roles.manage away", async () => {
     useAuthMock.mockReturnValue({
       user: { ...SUPERADMIN, is_superadmin: false } as never,
       loading: false,
@@ -130,6 +130,34 @@ describe("AdminRolesPage", () => {
     await waitFor(() => {
       expect(replaceMock).toHaveBeenCalledWith("/dashboard");
     });
+  });
+
+  it("renders for a non-superadmin who carries roles.manage in permissions", async () => {
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === "/api/v1/admin/roles") return { items: [] };
+      if (path === "/api/v1/admin/permissions") return CATALOG;
+      throw new Error(`unexpected path: ${path}`);
+    });
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["roles.manage"],
+      } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminRolesPage />);
+
+    // Reaches the data-load path (so the "New role" button is rendered) and
+    // does NOT redirect to /dashboard.
+    await screen.findByRole("button", { name: /new role/i });
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
   });
 
   it("opens the create modal and submits a new role", async () => {

--- a/frontend/tests/lib/auth.test.ts
+++ b/frontend/tests/lib/auth.test.ts
@@ -1,4 +1,4 @@
-import { isAdmin, isOwner, isSuperadmin } from "@/lib/auth";
+import { hasPlatformPermission, isAdmin, isOwner, isSuperadmin } from "@/lib/auth";
 import type { User } from "@/lib/types";
 
 
@@ -19,6 +19,8 @@ function makeUser(overrides: Partial<User> = {}): User {
     is_superadmin: false,
     is_active: true,
     mfa_enabled: false,
+    password_set: true,
+    allow_manual_balance_adjustment: false,
     subscription_status: null,
     subscription_plan: null,
     trial_end: null,
@@ -40,5 +42,37 @@ describe("frontend auth helpers", () => {
     expect(isAdmin(user)).toBe(true);
     expect(isOwner(user)).toBe(true);
     expect(isSuperadmin(user)).toBe(true);
+  });
+});
+
+describe("hasPlatformPermission", () => {
+  it("returns false for null/undefined users", () => {
+    expect(hasPlatformPermission(null, "roles.manage")).toBe(false);
+    expect(hasPlatformPermission(undefined, "roles.manage")).toBe(false);
+  });
+
+  it("returns true for superadmin regardless of permissions array", () => {
+    const user = makeUser({ is_superadmin: true });
+    expect(hasPlatformPermission(user, "roles.manage")).toBe(true);
+    expect(hasPlatformPermission(user, "anything.else")).toBe(true);
+  });
+
+  it("returns true for non-superadmin whose permissions array includes the key", () => {
+    const user = makeUser({ permissions: ["roles.manage", "audit.view"] });
+    expect(hasPlatformPermission(user, "roles.manage")).toBe(true);
+    expect(hasPlatformPermission(user, "audit.view")).toBe(true);
+  });
+
+  it("returns false for non-superadmin whose permissions array omits the key", () => {
+    const user = makeUser({ permissions: ["audit.view"] });
+    expect(hasPlatformPermission(user, "roles.manage")).toBe(false);
+  });
+
+  it("returns false for non-superadmin with empty or undefined permissions", () => {
+    expect(hasPlatformPermission(makeUser({ permissions: [] }), "roles.manage")).toBe(false);
+    expect(hasPlatformPermission(makeUser({ permissions: undefined }), "roles.manage")).toBe(
+      false,
+    );
+    expect(hasPlatformPermission(makeUser(), "roles.manage")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Backend already gates `/api/v1/admin/roles/*` on `require_permission("roles.manage")`, but the FE roles pages still hard-code `isSuperadmin(user)`. This closes the FE half of PR #142's review Finding B (LOW, forward-compat).

## What changed
- **Helper:** `hasPlatformPermission(user, key)` in `frontend/lib/auth.ts` — superadmin short-circuits to true; otherwise checks `user.permissions.includes(key)`.
- **Type:** Optional `permissions?: string[]` on `User` in `frontend/lib/types.ts`. Backend `/me` does not return it today; FE handles `undefined`.
- **Call sites swapped (6 total):**
  - `frontend/app/admin/roles/page.tsx`: redirect guard, data-load gate, render guard
  - `frontend/app/admin/roles/[id]/page.tsx`: redirect guard, data-load gate, render guard
- **Tests:**
  - `tests/lib/auth.test.ts` — 5 new cases for `hasPlatformPermission` (null/undefined, superadmin short-circuit, permissions includes/omits, empty/undefined permissions).
  - `tests/app/admin-roles-page.test.tsx` — added a non-superadmin-with-`roles.manage` case alongside the existing redirect case.
  - `tests/app/admin-role-detail-page.test.tsx` — new file mirroring the same three gate paths for the detail route.

## Behavior preserved today
Zero runtime change for any current user: `permissions` is undefined on every payload from `/me`, so each call site still resolves through the `is_superadmin` short-circuit.

## Forward-compat
The day backend `/me` returns a `permissions` array for non-superadmin platform admins, the new helper picks them up — no further FE call-site changes required.

## Out of scope (same finding class, deferred)
The following also gate on `isSuperadmin` and were intentionally not touched in this PR:
- `frontend/components/AppShell.tsx` (admin sidebar)
- `frontend/app/admin/orgs/page.tsx` and `[id]/page.tsx`
- `frontend/app/admin/audit/page.tsx`

## Verification
- `npx vitest run tests/lib/auth.test.ts tests/app/admin-roles-page.test.tsx tests/app/admin-role-detail-page.test.tsx` → 14/14 passing.
- `npx tsc --noEmit` — zero errors on the four production files (`lib/auth.ts`, `lib/types.ts`, the two roles pages). Test-file vitest-globals errors are pre-existing repo-wide.