### PR TITLE
chore(frontend): declare vitest globals in tsconfig types

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,6 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "types": ["vitest/globals", "node"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary

- Adds `"types": ["vitest/globals", "node"]` to `frontend/tsconfig.json` `compilerOptions` so test files can use `describe` / `it` / `expect` / `vi` / `beforeEach` etc. without import statements (vitest config already has `globals: true`).
- Fixes ~1830 spurious TS2304 errors (`Cannot find name 'vi'`, `Cannot find name 'describe'`, etc.) across the test suite.
- `node` is included alongside `vitest/globals` because the explicit `types` array overrides automatic `@types` inclusion, and `vitest.config.ts` uses `node:path`.

## Notes

- `tsc --noEmit` after the change: 9 pre-existing type-drift errors remain in test fixtures (Transaction missing `is_manual_adjustment`, User missing `password_set`/`allow_manual_balance_adjustment`, etc., introduced by Track E / PR #162). Those are unrelated and present on `main` already.
- React/React-DOM type resolution unaffected — both packages ship their own types in `node_modules/react` / `node_modules/react-dom`.