### PR TITLE
chore(accounts): list headers and fixed action column

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -288,6 +288,22 @@ export default function AccountsPage() {
                   <button type="submit" className={`w-full min-h-[44px] sm:w-auto sm:min-h-0 ${btnPrimary}`}>Create Account</button>
                 </form>
               )}
+              {/* Column header — visible only on md+ where the row uses
+                  the same outer grid template. Mirrors the Account
+                  Types card's header pattern but at md: because the
+                  account row's mobile-to-desktop break is md:, not sm:.
+                  Action header is sr-only since the column is button
+                  links rather than tabular data. */}
+              {accounts.length > 0 && (
+                <div
+                  data-testid="accounts-list-header"
+                  className="hidden border-b border-border-subtle px-3 pb-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted md:grid md:grid-cols-[minmax(0,1fr)_8rem_auto] md:items-center md:gap-4"
+                >
+                  <span>Account</span>
+                  <span className="text-right">Balance</span>
+                  <span className="sr-only">Actions</span>
+                </div>
+              )}
               <div className="space-y-1">
                 {accounts.map((a) => editAcctId === a.id ? (
                   <div key={a.id} className="flex flex-col gap-2 rounded-md bg-surface-raised px-3 py-2.5 sm:flex-row sm:items-center sm:gap-3">
@@ -302,12 +318,16 @@ export default function AccountsPage() {
                     </div>
                   </div>
                 ) : (
-                  <article key={a.id} className={`flex flex-col gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised md:flex-row md:items-center md:gap-4 ${!a.is_active ? "opacity-40" : ""}`}>
+                  <article
+                    key={a.id}
+                    data-testid={`account-row-${a.id}`}
+                    className={`flex flex-col gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-surface-raised md:grid md:grid-cols-[minmax(0,1fr)_8rem_auto] md:items-center md:gap-4 ${!a.is_active ? "opacity-40" : ""}`}
+                  >
                     {/* Description column: name + meta. The "DEFAULT"
                         badge is a fixed-width inline pill (NOT trailing
                         "· default" text), so toggling default never
                         changes how much room neighbouring text gets. */}
-                    <div className="min-w-0 flex-1">
+                    <div className="min-w-0 flex-1 md:flex-none">
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
                         <span className="truncate text-sm font-medium text-text-primary">{a.name}</span>
                         {a.is_default && (
@@ -320,13 +340,11 @@ export default function AccountsPage() {
                         {!a.is_active && <span className="text-xs text-danger">inactive</span>}
                       </div>
                     </div>
-                    {/* Fixed-width balance column — w-32 keeps the
-                        column position stable whether the row owns a
-                        "Default" action button or not, so toggling
-                        default no longer shifts numbers into adjacent
-                        cells. tabular-nums + text-right keep digits
-                        aligned across rows. */}
-                    <div className="flex shrink-0 flex-col items-start gap-0.5 md:w-32 md:items-end">
+                    {/* Fixed-width balance column — the outer grid
+                        reserves an 8rem slot at md:, so toggling
+                        Default never shifts the numbers. tabular-nums
+                        + text-right keep digits aligned across rows. */}
+                    <div className="flex shrink-0 flex-col items-start gap-0.5 md:items-end">
                       <span className="text-sm tabular-nums text-text-primary">
                         {formatAmount(a.balance)}{" "}
                         <span className="text-text-muted">{a.currency}</span>
@@ -337,26 +355,48 @@ export default function AccountsPage() {
                         </span>
                       ) : null}
                     </div>
-                    <div className="flex flex-wrap gap-3 md:justify-end">
-                      <button onClick={() => startEditAcct(a)} aria-label={`Edit ${a.name}`} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">Edit</button>
-                      {canAdjustBalance && a.is_active && (
-                        <button
-                          onClick={() => setAdjustingAccount(a)}
-                          aria-label={`Adjust balance of ${a.name}`}
-                          className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0"
-                        >
-                          Adjust balance
-                        </button>
+                    {/* Action column with fixed slots so links don't
+                        shift when an action is conditionally absent
+                        (e.g. "Set default" disappears once the row IS
+                        the default). Each conditional action renders an
+                        empty placeholder span when omitted, keeping
+                        every action's column position stable across
+                        rows. The "Adjust balance" slot is omitted from
+                        the template entirely when the user lacks the
+                        permission, so non-admin views aren't padded. */}
+                    <div
+                      data-testid={`account-row-actions-${a.id}`}
+                      className={`flex flex-wrap gap-3 md:grid md:items-center md:justify-end md:gap-3 ${
+                        canAdjustBalance
+                          ? "md:grid-cols-[3rem_7rem_5rem_5.5rem_4rem]"
+                          : "md:grid-cols-[3rem_5rem_5.5rem_4rem]"
+                      }`}
+                    >
+                      <button onClick={() => startEditAcct(a)} aria-label={`Edit ${a.name}`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-accent md:min-h-0 md:text-center">Edit</button>
+                      {canAdjustBalance && (
+                        a.is_active ? (
+                          <button
+                            onClick={() => setAdjustingAccount(a)}
+                            aria-label={`Adjust balance of ${a.name}`}
+                            className="min-h-[44px] text-left text-xs text-text-muted hover:text-accent md:min-h-0 md:text-center"
+                          >
+                            Adjust balance
+                          </button>
+                        ) : (
+                          <span aria-hidden="true" className="hidden md:block" />
+                        )
                       )}
-                      {!a.is_default && a.is_active && (
-                        <button onClick={async () => { try { await apiFetch(`/api/v1/accounts/${a.id}`, { method: "PUT", body: JSON.stringify({ is_default: true }) }); await reload(); } catch (err) { setError(extractErrorMessage(err)); } }} aria-label={`Set ${a.name} as default`} className="min-h-[44px] text-xs text-text-muted hover:text-accent md:min-h-0">
+                      {!a.is_default && a.is_active ? (
+                        <button onClick={async () => { try { await apiFetch(`/api/v1/accounts/${a.id}`, { method: "PUT", body: JSON.stringify({ is_default: true }) }); await reload(); } catch (err) { setError(extractErrorMessage(err)); } }} aria-label={`Set ${a.name} as default`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-accent md:min-h-0 md:text-center">
                           Set default
                         </button>
+                      ) : (
+                        <span aria-hidden="true" className="hidden md:block" />
                       )}
-                      <button onClick={() => handleToggleActive(a)} aria-label={a.is_active ? `Deactivate ${a.name}` : `Activate ${a.name}`} className="min-h-[44px] text-xs text-text-muted hover:text-text-secondary md:min-h-0">
+                      <button onClick={() => handleToggleActive(a)} aria-label={a.is_active ? `Deactivate ${a.name}` : `Activate ${a.name}`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-text-secondary md:min-h-0 md:text-center">
                         {a.is_active ? "Deactivate" : "Activate"}
                       </button>
-                      <button onClick={() => setConfirmDeleteAcctId(a.id)} aria-label={`Delete ${a.name}`} className="min-h-[44px] text-xs text-text-muted hover:text-danger md:min-h-0">Delete</button>
+                      <button onClick={() => setConfirmDeleteAcctId(a.id)} aria-label={`Delete ${a.name}`} className="min-h-[44px] text-left text-xs text-text-muted hover:text-danger md:min-h-0 md:text-center">Delete</button>
                     </div>
                   </article>
                 ))}

--- a/frontend/tests/app/accounts-list-headers.test.tsx
+++ b/frontend/tests/app/accounts-list-headers.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+
+import AccountsPage from "@/app/accounts/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/accounts",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+  allow_manual_balance_adjustment: false,
+};
+
+const ACCOUNT_TYPES = [
+  { id: 1, name: "Credit Card", slug: "credit_card", is_system: true, account_count: 1 },
+  { id: 2, name: "Checking", slug: "checking", is_system: true, account_count: 1 },
+];
+
+// Two rows: one default, one non-default. The fixed-slot grid must
+// produce identical action-column class lists for both rows, otherwise
+// "Set default" disappearing on the default row would let the remaining
+// links shift left (the bug PR #172 left behind on the accounts list).
+const ACCOUNTS = [
+  {
+    id: 10,
+    name: "Amex Primary",
+    account_type_id: 1,
+    account_type_name: "Credit Card",
+    account_type_slug: "credit_card",
+    balance: "0.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: false,
+    close_day: 5,
+  },
+  {
+    id: 20,
+    name: "ING Joint",
+    account_type_id: 2,
+    account_type_name: "Checking",
+    account_type_slug: "checking",
+    balance: "1500.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: true,
+    close_day: null,
+  },
+];
+
+function mockApi() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
+    if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("AccountsPage — list header row and fixed action column", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockApi();
+  });
+
+  it("renders an Account / Balance header above the accounts list", async () => {
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+
+    const header = screen.getByTestId("accounts-list-header");
+    expect(header).toBeInTheDocument();
+    // Hidden on mobile, grid on md+. Mirrors the Account Types card pattern.
+    expect(header.className).toContain("hidden");
+    expect(header.className).toContain("md:grid");
+
+    // Column labels — test exact column text, in order.
+    const columns = within(header).getAllByText(/Account|Balance|Actions/);
+    expect(columns[0]).toHaveTextContent(/^Account$/);
+    expect(columns[1]).toHaveTextContent(/^Balance$/);
+    // "Actions" is sr-only but still present in the accessible tree.
+    expect(within(header).getByText(/^Actions$/)).toBeInTheDocument();
+  });
+
+  it("does not render the header when there are no accounts", async () => {
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
+      if (url === "/api/v1/accounts") return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+      return Promise.resolve({});
+    }) as never);
+
+    render(<AccountsPage />);
+    await waitFor(() =>
+      expect(screen.getByText(/No accounts yet/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("accounts-list-header")).toBeNull();
+  });
+
+  it("uses the same action-column grid template regardless of DEFAULT badge", async () => {
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+
+    const nonDefaultActions = screen.getByTestId("account-row-actions-10");
+    const defaultActions = screen.getByTestId("account-row-actions-20");
+
+    // The grid-cols-* utility (which encodes the fixed-slot widths)
+    // must be identical between the two rows. If "Set default" being
+    // omitted on the default row collapsed an action slot, this would
+    // diverge — exactly the bug we are guarding against.
+    const gridCols = (el: HTMLElement) =>
+      Array.from(el.classList).find((c) => c.startsWith("md:grid-cols-"));
+    expect(gridCols(nonDefaultActions)).toBeDefined();
+    expect(gridCols(nonDefaultActions)).toBe(gridCols(defaultActions));
+
+    // Same number of grid children rendered on each row, so each slot
+    // is occupied either by a button or an aria-hidden placeholder.
+    expect(nonDefaultActions.children.length).toBe(defaultActions.children.length);
+  });
+
+  it("still renders Edit / Activate-Deactivate / Delete on the default row", async () => {
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/ING Joint/)).toBeInTheDocument());
+
+    // The default row keeps its non-conditional actions; only "Set
+    // default" is replaced by a placeholder.
+    expect(screen.getByRole("button", { name: /^Edit ING Joint$/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Deactivate ING Joint$/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Delete ING Joint$/ })).toBeInTheDocument();
+    // No "Set default" button on the default row.
+    expect(
+      screen.queryByRole("button", { name: /Set ING Joint as default/ }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

PR #172 added a column header row to the Account Types card on `/accounts`, but the Accounts list card was left without one. Screenshots from 2026-05-09 confirmed two bugs:

1. The Accounts list rendered with no Account / Balance header row, so the columns read as a wall of cells with no labels.
2. When a row carried the `DEFAULT` badge, "Set default" was correctly removed but the remaining action links shifted left because the action column had no fixed slots. Edit / Deactivate / Delete jumped between columns from row to row.

This is punch-list item 10, partial scope (headers + action column only). The account-type edit experience is Wave 2 and is intentionally untouched here.

## Implementation

- Added a `data-testid="accounts-list-header"` row above the accounts list with `Account` / `Balance` / `Actions` (last is `sr-only` since the cells are buttons, not labels). Styled to match the Account Types header (`text-[10px] font-semibold uppercase tracking-wider text-text-muted`, `border-b border-border-subtle`).
- Restructured the row from `flex md:flex-row` to `md:grid md:grid-cols-[minmax(0,1fr)_8rem_auto]` so the description, balance, and actions columns line up beneath their header labels.
- Replaced the action `flex flex-wrap` with a CSS grid that reserves one column per possible action (`md:grid-cols-[3rem_7rem_5rem_5.5rem_4rem]`). Conditional actions render an `aria-hidden` placeholder span when omitted, keeping every action's column position stable across rows.
- The `Adjust balance` slot is included in the template only when the viewer has the manual-adjustment permission, so non-admin views are not padded with an empty 7rem gap.
- `hidden md:grid` on the header preserves the existing mobile card stacking; mobile remains a flex column.
- No actions added or removed, no permission changes, no behavioural changes, layout only. Account type editing was not touched.

## Files changed

- `frontend/app/accounts/page.tsx`, header row + grid restructure of the row, fixed-slot action grid with placeholders.
- `frontend/tests/app/accounts-list-headers.test.tsx`, new vitest covering header presence, header column labels, identical action-grid template across DEFAULT vs non-DEFAULT rows, and absence of the header when the list is empty.

## Tests run

Inside a worktree-scoped frontend container (per CLAUDE.md guidance for parallel agents):

- `npx vitest run accounts`, 14/14 pass across 4 accounts test files (pending visibility, adjust balance, list headers, modal).
- `npx vitest run`, 306/306 pass across 53 test files. No regressions.
- `npx tsc --noEmit`, clean (with the worktree's own `tsconfig.json` mounted).

## Screenshot

Desktop, 1280 x 900, four mock accounts (one DEFAULT). Set default is omitted on the DEFAULT row but Deactivate and Delete stay in the same column positions as the non-DEFAULT rows above and below. The `ACCOUNT` and `BALANCE` header labels sit on the row above, mirroring the Account Types header pattern.

Local file: `~/.claude/projects/-Users-fjorge-src-pfv/screenshots/2026-05-09-accounts-list-headers.png`. Attach inline via the GitHub web UI before merging if the team prefers an embedded image.

## Known risks / follow-ups

- The grid template width values (`3rem 7rem 5rem 5.5rem 4rem`) are tuned to current button text. Renaming an action label (for example localising "Adjust balance" or "Deactivate") may require nudging a slot. Cheap to spot in code review.
- Mobile layout is unchanged, but the parallel responsive-parity audit team may revisit the row's mobile stacking later. Out of scope here.
- Account-type edit modal is Wave 2 and was not touched.

## Internal reviewers

- @flamarion (lead)

External review required before merge.