### PR TITLE
chore(import): surface expected CSV format before upload

### DIFF
--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -9,6 +9,7 @@ import AppShell from "@/components/AppShell";
 import CategorySelect from "@/components/ui/CategorySelect";
 import Spinner from "@/components/ui/Spinner";
 import ImportMarkAsTransferModal from "@/components/transactions/ImportMarkAsTransferModal";
+import CsvFormatHelp from "@/components/import/CsvFormatHelp";
 import { input, label, btnPrimary, btnSecondary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
 import type {
   Account,
@@ -337,6 +338,11 @@ function ImportPageContent() {
             Go to Categories
           </Link>
         </div>
+      )}
+
+      {/* ── Expected file format help ────────────────────────────────── */}
+      {step === "upload" && categories && categories.length > 0 && (
+        <CsvFormatHelp />
       )}
 
       {/* ── Step 1: Upload ──────────────────────────────────────────────── */}

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -340,7 +340,6 @@ function ImportPageContent() {
         </div>
       )}
 
-      {/* ── Expected file format help ────────────────────────────────── */}
       {step === "upload" && categories && categories.length > 0 && (
         <CsvFormatHelp />
       )}

--- a/frontend/components/import/CsvFormatHelp.tsx
+++ b/frontend/components/import/CsvFormatHelp.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { btnLink, btnSecondary, card } from "@/lib/styles";
+
+/**
+ * Pre-upload disclosure that surfaces what the importer actually accepts,
+ * so users do not discover format mismatches mid-flow.
+ *
+ * Source of truth for the copy below is backend/app/services/import_parser.py:
+ *   - Auto-detects ; or , as the delimiter (semicolon checked first because
+ *     ING NL exports use it and may carry commas inside quoted fields).
+ *   - Required header columns: Date, Name / Description, Debit/credit,
+ *     Amount (EUR). Optional: Counterparty, Transaction type, Account,
+ *     Code, Notifications, Resulting balance, Tag.
+ *   - Date format: 8-digit YYYYMMDD (e.g. 20260406).
+ *   - Amount format: European, comma decimal separator, optional period
+ *     thousands separator. Sign is encoded by the Debit/credit column,
+ *     not by a leading minus.
+ *   - Encoding: UTF-8. A leading BOM is tolerated.
+ *
+ * Other locales (US "." decimal, ISO dates, different headers) are not
+ * supported yet — see project_localized_import_intelligence.md.
+ */
+
+const SAMPLE_CSV =
+  '"Date";"Name / Description";"Account";"Counterparty";"Code";"Debit/credit";"Amount (EUR)";"Transaction type";"Notifications"\n' +
+  '"20260406";"Albert Heijn 1234";"NL00BANK0000000000";"NL00ALBE0000000000";"BA";"Debit";"42,17";"Payment terminal";"Pasvolgnr: 001"\n' +
+  '"20260405";"Salary Acme BV";"NL00BANK0000000000";"NL00ACME0000000000";"OV";"Credit";"3.250,00";"Online Banking";"Salary March"\n' +
+  '"20260404";"Spotify";"NL00BANK0000000000";"NL00SPOT0000000000";"ID";"Debit";"10,99";"iDEAL";"Subscription"\n';
+
+function downloadSample() {
+  const blob = new Blob([SAMPLE_CSV], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "pfv-import-example.csv";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export default function CsvFormatHelp() {
+  const [showExample, setShowExample] = useState(false);
+
+  return (
+    <>
+      <details className={`${card} group`}>
+        <summary
+          className="flex cursor-pointer list-none items-center justify-between gap-3 px-6 py-4 text-sm font-medium text-text-primary"
+          aria-label="Toggle expected file format help"
+        >
+          <span className="flex items-center gap-2">
+            <span aria-hidden className="text-text-muted">[?]</span>
+            Expected file format
+          </span>
+          <span className="text-xs uppercase tracking-wider text-text-muted group-open:hidden">
+            Show
+          </span>
+          <span className="hidden text-xs uppercase tracking-wider text-text-muted group-open:inline">
+            Hide
+          </span>
+        </summary>
+
+        <div className="space-y-3 border-t border-border px-6 py-4 text-sm text-text-secondary">
+          <p>
+            The importer currently accepts ING-style CSV exports.
+            Files are parsed in memory and previewed before any
+            transaction is written.
+          </p>
+
+          <dl className="grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-[max-content_1fr]">
+            <dt className="font-semibold text-text-primary">Delimiters</dt>
+            <dd>
+              Semicolon (<code>;</code>) or comma (<code>,</code>). Auto-detected
+              from the header line.
+            </dd>
+
+            <dt className="font-semibold text-text-primary">Required headers</dt>
+            <dd>
+              <code>Date</code>, <code>Name / Description</code>,
+              {" "}<code>Debit/credit</code>, <code>Amount (EUR)</code>.
+            </dd>
+
+            <dt className="font-semibold text-text-primary">Optional headers</dt>
+            <dd>
+              <code>Counterparty</code>, <code>Transaction type</code>,
+              {" "}<code>Account</code>, <code>Code</code>,
+              {" "}<code>Notifications</code>, <code>Resulting balance</code>,
+              {" "}<code>Tag</code>.
+            </dd>
+
+            <dt className="font-semibold text-text-primary">Date format</dt>
+            <dd>
+              <code>YYYYMMDD</code> with no separators (for example
+              {" "}<code>20260406</code> for 6 April 2026).
+            </dd>
+
+            <dt className="font-semibold text-text-primary">Decimal format</dt>
+            <dd>
+              European: comma is the decimal separator, period is an optional
+              thousands separator (for example <code>1.234,56</code>). The sign
+              comes from <code>Debit/credit</code>, so amounts stay positive.
+            </dd>
+
+            <dt className="font-semibold text-text-primary">Encoding</dt>
+            <dd>UTF-8. A leading byte order mark (BOM) is accepted.</dd>
+          </dl>
+
+          <div className="flex flex-wrap items-center gap-3 pt-2">
+            <button
+              type="button"
+              onClick={downloadSample}
+              className={btnSecondary}
+            >
+              Download example CSV
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowExample(true)}
+              className={btnLink}
+            >
+              View example
+            </button>
+          </div>
+
+          <p className="pt-1 text-xs text-text-muted">
+            Other formats (US decimal point, ISO dates, locale-specific bank
+            exports) are coming soon as part of the localized-import work.
+          </p>
+        </div>
+      </details>
+
+      {showExample && (
+        <CsvExampleModal onClose={() => setShowExample(false)} />
+      )}
+    </>
+  );
+}
+
+function CsvExampleModal({ onClose }: { onClose: () => void }) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    closeRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="csv-example-title"
+        className={`${card} w-full max-w-2xl p-6 shadow-xl`}
+      >
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <h2
+            id="csv-example-title"
+            className="text-lg font-semibold text-text-primary"
+          >
+            Example CSV (3 rows)
+          </h2>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            className={btnSecondary}
+            aria-label="Close example"
+          >
+            Close
+          </button>
+        </div>
+
+        <p className="mb-3 text-sm text-text-secondary">
+          Semicolon-delimited, UTF-8, European decimals, YYYYMMDD dates.
+          Quotes around values are optional, and the importer trims them.
+        </p>
+
+        <pre className="max-h-72 overflow-auto rounded-md border border-border bg-surface-raised p-3 text-xs text-text-primary">
+          <code>{SAMPLE_CSV}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/import/CsvFormatHelp.tsx
+++ b/frontend/components/import/CsvFormatHelp.tsx
@@ -20,7 +20,7 @@ import { btnLink, btnSecondary, card } from "@/lib/styles";
  *   - Encoding: UTF-8. A leading BOM is tolerated.
  *
  * Other locales (US "." decimal, ISO dates, different headers) are not
- * supported yet — see project_localized_import_intelligence.md.
+ * supported yet (see project_localized_import_intelligence.md).
  */
 
 const SAMPLE_CSV =

--- a/frontend/tests/components/csv-format-help.test.tsx
+++ b/frontend/tests/components/csv-format-help.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * Direct coverage for the pre-upload CsvFormatHelp disclosure.
+ *
+ * The component pulls double duty on the import page: a collapsed
+ * <details> summary with the full required/optional header list and
+ * format rules, plus an in-page "View example" modal and a
+ * "Download example CSV" Blob action. Each of those surfaces is
+ * exercised here so a regression in copy or wiring fails loudly.
+ *
+ * Source of truth for asserted strings is the component itself
+ * (frontend/components/import/CsvFormatHelp.tsx). The required and
+ * optional header sets must stay aligned with the parser at
+ * backend/app/services/import_parser.py.
+ */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import CsvFormatHelp from "@/components/import/CsvFormatHelp";
+
+describe("CsvFormatHelp", () => {
+  beforeEach(() => {
+    // The download path uses URL.createObjectURL / revokeObjectURL, which
+    // jsdom does not implement. Stub them so we can assert the call sites
+    // without crashing.
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => "blob:mock-url"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+
+    // The download path also calls anchor.click(), which jsdom tries to
+    // resolve as a navigation. We don't care about the navigation in this
+    // test, so no-op the prototype click to keep stderr clean. Restored
+    // by vi.restoreAllMocks() in afterEach.
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the disclosure collapsed by default with the body hidden", () => {
+    render(<CsvFormatHelp />);
+
+    // Summary is always present.
+    const summary = screen.getByText("Expected file format");
+    expect(summary).toBeInTheDocument();
+
+    // The wrapping <details> must NOT be open initially.
+    const details = summary.closest("details");
+    expect(details).not.toBeNull();
+    expect(details!.hasAttribute("open")).toBe(false);
+
+    // Show/Hide labels: only "Show" should be the visible state. Both
+    // labels live in the DOM (CSS toggles them via group-open:hidden), so
+    // we assert on the open attribute rather than visibility classes.
+    expect(screen.getByText("Show")).toBeInTheDocument();
+    expect(screen.getByText("Hide")).toBeInTheDocument();
+  });
+
+  it("reveals the full format details once the disclosure is opened", () => {
+    render(<CsvFormatHelp />);
+
+    const details = screen.getByText("Expected file format").closest("details")!;
+    // jsdom doesn't auto-open <details> on summary click in every version,
+    // so set the attribute directly to mimic an expanded panel. The body
+    // is rendered regardless; what we're asserting is that the copy is in
+    // the DOM and reachable.
+    details.setAttribute("open", "");
+
+    // Intro line.
+    expect(
+      screen.getByText(/importer currently accepts ING-style CSV exports/i),
+    ).toBeInTheDocument();
+
+    // Definition list labels.
+    expect(screen.getByText("Delimiters")).toBeInTheDocument();
+    expect(screen.getByText("Required headers")).toBeInTheDocument();
+    expect(screen.getByText("Optional headers")).toBeInTheDocument();
+    expect(screen.getByText("Date format")).toBeInTheDocument();
+    expect(screen.getByText("Decimal format")).toBeInTheDocument();
+    expect(screen.getByText("Encoding")).toBeInTheDocument();
+
+    // Date format value (YYYYMMDD with no separators).
+    expect(screen.getByText(/no separators/i)).toBeInTheDocument();
+    expect(screen.getByText("20260406")).toBeInTheDocument();
+
+    // Decimal rule mentions European comma decimal and the Debit/credit sign.
+    expect(
+      screen.getByText(/comma is the decimal separator/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1.234,56")).toBeInTheDocument();
+
+    // Encoding line mentions UTF-8 and BOM tolerance.
+    expect(
+      screen.getByText(/UTF-8\. A leading byte order mark/i),
+    ).toBeInTheDocument();
+  });
+
+  it("lists every required parser header inside the disclosure body", () => {
+    render(<CsvFormatHelp />);
+    screen
+      .getByText("Expected file format")
+      .closest("details")!
+      .setAttribute("open", "");
+
+    // Required headers from import_parser.py: Date, Name / Description,
+    // Debit/credit, Amount (EUR). Each appears as a <code> element inside
+    // the Required headers <dd>.
+    const requiredDt = screen.getByText("Required headers");
+    const requiredDd = requiredDt.nextElementSibling as HTMLElement;
+    expect(requiredDd).not.toBeNull();
+    const requiredText = requiredDd.textContent ?? "";
+    expect(requiredText).toContain("Date");
+    expect(requiredText).toContain("Name / Description");
+    expect(requiredText).toContain("Debit/credit");
+    expect(requiredText).toContain("Amount (EUR)");
+  });
+
+  it("lists every optional parser header inside the disclosure body", () => {
+    render(<CsvFormatHelp />);
+    screen
+      .getByText("Expected file format")
+      .closest("details")!
+      .setAttribute("open", "");
+
+    const optionalDt = screen.getByText("Optional headers");
+    const optionalDd = optionalDt.nextElementSibling as HTMLElement;
+    expect(optionalDd).not.toBeNull();
+    const optionalText = optionalDd.textContent ?? "";
+
+    // Optional headers from import_parser.py.
+    for (const header of [
+      "Counterparty",
+      "Transaction type",
+      "Account",
+      "Code",
+      "Notifications",
+      "Resulting balance",
+      "Tag",
+    ]) {
+      expect(optionalText).toContain(header);
+    }
+  });
+
+  it("downloads a sample CSV via a Blob URL when 'Download example CSV' is clicked", () => {
+    const createSpy = vi.spyOn(URL, "createObjectURL");
+    const revokeSpy = vi.spyOn(URL, "revokeObjectURL");
+
+    render(<CsvFormatHelp />);
+
+    const downloadBtn = screen.getByRole("button", {
+      name: /download example csv/i,
+    });
+    fireEvent.click(downloadBtn);
+
+    // The handler builds a Blob, hands it to createObjectURL, simulates a
+    // click on a synthetic anchor, then revokes the URL. We assert both
+    // sides of the lifecycle to catch leaks if a future refactor drops
+    // revokeObjectURL.
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const blobArg = createSpy.mock.calls[0][0] as Blob;
+    expect(blobArg).toBeInstanceOf(Blob);
+    expect(blobArg.type).toContain("text/csv");
+
+    expect(revokeSpy).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("opens the example modal on 'View example' and renders the 3-row sample", () => {
+    render(<CsvFormatHelp />);
+
+    // No modal until the user clicks View example.
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /view example/i }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(
+      screen.getByRole("heading", { name: /example csv \(3 rows\)/i }),
+    ).toBeInTheDocument();
+
+    // The three sample rows render inside a <pre><code> block. We don't
+    // care about whitespace, only that each merchant from SAMPLE_CSV is
+    // present so the user sees a realistic preview.
+    const code = dialog.querySelector("code");
+    expect(code).not.toBeNull();
+    const sampleText = code!.textContent ?? "";
+    expect(sampleText).toContain("Albert Heijn 1234");
+    expect(sampleText).toContain("Salary Acme BV");
+    expect(sampleText).toContain("Spotify");
+
+    // And the format hint paragraph is present.
+    expect(
+      screen.getByText(/semicolon-delimited, utf-8, european decimals/i),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the example modal when the Close button is clicked", () => {
+    render(<CsvFormatHelp />);
+
+    fireEvent.click(screen.getByRole("button", { name: /view example/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /close example/i }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes the example modal on Escape", () => {
+    render(<CsvFormatHelp />);
+
+    fireEvent.click(screen.getByRole("button", { name: /view example/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes the example modal when clicking the backdrop", () => {
+    render(<CsvFormatHelp />);
+
+    fireEvent.click(screen.getByRole("button", { name: /view example/i }));
+    const dialog = screen.getByRole("dialog");
+    // Backdrop is the dialog's parent (the fixed inset-0 wrapper). The
+    // component only closes when the click target equals currentTarget,
+    // so click the wrapper directly.
+    const backdrop = dialog.parentElement as HTMLElement;
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Today the only way to learn what the CSV importer accepts is to upload a file, get a parse error, read the toast, and adjust. The expected delimiter, header row, date format, and decimal style are nowhere on the page before that round trip.

## Implementation

- New `frontend/components/import/CsvFormatHelp.tsx` component: a `<details>` disclosure styled as the existing `card`, rendered above Step 1 of the import flow. The summary row shows "Expected file format" with a Show / Hide pill.
- Body of the disclosure lists, in a definition list:
  - Delimiters: semicolon or comma, auto-detected from the header line.
  - Required headers: `Date`, `Name / Description`, `Debit/credit`, `Amount (EUR)`.
  - Optional headers: `Counterparty`, `Transaction type`, `Account`, `Code`, `Notifications`, `Resulting balance`, `Tag`.
  - Date format: `YYYYMMDD` with no separators.
  - Decimal format: European, comma decimal separator, optional period thousands separator. Sign comes from the `Debit/credit` column.
  - Encoding: UTF-8, BOM tolerated.
- Two affordances at the bottom: `Download example CSV` (creates an in-memory Blob with three sample rows and triggers a browser download) and `View example` (opens a small modal with the same rows shown as preformatted text).
- Footer line flags that other locales (US decimal point, ISO dates, locale-specific bank exports) are coming as part of the localized-import track.
- All copy was derived from `backend/app/services/import_parser.py`, not from spec or memory, so it tracks parser truth.

## Files changed

- `frontend/app/import/page.tsx`: import the new component, render it above the upload card on the upload step.
- `frontend/components/import/CsvFormatHelp.tsx`: new component (collapsible disclosure plus example modal).

## Tests run

- `npx tsc --noEmit`: clean (run inside an isolated container scoped to this worktree).
- `npx vitest run tests/app/import-page.test.tsx`: 13 / 13 passing. The new component renders only on the upload step and is purely additive, so existing tests keep passing without modification.

No copy-only changes here. Component is small enough that the regression surface is the import-page test plus type-check.

## Screenshot

Captured against an isolated Next dev server bound to this worktree. The main `localhost` stack is bind-mounted from `/Users/fjorge/src/pfv` and would not have shown the new component.

- Collapsed: `/Users/fjorge/src/pfv/.claude/worktrees/agent-ab01a816f1793795f/.pr-screenshots/csv-format-help-collapsed.png`
- Expanded: `/Users/fjorge/src/pfv/.claude/worktrees/agent-ab01a816f1793795f/.pr-screenshots/csv-format-help-expanded.png`
- Example modal: `/Users/fjorge/src/pfv/.claude/worktrees/agent-ab01a816f1793795f/.pr-screenshots/csv-format-help-modal.png`

## Internal reviewers

@flamarion

External review required before merge.
