### PR TITLE
chore(ui): polish dashboard spending/pending/charts and accounts column alignment

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -193,11 +193,24 @@ export default function AccountsPage() {
                 </div>
                 <button type="submit" className={`w-full min-h-[44px] sm:w-auto sm:min-h-0 ${btnPrimary}`}>Add</button>
               </form>
+              {/* Column header — visible only on sm+ where the row uses
+                  the same grid template. Keeps the type name column
+                  proportional and pins the system badge + count to
+                  fixed-width slots so longer names can't push them out
+                  of alignment. */}
+              {accountTypes.length > 0 && (
+                <div className="hidden border-b border-border-subtle px-3 pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted sm:grid sm:grid-cols-[minmax(0,1fr)_4rem_3rem_auto] sm:items-center sm:gap-3">
+                  <span>Type</span>
+                  <span className="text-center">Tag</span>
+                  <span className="text-right" title="Number of accounts using this type">Count</span>
+                  <span className="sr-only">Actions</span>
+                </div>
+              )}
               <div className="space-y-1">
                 {accountTypes.map((at) => (
-                  <div key={at.id} className="group flex flex-col gap-2 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised sm:flex-row sm:items-center sm:justify-between">
+                  <div key={at.id} className="group flex flex-col gap-2 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised sm:grid sm:grid-cols-[minmax(0,1fr)_4rem_3rem_auto] sm:items-center sm:gap-3">
                     {editingTypeId === at.id ? (
-                      <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+                      <div className="flex flex-col gap-2 sm:col-span-4 sm:flex-row sm:items-center">
                         <label htmlFor={`edit-type-${at.id}`} className="sr-only">Edit type name</label>
                         <input id={`edit-type-${at.id}`} type="text" value={editingTypeName} onChange={(e) => setEditingTypeName(e.target.value)} className={`w-full sm:flex-1 ${input}`} autoFocus
                           onKeyDown={(e) => { if (e.key === "Enter") handleUpdateType(at.id); if (e.key === "Escape") setEditingTypeId(null); }} />
@@ -208,12 +221,14 @@ export default function AccountsPage() {
                       </div>
                     ) : (
                       <>
-                        <div className="flex min-w-0 flex-1 items-center gap-2">
-                          <span className="truncate text-sm text-text-primary">{at.name}</span>
-                          {at.is_system && <span className="shrink-0 rounded bg-surface-overlay px-1.5 py-0.5 text-[10px] font-medium text-text-muted">system</span>}
-                          <span className="shrink-0 text-xs text-text-muted" title={`${at.account_count} account(s)`}>{at.account_count}</span>
-                        </div>
-                        <div className="flex flex-wrap gap-3">
+                        <span className="min-w-0 truncate text-sm text-text-primary">{at.name}</span>
+                        <span className="text-left sm:text-center">
+                          {at.is_system && (
+                            <span className="inline-block rounded bg-surface-overlay px-1.5 py-0.5 text-[10px] font-medium text-text-muted">system</span>
+                          )}
+                        </span>
+                        <span className="text-xs tabular-nums text-text-muted sm:text-right" title={`${at.account_count} account(s)`}>{at.account_count}</span>
+                        <div className="flex flex-wrap gap-3 sm:justify-end">
                           {!at.is_system && (
                             <>
                               <button onClick={() => { setEditingTypeId(at.id); setEditingTypeName(at.name); }} aria-label={`Edit ${at.name}`} className="min-h-[44px] text-xs text-text-muted hover:text-accent sm:min-h-0">Edit</button>
@@ -287,17 +302,31 @@ export default function AccountsPage() {
                     </div>
                   </div>
                 ) : (
-                  <article key={a.id} className={`flex flex-col gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised md:flex-row md:items-center md:justify-between ${!a.is_active ? "opacity-40" : ""}`}>
+                  <article key={a.id} className={`flex flex-col gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised md:flex-row md:items-center md:gap-4 ${!a.is_active ? "opacity-40" : ""}`}>
+                    {/* Description column: name + meta. The "DEFAULT"
+                        badge is a fixed-width inline pill (NOT trailing
+                        "· default" text), so toggling default never
+                        changes how much room neighbouring text gets. */}
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
                         <span className="truncate text-sm font-medium text-text-primary">{a.name}</span>
+                        {a.is_default && (
+                          <span className="shrink-0 rounded border border-border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-text-secondary">
+                            Default
+                          </span>
+                        )}
                         <span className="text-xs text-text-muted">{a.account_type_name}</span>
-                        {a.is_default && <span className="text-xs text-accent">· default</span>}
                         {a.close_day && <span className="text-xs text-text-muted">· closes day {a.close_day}</span>}
                         {!a.is_active && <span className="text-xs text-danger">inactive</span>}
                       </div>
                     </div>
-                    <div className="flex shrink-0 flex-col items-end gap-0.5 md:ml-auto">
+                    {/* Fixed-width balance column — w-32 keeps the
+                        column position stable whether the row owns a
+                        "Default" action button or not, so toggling
+                        default no longer shifts numbers into adjacent
+                        cells. tabular-nums + text-right keep digits
+                        aligned across rows. */}
+                    <div className="flex shrink-0 flex-col items-start gap-0.5 md:w-32 md:items-end">
                       <span className="text-sm tabular-nums text-text-primary">
                         {formatAmount(a.balance)}{" "}
                         <span className="text-text-muted">{a.currency}</span>
@@ -308,7 +337,7 @@ export default function AccountsPage() {
                         </span>
                       ) : null}
                     </div>
-                    <div className="flex flex-wrap gap-3">
+                    <div className="flex flex-wrap gap-3 md:justify-end">
                       <button onClick={() => startEditAcct(a)} aria-label={`Edit ${a.name}`} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Edit</button>
                       {canAdjustBalance && a.is_active && (
                         <button
@@ -321,7 +350,7 @@ export default function AccountsPage() {
                       )}
                       {!a.is_default && a.is_active && (
                         <button onClick={async () => { try { await apiFetch(`/api/v1/accounts/${a.id}`, { method: "PUT", body: JSON.stringify({ is_default: true }) }); await reload(); } catch (err) { setError(extractErrorMessage(err)); } }} aria-label={`Set ${a.name} as default`} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">
-                          Default
+                          Set default
                         </button>
                       )}
                       <button onClick={() => handleToggleActive(a)} aria-label={a.is_active ? `Deactivate ${a.name}` : `Activate ${a.name}`} className="min-h-[44px] text-xs text-text-muted hover:text-text-secondary md:min-h-0">

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -12,6 +12,51 @@ import { input, label, btnPrimary, card, cardHeader, cardTitle, error as errorCl
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import type { BillingPeriod, Budget, Category } from "@/lib/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import { chartColor } from "@/lib/chart-colors";
+
+// D5: shape that rounds the spent bar's right edge when the stack has
+// no trailing remaining / over segment (i.e. exactly 100% utilization).
+// Recharts radius={[4,0,0,4]} on the Bar leaves the right corners
+// squared, which becomes visually obvious at high fill ratios where the
+// remaining segment is gone. We compute the per-bar payload here and
+// switch the right-side radius based on actual utilization.
+interface BudgetBarShapeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  fill?: string;
+  payload?: { spent: number; remaining: number; over: number };
+}
+
+function BudgetSpentBarShape(props: BudgetBarShapeProps) {
+  const { x = 0, y = 0, width = 0, height = 0, fill, payload } = props;
+  if (width <= 0 || height <= 0) return null;
+  // No remaining headroom AND no over-budget bar to the right → spent
+  // bar IS the full row, so round all four corners. Same render as a
+  // standalone bar.
+  const remaining = payload?.remaining ?? 0;
+  const over = payload?.over ?? 0;
+  const isFullRow = remaining <= 0 && over <= 0;
+  const r = Math.min(4, height / 2, width / 2);
+  const rightR = isFullRow ? r : 0;
+  // Clockwise rounded rect with per-side radius. Always rounds the
+  // left corners (this bar always starts at the row origin); the
+  // right corners pick up rounding only when no follow-on bar exists.
+  const path = [
+    `M ${x + r} ${y}`,
+    rightR > 0
+      ? `H ${x + width - rightR} Q ${x + width} ${y} ${x + width} ${y + rightR}`
+      : `H ${x + width}`,
+    rightR > 0
+      ? `V ${y + height - rightR} Q ${x + width} ${y + height} ${x + width - rightR} ${y + height}`
+      : `V ${y + height}`,
+    `H ${x + r} Q ${x} ${y + height} ${x} ${y + height - r}`,
+    `V ${y + r} Q ${x} ${y} ${x + r} ${y}`,
+    "Z",
+  ].join(" ");
+  return <path d={path} fill={fill} style={{ cursor: "pointer" }} />;
+}
 
 export default function BudgetsPage() {
   const { user, loading } = useAuth();
@@ -279,37 +324,49 @@ export default function BudgetsPage() {
                     over: Math.max(Number(b.spent) - Number(b.amount), 0),
                   }))} layout="vertical" margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
                     <XAxis type="number" hide />
-                    <YAxis type="category" dataKey="name" width={100} tick={{ fill: "#9ba8bd", fontSize: 11 }} />
+                    <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
                     <Tooltip
                       formatter={(v, name) => [
                         formatAmount(Number(v)),
-                        name === "spent" ? <span style={{ color: "#f87171" }}>Spent</span>
-                          : name === "over" ? <span style={{ color: "#f87171" }}>Over budget</span>
-                          : <span style={{ color: "#4ade80" }}>Remaining</span>,
+                        name === "spent" ? <span style={{ color: chartColor.spent }}>Spent</span>
+                          : name === "over" ? <span style={{ color: chartColor.over }}>Over budget</span>
+                          : <span style={{ color: chartColor.remaining }}>Remaining</span>,
                       ]}
                       contentStyle={{ fontSize: "11px" }}
                     />
-                    <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}
+                    {/* D5 fix: shape function recomputes corner radii
+                        per-row so a stack at >=100% utilization (no
+                        remaining segment, no over segment) still rounds
+                        its right edge. Static radius={[4,0,0,4]} on the
+                        Bar wouldn't, because the trailing remaining bar
+                        would normally own the right rounding. */}
+                    <Bar dataKey="spent" stackId="a" animationDuration={600}
                       cursor="pointer"
+                      shape={(props: BudgetBarShapeProps) => (
+                        <BudgetSpentBarShape {...props} />
+                      )}
                       onClick={(data) => {
                         const name = data?.name || data?.payload?.name;
                         if (name) router.push(`/transactions?category=${encodeURIComponent(name)}`);
                       }}
                     >
                       {budgets.map((b, i) => (
-                        <Cell key={i} fill={b.percent_used > 100 ? "#f87171" : b.percent_used > 80 ? "#f59e0b" : "#D4A64A"} />
+                        <Cell
+                          key={i}
+                          fill={b.percent_used > 100 ? chartColor.over : b.percent_used > 80 ? chartColor.watch : chartColor.spent}
+                        />
                       ))}
                     </Bar>
-                    <Bar dataKey="remaining" stackId="a" fill="#e8ebf0" radius={[0, 4, 4, 0]} animationDuration={600} />
-                    <Bar dataKey="over" stackId="a" fill="#f87171" radius={[0, 4, 4, 0]} animationDuration={600} />
+                    <Bar dataKey="remaining" stackId="a" fill={chartColor.remaining} radius={[0, 4, 4, 0]} animationDuration={600} />
+                    <Bar dataKey="over" stackId="a" fill={chartColor.over} radius={[4, 4, 4, 4]} animationDuration={600} />
                   </BarChart>
                 </ResponsiveContainer>
               </div>
               <div className="mt-3 flex gap-4 px-4 pb-2 text-[10px] text-text-muted">
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Spent</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f59e0b" }} /> &gt;80%</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over budget</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#e8ebf0" }} /> Remaining</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.spent }} /> Spent</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.watch }} /> &gt;80%</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.over }} /> Over budget</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.remaining }} /> Remaining</span>
               </div>
             </div>
           )}

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -13,50 +13,7 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 
 import type { BillingPeriod, Budget, Category } from "@/lib/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import { chartColor } from "@/lib/chart-colors";
