### PR TITLE
chore(frontend): backfill test fixtures for type drift

### DIFF
--- a/frontend/tests/app/forecast-plans-page.test.tsx
+++ b/frontend/tests/app/forecast-plans-page.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import ForecastPlansPage from "@/app/forecast-plans/page";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
+import type { ForecastPlan } from "@/lib/types";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -98,7 +99,7 @@ function makePlan(items: Array<{
     billing_period_id: PERIOD.id,
     period_start: PERIOD.start_date,
     period_end: null,
-    status: "draft" as const,
+    status: "draft" as ForecastPlan["status"],
     total_planned_income: 0,
     total_planned_expense: 0,
     total_actual_income: 0,

--- a/frontend/tests/components/accounts/adjust-balance-modal.test.tsx
+++ b/frontend/tests/components/accounts/adjust-balance-modal.test.tsx
@@ -69,7 +69,7 @@ describe("AdjustBalanceModal", () => {
     const onClose = vi.fn();
     const onAdjusted = vi.fn();
     vi.mocked(apiFetch).mockRejectedValueOnce(
-      new ApiResponseError(409, "No change to apply", { detail: "No change to apply" })
+      new ApiResponseError(409, "No change to apply", undefined, { detail: "No change to apply" })
     );
 
     render(

--- a/frontend/tests/components/auth-provider.test.tsx
+++ b/frontend/tests/components/auth-provider.test.tsx
@@ -27,6 +27,8 @@ const TEST_USER: User = {
   is_superadmin: false,
   is_active: true,
   mfa_enabled: false,
+  password_set: true,
+  allow_manual_balance_adjustment: false,
   subscription_status: null,
   subscription_plan: null,
   trial_end: null,

--- a/frontend/tests/components/transactions/link-as-transfer-modal.test.tsx
+++ b/frontend/tests/components/transactions/link-as-transfer-modal.test.tsx
@@ -24,6 +24,7 @@ const expenseLeg: Transaction = {
   date: "2026-04-29",
   settled_date: "2026-04-29",
   is_imported: false,
+  is_manual_adjustment: false,
 };
 
 const incomeLeg: Transaction = {
@@ -41,6 +42,7 @@ const incomeLeg: Transaction = {
   date: "2026-04-29",
   settled_date: "2026-04-29",
   is_imported: false,
+  is_manual_adjustment: false,
 };
 
 describe("LinkAsTransferModal", () => {

--- a/frontend/tests/components/transactions/mark-as-transfer-modal.test.tsx
+++ b/frontend/tests/components/transactions/mark-as-transfer-modal.test.tsx
@@ -24,6 +24,7 @@ const source: Transaction = {
   date: "2026-04-29",
   settled_date: "2026-04-29",
   is_imported: false,
+  is_manual_adjustment: false,
 };
 
 const accounts: Account[] = [

--- a/frontend/tests/components/transactions/unpair-transfer-modal.test.tsx
+++ b/frontend/tests/components/transactions/unpair-transfer-modal.test.tsx
@@ -68,6 +68,7 @@ const expenseLeg: Transaction = {
   date: "2026-04-28",
   settled_date: "2026-04-28",
   is_imported: false,
+  is_manual_adjustment: false,
 };
 
 const incomeLeg: Transaction = {
@@ -85,6 +86,7 @@ const incomeLeg: Transaction = {
   date: "2026-04-30",
   settled_date: "2026-04-30",
   is_imported: false,
+  is_manual_adjustment: false,
 };
 
 const categories: Category[] = [

--- a/frontend/tests/settings/organization-manual-balance-toggle.test.tsx
+++ b/frontend/tests/settings/organization-manual-balance-toggle.test.tsx
@@ -58,7 +58,7 @@ function makeUser(allow: boolean) {
 }
 
 function baseFixtures() {
-  return ((url: string) => {
+  return (url: string, _init?: RequestInit) => {
     if (url === "/api/v1/settings/billing-cycle")
       return Promise.resolve({ billing_cycle_day: 1 });
     if (url === "/api/v1/settings/billing-period")
@@ -68,7 +68,7 @@ function baseFixtures() {
     if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
     if (url === "/api/v1/category-rules") return Promise.resolve([]);
     return Promise.resolve({});
-  }) as never;
+  };
 }
 
 describe("OrganizationSettingsPage — manual balance adjustment toggle (Track E)", () => {


### PR DESCRIPTION
## Summary

PR #177 (vitest globals in tsconfig) un-masked 9 pre-existing TypeScript errors in test fixtures. The errors existed on main, but the missing-globals noise (~1830 errors) was hiding them. tsc now runs clean.

This PR is fixture-only. No source types or app code touched.

## Changes by category

**Transaction.is_manual_adjustment (Track E, PR #162)** added to:
- frontend/tests/components/transactions/link-as-transfer-modal.test.tsx (expense + income legs)
- frontend/tests/components/transactions/mark-as-transfer-modal.test.tsx (source)
- frontend/tests/components/transactions/unpair-transfer-modal.test.tsx (expense + income legs)

**User.password_set (PR #149) + User.allow_manual_balance_adjustment (Track E)** added to:
- frontend/tests/components/auth-provider.test.tsx (TEST_USER)

**ForecastPlan status type widened** on the makePlan helper:
- frontend/tests/app/forecast-plans-page.test.tsx, replacing 'draft' as const with 'draft' as ForecastPlan['status'] so the existing 'active' overrides on lines 474, 524, 586 type-check.

**ApiResponseError constructor mis-positioned argument** fixed in:
- frontend/tests/components/accounts/adjust-balance-modal.test.tsx, moving the detail object from the 3rd code parameter slot to the 4th detail parameter slot.

**baseFixtures() helper return mis-cast** in:
- frontend/tests/settings/organization-manual-balance-toggle.test.tsx. The cast as never on the returned function made the call site (baseFixtures()(url, init)) fail with "Type 'never' has no call signatures". Removed the cast and gave the inner function an explicit signature.

## Verification

- npx tsc --noEmit: 0 errors (was 9 on main)
- npx vitest run: 52 files / 299 tests passing