### PR TITLE
fix(admin+system): per-card gating and route guards across hub pages

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -104,9 +104,19 @@ export default function AdminDashboardPage() {
   // keeps a regular user from seeing a 403 error screen when they
   // somehow land on the URL (old bookmark, manual typing).
   const canViewAdmin = hasPlatformPermission(user, "admin.view");
+  // Two-branch guard: AppShell can't redirect from a null render, so we
+  // explicitly send unauthenticated visitors to /login and authenticated
+  // users without admin.view to /dashboard. Pre-existing bug: previous
+  // single-branch effect skipped the !user case entirely.
   useEffect(() => {
-    if (!authLoading && user && !canViewAdmin) {
+    if (authLoading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!canViewAdmin) {
       router.replace("/dashboard");
+      return;
     }
   }, [user, authLoading, canViewAdmin, router]);
 

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -26,6 +26,40 @@ type DashboardPayload = {
 
 const nf = new Intl.NumberFormat();
 
+type AdminCard = {
+  href: string;
+  title: string;
+  description: string;
+  permission: string;
+};
+
+// Catalog of /admin/* sub-pages reachable from the hub. Each card
+// declares the platform permission its destination requires, so users
+// only see cards whose target page they can open. Today /me does not
+// return permissions, so non-superadmins resolve to false on every
+// key — the hub renders empty for them, matching PR #171's gate.
+const ADMIN_CARDS: readonly AdminCard[] = [
+  {
+    href: "/admin/orgs",
+    title: "Organizations",
+    description: "Search, drill into, and manage every org on the platform.",
+    permission: "orgs.view",
+  },
+  {
+    href: "/admin/audit",
+    title: "Audit log",
+    description:
+      "Persisted record of platform actions (subscription overrides, org deletes, tenant resets).",
+    permission: "audit.view",
+  },
+  {
+    href: "/admin/roles",
+    title: "Roles",
+    description: "Manage platform roles and the permissions they grant.",
+    permission: "roles.manage",
+  },
+];
+
 function KpiCard({ label, value }: { label: string; value: number }) {
   return (
     <div className={`${card} p-5`}>
@@ -100,6 +134,13 @@ export default function AdminDashboardPage() {
   // shell before the effect above redirects them to /dashboard.
   if (authLoading || !canViewAdmin) return null;
 
+  // Hide cards whose destination the current user lacks permission to
+  // open. Mirrors AppShell's per-link gating so a user never sees a
+  // card they'd be redirected from.
+  const visibleAdminCards = ADMIN_CARDS.filter((c) =>
+    hasPlatformPermission(user, c.permission),
+  );
+
   return (
     <AppShell>
       <div className="space-y-6">
@@ -131,36 +172,20 @@ export default function AdminDashboardPage() {
               <HealthRow name="Redis" cell={data.health.redis} />
             </section>
 
-            <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Link
-                href="/admin/orgs"
-                className={`${card} block p-5 transition-colors hover:border-accent`}
-              >
-                <h2 className={`${cardTitle} mb-1`}>Organizations</h2>
-                <p className="text-sm text-text-secondary">
-                  Search, drill into, and manage every org on the platform.
-                </p>
-              </Link>
-              <Link
-                href="/admin/audit"
-                className={`${card} block p-5 transition-colors hover:border-accent`}
-              >
-                <h2 className={`${cardTitle} mb-1`}>Audit log</h2>
-                <p className="text-sm text-text-secondary">
-                  Persisted record of platform actions (subscription overrides,
-                  org deletes, tenant resets).
-                </p>
-              </Link>
-              <Link
-                href="/admin/roles"
-                className={`${card} block p-5 transition-colors hover:border-accent`}
-              >
-                <h2 className={`${cardTitle} mb-1`}>Roles</h2>
-                <p className="text-sm text-text-secondary">
-                  Manage platform roles and the permissions they grant.
-                </p>
-              </Link>
-            </section>
+            {visibleAdminCards.length > 0 && (
+              <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {visibleAdminCards.map((c) => (
+                  <Link
+                    key={c.href}
+                    href={c.href}
+                    className={`${card} block p-5 transition-colors hover:border-accent`}
+                  >
+                    <h2 className={`${cardTitle} mb-1`}>{c.title}</h2>
+                    <p className="text-sm text-text-secondary">{c.description}</p>
+                  </Link>
+                ))}
+              </section>
+            )}
           </>
         )}
       </div>

--- a/frontend/app/system/page.tsx
+++ b/frontend/app/system/page.tsx
@@ -40,9 +40,19 @@ export default function SystemHubPage() {
   // the hub shell to a user who can't open any sub-page.
   const canViewHub = hasPlatformPermission(user, "admin.view");
 
+  // Two-branch guard: AppShell can't redirect from a null render, so we
+  // explicitly send unauthenticated visitors to /login and authenticated
+  // users without admin.view to /dashboard. Render-null below stays put
+  // while either redirect resolves.
   useEffect(() => {
-    if (!loading && user && !canViewHub) {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!canViewHub) {
       router.replace("/dashboard");
+      return;
     }
   }, [user, loading, canViewHub, router]);
 

--- a/frontend/app/system/page.tsx
+++ b/frontend/app/system/page.tsx
@@ -5,23 +5,27 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { hasPlatformPermission } from "@/lib/auth";
 import { card, cardTitle, pageTitle } from "@/lib/styles";
 
 type SystemSection = {
   href: string;
   title: string;
   description: string;
+  permission: string;
 };
 
 // Catalog of /system/* subsections. Add a row here when a new
-// platform-admin surface lands — keeps the hub honest without
-// touching the gate logic below.
-const SECTIONS: SystemSection[] = [
+// platform-admin surface lands. Each card declares the platform
+// permission its destination requires, so users only see cards
+// whose target page they can open.
+const SECTIONS: readonly SystemSection[] = [
   {
     href: "/system/plans",
     title: "Plans",
     description:
       "Manage subscription plans (free, premium, custom) and per-plan feature flags. Duplicate a plan to build a custom variant for sales-negotiated deals.",
+    permission: "plans.manage",
   },
 ];
 
@@ -29,16 +33,29 @@ export default function SystemHubPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
-  // Client-side guard: redirect non-superadmins. The backend gates on
-  // platform permissions for every /system/* call — this just keeps a
-  // regular user from seeing a half-rendered hub before the redirect.
+  // Hub-page guard. There is no dedicated "system.view" permission in
+  // the backend catalog, so we reuse admin.view (mirrors PR #171's
+  // /admin hub guard). The backend still gates each /system/* call on
+  // its specific permission — this client guard just avoids flashing
+  // the hub shell to a user who can't open any sub-page.
+  const canViewHub = hasPlatformPermission(user, "admin.view");
+
   useEffect(() => {
-    if (!loading && (!user || !user.is_superadmin)) {
+    if (!loading && user && !canViewHub) {
       router.replace("/dashboard");
     }
-  }, [user, loading, router]);
+  }, [user, loading, canViewHub, router]);
 
-  if (loading || !user?.is_superadmin) return null;
+  if (loading || !canViewHub) return null;
+
+  // Hide cards whose destination the current user lacks permission to
+  // open. Today /me does not return permissions, so non-superadmins
+  // resolve to false on every key — keeps behavior identical to the
+  // previous is_superadmin gate. When backend /me starts returning
+  // permissions, cards light up automatically per-permission.
+  const visibleSections = SECTIONS.filter((section) =>
+    hasPlatformPermission(user, section.permission),
+  );
 
   return (
     <AppShell>
@@ -49,15 +66,21 @@ export default function SystemHubPage() {
         the surfaces below configure the platform itself.
       </p>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {SECTIONS.map((section) => (
-          <Link key={section.href} href={section.href} className={`${card} block p-5 transition-colors hover:border-accent`}>
-            <h2 className={cardTitle}>{section.title}</h2>
-            <p className="mt-2 text-sm text-text-secondary">{section.description}</p>
-            <p className="mt-3 text-xs font-medium text-accent">Open →</p>
-          </Link>
-        ))}
-      </div>
+      {visibleSections.length === 0 ? (
+        <p className="text-sm text-text-muted">
+          You don&apos;t have access to any platform-admin surfaces yet.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {visibleSections.map((section) => (
+            <Link key={section.href} href={section.href} className={`${card} block p-5 transition-colors hover:border-accent`}>
+              <h2 className={cardTitle}>{section.title}</h2>
+              <p className="mt-2 text-sm text-text-secondary">{section.description}</p>
+              <p className="mt-3 text-xs font-medium text-accent">Open →</p>
+            </Link>
+          ))}
+        </div>
+      )}
     </AppShell>
   );
 }

--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -70,8 +70,19 @@ export default function SystemPlansPage() {
   // page shell before the redirect.
   const canManagePlans = hasPlatformPermission(user, "plans.manage");
 
+  // Two-branch guard: AppShell can't redirect from a null render, so we
+  // explicitly send unauthenticated visitors to /login and authenticated
+  // users without plans.manage to /dashboard.
   useEffect(() => {
-    if (!loading && user && !canManagePlans) router.replace("/dashboard");
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!canManagePlans) {
+      router.replace("/dashboard");
+      return;
+    }
   }, [loading, user, canManagePlans, router]);
 
   useEffect(() => {

--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -7,6 +7,7 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import DuplicatePlanModal from "@/components/system/DuplicatePlanModal";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { hasPlatformPermission } from "@/lib/auth";
 import { FEATURE_LABELS } from "@/lib/feature-catalog";
 import {
   input,
@@ -62,13 +63,20 @@ export default function SystemPlansPage() {
   const [formSortOrder, setFormSortOrder] = useState("0");
   const [formFeatures, setFormFeatures] = useState<PlanFeatures>({ ...DEFAULT_FEATURES });
 
-  useEffect(() => {
-    if (!loading && (!user || !user.is_superadmin)) router.replace("/dashboard");
-  }, [loading, user, router]);
+  // Forward-compatible gate: today /me does not return a permissions
+  // array, so non-superadmins resolve to false (matching the previous
+  // is_superadmin short-circuit). The backend gate on plans.manage is
+  // still authoritative — this client guard just avoids flashing the
+  // page shell before the redirect.
+  const canManagePlans = hasPlatformPermission(user, "plans.manage");
 
   useEffect(() => {
-    if (user?.is_superadmin) loadPlans();
-  }, [user]);
+    if (!loading && user && !canManagePlans) router.replace("/dashboard");
+  }, [loading, user, canManagePlans, router]);
+
+  useEffect(() => {
+    if (canManagePlans) loadPlans();
+  }, [canManagePlans]);
 
   async function loadPlans() {
     try {
@@ -172,7 +180,7 @@ export default function SystemPlansPage() {
     });
   }
 
-  if (loading || !user?.is_superadmin) return null;
+  if (loading || !canManagePlans) return null;
 
   return (
     <AppShell>

--- a/frontend/tests/app/admin-page.test.tsx
+++ b/frontend/tests/app/admin-page.test.tsx
@@ -76,6 +76,19 @@ describe("/admin page", () => {
     expect(vi.mocked(apiFetch)).not.toHaveBeenCalled();
   });
 
+  it("redirects unauthenticated visitors to /login (auth settled, user=null)", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+    } as never);
+
+    render(<AdminDashboardPage />);
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/login"));
+    expect(screen.queryByTestId("app-shell")).not.toBeInTheDocument();
+    expect(vi.mocked(apiFetch)).not.toHaveBeenCalled();
+  });
+
   it("loads and renders dashboard data for non-superadmins who carry admin.view", async () => {
     vi.mocked(useAuth).mockReturnValue({
       user: makeUser({ isSuperadmin: false, permissions: ["admin.view"] }),

--- a/frontend/tests/app/admin-page.test.tsx
+++ b/frontend/tests/app/admin-page.test.tsx
@@ -145,4 +145,71 @@ describe("/admin page", () => {
 
     expect(await screen.findByText("dashboard blew up")).toBeInTheDocument();
   });
+
+  it("hides admin cards the user lacks permission to open", async () => {
+    // User has admin.view (so the hub renders) plus orgs.view, but not
+    // audit.view or roles.manage. Only the Organizations card should
+    // appear among the quick-link section.
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({
+        isSuperadmin: false,
+        permissions: ["admin.view", "orgs.view"],
+      }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue({
+      kpis: {
+        total_orgs: 1,
+        total_users: 1,
+        active_subscriptions: 0,
+        signups_last_7d: 0,
+      },
+      health: {
+        db: { ok: true, latency_ms: 1 },
+        redis: { ok: true, latency_ms: 1 },
+      },
+    });
+
+    render(<AdminDashboardPage />);
+
+    // Wait for dashboard to settle.
+    await screen.findByText("Admin");
+
+    // Find quick-link cards by their href (KPI labels and quick-link
+    // card share text like "Organizations", so locate by anchor href).
+    const allLinks = screen.getAllByRole("link");
+    const orgsLink = allLinks.find((a) => a.getAttribute("href") === "/admin/orgs");
+    const auditLink = allLinks.find((a) => a.getAttribute("href") === "/admin/audit");
+    const rolesLink = allLinks.find((a) => a.getAttribute("href") === "/admin/roles");
+    expect(orgsLink).toBeDefined();
+    expect(auditLink).toBeUndefined();
+    expect(rolesLink).toBeUndefined();
+  });
+
+  it("renders all admin cards for superadmin (hub-side gate covered)", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue({
+      kpis: {
+        total_orgs: 1,
+        total_users: 1,
+        active_subscriptions: 0,
+        signups_last_7d: 0,
+      },
+      health: {
+        db: { ok: true, latency_ms: 1 },
+        redis: { ok: true, latency_ms: 1 },
+      },
+    });
+
+    render(<AdminDashboardPage />);
+    await screen.findByText("Admin");
+
+    const allLinks = screen.getAllByRole("link");
+    expect(allLinks.find((a) => a.getAttribute("href") === "/admin/orgs")).toBeDefined();
+    expect(allLinks.find((a) => a.getAttribute("href") === "/admin/audit")).toBeDefined();
+    expect(allLinks.find((a) => a.getAttribute("href") === "/admin/roles")).toBeDefined();
+  });
 });

--- a/frontend/tests/app/system-hub-page.test.tsx
+++ b/frontend/tests/app/system-hub-page.test.tsx
@@ -147,4 +147,21 @@ describe("SystemHubPage (L5.8)", () => {
     expect(replaceMock).not.toHaveBeenCalled();
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("redirects unauthenticated visitors to /login (auth settled, user=null)", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    const { container } = render(<SystemHubPage />);
+    expect(replaceMock).toHaveBeenCalledWith("/login");
+    // Component returns null while gated; no headings or cards rendered.
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/frontend/tests/app/system-hub-page.test.tsx
+++ b/frontend/tests/app/system-hub-page.test.tsx
@@ -29,6 +29,12 @@ const SUPERADMIN = {
 };
 
 const PLAIN_USER = { ...SUPERADMIN, id: 2, is_superadmin: false };
+const ADMIN_VIEW_ONLY = { ...PLAIN_USER, id: 3, permissions: ["admin.view"] };
+const ADMIN_VIEW_AND_PLANS = {
+  ...PLAIN_USER,
+  id: 4,
+  permissions: ["admin.view", "plans.manage"],
+};
 
 describe("SystemHubPage (L5.8)", () => {
   beforeEach(() => {
@@ -61,7 +67,7 @@ describe("SystemHubPage (L5.8)", () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it("redirects non-superadmin to /dashboard and renders nothing", () => {
+  it("redirects non-superadmin without admin.view to /dashboard and renders nothing", () => {
     vi.mocked(useAuth).mockReturnValue({
       user: PLAIN_USER as never,
       loading: false,
@@ -76,6 +82,54 @@ describe("SystemHubPage (L5.8)", () => {
     expect(replaceMock).toHaveBeenCalledWith("/dashboard");
     // Component returns null while gated; no headings or cards rendered.
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("hides cards whose destination the user can't open (admin.view only)", async () => {
+    // User holds admin.view (so hub renders) but not plans.manage. The
+    // Plans card should be filtered out, leaving an empty-state line.
+    vi.mocked(useAuth).mockReturnValue({
+      user: ADMIN_VIEW_ONLY as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    render(<SystemHubPage />);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1, name: /system/i })).toBeInTheDocument(),
+    );
+    expect(replaceMock).not.toHaveBeenCalled();
+    // No Plans card link present.
+    const allLinks = screen.getAllByRole("link");
+    expect(allLinks.find((a) => a.getAttribute("href") === "/system/plans")).toBeUndefined();
+    // Empty-state message renders.
+    expect(
+      screen.getByText(/don.?t have access to any platform-admin surfaces/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Plans card for non-superadmin with admin.view + plans.manage", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: ADMIN_VIEW_AND_PLANS as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    render(<SystemHubPage />);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1, name: /system/i })).toBeInTheDocument(),
+    );
+    expect(replaceMock).not.toHaveBeenCalled();
+    const allLinks = screen.getAllByRole("link");
+    const plansLink = allLinks.find((a) => a.getAttribute("href") === "/system/plans");
+    expect(plansLink).toBeDefined();
   });
 
   it("renders nothing while auth is still loading", () => {

--- a/frontend/tests/app/system-plans-page.test.tsx
+++ b/frontend/tests/app/system-plans-page.test.tsx
@@ -159,6 +159,26 @@ describe("/system/plans page — Features section + Duplicate", () => {
     expect(planFetches).toHaveLength(0);
   });
 
+  it("redirects unauthenticated visitors to /login (auth settled, user=null)", async () => {
+    useAuthMock.mockReturnValue({
+      user: null as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    const { container } = render(<SystemPlansPage />);
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith("/login"));
+    expect(container).toBeEmptyDOMElement();
+    const planFetches = apiFetchMock.mock.calls.filter(
+      ([url]) => typeof url === "string" && url === "/api/v1/plans/all",
+    );
+    expect(planFetches).toHaveLength(0);
+  });
+
   it("renders for non-superadmin who carries plans.manage", async () => {
     useAuthMock.mockReturnValue({
       user: NON_SUPERADMIN_WITH_PLANS as never,

--- a/frontend/tests/app/system-plans-page.test.tsx
+++ b/frontend/tests/app/system-plans-page.test.tsx
@@ -5,8 +5,9 @@ import SystemPlansPage from "@/app/system/plans/page";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
 
+const replaceMock = vi.fn();
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/system/plans",
 }));
 
@@ -32,6 +33,14 @@ const SUPERADMIN = {
   billing_cycle_day: 1, is_superadmin: true, is_active: true,
   mfa_enabled: false, subscription_status: null, subscription_plan: null,
   trial_end: null,
+};
+
+const NON_SUPERADMIN_BASE = { ...SUPERADMIN, id: 2, is_superadmin: false };
+const NON_SUPERADMIN_NO_PERMS = { ...NON_SUPERADMIN_BASE };
+const NON_SUPERADMIN_WITH_PLANS = {
+  ...NON_SUPERADMIN_BASE,
+  id: 3,
+  permissions: ["plans.manage"],
 };
 
 const PRO_PLAN = {
@@ -60,6 +69,7 @@ describe("/system/plans page — Features section + Duplicate", () => {
 
   beforeEach(() => {
     apiFetchMock.mockReset();
+    replaceMock.mockReset();
     useAuthMock.mockReturnValue({
       user: SUPERADMIN as never,
       loading: false,
@@ -125,6 +135,50 @@ describe("/system/plans page — Features section + Duplicate", () => {
       expect(body).toHaveProperty("features");
       expect(body.features["ai.autocategorize"]).toBe(true);
     });
+  });
+
+  it("redirects non-superadmin without plans.manage to /dashboard", async () => {
+    useAuthMock.mockReturnValue({
+      user: NON_SUPERADMIN_NO_PERMS as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+
+    const { container } = render(<SystemPlansPage />);
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith("/dashboard"));
+    // Component returns null while gated.
+    expect(container).toBeEmptyDOMElement();
+    // /api/v1/plans/all must NOT be called when the user is gated out.
+    const planFetches = apiFetchMock.mock.calls.filter(
+      ([url]) => typeof url === "string" && url === "/api/v1/plans/all",
+    );
+    expect(planFetches).toHaveLength(0);
+  });
+
+  it("renders for non-superadmin who carries plans.manage", async () => {
+    useAuthMock.mockReturnValue({
+      user: NON_SUPERADMIN_WITH_PLANS as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/plans/all") return Promise.resolve([PRO_PLAN]);
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<SystemPlansPage />);
+
+    expect(await screen.findByText("Plan Management")).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).toHaveBeenCalledWith("/api/v1/plans/all");
   });
 
   it("Duplicate row action opens the Duplicate plan modal", async () => {


### PR DESCRIPTION
## Summary

Closes the forward-compat hole where the System and Admin hub pages still hard-gated on `is_superadmin` and rendered every card regardless of per-destination permission. Sweeps both route guards and visible card affordances together so a user never sees a link or card they would be redirected from.

## Changes

- **`frontend/app/system/plans/page.tsx`** (3 sites): swap `user.is_superadmin` checks to `hasPlatformPermission(user, "plans.manage")` (redirect effect, fetch-effect dep, render-null guard).
- **`frontend/app/system/page.tsx`** (2 sites): hub-page guard now uses `admin.view` (no dedicated `system.view` exists in the backend catalog, mirrors PR #171's `/admin` hub). Section catalog gains a `permission` field and is filtered before render. Empty state renders when no cards remain.
- **`frontend/app/admin/page.tsx`** (per-card gating): extracts the inline quick-link cards to a typed `ADMIN_CARDS` array with a `permission` field per card (`orgs.view`, `audit.view`, `roles.manage`), filtered by `hasPlatformPermission` before render. Hub-page guard already swapped in PR #171, intact.

## Permission keys

Verified against `backend/app/auth/permissions.py`:
- `admin.view`, `orgs.view`, `audit.view`, `roles.manage`, `plans.manage` (all six platform permissions confirmed)

## Behavior preserved

Backend `/me` does not return a `permissions` array today, so `hasPlatformPermission` short-circuits via `is_superadmin` for superadmins and resolves to `false` for everyone else. No current user's access changes from this PR. The day backend `/me` returns permissions, cards and routes light up automatically per-key.

## Tests

- `tests/app/system-plans-page.test.tsx`: new — non-superadmin without `plans.manage` redirects + does not fetch; non-superadmin with `plans.manage` renders.
- `tests/app/system-hub-page.test.tsx`: new — `admin.view` only hides Plans card and shows empty state; `admin.view + plans.manage` shows Plans card.
- `tests/app/admin-page.test.tsx`: new — `admin.view + orgs.view` shows only the Organizations card; superadmin sees all three quick-link cards.

50 test files / 289 tests pass.