### PR TITLE
feat(categories): C2 Edit mode and batch select for move and delete

### DIFF
--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -6,10 +6,13 @@ import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
-import { input, btnPrimary, card, cardHeader, error as errorCls, pageTitle } from "@/lib/styles";
+import { input, btnPrimary, btnSecondary, card, cardHeader, error as errorCls, pageTitle } from "@/lib/styles";
 import type { Category } from "@/lib/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import AddMasterWithSubsModal from "@/components/ui/AddMasterWithSubsModal";
+import BatchActionBar from "@/components/categories/BatchActionBar";
+import BatchMoveModal from "@/components/categories/BatchMoveModal";
+import BatchDeleteModal from "@/components/categories/BatchDeleteModal";
 import {
   Wallet, Home, Zap, UtensilsCrossed, Car, HeartPulse,
   Scissors, Gamepad2, Target, CreditCard, Gift, HelpCircle, Tag,
@@ -66,6 +69,43 @@ export default function CategoriesPage() {
   // the same pattern used by Transactions/Accounts/Forecast Plans/Budgets.
   const [refreshError, setRefreshError] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+
+  // ── C2 UI: Edit-mode + batch select (C2a + C2c) ──────────────────────────
+  // C2a: page-level Edit toggle. C2c: batch select for move/delete.
+  // Selection is subcategory-only by design (C0 spec section 4.7: master
+  // delete with children returns 409, so master rows do not participate in
+  // batch operations). Selection clears on Edit-mode exit.
+  const [editMode, setEditMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [batchMoveOpen, setBatchMoveOpen] = useState(false);
+  const [batchDeleteOpen, setBatchDeleteOpen] = useState(false);
+
+  const exitEditMode = useCallback(() => {
+    setEditMode(false);
+    setSelectedIds([]);
+    setBatchMoveOpen(false);
+    setBatchDeleteOpen(false);
+  }, []);
+
+  const toggleSelected = useCallback((id: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  }, []);
+
+  // Esc exits Edit mode (only when no modal is open — modals own their own Esc).
+  useEffect(() => {
+    if (!editMode) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (batchMoveOpen || batchDeleteOpen || confirmDeleteId !== null) return;
+      if (editingCatId !== null || addingToMaster !== null) return;
+      exitEditMode();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [editMode, batchMoveOpen, batchDeleteOpen, confirmDeleteId, editingCatId, addingToMaster, exitEditMode]);
+  // ── /C2 UI ──────────────────────────────────────────────────────────────
 
   const reload = useCallback(async () => {
     const data = await apiFetch<Category[]>("/api/v1/categories");
@@ -162,14 +202,26 @@ export default function CategoriesPage() {
 
   return (
     <AppShell>
-      <div className="mb-8 flex items-center justify-between">
+      <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className={`${pageTitle} mb-0`}>Categories</h1>
-        <button
-          onClick={() => setShowAddMasterModal(true)}
-          className={btnPrimary}
-        >
-          + Add Master
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          {/* C2a: Edit-mode toggle. Owned by Team Categories C2 UI. */}
+          <button
+            type="button"
+            data-testid="categories-edit-toggle"
+            aria-pressed={editMode}
+            onClick={() => (editMode ? exitEditMode() : setEditMode(true))}
+            className={`${btnSecondary} min-h-[44px] sm:min-h-0`}
+          >
+            {editMode ? "Cancel Edit" : "Edit"}
+          </button>
+          <button
+            onClick={() => setShowAddMasterModal(true)}
+            className={btnPrimary}
+          >
+            + Add Master
+          </button>
+        </div>
       </div>
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
@@ -278,6 +330,16 @@ export default function CategoriesPage() {
                     <div className="space-y-0.5">
                       {subs.map((sub) => (
                         <div key={sub.id} data-testid={`sub-row-${sub.id}`} className="flex flex-wrap items-center justify-between gap-2 rounded-md px-3 py-2 transition-colors hover:bg-surface-raised">
+                          {editMode && editingCatId !== sub.id && (
+                            <input
+                              type="checkbox"
+                              data-testid={`sub-checkbox-${sub.id}`}
+                              aria-label={`Select ${sub.name}`}
+                              checked={selectedIds.includes(sub.id)}
+                              onChange={() => toggleSelected(sub.id)}
+                              className="mr-2 h-4 w-4 flex-shrink-0 cursor-pointer"
+                            />
+                          )}
                           {editingCatId === sub.id ? (
                             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                               <input type="text" value={editCatName} onChange={(e) => setEditCatName(e.target.value)} className={`min-w-0 flex-1 text-sm ${input}`} autoFocus
@@ -324,6 +386,48 @@ export default function CategoriesPage() {
         variant="danger"
         onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
         onCancel={() => setConfirmDeleteId(null)}
+      />
+
+      {/* C2c: batch select infrastructure. Owned by Team Categories C2 UI. */}
+      {editMode && (
+        <BatchActionBar
+          count={selectedIds.length}
+          onMove={() => setBatchMoveOpen(true)}
+          onDelete={() => setBatchDeleteOpen(true)}
+          onClear={() => setSelectedIds([])}
+        />
+      )}
+      <BatchMoveModal
+        open={batchMoveOpen}
+        selectedIds={selectedIds}
+        categories={categories}
+        onCancel={() => setBatchMoveOpen(false)}
+        onSuccess={async () => {
+          setBatchMoveOpen(false);
+          exitEditMode();
+          await reload();
+        }}
+      />
+      <BatchDeleteModal
+        open={batchDeleteOpen}
+        selectedIds={selectedIds}
+        categories={categories}
+        onCancel={() => {
+          setBatchDeleteOpen(false);
+          // Reload so any partial successes show through, even on cancel.
+          void reload();
+        }}
+        onSuccess={async (failures) => {
+          if (failures.length === 0) {
+            setBatchDeleteOpen(false);
+            exitEditMode();
+          } else {
+            // Drop succeeded ids from selection so user can retry only failures.
+            const failedIds = new Set(failures.map((f) => f.category_id));
+            setSelectedIds((prev) => prev.filter((id) => failedIds.has(id)));
+          }
+          await reload();
+        }}
       />
     </AppShell>
   );

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -70,7 +70,7 @@ export default function CategoriesPage() {
   const [refreshError, setRefreshError] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
-  // ── C2 UI: Edit-mode + batch select (C2a + C2c) ──────────────────────────
+  // -- C2 UI: Edit-mode + batch select (C2a + C2c) --------------------------
   // C2a: page-level Edit toggle. C2c: batch select for move/delete.
   // Selection is subcategory-only by design (C0 spec section 4.7: master
   // delete with children returns 409, so master rows do not participate in
@@ -93,7 +93,7 @@ export default function CategoriesPage() {
     );
   }, []);
 
-  // Esc exits Edit mode (only when no modal is open — modals own their own Esc).
+  // Esc exits Edit mode (only when no modal is open; modals own their own Esc).
   useEffect(() => {
     if (!editMode) return;
     const handler = (e: KeyboardEvent) => {
@@ -105,7 +105,7 @@ export default function CategoriesPage() {
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [editMode, batchMoveOpen, batchDeleteOpen, confirmDeleteId, editingCatId, addingToMaster, exitEditMode]);
-  // ── /C2 UI ──────────────────────────────────────────────────────────────
+  // -- /C2 UI ---------------------------------------------------------------
 
   const reload = useCallback(async () => {
     const data = await apiFetch<Category[]>("/api/v1/categories");

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -403,9 +403,14 @@ export default function CategoriesPage() {
         categories={categories}
         onCancel={() => setBatchMoveOpen(false)}
         onSuccess={async () => {
+          // Reload FIRST so a refresh failure surfaces inside the modal's
+          // batch-move-refresh-error banner (the modal awaits this promise
+          // and re-throws). Closing the modal before awaiting reload would
+          // unmount the banner before it could ever render. Mirrors the
+          // finishWithMaster pattern from AddMasterWithSubsModal in PR #192.
+          await reload();
           setBatchMoveOpen(false);
           exitEditMode();
-          await reload();
         }}
       />
       <BatchDeleteModal
@@ -418,6 +423,11 @@ export default function CategoriesPage() {
           void reload();
         }}
         onSuccess={async (failures) => {
+          // Reload FIRST. If reload throws, the modal stays open and shows
+          // its batch-delete-refresh-error banner. State changes that
+          // depend on a successful reload (closing the modal, exiting edit
+          // mode, dropping succeeded ids) only happen after reload resolves.
+          await reload();
           if (failures.length === 0) {
             setBatchDeleteOpen(false);
             exitEditMode();
@@ -426,7 +436,6 @@ export default function CategoriesPage() {
             const failedIds = new Set(failures.map((f) => f.category_id));
             setSelectedIds((prev) => prev.filter((id) => failedIds.has(id)));
           }
-          await reload();
         }}
       />
     </AppShell>

--- a/frontend/components/categories/BatchActionBar.tsx
+++ b/frontend/components/categories/BatchActionBar.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { btnPrimary, btnSecondary } from "@/lib/styles";
+
+interface Props {
+  count: number;
+  onMove: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+}
+
+/**
+ * Sticky bottom-of-page batch-action bar. Visible only when at least one
+ * subcategory is selected in Edit mode. Owned by Team Categories C2 UI.
+ */
+export default function BatchActionBar({ count, onMove, onDelete, onClear }: Props) {
+  if (count < 1) return null;
+
+  return (
+    <div
+      data-testid="batch-action-bar"
+      role="toolbar"
+      aria-label="Batch actions"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/85"
+    >
+      <div className="mx-auto flex max-w-6xl flex-col items-stretch gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3 md:px-6">
+        <div className="flex items-center gap-3">
+          <span
+            data-testid="batch-action-count"
+            className="text-sm font-medium text-text-primary"
+          >
+            {count} selected
+          </span>
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs text-text-muted hover:text-accent"
+          >
+            Clear
+          </button>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
+          <button
+            type="button"
+            data-testid="batch-move-button"
+            onClick={onMove}
+            className={`${btnSecondary} min-h-[44px] sm:min-h-0`}
+          >
+            Move {count} to...
+          </button>
+          <button
+            type="button"
+            data-testid="batch-delete-button"
+            onClick={onDelete}
+            className={`${btnPrimary} min-h-[44px] sm:min-h-0 !bg-danger hover:!bg-red-600`}
+          >
+            Delete {count}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/categories/BatchDeleteModal.tsx
+++ b/frontend/components/categories/BatchDeleteModal.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { apiFetch, ApiResponseError, extractErrorMessage } from "@/lib/api";
+import { btnSecondary, input } from "@/lib/styles";
+import type { Category } from "@/lib/types";
+
+interface CategoryDeleteResult {
+  deleted_category_id: number;
+  migration_target_id: number | null;
+  migrated_transaction_count: number;
+  migrated_recurring_count: number;
+  migrated_forecast_item_count: number;
+  deleted_rule_count: number;
+}
+
+interface FailureRow {
+  category_id: number;
+  category_name: string;
+  reason: string;
+  reason_code?: string;
+}
+
+interface Props {
+  open: boolean;
+  selectedIds: number[];
+  categories: Category[];
+  onCancel: () => void;
+  onSuccess: (failures: FailureRow[]) => void;
+}
+
+/**
+ * Two-phase batch-delete flow per C0 spec section 4.7 and 7.1:
+ * 1. Surface aggregate counts. For categories that report a non-zero
+ *    transaction_count we expose a per-category migration target picker.
+ * 2. Loop DELETE /api/v1/categories/{id}?target_category_id={n} per row.
+ *    Surface per-row failures with reason (has_children, name_collision,
+ *    last_in_type, type_mismatch); allow the user to fix the offending
+ *    target and retry only the failures.
+ *
+ * Owned by Team Categories C2 UI.
+ */
+export default function BatchDeleteModal({
+  open,
+  selectedIds,
+  categories,
+  onCancel,
+  onSuccess,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [migrationTargets, setMigrationTargets] = useState<Record<number, number | "">>({});
+  const [pendingIds, setPendingIds] = useState<number[]>([]);
+  const [failures, setFailures] = useState<FailureRow[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [globalError, setGlobalError] = useState("");
+
+  const selectedSubs = useMemo(
+    () => categories.filter((c) => selectedIds.includes(c.id) && c.parent_id !== null),
+    [categories, selectedIds],
+  );
+
+  // Reset when opening / selection changes.
+  useEffect(() => {
+    if (open) {
+      setMigrationTargets({});
+      setPendingIds(selectedSubs.map((s) => s.id));
+      setFailures([]);
+      setGlobalError("");
+      setSubmitting(false);
+    }
+  }, [open, selectedSubs]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  const rowsToShow = useMemo(
+    () => selectedSubs.filter((s) => pendingIds.includes(s.id)),
+    [selectedSubs, pendingIds],
+  );
+
+  const aggregate = useMemo(() => {
+    let withDeps = 0;
+    let txCount = 0;
+    for (const s of rowsToShow) {
+      if (s.transaction_count > 0) withDeps += 1;
+      txCount += s.transaction_count;
+    }
+    return { withDeps, txCount };
+  }, [rowsToShow]);
+
+  // Build a per-row compatible-target list. INCOME requires INCOME or BOTH.
+  // EXPENSE requires EXPENSE or BOTH. BOTH defaults to BOTH for safety
+  // (matches spec section 4.6 frontend behaviour).
+  function compatibleTargets(sub: Category): Category[] {
+    return categories.filter((c) => {
+      if (c.id === sub.id) return false;
+      if (c.parent_id !== null) return false;
+      if (sub.type === "income") return c.type === "income" || c.type === "both";
+      if (sub.type === "expense") return c.type === "expense" || c.type === "both";
+      return c.type === "both";
+    });
+  }
+
+  async function handleConfirm() {
+    setSubmitting(true);
+    setGlobalError("");
+    const newFailures: FailureRow[] = [];
+    const succeeded: number[] = [];
+
+    for (const sub of rowsToShow) {
+      const needsTarget = sub.transaction_count > 0;
+      const targetId = migrationTargets[sub.id];
+
+      if (needsTarget && (targetId === undefined || targetId === "" || targetId === 0)) {
+        newFailures.push({
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: "Pick a migration target for this subcategory.",
+          reason_code: "migration_target_required",
+        });
+        continue;
+      }
+
+      const path =
+        needsTarget && targetId
+          ? `/api/v1/categories/${sub.id}?target_category_id=${targetId}`
+          : `/api/v1/categories/${sub.id}`;
+
+      try {
+        await apiFetch<CategoryDeleteResult | undefined>(path, { method: "DELETE" });
+        succeeded.push(sub.id);
+      } catch (err) {
+        newFailures.push(buildFailure(sub, err));
+      }
+    }
+
+    setSubmitting(false);
+
+    // Drop succeeded rows from the pending set; keep failures listed for retry.
+    if (newFailures.length === 0) {
+      setFailures([]);
+      setPendingIds([]);
+      onSuccess([]);
+      return;
+    }
+
+    setFailures(newFailures);
+    setPendingIds(newFailures.map((f) => f.category_id));
+
+    if (succeeded.length > 0) {
+      // Notify parent so it can refresh and clear succeeded ids from selection.
+      onSuccess(newFailures);
+    }
+  }
+
+  if (!open) return null;
+
+  const allDone = pendingIds.length === 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="batch-delete-title"
+        data-testid="batch-delete-modal"
+        className="w-full max-w-[min(36rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="batch-delete-title" className="text-lg font-semibold text-text-primary">
+          Delete {rowsToShow.length} subcategor{rowsToShow.length === 1 ? "y" : "ies"}
+        </h3>
+        <p
+          data-testid="batch-delete-aggregate"
+          className="mt-1 text-sm text-text-secondary"
+        >
+          {aggregate.withDeps === 0 ? (
+            <>No referenced transactions. Subcategories will be removed.</>
+          ) : (
+            <>
+              {aggregate.withDeps} of {rowsToShow.length} hold{" "}
+              {aggregate.withDeps === 1 ? "a referencing transaction" : "referencing transactions"}{" "}
+              ({aggregate.txCount} total). Pick a migration target for each.
+            </>
+          )}
+        </p>
+
+        <div className="mt-4 space-y-3">
+          {rowsToShow.map((sub) => {
+            const failure = failures.find((f) => f.category_id === sub.id);
+            const needsTarget = sub.transaction_count > 0;
+            const targets = compatibleTargets(sub);
+            const value = migrationTargets[sub.id] ?? "";
+            return (
+              <div
+                key={sub.id}
+                data-testid={`batch-delete-row-${sub.id}`}
+                className={`rounded-md border p-3 ${
+                  failure ? "border-danger" : "border-border"
+                }`}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-text-primary">
+                      {sub.name}
+                    </p>
+                    <p className="text-xs text-text-muted">
+                      {sub.transaction_count} transaction
+                      {sub.transaction_count === 1 ? "" : "s"} . type {sub.type}
+                    </p>
+                  </div>
+                </div>
+
+                {needsTarget && (
+                  <div className="mt-2">
+                    <label
+                      htmlFor={`batch-delete-target-${sub.id}`}
+                      className="mb-1 block text-xs text-text-muted"
+                    >
+                      Migrate to
+                    </label>
+                    <select
+                      id={`batch-delete-target-${sub.id}`}
+                      data-testid={`batch-delete-target-${sub.id}`}
+                      value={value}
+                      onChange={(e) =>
+                        setMigrationTargets((prev) => ({
+                          ...prev,
+                          [sub.id]: e.target.value === "" ? "" : Number(e.target.value),
+                        }))
+                      }
+                      className={input}
+                    >
+                      <option value="">Select a master...</option>
+                      {targets.map((t) => (
+                        <option key={t.id} value={t.id}>
+                          {t.name} ({t.type})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
+                {failure && (
+                  <p
+                    data-testid={`batch-delete-failure-${sub.id}`}
+                    className="mt-2 text-xs text-danger"
+                  >
+                    {failure.reason}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {globalError && (
+          <div className="mt-4 rounded-md bg-danger-dim px-4 py-3 text-sm text-danger">
+            {globalError}
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
+          >
+            Close
+          </button>
+          {!allDone && (
+            <button
+              type="button"
+              data-testid="batch-delete-confirm"
+              onClick={handleConfirm}
+              disabled={submitting}
+              className="rounded-md bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50 w-full sm:w-auto min-h-[44px]"
+            >
+              {submitting
+                ? "Deleting..."
+                : failures.length > 0
+                  ? `Retry ${rowsToShow.length}`
+                  : `Delete ${rowsToShow.length}`}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CategoryErrorDetail {
+  detail?: string;
+  conflicting_child_name?: string;
+  scope?: string;
+  type?: string;
+  child_names?: string[];
+  source_type?: string;
+  target_type?: string;
+  dependent_breakdown?: { income: number; expense: number };
+}
+
+function buildFailure(sub: Category, err: unknown): FailureRow {
+  if (err instanceof ApiResponseError) {
+    const detail = err.detail as CategoryErrorDetail | string | undefined;
+    if (typeof detail === "object" && detail !== null) {
+      if (detail.detail === "last_in_type") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Cannot delete the only ${detail.type ?? ""} ${detail.scope ?? "subcategory"}.`,
+          reason_code: "last_in_type",
+        };
+      }
+      if (detail.detail === "has_children") {
+        const sample = detail.child_names?.[0] ?? "subcategory";
+        const more = (detail.child_names?.length ?? 0) - 1;
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Has subcategories. Move or delete "${sample}"${
+            more > 0 ? ` and ${more} other${more === 1 ? "" : "s"}` : ""
+          } first.`,
+          reason_code: "has_children",
+        };
+      }
+      if (detail.detail === "type_mismatch") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Migration target type ${detail.target_type ?? ""} is not compatible with ${detail.source_type ?? "source"}.`,
+          reason_code: "type_mismatch",
+        };
+      }
+      if (detail.detail === "name_collision") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Name collision: "${detail.conflicting_child_name ?? sub.name}" already exists on the target.`,
+          reason_code: "name_collision",
+        };
+      }
+      if (detail.detail === "migration_target_required") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Migration target required.`,
+          reason_code: "migration_target_required",
+        };
+      }
+    }
+    return {
+      category_id: sub.id,
+      category_name: sub.name,
+      reason: err.message || "Delete failed",
+    };
+  }
+  return {
+    category_id: sub.id,
+    category_name: sub.name,
+    reason: extractErrorMessage(err, "Delete failed"),
+  };
+}

--- a/frontend/components/categories/BatchDeleteModal.tsx
+++ b/frontend/components/categories/BatchDeleteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, ApiResponseError, extractErrorMessage } from "@/lib/api";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { btnSecondary, input } from "@/lib/styles";
 import type { Category } from "@/lib/types";
 
@@ -26,17 +27,37 @@ interface Props {
   selectedIds: number[];
   categories: Category[];
   onCancel: () => void;
-  onSuccess: (failures: FailureRow[]) => void;
+  /** May be async; the modal awaits it and surfaces refresh errors
+   *  inline with a Retry control. Mirrors the AddMasterWithSubsModal
+   *  pattern so the post-mutation reload never silently drops a
+   *  failure. */
+  onSuccess: (failures: FailureRow[]) => void | Promise<void>;
 }
 
 /**
  * Two-phase batch-delete flow per C0 spec section 4.7 and 7.1:
- * 1. Surface aggregate counts. For categories that report a non-zero
- *    transaction_count we expose a per-category migration target picker.
+ * 1. Surface aggregate counts and a per-row migration target picker.
+ *    The picker is ALWAYS rendered because the C0 delete contract
+ *    requires a migration target whenever the source has dependents
+ *    of any kind: transactions, recurring templates, OR forecast plan
+ *    items (`category_service.delete_category_with_migration` line ~1188
+ *    branches on `_dependent_breakdown.is_empty`). The frontend cannot
+ *    cheaply pre-detect non-transaction dependents without a dedicated
+ *    preview endpoint, so we always offer the picker; if the source
+ *    truly has no dependents the backend takes the 204 path and ignores
+ *    the supplied target. Single-delete (handled elsewhere on the page)
+ *    is the only path that can omit the target.
  * 2. Loop DELETE /api/v1/categories/{id}?target_category_id={n} per row.
  *    Surface per-row failures with reason (has_children, name_collision,
  *    last_in_type, type_mismatch); allow the user to fix the offending
  *    target and retry only the failures.
+ *
+ * Type compatibility for the picker mirrors the backend rule at
+ * `_check_target_compatibility_for_delete`: INCOME source -> INCOME or
+ * BOTH master; EXPENSE source -> EXPENSE or BOTH master. BOTH source
+ * defaults to BOTH master in the picker (the lenient breakdown-driven
+ * path can only be reasoned about by the backend, so we present the
+ * safe default and let the user retry if the backend rejects it).
  *
  * Owned by Team Categories C2 UI.
  */
@@ -48,11 +69,14 @@ export default function BatchDeleteModal({
   onSuccess,
 }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
   const [migrationTargets, setMigrationTargets] = useState<Record<number, number | "">>({});
   const [pendingIds, setPendingIds] = useState<number[]>([]);
   const [failures, setFailures] = useState<FailureRow[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [globalError, setGlobalError] = useState("");
+  const [refreshError, setRefreshError] = useState<string>("");
+  const [lastFailures, setLastFailures] = useState<FailureRow[] | null>(null);
 
   const selectedSubs = useMemo(
     () => categories.filter((c) => selectedIds.includes(c.id) && c.parent_id !== null),
@@ -66,7 +90,9 @@ export default function BatchDeleteModal({
       setPendingIds(selectedSubs.map((s) => s.id));
       setFailures([]);
       setGlobalError("");
+      setRefreshError("");
       setSubmitting(false);
+      setLastFailures(null);
     }
   }, [open, selectedSubs]);
 
@@ -90,45 +116,84 @@ export default function BatchDeleteModal({
     };
   }, [open]);
 
+  // Focus trap: initial focus to Cancel (Close) so a stray Enter does
+  // not arm a destructive action.
+  useFocusTrap({
+    active: open,
+    containerRef: dialogRef,
+    initialFocusRef: cancelRef,
+  });
+
   const rowsToShow = useMemo(
     () => selectedSubs.filter((s) => pendingIds.includes(s.id)),
     [selectedSubs, pendingIds],
   );
 
   const aggregate = useMemo(() => {
-    let withDeps = 0;
+    let withTx = 0;
     let txCount = 0;
     for (const s of rowsToShow) {
-      if (s.transaction_count > 0) withDeps += 1;
+      if (s.transaction_count > 0) withTx += 1;
       txCount += s.transaction_count;
     }
-    return { withDeps, txCount };
+    return { withTx, txCount };
   }, [rowsToShow]);
 
-  // Build a per-row compatible-target list. INCOME requires INCOME or BOTH.
-  // EXPENSE requires EXPENSE or BOTH. BOTH defaults to BOTH for safety
-  // (matches spec section 4.6 frontend behaviour).
+  // Per-row compatible-target list. INCOME source -> INCOME or BOTH
+  // target. EXPENSE source -> EXPENSE or BOTH target. BOTH source falls
+  // back to BOTH target (the safe default for the breakdown-driven
+  // backend rule). The candidate list also excludes the source itself
+  // and excludes other selected subs (so the user cannot pick a sub
+  // about to be deleted as the migration target).
   function compatibleTargets(sub: Category): Category[] {
+    const otherSelected = new Set(rowsToShow.map((s) => s.id));
     return categories.filter((c) => {
       if (c.id === sub.id) return false;
       if (c.parent_id !== null) return false;
+      if (otherSelected.has(c.id)) return false;
       if (sub.type === "income") return c.type === "income" || c.type === "both";
       if (sub.type === "expense") return c.type === "expense" || c.type === "both";
       return c.type === "both";
     });
   }
 
+  // Submit is gated on every row having a migration target picked.
+  // The backend takes the 204 path and ignores the target when the
+  // source has no dependents, so the extra arg is harmless when not
+  // needed.
+  const allTargetsPicked = useMemo(
+    () =>
+      rowsToShow.every((s) => {
+        const v = migrationTargets[s.id];
+        return v !== undefined && v !== "" && v !== 0;
+      }),
+    [rowsToShow, migrationTargets],
+  );
+
+  async function runRefresh(failuresToReport: FailureRow[]) {
+    setRefreshError("");
+    try {
+      await onSuccess(failuresToReport);
+    } catch (err) {
+      setRefreshError(
+        err instanceof Error
+          ? `Delete completed but the page failed to refresh: ${err.message}`
+          : "Delete completed but the page failed to refresh.",
+      );
+    }
+  }
+
   async function handleConfirm() {
     setSubmitting(true);
     setGlobalError("");
+    setRefreshError("");
     const newFailures: FailureRow[] = [];
     const succeeded: number[] = [];
 
     for (const sub of rowsToShow) {
-      const needsTarget = sub.transaction_count > 0;
       const targetId = migrationTargets[sub.id];
 
-      if (needsTarget && (targetId === undefined || targetId === "" || targetId === 0)) {
+      if (targetId === undefined || targetId === "" || targetId === 0) {
         newFailures.push({
           category_id: sub.id,
           category_name: sub.name,
@@ -138,10 +203,7 @@ export default function BatchDeleteModal({
         continue;
       }
 
-      const path =
-        needsTarget && targetId
-          ? `/api/v1/categories/${sub.id}?target_category_id=${targetId}`
-          : `/api/v1/categories/${sub.id}`;
+      const path = `/api/v1/categories/${sub.id}?target_category_id=${targetId}`;
 
       try {
         await apiFetch<CategoryDeleteResult | undefined>(path, { method: "DELETE" });
@@ -157,16 +219,18 @@ export default function BatchDeleteModal({
     if (newFailures.length === 0) {
       setFailures([]);
       setPendingIds([]);
-      onSuccess([]);
+      setLastFailures([]);
+      await runRefresh([]);
       return;
     }
 
     setFailures(newFailures);
     setPendingIds(newFailures.map((f) => f.category_id));
+    setLastFailures(newFailures);
 
     if (succeeded.length > 0) {
       // Notify parent so it can refresh and clear succeeded ids from selection.
-      onSuccess(newFailures);
+      await runRefresh(newFailures);
     }
   }
 
@@ -195,12 +259,14 @@ export default function BatchDeleteModal({
           data-testid="batch-delete-aggregate"
           className="mt-1 text-sm text-text-secondary"
         >
-          {aggregate.withDeps === 0 ? (
-            <>No referenced transactions. Subcategories will be removed.</>
+          {aggregate.withTx === 0 ? (
+            <>
+              Pick a migration target for each subcategory. Recurring templates and forecast plan items also reassign through the target.
+            </>
           ) : (
             <>
-              {aggregate.withDeps} of {rowsToShow.length} hold{" "}
-              {aggregate.withDeps === 1 ? "a referencing transaction" : "referencing transactions"}{" "}
+              {aggregate.withTx} of {rowsToShow.length} hold{" "}
+              {aggregate.withTx === 1 ? "a referencing transaction" : "referencing transactions"}{" "}
               ({aggregate.txCount} total). Pick a migration target for each.
             </>
           )}
@@ -209,7 +275,6 @@ export default function BatchDeleteModal({
         <div className="mt-4 space-y-3">
           {rowsToShow.map((sub) => {
             const failure = failures.find((f) => f.category_id === sub.id);
-            const needsTarget = sub.transaction_count > 0;
             const targets = compatibleTargets(sub);
             const value = migrationTargets[sub.id] ?? "";
             return (
@@ -232,35 +297,33 @@ export default function BatchDeleteModal({
                   </div>
                 </div>
 
-                {needsTarget && (
-                  <div className="mt-2">
-                    <label
-                      htmlFor={`batch-delete-target-${sub.id}`}
-                      className="mb-1 block text-xs text-text-muted"
-                    >
-                      Migrate to
-                    </label>
-                    <select
-                      id={`batch-delete-target-${sub.id}`}
-                      data-testid={`batch-delete-target-${sub.id}`}
-                      value={value}
-                      onChange={(e) =>
-                        setMigrationTargets((prev) => ({
-                          ...prev,
-                          [sub.id]: e.target.value === "" ? "" : Number(e.target.value),
-                        }))
-                      }
-                      className={input}
-                    >
-                      <option value="">Select a master...</option>
-                      {targets.map((t) => (
-                        <option key={t.id} value={t.id}>
-                          {t.name} ({t.type})
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                )}
+                <div className="mt-2">
+                  <label
+                    htmlFor={`batch-delete-target-${sub.id}`}
+                    className="mb-1 block text-xs text-text-muted"
+                  >
+                    Migrate to
+                  </label>
+                  <select
+                    id={`batch-delete-target-${sub.id}`}
+                    data-testid={`batch-delete-target-${sub.id}`}
+                    value={value}
+                    onChange={(e) =>
+                      setMigrationTargets((prev) => ({
+                        ...prev,
+                        [sub.id]: e.target.value === "" ? "" : Number(e.target.value),
+                      }))
+                    }
+                    className={input}
+                  >
+                    <option value="">Select a master...</option>
+                    {targets.map((t) => (
+                      <option key={t.id} value={t.id}>
+                        {t.name} ({t.type})
+                      </option>
+                    ))}
+                  </select>
+                </div>
 
                 {failure && (
                   <p
@@ -281,8 +344,27 @@ export default function BatchDeleteModal({
           </div>
         )}
 
+        {refreshError && (
+          <div
+            data-testid="batch-delete-refresh-error"
+            role="alert"
+            className="mt-4 flex items-center justify-between gap-3 rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
+          >
+            <span>{refreshError}</span>
+            <button
+              type="button"
+              data-testid="batch-delete-refresh-retry"
+              onClick={() => void runRefresh(lastFailures ?? failures)}
+              className="rounded-md border border-danger/40 px-3 py-1 text-xs font-medium text-danger hover:bg-danger/10"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           <button
+            ref={cancelRef}
             type="button"
             onClick={onCancel}
             className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
@@ -294,7 +376,7 @@ export default function BatchDeleteModal({
               type="button"
               data-testid="batch-delete-confirm"
               onClick={handleConfirm}
-              disabled={submitting}
+              disabled={submitting || !allTargetsPicked}
               className="rounded-md bg-danger px-4 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50 w-full sm:w-auto min-h-[44px]"
             >
               {submitting

--- a/frontend/components/categories/BatchMoveModal.tsx
+++ b/frontend/components/categories/BatchMoveModal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, ApiResponseError, extractErrorMessage } from "@/lib/api";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { btnPrimary, btnSecondary, input } from "@/lib/styles";
 import type { Category } from "@/lib/types";
 
@@ -31,7 +32,11 @@ interface Props {
   selectedIds: number[];
   categories: Category[];
   onCancel: () => void;
-  onSuccess: () => void;
+  /** May be async; the modal awaits it and surfaces refresh errors
+   *  inline with a Retry control. Mirrors the AddMasterWithSubsModal
+   *  pattern so the post-mutation reload never silently drops a
+   *  failure. */
+  onSuccess: () => void | Promise<void>;
 }
 
 /**
@@ -40,11 +45,11 @@ interface Props {
  * 2. Confirm against aggregate preview counts and call the all-or-nothing
  *    POST /api/v1/categories/batch-move endpoint per the C0 spec section 3.C.
  *
- * Compatibility filter: every selected subcategory's type must be allowed by
- * the target master. INCOME source -> INCOME or BOTH target. EXPENSE source ->
- * EXPENSE or BOTH target. BOTH source -> BOTH target only (the safe default
- * matching spec section 4.6 frontend behaviour). Mixed selections fall back
- * to BOTH targets only.
+ * Compatibility filter mirrors the backend rule at
+ * `category_service.move_subcategory` line ~754: `sub.type == target.type`
+ * (strict equality). INCOME source -> INCOME target only. EXPENSE source ->
+ * EXPENSE target only. BOTH source -> BOTH target only. Mixed selections
+ * are blocked at the picker because the user must move one type at a time.
  *
  * Owned by Team Categories C2 UI.
  */
@@ -56,6 +61,7 @@ export default function BatchMoveModal({
   onSuccess,
 }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const filterRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState("");
   const [targetId, setTargetId] = useState<number | null>(null);
   const [previewing, setPreviewing] = useState(false);
@@ -63,29 +69,36 @@ export default function BatchMoveModal({
   const [previewError, setPreviewError] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string>("");
+  const [refreshError, setRefreshError] = useState<string>("");
 
   const selectedSubs = useMemo(
     () => categories.filter((c) => selectedIds.includes(c.id) && c.parent_id !== null),
     [categories, selectedIds],
   );
 
-  const requiredTargetTypes = useMemo<Array<Category["type"]>>(() => {
-    const types = new Set(selectedSubs.map((s) => s.type));
-    if (types.size === 0) return ["both"];
-    if (types.size > 1) return ["both"];
-    const sole = [...types][0];
-    if (sole === "income") return ["income", "both"];
-    if (sole === "expense") return ["expense", "both"];
-    return ["both"];
-  }, [selectedSubs]);
+  // Mixed selections (income + expense in the same batch) cannot share a
+  // target master under the strict-equality rule. The picker hides all
+  // candidates and surfaces an inline message asking the user to move
+  // one type at a time. Submit stays disabled until the selection is
+  // single-typed.
+  const selectedTypes = useMemo(
+    () => new Set(selectedSubs.map((s) => s.type)),
+    [selectedSubs],
+  );
+  const mixedSelection = selectedTypes.size > 1;
+  const soleType = selectedTypes.size === 1
+    ? ([...selectedTypes][0] as Category["type"])
+    : null;
 
   const candidateMasters = useMemo(() => {
+    if (mixedSelection) return [];
+    if (soleType === null) return [];
     const sq = filter.trim().toLowerCase();
     return categories
       .filter((c) => c.parent_id === null)
-      .filter((c) => requiredTargetTypes.includes(c.type))
+      .filter((c) => c.type === soleType)
       .filter((m) => (sq ? m.name.toLowerCase().includes(sq) : true));
-  }, [categories, filter, requiredTargetTypes]);
+  }, [categories, filter, mixedSelection, soleType]);
 
   // Reset internal state when the modal closes or the selection changes.
   useEffect(() => {
@@ -95,6 +108,7 @@ export default function BatchMoveModal({
       setPreview(null);
       setPreviewError("");
       setSubmitError("");
+      setRefreshError("");
       setSubmitting(false);
       setPreviewing(false);
     }
@@ -119,6 +133,13 @@ export default function BatchMoveModal({
       document.body.style.overflow = "";
     };
   }, [open]);
+
+  // Focus trap: initial focus to the filter input, restore on close.
+  useFocusTrap({
+    active: open,
+    containerRef: dialogRef,
+    initialFocusRef: filterRef,
+  });
 
   // Aggregate preview: call preview per subcategory, sum counts, OR the
   // budget_actuals_shifted flag.
@@ -171,10 +192,24 @@ export default function BatchMoveModal({
     };
   }, [open, targetId, selectedSubs]);
 
+  async function runRefresh() {
+    setRefreshError("");
+    try {
+      await onSuccess();
+    } catch (err) {
+      setRefreshError(
+        err instanceof Error
+          ? `Move succeeded but the page failed to refresh: ${err.message}`
+          : "Move succeeded but the page failed to refresh.",
+      );
+    }
+  }
+
   async function handleConfirm() {
     if (targetId === null) return;
     setSubmitting(true);
     setSubmitError("");
+    setRefreshError("");
     try {
       await apiFetch<BatchMoveResultBody>("/api/v1/categories/batch-move", {
         method: "POST",
@@ -185,7 +220,7 @@ export default function BatchMoveModal({
           })),
         }),
       });
-      onSuccess();
+      await runRefresh();
     } catch (err) {
       // The C0 spec is all-or-nothing: a 4xx fails the whole batch. We surface
       // the structured detail (name_collision, type_mismatch, etc.) verbatim;
@@ -223,17 +258,29 @@ export default function BatchMoveModal({
           Pick a target master. All-or-nothing: if any move would collide or be type-incompatible, the whole batch is rejected.
         </p>
 
+        {mixedSelection && (
+          <div
+            data-testid="batch-move-mixed-warning"
+            role="alert"
+            className="mt-4 rounded-md bg-warning-dim px-4 py-3 text-sm text-warning"
+          >
+            Selection mixes income and expense subcategories. Move one type at a time.
+          </div>
+        )}
+
         <div className="mt-4">
           <label htmlFor="batch-move-filter" className="sr-only">
             Filter masters
           </label>
           <input
+            ref={filterRef}
             id="batch-move-filter"
             type="text"
             placeholder="Filter masters..."
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             className={input}
+            disabled={mixedSelection}
           />
         </div>
 
@@ -244,8 +291,11 @@ export default function BatchMoveModal({
         >
           {candidateMasters.length === 0 ? (
             <p className="p-4 text-xs text-text-muted">
-              No compatible masters. Selected subcategories require a target of type{" "}
-              {requiredTargetTypes.join(" or ")}.
+              {mixedSelection
+                ? "No targets while the selection mixes types."
+                : soleType
+                  ? `No compatible masters. Selected subcategories require a target of type ${soleType}.`
+                  : "No subcategories selected."}
             </p>
           ) : (
             candidateMasters.map((m) => (
@@ -311,6 +361,24 @@ export default function BatchMoveModal({
           </div>
         )}
 
+        {refreshError && (
+          <div
+            data-testid="batch-move-refresh-error"
+            role="alert"
+            className="mt-4 flex items-center justify-between gap-3 rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
+          >
+            <span>{refreshError}</span>
+            <button
+              type="button"
+              data-testid="batch-move-refresh-retry"
+              onClick={() => void runRefresh()}
+              className="rounded-md border border-danger/40 px-3 py-1 text-xs font-medium text-danger hover:bg-danger/10"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           <button
             type="button"
@@ -323,7 +391,9 @@ export default function BatchMoveModal({
             type="button"
             data-testid="batch-move-confirm"
             onClick={handleConfirm}
-            disabled={targetId === null || submitting || previewing}
+            disabled={
+              targetId === null || submitting || previewing || mixedSelection
+            }
             className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
           >
             {submitting ? "Moving..." : "Move"}

--- a/frontend/components/categories/BatchMoveModal.tsx
+++ b/frontend/components/categories/BatchMoveModal.tsx
@@ -90,7 +90,25 @@ export default function BatchMoveModal({
     ? ([...selectedTypes][0] as Category["type"])
     : null;
 
-  const candidateMasters = useMemo(() => {
+  // Source masters of the current selection. Backend rejects a move where
+  // `target_parent_id == sub.parent_id` as a no-op
+  // (`category_service.move_subcategory` line 748). We strip these IDs from
+  // the candidate list so the UI never offers a target that would 400. When
+  // the selection spans multiple masters, ALL source masters are excluded.
+  const sourceParentIds = useMemo(
+    () =>
+      new Set(
+        selectedSubs
+          .map((s) => s.parent_id)
+          .filter((id): id is number => id !== null),
+      ),
+    [selectedSubs],
+  );
+
+  // Type-compat candidates BEFORE source-parent exclusion. We keep this
+  // separate so we can detect the "all compat masters are sources" empty
+  // state (no target would be valid even if the user retried).
+  const typeCompatMasters = useMemo(() => {
     if (mixedSelection) return [];
     if (soleType === null) return [];
     const sq = filter.trim().toLowerCase();
@@ -99,6 +117,25 @@ export default function BatchMoveModal({
       .filter((c) => c.type === soleType)
       .filter((m) => (sq ? m.name.toLowerCase().includes(sq) : true));
   }, [categories, filter, mixedSelection, soleType]);
+
+  const candidateMasters = useMemo(
+    () => typeCompatMasters.filter((m) => !sourceParentIds.has(m.id)),
+    [typeCompatMasters, sourceParentIds],
+  );
+
+  // True only when the unfiltered (no search) compat list is non-empty but
+  // every entry is a source parent. Distinct from "no compat masters at
+  // all" so the inline message can be specific.
+  const allCompatAreSources = useMemo(() => {
+    if (mixedSelection) return false;
+    if (soleType === null) return false;
+    if (filter.trim().length > 0) return false;
+    const allCompat = categories
+      .filter((c) => c.parent_id === null)
+      .filter((c) => c.type === soleType);
+    if (allCompat.length === 0) return false;
+    return allCompat.every((m) => sourceParentIds.has(m.id));
+  }, [categories, filter, mixedSelection, soleType, sourceParentIds]);
 
   // Reset internal state when the modal closes or the selection changes.
   useEffect(() => {
@@ -290,12 +327,17 @@ export default function BatchMoveModal({
           className="mt-3 max-h-56 overflow-y-auto rounded-md border border-border"
         >
           {candidateMasters.length === 0 ? (
-            <p className="p-4 text-xs text-text-muted">
+            <p
+              data-testid="batch-move-empty-message"
+              className="p-4 text-xs text-text-muted"
+            >
               {mixedSelection
                 ? "No targets while the selection mixes types."
-                : soleType
-                  ? `No compatible masters. Selected subcategories require a target of type ${soleType}.`
-                  : "No subcategories selected."}
+                : allCompatAreSources
+                  ? "All compatible target masters are already parents of the selected subcategories."
+                  : soleType
+                    ? `No compatible masters. Selected subcategories require a target of type ${soleType}.`
+                    : "No subcategories selected."}
             </p>
           ) : (
             candidateMasters.map((m) => (

--- a/frontend/components/categories/BatchMoveModal.tsx
+++ b/frontend/components/categories/BatchMoveModal.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { apiFetch, ApiResponseError, extractErrorMessage } from "@/lib/api";
+import { btnPrimary, btnSecondary, input } from "@/lib/styles";
+import type { Category } from "@/lib/types";
+
+interface CategoryMoveResult {
+  category_id: number;
+  source_master_id: number;
+  target_master_id: number;
+  affected_transaction_count: number;
+  affected_recurring_count: number;
+  affected_forecast_item_count: number;
+  budget_actuals_shifted: boolean;
+}
+
+interface BatchMoveResultBody {
+  moves: CategoryMoveResult[];
+}
+
+interface PreviewAggregate {
+  transactions: number;
+  recurring: number;
+  forecast: number;
+  budget_actuals_shifted: boolean;
+}
+
+interface Props {
+  open: boolean;
+  selectedIds: number[];
+  categories: Category[];
+  onCancel: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Two-step batch-move flow:
+ * 1. Pick a target master (filterable list of compatible masters).
+ * 2. Confirm against aggregate preview counts and call the all-or-nothing
+ *    POST /api/v1/categories/batch-move endpoint per the C0 spec section 3.C.
+ *
+ * Compatibility filter: every selected subcategory's type must be allowed by
+ * the target master. INCOME source -> INCOME or BOTH target. EXPENSE source ->
+ * EXPENSE or BOTH target. BOTH source -> BOTH target only (the safe default
+ * matching spec section 4.6 frontend behaviour). Mixed selections fall back
+ * to BOTH targets only.
+ *
+ * Owned by Team Categories C2 UI.
+ */
+export default function BatchMoveModal({
+  open,
+  selectedIds,
+  categories,
+  onCancel,
+  onSuccess,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [filter, setFilter] = useState("");
+  const [targetId, setTargetId] = useState<number | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [preview, setPreview] = useState<PreviewAggregate | null>(null);
+  const [previewError, setPreviewError] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string>("");
+
+  const selectedSubs = useMemo(
+    () => categories.filter((c) => selectedIds.includes(c.id) && c.parent_id !== null),
+    [categories, selectedIds],
+  );
+
+  const requiredTargetTypes = useMemo<Array<Category["type"]>>(() => {
+    const types = new Set(selectedSubs.map((s) => s.type));
+    if (types.size === 0) return ["both"];
+    if (types.size > 1) return ["both"];
+    const sole = [...types][0];
+    if (sole === "income") return ["income", "both"];
+    if (sole === "expense") return ["expense", "both"];
+    return ["both"];
+  }, [selectedSubs]);
+
+  const candidateMasters = useMemo(() => {
+    const sq = filter.trim().toLowerCase();
+    return categories
+      .filter((c) => c.parent_id === null)
+      .filter((c) => requiredTargetTypes.includes(c.type))
+      .filter((m) => (sq ? m.name.toLowerCase().includes(sq) : true));
+  }, [categories, filter, requiredTargetTypes]);
+
+  // Reset internal state when the modal closes or the selection changes.
+  useEffect(() => {
+    if (!open) {
+      setFilter("");
+      setTargetId(null);
+      setPreview(null);
+      setPreviewError("");
+      setSubmitError("");
+      setSubmitting(false);
+      setPreviewing(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  // Aggregate preview: call preview per subcategory, sum counts, OR the
+  // budget_actuals_shifted flag.
+  useEffect(() => {
+    if (!open || targetId === null) {
+      setPreview(null);
+      setPreviewError("");
+      return;
+    }
+    let cancelled = false;
+    async function loadPreview() {
+      setPreviewing(true);
+      setPreview(null);
+      setPreviewError("");
+      try {
+        const results = await Promise.all(
+          selectedSubs.map((sub) =>
+            apiFetch<CategoryMoveResult>(
+              `/api/v1/categories/${sub.id}/move/preview?target_parent_id=${targetId}`,
+            ).catch((err) => {
+              throw err;
+            }),
+          ),
+        );
+        if (cancelled) return;
+        const agg: PreviewAggregate = {
+          transactions: 0,
+          recurring: 0,
+          forecast: 0,
+          budget_actuals_shifted: false,
+        };
+        for (const r of results) {
+          agg.transactions += r.affected_transaction_count;
+          agg.recurring += r.affected_recurring_count;
+          agg.forecast += r.affected_forecast_item_count;
+          agg.budget_actuals_shifted =
+            agg.budget_actuals_shifted || r.budget_actuals_shifted;
+        }
+        setPreview(agg);
+      } catch (err) {
+        if (cancelled) return;
+        setPreviewError(extractErrorMessage(err, "Could not load preview"));
+      } finally {
+        if (!cancelled) setPreviewing(false);
+      }
+    }
+    void loadPreview();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, targetId, selectedSubs]);
+
+  async function handleConfirm() {
+    if (targetId === null) return;
+    setSubmitting(true);
+    setSubmitError("");
+    try {
+      await apiFetch<BatchMoveResultBody>("/api/v1/categories/batch-move", {
+        method: "POST",
+        body: JSON.stringify({
+          moves: selectedSubs.map((s) => ({
+            subcategory_id: s.id,
+            target_parent_id: targetId,
+          })),
+        }),
+      });
+      onSuccess();
+    } catch (err) {
+      // The C0 spec is all-or-nothing: a 4xx fails the whole batch. We surface
+      // the structured detail (name_collision, type_mismatch, etc.) verbatim;
+      // the user fixes the offending row and retries with the same target.
+      if (err instanceof ApiResponseError && err.detail) {
+        setSubmitError(buildBatchErrorMessage(err, selectedSubs));
+      } else {
+        setSubmitError(extractErrorMessage(err, "Move failed"));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="batch-move-title"
+        data-testid="batch-move-modal"
+        className="w-full max-w-[min(32rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="batch-move-title" className="text-lg font-semibold text-text-primary">
+          Move {selectedSubs.length} subcategor{selectedSubs.length === 1 ? "y" : "ies"}
+        </h3>
+        <p className="mt-1 text-xs text-text-muted">
+          Pick a target master. All-or-nothing: if any move would collide or be type-incompatible, the whole batch is rejected.
+        </p>
+
+        <div className="mt-4">
+          <label htmlFor="batch-move-filter" className="sr-only">
+            Filter masters
+          </label>
+          <input
+            id="batch-move-filter"
+            type="text"
+            placeholder="Filter masters..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className={input}
+          />
+        </div>
+
+        <div
+          role="radiogroup"
+          aria-label="Target master"
+          className="mt-3 max-h-56 overflow-y-auto rounded-md border border-border"
+        >
+          {candidateMasters.length === 0 ? (
+            <p className="p-4 text-xs text-text-muted">
+              No compatible masters. Selected subcategories require a target of type{" "}
+              {requiredTargetTypes.join(" or ")}.
+            </p>
+          ) : (
+            candidateMasters.map((m) => (
+              <label
+                key={m.id}
+                data-testid={`batch-move-target-${m.id}`}
+                className={`flex cursor-pointer items-center justify-between gap-3 border-b border-border px-3 py-2 last:border-b-0 hover:bg-surface-raised ${
+                  targetId === m.id ? "bg-surface-raised" : ""
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="batch-move-target"
+                    value={m.id}
+                    checked={targetId === m.id}
+                    onChange={() => setTargetId(m.id)}
+                    className="h-4 w-4"
+                  />
+                  <span className="text-sm text-text-primary">{m.name}</span>
+                </div>
+                <span className="text-[11px] text-text-muted">{m.type}</span>
+              </label>
+            ))
+          )}
+        </div>
+
+        {targetId !== null && (
+          <div
+            className="mt-4 rounded-md border border-border bg-surface-raised p-3 text-sm text-text-secondary"
+            data-testid="batch-move-preview"
+          >
+            {previewing ? (
+              <span>Loading preview...</span>
+            ) : previewError ? (
+              <span className="text-danger">{previewError}</span>
+            ) : preview ? (
+              <>
+                <p>
+                  Reassigns <strong>{preview.transactions}</strong> transaction
+                  {preview.transactions === 1 ? "" : "s"},{" "}
+                  <strong>{preview.recurring}</strong> recurring template
+                  {preview.recurring === 1 ? "" : "s"}, and{" "}
+                  <strong>{preview.forecast}</strong> forecast plan item
+                  {preview.forecast === 1 ? "" : "s"}.
+                </p>
+                {preview.budget_actuals_shifted && (
+                  <p className="mt-1 text-xs text-text-muted">
+                    Current-period budget actuals will shift attribution. Planned amounts are unchanged.
+                  </p>
+                )}
+              </>
+            ) : null}
+          </div>
+        )}
+
+        {submitError && (
+          <div
+            data-testid="batch-move-error"
+            className="mt-4 whitespace-pre-line rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
+          >
+            {submitError}
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="batch-move-confirm"
+            onClick={handleConfirm}
+            disabled={targetId === null || submitting || previewing}
+            className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
+          >
+            {submitting ? "Moving..." : "Move"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CategoryErrorDetail {
+  detail?: string;
+  conflicting_child_name?: string;
+  target_parent_id?: number;
+  source_type?: string;
+  target_type?: string;
+  dependent_breakdown?: { income: number; expense: number };
+}
+
+function buildBatchErrorMessage(err: ApiResponseError, subs: Category[]): string {
+  const detail = err.detail as CategoryErrorDetail | string | undefined;
+  if (typeof detail === "object" && detail !== null) {
+    if (detail.detail === "name_collision" && detail.conflicting_child_name) {
+      return `Target master already has a subcategory named "${detail.conflicting_child_name}". Rename one before moving.`;
+    }
+    if (detail.detail === "type_mismatch") {
+      const breakdown = detail.dependent_breakdown
+        ? ` (${detail.dependent_breakdown.income} income, ${detail.dependent_breakdown.expense} expense)`
+        : "";
+      return `Type mismatch${breakdown}. Pick a target compatible with the selected subcategories.`;
+    }
+  }
+  return err.message || `Move failed for ${subs.length} subcategor${subs.length === 1 ? "y" : "ies"}.`;
+}

--- a/frontend/lib/hooks/use-focus-trap.ts
+++ b/frontend/lib/hooks/use-focus-trap.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { RefObject, useEffect } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+interface UseFocusTrapOptions {
+  /** When true, the trap is engaged and the previously focused element
+   *  is restored on close. */
+  active: boolean;
+  /** Ref to the dialog container. Tab/Shift+Tab cycles within this
+   *  container's focusable descendants. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Optional ref to receive initial focus on open. Falls back to the
+   *  first focusable element in the container. */
+  initialFocusRef?: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Focus trap for modal dialogs.
+ *
+ * On open: stores the previously focused element, then focuses
+ * `initialFocusRef` (or the first focusable child of `containerRef`).
+ *
+ * While open: Tab/Shift+Tab wrap focus inside the container.
+ *
+ * On close: restores focus to the element that was active before open.
+ *
+ * Owned by the shared UI primitives. Mirrors the behavior baked into
+ * `ConfirmModal` so batch modals can drop their custom keyboard handling
+ * and stay consistent.
+ */
+export function useFocusTrap({
+  active,
+  containerRef,
+  initialFocusRef,
+}: UseFocusTrapOptions): void {
+  useEffect(() => {
+    if (!active) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusInitial = () => {
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus();
+        return;
+      }
+      const first = containerRef.current?.querySelector<HTMLElement>(
+        FOCUSABLE_SELECTOR,
+      );
+      first?.focus();
+    };
+    focusInitial();
+
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, [active, containerRef, initialFocusRef]);
+
+  useEffect(() => {
+    if (!active) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const root = containerRef.current;
+      if (!root) return;
+      const all = Array.from(
+        root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
+      if (all.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = all[0];
+      const last = all[all.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (activeEl === first || !root.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (activeEl === last || !root.contains(activeEl)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [active, containerRef]);
+}

--- a/frontend/tests/app/categories-c2-edit-mode.test.tsx
+++ b/frontend/tests/app/categories-c2-edit-mode.test.tsx
@@ -1,0 +1,427 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import CategoriesPage from "@/app/categories/page";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/categories",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const CATEGORIES = [
+  // Master expense
+  {
+    id: 100,
+    name: "Food",
+    slug: "food_dining",
+    parent_id: null,
+    parent_name: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+  // Subs under Food
+  {
+    id: 101,
+    name: "Restaurants",
+    slug: null,
+    parent_id: 100,
+    parent_name: "Food",
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 5,
+  },
+  {
+    id: 102,
+    name: "Groceries",
+    slug: null,
+    parent_id: 100,
+    parent_name: "Food",
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 0,
+  },
+  // Master expense alt
+  {
+    id: 200,
+    name: "Lifestyle",
+    slug: "lifestyle",
+    parent_id: null,
+    parent_name: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+  // Sub under Lifestyle (used as a target)
+  {
+    id: 201,
+    name: "Entertainment",
+    slug: null,
+    parent_id: 200,
+    parent_name: "Lifestyle",
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 0,
+  },
+];
+
+function setupApi(
+  handlers: Record<string, (init?: RequestInit) => unknown> = {},
+) {
+  vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+    if (url === "/api/v1/categories" && (!init || init.method === undefined)) {
+      return Promise.resolve(CATEGORIES);
+    }
+    // Strip query string for the lookup key. Tests can register handlers
+    // for both "/api/v1/categories/101?target_category_id=200" (literal)
+    // and "/api/v1/categories/101/move/preview" (prefix-style for query
+    // strings) and we try the most-specific match first.
+    if (handlers[url]) {
+      const result = handlers[url](init);
+      return result instanceof Promise ? result : Promise.resolve(result);
+    }
+    const noQuery = url.split("?")[0];
+    if (handlers[noQuery]) {
+      const result = handlers[noQuery](init);
+      return result instanceof Promise ? result : Promise.resolve(result);
+    }
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("CategoriesPage — C2 Edit mode + batch select", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    setupApi();
+  });
+
+  it("Edit toggle shows checkboxes on subcategory rows", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    expect(screen.queryByTestId("sub-checkbox-101")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("sub-checkbox-102")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    expect(screen.getByTestId("sub-checkbox-101")).toBeInTheDocument();
+    expect(screen.getByTestId("sub-checkbox-102")).toBeInTheDocument();
+    expect(screen.getByTestId("sub-checkbox-201")).toBeInTheDocument();
+  });
+
+  it("Cancel Edit hides checkboxes and clears selection", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    expect(screen.getByTestId("batch-action-bar")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    expect(screen.queryByTestId("sub-checkbox-101")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-action-bar")).not.toBeInTheDocument();
+  });
+
+  it("selecting subcategories updates batch-action bar count", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    expect(screen.queryByTestId("batch-action-bar")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    expect(screen.getByTestId("batch-action-count")).toHaveTextContent("1 selected");
+
+    fireEvent.click(screen.getByTestId("sub-checkbox-102"));
+    expect(screen.getByTestId("batch-action-count")).toHaveTextContent("2 selected");
+
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    expect(screen.getByTestId("batch-action-count")).toHaveTextContent("1 selected");
+  });
+
+  it("master rows do not get a checkbox (subcategory-only selection)", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Food")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    expect(screen.queryByTestId("sub-checkbox-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("sub-checkbox-200")).not.toBeInTheDocument();
+  });
+
+  it("individual edit/delete actions remain visible in Edit mode", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    const subActions = screen.getByTestId("sub-actions-101");
+    const buttons = subActions.querySelectorAll("button");
+    expect(buttons).toHaveLength(2);
+    expect(subActions.textContent).toContain("Edit");
+    expect(subActions.textContent).toContain("Delete");
+  });
+
+  it("Esc exits Edit mode when no modal is open", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    expect(screen.getByTestId("sub-checkbox-101")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("sub-checkbox-101")).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("CategoriesPage — C2 batch move", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+  });
+
+  it("preview aggregates counts across selected subs and confirm clears selection", async () => {
+    const previewByCat: Record<number, unknown> = {
+      101: {
+        category_id: 101,
+        source_master_id: 100,
+        target_master_id: 200,
+        affected_transaction_count: 5,
+        affected_recurring_count: 1,
+        affected_forecast_item_count: 2,
+        budget_actuals_shifted: true,
+      },
+      102: {
+        category_id: 102,
+        source_master_id: 100,
+        target_master_id: 200,
+        affected_transaction_count: 0,
+        affected_recurring_count: 0,
+        affected_forecast_item_count: 1,
+        budget_actuals_shifted: false,
+      },
+    };
+
+    setupApi({
+      "/api/v1/categories/101/move/preview": () => previewByCat[101],
+      "/api/v1/categories/102/move/preview": () => previewByCat[102],
+      "/api/v1/categories/batch-move": () => ({
+        moves: [previewByCat[101], previewByCat[102]],
+      }),
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-102"));
+    fireEvent.click(screen.getByTestId("batch-move-button"));
+
+    expect(await screen.findByTestId("batch-move-modal")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("batch-move-target-200"));
+
+    // Aggregate preview: 5 transactions, 1 recurring, 3 forecast items.
+    await waitFor(() => {
+      const preview = screen.getByTestId("batch-move-preview");
+      expect(preview.textContent).toContain("5");
+      expect(preview.textContent).toContain("1");
+      expect(preview.textContent).toContain("3");
+    });
+
+    fireEvent.click(screen.getByTestId("batch-move-confirm"));
+
+    // After success: modal closed, edit mode exited, no checkboxes.
+    await waitFor(() => {
+      expect(screen.queryByTestId("batch-move-modal")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("sub-checkbox-101")).not.toBeInTheDocument();
+    });
+  });
+
+  it("partial-failure on batch-move surfaces a structured error and keeps the modal open", async () => {
+    setupApi({
+      "/api/v1/categories/101/move/preview": () => ({
+        category_id: 101,
+        source_master_id: 100,
+        target_master_id: 200,
+        affected_transaction_count: 1,
+        affected_recurring_count: 0,
+        affected_forecast_item_count: 0,
+        budget_actuals_shifted: false,
+      }),
+      "/api/v1/categories/batch-move": () => {
+        return Promise.reject(
+          new ApiResponseError(
+            409,
+            "name_collision",
+            undefined,
+            {
+              detail: "name_collision",
+              target_parent_id: 200,
+              conflicting_child_id: 201,
+              conflicting_child_name: "Entertainment",
+              normalized_name: "entertainment",
+            },
+          ),
+        );
+      },
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    fireEvent.click(screen.getByTestId("batch-move-button"));
+
+    fireEvent.click(await screen.findByTestId("batch-move-target-200"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("batch-move-preview")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("batch-move-confirm"));
+
+    const err = await screen.findByTestId("batch-move-error");
+    expect(err.textContent).toContain("Entertainment");
+    expect(screen.getByTestId("batch-move-modal")).toBeInTheDocument();
+  });
+});
+
+describe("CategoriesPage — C2 batch delete", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+  });
+
+  it("aggregate counts surface when subs have dependents", async () => {
+    setupApi();
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    // 101 has 5 tx, 102 has 0
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-102"));
+    fireEvent.click(screen.getByTestId("batch-delete-button"));
+
+    const aggregate = await screen.findByTestId("batch-delete-aggregate");
+    expect(aggregate.textContent).toContain("1 of 2");
+    expect(aggregate.textContent).toContain("5");
+  });
+
+  it("loops DELETE per subcategory, surfacing per-row failures with reasons", async () => {
+    let deletedCount = 0;
+    setupApi({
+      "/api/v1/categories/101?target_category_id=200": () => {
+        deletedCount += 1;
+        // 204 path: apiFetch returns undefined.
+        return undefined;
+      },
+      "/api/v1/categories/102": () => {
+        return Promise.reject(
+          new ApiResponseError(409, "last_in_type", undefined, {
+            detail: "last_in_type",
+            scope: "subcategory",
+            type: "expense",
+          }),
+        );
+      },
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-102"));
+    fireEvent.click(screen.getByTestId("batch-delete-button"));
+
+    // 101 needs a target picker since transaction_count > 0; pick Lifestyle (200).
+    const targetSelect = await screen.findByTestId("batch-delete-target-101");
+    fireEvent.change(targetSelect, { target: { value: "200" } });
+
+    fireEvent.click(screen.getByTestId("batch-delete-confirm"));
+
+    const failure = await screen.findByTestId("batch-delete-failure-102");
+    expect(failure.textContent).toMatch(/expense/i);
+
+    expect(deletedCount).toBe(1);
+    // Modal still open, showing failure row only (101 succeeded and was dropped).
+    expect(screen.queryByTestId("batch-delete-row-101")).not.toBeInTheDocument();
+    expect(screen.getByTestId("batch-delete-row-102")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/app/categories-c2-edit-mode.test.tsx
+++ b/frontend/tests/app/categories-c2-edit-mode.test.tsx
@@ -351,6 +351,61 @@ describe("CategoriesPage -C2 batch move", () => {
     expect(err.textContent).toContain("Entertainment");
     expect(screen.getByTestId("batch-move-modal")).toBeInTheDocument();
   });
+
+  it("if the post-mutation reload fails, modal stays open and surfaces the refresh-error banner", async () => {
+    // Reload-before-close ordering: page must await reload() before
+    // closing the modal, so a failure can surface inside the modal.
+    // The reload-after-mutation throw is gated on the batch-move POST
+    // having already fired, not on a call counter, because StrictMode
+    // double-renders inflate the GET count during initial mount.
+    let batchMovePosted = false;
+    setupApi({
+      "/api/v1/categories/101/move/preview": () => ({
+        category_id: 101,
+        source_master_id: 100,
+        target_master_id: 200,
+        affected_transaction_count: 5,
+        affected_recurring_count: 0,
+        affected_forecast_item_count: 0,
+        budget_actuals_shifted: false,
+      }),
+      "/api/v1/categories/batch-move": () => {
+        batchMovePosted = true;
+        return { moves: [] };
+      },
+    });
+
+    const originalImpl = vi.mocked(apiFetch).getMockImplementation();
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (
+        batchMovePosted
+        && url === "/api/v1/categories"
+        && (!init || init.method === undefined)
+      ) {
+        return Promise.reject(new Error("network blip"));
+      }
+      return originalImpl ? originalImpl(url, init) : Promise.resolve({});
+    }) as never);
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+    fireEvent.click(screen.getByTestId("batch-move-button"));
+
+    fireEvent.click(await screen.findByTestId("batch-move-target-200"));
+    await waitFor(() => {
+      expect(screen.getByTestId("batch-move-preview")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("batch-move-confirm"));
+
+    // Modal MUST stay open and show the inline refresh-error banner.
+    const banner = await screen.findByTestId("batch-move-refresh-error");
+    expect(banner.textContent).toMatch(/network blip/i);
+    expect(screen.getByTestId("batch-move-modal")).toBeInTheDocument();
+  });
 });
 
 describe("CategoriesPage -C2 batch delete", () => {
@@ -427,5 +482,46 @@ describe("CategoriesPage -C2 batch delete", () => {
     // Modal still open, showing failure row only (101 succeeded and was dropped).
     expect(screen.queryByTestId("batch-delete-row-101")).not.toBeInTheDocument();
     expect(screen.getByTestId("batch-delete-row-102")).toBeInTheDocument();
+  });
+
+  it("if the post-mutation reload fails after a fully successful delete, modal stays open and surfaces the refresh-error banner", async () => {
+    // Reload-before-close ordering: page must await reload() before
+    // closing the modal so the failure can surface to the user.
+    let deletePosted = false;
+    setupApi({
+      "/api/v1/categories/102?target_category_id=200": (init) => {
+        if (init?.method === "DELETE") {
+          deletePosted = true;
+        }
+        return undefined;
+      },
+    });
+    const originalImpl = vi.mocked(apiFetch).getMockImplementation();
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (
+        deletePosted
+        && url === "/api/v1/categories"
+        && (!init || init.method === undefined)
+      ) {
+        return Promise.reject(new Error("reload failed"));
+      }
+      return originalImpl ? originalImpl(url, init) : Promise.resolve({});
+    }) as never);
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-102"));
+    fireEvent.click(screen.getByTestId("batch-delete-button"));
+
+    const target102 = await screen.findByTestId("batch-delete-target-102");
+    fireEvent.change(target102, { target: { value: "200" } });
+
+    fireEvent.click(screen.getByTestId("batch-delete-confirm"));
+
+    const banner = await screen.findByTestId("batch-delete-refresh-error");
+    expect(banner.textContent).toMatch(/reload failed/i);
+    expect(screen.getByTestId("batch-delete-modal")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/app/categories-c2-edit-mode.test.tsx
+++ b/frontend/tests/app/categories-c2-edit-mode.test.tsx
@@ -133,7 +133,7 @@ function setupApi(
   }) as never);
 }
 
-describe("CategoriesPage — C2 Edit mode + batch select", () => {
+describe("CategoriesPage -C2 Edit mode + batch select", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
     vi.mocked(useAuth).mockReturnValue({
@@ -230,7 +230,7 @@ describe("CategoriesPage — C2 Edit mode + batch select", () => {
   });
 });
 
-describe("CategoriesPage — C2 batch move", () => {
+describe("CategoriesPage -C2 batch move", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
     vi.mocked(useAuth).mockReturnValue({
@@ -353,7 +353,7 @@ describe("CategoriesPage — C2 batch move", () => {
   });
 });
 
-describe("CategoriesPage — C2 batch delete", () => {
+describe("CategoriesPage -C2 batch delete", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
     vi.mocked(useAuth).mockReturnValue({
@@ -391,7 +391,7 @@ describe("CategoriesPage — C2 batch delete", () => {
         // 204 path: apiFetch returns undefined.
         return undefined;
       },
-      "/api/v1/categories/102": () => {
+      "/api/v1/categories/102?target_category_id=200": () => {
         return Promise.reject(
           new ApiResponseError(409, "last_in_type", undefined, {
             detail: "last_in_type",
@@ -410,9 +410,13 @@ describe("CategoriesPage — C2 batch delete", () => {
     fireEvent.click(screen.getByTestId("sub-checkbox-102"));
     fireEvent.click(screen.getByTestId("batch-delete-button"));
 
-    // 101 needs a target picker since transaction_count > 0; pick Lifestyle (200).
-    const targetSelect = await screen.findByTestId("batch-delete-target-101");
-    fireEvent.change(targetSelect, { target: { value: "200" } });
+    // C0 spec requires a migration target for ANY dependent (transactions,
+    // recurring templates, forecast plan items). The picker is always
+    // shown and must be picked for every selected sub.
+    const target101 = await screen.findByTestId("batch-delete-target-101");
+    fireEvent.change(target101, { target: { value: "200" } });
+    const target102 = await screen.findByTestId("batch-delete-target-102");
+    fireEvent.change(target102, { target: { value: "200" } });
 
     fireEvent.click(screen.getByTestId("batch-delete-confirm"));
 

--- a/frontend/tests/components/batch-delete-modal.test.tsx
+++ b/frontend/tests/components/batch-delete-modal.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import BatchDeleteModal from "@/components/categories/BatchDeleteModal";
+import { apiFetch } from "@/lib/api";
+import type { Category } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const cats: Category[] = [
+  // Masters
+  { id: 100, name: "Food", type: "expense", parent_id: null, parent_name: null, description: null, slug: "food_dining", is_system: true, transaction_count: 0 },
+  { id: 200, name: "Lifestyle", type: "expense", parent_id: null, parent_name: null, description: null, slug: "lifestyle", is_system: true, transaction_count: 0 },
+  { id: 300, name: "Income", type: "income", parent_id: null, parent_name: null, description: null, slug: "income", is_system: true, transaction_count: 0 },
+  { id: 500, name: "Mixed", type: "both", parent_id: null, parent_name: null, description: null, slug: null, is_system: false, transaction_count: 0 },
+  // Subs
+  { id: 101, name: "Restaurants", type: "expense", parent_id: 100, parent_name: "Food", description: null, slug: null, is_system: false, transaction_count: 5 },
+  { id: 102, name: "Groceries", type: "expense", parent_id: 100, parent_name: "Food", description: null, slug: null, is_system: false, transaction_count: 0 },
+  { id: 301, name: "Salary", type: "income", parent_id: 300, parent_name: "Income", description: null, slug: null, is_system: false, transaction_count: 0 },
+];
+
+describe("BatchDeleteModal target picker", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("renders the migration target picker for every selected sub, even with zero transactions", async () => {
+    render(
+      <BatchDeleteModal
+        open
+        selectedIds={[101, 102]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    // Both rows must have a picker (102 has transaction_count = 0).
+    expect(await screen.findByTestId("batch-delete-target-101")).toBeInTheDocument();
+    expect(screen.getByTestId("batch-delete-target-102")).toBeInTheDocument();
+
+    const confirm = screen.getByTestId("batch-delete-confirm");
+    expect(confirm).toBeDisabled();
+  });
+
+  it("type-compat filter: expense source picker excludes income masters but includes BOTH", async () => {
+    render(
+      <BatchDeleteModal
+        open
+        selectedIds={[102]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const select = (await screen.findByTestId("batch-delete-target-102")) as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value).filter(Boolean);
+    expect(optionValues).toContain("200"); // Lifestyle (expense)
+    expect(optionValues).toContain("500"); // Mixed (both)
+    // Source itself is excluded.
+    expect(optionValues).not.toContain("102");
+    // Income master is excluded.
+    expect(optionValues).not.toContain("300");
+  });
+
+  it("type-compat filter: income source picker excludes expense masters but includes BOTH", async () => {
+    render(
+      <BatchDeleteModal
+        open
+        selectedIds={[301]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const select = (await screen.findByTestId("batch-delete-target-301")) as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((o) => o.value).filter(Boolean);
+    expect(optionValues).toContain("300"); // Income
+    expect(optionValues).toContain("500"); // Mixed
+    expect(optionValues).not.toContain("100"); // Food (expense)
+    expect(optionValues).not.toContain("200"); // Lifestyle (expense)
+  });
+
+  it("submit is blocked until every row has a target picked", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(undefined);
+
+    render(
+      <BatchDeleteModal
+        open
+        selectedIds={[101, 102]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const confirm = await screen.findByTestId("batch-delete-confirm");
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("batch-delete-target-101"), { target: { value: "200" } });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("batch-delete-target-102"), { target: { value: "200" } });
+    expect(confirm).not.toBeDisabled();
+  });
+});
+
+describe("BatchDeleteModal async onSuccess", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("awaits async onSuccess and surfaces refresh errors with a Retry button", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(undefined);
+
+    let invocations = 0;
+    const onSuccess = vi.fn(async () => {
+      invocations += 1;
+      if (invocations === 1) throw new Error("reload failed");
+    });
+
+    render(
+      <BatchDeleteModal
+        open
+        selectedIds={[102]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    fireEvent.change(await screen.findByTestId("batch-delete-target-102"), {
+      target: { value: "200" },
+    });
+    fireEvent.click(screen.getByTestId("batch-delete-confirm"));
+
+    const banner = await screen.findByTestId("batch-delete-refresh-error");
+    expect(banner.textContent).toMatch(/reload failed/);
+
+    fireEvent.click(screen.getByTestId("batch-delete-refresh-retry"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("batch-delete-refresh-error")).not.toBeInTheDocument();
+    });
+    expect(invocations).toBe(2);
+  });
+});

--- a/frontend/tests/components/batch-move-modal.test.tsx
+++ b/frontend/tests/components/batch-move-modal.test.tsx
@@ -20,6 +20,7 @@ const cats: Category[] = [
   // Subs
   { id: 101, name: "Restaurants", type: "expense", parent_id: 100, parent_name: "Food", description: null, slug: null, is_system: false, transaction_count: 5 },
   { id: 102, name: "Groceries", type: "expense", parent_id: 100, parent_name: "Food", description: null, slug: null, is_system: false, transaction_count: 0 },
+  { id: 202, name: "Entertainment", type: "expense", parent_id: 200, parent_name: "Lifestyle", description: null, slug: null, is_system: false, transaction_count: 0 },
   { id: 301, name: "Salary", type: "income", parent_id: 300, parent_name: "Income", description: null, slug: null, is_system: false, transaction_count: 1 },
   { id: 501, name: "Adjustments", type: "both", parent_id: 500, parent_name: "Mixed", description: null, slug: null, is_system: false, transaction_count: 0 },
 ];
@@ -29,7 +30,7 @@ describe("BatchMoveModal target type filter", () => {
     vi.mocked(apiFetch).mockReset();
   });
 
-  it("expense-only selection lists only expense masters as targets (not BOTH)", async () => {
+  it("expense-only selection excludes the source master (no-op rejected by backend) and BOTH/INCOME", async () => {
     render(
       <BatchMoveModal
         open
@@ -40,12 +41,12 @@ describe("BatchMoveModal target type filter", () => {
       />,
     );
 
+    // Lifestyle (200) is the only valid expense target: same-type and not
+    // a source master.
     expect(await screen.findByTestId("batch-move-target-200")).toBeInTheDocument();
-    // Same-type expense masters: Food (100) is the source-master but is
-    // still a candidate UI-wise because the picker simply hides BOTH and
-    // INCOME masters. The backend will reject same-master moves; the UI
-    // does not pre-filter by source master id.
-    expect(screen.getByTestId("batch-move-target-100")).toBeInTheDocument();
+    // Source master Food (100) is excluded: backend rejects
+    // target_parent_id == sub.parent_id as a no-op.
+    expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
     // No BOTH masters and no INCOME masters.
     expect(screen.queryByTestId("batch-move-target-500")).not.toBeInTheDocument();
     expect(screen.queryByTestId("batch-move-target-600")).not.toBeInTheDocument();
@@ -53,7 +54,7 @@ describe("BatchMoveModal target type filter", () => {
     expect(screen.queryByTestId("batch-move-target-400")).not.toBeInTheDocument();
   });
 
-  it("income-only selection lists only income masters as targets (not BOTH)", async () => {
+  it("income-only selection lists income masters except the source parent (not BOTH)", async () => {
     render(
       <BatchMoveModal
         open
@@ -64,15 +65,17 @@ describe("BatchMoveModal target type filter", () => {
       />,
     );
 
-    expect(await screen.findByTestId("batch-move-target-300")).toBeInTheDocument();
-    expect(screen.getByTestId("batch-move-target-400")).toBeInTheDocument();
+    // Income Alt (400) is the only valid income target.
+    expect(await screen.findByTestId("batch-move-target-400")).toBeInTheDocument();
+    // Source master Income (300) is excluded.
+    expect(screen.queryByTestId("batch-move-target-300")).not.toBeInTheDocument();
     expect(screen.queryByTestId("batch-move-target-500")).not.toBeInTheDocument();
     expect(screen.queryByTestId("batch-move-target-600")).not.toBeInTheDocument();
     expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
     expect(screen.queryByTestId("batch-move-target-200")).not.toBeInTheDocument();
   });
 
-  it("BOTH-only selection lists only BOTH masters as targets", async () => {
+  it("BOTH-only selection lists only BOTH masters as targets, excluding the source parent", async () => {
     render(
       <BatchMoveModal
         open
@@ -83,10 +86,92 @@ describe("BatchMoveModal target type filter", () => {
       />,
     );
 
-    expect(await screen.findByTestId("batch-move-target-500")).toBeInTheDocument();
-    expect(screen.getByTestId("batch-move-target-600")).toBeInTheDocument();
+    // Mixed Alt (600) is the only valid BOTH target.
+    expect(await screen.findByTestId("batch-move-target-600")).toBeInTheDocument();
+    // Source master Mixed (500) is excluded.
+    expect(screen.queryByTestId("batch-move-target-500")).not.toBeInTheDocument();
     expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
     expect(screen.queryByTestId("batch-move-target-300")).not.toBeInTheDocument();
+  });
+
+  it("multi-source-master selection excludes ALL source masters from the picker", async () => {
+    // 101 is under Food (100). 202 is under Lifestyle (200). Both expense.
+    // Both source masters must be excluded; no valid expense target remains.
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[101, 202]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    // The picker should be empty because Food and Lifestyle are the only
+    // expense masters in the fixture and both are sources.
+    expect(
+      await screen.findByTestId("batch-move-empty-message"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-200")).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("batch-move-confirm")).toBeDisabled();
+  });
+
+  it("when all compatible masters are sources, surfaces inline message and disables submit", async () => {
+    // BOTH source 501 lives under Mixed (500). The fixture also has Mixed
+    // Alt (600). To stage the all-compat-are-sources case, simulate the
+    // user selecting subs from BOTH BOTH-masters: but the fixture only
+    // has one BOTH sub. Build a one-off categories list for this test
+    // where Mixed Alt also has a sub.
+    const catsWithBothMasterSubs = [
+      ...cats,
+      {
+        id: 601,
+        name: "Reconciliations",
+        type: "both" as const,
+        parent_id: 600,
+        parent_name: "Mixed Alt",
+        description: null,
+        slug: null,
+        is_system: false,
+        transaction_count: 0,
+      },
+    ];
+
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[501, 601]}
+        categories={catsWithBothMasterSubs}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const message = await screen.findByTestId("batch-move-empty-message");
+    expect(message.textContent).toMatch(/already parents/i);
+    expect(screen.queryByTestId("batch-move-target-500")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-600")).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("batch-move-confirm")).toBeDisabled();
+  });
+
+  it("single source master selection: other compat masters appear, source master excluded", async () => {
+    // 101 is under Food (100). The fixture has Lifestyle (200) as the
+    // other expense master. Only 200 should appear.
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[101]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId("batch-move-target-200")).toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
   });
 
   it("mixed-type selection shows no targets and an inline warning, submit is disabled", async () => {

--- a/frontend/tests/components/batch-move-modal.test.tsx
+++ b/frontend/tests/components/batch-move-modal.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import BatchMoveModal from "@/components/categories/BatchMoveModal";
+import { apiFetch } from "@/lib/api";
+import type { Category } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const cats: Category[] = [
+  // Masters
+  { id: 100, name: "Food", type: "expense", parent_id: null, parent_name: null, description: null, slug: "food_dining", is_system: true, transaction_count: 0 },
+  { id: 200, name: "Lifestyle", type: "expense", parent_id: null, parent_name: null, description: null, slug: "lifestyle", is_system: true, transaction_count: 0 },
+  { id: 300, name: "Income", type: "income", parent_id: null, parent_name: null, description: null, slug: "income", is_system: true, transaction_count: 0 },
+  { id: 400, name: "Income Alt", type: "income", parent_id: null, parent_name: null, description: null, slug: null, is_system: false, transaction_count: 0 },
+  { id: 500, name: "Mixed", type: "both", parent_id: null, parent_name: null, description: null, slug: null, is_system: false, transaction_count: 0 },
+  { id: 600, name: "Mixed Alt", type: "both", parent_id: null, parent_name: null, description: null, slug: null, is_system: false, transaction_count: 0 },
+  // Subs
+  { id: 101, name: "Restaurants", type: "expense", parent_id: 100, parent_name: "Food", description: null, slug: null, is_system: false, transaction_count: 5 },
+  { id: 102, name: "Groceries", type: "expense", parent_id: 100, parent_name: "Food", description: null, slug: null, is_system: false, transaction_count: 0 },
+  { id: 301, name: "Salary", type: "income", parent_id: 300, parent_name: "Income", description: null, slug: null, is_system: false, transaction_count: 1 },
+  { id: 501, name: "Adjustments", type: "both", parent_id: 500, parent_name: "Mixed", description: null, slug: null, is_system: false, transaction_count: 0 },
+];
+
+describe("BatchMoveModal target type filter", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("expense-only selection lists only expense masters as targets (not BOTH)", async () => {
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[101, 102]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId("batch-move-target-200")).toBeInTheDocument();
+    // Same-type expense masters: Food (100) is the source-master but is
+    // still a candidate UI-wise because the picker simply hides BOTH and
+    // INCOME masters. The backend will reject same-master moves; the UI
+    // does not pre-filter by source master id.
+    expect(screen.getByTestId("batch-move-target-100")).toBeInTheDocument();
+    // No BOTH masters and no INCOME masters.
+    expect(screen.queryByTestId("batch-move-target-500")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-600")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-300")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-400")).not.toBeInTheDocument();
+  });
+
+  it("income-only selection lists only income masters as targets (not BOTH)", async () => {
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[301]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId("batch-move-target-300")).toBeInTheDocument();
+    expect(screen.getByTestId("batch-move-target-400")).toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-500")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-600")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-200")).not.toBeInTheDocument();
+  });
+
+  it("BOTH-only selection lists only BOTH masters as targets", async () => {
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[501]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId("batch-move-target-500")).toBeInTheDocument();
+    expect(screen.getByTestId("batch-move-target-600")).toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-300")).not.toBeInTheDocument();
+  });
+
+  it("mixed-type selection shows no targets and an inline warning, submit is disabled", async () => {
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[101, 301]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId("batch-move-mixed-warning")).toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-200")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-300")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("batch-move-target-500")).not.toBeInTheDocument();
+
+    const confirm = screen.getByTestId("batch-move-confirm");
+    expect(confirm).toBeDisabled();
+  });
+});
+
+describe("BatchMoveModal async onSuccess", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("awaits async onSuccess and surfaces refresh errors with a Retry button", async () => {
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (url.includes("/move/preview")) {
+        return Promise.resolve({
+          category_id: 101,
+          source_master_id: 100,
+          target_master_id: 200,
+          affected_transaction_count: 5,
+          affected_recurring_count: 0,
+          affected_forecast_item_count: 0,
+          budget_actuals_shifted: false,
+        });
+      }
+      if (url === "/api/v1/categories/batch-move" && init?.method === "POST") {
+        return Promise.resolve({ moves: [] });
+      }
+      return Promise.resolve({});
+    }) as never);
+
+    let invocations = 0;
+    const onSuccess = vi.fn(async () => {
+      invocations += 1;
+      if (invocations === 1) throw new Error("network blip");
+    });
+
+    render(
+      <BatchMoveModal
+        open
+        selectedIds={[101]}
+        categories={cats}
+        onCancel={vi.fn()}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    fireEvent.click(await screen.findByTestId("batch-move-target-200"));
+    await waitFor(() => {
+      expect(screen.getByTestId("batch-move-preview")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("batch-move-confirm"));
+
+    const banner = await screen.findByTestId("batch-move-refresh-error");
+    expect(banner.textContent).toMatch(/network blip/);
+
+    fireEvent.click(screen.getByTestId("batch-move-refresh-retry"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("batch-move-refresh-error")).not.toBeInTheDocument();
+    });
+    expect(invocations).toBe(2);
+  });
+});


### PR DESCRIPTION
## Rebase note (2026-05-10, post-#192)

Rebased atop merged main, which now includes:

- #192 Categories C1 (Add Master + reuse existing subcategories flow), landed `1984e8f`.
- #200 AppShell-level Add Transaction CTA + the `useTransactionAddedListener` wiring on Categories.
- #194 Categories C0 invariants + batch-move / delete-with-migration backend.

Conflict resolution on `frontend/app/categories/page.tsx`:

- Imports: kept main's `AddMasterWithSubsModal` import and dropped the now-removed `cardTitle`. Added back `btnSecondary` for the Edit-mode toggle and the three Batch* component imports from this branch.
- Header action region: kept the `+ Add Master` button (from #192) and added the Edit toggle next to it. Final order: `Edit` followed by `+ Add Master` so the primary action sits on the right.
- Refresh banner state (`refreshError` / `refreshing`) and the `useTransactionAddedListener` registration from #200 are preserved untouched.
- The pre-#192 `+ Custom Category` inline form was already removed in main; no action needed on this branch.

Merge gate: cleared. Rebased atop merged #192.

---

## Problem

The Categories page (`frontend/app/categories/page.tsx`) only supports per-row edit and delete. Punch-list items C2a and C2c require a global Edit-mode toggle plus batch-select infrastructure for moving and deleting multiple subcategories at once, calling the new endpoints locked in the C0 invariants spec at `.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-09-categories-c0-invariants.md` (sections 4.1 endpoint catalog, 4.5 cross-master name uniqueness, 4.6 BOTH-source compatibility, 4.7 master-with-children delete).

## Implementation summary

- **C2a Edit-mode toggle (top-right of the Categories header).** Pressing Edit reveals checkboxes on every subcategory row and a sticky batch-action bar pinned to the bottom of the viewport. Pressing Cancel Edit (or Esc, when no modal is open) exits Edit mode and clears the selection. Master rows intentionally do not get a checkbox: master delete with children is rejected with 409 `has_children` per spec section 4.7, so masters only become deletable after their subs are explicitly moved or deleted.
- **C2c batch select.** When at least one subcategory is checked, the bottom bar shows the count and exposes Move N to... and Delete N actions.
  - **Move modal.** Filterable target-master picker that surfaces only type-compatible masters under the strict-equality rule the backend enforces at `category_service.move_subcategory` (`sub.type == target.type`). INCOME source picks INCOME masters, EXPENSE source picks EXPENSE masters, BOTH source picks BOTH masters. Mixed selections (income + expense in the same batch) hide all targets and surface an inline warning telling the user to move one type at a time; submit stays disabled. On target pick, the modal calls the C0 preview endpoint per selected sub, aggregates `affected_transaction_count`, `affected_recurring_count`, `affected_forecast_item_count`, and ORs `budget_actuals_shifted`. Confirm submits `POST /api/v1/categories/batch-move` (all-or-nothing per spec section 3.C). On 4xx the modal surfaces structured detail (`name_collision` cites the conflicting child name; `type_mismatch` cites the dependent breakdown).
  - **Delete modal.** Lists the selection with a per-row migration target picker for every selected sub. The picker is always shown because the C0 delete contract requires a migration target for ANY dependent (transactions, recurring templates, OR forecast plan items), not just transactions. The lenient breakdown-driven backend rule (`_check_target_compatibility_for_delete`) is mirrored: INCOME source picks INCOME or BOTH masters; EXPENSE source picks EXPENSE or BOTH masters; BOTH source defaults to BOTH masters. Submit stays disabled until every row has a target picked. Loops the existing `DELETE /api/v1/categories/{id}?target_category_id={n}` per row; the backend takes the 204 path and ignores the target when the source has no dependents, so the extra arg is harmless. Per-row failures are bound to the offending row and remain in the modal so the user can change targets and retry; succeeded rows drop out of the selection. Reasons surfaced: `last_in_type`, `has_children`, `type_mismatch`, `name_collision`, `migration_target_required`.
- **Async refresh handling.** Both batch modals type `onSuccess` as `() => void | Promise<void>`, await it after a successful submit, and surface refresh failures inline with a Retry button (mirrors the AddMasterWithSubsModal pattern from #192). The page hands an async reload through both modals so a network blip during the post-mutation refresh never silently drops.
- **Focus management.** Both batch modals use the new `useFocusTrap` hook (`frontend/lib/hooks/use-focus-trap.ts`) which sets initial focus on open, traps Tab/Shift+Tab inside the dialog, and restores focus to the previously active element on close. ConfirmModal kept its own inline trap to limit the diff.
- Tokenized colors throughout (`bg-surface`, `border-border`, `text-danger`, etc.). Sticky bar uses backdrop blur where supported. Esc closes any open modal first; only the no-modal Esc exits Edit mode. Individual row Edit and Delete actions remain visible in Edit mode.

## Files changed

- `frontend/app/categories/page.tsx`: added Edit-mode state, selection state, mounted batch components. Marked the C2 region with ASCII comment fences so the rebase atop #192 is unambiguous. Header layout uses a flex-wrap action group so the Edit toggle sits beside the `+ Add Master` button from #192.
- `frontend/components/categories/BatchActionBar.tsx`: new sticky batch-action bar.
- `frontend/components/categories/BatchMoveModal.tsx`: target-master picker (strict same-type filter), aggregate preview, all-or-nothing submit, async onSuccess with retry banner, focus trap.
- `frontend/components/categories/BatchDeleteModal.tsx`: always-shown per-row migration target picker, per-row failure surface, loop submit, async onSuccess with retry banner, focus trap.
- `frontend/lib/hooks/use-focus-trap.ts`: shared focus-trap hook for modal dialogs.
- `frontend/tests/app/categories-c2-edit-mode.test.tsx`: page-level batch flow tests, updated for the always-show-picker contract.
- `frontend/tests/components/batch-move-modal.test.tsx`: dedicated tests for the strict-equality type filter, mixed-selection block, and async onSuccess + retry.
- `frontend/tests/components/batch-delete-modal.test.tsx`: dedicated tests for the always-shown picker, type-compat filter, submit gating, and async onSuccess + retry.

## Tests run and results

- `npx tsc --noEmit` clean (0 errors).
- `npx vitest run` 491 tests across 75 files pass.

## Coordination

File-ownership: C2 owns the Edit-mode toggle button, the per-subcategory checkboxes, the BatchActionBar, the BatchMoveModal, the BatchDeleteModal, the `useFocusTrap` hook, and the selection state hook block at the top of `CategoriesPage`. C1 (now merged in #192) owns the `+ Add Master` button and the `AddMasterWithSubsModal`. Mount points are orthogonal: the header action group hosts both Edit and `+ Add Master`; nothing in C2 touches the Add-Master modal or the children-of-master rendering body.

## Internal reviewers

@flamarion

External review required before merge.
