### PR TITLE
feat(backend): structured migrate job logging

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -190,7 +190,7 @@ jobs:
     dockerfile_path: backend/Dockerfile
     instance_count: 1
     instance_size_slug: basic-xxs
-    run_command: alembic upgrade head
+    run_command: python /app/scripts/migrate.py
     envs:
       - key: APP_ENV
         scope: RUN_AND_BUILD_TIME

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ frontend/
 
 - **All config via env vars** — pydantic-settings in backend, NEXT_PUBLIC_ prefix in frontend
 - **Stateless backend** — no in-memory state, no filesystem dependencies. Ready for horizontal scaling.
-- **Migrations run on startup** — backend auto-runs `alembic upgrade head` at boot. In production K8s, use an init container instead to avoid races across replicas.
+- **Migrations run on startup** — backend auto-runs `alembic upgrade head` at boot in dev via the FastAPI lifespan. The K8s init container, DO App Platform PRE_DEPLOY job, `docker-compose.prod.yml` migrate service, and `./pfv migrate` all go through the migrate wrapper at `backend/scripts/migrate.py`, which drives alembic per revision and emits structured JSON events (grep `migrate.start`, `migrate.step.start`, `migrate.complete`, `migrate.no_op`, `migrate.failed`).
 - **First user is superadmin** — the first registered user gets `is_superadmin=True` automatically. No seed data needed.
 - **Org-scoped data** — all user data is scoped to an organization. Every query must filter by org_id.
 - **API versioning** — all API routes are prefixed with `/api/v1/`. New routers must use `APIRouter(prefix="/api/v1/{resource}")`. Breaking changes go in `/api/v2/` while v1 stays operational.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,8 +349,10 @@ python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().d
 Migrations run in one of three ways depending on environment:
 
 - **Development** (`./pfv start`): the backend lifespan calls `_run_migrations()` on startup. Convenient for a single-container local stack.