-
-// D5: shape that rounds the spent bar's right edge when the stack has
-// no trailing remaining / over segment (i.e. exactly 100% utilization).
-// Recharts radius={[4,0,0,4]} on the Bar leaves the right corners
-// squared, which becomes visually obvious at high fill ratios where the
-// remaining segment is gone. We compute the per-bar payload here and
-// switch the right-side radius based on actual utilization.
-interface BudgetBarShapeProps {
-  x?: number;
-  y?: number;
-  width?: number;
-  height?: number;
-  fill?: string;
-  payload?: { spent: number; remaining: number; over: number };
-}
-
-function BudgetSpentBarShape(props: BudgetBarShapeProps) {
-  const { x = 0, y = 0, width = 0, height = 0, fill, payload } = props;
-  if (width <= 0 || height <= 0) return null;
-  // No remaining headroom AND no over-budget bar to the right → spent
-  // bar IS the full row, so round all four corners. Same render as a
-  // standalone bar.
-  const remaining = payload?.remaining ?? 0;
-  const over = payload?.over ?? 0;
-  const isFullRow = remaining <= 0 && over <= 0;
-  const r = Math.min(4, height / 2, width / 2);
-  const rightR = isFullRow ? r : 0;
-  // Clockwise rounded rect with per-side radius. Always rounds the
-  // left corners (this bar always starts at the row origin); the
-  // right corners pick up rounding only when no follow-on bar exists.
-  const path = [
-    `M ${x + r} ${y}`,
-    rightR > 0
-      ? `H ${x + width - rightR} Q ${x + width} ${y} ${x + width} ${y + rightR}`
-      : `H ${x + width}`,
-    rightR > 0
-      ? `V ${y + height - rightR} Q ${x + width} ${y + height} ${x + width - rightR} ${y + height}`
-      : `V ${y + height}`,
-    `H ${x + r} Q ${x} ${y + height} ${x} ${y + height - r}`,
-    `V ${y + r} Q ${x} ${y} ${x + r} ${y}`,
-    "Z",
-  ].join(" ");
-  return <path d={path} fill={fill} style={{ cursor: "pointer" }} />;
-}
+import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 
 export default function BudgetsPage() {
   const { user, loading } = useAuth();
@@ -334,15 +291,16 @@ export default function BudgetsPage() {
                       ]}
                       contentStyle={{ fontSize: "11px" }}
                     />
