### PR TITLE
chore(transactions): align pending pill color with dashboard

### DIFF
--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1084,7 +1084,7 @@ function TransactionsPageContent() {
                           <span className="col-span-1 text-sm text-text-secondary truncate">{tx.category_name}</span>
                           <span className="col-span-1 text-center">
                             {isTransfer ? (
-                              <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                              <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-warning-dim text-warning"}`}>
                                 {tx.status}
                               </span>
                             ) : (
@@ -1099,7 +1099,7 @@ function TransactionsPageContent() {
                                   className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
                                     tx.status === "settled"
                                       ? "bg-success-dim text-success"
-                                      : "bg-surface-overlay text-text-muted"
+                                      : "bg-warning-dim text-warning"
                                   }`}
                                 >
                                   {tx.status}
@@ -1308,7 +1308,7 @@ function TransactionsPageContent() {
                               </div>
                             )}
                             {isTransfer ? (
-                              <span className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-surface-overlay text-text-muted"}`}>
+                              <span className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-warning-dim text-warning"}`}>
                                 {tx.status}
                               </span>
                             ) : (
@@ -1323,7 +1323,7 @@ function TransactionsPageContent() {
                                   className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
                                     tx.status === "settled"
                                       ? "bg-success-dim text-success"
-                                      : "bg-surface-overlay text-text-muted"
+                                      : "bg-warning-dim text-warning"
                                   }`}
                                 >
                                   {tx.status}


### PR DESCRIPTION
## Summary

The pending status pill on `/transactions` (both desktop row and mobile card, transfer and non-transfer variants) used `bg-surface-overlay text-text-muted`, which renders as faded gray. The dashboard's `AccountTile` pending pill uses `bg-warning-dim text-warning`, which actually reads as a state. Standardizing on the dashboard token so pending is consistent across surfaces.

Touched: `frontend/app/transactions/page.tsx` (4 occurrences, single token swap).

Settled pill (`bg-success-dim text-success`) untouched. No tests changed; the existing 24 transactions tests all pass.