### PR TITLE
chore(ci): gate prod deploy on semantic-release outcome

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,22 @@
-name: Deploy to Production
+# Manual production deploy escape hatch.
+#
+# Automatic production deploys are now driven by release.yml's gated
+# `deploy` job, which only fires when semantic-release decides the merge
+# warrants a new release. That means infra-only commits that don't
+# trigger a release (chore(.do), chore(nginx), chore(infra),
+# chore(Dockerfile), ...) will NOT auto-deploy. When such a change must
+# ship, an operator runs this workflow manually:
+#
+#   gh workflow run deploy.yml --ref main
+#
+# The job body intentionally mirrors release.yml's deploy + smoke-tests
+# jobs so the manual path produces the same artifact and runs the same
+# post-deploy checks.
+
+name: Deploy to Production (manual)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      # Application code that ships to prod. Any change here may need a redeploy.
-      - "backend/**"
-      - "frontend/**"
-      - "nginx/**"
-      # Prod app spec on DO App Platform. Source of truth for prod runtime config.
-      - ".do/**"
-      # Image-build inputs. The Dockerfiles are referenced from .do/app.yaml.
-      - "Dockerfile*"
-      # NOTE: docker-compose*.yml is intentionally NOT in this list — it's
-      # local-dev only; prod uses .do/app.yaml. PR #105's two test-mount
-      # tweaks to docker-compose.yml triggered redundant prod deploys.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,23 @@
+# Release orchestrator for main.
+#
+# This workflow is the single arbiter of "should we ship". It runs
+# semantic-release first; if (and only if) semantic-release decides a new
+# release is warranted, the gated `deploy` job pushes .do/app.yaml to DO
+# App Platform, and `smoke-tests` then asserts the live app actually
+# serves traffic. Path-only triggers were the previous gate but they
+# couldn't tell a `chore(frontend): tsconfig` apart from a real shipping
+# change, so chore commits were redeploying production. The semantic-
+# release outcome is now the gate instead. deploy.yml is preserved as a
+# manual `workflow_dispatch` escape hatch for the rare case where an
+# infra-only change (chore(.do), chore(nginx), chore(infra), ...) needs
+# to ship without a version bump.
+#
+# Why the gating job and not `on: release: { types: [published] }` on
+# deploy.yml: GitHub does not cascade workflow runs from releases that
+# are created by GITHUB_TOKEN, which is exactly what semantic-release
+# uses. See
+# https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+
 name: Release
 
 on:
@@ -23,6 +43,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,6 +54,7 @@ jobs:
           persist-credentials: false
 
       - name: Semantic Release
+        id: semantic
         uses: cycjimmy/semantic-release-action@v6
         with:
           semantic_version: 24
@@ -38,3 +62,69 @@ jobs:
             conventional-changelog-conventionalcommits@8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to DigitalOcean App Platform
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          # NOTE: Do NOT add `app_name` here. The v2 action's createSpec
+          # logic (deploy/main.go) takes EITHER `app_name` OR
+          # `app_spec_location`: with both set, it fetches the live spec
+          # by name and ignores the file. Edits to .do/app.yaml then
+          # silently never reach App Platform — that is the bug that let
+          # PR #79's migration sit un-applied for hours after merge.
+          # With only `app_spec_location`, the action reads the file and
+          # picks up the app via its top-level `name:` field. .do/app.yaml
+          # MUST list every secret with its encrypted EV[...] value, since
+          # any SECRET not declared in this file gets removed from the
+          # live app on push (we hit that exact failure mode 2026-04-25,
+          # backend crashlooped on a placeholder JWT_SECRET_KEY).
+          app_spec_location: .do/app.yaml
+
+  # L0.5 — Post-deploy smoke tests. Runs only after `deploy` succeeds
+  # so a failed deploy never reports as a smoke-test failure (the
+  # `needs: deploy` gate plus our `on: push: branches: [main]` trigger
+  # together guarantee this never runs on PRs or forks).
+  #
+  # Asserts the live app can serve traffic — DO marking the deploy
+  # ACTIVE is necessary but not sufficient. See scripts/smoke-test.sh
+  # for the surface and the smoke-user invariants (must exist, must be
+  # email_verified, must NOT have MFA enabled).
+  smoke-tests:
+    runs-on: ubuntu-latest
+    needs: deploy
+    permissions:
+      contents: read
+      # Required by the failure-notification step below to open or
+      # comment on a GitHub issue when the smoke job fails. Scoped to
+      # this job only so the deploy job stays read-only.
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run smoke tests against production
+        env:
+          SMOKE_BASE_URL: https://app.thebetterdecision.com
+          SMOKE_USERNAME: ${{ secrets.SMOKE_USERNAME }}
+          SMOKE_PASSWORD: ${{ secrets.SMOKE_PASSWORD }}
+        run: ./scripts/smoke-test.sh
+
+      - name: Notify on smoke failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+        run: ./scripts/notify-smoke-failure.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,7 +385,7 @@ Migration files are in `backend/alembic/versions/` and follow sequential numberi
 - **Never push directly to `main`** — always branch + PR
 - Feature branches: `feat/<name>`
 - Fix branches: `fix/<name>`
-- Merge to `main` triggers production deployment via GitHub Actions
+- Merge to `main` triggers production deployment via GitHub Actions only when the commit is release-eligible (`feat`, `fix`, `perf`, `revert`). `chore`, `docs`, `refactor`, `test`, and similar commits are not auto-deployed; see the Deployment section for the manual escape hatch.
 
 ---
 