-                    {/* D5 fix: shape function recomputes corner radii
-                        per-row so a stack at >=100% utilization (no
-                        remaining segment, no over segment) still rounds
-                        its right edge. Static radius={[4,0,0,4]} on the
-                        Bar wouldn't, because the trailing remaining bar
-                        would normally own the right rounding. */}
+                    {/* D5 fix: shared BudgetSpentBarShape recomputes
+                        corner radii per-row so a stack at >=100%
+                        utilization (no remaining segment, no over
+                        segment) still rounds its right edge. Static
+                        radius={[4,0,0,4]} on the Bar wouldn't, because
+                        the trailing remaining bar would normally own
+                        the right rounding. */}
                     <Bar dataKey="spent" stackId="a" animationDuration={600}
                       cursor="pointer"
-                      shape={(props: BudgetBarShapeProps) => (
+                      shape={(props: BudgetSpentBarShapeProps) => (
                         <BudgetSpentBarShape {...props} />
                       )}
                       onClick={(data) => {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, pa
 
 import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import CategorySelect from "@/components/ui/CategorySelect";
+import { chartColor } from "@/lib/chart-colors";
 import OnTrackTile from "@/components/dashboard/OnTrackTile";
 import AccountMonthEndForecast, {
   type AccountMonthEndForecastResponse,
@@ -780,19 +781,31 @@ export default function DashboardPage() {
                       </PieChart>
                     </ResponsiveContainer>
                   </div>
+                  {/* D2 (2026-05-08): fill the description-to-amount
+                      gap with a "% of total" column instead of leaving
+                      it as dead whitespace. Layout: dot + name (flex-1
+                      truncate) + percent (right-aligned, fixed col) +
+                      amount (right-aligned, fixed col). Tabular-nums on
+                      both numeric columns keeps digits aligned across
+                      rows. */}
                   <div className="w-full space-y-1.5 sm:flex-1">
-                    {donutData.slice(0, 10).map((d, i) => (
-                      <button key={d.name} onClick={() => setChartFilter(chartFilter === d.name ? null : d.name)}
-                        className={`flex w-full items-center justify-between rounded px-1.5 py-0.5 transition-colors hover:bg-surface-raised ${chartFilter === d.name ? "bg-surface-overlay" : ""}`}>
-                        <div className="flex items-center gap-2">
-                          <div className="h-2.5 w-2.5 rounded-full" style={{ background: CHART_COLORS[i % CHART_COLORS.length] }} />
-                          <span className="text-xs text-text-secondary">{d.name}</span>
-                        </div>
-                        <span className="text-xs tabular-nums text-text-muted">{formatAmount(d.value)}</span>
-                      </button>
-                    ))}
+                    {(() => {
+                      const totalSpend = donutData.reduce((s, d) => s + d.value, 0);
+                      return donutData.slice(0, 10).map((d, i) => {
+                        const pct = totalSpend > 0 ? (d.value / totalSpend) * 100 : 0;
+                        return (
+                          <button key={d.name} onClick={() => setChartFilter(chartFilter === d.name ? null : d.name)}
+                            className={`grid w-full grid-cols-[auto_minmax(0,1fr)_3rem_auto] items-center gap-2 rounded px-1.5 py-0.5 transition-colors hover:bg-surface-raised ${chartFilter === d.name ? "bg-surface-overlay" : ""}`}>
+                            <div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: CHART_COLORS[i % CHART_COLORS.length] }} />
+                            <span className="min-w-0 truncate text-left text-xs text-text-secondary">{d.name}</span>
+                            <span className="text-right text-[10px] tabular-nums text-text-muted">{pct.toFixed(0)}%</span>
+                            <span className="text-right text-xs tabular-nums text-text-muted">{formatAmount(d.value)}</span>
+                          </button>
+                        );
+                      });
+                    })()}
                     {donutData.length > 10 && (
-                      <p className="px-1.5 text-[10px] text-text-muted">+{donutData.length - 10} more — click chart to filter</p>
+                      <p className="px-1.5 text-[10px] text-text-muted">+{donutData.length - 10} more (click chart to filter)</p>
                     )}
                   </div>
                 </div>
@@ -818,11 +831,11 @@ export default function DashboardPage() {
                       pct: b.percent_used,
                     }))} layout="vertical" margin={{ left: 0, right: 20, top: 0, bottom: 0 }}>
                       <XAxis type="number" hide />
-                      <YAxis type="category" dataKey="name" width={100} tick={{ fill: "var(--color-text-secondary)", fontSize: 11 }} />
+                      <YAxis type="category" dataKey="name" width={100} tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
                       <Tooltip
                         formatter={(v, name) => [
                           formatAmount(Number(v)),
-                          name === "spent" ? <span style={{ color: "var(--color-chart-5)" }}>Spent</span> : <span style={{ color: "var(--color-chart-2)" }}>Remaining</span>,
+                          name === "spent" ? <span style={{ color: chartColor.spent }}>Spent</span> : <span style={{ color: chartColor.remaining }}>Remaining</span>,
                         ]}
                         contentStyle={{ fontSize: "11px" }}
                       />
@@ -834,18 +847,18 @@ export default function DashboardPage() {
                         }}
                       >
                         {budgets.slice(0, 6).map((b, i) => (
-                          <Cell key={i} fill={b.percent_used > 100 ? "var(--color-chart-5)" : b.percent_used > 80 ? "var(--color-chart-4)" : "var(--color-chart-1)"} />
+                          <Cell key={i} fill={b.percent_used > 100 ? chartColor.over : b.percent_used > 80 ? chartColor.watch : chartColor.spent} />
                         ))}
                       </Bar>
