### PR TITLE
fix(categories): mobile pass — reflow master row actions, bump subcategory hit areas

### DIFF
--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -207,15 +207,15 @@ export default function CategoriesPage() {
             const Icon = (master.slug && CATEGORY_ICONS[master.slug]) || Tag;
             return (
               <div key={master.id} className={card}>
-                <div className={`flex flex-wrap items-center justify-between gap-2 ${cardHeader}`}>
-                  <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                <div data-testid={`master-row-${master.id}`} className={`flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between ${cardHeader}`}>
+                  <div className="flex min-w-0 w-full items-center gap-2.5 sm:w-auto sm:flex-1">
                     <Icon className="h-4 w-4 flex-shrink-0 text-text-muted" />
                     {editingCatId === master.id ? (
                       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                         <input type="text" value={editCatName} onChange={(e) => setEditCatName(e.target.value)} className={`min-w-0 flex-1 text-sm ${input}`} autoFocus
                           onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(master.id); if (e.key === "Escape") setEditingCatId(null); }} />
-                        <button onClick={() => handleEditCat(master.id)} className="text-xs text-accent min-h-[44px] md:min-h-0">Save</button>
-                        <button onClick={() => setEditingCatId(null)} className="text-xs text-text-muted min-h-[44px] md:min-h-0">Cancel</button>
+                        <button onClick={() => handleEditCat(master.id)} className="inline-flex min-h-[44px] items-center px-1 text-xs text-accent md:min-h-0">Save</button>
+                        <button onClick={() => setEditingCatId(null)} className="inline-flex min-h-[44px] items-center px-1 text-xs text-text-muted md:min-h-0">Cancel</button>
                       </div>
                     ) : (
                       <>
@@ -225,15 +225,15 @@ export default function CategoriesPage() {
                       </>
                     )}
                   </div>
-                  <div className="flex flex-wrap items-center gap-2 md:gap-3">
+                  <div data-testid={`master-actions-${master.id}`} className="flex flex-wrap items-center gap-1 sm:gap-2 md:gap-3">
                     <button
                       onClick={() => { setAddingToMaster(addingToMaster === master.id ? null : master.id); setNewSubName(""); setNewSubDesc(""); }}
-                      className="text-xs text-accent hover:text-accent-hover min-h-[44px] md:min-h-0"
+                      className="inline-flex min-h-[44px] items-center px-2 text-xs text-accent hover:text-accent-hover md:min-h-0 md:px-0"
                     >
                       {addingToMaster === master.id ? "Cancel" : "+ Add Sub"}
                     </button>
-                    <button onClick={() => { setEditingCatId(master.id); setEditCatName(master.name); }} className="text-xs text-text-muted hover:text-accent min-h-[44px] md:min-h-0">Edit</button>
-                    <button onClick={() => setConfirmDeleteId(master.id)} aria-label={`Delete ${master.name}`} className="text-xs text-text-muted hover:text-danger min-h-[44px] md:min-h-0">Delete</button>
+                    <button onClick={() => { setEditingCatId(master.id); setEditCatName(master.name); }} className="inline-flex min-h-[44px] items-center px-2 text-xs text-text-muted hover:text-accent md:min-h-0 md:px-0">Edit</button>
+                    <button onClick={() => setConfirmDeleteId(master.id)} aria-label={`Delete ${master.name}`} className="inline-flex min-h-[44px] items-center px-2 text-xs text-text-muted hover:text-danger md:min-h-0 md:px-0">Delete</button>
                   </div>
                 </div>
 
@@ -259,13 +259,13 @@ export default function CategoriesPage() {
                   {subs.length > 0 ? (
                     <div className="space-y-0.5">
                       {subs.map((sub) => (
-                        <div key={sub.id} className="flex flex-wrap items-center justify-between gap-2 rounded-md px-3 py-2 transition-colors hover:bg-surface-raised">
+                        <div key={sub.id} data-testid={`sub-row-${sub.id}`} className="flex flex-wrap items-center justify-between gap-2 rounded-md px-3 py-2 transition-colors hover:bg-surface-raised">
                           {editingCatId === sub.id ? (
                             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                               <input type="text" value={editCatName} onChange={(e) => setEditCatName(e.target.value)} className={`min-w-0 flex-1 text-sm ${input}`} autoFocus
                                 onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(sub.id); if (e.key === "Escape") setEditingCatId(null); }} />
-                              <button onClick={() => handleEditCat(sub.id)} className="text-xs text-accent min-h-[44px] md:min-h-0">Save</button>
-                              <button onClick={() => setEditingCatId(null)} className="text-xs text-text-muted min-h-[44px] md:min-h-0">Cancel</button>
+                              <button onClick={() => handleEditCat(sub.id)} className="inline-flex min-h-[44px] items-center px-2 text-xs text-accent md:min-h-0 md:px-0">Save</button>
+                              <button onClick={() => setEditingCatId(null)} className="inline-flex min-h-[44px] items-center px-2 text-xs text-text-muted md:min-h-0 md:px-0">Cancel</button>
                             </div>
                           ) : (
                             <>
@@ -274,9 +274,9 @@ export default function CategoriesPage() {
                                 {sub.description && <span className="ml-2 text-xs text-text-muted">{sub.description}</span>}
                                 <span className="ml-2 text-xs text-text-muted" title={`${sub.transaction_count} transaction(s)`}>{sub.transaction_count}</span>
                               </div>
-                              <div className="flex flex-wrap gap-2">
-                                <button onClick={() => { setEditingCatId(sub.id); setEditCatName(sub.name); }} className="text-xs text-text-muted hover:text-accent min-h-[44px] md:min-h-0">Edit</button>
-                                <button onClick={() => setConfirmDeleteId(sub.id)} aria-label={`Delete ${sub.name}`} className="text-xs text-text-muted hover:text-danger min-h-[44px] md:min-h-0">Delete</button>
+                              <div data-testid={`sub-actions-${sub.id}`} className="flex flex-wrap gap-1 sm:gap-2">
+                                <button onClick={() => { setEditingCatId(sub.id); setEditCatName(sub.name); }} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 text-xs text-text-muted hover:text-accent md:min-h-0 md:min-w-0 md:px-0">Edit</button>
+                                <button onClick={() => setConfirmDeleteId(sub.id)} aria-label={`Delete ${sub.name}`} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 text-xs text-text-muted hover:text-danger md:min-h-0 md:min-w-0 md:px-0">Delete</button>
                               </div>
                             </>
                           )}

--- a/frontend/tests/app/categories-mobile-pass.test.tsx
+++ b/frontend/tests/app/categories-mobile-pass.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import CategoriesPage from "@/app/categories/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/categories",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const CATEGORIES = [
+  // Master with a long name that previously truncated to "D..." at 375px
+  {
+    id: 100,
+    name: "Debt Repayment",
+    slug: "debt",
+    parent_id: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+  {
+    id: 101,
+    name: "Credit Card",
+    slug: null,
+    parent_id: 100,
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 3,
+  },
+  {
+    id: 102,
+    name: "Financial Goals",
+    slug: "financial_goals",
+    parent_id: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+];
+
+describe("CategoriesPage — mobile pass", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/categories") return Promise.resolve(CATEGORIES);
+      return Promise.resolve({});
+    }) as never);
+  });
+
+  it("renders the full master category name (no single-character truncation at mobile)", async () => {
+    render(<CategoriesPage />);
+    // The whole name must be present in the DOM, regardless of viewport.
+    // The visual truncation under sm: must not chop the underlying text node.
+    await waitFor(() => expect(screen.getByText("Debt Repayment")).toBeInTheDocument());
+    expect(screen.getByText("Financial Goals")).toBeInTheDocument();
+  });
+
+  it("master row reflows actions to a second line below sm breakpoint", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Debt Repayment")).toBeInTheDocument());
+    const row = screen.getByTestId("master-row-100");
+    // Mobile: column stack; sm+: row layout. The row container drives the wrap.
+    expect(row.className).toContain("flex-col");
+    expect(row.className).toContain("sm:flex-row");
+  });
+
+  it("master action group keeps all three actions visible (no kebab hide)", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Debt Repayment")).toBeInTheDocument());
+    const actions = screen.getByTestId("master-actions-100");
+    // All three actions present and tappable.
+    expect(actions.querySelectorAll("button")).toHaveLength(3);
+    expect(actions.textContent).toContain("+ Add Sub");
+    expect(actions.textContent).toContain("Edit");
+    expect(actions.textContent).toContain("Delete");
+  });
+
+  it("subcategory Edit/Delete buttons have a 44px mobile hit area", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Credit Card")).toBeInTheDocument());
+    const subActions = screen.getByTestId("sub-actions-101");
+    const buttons = subActions.querySelectorAll("button");
+    expect(buttons).toHaveLength(2);
+    for (const btn of Array.from(buttons)) {
+      // Hit area is achieved via min-h-[44px] + min-w-[44px] + px-2 padding
+      // which collapses back to compact desktop sizing at md:.
+      expect(btn.className).toContain("min-h-[44px]");
+      expect(btn.className).toContain("min-w-[44px]");
+      expect(btn.className).toContain("md:min-h-0");
+      expect(btn.className).toContain("md:min-w-0");
+    }
+  });
+
+  it("subcategory Delete button keeps its accessible name", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Credit Card")).toBeInTheDocument());
+    // aria-label preserved so screen readers still get a per-row label.
+    expect(screen.getByLabelText("Delete Credit Card")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Mobile-pass follow-up from the 2026-05-08 responsive audit on `/categories`.

- Master row stacks below `sm:` so the action group (`+ Add Sub`, `Edit`, `Delete`) drops to its own line. Long names like "Debt Repayment" and "Financial Goals" now render in full at 375 instead of collapsing to `D...` / `Fi...`. Desktop layout (`sm:flex-row sm:flex-wrap sm:items-center sm:justify-between`) is unchanged.
- Subcategory Edit/Delete keep the codebase's text-label convention but gain a 44x44 mobile hit area via `inline-flex`, `min-h-[44px]`, `min-w-[44px]`, and `px-2` padding. The compact desktop sizing returns at `md:` via `md:min-h-0`, `md:min-w-0`, `md:px-0`.
- Adds `tests/app/categories-mobile-pass.test.tsx` (5 tests) covering full-name render, column reflow at mobile, action visibility (no kebab hide), hit-area classes on subcategory buttons, and aria-label preservation.

Why text labels and not icon buttons: the codebase has no Pencil/Trash icon-button precedent. Transactions, recurring, and accounts all use text-label buttons with `aria-label`s for the same Edit/Delete pattern. Following that convention.

## Notes

- Tablet (`sm:`-`md:` 640-768px) buttons inherit the 44px hit area too. That's a small UX win for touch tablets and reverts at desktop `md:`+.
- Frontend test suite: 288 passing across 51 files (5 new).