### PR TITLE
chore(ci): refresh stale comments in release.yml and deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,8 @@ jobs:
 
   # L0.5 — Post-deploy smoke tests. Runs only after `deploy` succeeds
   # so a failed deploy never reports as a smoke-test failure (the
-  # `needs: deploy` gate plus our `on: push: branches: [main]` trigger
-  # together guarantee this never runs on PRs or forks).
+  # `needs: deploy` gate plus this workflow's `workflow_dispatch`-only
+  # trigger together guarantee this never runs on PRs or forks).
   #
   # Asserts the live app can serve traffic — DO marking the deploy
   # ACTIVE is necessary but not sufficient. See scripts/smoke-test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,14 @@ name: Release
 on:
   push:
     branches: [main]
-    # Only fire when the change might actually warrant a release. Chore /
-    # docs / workflow / dev-tooling commits don't ship to users, so running
-    # semantic-release for them is wasted CI minutes (the no-op release
-    # noise on every merge is what prompted this filter, 2026-05-02).
-    # Mirror deploy.yml's allowlist so the two stay in sync.
+    # Coarse "is this a code or config change" filter. Skips runs for
+    # merges that only touch paths outside the allowlist (root-level docs,
+    # .github scaffolding, infra/terraform, memory snapshots, etc.) so we
+    # don't pay CI minutes to analyze a release that semantic-release
+    # would no-op anyway. This filter is NOT the deploy gate: chore/docs/
+    # refactor commits inside the allowlist still run release.yml, and
+    # the gated `deploy` job below decides whether to ship based on
+    # semantic-release's `new_release_published` output.
     paths:
       - "backend/**"
       - "frontend/**"


### PR DESCRIPTION
## Summary

Follow-up to PR #178. Two workflow comments still described the pre-#178 setup:

- `release.yml:26-30` — claimed the path filter prevented chore commits from running semantic-release. After #178, chore commits inside the path allowlist DO run release.yml and simply no-op on the gated deploy step. The path filter remains useful as a coarse "is this a code or config change" gate so we don't analyze releases on docs-only or infra-terraform-only merges, but its purpose is now narrower than the comment described.
- `deploy.yml:49-52` — referenced an `on: push: branches: [main]` trigger that no longer exists; this workflow is now `workflow_dispatch`-only.

Comment-only change, no behavior impact. Will exercise the new chore-no-deploy path on merge.