@@ -399,7 +399,10 @@ The app is deployed on DO App Platform (Amsterdam region). MySQL 8 and Redis are
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `deploy.yml` | Push to `main` | Deploys to production via `digitalocean/app_action/deploy@v2`, pushing `.do/app.yaml` as the authoritative spec |
+| `release.yml` | Push to `main` (release-eligible commits only) | Runs semantic-release. If a new release is published, deploys `.do/app.yaml` to DO App Platform via `digitalocean/app_action/deploy@v2`, then runs `scripts/smoke-test.sh` against production. |
+| `deploy.yml` | Manual (`workflow_dispatch`) | Emergency redeploy escape hatch. Same DO action and smoke-test job, but not auto-triggered. Use when an infra-only change (`chore(.do)`, `chore(infra)`, `chore(nginx)`) needs to ship without a version bump. |
+
+The orchestration is intentional: semantic-release is the single arbiter of "should we ship". A path filter cannot tell a `chore(frontend)` apart from a real shipping change, which previously caused chore commits to redeploy production. Gating `deploy` on `new_release_published == 'true'` (a job output of the semantic-release step) ensures only release-eligible commits reach App Platform automatically. The naive `on: release: { types: [published] }` shortcut does not work because GitHub does not cascade workflow runs from `GITHUB_TOKEN`-created releases.
 
 **Required GitHub repository secret:**
 
@@ -411,14 +414,21 @@ The app is deployed on DO App Platform (Amsterdam region). MySQL 8 and Redis are
 
 ### Manual Deployment
 
-If you need to deploy without GitHub Actions:
+The primary manual path is the `deploy.yml` workflow, which runs the same DO action and smoke-test job as the auto-deploy path:
+
+```bash
+# Trigger the manual workflow on main (preferred for chore(infra), chore(.do), etc.)
+gh workflow run deploy.yml --ref main
+```
+
+If GitHub Actions is unavailable or you need to bypass it entirely (using `doctl` directly):
 
 ```bash
 # Install doctl
 brew install doctl
 doctl auth init
 
-# Push the spec (preferred — covers vpc, components, env, and secrets)
+# Push the spec (covers vpc, components, env, and secrets)
 doctl apps update <app-id> --spec .do/app.yaml
 
 # Or trigger a redeploy of the current spec

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, architecture details, environm
 
 ## Deployment
 
-Production runs on DigitalOcean App Platform (Amsterdam). Merging to `main` triggers automatic deployment via GitHub Actions. See [CONTRIBUTING.md](CONTRIBUTING.md#deployment) for details.
+Production runs on DigitalOcean App Platform (Amsterdam). Automatic deployment is gated on semantic-release: only commits classified as a release (`feat`, `fix`, `perf`, `revert`) are auto-deployed by GitHub Actions on merge to `main`. `chore`, `docs`, `refactor`, `test`, and similar non-release commits do not auto-deploy. Infra-only changes that need to ship without a version bump use a manual workflow run. See [CONTRIBUTING.md](CONTRIBUTING.md#deployment) for details.
 
 ## License
 


### PR DESCRIPTION
## Bug

Both `.github/workflows/release.yml` and `.github/workflows/deploy.yml` trigger on `push: main` with the same path filter (`backend/**`, `frontend/**`, `nginx/**`, `.do/**`, `Dockerfile*`). That filter cannot distinguish a `chore(frontend): tsconfig` from a real shipping change, so any `chore(*)` commit touching one of those paths redeploys production even though semantic-release correctly maps `chore` to `release: false` and skips it. release.yml today is wasted CI minutes (no-op semantic-release run); deploy.yml is the real bug, since it actually pushes `.do/app.yaml` to App Platform on every merge that lands files in those paths.

PR #177 (`chore(frontend): declare vitest globals in tsconfig types`) is the immediate trigger that surfaced this. It only touches `frontend/tsconfig.json` and would otherwise have caused a no-op redeploy on merge.

## Fix

`release.yml` becomes the single arbiter of "should we ship":

1. The semantic-release step gets `id: semantic`. The `release` job exposes `new_release_published` and `new_release_git_tag` as job outputs.
2. A new `deploy` job, `needs: release` and `if: needs.release.outputs.new_release_published == 'true'`, runs the existing `digitalocean/app_action/deploy@v2` step against `.do/app.yaml`.
3. A new `smoke-tests` job, `needs: deploy`, runs `scripts/smoke-test.sh` and the existing `notify-smoke-failure.sh` failure hook with the `issues: write` scope.

All comments documenting the DO action `app_name` vs `app_spec_location` bug (PR #79), the `.do/app.yaml` SECRET trap (2026-04-25), and the smoke-user invariants are preserved verbatim from `deploy.yml`.

`deploy.yml` is reduced to `on: workflow_dispatch:` only. The `deploy` and `smoke-tests` jobs are kept intact so the manual path produces the same artifact. Operators trigger it with `gh workflow run deploy.yml --ref main` for the rare infra-only change that needs to ship without a version bump.

## Why not `on: release: { types: [published] }`

GitHub does not cascade workflow runs from releases that are created via `GITHUB_TOKEN`, which is exactly what `cycjimmy/semantic-release-action` uses. Documented at https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow. The job-level `needs` + `if` gate is the supported pattern for this case.

## Policy caveat

Under this design, only commit types that semantic-release recognizes as releases (`feat`, `fix`, `perf`, `revert`) will auto-deploy. `chore(infra)`, `chore(.do)`, `chore(nginx)`, `chore(Dockerfile)`, and similar non-release commits will NOT auto-deploy on merge. Operator runs `gh workflow run deploy.yml --ref main` to ship those manually. No special exception rules.

## Merge order

This PR should land before #177. Once this is on main, merging #177 (a `chore` commit) will correctly skip both release and deploy.