### PR TITLE
fix(transactions): repair quick-filter buttons and preserve sort direction

### DIFF
--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -20,6 +20,27 @@ import UnpairTransferModal from "@/components/transactions/UnpairTransferModal";
 
 const PAGE_SIZE = 20;
 
+// Column-aware sort defaults. When the user clicks a different column, that
+// column's natural default direction is applied (Option B in the data-table
+// pattern). Same-column clicks toggle direction. Numeric/date columns default
+// to "desc" because most users want most-recent / largest-first.
+type SortField =
+  | "date"
+  | "description"
+  | "account_name"
+  | "category_name"
+  | "status"
+  | "amount";
+
+const SORT_DEFAULTS: Record<SortField, "asc" | "desc"> = {
+  date: "desc",
+  amount: "desc",
+  description: "asc",
+  account_name: "asc",
+  category_name: "asc",
+  status: "asc",
+};
+
 export default function TransactionsPage() {
   return (
     <Suspense fallback={
@@ -71,7 +92,7 @@ function TransactionsPageContent() {
   const [filterDateFrom, setFilterDateFrom] = useState("");
   const [filterDateTo, setFilterDateTo] = useState("");
   const [filterSearch, setFilterSearch] = useState("");
-  const [sortField, setSortField] = useState<"date" | "description" | "account_name" | "category_name" | "status" | "amount">("date");
+  const [sortField, setSortField] = useState<SortField>("date");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
   // Billing periods for filter
@@ -497,10 +518,17 @@ function TransactionsPageContent() {
 
   const activeAccounts = accounts.filter((a) => a.is_active);
 
-  // Sort helper
-  function toggleSort(field: typeof sortField) {
-    if (sortField === field) setSortDir(sortDir === "asc" ? "desc" : "asc");
-    else { setSortField(field); setSortDir(field === "date" ? "desc" : "asc"); }
+  // Sort helper. Same-column click toggles direction. Different-column click
+  // applies that column's natural default (see SORT_DEFAULTS above) so users
+  // get a sensible starting state instead of always-asc, which felt like
+  // their previous direction was "dropped".
+  function toggleSort(field: SortField) {
+    if (sortField === field) {
+      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortField(field);
+      setSortDir(SORT_DEFAULTS[field]);
+    }
   }
   const sortedTransactions = [...transactions].sort((a, b) => {
     let cmp = 0;
@@ -745,16 +773,69 @@ function TransactionsPageContent() {
           <input id="f-search" type="text" placeholder="Search descriptions..." value={filterSearch} onChange={(e) => setFilterSearch(e.target.value)} className={input} />
         </div>
         <div className="flex flex-wrap gap-1">
-          {[
-            { label: "Today", fn: () => { const d = todayISO(); setFilterDateFrom(d); setFilterDateTo(d); } },
-            { label: "This Week", fn: () => { const now = new Date(); const day = now.getDay(); const diff = day === 0 ? 6 : day - 1; const mon = new Date(now); mon.setDate(now.getDate() - diff); setFilterDateFrom(formatLocalDate(mon)); setFilterDateTo(todayISO()); } },
-            { label: "This Month", fn: () => { const now = new Date(); setFilterDateFrom(formatLocalDate(new Date(now.getFullYear(), now.getMonth(), 1))); setFilterDateTo(todayISO()); } },
-            { label: "All", fn: () => { setFilterDateFrom(""); setFilterDateTo(""); } },
-          ].map((p) => (
-            <button key={p.label} type="button" onClick={p.fn} className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised min-h-[44px] sm:min-h-0">
-              {p.label}
-            </button>
-          ))}
+          {(() => {
+            // Quick-filter buttons. Each clears `filterPeriod` first because the
+            // period filter overrides date_from/date_to in the URL builder, so
+            // leaving it set would silently make the click a no-op.
+            const setRange = (from: string, to: string) => {
+              setFilterPeriod("");
+              setFilterDateFrom(from);
+              setFilterDateTo(to);
+            };
+            const presets: { label: string; fn: () => void }[] = [
+              {
+                label: "Today",
+                fn: () => {
+                  const d = todayISO();
+                  setRange(d, d);
+                },
+              },
+              {
+                label: "This Week",
+                fn: () => {
+                  const now = new Date();
+                  const day = now.getDay();
+                  const diff = day === 0 ? 6 : day - 1; // Monday = start of week
+                  const mon = new Date(now);
+                  mon.setDate(now.getDate() - diff);
+                  setRange(formatLocalDate(mon), todayISO());
+                },
+              },
+              {
+                label: "This Month",
+                fn: () => {
+                  const now = new Date();
+                  setRange(
+                    formatLocalDate(new Date(now.getFullYear(), now.getMonth(), 1)),
+                    todayISO(),
+                  );
+                },
+              },
+              {
+                label: "All",
+                fn: () => setRange("", ""),
+              },
+            ];
+            // Optional "Current Period" preset, only when an open billing
+            // period exists. It sets the period filter (which the URL builder
+            // already prefers) and clears any explicit date range.
+            const currentPeriod = periods.find((p) => p.end_date === null);
+            if (currentPeriod) {
+              presets.push({
+                label: "Current Period",
+                fn: () => {
+                  setFilterDateFrom("");
+                  setFilterDateTo("");
+                  setFilterPeriod(String(currentPeriod.id));
+                },
+              });
+            }
+            return presets.map((p) => (
+              <button key={p.label} type="button" onClick={p.fn} className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised min-h-[44px] sm:min-h-0">
+                {p.label}
+              </button>
+            ));
+          })()}
         </div>
       </div>
       <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-3">
@@ -790,11 +871,11 @@ function TransactionsPageContent() {
         </div>
         <div className="w-full sm:w-auto">
           <label htmlFor="f-from" className="sr-only">From date</label>
-          <input id="f-from" type="date" value={filterDateFrom} onChange={(e) => setFilterDateFrom(e.target.value)} className={`w-full sm:w-32 ${input}`} placeholder="From" />
+          <input id="f-from" type="date" value={filterDateFrom} onChange={(e) => { setFilterPeriod(""); setFilterDateFrom(e.target.value); }} className={`w-full sm:w-32 ${input}`} placeholder="From" />
         </div>
         <div className="w-full sm:w-auto">
           <label htmlFor="f-to" className="sr-only">To date</label>
-          <input id="f-to" type="date" value={filterDateTo} onChange={(e) => setFilterDateTo(e.target.value)} className={`w-full sm:w-32 ${input}`} placeholder="To" />
+          <input id="f-to" type="date" value={filterDateTo} onChange={(e) => { setFilterPeriod(""); setFilterDateTo(e.target.value); }} className={`w-full sm:w-32 ${input}`} placeholder="To" />
         </div>
         {periods.length > 0 && (
           <div className="w-full sm:w-auto">

--- a/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
+++ b/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
@@ -1,0 +1,445 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT = {
+  id: 100, name: "Checking", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CATEGORY = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+// Helper: format Date as local YYYY-MM-DD (mirrors lib/format.formatLocalDate
+// so tests don't drift in non-UTC test environments).
+function isoLocal(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function todayLocal(): string {
+  return isoLocal(new Date());
+}
+
+type Period = { id: number; start_date: string; end_date: string | null };
+
+function setupApiFetch(periods: Period[] = []) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return periods as never;
+    if (url.startsWith("/api/v1/transactions")) return [] as never;
+    return null as never;
+  });
+  return apiFetchMock;
+}
+
+function lastListUrl(mock: ReturnType<typeof vi.mocked<typeof apiFetch>>): string | null {
+  for (let i = mock.mock.calls.length - 1; i >= 0; i--) {
+    const url = mock.mock.calls[i][0] as string;
+    if (typeof url === "string" && url.startsWith("/api/v1/transactions?")) {
+      return url;
+    }
+  }
+  return null;
+}
+
+function listUrlsAfter(
+  mock: ReturnType<typeof vi.mocked<typeof apiFetch>>,
+  startIndex: number,
+): string[] {
+  const out: string[] = [];
+  for (let i = startIndex; i < mock.mock.calls.length; i++) {
+    const url = mock.mock.calls[i][0] as string;
+    if (typeof url === "string" && url.startsWith("/api/v1/transactions?")) {
+      out.push(url);
+    }
+  }
+  return out;
+}
+
+describe("TransactionsPage — quick filter buttons", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("Today button sends date_from=date_to=today and clears any prior period filter", async () => {
+    const periods: Period[] = [
+      { id: 7, start_date: "2026-05-01", end_date: null }, // current/open
+    ];
+    const mock = setupApiFetch(periods);
+
+    render(<TransactionsPage />);
+
+    // Wait for initial fetches.
+    await waitFor(() => {
+      expect(lastListUrl(mock)).not.toBeNull();
+    });
+
+    // Pre-select "Current Period" via the dropdown to seed the state, then
+    // confirm clicking Today swaps it to a date_from/date_to pair.
+    const periodSelect = await screen.findByLabelText("Billing period");
+    fireEvent.change(periodSelect, { target: { value: "7" } });
+
+    await waitFor(() => {
+      const url = lastListUrl(mock);
+      expect(url).toContain("date_from=2026-05-01");
+    });
+
+    const todayBtn = screen.getByRole("button", { name: "Today" });
+    const startIdx = mock.mock.calls.length;
+    fireEvent.click(todayBtn);
+
+    const today = todayLocal();
+    await waitFor(() => {
+      const after = listUrlsAfter(mock, startIdx);
+      expect(after.length).toBeGreaterThan(0);
+      const last = after[after.length - 1];
+      expect(last).toContain(`date_from=${today}`);
+      expect(last).toContain(`date_to=${today}`);
+    });
+  });
+
+  it("This Month button sends date_from=first-of-month and date_to=today", async () => {
+    const mock = setupApiFetch();
+
+    render(<TransactionsPage />);
+
+    await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
+
+    const startIdx = mock.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "This Month" }));
+
+    const now = new Date();
+    const firstOfMonth = isoLocal(new Date(now.getFullYear(), now.getMonth(), 1));
+    const today = todayLocal();
+    await waitFor(() => {
+      const after = listUrlsAfter(mock, startIdx);
+      expect(after.length).toBeGreaterThan(0);
+      const last = after[after.length - 1];
+      expect(last).toContain(`date_from=${firstOfMonth}`);
+      expect(last).toContain(`date_to=${today}`);
+    });
+  });
+
+  it("This Week button sends date_from=Monday-of-this-week and date_to=today", async () => {
+    const mock = setupApiFetch();
+
+    render(<TransactionsPage />);
+
+    await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
+
+    const startIdx = mock.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "This Week" }));
+
+    const now = new Date();
+    const day = now.getDay();
+    const diff = day === 0 ? 6 : day - 1;
+    const mon = new Date(now);
+    mon.setDate(now.getDate() - diff);
+    const monIso = isoLocal(mon);
+    const today = todayLocal();
+
+    await waitFor(() => {
+      const after = listUrlsAfter(mock, startIdx);
+      expect(after.length).toBeGreaterThan(0);
+      const last = after[after.length - 1];
+      expect(last).toContain(`date_from=${monIso}`);
+      expect(last).toContain(`date_to=${today}`);
+    });
+  });
+
+  it("All button drops every date constraint, including a previously-selected period", async () => {
+    const periods: Period[] = [
+      { id: 7, start_date: "2026-05-01", end_date: null },
+    ];
+    const mock = setupApiFetch(periods);
+
+    render(<TransactionsPage />);
+    await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
+
+    // Seed: pick the open period from the dropdown.
+    const periodSelect = await screen.findByLabelText("Billing period");
+    fireEvent.change(periodSelect, { target: { value: "7" } });
+    await waitFor(() => {
+      const url = lastListUrl(mock);
+      expect(url).toContain("date_from=2026-05-01");
+    });
+
+    const startIdx = mock.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+
+    await waitFor(() => {
+      const after = listUrlsAfter(mock, startIdx);
+      expect(after.length).toBeGreaterThan(0);
+      const last = after[after.length - 1];
+      expect(last).not.toContain("date_from=");
+      expect(last).not.toContain("date_to=");
+    });
+  });
+
+  it("Current Period button is shown when an open period exists and pins the period filter", async () => {
+    const periods: Period[] = [
+      { id: 5, start_date: "2026-04-01", end_date: "2026-04-30" },
+      { id: 6, start_date: "2026-05-01", end_date: null },
+    ];
+    const mock = setupApiFetch(periods);
+
+    render(<TransactionsPage />);
+    await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
+
+    const currentBtn = await screen.findByRole("button", { name: /current period/i });
+    const startIdx = mock.mock.calls.length;
+    fireEvent.click(currentBtn);
+
+    await waitFor(() => {
+      const after = listUrlsAfter(mock, startIdx);
+      expect(after.length).toBeGreaterThan(0);
+      const last = after[after.length - 1];
+      // Open period: only date_from is sent; date_to is omitted because
+      // end_date is null on the current/open billing period.
+      expect(last).toContain("date_from=2026-05-01");
+      expect(last).not.toContain("date_to=");
+    });
+  });
+
+  it("Current Period button is NOT rendered when no open billing period exists", async () => {
+    // All periods closed (every end_date is set) — no open period to pin.
+    const periods: Period[] = [
+      { id: 5, start_date: "2026-04-01", end_date: "2026-04-30" },
+    ];
+    setupApiFetch(periods);
+
+    render(<TransactionsPage />);
+
+    // Sanity: the dropdown loads (so periods are present), but no quick button.
+    await screen.findByLabelText("Billing period");
+    expect(screen.queryByRole("button", { name: /current period/i })).toBeNull();
+  });
+
+  it("Manually editing the From-date input clears any pinned period filter", async () => {
+    const periods: Period[] = [{ id: 7, start_date: "2026-05-01", end_date: null }];
+    const mock = setupApiFetch(periods);
+
+    render(<TransactionsPage />);
+    await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
+
+    // Pin the open period via the dropdown first.
+    const periodSelect = await screen.findByLabelText("Billing period");
+    fireEvent.change(periodSelect, { target: { value: "7" } });
+    await waitFor(() => {
+      const url = lastListUrl(mock);
+      expect(url).toContain("date_from=2026-05-01");
+    });
+
+    // Now type a different From-date — this must drop the period and use
+    // the typed value instead.
+    const startIdx = mock.mock.calls.length;
+    const fromInput = screen.getByLabelText("From date");
+    fireEvent.change(fromInput, { target: { value: "2026-03-15" } });
+
+    await waitFor(() => {
+      const after = listUrlsAfter(mock, startIdx);
+      expect(after.length).toBeGreaterThan(0);
+      const last = after[after.length - 1];
+      expect(last).toContain("date_from=2026-03-15");
+    });
+  });
+});
+
+describe("TransactionsPage — sort direction across columns (Option B)", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function getDesktopHeader(name: string): HTMLElement {
+    // The desktop header buttons are scoped to the hidden-md+ wrapper. The
+    // useful identifier in jsdom is the visible text including the indicator
+    // arrow. We just match by leading text.
+    const buttons = screen
+      .getAllByRole("button")
+      .filter((b) => b.textContent?.startsWith(name));
+    if (buttons.length === 0) {
+      throw new Error(`No header button starting with "${name}"`);
+    }
+    return buttons[0];
+  }
+
+  async function awaitHeadersReady() {
+    // The page kicks off two fetches in parallel: loadRefs() (sets accounts,
+    // categories, billing periods) and loadTransactions() (the row data).
+    // When loadRefs finishes, periods updates which re-creates the
+    // loadTransactions callback, which re-runs the load effect and flips
+    // `fetching` back to true briefly. Headers disappear during that window.
+    //
+    // To avoid racing the test against that flicker, wait for ALL six column
+    // header buttons to be present at the same time AND stay present for
+    // two consecutive polls.
+    const required = ["Date", "Description", "Account", "Category", "Status", "Amount"];
+    let stable = 0;
+    await waitFor(
+      () => {
+        const labels = screen.queryAllByRole("button").map((b) => b.textContent ?? "");
+        const allPresent = required.every((name) =>
+          labels.some((t) => t.startsWith(name)),
+        );
+        if (!allPresent) {
+          stable = 0;
+          throw new Error("not all headers rendered yet");
+        }
+        stable++;
+        if (stable < 2) {
+          throw new Error("headers present but not yet stable");
+        }
+      },
+      { timeout: 5000, interval: 25 },
+    );
+  }
+
+  it("Default state: Date column shows desc indicator", async () => {
+    setupApiFetch();
+    render(<TransactionsPage />);
+
+    await awaitHeadersReady();
+    expect(getDesktopHeader("Date").textContent).toMatch(/Date.*↓/);
+  });
+
+  it("Switching from Date (desc) to Description applies the column's natural default (asc)", async () => {
+    setupApiFetch();
+    render(<TransactionsPage />);
+
+    await awaitHeadersReady();
+
+    fireEvent.click(getDesktopHeader("Description"));
+
+    await waitFor(() => {
+      expect(getDesktopHeader("Description").textContent).toMatch(/Description.*↑/);
+    });
+  });
+
+  it("Switching from Description (asc) to Amount applies Amount's natural default (desc), not asc", async () => {
+    setupApiFetch();
+    render(<TransactionsPage />);
+
+    await awaitHeadersReady();
+
+    // First click description so we're on an asc column.
+    fireEvent.click(getDesktopHeader("Description"));
+    await waitFor(() => {
+      expect(getDesktopHeader("Description").textContent).toMatch(/↑/);
+    });
+
+    // Now click Amount — should land on desc (Amount's natural default),
+    // NOT inherit Description's asc and NOT default to asc.
+    fireEvent.click(getDesktopHeader("Amount"));
+    await waitFor(() => {
+      expect(getDesktopHeader("Amount").textContent).toMatch(/Amount.*↓/);
+    });
+  });
+
+  it("Same-column click toggles direction (Date desc -> Date asc -> Date desc)", async () => {
+    setupApiFetch();
+    render(<TransactionsPage />);
+
+    await awaitHeadersReady();
+    expect(getDesktopHeader("Date").textContent).toMatch(/Date.*↓/);
+
+    fireEvent.click(getDesktopHeader("Date"));
+    await waitFor(() => {
+      expect(getDesktopHeader("Date").textContent).toMatch(/Date.*↑/);
+    });
+
+    fireEvent.click(getDesktopHeader("Date"));
+    await waitFor(() => {
+      expect(getDesktopHeader("Date").textContent).toMatch(/Date.*↓/);
+    });
+  });
+
+  it("Switching from Amount (desc) to Status applies Status's natural default (asc)", async () => {
+    setupApiFetch();
+    render(<TransactionsPage />);
+
+    await awaitHeadersReady();
+
+    // Land on Amount via its natural default first.
+    fireEvent.click(getDesktopHeader("Amount"));
+    await waitFor(() => {
+      expect(getDesktopHeader("Amount").textContent).toMatch(/↓/);
+    });
+
+    fireEvent.click(getDesktopHeader("Status"));
+    await waitFor(() => {
+      expect(getDesktopHeader("Status").textContent).toMatch(/Status.*↑/);
+    });
+  });
+});

--- a/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
+++ b/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
@@ -335,31 +335,37 @@ describe("TransactionsPage — sort direction across columns (Option B)", () => 
     return buttons[0];
   }
 
-  async function awaitHeadersReady() {
+  async function awaitHeadersReady(
+    mock: ReturnType<typeof vi.mocked<typeof apiFetch>>,
+  ) {
     // The page kicks off two fetches in parallel: loadRefs() (sets accounts,
     // categories, billing periods) and loadTransactions() (the row data).
     // When loadRefs finishes, periods updates which re-creates the
     // loadTransactions callback, which re-runs the load effect and flips
     // `fetching` back to true briefly. Headers disappear during that window.
     //
-    // To avoid racing the test against that flicker, wait for ALL six column
-    // header buttons to be present at the same time AND stay present for
-    // two consecutive polls.
+    // A "two consecutive polls" stability check isn't enough — under CI's
+    // slower scheduler the flicker can land between awaitHeadersReady
+    // returning and the next getDesktopHeader call. Instead, gate on a
+    // deterministic signal: the page has issued a SECOND /transactions
+    // request (the post-periods refetch) AND headers are currently visible.
+    // After the second transactions response resolves, fetching settles
+    // permanently because nothing else updates loadTransactions' deps.
     const required = ["Date", "Description", "Account", "Category", "Status", "Amount"];
-    let stable = 0;
     await waitFor(
       () => {
+        const txCalls = mock.mock.calls.filter(
+          (c) => typeof c[0] === "string" && (c[0] as string).startsWith("/api/v1/transactions"),
+        ).length;
+        if (txCalls < 2) {
+          throw new Error(`waiting for post-periods refetch (saw ${txCalls})`);
+        }
         const labels = screen.queryAllByRole("button").map((b) => b.textContent ?? "");
         const allPresent = required.every((name) =>
           labels.some((t) => t.startsWith(name)),
         );
         if (!allPresent) {
-          stable = 0;
           throw new Error("not all headers rendered yet");
-        }
-        stable++;
-        if (stable < 2) {
-          throw new Error("headers present but not yet stable");
         }
       },
       { timeout: 5000, interval: 25 },
@@ -367,18 +373,18 @@ describe("TransactionsPage — sort direction across columns (Option B)", () => 
   }
 
   it("Default state: Date column shows desc indicator", async () => {
-    setupApiFetch();
+    const mock = setupApiFetch();
     render(<TransactionsPage />);
 
-    await awaitHeadersReady();
+    await awaitHeadersReady(mock);
     expect(getDesktopHeader("Date").textContent).toMatch(/Date.*↓/);
   });
 
   it("Switching from Date (desc) to Description applies the column's natural default (asc)", async () => {
-    setupApiFetch();
+    const mock = setupApiFetch();
     render(<TransactionsPage />);
 
-    await awaitHeadersReady();
+    await awaitHeadersReady(mock);
 
     fireEvent.click(getDesktopHeader("Description"));
 
@@ -388,10 +394,10 @@ describe("TransactionsPage — sort direction across columns (Option B)", () => 
   });
 
   it("Switching from Description (asc) to Amount applies Amount's natural default (desc), not asc", async () => {
-    setupApiFetch();
+    const mock = setupApiFetch();
     render(<TransactionsPage />);
 
-    await awaitHeadersReady();
+    await awaitHeadersReady(mock);
 
     // First click description so we're on an asc column.
     fireEvent.click(getDesktopHeader("Description"));
@@ -408,10 +414,10 @@ describe("TransactionsPage — sort direction across columns (Option B)", () => 
   });
 
   it("Same-column click toggles direction (Date desc -> Date asc -> Date desc)", async () => {
-    setupApiFetch();
+    const mock = setupApiFetch();
     render(<TransactionsPage />);
 
-    await awaitHeadersReady();
+    await awaitHeadersReady(mock);
     expect(getDesktopHeader("Date").textContent).toMatch(/Date.*↓/);
 
     fireEvent.click(getDesktopHeader("Date"));
@@ -426,10 +432,10 @@ describe("TransactionsPage — sort direction across columns (Option B)", () => 
   });
 
   it("Switching from Amount (desc) to Status applies Status's natural default (asc)", async () => {
-    setupApiFetch();
+    const mock = setupApiFetch();
     render(<TransactionsPage />);
 
-    await awaitHeadersReady();
+    await awaitHeadersReady(mock);
 
     // Land on Amount via its natural default first.
     fireEvent.click(getDesktopHeader("Amount"));


### PR DESCRIPTION
## Summary
Two launch-blocking UX correctness bugs on the Transactions page from the 2026-05-08 user-feedback batch.

## Findings addressed

### Quick filter buttons (Today / This Week / This Month / All / Current Period)
The buttons were silently no-ops because the date_from/date_to fields they wrote were being overridden by a stale `filterPeriod` selection in the URL builder. Each quick-filter handler now clears `filterPeriod` first so the date range it writes actually reaches the backend query.

### Sort direction preserved across column changes
Sort direction used to reset to ascending whenever the user clicked a different column header, which read as "the sort I just set was thrown away". Each column now has a natural default (date and amount default to descending, text columns to ascending) which only kicks in on a different-column click; same-column clicks still toggle direction. `SORT_DEFAULTS` lives next to the `SortField` type so future columns drop in alongside.

## Tests
New file `frontend/tests/app/transactions-quick-filters-and-sort.test.tsx` covers:
- All five quick-filter buttons with date-math fixtures (Today, This Week, This Month, All, Current Period).
- Period-clear pre-condition (button cancels a stale period selection).
- Same-column click toggles direction.
- Different-column click applies that column's `SORT_DEFAULTS` natural direction.

## Verification
- `npx vitest run transactions-quick-filters-and-sort transactions-promote-recurring` → 18/18 pass.
- `npx tsc --noEmit` clean on production code.