-                      <Bar dataKey="remaining" stackId="a" fill="var(--color-border)" radius={[0, 4, 4, 0]} animationDuration={600} />
+                      <Bar dataKey="remaining" stackId="a" fill={chartColor.remaining} radius={[0, 4, 4, 0]} animationDuration={600} />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
                 <div className="flex flex-wrap gap-3 px-4 pb-3 text-[10px] text-text-muted">
-                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-1)" }} /> Spent</span>
-                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-4)" }} /> &gt;80%</span>
-                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-5)" }} /> Over budget</span>
-                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-border)" }} /> Remaining</span>
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.spent }} /> Spent</span>
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.watch }} /> &gt;80%</span>
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.over }} /> Over budget</span>
+                  <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.remaining }} /> Remaining</span>
                 </div>
                 </>
               ) : (
@@ -879,22 +892,22 @@ export default function DashboardPage() {
                           margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
                         >
                           <XAxis type="number" hide />
-                          <YAxis type="category" dataKey="name" width={90} tick={{ fill: "var(--color-text-secondary)", fontSize: 10 }} />
+                          <YAxis type="category" dataKey="name" width={90} tick={{ fill: chartColor.axisTick, fontSize: 10 }} />
                           <Tooltip
                             formatter={(v, name) => [
                               formatAmount(Number(v)),
-                              name === "planned" ? <span style={{ color: "var(--color-chart-1)" }}>Planned</span> : <span style={{ color: "var(--color-chart-2)" }}>Actual</span>,
+                              name === "planned" ? <span style={{ color: chartColor.planned }}>Planned</span> : <span style={{ color: chartColor.actual }}>Actual</span>,
                             ]}
                             contentStyle={{ fontSize: "11px" }}
                           />
-                          <Bar dataKey="planned" fill="var(--color-chart-1)" radius={[4, 4, 4, 4]} animationDuration={600}
+                          <Bar dataKey="planned" fill={chartColor.planned} radius={[4, 4, 4, 4]} animationDuration={600}
                             cursor="pointer"
                             onClick={(_, idx) => {
                               const name = expenseItems[idx]?.category_name;
                               if (name) setChartFilter(chartFilter === name ? null : name);
                             }}
                           />
-                          <Bar dataKey="actual" fill="var(--color-chart-2)" radius={[4, 4, 4, 4]} animationDuration={600} />
+                          <Bar dataKey="actual" fill={chartColor.actual} radius={[4, 4, 4, 4]} animationDuration={600} />
                         </BarChart>
                       </ResponsiveContainer>
                     </div>
@@ -912,8 +925,8 @@ export default function DashboardPage() {
                 );
               })()}
               <div className="mt-2 flex gap-3 text-[10px] text-text-muted">
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-1)" }} /> Planned</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--color-chart-2)" }} /> Actual</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.planned }} /> Planned</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.actual }} /> Actual</span>
               </div>
             </div>
           </div>
