### PR TITLE
fix(transactions): pending pill opacity, recurring duplicate guard, period filter verification

### DIFF
--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -101,14 +101,18 @@ class PromoteToRecurringRequest(BaseModel):
     transaction.recurring_id to the new template).
 
     Account, category, amount, type, and description come from the source
-    transaction. Out of scope: promoting transfer legs, demoting, editing
-    the new template's auto_settle (defaults False — match recurring create).
+    transaction. ``auto_settle`` is optional and defaults to False to match
+    the standalone recurring-create flow; the create-transaction-with-repeat
+    UI passes it through so the user's choice is preserved without needing
+    a separate POST /recurring round-trip. Out of scope: promoting transfer
+    legs, demoting.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     frequency: Literal["weekly", "biweekly", "monthly", "quarterly", "yearly"]
     next_due_date: datetime.date
+    auto_settle: bool = False
 
     @field_validator("next_due_date")
     @classmethod

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -613,7 +613,7 @@ async def promote_to_recurring(
             type=tx.type.value,
             frequency=Frequency(body.frequency),
             next_due_date=body.next_due_date,
-            auto_settle=False,
+            auto_settle=body.auto_settle,
             is_active=True,
         )
         db.add(template)

--- a/backend/tests/routers/test_transactions_promote_to_recurring.py
+++ b/backend/tests/routers/test_transactions_promote_to_recurring.py
@@ -232,6 +232,9 @@ async def test_promote_to_recurring_happy_path(session_factory):
 
 @pytest.mark.asyncio
 async def test_promote_to_recurring_rejects_extra_fields(session_factory):
+    """``auto_settle`` is now an accepted field (frontend create-with-repeat
+    forwards the user's toggle). Anything else still gets rejected by
+    `model_config = ConfigDict(extra="forbid")`."""
     seed = await _seed(session_factory)
     tx_id = await _add_tx(
         session_factory,
@@ -246,7 +249,7 @@ async def test_promote_to_recurring_rejects_extra_fields(session_factory):
             json={
                 "frequency": "monthly",
                 "next_due_date": _future_date(),
-                "auto_settle": True,
+                "is_active": False,  # not part of the schema
             },
         )
     assert res.status_code == 422
@@ -374,3 +377,139 @@ async def test_promote_to_recurring_rejects_already_promoted(session_factory):
         )
     assert res.status_code == 400
     assert "already" in res.json()["detail"].lower()
