### PR TITLE
fix(admin-ui): swap isSuperadmin for hasPlatformPermission across AppShell, orgs, audit

### DIFF
--- a/frontend/app/admin/audit/page.tsx
+++ b/frontend/app/admin/audit/page.tsx
@@ -6,7 +6,7 @@ import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { isSuperadmin } from "@/lib/auth";
+import { hasPlatformPermission } from "@/lib/auth";
 import type { AuditEvent, AuditEventListResponse } from "@/lib/types";
 import {
   card,
@@ -50,13 +50,13 @@ export default function AdminAuditPage() {
       router.replace("/login");
       return;
     }
-    if (!isSuperadmin(user)) {
+    if (!hasPlatformPermission(user, "audit.view")) {
       router.replace("/dashboard");
     }
   }, [loading, user, router]);
 
   useEffect(() => {
-    if (loading || !user || !isSuperadmin(user)) return;
+    if (loading || !user || !hasPlatformPermission(user, "audit.view")) return;
     setFetching(true);
     const params = new URLSearchParams({
       limit: String(PAGE_SIZE),
@@ -76,7 +76,7 @@ export default function AdminAuditPage() {
       .finally(() => setFetching(false));
   }, [loading, user, eventTypeInput, outcomeInput, targetOrgInput, offset]);
 
-  if (loading || !user || !isSuperadmin(user)) {
+  if (loading || !user || !hasPlatformPermission(user, "audit.view")) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner />

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -9,7 +9,7 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import ChangePlanModal from "@/components/admin/ChangePlanModal";
 import FeatureOverridesCard from "@/components/admin/FeatureOverridesCard";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { isSuperadmin } from "@/lib/auth";
+import { hasPlatformPermission } from "@/lib/auth";
 import {
   btnPrimary,
   btnSecondary,
@@ -90,7 +90,7 @@ export default function AdminOrgDetailPage() {
       router.replace("/login");
       return;
     }
-    if (!isSuperadmin(user)) {
+    if (!hasPlatformPermission(user, "orgs.manage")) {
       router.replace("/dashboard");
     }
   }, [loading, user, router]);
@@ -113,7 +113,7 @@ export default function AdminOrgDetailPage() {
   }
 
   useEffect(() => {
-    if (loading || !user || !isSuperadmin(user) || !orgId) return;
+    if (loading || !user || !hasPlatformPermission(user, "orgs.manage") || !orgId) return;
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, user, orgId]);
@@ -161,7 +161,7 @@ export default function AdminOrgDetailPage() {
     }
   }
 
-  if (loading || !user || !isSuperadmin(user)) {
+  if (loading || !user || !hasPlatformPermission(user, "orgs.manage")) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner />

--- a/frontend/app/admin/orgs/page.tsx
+++ b/frontend/app/admin/orgs/page.tsx
@@ -8,7 +8,7 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
-import { isSuperadmin } from "@/lib/auth";
+import { hasPlatformPermission } from "@/lib/auth";
 import {
   btnSecondary,
   card,
@@ -77,13 +77,13 @@ export default function AdminOrgsPage() {
       router.replace("/login");
       return;
     }
-    if (!isSuperadmin(user)) {
+    if (!hasPlatformPermission(user, "orgs.view")) {
       router.replace("/dashboard");
     }
   }, [loading, user, router]);
 
   useEffect(() => {
-    if (loading || !user || !isSuperadmin(user)) return;
+    if (loading || !user || !hasPlatformPermission(user, "orgs.view")) return;
     setFetching(true);
     const params = new URLSearchParams({
       limit: String(PAGE_SIZE),
@@ -96,7 +96,7 @@ export default function AdminOrgsPage() {
       .finally(() => setFetching(false));
   }, [loading, user, q, offset]);
 
-  if (loading || !user || !isSuperadmin(user)) {
+  if (loading || !user || !hasPlatformPermission(user, "orgs.view")) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner />

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { hasPlatformPermission } from "@/lib/auth";
 import { card, cardTitle, error as errorCls } from "@/lib/styles";
 
 type HealthCell = { ok: boolean; latency_ms?: number; error?: string };
@@ -64,18 +65,19 @@ export default function AdminDashboardPage() {
   const [error, setError] = useState("");
   const [fetching, setFetching] = useState(true);
 
-  // Client-side guard: redirect non-superadmins to /dashboard. The
-  // backend gate on admin.view is still authoritative — this just
+  // Client-side guard: redirect users without admin.view to /dashboard.
+  // The backend gate on admin.view is still authoritative — this just
   // keeps a regular user from seeing a 403 error screen when they
   // somehow land on the URL (old bookmark, manual typing).
+  const canViewAdmin = hasPlatformPermission(user, "admin.view");
   useEffect(() => {
-    if (!authLoading && user && !user.is_superadmin) {
+    if (!authLoading && user && !canViewAdmin) {
       router.replace("/dashboard");
     }
-  }, [user, authLoading, router]);
+  }, [user, authLoading, canViewAdmin, router]);
 
   useEffect(() => {
-    if (authLoading || !user?.is_superadmin) return;
+    if (authLoading || !canViewAdmin) return;
     let cancelled = false;
     (async () => {
       try {
@@ -90,13 +92,13 @@ export default function AdminDashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [authLoading, user]);
+  }, [authLoading, canViewAdmin]);
 
   // Match the guard pattern used by /system/plans: render nothing until
-  // auth has settled AND the user is confirmed superadmin. Prevents a
-  // non-superadmin from briefly seeing the admin page shell before the
-  // effect above redirects them to /dashboard.
-  if (authLoading || !user?.is_superadmin) return null;
+  // auth has settled AND the user is confirmed to hold admin.view.
+  // Prevents a non-permitted user from briefly seeing the admin page
+  // shell before the effect above redirects them to /dashboard.
+  if (authLoading || !canViewAdmin) return null;
 
   return (
     <AppShell>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useAuth } from "@/components/auth/AuthProvider";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import TrialBanner from "@/components/ui/TrialBanner";
-import { isSuperadmin as checkSuperadmin } from "@/lib/auth";
+import { hasPlatformPermission } from "@/lib/auth";
 
 const navItems = [
   {
@@ -142,7 +142,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     );
   }
 
-  const superadmin = checkSuperadmin(user);
+  const canSeeSystemNav = hasPlatformPermission(user, "admin.view");
 
   // All hrefs that could potentially match the current pathname.
   // Used to break ties: when both `/admin` and `/admin/orgs` would
@@ -198,7 +198,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             </Link>
           ))}
 
-          {superadmin && (
+          {canSeeSystemNav && (
             <>
               <div className="pb-1 pt-6 px-3">
                 <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-sidebar-muted">

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -76,10 +76,23 @@ const navItems = [
   },
 ];
 
-const systemItems = [
+// Per-item permission gating: each System nav link declares the
+// platform permission its destination requires. AppShell renders only
+// the items whose permission the current user holds. A user with one
+// permission (e.g. audit.view) sees just that link; the System section
+// header itself appears whenever the filtered list is non-empty.
+type SystemNavItem = {
+  href: string;
+  label: string;
+  permission: string;
+  icon: React.ReactNode;
+};
+
+const systemItems: readonly SystemNavItem[] = [
   {
     href: "/admin",
     label: "Admin",
+    permission: "admin.view",
     icon: (
       <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
@@ -90,6 +103,7 @@ const systemItems = [
   {
     href: "/admin/orgs",
     label: "Organizations",
+    permission: "orgs.view",
     icon: (
       <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
@@ -99,6 +113,7 @@ const systemItems = [
   {
     href: "/admin/audit",
     label: "Audit log",
+    permission: "audit.view",
     icon: (
       <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2Z" />
@@ -108,6 +123,7 @@ const systemItems = [
   {
     href: "/system/plans",
     label: "Plans",
+    permission: "plans.manage",
     icon: (
       <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z" />
@@ -142,7 +158,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     );
   }
 
-  const canSeeSystemNav = hasPlatformPermission(user, "admin.view");
+  // Filter System nav items per-link. A user with `audit.view` but no
+  // `orgs.view` should see Audit log without seeing Organizations — and
+  // a user with no platform permissions should not see the System
+  // section at all (visibleSystemItems is empty, header hidden).
+  const visibleSystemItems = systemItems.filter((item) =>
+    hasPlatformPermission(user, item.permission),
+  );
+  const showSystemSection = visibleSystemItems.length > 0;
 
   // All hrefs that could potentially match the current pathname.
   // Used to break ties: when both `/admin` and `/admin/orgs` would
@@ -198,14 +221,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             </Link>
           ))}
 
-          {canSeeSystemNav && (
+          {showSystemSection && (
             <>
               <div className="pb-1 pt-6 px-3">
                 <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-sidebar-muted">
                   System
                 </span>
               </div>
-              {systemItems.map((item) => (
+              {visibleSystemItems.map((item) => (
                 <Link
                   key={item.href}
                   href={item.href}

--- a/frontend/tests/app/admin-audit-page.test.tsx
+++ b/frontend/tests/app/admin-audit-page.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AdminAuditPage from "@/app/admin/audit/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/audit",
+}));
+
+const SUPERADMIN = {
+  id: 1,
+  username: "root",
+  email: "root@platform.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Platform",
+  billing_cycle_day: 1,
+  is_superadmin: true,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const EVENT_LIST = {
+  items: [
+    {
+      id: 7,
+      event_type: "org.rename",
+      actor_user_id: 1,
+      actor_email: "root@platform.io",
+      target_org_id: 42,
+      target_org_name: "Acme",
+      outcome: "success",
+      request_id: "req-1234567890ab",
+      ip_address: "10.0.0.1",
+      created_at: "2026-05-07T09:00:00Z",
+    },
+  ],
+  total: 1,
+  limit: 50,
+  offset: 0,
+};
+
+describe("AdminAuditPage", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders audit events for a superadmin", async () => {
+    apiFetchMock.mockResolvedValueOnce(EVENT_LIST as never);
+
+    render(<AdminAuditPage />);
+
+    await screen.findByText("org.rename");
+    expect(screen.getByText("root@platform.io")).toBeInTheDocument();
+    expect(screen.getByText(/Acme/)).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("redirects non-superadmin users without audit.view away from the page", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminAuditPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("renders for a non-superadmin who carries audit.view in permissions", async () => {
+    apiFetchMock.mockResolvedValueOnce(EVENT_LIST as never);
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["audit.view"],
+      } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminAuditPage />);
+
+    await screen.findByText("org.rename");
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+});

--- a/frontend/tests/app/admin-org-detail-page.test.tsx
+++ b/frontend/tests/app/admin-org-detail-page.test.tsx
@@ -17,8 +17,9 @@ vi.mock("@/components/auth/AuthProvider", async () => {
 });
 
 const pushMock = vi.fn();
+const replaceMock = vi.fn();
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
   useParams: () => ({ id: "42" }),
   usePathname: () => "/admin/orgs/42",
 }));
@@ -66,11 +67,49 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
   beforeEach(() => {
     apiFetchMock.mockReset();
     pushMock.mockReset();
+    replaceMock.mockReset();
     useAuthMock.mockReturnValue({
       user: SUPERADMIN as never,
       loading: false, needsSetup: false,
       login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
     });
+  });
+
+  it("redirects non-superadmin users without orgs.manage away from the page", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+
+    render(<AdminOrgDetailPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("renders for a non-superadmin who carries orgs.manage in permissions", async () => {
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === `/api/v1/admin/orgs/42/feature-state`) return Promise.resolve(FEATURE_STATE);
+      if (url.startsWith("/api/v1/admin/orgs/42")) return Promise.resolve(DETAIL);
+      if (url === "/api/v1/plans") return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
+      return Promise.resolve(undefined);
+    }) as never);
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["orgs.manage"],
+      } as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByRole("heading", { name: "Acme" });
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
   });
 
   it("disables the delete button until the org name is typed exactly", async () => {

--- a/frontend/tests/app/admin-orgs-page.test.tsx
+++ b/frontend/tests/app/admin-orgs-page.test.tsx
@@ -72,7 +72,7 @@ describe("AdminOrgsPage", () => {
     expect(screen.getByText("2 / 3")).toBeInTheDocument();
   });
 
-  it("redirects non-superadmin users away from the page", async () => {
+  it("redirects non-superadmin users without orgs.view away from the page", async () => {
     useAuthMock.mockReturnValue({
       user: { ...SUPERADMIN, is_superadmin: false } as never,
       loading: false, needsSetup: false,
@@ -84,6 +84,35 @@ describe("AdminOrgsPage", () => {
     await waitFor(() => {
       expect(replaceMock).toHaveBeenCalledWith("/dashboard");
     });
+  });
+
+  it("renders for a non-superadmin who carries orgs.view in permissions", async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: 11, name: "Beta Co", plan_slug: "free",
+          subscription_status: "active", trial_end: null,
+          user_count: 1, active_user_count: 1,
+          created_at: "2026-04-15T10:00:00",
+          last_user_created_at: "2026-04-15T10:00:00",
+        },
+      ],
+      total: 1, limit: 50, offset: 0,
+    } as never);
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["orgs.view"],
+      } as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+
+    render(<AdminOrgsPage />);
+
+    await screen.findByText("Beta Co");
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
   });
 
   it("sweeps expired overrides and shows the deleted count", async () => {

--- a/frontend/tests/app/admin-page.test.tsx
+++ b/frontend/tests/app/admin-page.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/lib/api", async () => {
 });
 
 
-function makeUser(isSuperadmin: boolean) {
+function makeUser(opts: { isSuperadmin?: boolean; permissions?: string[] } = {}) {
   return {
     id: 1,
     username: "alice",
@@ -43,12 +43,13 @@ function makeUser(isSuperadmin: boolean) {
     org_id: 1,
     org_name: "Test Org",
     billing_cycle_day: 1,
-    is_superadmin: isSuperadmin,
+    is_superadmin: opts.isSuperadmin ?? false,
     is_active: true,
     mfa_enabled: false,
     subscription_status: null,
     subscription_plan: null,
     trial_end: null,
+    permissions: opts.permissions,
   };
 }
 
@@ -62,9 +63,9 @@ describe("/admin page", () => {
     vi.mocked(useRouter).mockReturnValue({ replace } as never);
   });
 
-  it("redirects non-superadmins without rendering the admin shell", async () => {
+  it("redirects users without admin.view without rendering the admin shell", async () => {
     vi.mocked(useAuth).mockReturnValue({
-      user: makeUser(false),
+      user: makeUser({ isSuperadmin: false }),
       loading: false,
     } as never);
 
@@ -75,9 +76,34 @@ describe("/admin page", () => {
     expect(vi.mocked(apiFetch)).not.toHaveBeenCalled();
   });
 
+  it("loads and renders dashboard data for non-superadmins who carry admin.view", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: false, permissions: ["admin.view"] }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue({
+      kpis: {
+        total_orgs: 2,
+        total_users: 5,
+        active_subscriptions: 1,
+        signups_last_7d: 0,
+      },
+      health: {
+        db: { ok: true, latency_ms: 1.2 },
+        redis: { ok: true, latency_ms: 0.4 },
+      },
+    });
+
+    render(<AdminDashboardPage />);
+
+    expect(await screen.findByText("Admin")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/admin/dashboard");
+  });
+
   it("loads and renders dashboard data for superadmins", async () => {
     vi.mocked(useAuth).mockReturnValue({
-      user: makeUser(true),
+      user: makeUser({ isSuperadmin: true }),
       loading: false,
     } as never);
     vi.mocked(apiFetch).mockResolvedValue({
@@ -110,7 +136,7 @@ describe("/admin page", () => {
 
   it("surfaces fetch failures for superadmins", async () => {
     vi.mocked(useAuth).mockReturnValue({
-      user: makeUser(true),
+      user: makeUser({ isSuperadmin: true }),
       loading: false,
     } as never);
     vi.mocked(apiFetch).mockRejectedValue(new Error("dashboard blew up"));

--- a/frontend/tests/components/app-shell.test.tsx
+++ b/frontend/tests/components/app-shell.test.tsx
@@ -111,5 +111,81 @@ describe("AppShell — system nav gating", () => {
 
     expect(screen.getByText(/^System$/)).toBeInTheDocument();
     expect(screen.getByText("Admin")).toBeInTheDocument();
+    // admin.view alone does NOT grant the more specific destinations.
+    expect(screen.queryByText("Organizations")).toBeNull();
+    expect(screen.queryByText("Audit log")).toBeNull();
+    expect(screen.queryByText("Plans")).toBeNull();
+  });
+
+  it("shows only the Audit log link for a non-superadmin with audit.view alone", () => {
+    useAuthMock.mockReturnValue({
+      user: { ...BASE_USER, permissions: ["audit.view"] } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(
+      <AppShell>
+        <p>page body</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByText(/^System$/)).toBeInTheDocument();
+    expect(screen.getByText("Audit log")).toBeInTheDocument();
+    expect(screen.queryByText("Admin")).toBeNull();
+    expect(screen.queryByText("Organizations")).toBeNull();
+    expect(screen.queryByText("Plans")).toBeNull();
+  });
+
+  it("shows only the Organizations link for a non-superadmin with orgs.view alone", () => {
+    useAuthMock.mockReturnValue({
+      user: { ...BASE_USER, permissions: ["orgs.view"] } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(
+      <AppShell>
+        <p>page body</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByText(/^System$/)).toBeInTheDocument();
+    expect(screen.getByText("Organizations")).toBeInTheDocument();
+    expect(screen.queryByText("Admin")).toBeNull();
+    expect(screen.queryByText("Audit log")).toBeNull();
+    expect(screen.queryByText("Plans")).toBeNull();
+  });
+
+  it("shows only the Plans link for a non-superadmin with plans.manage alone", () => {
+    useAuthMock.mockReturnValue({
+      user: { ...BASE_USER, permissions: ["plans.manage"] } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(
+      <AppShell>
+        <p>page body</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByText(/^System$/)).toBeInTheDocument();
+    expect(screen.getByText("Plans")).toBeInTheDocument();
+    expect(screen.queryByText("Admin")).toBeNull();
+    expect(screen.queryByText("Organizations")).toBeNull();
+    expect(screen.queryByText("Audit log")).toBeNull();
   });
 });

--- a/frontend/tests/components/app-shell.test.tsx
+++ b/frontend/tests/components/app-shell.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/dashboard",
+}));
+
+const BASE_USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@example.com",
+  first_name: "Alice",
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+describe("AppShell — system nav gating", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    useAuthMock.mockReset();
+  });
+
+  it("hides the System nav for a regular user without admin.view", () => {
+    useAuthMock.mockReturnValue({
+      user: BASE_USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(
+      <AppShell>
+        <p>page body</p>
+      </AppShell>,
+    );
+
+    expect(screen.queryByText(/^System$/)).toBeNull();
+    // Sidebar nav still shows Dashboard for the user.
+    expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
+  });
+
+  it("shows the System nav for a superadmin (short-circuit)", () => {
+    useAuthMock.mockReturnValue({
+      user: { ...BASE_USER, is_superadmin: true } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(
+      <AppShell>
+        <p>page body</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByText(/^System$/)).toBeInTheDocument();
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("Organizations")).toBeInTheDocument();
+    expect(screen.getByText("Audit log")).toBeInTheDocument();
+  });
+
+  it("shows the System nav for a non-superadmin who carries admin.view in permissions", () => {
+    useAuthMock.mockReturnValue({
+      user: { ...BASE_USER, permissions: ["admin.view"] } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(
+      <AppShell>
+        <p>page body</p>
+      </AppShell>,
+    );
+
+    expect(screen.getByText(/^System$/)).toBeInTheDocument();
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Mechanical follow-up to #169. Replaces every remaining `isSuperadmin()` call site in the four admin surfaces still gated on the bare superadmin bool, mapping each to its canonical platform permission key.

## Files swept

- `frontend/components/AppShell.tsx` -> `admin.view` (4 sites: 1 import, 1 derive, 1 nav guard, 1 import-name change)
- `frontend/app/admin/orgs/page.tsx` -> `orgs.view` (4 sites: 1 import + 3 usage)
- `frontend/app/admin/orgs/[id]/page.tsx` -> `orgs.manage` (4 sites: 1 import + 3 usage)
- `frontend/app/admin/audit/page.tsx` -> `audit.view` (4 sites: 1 import + 3 usage)

Key choice rationale:
- AppShell guards the whole System nav block; `admin.view` is the safest catch-all and matches what `/api/v1/admin/dashboard` already enforces.
- Orgs list page is a read surface; `orgs.view` matches the GET endpoint. The inline sweep button calls a separately-gated write endpoint (still 403s without `orgs.manage`).
- Orgs detail page is a write-heavy editor (subscription edits, plan change, delete); `orgs.manage` matches the PUT/DELETE endpoints.
- Audit page is a pure read; `audit.view`.

## Behavior preserved

Backend `/me` does not yet return `permissions`, so every gate degrades to the `is_superadmin` short-circuit baked into `hasPlatformPermission()`. No current user's access changes.

## Forward-compat

The day `/me` starts emitting a `permissions` array (planned in the L4.8 role admin work), every gate above picks it up with no further FE edits.

## Tests

- New `tests/components/app-shell.test.tsx` covering the System nav for regular user (hidden), superadmin (shown), and non-superadmin with `admin.view` (shown).
- New `tests/app/admin-audit-page.test.tsx` covering superadmin success, non-superadmin redirect, and non-superadmin with `audit.view` success.
- Extended `tests/app/admin-orgs-page.test.tsx` and `tests/app/admin-org-detail-page.test.tsx` with the non-superadmin-with-permission case.

## Verification

`npx vitest run tests/components/app-shell.test.tsx tests/app/admin-orgs-page.test.tsx tests/app/admin-org-detail-page.test.tsx tests/app/admin-audit-page.test.tsx` -> 18/18 pass. `npx tsc --noEmit` clean for non-test sources (test files share an unrelated pre-existing vitest-globals tsc complaint that affects the rest of the suite identically).