### PR TITLE
ci(release): skip semantic-release for perf commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,6 @@
           { "scope": "infra", "release": false },
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
-          { "type": "perf", "release": "patch" },
           { "type": "revert", "release": "patch" },
           { "type": "chore", "release": false },
           { "type": "docs", "release": false },
@@ -23,7 +22,8 @@
           { "type": "refactor", "release": false },
           { "type": "test", "release": false },
           { "type": "build", "release": false },
-          { "type": "ci", "release": false }
+          { "type": "ci", "release": false },
+          { "type": "perf", "release": false }
         ]
       }
     ],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,7 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
+          { "breaking": true, "release": "major" },
           { "scope": "ci", "release": false },
           { "scope": "deps", "release": false },
           { "scope": "deps-dev", "release": false },


### PR DESCRIPTION
## Problem

PR #187 (a `docs(recurring): clarify removal preserves past occurrences` commit) was suspected of triggering a semantic-release version bump and an App Platform deploy. Investigation against the actual run history shows the analyzer did the right thing for #187 (run [25598884988](https://github.com/flamarion/pfv/actions/runs/25598884988) confirms "The commit should not trigger a release" then "Analysis of 2 commits complete: no release", and the gated `deploy` and `smoke-tests` jobs were both skipped). The release that landed minutes later (v0.44.2) was cut by PR #186, a legitimate `fix:` commit, not by #187.

So the immediate symptom was a misattribution. That said, this PR still hardens the analyzer config to make the project intent unambiguous: **only `feat`, `fix`, `revert`, and any commit with a `BREAKING CHANGE:` footer should cut a release. Everything else, including `perf`, should no-op the analyzer.**

## Implementation

Two changes to `.releaserc.json`:

1. Move `perf` from `release: patch` to `release: false` so plain `perf:` commits no longer cut a patch.
2. Add `{ "breaking": true, "release": "major" }` as the first entry in `releaseRules`. This preserves a major release for any breaking-change commit (`perf!:`, `docs!:`, `fix!:`, `feat!:`, etc.) regardless of the per-type rule on that commit's prefix.

The existing rules already covered `docs`, `chore`, `style`, `refactor`, `test`, `build`, and `ci` as `release: false`, so no behavior change for those types. `perf` was the lone outlier still mapped to a patch bump despite the project's stated convention that only customer-visible bug fixes and features should ship a version. (Conventional Commits' default does treat `perf` as a patch; we are deliberately diverging.)

The full skip list is now: `chore`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `perf`. Combined with the release.yml gate added in PR #178 (deploy job runs only when `new_release_published == 'true'`), non-shipping commits cannot trigger an App Platform deploy or a git tag.

## Files changed

- `.releaserc.json`: `perf` moved from `release: patch` to `release: false`, and a leading `{ "breaking": true, "release": "major" }` rule added to the `releaseRules` array.

## Verification

- JSON validity: `cat .releaserc.json | jq .` returns clean.
- Rule semantics: per the [commit-analyzer rules-matching docs](https://github.com/semantic-release/commit-analyzer#rules-matching), every commit is tested against every rule in `releaseRules`, and the highest release type across all matching rules wins. There is no first-match short-circuit. So `perf: cache hot path` matches only the `{ "type": "perf", "release": false }` rule and produces no release. A `perf!: drop legacy field` commit matches both the `perf` rule and the new `{ "breaking": true, "release": "major" }` rule, and the highest type (`major`) wins, so breaking changes still cut a major regardless of the type prefix.
- Empirical baseline from PR #187's run confirms the analyzer already correctly skipped `docs(recurring): ...`, so the same skip semantics apply unchanged for the rest of the type list.
- No behavior change for `feat`, `fix`, `revert`, or any commit with a BREAKING CHANGE footer or `!` suffix.

## Known risks

None expected. The change tightens, not loosens, what cuts a release. The only operational nuance: a real performance regression fix that today might have been written as `perf:` should be written as `fix(perf): ...` (or similar with a `fix` type) to ship a release. This matches the project's existing pattern.

The in-flight v0.44.2 release for PR #186 is unrelated to this PR and ships normally.

## Internal reviewers

@flamarion

External review required before merge.