@@ -975,8 +988,10 @@ export default function DashboardPage() {
                         >
                           {/* Outer button carries the WCAG 2.5.8
                               touch-target hit area; inner span keeps
-                              the lean visual that matches /transactions. */}
-                          <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                              the lean visual that matches /transactions.
+                              Pending uses the warning token so it reads
+                              as actionable, not muted gray. */}
+                          <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-warning-dim text-warning"}`}>
                             {tx.status}
                           </span>
                         </button>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -15,6 +15,7 @@ import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, pa
 import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import CategorySelect from "@/components/ui/CategorySelect";
 import { chartColor } from "@/lib/chart-colors";
+import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import OnTrackTile from "@/components/dashboard/OnTrackTile";
 import AccountMonthEndForecast, {
   type AccountMonthEndForecastResponse,
@@ -839,8 +840,16 @@ export default function DashboardPage() {
                         ]}
                         contentStyle={{ fontSize: "11px" }}
                       />
-                      <Bar dataKey="spent" stackId="a" radius={[4, 0, 0, 4]} animationDuration={600}
+                      {/* D5 follow-up: shared BudgetSpentBarShape so
+                          the spent bar rounds its right edge at >=100%
+                          utilization (when the trailing remaining
+                          segment collapses to zero). Static
+                          radius={[4,0,0,4]} left those rows squared. */}
+                      <Bar dataKey="spent" stackId="a" animationDuration={600}
                         cursor="pointer"
