### PR TITLE
fix(accounts): keep pending visible when credit card balance is zero

### DIFF
--- a/frontend/components/dashboard/AccountTile.tsx
+++ b/frontend/components/dashboard/AccountTile.tsx
@@ -29,7 +29,7 @@ export default function AccountTilesCard({
           <AccountTileRow
             key={account.id}
             account={account}
-            hasPending={(pendingByAccount[account.id] ?? 0) !== 0}
+            pendingAmount={pendingByAccount[account.id] ?? 0}
           />
         ))}
       </div>
@@ -39,11 +39,16 @@ export default function AccountTilesCard({
 
 export interface AccountTileRowProps {
   account: Account;
-  hasPending: boolean;
+  // Signed pending magnitude for this account (income +, expense -).
+  // The row renders Math.abs() under the balance, so the sign is just
+  // used to compute the magnitude; the row's "Pending: X.XX" copy is
+  // unsigned and matches the accounts-page idiom.
+  pendingAmount: number;
 }
 
-export function AccountTileRow({ account, hasPending }: AccountTileRowProps) {
+export function AccountTileRow({ account, pendingAmount }: AccountTileRowProps) {
   const typeLabel = account.account_type_name ?? null;
+  const hasPending = pendingAmount !== 0;
 
   return (
     <Link
@@ -85,12 +90,28 @@ export function AccountTileRow({ account, hasPending }: AccountTileRowProps) {
           )}
         </div>
       </div>
-      <p
-        className="shrink-0 text-[11px] tabular-nums text-text-muted"
-        aria-label="Current balance, secondary"
-      >
-        {formatAmount(account.balance)}
-      </p>
+      {/* Two-line right column: balance on top, pending magnitude on
+          the second line when non-zero. Pending stays visible
+          regardless of balance, so a paid-off credit card with stored
+          balance 0 still surfaces the committed-but-not-settled amount.
+          Both lines tabular-nums + right-aligned + shrink-0 so digits
+          line up across rows and the column never wraps. */}
+      <div className="flex shrink-0 flex-col items-end gap-0.5">
+        <p
+          className="text-[11px] tabular-nums text-text-muted"
+          aria-label="Current balance, secondary"
+        >
+          {formatAmount(account.balance)}
+        </p>
+        {hasPending && (
+          <p
+            className="text-[10px] tabular-nums text-warning"
+            aria-label="Pending, not yet settled"
+          >
+            Pending: {formatAmount(Math.abs(pendingAmount))}
+          </p>
+        )}
+      </div>
     </Link>
   );
 }

--- a/frontend/tests/components/dashboard/account-tile.test.tsx
+++ b/frontend/tests/components/dashboard/account-tile.test.tsx
@@ -55,7 +55,7 @@ describe("AccountTileRow — identity/status/navigation surface", () => {
     expect(screen.queryByText(/^Primary$/i)).not.toBeInTheDocument();
   });
 
-  it("shows a Pending badge only when hasPending is true", () => {
+  it("shows a Pending badge only when pendingAmount is non-zero", () => {
     const { rerender } = render(
       <AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />,
     );

--- a/frontend/tests/components/dashboard/account-tile.test.tsx
+++ b/frontend/tests/components/dashboard/account-tile.test.tsx
@@ -33,7 +33,7 @@ const SECONDARY_SAVINGS: Account = {
 
 describe("AccountTileRow — identity/status/navigation surface", () => {
   it("renders account name and account-type label", () => {
-    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />);
     // Both the account name and the account-type label are "Checking",
     // so we expect two matches: name (medium-emphasis) + type (muted
     // subtext).
@@ -41,39 +41,73 @@ describe("AccountTileRow — identity/status/navigation surface", () => {
   });
 
   it("renders the currency code", () => {
-    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />);
     expect(screen.getByText(/^EUR$/)).toBeInTheDocument();
   });
 
   it("shows the Primary badge on the default account, not on others", () => {
     const { rerender } = render(
-      <AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />,
+      <AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />,
     );
     expect(screen.getByText(/^Primary$/i)).toBeInTheDocument();
 
-    rerender(<AccountTileRow account={SECONDARY_SAVINGS} hasPending={false} />);
+    rerender(<AccountTileRow account={SECONDARY_SAVINGS} pendingAmount={0} />);
     expect(screen.queryByText(/^Primary$/i)).not.toBeInTheDocument();
   });
 
   it("shows a Pending badge only when hasPending is true", () => {
     const { rerender } = render(
-      <AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />,
+      <AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />,
     );
     expect(screen.queryByText(/^Pending$/i)).not.toBeInTheDocument();
 
-    rerender(<AccountTileRow account={PRIMARY_CHECKING} hasPending={true} />);
+    rerender(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={-50} />);
     expect(screen.getByText(/^Pending$/i)).toBeInTheDocument();
   });
 
+  // L3.4 (visibility): a credit card whose stored balance has been paid
+  // down to 0 but still has unsettled charges must surface the pending
+  // magnitude on the dashboard tile. Pre-fix the tile only flashed a
+  // small "Pending" pill with no number; the user lost sight of money
+  // that's still legitimately committed.
+  it("renders the pending magnitude alongside balance when balance is zero", () => {
+    const PAID_OFF_CC: Account = {
+      ...PRIMARY_CHECKING,
+      id: 99,
+      name: "Amex Primary",
+      account_type_name: "Credit Card",
+      account_type_slug: "credit_card",
+      balance: 0 as unknown as number,
+      is_default: false,
+    };
+    render(<AccountTileRow account={PAID_OFF_CC} pendingAmount={-150} />);
+    // Balance is still rendered (0.00), AND the pending magnitude is
+    // visible. Sign of pendingAmount drops out (Math.abs); the copy is
+    // unsigned, matching the accounts-page "Pending: 150.00" idiom.
+    expect(screen.getByText(/^0\.00$/)).toBeInTheDocument();
+    expect(screen.getByText(/Pending: 150\.00/)).toBeInTheDocument();
+  });
+
+  it("does NOT render the pending magnitude when pending is zero", () => {
+    render(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />);
+    expect(screen.queryByText(/Pending:/)).not.toBeInTheDocument();
+  });
+
+  it("renders pending magnitude alongside non-zero balance (positive case)", () => {
+    render(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={-200} />);
+    expect(screen.getByText(/1,000\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/Pending: 200\.00/)).toBeInTheDocument();
+  });
+
   it("renders as a link to /accounts (click-through navigation)", () => {
-    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />);
     const link = screen.getByTestId("account-tile");
     expect(link.tagName).toBe("A");
     expect(link).toHaveAttribute("href", "/accounts");
   });
 
   it("balance text is muted (forecast card is the numeric authority, tile is secondary)", () => {
-    render(<AccountTileRow account={PRIMARY_CHECKING} hasPending={false} />);
+    render(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />);
     // 1,000.00 appears, but as small muted secondary text — not the
     // primary visual anchor of the tile.
     const balance = screen.getByText(/1,000\.00/);


### PR DESCRIPTION
## Symptom

When a credit-card account's stored balance reaches 0 (the card has been paid off), pending charges that haven't yet settled vanish from the dashboard. The user loses sight of money that's still legitimately committed.

Repro: pay off a CC so its stored balance is 0. Add (or import) a pending charge on the same card. Open /dashboard. Pre-fix the per-account tile shows "0.00" and a tiny "Pending" pill, but no magnitude. The dollars-and-cents amount only shows up if the user navigates to /accounts or to the right-side Forecast card (and the latter only renders for the current period).

## What changed

Frontend-only. The dashboard's per-account tile (`AccountTile.tsx`) now renders the pending magnitude on a second line under the balance, formatted as "Pending: X.XX" (matching the accounts page idiom and the warning color token already used elsewhere). The pill in the meta line stays as a visual indicator; the magnitude line is the unambiguous truth.

The `AccountTileRow` prop changed from a `hasPending: boolean` to a signed `pendingAmount: number`. The row uses `Math.abs()` to render the magnitude, so the income-positive / expense-negative convention drops out of the copy.

## What did NOT change

- `Account.balance` math, transaction settlement timing, reconciliation, or how transactions affect stored balance.
- The canonical pending sources (`compute_account_balance_forecast` service and the dashboard's existing all-time pending-status fetch).
- Forecast service core logic.
- Manual-balance-adjustment plumbing.
- Any backend route, schema, or model.

## Affected surfaces

- **Dashboard** (`/dashboard`): the per-account tile now shows pending magnitude when non-zero, regardless of balance.
- **Accounts** (`/accounts`): already correct (covered by `accounts-pending-visibility.test.tsx` from the earlier L3.4 work). Verified end-to-end; no change needed on this surface.

## Tests

- `frontend/tests/components/dashboard/account-tile.test.tsx`: three new cases.
  - "renders the pending magnitude alongside balance when balance is zero" (the exact L3.4 scenario, asserts both `0.00` and `Pending: 150.00` are visible).
  - "does NOT render the pending magnitude when pending is zero" (zero-zero handled, no redundant `Pending: 0.00`).
  - "renders pending magnitude alongside non-zero balance (positive case)" (balance + pending coexist).
- Existing `account-tile.test.tsx` cases updated to the new prop shape (`pendingAmount` replaces `hasPending`).
- All 299 frontend tests pass; backend `test_account_balance_forecast_service.py` still passes (no backend change).