### PR TITLE
fix(backend): set PYTHONUNBUFFERED=1 so log lines flush immediately

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,6 +21,12 @@ RUN addgroup --system --gid 1001 backend && \
 USER backend
 
 ENV PYTHONPATH=/app
+# Force unbuffered stdout/stderr so log lines reach the docker log driver
+# (and the App Platform log capture) immediately. Without this, Python
+# block-buffers stdout when not attached to a TTY, which makes
+# `./pfv logs -f` and the prod log stream appear to "stop" while the
+# buffer fills before flushing.
+ENV PYTHONUNBUFFERED=1
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
Without `PYTHONUNBUFFERED`, Python block-buffers stdout when stdout is not a TTY (which is the case under docker and DO App Platform). Log lines accumulate in 4–8 KB chunks before reaching the docker log driver, so `./pfv logs -f` and the prod log stream appear to "stop" between bursts. Setting `PYTHONUNBUFFERED=1` forces line buffering and gives immediate visibility.

## Scope
- `backend/Dockerfile`: add `ENV PYTHONUNBUFFERED=1` next to the existing `ENV PYTHONPATH=/app`. Affects both local dev (via `docker compose up --build backend`) and prod (via the next App Platform deploy).

## Verification
- Local rebuild: confirmed `PYTHONUNBUFFERED=1` is set in the running container.
- Live test: `curl /api/v1/auth/status` followed by `docker compose logs -f` — request line appeared within ~40 ms of the request firing. Before this change, log entries were arriving in bursts.

## Production impact
Prod has the same buffering behavior today. This PR fixes that on the next App Platform deploy. No runtime-behavior change beyond log-line latency.