-- **Local prod simulation** (`./pfv prod`): a one-shot `migrate` service defined in `docker-compose.prod.yml` runs `alembic upgrade head` and exits; the backend then starts with `APP_ENV=production` which skips the startup migration.
-- **Production (DO App Platform)**: a dedicated `PRE_DEPLOY` job defined in `.do/app.yaml` runs `alembic upgrade head` before any backend replica starts. The backend skips the startup migration because `APP_ENV=production`. **Operator note:** secrets (especially `DATABASE_URL`) must be configured against the `migrate` job component in the DO console — App Platform does not auto-inherit secrets across components.
+- **Local prod simulation** (`./pfv prod`): a one-shot `migrate` service defined in `docker-compose.prod.yml` runs the migrate wrapper at `/app/scripts/migrate.py` and exits; the backend then starts with `APP_ENV=production` which skips the startup migration.
+- **Production (DO App Platform)**: a dedicated `PRE_DEPLOY` job defined in `.do/app.yaml` runs the migrate wrapper at `/app/scripts/migrate.py` before any backend replica starts. The backend skips the startup migration because `APP_ENV=production`. **Operator note:** secrets (especially `DATABASE_URL`) must be configured against the `migrate` job component in the DO console — App Platform does not auto-inherit secrets across components.
+
+The migrate wrapper (`backend/scripts/migrate.py`) does not replace alembic, it wraps it. Internally it drives `alembic upgrade <revision>` one revision at a time and streams alembic's own stdout and stderr through unchanged, while emitting structured JSON events around each step so a deploy log is triageable on its own. Grep for the event names: `migrate.start`, `migrate.step.start`, `migrate.step.end`, `migrate.complete`, `migrate.no_op`, `migrate.failed`. The wrapper's exit code matches alembic's, so the PRE_DEPLOY gate still blocks deploy on a failed migration.
 
 ```bash
 # Create a new migration

--- a/backend/scripts/migrate.py
+++ b/backend/scripts/migrate.py
@@ -1,0 +1,296 @@
+"""Structured-logging wrapper around `alembic upgrade`.
+
+Goal: an operator triaging a deploy from the logs alone can answer
+"did the migrate job do anything, and if so what?" without re-running it.
+
+Behaviour vs. raw `alembic upgrade head`:
+  * Same exit code (0 on success, alembic's exit code on failure, 1 on
+    pre-flight/safety errors). PRE_DEPLOY contract preserved.
+  * Same stdout / stderr from alembic. We do NOT capture, summarize, or
+    reorder it; alembic's lines stream through unchanged. The only
+    additions are extra structured JSON events emitted by THIS wrapper
+    (via the existing structlog config in app.logging) before / between /
+    after each per-revision subprocess invocation.
+  * Multi-head detection. If ScriptDirectory.get_heads() returns more
+    than one revision we refuse to act and emit migrate.failed with
+    reason="multiple_heads"; alembic's own behaviour ("ambiguous") is
+    surfaced as a structured event instead of a deep stack trace.
+  * Per-step events let an operator see how many revisions ran, in which
+    order, and how long each took.
+
+env.py is intentionally NOT modified; this script drives alembic from the
+outside via the public Python API + subprocess invocation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import threading
+import time
+from typing import IO, Optional
+
+import structlog
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.logging import setup_logging
+
+
+ALEMBIC_INI = "/app/alembic.ini"
+
+
+def _safe_url_fields(database_url: Optional[str]) -> dict[str, str]:
+    """Return a small dict with dialect + database name only.
+
+    NEVER includes username, password, host, or port. If we can't parse
+    the URL we return an empty dict — silent is better than leaking.
+    """
+    if not database_url:
+        return {}
+    try:
+        url = make_url(database_url)
+    except Exception:
+        return {}
+    fields: dict[str, str] = {}
+    if url.get_backend_name():
+        fields["dialect"] = url.get_backend_name()
+    if url.database:
+        fields["database"] = url.database
+    return fields
+
+
+def _resolve_database_url(alembic_cfg: Config) -> Optional[str]:
+    """Mirror env.py's resolution: DATABASE_URL env var wins."""
+    return os.getenv("DATABASE_URL") or alembic_cfg.get_main_option(
+        "sqlalchemy.url"
+    )
+
+
+def _get_current_revision_sync(database_url: str) -> Optional[str]:
+    """Read alembic_version via a short-lived async engine."""
+
+    def _get_rev(connection) -> Optional[str]:
+        ctx = MigrationContext.configure(connection)
+        return ctx.get_current_revision()
+
+    async def _run() -> Optional[str]:
+        engine = create_async_engine(database_url)
+        try:
+            async with engine.connect() as conn:
+                return await conn.run_sync(_get_rev)
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+def _pump_stream(src: IO[str], dst: IO[str]) -> None:
+    """Forward every line from src to dst as it arrives.
+
+    Used to keep alembic's stdout / stderr separate without buffering
+    past line granularity. Flush after each line so log collectors see
+    output as it happens.
+    """
+    try:
+        for line in iter(src.readline, ""):
+            dst.write(line)
+            dst.flush()
+    finally:
+        try:
+            src.close()
+        except Exception:
+            pass
+
+
+def _run_alembic_upgrade(revision: str) -> int:
+    """Run `alembic upgrade <revision>` and stream its output.
+
+    Returns the subprocess return code. stdout -> our stdout, stderr ->
+    our stderr; nothing is captured.
+    """
+    proc = subprocess.Popen(
+        ["alembic", "-c", ALEMBIC_INI, "upgrade", revision],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    # Threaded forwarders keep stdout and stderr from interleaving on a
+    # single pipe; subprocess.communicate would also work but it buffers
+    # until the process exits, which would hide the migration's own
+    # progress lines until completion.
+    stdout_thread = threading.Thread(
+        target=_pump_stream, args=(proc.stdout, sys.stdout), daemon=True
+    )
+    stderr_thread = threading.Thread(
+        target=_pump_stream, args=(proc.stderr, sys.stderr), daemon=True
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    rc = proc.wait()
+    stdout_thread.join()
+    stderr_thread.join()
+    return rc
+
+
+def main() -> int:
+    setup_logging()
+    log = structlog.get_logger("migrate")
+
+    alembic_cfg = Config(ALEMBIC_INI)
+    database_url = _resolve_database_url(alembic_cfg)
+    safe_url = _safe_url_fields(database_url)
+
+    script = ScriptDirectory.from_config(alembic_cfg)
+    heads = list(script.get_heads())
+
+    # Multi-head guard: refuse to pick. One of those branches has to be
+    # merged with `alembic merge` before deploy; auto-picking is exactly
+    # the "silent wrong choice" we want logs to flag.
+    if len(heads) > 1:
+        log.error(
+            "migrate.failed",
+            revision=None,
+            step_index=None,
+            step_count=0,
+            duration_ms=0,
+            returncode=1,
+            reason="multiple_heads",
+            heads=heads,
+            **safe_url,
+        )
+        return 1
+
+    if not heads:
+        # No revisions at all; alembic itself would no-op. Treat as no-op.
+        log.info("migrate.no_op", revision=None, **safe_url)
+        return 0
+
+    head = heads[0]
+
+    if not database_url:
+        # Without a URL we can't read alembic_version; let alembic's own
+        # error handling fire by delegating once.
+        log.error(
+            "migrate.failed",
+            revision=None,
+            step_index=None,
+            step_count=0,
+            duration_ms=0,
+            returncode=1,
+            reason="missing_database_url",
+        )
+        return 1
+
+    try:
+        current = _get_current_revision_sync(database_url)
+    except Exception as exc:
+        # Deliberately log only the exception class, not str(exc): driver
+        # errors routinely embed username/host/port (e.g. pymysql's
+        # "Access denied for user 'foo'@'10.x.x.x'"), which would defeat
+        # the redaction guarantee on the migrate.failed event.
+        log.error(
+            "migrate.failed",
+            revision=None,
+            step_index=None,
+            step_count=0,
+            duration_ms=0,
+            returncode=1,
+            reason="unexpected_exception",
+            error_type=type(exc).__name__,
+            **safe_url,
+        )
+        return 1
+
+    if current == head:
+        log.info("migrate.no_op", revision=head, **safe_url)
+        return 0
+
+    # Pending revisions = everything strictly newer than `current` up to
+    # and including `head`. iterate_revisions(head, current) returns
+    # newest-first and excludes the lower bound, so a reverse gives us
+    # apply order.
+    pending = list(script.iterate_revisions(head, current))
+    pending.reverse()
+    step_count = len(pending)
+
+    log.info(
+        "migrate.start",
+        from_revision=current,
+        to_revision=head,
+        step_count=step_count,
+        **safe_url,
+    )
+
+    overall_start = time.monotonic()
+    applied = 0
+    for index, rev in enumerate(pending, start=1):
+        description = (rev.doc or "").strip() or None
+        log.info(
+            "migrate.step.start",
+            revision=rev.revision,
+            step_index=index,
+            step_count=step_count,
+            description=description,
+        )
+        step_start = time.monotonic()
+        try:
+            rc = _run_alembic_upgrade(rev.revision)
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - step_start) * 1000)
+            # Same redaction concern as the bootstrap-time handler: don't
+            # str(exc) onto the structured event.
+            log.error(
+                "migrate.failed",
+                revision=rev.revision,
+                step_index=index,
+                step_count=step_count,
+                duration_ms=duration_ms,
+                returncode=1,
+                reason="unexpected_exception",
+                error_type=type(exc).__name__,
+            )
+            return 1
+
+        duration_ms = int((time.monotonic() - step_start) * 1000)
+        if rc != 0:
+            log.error(
+                "migrate.failed",
+                revision=rev.revision,
+                step_index=index,
+                step_count=step_count,
+                duration_ms=duration_ms,
+                returncode=rc,
+                reason="alembic_nonzero_exit",
+            )
+            return rc
+
+        log.info(
+            "migrate.step.end",
+            revision=rev.revision,
+            step_index=index,
+            step_count=step_count,
+            duration_ms=duration_ms,
+            returncode=0,
+        )
+        applied += 1
+
+    total_ms = int((time.monotonic() - overall_start) * 1000)
+    log.info(
+        "migrate.complete",
+        from_revision=current,
+        to_revision=head,
+        applied_count=applied,
+        duration_ms=total_ms,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_deploy_workflow.py
+++ b/backend/tests/test_deploy_workflow.py
@@ -68,7 +68,12 @@ def test_deploy_workflow_pushes_app_spec():
 def test_app_spec_declares_predeploy_migrate_job():
     spec = APP_SPEC.read_text()
     assert "kind: PRE_DEPLOY" in spec, "spec must declare PRE_DEPLOY migrate"
-    assert "alembic upgrade head" in spec, "PRE_DEPLOY job must run alembic"
+    # The PRE_DEPLOY job invokes the structured-logging migrate wrapper
+    # (backend/scripts/migrate.py), which drives alembic from outside via
+    # the Python API + per-revision subprocess.
+    assert "scripts/migrate.py" in spec, (
+        "PRE_DEPLOY job must run the migrate wrapper (backend/scripts/migrate.py)"
+    )
 
 
 def test_migrate_job_binds_database_url():

--- a/backend/tests/test_migrate_script.py
+++ b/backend/tests/test_migrate_script.py
@@ -1,0 +1,329 @@
+"""Tests for the structured-logging migrate wrapper.
+
+Unit tests only; no real DB / no real alembic invocation. We mock
+ScriptDirectory, the current-revision lookup, and subprocess.Popen, then
+inspect the structlog events the script emits via testing.LogCapture.
+
+Coverage:
+  * no-op (current == head)
+  * multi-step success (event order, fields, applied_count)
+  * alembic non-zero exit propagation
+  * multi-head detection (no upgrade attempted, exit non-zero)
+  * DB URL redaction (password / host / user never appear in events)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import structlog
+from structlog.testing import LogCapture
+
+from scripts import migrate
+
+
+@pytest.fixture
+def cap_logs():
+    """Reroute structlog through LogCapture; restore on teardown.
+
+    Calling migrate.setup_logging() inside main() reconfigures structlog
+    with the JSON pipeline. We re-configure AFTER setup_logging runs (via
+    a side-effect on the patch) so the capturing processor wins.
+    """
+    capture = LogCapture()
+
+    original_configure = structlog.configure
+
+    def _configure_with_capture(*args: Any, **kwargs: Any) -> None:
+        # Replace processors with the capture so events land in `capture`.
+        structlog.configure(
+            processors=[capture],
+            wrapper_class=structlog.BoundLogger,
+            context_class=dict,
+            logger_factory=structlog.PrintLoggerFactory(),
+            cache_logger_on_first_use=False,
+        )
+
+    # Patch app.logging.setup_logging where the migrate module imports it.
+    with patch.object(migrate, "setup_logging", _configure_with_capture):
+        yield capture
+
+    # Restore default config so other tests aren't affected.
+    structlog.reset_defaults()
+
+
+def _fake_revision(revision: str, doc: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(revision=revision, doc=doc)
+
+
+class _FakeScriptDirectory:
+    def __init__(self, heads: list[str], revisions: list[SimpleNamespace]):
+        self._heads = heads
+        # revisions are in apply order (oldest -> newest); iterate_revisions
+        # returns newest-first, excluding the lower bound.
+        self._revisions = revisions
+
+    def get_heads(self) -> list[str]:
+        return list(self._heads)
+
+    def iterate_revisions(self, upper: str, lower: str | None):
+        revs_newest_first = list(reversed(self._revisions))
+        if lower is None:
+            return iter(revs_newest_first)
+        # Exclude the lower bound (alembic semantics).
+        out: list[SimpleNamespace] = []
+        for r in revs_newest_first:
+            if r.revision == lower:
+                break
+            out.append(r)
+        return iter(out)
+
+
+def _patch_alembic(monkeypatch, *, heads: list[str], revisions: list[SimpleNamespace]):
+    fake = _FakeScriptDirectory(heads=heads, revisions=revisions)
+    monkeypatch.setattr(
+        migrate.ScriptDirectory, "from_config", classmethod(lambda cls, cfg: fake)
+    )
+
+
+def _set_database_url(monkeypatch, url: str | None) -> None:
+    if url is None:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("DATABASE_URL", url)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_op_when_current_equals_head(cap_logs, monkeypatch):
+    revs = [_fake_revision("001"), _fake_revision("002")]
+    _patch_alembic(monkeypatch, heads=["002"], revisions=revs)
+    _set_database_url(monkeypatch, "mysql+aiomysql://u:p@h/dbname")
+
+    monkeypatch.setattr(migrate, "_get_current_revision_sync", lambda url: "002")
+
+    # subprocess must NOT be invoked on a no-op.
+    def _boom(*_a, **_kw):
+        raise AssertionError("subprocess should not be called on no-op")
+
+    monkeypatch.setattr(migrate.subprocess, "Popen", _boom)
+
+    rc = migrate.main()
+    assert rc == 0
+
+    events = [e["event"] for e in cap_logs.entries]
+    assert events == ["migrate.no_op"]
+    entry = cap_logs.entries[0]
+    assert entry["revision"] == "002"
+    assert entry.get("dialect") == "mysql"
+    assert entry.get("database") == "dbname"
+
+
+def test_multi_step_success_emits_full_event_sequence(cap_logs, monkeypatch):
+    revs = [
+        _fake_revision("a", doc="first"),
+        _fake_revision("b", doc="second"),
+        _fake_revision("c", doc="third"),
+    ]
+    _patch_alembic(monkeypatch, heads=["c"], revisions=revs)
+    _set_database_url(monkeypatch, "mysql+aiomysql://u:p@h/dbname")
+    monkeypatch.setattr(migrate, "_get_current_revision_sync", lambda url: "a")
+
+    calls: list[str] = []
+
+    def _fake_run(rev: str) -> int:
+        calls.append(rev)
+        return 0
+
+    monkeypatch.setattr(migrate, "_run_alembic_upgrade", _fake_run)
+
+    rc = migrate.main()
+    assert rc == 0
+
+    # Each pending rev (b, c) was upgraded in order.
+    assert calls == ["b", "c"]
+
+    events = [e["event"] for e in cap_logs.entries]
+    assert events == [
+        "migrate.start",
+        "migrate.step.start",
+        "migrate.step.end",
+        "migrate.step.start",
+        "migrate.step.end",
+        "migrate.complete",
+    ]
+
+    start = cap_logs.entries[0]
+    assert start["from_revision"] == "a"
+    assert start["to_revision"] == "c"
+    assert start["step_count"] == 2
+
+    step1_start = cap_logs.entries[1]
+    assert step1_start["revision"] == "b"
+    assert step1_start["step_index"] == 1
+    assert step1_start["step_count"] == 2
+    assert step1_start["description"] == "second"
+
+    step1_end = cap_logs.entries[2]
+    assert step1_end["revision"] == "b"
+    assert step1_end["step_index"] == 1
+    assert step1_end["returncode"] == 0
+    assert isinstance(step1_end["duration_ms"], int)
+
+    step2_start = cap_logs.entries[3]
+    assert step2_start["revision"] == "c"
+    assert step2_start["step_index"] == 2
+    assert step2_start["description"] == "third"
+
+    complete = cap_logs.entries[5]
+    assert complete["from_revision"] == "a"
+    assert complete["to_revision"] == "c"
+    assert complete["applied_count"] == 2
+    assert isinstance(complete["duration_ms"], int)
+
+
+def test_alembic_nonzero_exit_propagates(cap_logs, monkeypatch):
+    revs = [_fake_revision("a"), _fake_revision("b"), _fake_revision("c")]
+    _patch_alembic(monkeypatch, heads=["c"], revisions=revs)
+    _set_database_url(monkeypatch, "mysql+aiomysql://u:p@h/dbname")
+    monkeypatch.setattr(migrate, "_get_current_revision_sync", lambda url: "a")
+
+    def _fake_run(rev: str) -> int:
+        # Second pending revision fails.
+        return 0 if rev == "b" else 7
+
+    monkeypatch.setattr(migrate, "_run_alembic_upgrade", _fake_run)
+
+    rc = migrate.main()
+    assert rc == 7
+
+    events = [e["event"] for e in cap_logs.entries]
+    assert events == [
+        "migrate.start",
+        "migrate.step.start",  # b
+        "migrate.step.end",  # b
+        "migrate.step.start",  # c
+        "migrate.failed",  # c
+    ]
+    failed = cap_logs.entries[-1]
+    assert failed["revision"] == "c"
+    assert failed["step_index"] == 2
+    assert failed["step_count"] == 2
+    assert failed["returncode"] == 7
+    assert failed["reason"] == "alembic_nonzero_exit"
+    assert isinstance(failed["duration_ms"], int)
+
+
+def test_multi_head_detection_refuses(cap_logs, monkeypatch):
+    revs = [_fake_revision("a"), _fake_revision("b")]
+    _patch_alembic(monkeypatch, heads=["a", "b"], revisions=revs)
+    _set_database_url(monkeypatch, "mysql+aiomysql://u:p@h/dbname")
+
+    # Should not be called.
+    def _boom_url(_url):
+        raise AssertionError(
+            "_get_current_revision_sync should not run on multi-head"
+        )
+
+    def _boom_run(_rev):
+        raise AssertionError(
+            "_run_alembic_upgrade should not run on multi-head"
+        )
+
+    monkeypatch.setattr(migrate, "_get_current_revision_sync", _boom_url)
+    monkeypatch.setattr(migrate, "_run_alembic_upgrade", _boom_run)
+
+    rc = migrate.main()
+    assert rc == 1
+
+    assert len(cap_logs.entries) == 1
+    failed = cap_logs.entries[0]
+    assert failed["event"] == "migrate.failed"
+    assert failed["reason"] == "multiple_heads"
+    assert failed["heads"] == ["a", "b"]
+    assert failed["returncode"] == 1
+
+
+def test_db_url_redaction_no_password_or_host_or_user(cap_logs, monkeypatch):
+    """Sweep every emitted event in every code path to confirm secrets
+    never reach the log stream.
+
+    Tries each major exit path (no-op, success, failure, multi-head) so
+    one regression in any of them shows up here.
+    """
+    secret_url = "mysql+aiomysql://supersecretuser:supersecretpassword@db.internal:3306/dbname"
+    forbidden = [
+        "supersecretuser",
+        "supersecretpassword",
+        "db.internal",
+        ":3306",
+    ]
+
+    def _assert_clean() -> None:
+        for entry in cap_logs.entries:
+            blob = repr(entry)
+            for token in forbidden:
+                assert token not in blob, (
+                    f"forbidden token {token!r} leaked into event: {entry!r}"
+                )
+
+    # 1. no-op path
+    revs = [_fake_revision("001")]
+    _patch_alembic(monkeypatch, heads=["001"], revisions=revs)
+    _set_database_url(monkeypatch, secret_url)
+    monkeypatch.setattr(migrate, "_get_current_revision_sync", lambda url: "001")
+    monkeypatch.setattr(
+        migrate.subprocess,
+        "Popen",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("no subprocess on no-op")
+        ),
+    )
+    assert migrate.main() == 0
+    _assert_clean()
+    cap_logs.entries.clear()
+
+    # 2. success path
+    revs = [_fake_revision("a"), _fake_revision("b")]
+    _patch_alembic(monkeypatch, heads=["b"], revisions=revs)
+    monkeypatch.setattr(migrate, "_get_current_revision_sync", lambda url: "a")
+    monkeypatch.setattr(migrate, "_run_alembic_upgrade", lambda rev: 0)
+    assert migrate.main() == 0
+    _assert_clean()
+    cap_logs.entries.clear()
+
+    # 3. failure path
+    monkeypatch.setattr(migrate, "_run_alembic_upgrade", lambda rev: 5)
+    assert migrate.main() == 5
+    _assert_clean()
+    cap_logs.entries.clear()
+
+    # 4. multi-head path
+    _patch_alembic(monkeypatch, heads=["a", "b"], revisions=revs)
+    assert migrate.main() == 1
+    _assert_clean()
+
+
+def test_safe_url_fields_extracts_only_dialect_and_database():
+    """Direct unit check on the redaction helper."""
+    fields = migrate._safe_url_fields(
+        "mysql+aiomysql://u:p@h:3306/mydb"
+    )
+    assert fields == {"dialect": "mysql", "database": "mydb"}
+
+
+def test_safe_url_fields_returns_empty_on_garbage():
+    assert migrate._safe_url_fields(None) == {}
+    assert migrate._safe_url_fields("") == {}
+    # An unparseable URL should yield {} rather than raising.
+    bad = migrate._safe_url_fields("\x00not a url\x00")
+    assert isinstance(bad, dict)
+    # Critically: nothing leaked.
+    for token in ("not", "a", "url"):
+        assert token not in repr(bad)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,7 +25,7 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-    command: ["alembic", "upgrade", "head"]
+    command: ["python", "/app/scripts/migrate.py"]
     restart: "no"
 
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     volumes:
       - ./backend/app:/app/app
       - ./backend/alembic:/app/alembic
+      - ./backend/scripts:/app/scripts
       - ./backend/tests:/app/tests
       # Read-only mounts so test_deploy_workflow.py can locate
       # repo-root .github/workflows/deploy.yml and .do/app.yaml.

--- a/k8s/templates/backend.yaml
+++ b/k8s/templates/backend.yaml
@@ -21,7 +21,7 @@ spec:
         - name: migrate
           image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag }}"
           imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
-          command: ["alembic", "upgrade", "head"]
+          command: ["python", "/app/scripts/migrate.py"]
           envFrom:
             - secretRef:
                 name: {{ .Release.Name }}-secrets

--- a/pfv
+++ b/pfv
@@ -86,7 +86,7 @@ cmd_reset() {
 }
 
 cmd_migrate() {
-  docker compose exec backend alembic upgrade head
+  docker compose exec backend python /app/scripts/migrate.py
 }
 
 cmd_logs() {


### PR DESCRIPTION
## Why

Today's migrate job log gives an operator nothing actionable. On a no-op deploy it emits two terse alembic info lines (`Context impl MySQLImpl.`, `Will assume non-transactional DDL.`) and stops. On a real upgrade it streams alembic's per-step output, but there's no machine-readable shape, no per-step timing, and no clear top/tail. Triaging "did this deploy actually run a migration, and if so what" from logs alone is harder than it should be.

## What

New `backend/scripts/migrate.py` wrapper that drives alembic from the outside. Approach (Option A): use the alembic Python API to read the current revision and resolve the head, walk pending revisions in apply order, and run each one as `alembic upgrade <revision>` in its own subprocess. Around each step the wrapper emits a structured event via the existing `app.logging.setup_logging()` pipeline so the JSON shape matches the rest of the backend.

Events:
- `migrate.start` (`from_revision`, `to_revision`, `step_count`)
- `migrate.no_op` (`revision`)
- `migrate.step.start` / `migrate.step.end` (`revision`, `step_index`, `step_count`, `description`, `duration_ms`)
- `migrate.complete` (`from_revision`, `to_revision`, `applied_count`, `duration_ms`)
- `migrate.failed` (`reason` is `multiple_heads`, `alembic_nonzero_exit`, `unexpected_exception`, or `missing_database_url`)

All four migrate entrypoints now use the wrapper: `.do/app.yaml` PRE_DEPLOY job, `k8s/templates/backend.yaml` init container, `docker-compose.prod.yml` migrate service, and `./pfv migrate`. The dev compose file gains a `./backend/scripts:/app/scripts` bind mount so `./pfv migrate` picks up changes without a rebuild.

## Preserved by design

- `backend/alembic/env.py` is intentionally untouched.
- When alembic runs, its stdout and stderr stream through unchanged (line-buffered, one forwarder thread per stream). Note: preflight failures (cannot reach DB, bad credentials) are caught by the wrapper before any alembic subprocess is spawned, so on those paths only the structured `migrate.failed` event is emitted; alembic stderr is not the safety net there.
- Exit code matches alembic's when alembic ran, and is `1` on preflight failures, so the PRE_DEPLOY gate still blocks deploy on failure either way.

## Redaction

The DB URL is parsed via `sqlalchemy.engine.url.make_url` and only `dialect` and `database` ever reach the log stream (no user, password, host, port). Driver-side exception strings (which would embed `user@host` for connection errors) are NOT forwarded to events; only the exception class name is logged via `error_type`. A dedicated test sweeps every code path for known forbidden tokens.

## Tests

`backend/tests/test_migrate_script.py` covers no-op, multi-step success with full event ordering, alembic non-zero exit propagation (return code passes through), multi-head detection (refuses to act, exits 1), and DB URL redaction across all four exit paths. Mocks `ScriptDirectory.from_config`, `_get_current_revision_sync`, and `_run_alembic_upgrade` so this stays a fast unit test.

`backend/tests/test_deploy_workflow.py` updated: the existing assertion that the PRE_DEPLOY job runs alembic now checks for `scripts/migrate.py` instead of the literal `alembic upgrade head`.

Full backend suite: `687 passed, 2 skipped` after the change.

## Smoke samples

No-op (dev DB at head):

```
{"event": "Context impl MySQLImpl.", "level": "info", "logger": "alembic.runtime.migration"}
{"event": "Will assume non-transactional DDL.", "level": "info", "logger": "alembic.runtime.migration"}
{"revision": "036_settled_implies_settled_date", "dialect": "mysql", "database": "pfv2", "event": "migrate.no_op", "level": "info", "logger": "migrate"}
```

Multi-step (fresh DB, applying all 36 revisions):

```
{"from_revision": null, "to_revision": "036_settled_implies_settled_date", "step_count": 36, "dialect": "mysql", "database": "pfv2_smoke", "event": "migrate.start", "level": "info", "logger": "migrate"}
{"revision": "001", "step_index": 1, "step_count": 36, "description": "Initial users and organizations", "event": "migrate.step.start", "level": "info", "logger": "migrate"}
INFO  [alembic.runtime.migration] Running upgrade  -> 001, Initial users and organizations
{"revision": "001", "step_index": 1, "step_count": 36, "duration_ms": 276, "returncode": 0, "event": "migrate.step.end", "level": "info", "logger": "migrate"}
... (34 more steps) ...
{"from_revision": null, "to_revision": "036_settled_implies_settled_date", "applied_count": 36, "duration_ms": 9740, "event": "migrate.complete", "level": "info", "logger": "migrate"}
```

Failure (bad credentials):

```
{"revision": null, "step_index": null, "step_count": 0, "duration_ms": 0, "returncode": 1, "reason": "unexpected_exception", "error_type": "OperationalError", "dialect": "mysql", "database": "pfv2", "event": "migrate.failed", "level": "error", "logger": "migrate"}
exit=1
```

## Notes

- This is `feat(backend)` so it deploys via the new release.yml gate when merged.
- The k8s helm chart init container was updated for parity, even though it's not on the active deploy path today.