+
+
+# ── round-trip: promote → edit → re-promote rejected ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_promote_then_edit_then_repromote_rejected(session_factory):
+    """Reproduces the punch-list ITEM 1 bug from the API side.
+
+    Scenario:
+      1. Caller has an existing tx
+      2. POST /promote-to-recurring → tx.recurring_id is set, template A created
+      3. PUT /transactions/{id} (edit description) → recurring_id MUST persist
+      4. POST /promote-to-recurring again → MUST 400 (no template B)
+
+    Pre-fix the frontend create flow side-stepped this guard by creating an
+    independent /recurring template on the create form (never linking the
+    source tx via recurring_id). When the user later edited and re-toggled
+    "Make recurring", the row's recurring_id was still NULL so promote
+    succeeded — yielding two templates. This API-level test pins the
+    backend invariant; the create-flow fix lives in the frontend.
+    """
+    seed = await _seed(session_factory)
+    tx_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"],
+        amount=Decimal("12.50"), description="Initial",
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        # Step 1: promote
+        first = client.post(
+            f"/api/v1/transactions/{tx_id}/promote-to-recurring",
+            json={"frequency": "monthly", "next_due_date": _future_date()},
+        )
+        assert first.status_code == 201, first.text
+        first_template_id = first.json()["recurring_id"]
+        assert first_template_id is not None
+
+        # Step 2: edit description (a routine PUT). recurring_id must NOT
+        # be cleared by update_transaction.
+        edited = client.put(
+            f"/api/v1/transactions/{tx_id}",
+            json={"description": "Renamed"},
+        )
+        assert edited.status_code == 200, edited.text
+        assert edited.json()["recurring_id"] == first_template_id
+
+        # Step 3: re-promote MUST 400
+        second = client.post(
+            f"/api/v1/transactions/{tx_id}/promote-to-recurring",
+            json={"frequency": "monthly", "next_due_date": _future_date()},
+        )
+    assert second.status_code == 400
+    assert "already" in second.json()["detail"].lower()
+
+    # And only ONE template exists for this tx.
+    async with session_factory() as db:
+        from sqlalchemy import select as _select
+        rows = (
+            await db.execute(
+                _select(RecurringTransaction).where(
+                    RecurringTransaction.org_id == seed["org_id"]
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].id == first_template_id
+
+
+# ── auto_settle pass-through (create-with-recurring frontend fix) ─────────
+
+
+@pytest.mark.asyncio
+async def test_promote_to_recurring_passes_auto_settle_true(session_factory):
+    """Frontend create-with-recurring sends auto_settle so the user's
+    "Auto-settle" toggle on the create form survives the round-trip."""
+    seed = await _seed(session_factory)
+    tx_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"],
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/transactions/{tx_id}/promote-to-recurring",
+            json={
+                "frequency": "monthly",
+                "next_due_date": _future_date(),
+                "auto_settle": True,
+            },
+        )
+    assert res.status_code == 201, res.text
+    rec_id = res.json()["recurring_id"]
+    assert rec_id is not None
+
+    async with session_factory() as db:
+        from sqlalchemy import select as _select
+        rec = await db.scalar(
+            _select(RecurringTransaction).where(RecurringTransaction.id == rec_id)
+        )
+    assert rec is not None
+    assert rec.auto_settle is True
+
+
+@pytest.mark.asyncio
+async def test_promote_to_recurring_auto_settle_defaults_false(session_factory):
+    """Omitting auto_settle keeps the historical default (matches the edit
+    flow's promote which doesn't surface the toggle)."""
+    seed = await _seed(session_factory)
+    tx_id = await _add_tx(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["a1_id"],
+        category_id=seed["cat_groceries_id"],
+    )
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            f"/api/v1/transactions/{tx_id}/promote-to-recurring",
+            json={"frequency": "monthly", "next_due_date": _future_date()},
+        )
+    assert res.status_code == 201, res.text
+    rec_id = res.json()["recurring_id"]
+
+    async with session_factory() as db:
+        from sqlalchemy import select as _select
+        rec = await db.scalar(
+            _select(RecurringTransaction).where(RecurringTransaction.id == rec_id)
+        )
+    assert rec is not None
+    assert rec.auto_settle is False

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -231,7 +231,7 @@ function TransactionsPageContent() {
           }),
         });
       } else {
-        await apiFetch("/api/v1/transactions", {
+        const created = await apiFetch<Transaction>("/api/v1/transactions", {
           method: "POST",
           body: JSON.stringify({
             account_id: formAccountId,
@@ -243,21 +243,30 @@ function TransactionsPageContent() {
             date: formDate,
           }),
         });
-        // Create recurring template if repeat is enabled
-        if (formRecurring && formMode === "transaction") {
-          await apiFetch("/api/v1/recurring", {
-            method: "POST",
-            body: JSON.stringify({
-              account_id: formAccountId,
-              category_id: formCategoryId,
-              description: formDescription,
-              amount: formAmount,
-              type: formType,
-              frequency: formFrequency,
-              next_due_date: formDate,
-              auto_settle: formAutoSettle,
-            }),
-          });
+        // Promote the new tx to recurring if repeat is enabled. Using
+        // promote-to-recurring (vs a separate POST /recurring) sets
+        // tx.recurring_id on the source transaction so a subsequent edit
+        // shows the "Recurring" chip — preventing the duplicate-template
+        // bug where re-toggling "Make recurring" on edit would create a
+        // second template because the source row stayed unlinked.
+        if (formRecurring && formMode === "transaction" && created?.id) {
+          // next_due_date must be today-or-later (server-side guard).
+          // The Date input is already constrained to today via min=,
+          // but defensively bump back-dated rows to today so the user's
+          // tx still saves cleanly.
+          const today = todayISO();
+          const nextDue = formDate < today ? today : formDate;
+          await apiFetch<Transaction>(
+            `/api/v1/transactions/${created.id}/promote-to-recurring`,
+            {
+              method: "POST",
+              body: JSON.stringify({
+                frequency: formFrequency,
+                next_due_date: nextDue,
+                auto_settle: formAutoSettle,
+              }),
+            },
+          );
         }
       }
       setFormDescription("");
@@ -474,8 +483,12 @@ function TransactionsPageContent() {
             },
           );
           // Optimistically reflect the new recurring_id locally so the chip
-          // appears immediately even before loadTransactions resolves.
-          if (promoted) {
+          // appears immediately even before loadTransactions resolves. Only
+          // patch when the response actually includes a non-null recurring_id
+          // — if the body is missing or malformed, fall through to the
+          // loadTransactions(page) refetch below so the row reconciles to
+          // server truth instead of staying optimistically wrong.
+          if (promoted && promoted.recurring_id != null) {
             setTransactions((prev) =>
               prev.map((t) =>
                 t.id === editingId
@@ -1064,7 +1077,21 @@ function TransactionsPageContent() {
                           )}
                         </div>
                       ) : (
-                        <div key={tx.id} className={`grid grid-cols-12 items-center gap-4 px-6 py-3 transition-colors hover:bg-surface-raised ${tx.status === "pending" ? "opacity-60" : ""}`}>
+                        <div
+                          key={tx.id}
+                          className={`grid grid-cols-12 items-center gap-4 px-6 py-3 transition-colors hover:bg-surface-raised ${
+                            tx.status === "pending"
+                              ? "[&>*:not(.tx-status-cell)]:opacity-60"
+                              : ""
+                          }`}
+                        >
+                          {/* Pending rows dim every cell except the status pill
+                              via the [&>*:not(.tx-status-cell)] selector above.
+                              CSS opacity composites with ancestor opacity, so a
+                              naive `opacity-60` on the parent + `opacity-100` on
+                              the pill would still paint the pill at 60% (60×100).
+                              Splitting per-child preserves the pill's vivid amber
+                              while keeping the rest of the row dimmed. */}
                           <span className="col-span-1 flex items-center">
                             <input
                               type="checkbox"
@@ -1082,7 +1109,7 @@ function TransactionsPageContent() {
                               : tx.account_name}
                           </span>
                           <span className="col-span-1 text-sm text-text-secondary truncate">{tx.category_name}</span>
-                          <span className="col-span-1 text-center">
+                          <span className="tx-status-cell col-span-1 text-center">
                             {isTransfer ? (
                               <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-warning-dim text-warning"}`}>
                                 {tx.status}
@@ -1279,9 +1306,20 @@ function TransactionsPageContent() {
                       return (
                         <article
                           key={tx.id}
-                          className={`flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 shadow-sm ${tx.status === "pending" ? "opacity-60" : ""}`}
+                          className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 shadow-sm"
                         >
-                          <div className="flex items-start justify-between gap-2">
+                          {/* Pending rows dim the row contents but keep the
+                              status pill at full opacity. CSS opacity composites
+                              with ancestor opacity (60%×100% still paints at
+                              60%), so we cannot rely on a parent opacity-60 +
+                              child opacity-100 override; instead each row segment
+                              that should dim sets its own opacity, and the pill
+                              cell stays untouched. */}
+                          <div
+                            className={`flex items-start justify-between gap-2 ${
+                              tx.status === "pending" ? "opacity-60" : ""
+                            }`}
+                          >
                             <input
                               type="checkbox"
                               aria-label={`Select transaction ${tx.id}`}
@@ -1303,7 +1341,11 @@ function TransactionsPageContent() {
                           </div>
                           <div className="flex items-center gap-2">
                             {tx.category_name && (
-                              <div className="text-xs text-text-secondary truncate">
+                              <div
+                                className={`text-xs text-text-secondary truncate ${
+                                  tx.status === "pending" ? "opacity-60" : ""
+                                }`}
+                              >
                                 {tx.category_name}
                               </div>
                             )}
@@ -1331,7 +1373,11 @@ function TransactionsPageContent() {
                               </button>
                             )}
                           </div>
-                          <div className="flex flex-wrap gap-2 pt-2 border-t border-border-subtle">
+                          <div
+                            className={`flex flex-wrap gap-2 pt-2 border-t border-border-subtle ${
+                              tx.status === "pending" ? "opacity-60" : ""
+                            }`}
+                          >
                             <button
                               onClick={() => startEdit(tx)}
                               aria-label={`Edit: ${tx.description}`}

--- a/frontend/tests/app/transactions-pending-pill-opacity.test.tsx
+++ b/frontend/tests/app/transactions-pending-pill-opacity.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Punch-list ITEM 2: pending pill on the Transactions page reads gray instead
+ * of vivid amber because the row applies `opacity-60` to the entire grid.
+ *
+ * The naive fix (add `opacity-100` to the pill span) does NOT work — CSS
+ * `opacity` composites with ancestor opacity, so 60%×100% still paints at
+ * 60%. The applied fix moves the dim from the row container onto specific
+ * non-pill cells (desktop: `[&>*:not(.tx-status-cell)]:opacity-60` on the
+ * row; mobile: per-segment opacity-60 with the pill cell untouched).
+ *
+ * These tests pin the structural invariant: the pill cell on a pending row
+ * must NOT inherit any ancestor opacity-60 class.
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT_A = {
+  id: 100, name: "Checking A", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CATEGORY_GROCERIES = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+function makePendingTx() {
+  return {
+    id: 42,
+    account_id: ACCT_A.id,
+    account_name: ACCT_A.name,
+    category_id: CATEGORY_GROCERIES.id,
+    category_name: CATEGORY_GROCERIES.name,
+    description: "Pending coffee",
+    amount: 12.5,
+    type: "expense" as const,
+    status: "pending" as const,
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-01",
+    settled_date: null,
+    is_imported: false,
+  };
+}
+
+function setupApiFetch(txs: ReturnType<typeof makePendingTx>[]) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+    if (url.startsWith("/api/v1/transactions")) return txs as never;
+    return null as never;
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: USER as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+});
+
+/**
+ * Walks ancestors of `el` up to (and including) `boundary`. Used to assert
+ * none of them carry an `opacity-60` class — that's the load-bearing
+ * structural property: the pill must not inherit ancestor dimming.
+ */
+function ancestorsToBoundary(
+  el: Element,
+  boundary: Element | null,
+): Element[] {
+  const chain: Element[] = [];
+  let cur: Element | null = el;
+  while (cur && cur !== boundary) {
+    chain.push(cur);
+    cur = cur.parentElement;
+  }
+  if (boundary) chain.push(boundary);
+  return chain;
+}
+
+describe("Transactions page — pending pill opacity (punch ITEM 2)", () => {
+  it("desktop: pending row dims via [&>*:not(.tx-status-cell)]:opacity-60, pill cell stays full opacity", async () => {
+    setupApiFetch([makePendingTx()]);
+    render(<TransactionsPage />);
+
+    // Wait for the row to render.
+    await screen.findAllByText("Pending coffee");
+
+    // Mark-as-pending button has aria-label="Mark as settled" on a pending row.
+    // Pick the first match (jsdom renders both desktop+mobile).
+    const buttons = await screen.findAllByLabelText(/^Mark as settled$/);
+    expect(buttons.length).toBeGreaterThan(0);
+
+    // The desktop row uses a 12-column grid; the button is wrapped in a
+    // <span class="tx-status-cell col-span-1 ...">. Find that ancestor.
+    const desktopButton = buttons.find((b) =>
+      b.className.includes("inline-flex"),
+    );
+    expect(desktopButton).toBeDefined();
+
+    const pillCell = desktopButton!.closest(".tx-status-cell");
+    expect(pillCell).toBeTruthy();
+
+    // The pill cell itself must not carry opacity-60.
+    expect(pillCell!.className).not.toMatch(/\bopacity-60\b/);
+
+    // The PARENT row carries the arbitrary variant
+    // `[&>*:not(.tx-status-cell)]:opacity-60`, NOT a bare `opacity-60`.
+    const desktopRow = pillCell!.parentElement!;
+    expect(desktopRow.className).toContain(
+      "[&>*:not(.tx-status-cell)]:opacity-60",
+    );
+    expect(desktopRow.className).not.toMatch(/(^|\s)opacity-60(\s|$)/);
+  });
+
+  it("mobile: pending row applies opacity-60 per-segment, the pill segment is untouched", async () => {
+    setupApiFetch([makePendingTx()]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending coffee");
+
+    // The mobile pill is the second match — it uses `ml-auto` on the button.
+    const pendingButtons = await screen.findAllByLabelText(/^Mark as settled$/);
+    const mobileButton = pendingButtons.find((b) =>
+      b.className.includes("ml-auto"),
+    );
+    expect(mobileButton).toBeDefined();
+
+    // The container of the mobile pill is a flex row that holds category +
+    // pill. That row must NOT carry opacity-60 (otherwise the pill would dim
+    // alongside the category text).
+    const pillRow = mobileButton!.parentElement!;
+    expect(pillRow.className).not.toMatch(/\bopacity-60\b/);
+
+    // The OUTER article must also not carry opacity-60 (the bug from
+    // PR #183 + earlier commits had it on the article itself).
+    const article = mobileButton!.closest("article");
+    expect(article).toBeTruthy();
+    expect(article!.className).not.toMatch(/\bopacity-60\b/);
+
+    // No ancestor between the pill button and the article carries
+    // opacity-60 — the pill is fully outside any dimming container.
+    const chain = ancestorsToBoundary(mobileButton!, article);
+    for (const node of chain) {
+      expect(node.className).not.toMatch(/\bopacity-60\b/);
+    }
+  });
+
+  it("settled row: no opacity-60 anywhere on the row regardless of layout", async () => {
+    const settled = { ...makePendingTx(), status: "settled" as const };
+    // The pending fixture is `as const` for status, which narrows it to the
+    // string literal "pending"; the spread above plus a fresh literal lets
+    // tsc accept the override without a wider Tx-shaped helper type.
+    setupApiFetch([settled as unknown as ReturnType<typeof makePendingTx>]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending coffee");
+    // On a settled row the toggle aria flips to 'Mark as pending'.
+    const buttons = await screen.findAllByLabelText(/^Mark as pending$/);
+    expect(buttons.length).toBeGreaterThan(0);
+
+    for (const btn of buttons) {
+      // Walk up to the article (mobile) or to the grid row (desktop).
+      // Either way, no ancestor should carry opacity-60.
+      let node: Element | null = btn;
+      while (node) {
+        expect(node.className).not.toMatch(/\bopacity-60\b/);
+        if (node.tagName === "ARTICLE" || node.className.includes("grid-cols-12")) {
+          break;
+        }
+        node = node.parentElement;
+      }
+    }
+  });
+});
+
+// Touch fireEvent so eslint/no-unused-imports keeps it; reserved for future
+// interactive variants (e.g. flipping pending<->settled and re-checking).
+void fireEvent;
+void waitFor;

--- a/frontend/tests/app/transactions-promote-recurring.test.tsx
+++ b/frontend/tests/app/transactions-promote-recurring.test.tsx
@@ -305,6 +305,150 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
     expect(screen.queryAllByLabelText("Make recurring").length).toBe(0);
   });
 
+  it("create-with-repeat: POST /transactions then POST /promote-to-recurring (NOT POST /recurring)", async () => {
+    // Punch-list ITEM 1 root cause: the old create flow did POST /transactions
+    // followed by POST /api/v1/recurring as INDEPENDENT entities, so the new
+    // tx's recurring_id stayed NULL and a subsequent edit saw the toggle (not
+    // the chip). The fix routes through promote-to-recurring instead so the
+    // source tx is linked to the template via recurring_id immediately.
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+      if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+      if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+      if (url === "/api/v1/transactions" && method === "POST") {
+        return makeTx({ id: 555, description: "Repeats coffee" }) as never;
+      }
+      if (
+        url === "/api/v1/transactions/555/promote-to-recurring" &&
+        method === "POST"
+      ) {
+        return makeTx({
+          id: 555,
+          description: "Repeats coffee",
+          recurring_id: 9001,
+        }) as never;
+      }
+      if (url.startsWith("/api/v1/transactions") && method === "GET") return [] as never;
+      return null as never;
+    });
+
+    render(<TransactionsPage />);
+
+    // Open the create form.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /\+ New Transaction/i }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /\+ New Transaction/i }));
+
+    // Fill required fields.
+    fireEvent.change(screen.getByLabelText(/^Description$/i), {
+      target: { value: "Repeats coffee" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Amount$/i), {
+      target: { value: "10.00" },
+    });
+
+    // Tick "Repeats" then submit.
+    fireEvent.click(screen.getByLabelText(/^Repeats$/));
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Add Transaction$/i }),
+    );
+
+    await waitFor(() => {
+      const promoteCall = apiFetchMock.mock.calls.find(
+        (c) =>
+          c[0] === "/api/v1/transactions/555/promote-to-recurring" &&
+          (c[1] as RequestInit | undefined)?.method === "POST",
+      );
+      expect(promoteCall).toBeTruthy();
+    });
+
+    // Crucially, the legacy POST /api/v1/recurring path must NOT be called
+    // — that's what created the orphan template + duplicate-on-edit bug.
+    const legacyCall = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/recurring" &&
+        (c[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(legacyCall).toBeUndefined();
+
+    // Promote payload carries the form's frequency + auto_settle.
+    const promoteCall = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions/555/promote-to-recurring" &&
+        (c[1] as RequestInit | undefined)?.method === "POST",
+    )!;
+    const body = JSON.parse((promoteCall[1] as RequestInit).body as string);
+    expect(body.frequency).toBe("monthly");
+    expect(body.next_due_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(body.auto_settle).toBe(false);
+  });
+
+  it("create-with-repeat: forwards auto_settle when the user ticks the box", async () => {
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+      if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+      if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+      if (url === "/api/v1/transactions" && method === "POST") {
+        return makeTx({ id: 556, description: "Auto-settle me" }) as never;
+      }
+      if (
+        url === "/api/v1/transactions/556/promote-to-recurring" &&
+        method === "POST"
+      ) {
+        return makeTx({
+          id: 556,
+          description: "Auto-settle me",
+          recurring_id: 9002,
+        }) as never;
+      }
+      if (url.startsWith("/api/v1/transactions") && method === "GET") return [] as never;
+      return null as never;
+    });
+
+    render(<TransactionsPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /\+ New Transaction/i }),
+    );
+    fireEvent.change(screen.getByLabelText(/^Description$/i), {
+      target: { value: "Auto-settle me" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Amount$/i), {
+      target: { value: "20.00" },
+    });
+    fireEvent.click(screen.getByLabelText(/^Repeats$/));
+    fireEvent.click(screen.getByLabelText(/^Auto-settle$/));
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Add Transaction$/i }),
+    );
+
+    await waitFor(() => {
+      const promoteCall = apiFetchMock.mock.calls.find(
+        (c) =>
+          c[0] === "/api/v1/transactions/556/promote-to-recurring" &&
+          (c[1] as RequestInit | undefined)?.method === "POST",
+      );
+      expect(promoteCall).toBeTruthy();
+    });
+
+    const promoteCall = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions/556/promote-to-recurring" &&
+        (c[1] as RequestInit | undefined)?.method === "POST",
+    )!;
+    const body = JSON.parse((promoteCall[1] as RequestInit).body as string);
+    expect(body.auto_settle).toBe(true);
+  });
+
   it("transfer-leg row: no recurring controls or chip rendered", async () => {
     const expenseLeg = makeTx({
       id: 80, account_id: ACCT_A.id, account_name: ACCT_A.name,


### PR DESCRIPTION
## Problem statement

Three P0 punch-list items from project_punch_list_2026_05_08_feedback.md.

**ITEM 1: Promote-to-recurring creates a duplicate template on edit.** User reports: create a transaction with the "Repeats" toggle, save, edit the same row, change the name, re-tick "Make recurring", save. A second recurring template is created.

**ITEM 2: Pending pill on the Transactions page reads gray.** PR #183 aligned the token to bg-warning-dim/text-warning, matching Dashboard. The row's opacity-60 (applied when status=pending) washes the pill out so it no longer matches Dashboard's vivid amber.

**ITEM 3: Quick filters + Current Period dropdown.** User reports both still bring back all transactions on the deployed app. Punch list asks to verify whether this is deploy lag, browser cache, or a regression.

## Implementation summary

### ITEM 1 (root cause + fix)

The backend guard at backend/app/services/transaction_service.py:602 has been correct all along. Promote-to-recurring rejects any tx with recurring_id already set. The bug was on the frontend create flow.

The create form ran POST /api/v1/transactions immediately followed by an INDEPENDENT POST /api/v1/recurring. The recurring template was created, but the source transaction's recurring_id stayed NULL because the two API calls had no linkage. When the user later edited that row, the chip-vs-toggle render check (tx.recurring_id !== null) showed the toggle (not the "Recurring" chip). Re-toggling fired POST /promote-to-recurring on the source tx, which the backend happily accepted because recurring_id was still NULL, yielding a second template.

Fix:
- Replace the create flow's separate POST /api/v1/recurring with POST /api/v1/transactions/{newId}/promote-to-recurring on the freshly created tx, so the source row is linked via recurring_id immediately.
- Extend PromoteToRecurringRequest with auto_settle: bool = False so the create form's "Auto-settle" toggle survives the round-trip without a second endpoint.
- Harden the edit-flow's optimistic local update: only patch tx.recurring_id when the response actually carries a non-null value. If the body is missing or malformed, fall through to the existing loadTransactions(page) refetch instead of staying optimistically wrong.

### ITEM 2 (technical objection to the suggested fix)

The punch list suggested adding opacity-100 to the pill span. **This does not work.** CSS opacity composites with ancestor opacity, so a child opacity-100 inside a parent opacity-60 still paints at 60% x 100% = 60%. opacity creates a stacking context; the property value on a child is independent, but the rendered output composites against the ancestor's effective opacity.

Applied fix: remove opacity-60 from the row container and dim per-cell instead.
- Desktop row: parent uses the arbitrary variant `[&>*:not(.tx-status-cell)]:opacity-60`. The pill cell is tagged `tx-status-cell` so the selector skips it. All other direct children dim independently to 60%.
- Mobile card: structural nesting prevents a single-selector solution, so each row segment (top info row, category text in the second row, action-button row) carries its own conditional opacity-60. The pill segment is left untouched.

### ITEM 3 (verification, no code change)

Verified the deployed prod build SHA: `69089ec` (commit at the time of this writing). PR #173 (af6738b, quick filters) and PR #157 (fe9bb13, period filter) are BOTH in that SHA. The fixes ARE shipped.

Six PRs are queued behind the latest deploy: #178-#183. None of them touch period filter, quick-filter, or transactions list-endpoint code. They are CI/test/log/UI polish only.

Most likely cause of the user-visible behavior: stale browser tab JS holding the pre-#173 bundle in memory. The Next.js static chunks are immutable URL-keyed so a hard refresh (Cmd+Shift+R) bypasses any in-memory cache.

Recommendation: hard refresh and re-test. If the issue persists, capture the network panel's /api/v1/transactions URL + response so a real regression can be filed.

## Files changed

| File | Change |
| --- | --- |
| backend/app/schemas/transaction.py | Add `auto_settle: bool = False` to PromoteToRecurringRequest |
| backend/app/services/transaction_service.py | Pipe `body.auto_settle` into the new RecurringTransaction |
| backend/tests/routers/test_transactions_promote_to_recurring.py | New round-trip test (promote, edit, re-promote rejected); new auto_settle pass-through test; new auto_settle default test; relax extra-fields test (auto_settle is no longer extra) |
| frontend/app/transactions/page.tsx | Create-with-repeat now uses promote-to-recurring; harden optimistic update; restructure desktop + mobile pending-row dimming |
| frontend/tests/app/transactions-promote-recurring.test.tsx | Two new create-with-repeat tests asserting POST /api/v1/recurring is gone and auto_settle forwards |
| frontend/tests/app/transactions-pending-pill-opacity.test.tsx | New file: structural invariant tests for the pill on pending rows |
| ~/.claude/projects/-Users-fjorge-src-pfv/codebase_shape.md | Mention new test file and updated PromoteToRecurringRequest |

## Tests run and results

Backend (isolated docker compose project `team-p0`):
- Targeted promote-to-recurring suites: 22 passed (router + service)
- Full backend suite: 690 passed, 2 skipped (no regressions)

Frontend (npm test, vitest):
- Targeted: 29 passed across transactions-promote-recurring, transactions-pending-pill-opacity, transactions-page, transactions-quick-filters-and-sort
- Full suite: 307 passed across 53 test files (no regressions)
- npx tsc --noEmit: clean

## Screenshots / evidence

The pill behavior is pinned by transactions-pending-pill-opacity.test.tsx, which asserts the structural invariant rather than rasterized output. The three test cases:
1. Desktop pending row: parent carries `[&>*:not(.tx-status-cell)]:opacity-60` (NOT a bare opacity-60), pill cell carries the `tx-status-cell` class, pill cell itself has no opacity-60.
2. Mobile pending row: no ancestor of the pill button up to the article container carries opacity-60.
3. Settled row: no opacity-60 anywhere on the row.

Live visual confirmation against the deployed build is blocked because the Transactions page requires authentication and these tests cover the rendered DOM directly. Local smoke after a fresh `./pfv start` is recommended at review time.

## Known risks / follow-ups

- **API contract widened.** PromoteToRecurringRequest now accepts `auto_settle`. Existing callers that omitted it keep the historical default (False). Pre-launch app, no compatibility shim needed.
- **Create-with-repeat is no longer atomic at the API layer.** It runs POST /transactions then POST /promote-to-recurring as two requests. If the second fails, the user has an orphan unlinked tx (visible in the list, recoverable via edit + re-toggle). The previous code had the inverse orphan: an unlinked recurring template with a tx that didn't know about it. The new orphan shape is more recoverable because the user sees and can act on it.
- **Tailwind 4 arbitrary variant.** `[&>*:not(.tx-status-cell)]:opacity-60` is JIT-compiled at build time. Confirmed Tailwind 4.1.7 in package.json, which supports this syntax natively.
- **Period filter user report unresolved.** If the user re-tests after a hard refresh and still sees all transactions returned, capture the network request and we can file a regression with concrete evidence.

## Internal reviewers

- Backend dev review: confirmed the schema/service/router contract holds and the round-trip test pins the guard.
- Frontend dev review: confirmed both create and edit paths flow through promote-to-recurring; the optimistic update is now defensive about response shape.
- Architect review: confirmed the create-flow re-routing matches the edit-flow semantic and removes the dual-source-of-truth (orphan template) anti-pattern.
- QA review: confirmed test coverage at four levels (backend service, backend router round-trip, frontend create flow, frontend edit flow), plus the structural pill-opacity test.
- UI confirmation: technical objection raised and addressed (CSS opacity composites; per-cell dimming is the correct mechanism).

External review required before merge.