### PR TITLE
chore(responsive): give tablet portrait a 2-up grid

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -179,7 +179,7 @@ export default function AccountsPage() {
       {fetching ? (
         <Spinner />
       ) : (
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2">
           {/* Account Types */}
           <div className={card}>
             <div className={cardHeader}>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -708,9 +708,11 @@ export default function DashboardPage() {
           {/* ═══ ROW 2: Accounts sidebar + Forecast card, side-by-side ═══
               Tiles share ONE card with internal divider rows; the
               Forecast card on the right is the numeric authority for
-              Balance + EOMF. 1fr/3fr split — forecast dominates.
+              Balance + EOMF. Layout is three-tier: stacks vertically
+              below `md`, equal 2-up columns from `md` to `lg`, then
+              the 1fr/3fr split (forecast dominates) at `lg` and above.
               items-start so each card sits at its natural height
-              (mismatch is intentional). Stacks vertically below `lg`. */}
+              (mismatch is intentional). */}
           {(() => {
             // Non-primary accounts sort alphabetically by name (locale-
             // aware, case-insensitive). Stable across transactions: a

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -728,7 +728,7 @@ export default function DashboardPage() {
               : others;
 
             return (
-              <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,3fr)]">
+              <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,3fr)]">
                 <AccountTilesCard
                   accounts={orderedAccounts}
                   pendingByAccount={pendingByAccount}
@@ -751,7 +751,7 @@ export default function DashboardPage() {
           })()}
 
           {/* ═══ ROW 3: Three equal charts ═══ */}
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {/* Spending by category (donut) */}
             <div className={`${card} p-5`}>
               <h2 className={`mb-3 ${cardTitle}`}>Spending by Category</h2>


### PR DESCRIPTION
## Problem

R1 responsive parity audit (`audits/2026-05-09-r1-responsive-parity.md`, recommendation **PR-1** in section 5) found that tablet portrait (768 px) is treated as mobile across the dashboard and accounts pages. ROW 2 of the dashboard, ROW 3 of the dashboard, and the accounts page wrapper each only break out of a single column at `lg:` (1024). At 768 wide, an iPad in portrait gets the 375 mobile layout with bigger fonts, not a real tablet layout. Adding an `md:` step lights up tablet portrait at minimal cost without affecting mobile or desktop.

## Implementation

Three class additions, one per grid wrapper:

- `frontend/app/dashboard/page.tsx` line 731 (Account tiles + Account Month-End Forecast row): added `md:grid-cols-2`. Existing `lg:grid-cols-[minmax(0,1fr)_minmax(0,3fr)]` 1fr/3fr template still takes over at 1024+.
- `frontend/app/dashboard/page.tsx` line 754 (Spending by Category, Budget Progress, Forecast by Category row): added `md:grid-cols-2`. Existing `lg:grid-cols-3` still takes over at 1024+.
- `frontend/app/accounts/page.tsx` line 182 (Account Types + Accounts cards wrapper): added `md:grid-cols-2`. Existing `lg:grid-cols-2` retained verbatim.

## Files changed

- `frontend/app/dashboard/page.tsx` (2 lines)
- `frontend/app/accounts/page.tsx` (1 line)

## Tests

- `cd frontend && npx tsc --noEmit`: clean.
- `cd frontend && npx vitest run`: 311 tests in 54 files, all passing.

## Screenshots at 768 px (the new 2-column layout)

Saved to `/tmp/r1-tablet-bump-screenshots/` on the local machine.

- `dashboard-768.png`: Spending by Category and Budget Progress sit side-by-side; Forecast by Category wraps to row 2 column 1 in a 2-up grid. Previously all three stacked in a single column.
- `accounts-768.png`: Account Types card on the left, Accounts card on the right. Previously stacked in a single column.

Desktop verification at 1280 px (no regression):

- `dashboard-1280.png`: Three cards remain in a 3-column grid via `lg:grid-cols-3`.
- `accounts-1280.png`: Two cards remain side-by-side via `lg:grid-cols-2`.

## Merge gate

Merge gate: independent. Can land any time.

## Internal reviewers

- @flamarion (PFV maintainer)

External review required before merge.