### PR TITLE
docs(recurring): clarify removal preserves past occurrences

### DIFF
--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -151,6 +151,14 @@ export default function DocsPage() {
               into a recurring template, so the same charge generates
               automatically next period.
             </p>
+            <p>
+              Removing a recurring template only drops future,
+              un-materialized occurrences. Past occurrences stay in
+              your transaction history because they are real money
+              movements, so balances are not affected. This is
+              intentional: the template only schedules what has not
+              happened yet.
+            </p>
 
             <h3>Marking transactions as a transfer pair</h3>
             <p>


### PR DESCRIPTION
## Problem

The in-app /docs Recurring section explains how to promote a transaction into a recurring template, but it does not say what removing a template does. Users have asked whether removal will retroactively wipe history, which it does not. Calling that out in the docs avoids the worry and matches the actual server behavior.

## Implementation

Adds a short paragraph in `frontend/app/docs/page.tsx`, immediately after the Promoting a transaction to recurring section, stating:

- Removing a template drops only future, un-materialized occurrences.
- Past occurrences stay in transaction history because they are real money movements, so balances are unaffected.
- This is intentional behavior, not a bug.

Tone matches the rest of the page: short prose, no em-dashes, no UI labels invented that do not exist.

## Files changed

- `frontend/app/docs/page.tsx` — three sentences appended to the Recurring promote section.

## Tests run

No test changes, copy-only.

`npx tsc --noEmit` clean (run inside an isolated container scoped to this worktree).

## Internal reviewers

@flamarion

External review required before merge.