+                        shape={(props: BudgetSpentBarShapeProps) => (
+                          <BudgetSpentBarShape {...props} />
+                        )}
                         onClick={(_, idx) => {
                           const name = budgets.slice(0, 6)[idx]?.category_name;
                           if (name) setChartFilter(chartFilter === name ? null : name);

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -32,6 +32,7 @@ import {
 
 } from "recharts";
 import type { BillingPeriod, Category, ForecastPlan, ForecastPlanItem } from "@/lib/types";
+import { chartColor } from "@/lib/chart-colors";
 
 // "Auto" is the honest label for source=history (PR #146 #1). populate
 // surfaces both 3-month-average rows AND current-period-only rows under
@@ -800,18 +801,18 @@ export default function ForecastPlansPage() {
                       type="category"
                       dataKey="name"
                       width={100}
-                      tick={{ fill: "#9ba8bd", fontSize: 11 }}
+                      tick={{ fill: chartColor.axisTick, fontSize: 11 }}
                     />
                     <Tooltip
                       formatter={(v, name) => [
                         formatAmount(Number(v)),
-                        name === "planned" ? <span style={{ color: "#D4A64A" }}>Planned</span> : <span style={{ color: "#4ade80" }}>Actual</span>,
+                        name === "planned" ? <span style={{ color: chartColor.planned }}>Planned</span> : <span style={{ color: chartColor.actual }}>Actual</span>,
                       ]}
                       contentStyle={{ fontSize: "11px" }}
                     />
                     <Bar
                       dataKey="planned"
-                      fill="#D4A64A"
+                      fill={chartColor.planned}
                       radius={[4, 4, 4, 4]}
                       animationDuration={600}
                       cursor="pointer"
@@ -822,14 +823,14 @@ export default function ForecastPlansPage() {
                     />
                     <Bar
                       dataKey="actual"
-                      fill="#4ade80"
+                      fill={chartColor.actual}
                       radius={[4, 4, 4, 4]}
                       animationDuration={600}
                     >
                       {chartData.map((d, i) => (
                         <Cell
                           key={i}
-                          fill={d.actual > d.planned ? "#f87171" : "#4ade80"}
+                          fill={d.actual > d.planned ? chartColor.over : chartColor.actual}
                         />
                       ))}
                     </Bar>
@@ -837,9 +838,9 @@ export default function ForecastPlansPage() {
                 </ResponsiveContainer>
               </div>
               <div className="mt-3 flex gap-4 px-4 pb-2 text-[10px] text-text-muted">
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#D4A64A" }} /> Planned</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#4ade80" }} /> Under plan</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: "#f87171" }} /> Over plan</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.planned }} /> Planned</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.actual }} /> Under plan</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.over }} /> Over plan</span>
               </div>
             </div>
           )}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -33,6 +33,8 @@
   --theme-success-dim: rgba(74, 222, 128, 0.12);
   --theme-info: #5FA8D3;
   --theme-info-dim: rgba(95, 168, 211, 0.12);
+  --theme-warning: #f59e0b;
+  --theme-warning-dim: rgba(245, 158, 11, 0.16);
 
   --theme-sidebar-bg: #06101e;
   --theme-sidebar-text: #7a8da6;
@@ -68,6 +70,8 @@
   --theme-success-dim: rgba(22, 163, 74, 0.06);
   --theme-info: #2d7db3;
   --theme-info-dim: rgba(45, 125, 179, 0.08);
+  --theme-warning: #b45309;
+  --theme-warning-dim: rgba(180, 83, 9, 0.10);
 
   --theme-sidebar-bg: #0B1F3A;
   --theme-sidebar-text: #7a8da6;
@@ -102,6 +106,8 @@
   --color-success-dim: var(--theme-success-dim);
   --color-info: var(--theme-info);
   --color-info-dim: var(--theme-info-dim);
+  --color-warning: var(--theme-warning);
+  --color-warning-dim: var(--theme-warning-dim);
 
   --color-sidebar-bg: var(--theme-sidebar-bg);
   --color-sidebar-text: var(--theme-sidebar-text);

--- a/frontend/components/dashboard/AccountTile.tsx
+++ b/frontend/components/dashboard/AccountTile.tsx
@@ -70,12 +70,13 @@ export function AccountTileRow({ account, hasPending }: AccountTileRowProps) {
           {hasPending && (
             <>
               <span aria-hidden="true">·</span>
-              {/* Neutral pending treatment using semantic tokens (raw
-                  palette colors are forbidden). Matches the lean
-                  pending pill style on /transactions; avoids competing
-                  with the gold accent on the Quick Add button. */}
+              {/* Pending pill. Sizing + typography match the Transactions
+                  page pill (text-[10px] + font-medium, no uppercase).
+                  Color uses the warning token so pending is actually
+                  spottable, instead of fading into muted-gray noise the
+                  way `text-text-muted` did. */}
               <span
-                className="rounded bg-surface-overlay px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-text-muted"
+                className="rounded bg-warning-dim px-1.5 py-0.5 text-[10px] font-medium text-warning"
                 aria-label="Has pending transactions"
               >
                 Pending

--- a/frontend/lib/chart-colors.ts
+++ b/frontend/lib/chart-colors.ts
@@ -1,0 +1,23 @@
+// Shared chart color tokens. Centralized so Dashboard and the dedicated
+// Budget / Forecast surfaces don't drift apart visually (D4, 2026-05-08).
+//
+// Each value is a CSS variable defined in `app/globals.css` so theme
+// switches cascade automatically and we never embed raw palette hexes
+// in component code.
+//
+// Semantic intent — keep these mappings stable across surfaces:
+//   PLANNED   → accent (gold)            the user's intended commitment
+//   ACTUAL    → success (green)          settled spending under plan
+//   SPENT     → accent (gold)            same gold as PLANNED, intentional
+//   WATCH     → text-secondary (neutral) 80%-100% utilization
+//   OVER      → danger (red)             over plan / over budget
+//   REMAINING → border (neutral track)   remaining headroom in a stack
+export const chartColor = {
+  planned: "var(--color-accent)",
+  actual: "var(--color-success)",
+  spent: "var(--color-accent)",
+  watch: "var(--color-text-secondary)",
+  over: "var(--color-danger)",
+  remaining: "var(--color-border)",
+  axisTick: "var(--color-text-secondary)",
+} as const;

--- a/frontend/lib/chart-shapes.tsx
+++ b/frontend/lib/chart-shapes.tsx
@@ -1,0 +1,81 @@
+// Shared recharts shape primitives. Centralized so Dashboard and the
+// dedicated Budgets surface render the same rounded-edge behavior at
+// high utilization (D5 follow-up, 2026-05-08).
+//
+// The "spent" segment in a stacked horizontal budget bar should round
+// its right edge ONLY when there is no follow-on segment (remaining or
+// over) to its right; otherwise the bars wouldn't butt up cleanly. A
+// static `radius={[4, 0, 0, 4]}` on the Bar leaves the right corners
+// squared even at >=100% utilization (when the trailing segment has
+// collapsed to zero width), which becomes visually obvious. This shape
+// computes per-row corner radii from the row payload so both surfaces
+// pick up the rounding rule once.
+
+import type { ReactElement } from "react";
+
+export interface BudgetSpentBarPayload {
+  spent?: number;
+  remaining?: number;
+  over?: number;
+}
+
+export interface BudgetSpentBarShapeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  fill?: string;
+  payload?: BudgetSpentBarPayload;
+}
+
+/**
+ * Decide the per-corner radius for a stacked "spent" bar segment.
+ * Exposed for unit testing; consumers should use `BudgetSpentBarShape`.
+ *
+ * Rule: left corners always rounded (this segment always starts at the
+ * row origin). Right corners rounded only when no trailing segment
+ * (remaining > 0 or over > 0) would render to the right of this one.
+ */
+export function budgetSpentBarRadii(
+  payload: BudgetSpentBarPayload | undefined,
+  width: number,
+  height: number,
+): { left: number; right: number } {
+  const remaining = payload?.remaining ?? 0;
+  const over = payload?.over ?? 0;
+  const isFullRow = remaining <= 0 && over <= 0;
+  const r = Math.min(4, height / 2, width / 2);
+  return { left: r, right: isFullRow ? r : 0 };
+}
+
+/**
+ * Recharts custom shape for the "spent" Bar in a stacked horizontal
+ * budget chart. Use as `<Bar shape={(props) => <BudgetSpentBarShape {...props} />} />`.
+ *
+ * Works for surfaces that stack {spent, remaining} (Dashboard) and
+ * {spent, remaining, over} (Budgets) — surfaces without an `over`
+ * segment simply have `over=0` in the row payload.
+ */
+export function BudgetSpentBarShape(
+  props: BudgetSpentBarShapeProps,
+): ReactElement | null {
+  const { x = 0, y = 0, width = 0, height = 0, fill, payload } = props;
+  if (width <= 0 || height <= 0) return null;
+  const { left, right } = budgetSpentBarRadii(payload, width, height);
+  // Clockwise rounded rect with per-side radius. Left corners always
+  // round (this bar starts at the row origin); right corners pick up
+  // rounding only when no follow-on segment exists.
+  const path = [
+    `M ${x + left} ${y}`,
+    right > 0
+      ? `H ${x + width - right} Q ${x + width} ${y} ${x + width} ${y + right}`
+      : `H ${x + width}`,
+    right > 0
+      ? `V ${y + height - right} Q ${x + width} ${y + height} ${x + width - right} ${y + height}`
+      : `V ${y + height}`,
+    `H ${x + left} Q ${x} ${y + height} ${x} ${y + height - left}`,
+    `V ${y + left} Q ${x} ${y} ${x + left} ${y}`,
+    "Z",
+  ].join(" ");
+  return <path d={path} fill={fill} style={{ cursor: "pointer" }} />;
+}

--- a/frontend/tests/lib/chart-shapes.test.tsx
+++ b/frontend/tests/lib/chart-shapes.test.tsx
@@ -1,0 +1,114 @@
+import { render } from "@testing-library/react";
+
+import {
+  BudgetSpentBarShape,
+  budgetSpentBarRadii,
+} from "@/lib/chart-shapes";
+
+describe("budgetSpentBarRadii", () => {
+  // The whole point of the shared shape is that BOTH Dashboard
+  // (spent + remaining stack) and Budgets (spent + remaining + over
+  // stack) render identically rounded edges at high utilization.
+  it("rounds all four corners when nothing trails the spent segment", () => {
+    // Exactly 100% on Dashboard: remaining=0, over absent.
+    expect(budgetSpentBarRadii({ spent: 100, remaining: 0 }, 200, 24))
+      .toEqual({ left: 4, right: 4 });
+
+    // Exactly 100% on Budgets: remaining=0, over=0.
+    expect(budgetSpentBarRadii({ spent: 100, remaining: 0, over: 0 }, 200, 24))
+      .toEqual({ left: 4, right: 4 });
+  });
+
+  it("squares the right edge whenever a remaining segment trails", () => {
+    // Dashboard at 50%: remaining > 0 → right edge squared so the
+    // remaining bar butts up cleanly.
+    expect(budgetSpentBarRadii({ spent: 50, remaining: 50 }, 100, 24))
+      .toEqual({ left: 4, right: 0 });
+  });
+
+  it("squares the right edge whenever an over segment trails", () => {
+    // Budgets at 120%: spent saturates the budget, over carries the
+    // overflow → right edge squared so the over bar butts up cleanly.
+    expect(budgetSpentBarRadii({ spent: 100, remaining: 0, over: 20 }, 100, 24))
+      .toEqual({ left: 4, right: 0 });
+  });
+
+  it("clamps the radius for very narrow or very short bars", () => {
+    // The shape can't ask for r=4 if the bar is only 4px tall — it
+    // would fold in on itself. We clamp to half-height / half-width.
+    expect(budgetSpentBarRadii({ remaining: 0 }, 100, 4))
+      .toEqual({ left: 2, right: 2 });
+    expect(budgetSpentBarRadii({ remaining: 0 }, 6, 24))
+      .toEqual({ left: 3, right: 3 });
+  });
+
+  it("treats a missing payload as a full row (defensive)", () => {
+    // Recharts has been known to call shape with undefined payload
+    // during animation init; we render a closed rounded rect rather
+    // than crashing.
+    expect(budgetSpentBarRadii(undefined, 100, 24))
+      .toEqual({ left: 4, right: 4 });
+  });
+});
+
+describe("BudgetSpentBarShape", () => {
+  it("returns null for zero-area bars (recharts emits these mid-animation)", () => {
+    const { container: emptyW } = render(
+      <svg>
+        <BudgetSpentBarShape x={0} y={0} width={0} height={24} fill="#000" />
+      </svg>,
+    );
+    expect(emptyW.querySelector("path")).toBeNull();
+
+    const { container: emptyH } = render(
+      <svg>
+        <BudgetSpentBarShape x={0} y={0} width={100} height={0} fill="#000" />
+      </svg>,
+    );
+    expect(emptyH.querySelector("path")).toBeNull();
+  });
+
+  it("renders a rounded path at full row utilization", () => {
+    const { container } = render(
+      <svg>
+        <BudgetSpentBarShape
+          x={0}
+          y={0}
+          width={200}
+          height={24}
+          fill="#abc"
+          payload={{ spent: 100, remaining: 0, over: 0 }}
+        />
+      </svg>,
+    );
+    const path = container.querySelector("path");
+    expect(path).not.toBeNull();
+    const d = path!.getAttribute("d") ?? "";
+    // Both right corners use a quadratic curve when full-row → two Q
+    // commands instead of straight H/V on the right side.
+    const qCount = (d.match(/Q /g) ?? []).length;
+    expect(qCount).toBe(4);
+    expect(path!.getAttribute("fill")).toBe("#abc");
+  });
+
+  it("renders a half-rounded path when a trailing segment is present", () => {
+    const { container } = render(
+      <svg>
+        <BudgetSpentBarShape
+          x={0}
+          y={0}
+          width={120}
+          height={24}
+          fill="#def"
+          payload={{ spent: 60, remaining: 60, over: 0 }}
+        />
+      </svg>,
+    );
+    const path = container.querySelector("path");
+    expect(path).not.toBeNull();
+    const d = path!.getAttribute("d") ?? "";
+    // Left corners only → two Q commands.
+    const qCount = (d.match(/Q /g) ?? []).length;
+    expect(qCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
Six small visual fixes from the 2026-05-08 user-feedback batch. Frontend-only, no copy or behavior changes beyond the listed polish.

## Findings addressed
- **D2 — dashboard spending card whitespace.** Tightened the description-to-amount gap and added a small `%` column. **Scope intent:** keep the spending card a compact visual summary, not a full data table. The percentage is read-only with no sort affordance, mirroring the rest of the dashboard tile aesthetic. If we want full sortable columns with persistent sort, that is a separate "promote spending card to a table" PR.
- **D3 — pending pill parity with Transactions.** Standardized to `bg-warning-dim + text-warning`, same height. `AccountTile` picks up the same treatment.
- **D4 — bar chart color parity.** Extracted shared chart tokens to `frontend/lib/chart-colors.ts` (planned, actual, over, watch, remaining, axisTick) backed by CSS variables in `globals.css`. Dashboard, Budgets, and Forecast Plans now share one palette so theming and visual parity stay in lockstep.
- **D5 — bar chart rounded edges over 80%.** Bar fills apply matching radius alongside the parent track so bars over 80% no longer square off at the top. (Note: a follow-up will unify the high-utilization rounded shape across Dashboard Budget Progress AND Budgets, since this PR only touches the Budgets surface.)
- **A1 — accounts default-shift bleed.** Balance column moved into a fixed-width slot so toggling the default-account indicator no longer shifts the number into the adjacent column.
- **A2 — account-type card column alignment.** Added column headers and grid alignment so longer type names no longer push the system tag and account count out of alignment.

## Files
- `frontend/app/accounts/page.tsx`
- `frontend/app/budgets/page.tsx`
- `frontend/app/dashboard/page.tsx`
- `frontend/app/forecast-plans/page.tsx` (consumes the new shared chart-color tokens)
- `frontend/app/globals.css` (CSS variables backing the tokens)
- `frontend/components/dashboard/AccountTile.tsx`
- `frontend/lib/chart-colors.ts` (new)

## Verification
- `npx tsc --noEmit` clean on the touched production files.
- Existing component test suites pass: `account-tile`, `account-month-end-forecast`, `on-track-tile`, plus the broader 124 frontend tests.