### PR TITLE
feat(categories): add master + reuse existing subcategories flow (C1)

### DIFF
--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -199,8 +199,11 @@ export default function CategoriesPage() {
         <AddMasterWithSubsModal
           categories={categories}
           onCreated={async () => {
-            setShowAddMasterModal(false);
+            // Reload first; only close the modal if the reload
+            // succeeded so the modal can surface a retry-refresh
+            // affordance on failure.
             await reload();
+            setShowAddMasterModal(false);
           }}
           onCancel={() => setShowAddMasterModal(false)}
         />

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -6,9 +6,10 @@ import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
-import { input, btnPrimary, card, cardHeader, cardTitle, error as errorCls, pageTitle } from "@/lib/styles";
+import { input, btnPrimary, card, cardHeader, error as errorCls, pageTitle } from "@/lib/styles";
 import type { Category } from "@/lib/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
+import AddMasterWithSubsModal from "@/components/ui/AddMasterWithSubsModal";
 import {
   Wallet, Home, Zap, UtensilsCrossed, Car, HeartPulse,
   Scissors, Gamepad2, Target, CreditCard, Gift, HelpCircle, Tag,
@@ -54,11 +55,9 @@ export default function CategoriesPage() {
   // Search
   const [search, setSearch] = useState("");
 
-  // Add custom master form
-  const [showAddMaster, setShowAddMaster] = useState(false);
-  const [newMasterName, setNewMasterName] = useState("");
-  const [newMasterType, setNewMasterType] = useState<"income" | "expense" | "both">("expense");
-  const [newMasterDesc, setNewMasterDesc] = useState("");
+  // Add Master modal (C1: create master that reuses existing
+  // subcategories via batch move).
+  const [showAddMasterModal, setShowAddMasterModal] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
   // Refresh banner state for the AppShell-level "transaction added" event.
@@ -139,25 +138,6 @@ export default function CategoriesPage() {
     } catch (err) { setError(extractErrorMessage(err)); }
   }
 
-  async function handleAddMaster(e: FormEvent) {
-    e.preventDefault();
-    setError("");
-    try {
-      await apiFetch("/api/v1/categories", {
-        method: "POST",
-        body: JSON.stringify({
-          name: newMasterName,
-          type: newMasterType,
-          description: newMasterDesc || null,
-        }),
-      });
-      setNewMasterName("");
-      setNewMasterDesc("");
-      setShowAddMaster(false);
-      await reload();
-    } catch (err) { setError(extractErrorMessage(err)); }
-  }
-
   async function handleEditCat(id: number) {
     if (!editCatName.trim()) return;
     setError("");
@@ -184,8 +164,11 @@ export default function CategoriesPage() {
     <AppShell>
       <div className="mb-8 flex items-center justify-between">
         <h1 className={`${pageTitle} mb-0`}>Categories</h1>
-        <button onClick={() => setShowAddMaster(!showAddMaster)} className={btnPrimary}>
-          {showAddMaster ? "Cancel" : "+ Custom Category"}
+        <button
+          onClick={() => setShowAddMasterModal(true)}
+          className={btnPrimary}
+        >
+          + Add Master
         </button>
       </div>
 
@@ -212,29 +195,15 @@ export default function CategoriesPage() {
         </div>
       )}
 
-      {showAddMaster && (
-        <div className={`mb-6 ${card} p-6`}>
-          <h2 className={`mb-4 ${cardTitle}`}>New Master Category</h2>
-          <form onSubmit={handleAddMaster} className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
-            <div className="flex-1 w-full sm:min-w-[200px]">
-              <label htmlFor="master-name" className="sr-only">Name</label>
-              <input id="master-name" type="text" required placeholder="Category name" value={newMasterName} onChange={(e) => setNewMasterName(e.target.value)} className={input} />
-            </div>
-            <div className="w-full sm:w-32">
-              <label htmlFor="master-type" className="sr-only">Type</label>
-              <select id="master-type" value={newMasterType} onChange={(e) => setNewMasterType(e.target.value as typeof newMasterType)} className={input}>
-                <option value="expense">Expense</option>
-                <option value="income">Income</option>
-                <option value="both">Both</option>
-              </select>
-            </div>
-            <div className="flex-1 w-full sm:min-w-[200px]">
-              <label htmlFor="master-desc" className="sr-only">Description</label>
-              <input id="master-desc" type="text" placeholder="Description (optional)" value={newMasterDesc} onChange={(e) => setNewMasterDesc(e.target.value)} className={input} />
-            </div>
-            <button type="submit" className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>Add</button>
-          </form>
-        </div>
+      {showAddMasterModal && (
+        <AddMasterWithSubsModal
+          categories={categories}
+          onCreated={async () => {
+            setShowAddMasterModal(false);
+            await reload();
+          }}
+          onCancel={() => setShowAddMasterModal(false)}
+        />
       )}
 
       {!fetching && allMasters.length > 6 && (

--- a/frontend/components/ui/AddMasterWithSubsModal.tsx
+++ b/frontend/components/ui/AddMasterWithSubsModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import { ApiResponseError, apiFetch, extractErrorMessage } from "@/lib/api";
 import {
   btnPrimary,
@@ -97,16 +98,15 @@ export default function AddMasterWithSubsModal({
     };
   }, [mounted]);
 
-  // Escape closes the confirm dialog if open, otherwise the parent
-  // modal. Tab trap stays inside the parent modal.
+  // Escape closes the parent modal. ConfirmModal owns its own Escape
+  // and Tab handling when it is open, so we gate this trap on
+  // !confirmOpen to avoid stealing keyboard input from the confirm
+  // dialog (which previously trapped Tab inside the parent modal and
+  // made Confirm/Cancel buttons unreachable).
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !submitting) {
+      if (e.key === "Escape" && !submitting && !confirmOpen) {
         e.stopPropagation();
-        if (confirmOpen) {
-          setConfirmOpen(false);
-          return;
-        }
         if (createdMaster) {
           // After a master was created the parent should still get the
           // master so its list refreshes; treat Esc as Done.
@@ -116,7 +116,7 @@ export default function AddMasterWithSubsModal({
         onCancel();
         return;
       }
-      if (e.key === "Tab") {
+      if (e.key === "Tab" && !confirmOpen) {
         const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         );
@@ -487,70 +487,17 @@ export default function AddMasterWithSubsModal({
         </form>
       </div>
 
-      {confirmOpen && (
-        <ConfirmInline
-          title={`Create "${trimmedName || "master"}" and move ${selectedSubIds.size} subcategor${selectedSubIds.size === 1 ? "y" : "ies"}?`}
-          message={confirmMessage}
-          onYes={handleConfirmYes}
-          onNo={() => setConfirmOpen(false)}
-        />
-      )}
+      <ConfirmModal
+        open={confirmOpen}
+        title={`Create "${trimmedName || "master"}" and move ${selectedSubIds.size} subcategor${selectedSubIds.size === 1 ? "y" : "ies"}?`}
+        message={confirmMessage}
+        confirmLabel="Yes, create and move"
+        cancelLabel="Cancel"
+        onConfirm={handleConfirmYes}
+        onCancel={() => setConfirmOpen(false)}
+      />
     </div>
   );
 
   return createPortal(modal, document.body);
-}
-
-/**
- * Tiny confirm dialog stacked over the parent modal. Self-contained so
- * we don't import ConfirmModal and create a portal-inside-portal mess.
- */
-function ConfirmInline(props: {
-  title: string;
-  message: string;
-  onYes: () => void;
-  onNo: () => void;
-}) {
-  const { title, message, onYes, onNo } = props;
-  return (
-    <div
-      className="fixed inset-0 z-[110] flex items-center justify-center bg-bg/80 p-4"
-      onClick={onNo}
-    >
-      <div
-        role="alertdialog"
-        aria-modal="true"
-        aria-labelledby="add-master-confirm-title"
-        className="w-full max-w-md rounded-lg border border-border bg-surface p-6 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h3
-          id="add-master-confirm-title"
-          className="text-lg font-semibold text-text-primary"
-        >
-          {title}
-        </h3>
-        <p
-          className="mt-2 whitespace-pre-line text-sm text-text-secondary"
-          data-testid="confirm-message"
-        >
-          {message}
-        </p>
-        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <button
-            onClick={onNo}
-            className={`${btnSecondary} min-h-[44px] sm:w-auto`}
-          >
-            Cancel
-          </button>
-          <button
-            onClick={onYes}
-            className={`${btnPrimary} min-h-[44px] sm:w-auto`}
-          >
-            Yes, create and move
-          </button>
-        </div>
-      </div>
-    </div>
-  );
 }

--- a/frontend/components/ui/AddMasterWithSubsModal.tsx
+++ b/frontend/components/ui/AddMasterWithSubsModal.tsx
@@ -153,11 +153,14 @@ export default function AddMasterWithSubsModal({
 
   // Group existing subcategories by their current master so the picker
   // mirrors the page's structure. The list only shows subs whose
-  // effective type is compatible with the target type the user picked.
-  // For type=both the picker shows everything; for income/expense it
-  // shows matching subs plus "both"-typed subs (which are compatible
-  // either way). Cross-type moves would 400 type_mismatch on the move
-  // endpoint per C0 spec section 4.6, so we filter them out in the UI.
+  // effective type matches the target type the user picked. Per the
+  // C0 spec section 4.6 and `category_service.move_subcategory`, the
+  // backend rejects any move where `sub.type != target.type` with 400
+  // type_mismatch. Filter cross-type subs out of the UI to mirror the
+  // backend rule exactly:
+  //   - target=INCOME  -> only INCOME subs are selectable.
+  //   - target=EXPENSE -> only EXPENSE subs are selectable.
+  //   - target=BOTH    -> only BOTH subs are selectable.
   const groups = useMemo(() => {
     const masters = categories.filter((c) => c.parent_id === null);
     const subsByMaster = new Map<number, Category[]>();
@@ -168,11 +171,7 @@ export default function AddMasterWithSubsModal({
         subsByMaster.set(c.parent_id, list);
       }
     }
-    const compatible = (sub: Category): boolean => {
-      if (type === "both") return true;
-      if (sub.type === "both") return true;
-      return sub.type === type;
-    };
+    const compatible = (sub: Category): boolean => sub.type === type;
     return masters
       .map((master) => ({
         master,

--- a/frontend/components/ui/AddMasterWithSubsModal.tsx
+++ b/frontend/components/ui/AddMasterWithSubsModal.tsx
@@ -39,9 +39,11 @@ interface Props {
   categories: Category[];
   /** Called when the master has been created and any selected
    *  subcategories were moved successfully. The page should refresh
-   *  its category list after this fires.
+   *  its category list after this fires. May be async; the modal
+   *  awaits it and surfaces reload errors inline so the page never
+   *  silently drops a refresh failure.
    */
-  onCreated: (created: Category) => void;
+  onCreated: (created: Category) => void | Promise<void>;
   onCancel: () => void;
 }
 
@@ -78,6 +80,7 @@ export default function AddMasterWithSubsModal({
   const [errorText, setErrorText] = useState<string | null>(null);
   const [createdMaster, setCreatedMaster] = useState<Category | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [reloadError, setReloadError] = useState(false);
   const [mounted, setMounted] = useState(false);
 
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -110,7 +113,7 @@ export default function AddMasterWithSubsModal({
         if (createdMaster) {
           // After a master was created the parent should still get the
           // master so its list refreshes; treat Esc as Done.
-          onCreated(createdMaster);
+          void finishWithMaster(createdMaster);
           return;
         }
         onCancel();
@@ -208,7 +211,7 @@ export default function AddMasterWithSubsModal({
       // failed atomically (no partial commit). Rerun with the current
       // selection.
       if (subIds.length === 0) {
-        onCreated(createdMaster);
+        void finishWithMaster(createdMaster);
         return;
       }
       void runBatchMove(createdMaster, subIds);
@@ -256,7 +259,7 @@ export default function AddMasterWithSubsModal({
 
     if (subIds.length === 0) {
       setSubmitting(false);
-      onCreated(master);
+      await finishWithMaster(master);
       return;
     }
 
@@ -292,7 +295,25 @@ export default function AddMasterWithSubsModal({
     }
 
     setSubmitting(false);
-    onCreated(master);
+    await finishWithMaster(master);
+  }
+
+  // Final step: notify the parent. The parent reload may be async and
+  // may fail (network blip during the post-mutation refresh). Surface
+  // the error inline with a Retry-refresh button instead of dropping
+  // the promise silently.
+  async function finishWithMaster(master: Category) {
+    try {
+      await onCreated(master);
+      setReloadError(false);
+    } catch (err) {
+      setReloadError(true);
+      setErrorText(
+        err instanceof Error
+          ? `Master created but the page failed to refresh: ${err.message}`
+          : "Master created but the page failed to refresh.",
+      );
+    }
   }
 
   const submitLabel = submitting
@@ -458,6 +479,16 @@ export default function AddMasterWithSubsModal({
           {errorText && (
             <div role="alert" className={errorCls}>
               {errorText}
+              {reloadError && createdMaster && (
+                <button
+                  type="button"
+                  onClick={() => void finishWithMaster(createdMaster)}
+                  className="ml-3 underline"
+                  data-testid="retry-refresh"
+                >
+                  Retry refresh
+                </button>
+              )}
             </div>
           )}
 
@@ -466,7 +497,7 @@ export default function AddMasterWithSubsModal({
               type="button"
               onClick={() => {
                 if (createdMaster) {
-                  onCreated(createdMaster);
+                  void finishWithMaster(createdMaster);
                   return;
                 }
                 onCancel();

--- a/frontend/components/ui/AddMasterWithSubsModal.tsx
+++ b/frontend/components/ui/AddMasterWithSubsModal.tsx
@@ -16,7 +16,7 @@ import type { Category } from "@/lib/types";
 
 type MasterType = "income" | "expense" | "both";
 
-interface MovePreviewResult {
+interface CategoryMoveResult {
   category_id: number;
   source_master_id: number;
   target_master_id: number;
@@ -26,17 +26,8 @@ interface MovePreviewResult {
   budget_actuals_shifted: boolean;
 }
 
-interface AggregateCounts {
-  transactions: number;
-  recurring: number;
-  forecast_items: number;
-}
-
-interface FailedMove {
-  subcategory_id: number;
-  subcategory_name: string;
-  status: number;
-  message: string;
+interface BatchMoveResult {
+  moves: CategoryMoveResult[];
 }
 
 interface Props {
@@ -45,10 +36,9 @@ interface Props {
    *  grouped by current master.
    */
   categories: Category[];
-  /** Called when the master has been created (and any selected
-   *  subcategories were attempted). The page should refresh its
-   *  category list after this fires. May fire after a partial-success
-   *  retry when the user clicks Done.
+  /** Called when the master has been created and any selected
+   *  subcategories were moved successfully. The page should refresh
+   *  its category list after this fires.
    */
   onCreated: (created: Category) => void;
   onCancel: () => void;
@@ -61,24 +51,19 @@ interface Props {
  *
  * Backend contract (C0 spec, sections 4.1 / 4.2 / 4.5):
  *   1. POST /api/v1/categories                                (create master).
- *   2. GET /api/v1/categories/{id}/move/preview?target_parent_id=N
- *                                                              (preview counts, read-only).
- *   3. PATCH /api/v1/categories/{id}/move {target_parent_id}  (move sub).
+ *   2. POST /api/v1/categories/batch-move                     (atomic
+ *      multi-row move; either all selected subs move or none do).
  *
  * Order of operations when subs are selected:
  *   - Confirm dialog with generic copy ("Affected transactions and
  *     forecast items will be reassigned. Planned budgets are not
  *     changed.") because we cannot preview before the master exists.
- *   - On Yes: POST creates the master, then we GET the preview for
- *     each selected sub against the new master id and accumulate
- *     counts (best-effort, displayed in the success summary), then
- *     PATCH each sub.
- *
- * Partial-success: if the master creates and one or more moves fail
- * (e.g. 409 name_collision), the master is kept, the failed rows are
- * highlighted, and the primary button switches to "Retry failed
- * moves" so the user can adjust selections (rename a colliding sub on
- * the categories page, or unselect it) and try again.
+ *   - On Yes: POST creates the master, then a single POST to
+ *     /batch-move runs all selected moves atomically. On error the
+ *     master remains (it was created in a separate POST that already
+ *     committed) and the user can adjust selections and retry. Error
+ *     messages from the response surface inline; no per-row retry/skip
+ *     flow exists, the contract is all-or-nothing.
  */
 export default function AddMasterWithSubsModal({
   categories,
@@ -90,11 +75,8 @@ export default function AddMasterWithSubsModal({
   const [selectedSubIds, setSelectedSubIds] = useState<Set<number>>(new Set());
   const [submitting, setSubmitting] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
-  const [failedMoves, setFailedMoves] = useState<FailedMove[]>([]);
   const [createdMaster, setCreatedMaster] = useState<Category | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [aggregateCounts, setAggregateCounts] =
-    useState<AggregateCounts | null>(null);
   const [mounted, setMounted] = useState(false);
 
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -126,7 +108,7 @@ export default function AddMasterWithSubsModal({
           return;
         }
         if (createdMaster) {
-          // After a partial success the parent should still get the
+          // After a master was created the parent should still get the
           // master so its list refreshes; treat Esc as Done.
           onCreated(createdMaster);
           return;
@@ -212,10 +194,10 @@ export default function AddMasterWithSubsModal({
 
   // Click on the form's primary button. Three flows:
   //   (a) No subs selected and no master yet: create master directly.
-  //   (b) Subs selected and no master yet: open confirm dialog with
-  //       generic copy. Yes triggers create + previews + moves.
-  //   (c) Master already created (partial-success retry path): re-run
-  //       the moves for the still-selected subs only.
+  //   (b) Subs selected and no master yet: open confirm dialog. Yes
+  //       triggers create + atomic batch-move.
+  //   (c) Master already created (post-error retry path): rerun the
+  //       atomic batch-move with the still-selected subs.
   function handlePrimaryClick() {
     if (!nameValid || submitting) return;
     setErrorText(null);
@@ -223,12 +205,14 @@ export default function AddMasterWithSubsModal({
     const subIds = Array.from(selectedSubIds);
 
     if (createdMaster) {
-      // Retry path. Master already exists; just move the selection.
+      // Master already created from a prior attempt; the batch-move
+      // failed atomically (no partial commit). Rerun with the current
+      // selection.
       if (subIds.length === 0) {
         onCreated(createdMaster);
         return;
       }
-      void runMoves(createdMaster, subIds);
+      void runBatchMove(createdMaster, subIds);
       return;
     }
 
@@ -239,7 +223,6 @@ export default function AddMasterWithSubsModal({
     }
 
     // Subs selected: confirm before mutating anything.
-    setAggregateCounts(null);
     setConfirmOpen(true);
   }
 
@@ -249,12 +232,11 @@ export default function AddMasterWithSubsModal({
     await runCreate(subIds);
   }
 
-  // Phase 1: create master. Phase 2: optional previews for the success
-  // summary. Phase 3: move each selected sub.
+  // Phase 1: create master. Phase 2: atomic batch-move of all selected
+  // subs in a single backend call (all-or-nothing per C0 §3.C).
   async function runCreate(subIds: number[]) {
     setSubmitting(true);
     setErrorText(null);
-    setFailedMoves([]);
 
     let master: Category;
     try {
@@ -279,113 +261,63 @@ export default function AddMasterWithSubsModal({
       return;
     }
 
-    // Best-effort preview for the success summary; we already have the
-    // user's intent confirmed, so a preview failure here is silent.
-    let counts: AggregateCounts | null = {
-      transactions: 0,
-      recurring: 0,
-      forecast_items: 0,
-    };
-    try {
-      for (const subId of subIds) {
-        const r = await apiFetch<MovePreviewResult>(
-          `/api/v1/categories/${subId}/move/preview?target_parent_id=${master.id}`,
-        );
-        counts.transactions += r.affected_transaction_count;
-        counts.recurring += r.affected_recurring_count;
-        counts.forecast_items += r.affected_forecast_item_count;
-      }
-    } catch {
-      counts = null;
-    }
-    setAggregateCounts(counts);
-
-    await runMoves(master, subIds);
+    await runBatchMove(master, subIds);
   }
 
-  async function runMoves(master: Category, subIds: number[]) {
-    const masterId = master.id;
+  async function runBatchMove(master: Category, subIds: number[]) {
     setSubmitting(true);
     setErrorText(null);
-    setFailedMoves([]);
 
-    const failures: FailedMove[] = [];
-    const succeededIds: number[] = [];
-    for (const subId of subIds) {
-      const subRecord = categories.find((c) => c.id === subId);
-      try {
-        await apiFetch(`/api/v1/categories/${subId}/move`, {
-          method: "PATCH",
-          body: JSON.stringify({ target_parent_id: masterId }),
-        });
-        succeededIds.push(subId);
-      } catch (err) {
-        const status = err instanceof ApiResponseError ? err.status : 0;
-        const message =
-          err instanceof ApiResponseError
-            ? err.message
-            : extractErrorMessage(err, "Move failed");
-        failures.push({
-          subcategory_id: subId,
-          subcategory_name: subRecord?.name ?? `#${subId}`,
-          status,
-          message,
-        });
-      }
-    }
-
-    // Drop succeeded moves from selection so a retry only repeats the
-    // failures.
-    if (succeededIds.length > 0) {
-      setSelectedSubIds((prev) => {
-        const next = new Set(prev);
-        for (const id of succeededIds) next.delete(id);
-        return next;
+    try {
+      await apiFetch<BatchMoveResult>("/api/v1/categories/batch-move", {
+        method: "POST",
+        body: JSON.stringify({
+          moves: subIds.map((id) => ({
+            subcategory_id: id,
+            target_parent_id: master.id,
+          })),
+        }),
       });
-    }
-
-    setSubmitting(false);
-
-    if (failures.length === 0) {
-      onCreated(master);
+    } catch (err) {
+      const message =
+        err instanceof ApiResponseError
+          ? err.message
+          : extractErrorMessage(err, "Batch move failed");
+      // Atomic semantics: nothing moved. The master row remains because
+      // its POST already committed in the previous step. The user can
+      // adjust the selection (rename a colliding sub, unselect it,
+      // etc.) and click submit again to retry against the same master.
+      setErrorText(message);
+      setSubmitting(false);
       return;
     }
 
-    setFailedMoves(failures);
-    setErrorText(
-      failures.length === subIds.length
-        ? `All ${failures.length} subcategory move${failures.length > 1 ? "s" : ""} failed. The master "${trimmedName}" was created. Adjust your selection and retry.`
-        : `${failures.length} of ${subIds.length} subcategory moves failed. The master "${trimmedName}" was created and ${succeededIds.length} subcategor${succeededIds.length === 1 ? "y was" : "ies were"} moved successfully. Adjust and retry, or click Done.`,
-    );
+    setSubmitting(false);
+    onCreated(master);
   }
 
-  const inRetryState = createdMaster !== null && failedMoves.length > 0;
   const submitLabel = submitting
     ? "Working..."
-    : inRetryState
-      ? "Retry failed moves"
+    : createdMaster !== null
+      ? "Retry move"
       : selectedSubIds.size > 0
         ? "Create master and move"
         : "Create master";
 
-  // In retry state we require at least one selected sub (otherwise the
-  // user should click Done). In initial state we only require a valid
-  // name.
+  // After the master is created, the user is in the post-error retry
+  // state if a batch-move failed. They need to either fix the
+  // selection and retry, or click Done.
   const canSubmit =
     nameValid &&
     !submitting &&
-    (inRetryState ? selectedSubIds.size > 0 : true);
+    (createdMaster !== null ? selectedSubIds.size > 0 : true);
 
   // Confirm dialog copy. Pre-mutation we have no preview yet, so use
   // generic copy per spec section 4.2.
-  const confirmMessage = (() => {
-    const count = selectedSubIds.size;
-    const lead = `Create master "${trimmedName}" and move ${count} subcategor${count === 1 ? "y" : "ies"} under it?`;
-    if (aggregateCounts) {
-      return `${lead}\n\nThis will reassign ${aggregateCounts.transactions} transaction${aggregateCounts.transactions === 1 ? "" : "s"}, ${aggregateCounts.recurring} recurring template${aggregateCounts.recurring === 1 ? "" : "s"}, and ${aggregateCounts.forecast_items} forecast plan item${aggregateCounts.forecast_items === 1 ? "" : "s"} at read time. Planned budgets are not changed; run "Refresh from Forecast" on the Forecast Plans page to re-attribute plans.`;
-    }
-    return `${lead}\n\nAffected transactions and forecast items will be reassigned to the new master. Planned budgets are not changed.`;
-  })();
+  const confirmCount = selectedSubIds.size;
+  const confirmMessage =
+    `Create master "${trimmedName}" and move ${confirmCount} subcategor${confirmCount === 1 ? "y" : "ies"} under it?\n\n` +
+    "Affected transactions and forecast items will be reassigned to the new master. Planned budgets are not changed.";
 
   if (!mounted) return null;
 
@@ -489,53 +421,34 @@ export default function AddMasterWithSubsModal({
                       {master.name}
                     </p>
                     <ul className="space-y-1 pl-2">
-                      {subs.map((sub) => {
-                        const failed = failedMoves.find(
-                          (f) => f.subcategory_id === sub.id,
-                        );
-                        return (
-                          <li key={sub.id}>
-                            <label
-                              data-testid={`sub-row-${sub.id}`}
-                              className={`flex items-start gap-2 rounded px-2 py-1.5 text-sm hover:bg-surface ${failed ? "ring-1 ring-danger" : ""}`}
-                            >
-                              <input
-                                type="checkbox"
-                                checked={selectedSubIds.has(sub.id)}
-                                onChange={() => toggleSub(sub.id)}
-                                disabled={submitting}
-                                className="mt-0.5"
-                                aria-label={`Move subcategory ${sub.name} under new master`}
-                              />
-                              <span className="flex-1">
-                                <span className="text-text-primary">
-                                  {sub.name}
-                                </span>
-                                {sub.transaction_count > 0 && (
-                                  <span className="ml-2 text-xs text-text-muted">
-                                    {sub.transaction_count} txn
-                                    {sub.transaction_count === 1 ? "" : "s"}
-                                  </span>
-                                )}
-                                {failed && (
-                                  <span
-                                    className="mt-0.5 block text-xs text-danger"
-                                    data-testid={`sub-failed-${sub.id}`}
-                                  >
-                                    Failed
-                                    {failed.status === 409
-                                      ? " (name conflicts in target master)"
-                                      : failed.status
-                                        ? ` (${failed.status})`
-                                        : ""}
-                                    : {failed.message}
-                                  </span>
-                                )}
+                      {subs.map((sub) => (
+                        <li key={sub.id}>
+                          <label
+                            data-testid={`sub-row-${sub.id}`}
+                            className="flex items-start gap-2 rounded px-2 py-1.5 text-sm hover:bg-surface"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selectedSubIds.has(sub.id)}
+                              onChange={() => toggleSub(sub.id)}
+                              disabled={submitting}
+                              className="mt-0.5"
+                              aria-label={`Move subcategory ${sub.name} under new master`}
+                            />
+                            <span className="flex-1">
+                              <span className="text-text-primary">
+                                {sub.name}
                               </span>
-                            </label>
-                          </li>
-                        );
-                      })}
+                              {sub.transaction_count > 0 && (
+                                <span className="ml-2 text-xs text-text-muted">
+                                  {sub.transaction_count} txn
+                                  {sub.transaction_count === 1 ? "" : "s"}
+                                </span>
+                              )}
+                            </span>
+                          </label>
+                        </li>
+                      ))}
                     </ul>
                   </li>
                 ))}

--- a/frontend/components/ui/AddMasterWithSubsModal.tsx
+++ b/frontend/components/ui/AddMasterWithSubsModal.tsx
@@ -235,7 +235,7 @@ export default function AddMasterWithSubsModal({
   }
 
   // Phase 1: create master. Phase 2: atomic batch-move of all selected
-  // subs in a single backend call (all-or-nothing per C0 §3.C).
+  // subs in a single backend call (all-or-nothing per C0 section 3.C).
   async function runCreate(subIds: number[]) {
     setSubmitting(true);
     setErrorText(null);
@@ -518,15 +518,17 @@ export default function AddMasterWithSubsModal({
         </form>
       </div>
 
-      <ConfirmModal
-        open={confirmOpen}
-        title={`Create "${trimmedName || "master"}" and move ${selectedSubIds.size} subcategor${selectedSubIds.size === 1 ? "y" : "ies"}?`}
-        message={confirmMessage}
-        confirmLabel="Yes, create and move"
-        cancelLabel="Cancel"
-        onConfirm={handleConfirmYes}
-        onCancel={() => setConfirmOpen(false)}
-      />
+      {confirmOpen && (
+        <ConfirmModal
+          open={confirmOpen}
+          title={`Create "${trimmedName || "master"}" and move ${selectedSubIds.size} subcategor${selectedSubIds.size === 1 ? "y" : "ies"}?`}
+          message={confirmMessage}
+          confirmLabel="Yes, create and move"
+          cancelLabel="Cancel"
+          onConfirm={handleConfirmYes}
+          onCancel={() => setConfirmOpen(false)}
+        />
+      )}
     </div>
   );
 

--- a/frontend/components/ui/AddMasterWithSubsModal.tsx
+++ b/frontend/components/ui/AddMasterWithSubsModal.tsx
@@ -1,0 +1,644 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { ApiResponseError, apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  error as errorCls,
+  input,
+  label as labelCls,
+} from "@/lib/styles";
+import type { Category } from "@/lib/types";
+
+type MasterType = "income" | "expense" | "both";
+
+interface MovePreviewResult {
+  category_id: number;
+  source_master_id: number;
+  target_master_id: number;
+  affected_transaction_count: number;
+  affected_recurring_count: number;
+  affected_forecast_item_count: number;
+  budget_actuals_shifted: boolean;
+}
+
+interface AggregateCounts {
+  transactions: number;
+  recurring: number;
+  forecast_items: number;
+}
+
+interface FailedMove {
+  subcategory_id: number;
+  subcategory_name: string;
+  status: number;
+  message: string;
+}
+
+interface Props {
+  /** All loaded categories (masters + subcategories). Used to render
+   *  the "Move existing subcategories under this master" picker
+   *  grouped by current master.
+   */
+  categories: Category[];
+  /** Called when the master has been created (and any selected
+   *  subcategories were attempted). The page should refresh its
+   *  category list after this fires. May fire after a partial-success
+   *  retry when the user clicks Done.
+   */
+  onCreated: (created: Category) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Modal for the C1 punch-list flow: create a new master category and,
+ * in the same flow, move a user-picked set of existing subcategories
+ * underneath it.
+ *
+ * Backend contract (C0 spec, sections 4.1 / 4.2 / 4.5):
+ *   1. POST /api/v1/categories                                (create master).
+ *   2. GET /api/v1/categories/{id}/move/preview?target_parent_id=N
+ *                                                              (preview counts, read-only).
+ *   3. PATCH /api/v1/categories/{id}/move {target_parent_id}  (move sub).
+ *
+ * Order of operations when subs are selected:
+ *   - Confirm dialog with generic copy ("Affected transactions and
+ *     forecast items will be reassigned. Planned budgets are not
+ *     changed.") because we cannot preview before the master exists.
+ *   - On Yes: POST creates the master, then we GET the preview for
+ *     each selected sub against the new master id and accumulate
+ *     counts (best-effort, displayed in the success summary), then
+ *     PATCH each sub.
+ *
+ * Partial-success: if the master creates and one or more moves fail
+ * (e.g. 409 name_collision), the master is kept, the failed rows are
+ * highlighted, and the primary button switches to "Retry failed
+ * moves" so the user can adjust selections (rename a colliding sub on
+ * the categories page, or unselect it) and try again.
+ */
+export default function AddMasterWithSubsModal({
+  categories,
+  onCreated,
+  onCancel,
+}: Props) {
+  const [name, setName] = useState("");
+  const [type, setType] = useState<MasterType>("expense");
+  const [selectedSubIds, setSelectedSubIds] = useState<Set<number>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const [failedMoves, setFailedMoves] = useState<FailedMove[]>([]);
+  const [createdMaster, setCreatedMaster] = useState<Category | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [aggregateCounts, setAggregateCounts] =
+    useState<AggregateCounts | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    nameRef.current?.focus();
+    nameRef.current?.select();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, [mounted]);
+
+  // Escape closes the confirm dialog if open, otherwise the parent
+  // modal. Tab trap stays inside the parent modal.
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !submitting) {
+        e.stopPropagation();
+        if (confirmOpen) {
+          setConfirmOpen(false);
+          return;
+        }
+        if (createdMaster) {
+          // After a partial success the parent should still get the
+          // master so its list refreshes; treat Esc as Done.
+          onCreated(createdMaster);
+          return;
+        }
+        onCancel();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const visible = Array.from(focusable).filter(
+          (el) => !el.hasAttribute("disabled") && el.offsetParent !== null
+        );
+        if (visible.length === 0) return;
+        const first = visible[0];
+        const last = visible[visible.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [submitting, confirmOpen, createdMaster, onCancel, onCreated]);
+
+  // Lock body scroll while open.
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  const trimmedName = name.trim();
+  const nameValid = trimmedName.length > 0 && trimmedName.length <= 100;
+
+  // Group existing subcategories by their current master so the picker
+  // mirrors the page's structure. The list only shows subs whose
+  // effective type is compatible with the target type the user picked.
+  // For type=both the picker shows everything; for income/expense it
+  // shows matching subs plus "both"-typed subs (which are compatible
+  // either way). Cross-type moves would 400 type_mismatch on the move
+  // endpoint per C0 spec section 4.6, so we filter them out in the UI.
+  const groups = useMemo(() => {
+    const masters = categories.filter((c) => c.parent_id === null);
+    const subsByMaster = new Map<number, Category[]>();
+    for (const c of categories) {
+      if (c.parent_id !== null) {
+        const list = subsByMaster.get(c.parent_id) ?? [];
+        list.push(c);
+        subsByMaster.set(c.parent_id, list);
+      }
+    }
+    const compatible = (sub: Category): boolean => {
+      if (type === "both") return true;
+      if (sub.type === "both") return true;
+      return sub.type === type;
+    };
+    return masters
+      .map((master) => ({
+        master,
+        subs: (subsByMaster.get(master.id) ?? []).filter(compatible),
+      }))
+      .filter((g) => g.subs.length > 0);
+  }, [categories, type]);
+
+  const totalCandidates = groups.reduce((acc, g) => acc + g.subs.length, 0);
+
+  const toggleSub = (id: number) => {
+    setSelectedSubIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  // Click on the form's primary button. Three flows:
+  //   (a) No subs selected and no master yet: create master directly.
+  //   (b) Subs selected and no master yet: open confirm dialog with
+  //       generic copy. Yes triggers create + previews + moves.
+  //   (c) Master already created (partial-success retry path): re-run
+  //       the moves for the still-selected subs only.
+  function handlePrimaryClick() {
+    if (!nameValid || submitting) return;
+    setErrorText(null);
+
+    const subIds = Array.from(selectedSubIds);
+
+    if (createdMaster) {
+      // Retry path. Master already exists; just move the selection.
+      if (subIds.length === 0) {
+        onCreated(createdMaster);
+        return;
+      }
+      void runMoves(createdMaster, subIds);
+      return;
+    }
+
+    if (subIds.length === 0) {
+      // Empty selection: create the master with no confirm.
+      void runCreate([]);
+      return;
+    }
+
+    // Subs selected: confirm before mutating anything.
+    setAggregateCounts(null);
+    setConfirmOpen(true);
+  }
+
+  async function handleConfirmYes() {
+    setConfirmOpen(false);
+    const subIds = Array.from(selectedSubIds);
+    await runCreate(subIds);
+  }
+
+  // Phase 1: create master. Phase 2: optional previews for the success
+  // summary. Phase 3: move each selected sub.
+  async function runCreate(subIds: number[]) {
+    setSubmitting(true);
+    setErrorText(null);
+    setFailedMoves([]);
+
+    let master: Category;
+    try {
+      master = await apiFetch<Category>("/api/v1/categories", {
+        method: "POST",
+        body: JSON.stringify({ name: trimmedName, type }),
+      });
+    } catch (err) {
+      const message =
+        err instanceof ApiResponseError
+          ? err.message
+          : extractErrorMessage(err, "Failed to create master");
+      setErrorText(message);
+      setSubmitting(false);
+      return;
+    }
+    setCreatedMaster(master);
+
+    if (subIds.length === 0) {
+      setSubmitting(false);
+      onCreated(master);
+      return;
+    }
+
+    // Best-effort preview for the success summary; we already have the
+    // user's intent confirmed, so a preview failure here is silent.
+    let counts: AggregateCounts | null = {
+      transactions: 0,
+      recurring: 0,
+      forecast_items: 0,
+    };
+    try {
+      for (const subId of subIds) {
+        const r = await apiFetch<MovePreviewResult>(
+          `/api/v1/categories/${subId}/move/preview?target_parent_id=${master.id}`,
+        );
+        counts.transactions += r.affected_transaction_count;
+        counts.recurring += r.affected_recurring_count;
+        counts.forecast_items += r.affected_forecast_item_count;
+      }
+    } catch {
+      counts = null;
+    }
+    setAggregateCounts(counts);
+
+    await runMoves(master, subIds);
+  }
+
+  async function runMoves(master: Category, subIds: number[]) {
+    const masterId = master.id;
+    setSubmitting(true);
+    setErrorText(null);
+    setFailedMoves([]);
+
+    const failures: FailedMove[] = [];
+    const succeededIds: number[] = [];
+    for (const subId of subIds) {
+      const subRecord = categories.find((c) => c.id === subId);
+      try {
+        await apiFetch(`/api/v1/categories/${subId}/move`, {
+          method: "PATCH",
+          body: JSON.stringify({ target_parent_id: masterId }),
+        });
+        succeededIds.push(subId);
+      } catch (err) {
+        const status = err instanceof ApiResponseError ? err.status : 0;
+        const message =
+          err instanceof ApiResponseError
+            ? err.message
+            : extractErrorMessage(err, "Move failed");
+        failures.push({
+          subcategory_id: subId,
+          subcategory_name: subRecord?.name ?? `#${subId}`,
+          status,
+          message,
+        });
+      }
+    }
+
+    // Drop succeeded moves from selection so a retry only repeats the
+    // failures.
+    if (succeededIds.length > 0) {
+      setSelectedSubIds((prev) => {
+        const next = new Set(prev);
+        for (const id of succeededIds) next.delete(id);
+        return next;
+      });
+    }
+
+    setSubmitting(false);
+
+    if (failures.length === 0) {
+      onCreated(master);
+      return;
+    }
+
+    setFailedMoves(failures);
+    setErrorText(
+      failures.length === subIds.length
+        ? `All ${failures.length} subcategory move${failures.length > 1 ? "s" : ""} failed. The master "${trimmedName}" was created. Adjust your selection and retry.`
+        : `${failures.length} of ${subIds.length} subcategory moves failed. The master "${trimmedName}" was created and ${succeededIds.length} subcategor${succeededIds.length === 1 ? "y was" : "ies were"} moved successfully. Adjust and retry, or click Done.`,
+    );
+  }
+
+  const inRetryState = createdMaster !== null && failedMoves.length > 0;
+  const submitLabel = submitting
+    ? "Working..."
+    : inRetryState
+      ? "Retry failed moves"
+      : selectedSubIds.size > 0
+        ? "Create master and move"
+        : "Create master";
+
+  // In retry state we require at least one selected sub (otherwise the
+  // user should click Done). In initial state we only require a valid
+  // name.
+  const canSubmit =
+    nameValid &&
+    !submitting &&
+    (inRetryState ? selectedSubIds.size > 0 : true);
+
+  // Confirm dialog copy. Pre-mutation we have no preview yet, so use
+  // generic copy per spec section 4.2.
+  const confirmMessage = (() => {
+    const count = selectedSubIds.size;
+    const lead = `Create master "${trimmedName}" and move ${count} subcategor${count === 1 ? "y" : "ies"} under it?`;
+    if (aggregateCounts) {
+      return `${lead}\n\nThis will reassign ${aggregateCounts.transactions} transaction${aggregateCounts.transactions === 1 ? "" : "s"}, ${aggregateCounts.recurring} recurring template${aggregateCounts.recurring === 1 ? "" : "s"}, and ${aggregateCounts.forecast_items} forecast plan item${aggregateCounts.forecast_items === 1 ? "" : "s"} at read time. Planned budgets are not changed; run "Refresh from Forecast" on the Forecast Plans page to re-attribute plans.`;
+    }
+    return `${lead}\n\nAffected transactions and forecast items will be reassigned to the new master. Planned budgets are not changed.`;
+  })();
+
+  if (!mounted) return null;
+
+  const modal = (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-bg/80 p-4">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-master-with-subs-title"
+        className={`${card} flex max-h-[90vh] w-full max-w-2xl flex-col p-6 shadow-xl`}
+      >
+        <h2
+          id="add-master-with-subs-title"
+          className="mb-4 text-lg font-semibold text-text-primary"
+        >
+          New master category
+        </h2>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handlePrimaryClick();
+          }}
+          className="flex min-h-0 flex-1 flex-col gap-4"
+        >
+          <div>
+            <label htmlFor="add-master-name" className={labelCls}>
+              Master name
+            </label>
+            <input
+              ref={nameRef}
+              id="add-master-name"
+              type="text"
+              required
+              maxLength={100}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={input}
+              autoComplete="off"
+              disabled={submitting || createdMaster !== null}
+            />
+            {createdMaster !== null && (
+              <p className="mt-1 text-xs text-text-muted">
+                Master already created. Adjust the subcategory selection and
+                retry, or click Done.
+              </p>
+            )}
+          </div>
+
+          <fieldset disabled={submitting || createdMaster !== null}>
+            <legend className={labelCls}>Type</legend>
+            <div className="flex gap-4 text-sm text-text-primary">
+              {(["expense", "income", "both"] as const).map((t) => (
+                <label key={t} className="flex items-center gap-1.5">
+                  <input
+                    type="radio"
+                    name="add-master-type"
+                    value={t}
+                    checked={type === t}
+                    onChange={() => {
+                      setType(t);
+                      // Clear selections incompatible with the new type
+                      // so the user can't carry forward a now-invalid
+                      // pick.
+                      setSelectedSubIds(new Set());
+                    }}
+                  />
+                  <span className="capitalize">{t}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="min-h-0 flex-1 overflow-y-auto rounded-md border border-border bg-surface-raised p-3">
+            <div className="mb-2 flex items-center justify-between">
+              <p className={labelCls + " mb-0"}>
+                Move existing subcategories under this master
+              </p>
+              <span
+                className="text-xs text-text-muted"
+                data-testid="selected-count"
+              >
+                {selectedSubIds.size} selected
+              </span>
+            </div>
+
+            {totalCandidates === 0 ? (
+              <p className="py-4 text-sm text-text-muted">
+                No compatible subcategories to move. You can still create the
+                master and add subcategories later.
+              </p>
+            ) : (
+              <ul className="space-y-3" data-testid="sub-picker">
+                {groups.map(({ master, subs }) => (
+                  <li key={master.id} data-testid={`group-${master.id}`}>
+                    <p
+                      className="mb-1 text-xs font-semibold uppercase tracking-wide text-text-muted"
+                      data-testid={`group-${master.id}-label`}
+                    >
+                      {master.name}
+                    </p>
+                    <ul className="space-y-1 pl-2">
+                      {subs.map((sub) => {
+                        const failed = failedMoves.find(
+                          (f) => f.subcategory_id === sub.id,
+                        );
+                        return (
+                          <li key={sub.id}>
+                            <label
+                              data-testid={`sub-row-${sub.id}`}
+                              className={`flex items-start gap-2 rounded px-2 py-1.5 text-sm hover:bg-surface ${failed ? "ring-1 ring-danger" : ""}`}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={selectedSubIds.has(sub.id)}
+                                onChange={() => toggleSub(sub.id)}
+                                disabled={submitting}
+                                className="mt-0.5"
+                                aria-label={`Move subcategory ${sub.name} under new master`}
+                              />
+                              <span className="flex-1">
+                                <span className="text-text-primary">
+                                  {sub.name}
+                                </span>
+                                {sub.transaction_count > 0 && (
+                                  <span className="ml-2 text-xs text-text-muted">
+                                    {sub.transaction_count} txn
+                                    {sub.transaction_count === 1 ? "" : "s"}
+                                  </span>
+                                )}
+                                {failed && (
+                                  <span
+                                    className="mt-0.5 block text-xs text-danger"
+                                    data-testid={`sub-failed-${sub.id}`}
+                                  >
+                                    Failed
+                                    {failed.status === 409
+                                      ? " (name conflicts in target master)"
+                                      : failed.status
+                                        ? ` (${failed.status})`
+                                        : ""}
+                                    : {failed.message}
+                                  </span>
+                                )}
+                              </span>
+                            </label>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {errorText && (
+            <div role="alert" className={errorCls}>
+              {errorText}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={() => {
+                if (createdMaster) {
+                  onCreated(createdMaster);
+                  return;
+                }
+                onCancel();
+              }}
+              disabled={submitting}
+              className={btnSecondary}
+            >
+              {createdMaster ? "Done" : "Cancel"}
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className={btnPrimary}
+            >
+              {submitLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {confirmOpen && (
+        <ConfirmInline
+          title={`Create "${trimmedName || "master"}" and move ${selectedSubIds.size} subcategor${selectedSubIds.size === 1 ? "y" : "ies"}?`}
+          message={confirmMessage}
+          onYes={handleConfirmYes}
+          onNo={() => setConfirmOpen(false)}
+        />
+      )}
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}
+
+/**
+ * Tiny confirm dialog stacked over the parent modal. Self-contained so
+ * we don't import ConfirmModal and create a portal-inside-portal mess.
+ */
+function ConfirmInline(props: {
+  title: string;
+  message: string;
+  onYes: () => void;
+  onNo: () => void;
+}) {
+  const { title, message, onYes, onNo } = props;
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-center justify-center bg-bg/80 p-4"
+      onClick={onNo}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="add-master-confirm-title"
+        className="w-full max-w-md rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          id="add-master-confirm-title"
+          className="text-lg font-semibold text-text-primary"
+        >
+          {title}
+        </h3>
+        <p
+          className="mt-2 whitespace-pre-line text-sm text-text-secondary"
+          data-testid="confirm-message"
+        >
+          {message}
+        </p>
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            onClick={onNo}
+            className={`${btnSecondary} min-h-[44px] sm:w-auto`}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onYes}
+            className={`${btnPrimary} min-h-[44px] sm:w-auto`}
+          >
+            Yes, create and move
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/components/add-master-with-subs-modal.test.tsx
+++ b/frontend/tests/components/add-master-with-subs-modal.test.tsx
@@ -286,10 +286,16 @@ describe("AddMasterWithSubsModal", () => {
     );
 
     // Confirm dialog appears with generic copy (no preview yet because
-    // the master hasn't been created).
-    const confirmMsg = await screen.findByTestId("confirm-message");
-    expect(confirmMsg).toHaveTextContent(/Create master "Dining out"/);
-    expect(confirmMsg).toHaveTextContent(/Affected transactions and forecast items/);
+    // the master hasn't been created). ConfirmModal renders the title
+    // as an h3 and the message in a p alongside it.
+    expect(
+      await screen.findByText(
+        /Create "Dining out" and move 1 subcategory\?/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Affected transactions and forecast items/i),
+    ).toBeInTheDocument();
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
@@ -342,7 +348,12 @@ describe("AddMasterWithSubsModal", () => {
       screen.getByRole("button", { name: /Create master and move/i }),
     );
 
-    const confirmDialog = await screen.findByRole("alertdialog");
+    // ConfirmModal uses role=dialog. Find the dialog containing the
+    // Yes button and click it.
+    const dialogs = await screen.findAllByRole("dialog");
+    const confirmDialog = dialogs.find((d) =>
+      within(d).queryByRole("button", { name: /Yes, create and move/i }),
+    ) as HTMLElement;
     fireEvent.click(
       within(confirmDialog).getByRole("button", {
         name: /Yes, create and move/i,
@@ -402,7 +413,12 @@ describe("AddMasterWithSubsModal", () => {
       screen.getByRole("button", { name: /Create master and move/i }),
     );
 
-    const confirmDialog = await screen.findByRole("alertdialog");
+    // ConfirmModal uses role=dialog. Find the dialog containing the
+    // Yes button and click it.
+    const dialogs = await screen.findAllByRole("dialog");
+    const confirmDialog = dialogs.find((d) =>
+      within(d).queryByRole("button", { name: /Yes, create and move/i }),
+    ) as HTMLElement;
     fireEvent.click(
       within(confirmDialog).getByRole("button", {
         name: /Yes, create and move/i,
@@ -477,7 +493,12 @@ describe("AddMasterWithSubsModal", () => {
       screen.getByRole("button", { name: /Create master and move/i }),
     );
 
-    const confirmDialog = await screen.findByRole("alertdialog");
+    // ConfirmModal uses role=dialog. Find the dialog containing the
+    // Yes button and click it.
+    const dialogs = await screen.findAllByRole("dialog");
+    const confirmDialog = dialogs.find((d) =>
+      within(d).queryByRole("button", { name: /Yes, create and move/i }),
+    ) as HTMLElement;
     fireEvent.click(
       within(confirmDialog).getByRole("button", {
         name: /Yes, create and move/i,
@@ -558,5 +579,40 @@ describe("AddMasterWithSubsModal", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }));
     expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("confirm dialog autofocuses its confirm button so keyboard users can reach it", async () => {
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Restaurants under new master"),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /Create master and move/i }),
+    );
+
+    // ConfirmModal autofocuses its confirm button on open. The
+    // previous inline alertdialog left focus trapped in the parent
+    // modal, making the confirm/cancel buttons unreachable. With
+    // ConfirmModal, focus moves to the Yes button automatically.
+    const confirmBtn = await screen.findByRole("button", {
+      name: /Yes, create and move/i,
+    });
+    await waitFor(() => expect(document.activeElement).toBe(confirmBtn));
+    expect(confirmBtn).not.toBeDisabled();
+
+    // Cancel buttons are present and reachable. The confirm dialog's
+    // Cancel and the parent modal's Cancel both have accessible names.
+    const cancelBtns = screen.getAllByRole("button", { name: /^Cancel$/i });
+    expect(cancelBtns.length).toBeGreaterThanOrEqual(1);
+    cancelBtns.forEach((b) => expect(b).not.toBeDisabled());
   });
 });

--- a/frontend/tests/components/add-master-with-subs-modal.test.tsx
+++ b/frontend/tests/components/add-master-with-subs-modal.test.tsx
@@ -44,6 +44,17 @@ const cats: Category[] = [
     is_system: true,
     transaction_count: 0,
   },
+  {
+    id: 4,
+    name: "Mixed",
+    type: "both",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: null,
+    is_system: false,
+    transaction_count: 0,
+  },
   // Subcategories.
   {
     id: 11,
@@ -89,6 +100,17 @@ const cats: Category[] = [
     is_system: false,
     transaction_count: 3,
   },
+  {
+    id: 41,
+    name: "Adjustments",
+    type: "both",
+    parent_id: 4,
+    parent_name: "Mixed",
+    description: null,
+    slug: null,
+    is_system: false,
+    transaction_count: 0,
+  },
 ];
 
 const newMaster: Category = {
@@ -128,10 +150,14 @@ describe("AddMasterWithSubsModal", () => {
     expect(screen.getByRole("radio", { name: /both/i })).toBeInTheDocument();
 
     // Default type is expense, so Food + Lifestyle groups should be
-    // present, Income group should not (its sub Salary is income-only).
+    // present. Income group must not (its sub Salary is INCOME), and
+    // Mixed group must not (its sub Adjustments is BOTH). The backend
+    // strict-equal type rule (`sub.type == target.type`) is mirrored
+    // in the UI filter.
     expect(screen.getByTestId("group-1-label")).toHaveTextContent("Food");
     expect(screen.getByTestId("group-2-label")).toHaveTextContent("Lifestyle");
     expect(screen.queryByTestId("group-3-label")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("group-4-label")).not.toBeInTheDocument();
 
     // Each compatible sub renders a checkbox.
     expect(
@@ -146,9 +172,13 @@ describe("AddMasterWithSubsModal", () => {
     expect(
       screen.queryByLabelText("Move subcategory Salary under new master"),
     ).not.toBeInTheDocument();
+    // BOTH-typed subcategory must NOT show under an EXPENSE master.
+    expect(
+      screen.queryByLabelText("Move subcategory Adjustments under new master"),
+    ).not.toBeInTheDocument();
   });
 
-  it("regroups when the user switches type to income (only income subs visible)", async () => {
+  it("INCOME master only shows INCOME subs (BOTH and EXPENSE filtered out)", async () => {
     render(
       <AddMasterWithSubsModal
         categories={cats}
@@ -160,6 +190,38 @@ describe("AddMasterWithSubsModal", () => {
     expect(screen.getByTestId("group-3-label")).toHaveTextContent("Income");
     expect(screen.queryByTestId("group-1-label")).not.toBeInTheDocument();
     expect(screen.queryByTestId("group-2-label")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("group-4-label")).not.toBeInTheDocument();
+    // BOTH sub Adjustments must NOT appear under an INCOME master.
+    expect(
+      screen.queryByLabelText("Move subcategory Adjustments under new master"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("BOTH master only shows BOTH subs (INCOME and EXPENSE filtered out)", async () => {
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /both/i }));
+    // Only the Mixed group renders; Adjustments (BOTH) is the only
+    // compatible sub.
+    expect(screen.getByTestId("group-4-label")).toHaveTextContent("Mixed");
+    expect(screen.queryByTestId("group-1-label")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("group-2-label")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("group-3-label")).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Move subcategory Adjustments under new master"),
+    ).toBeInTheDocument();
+    // INCOME and EXPENSE subs are NOT compatible with a BOTH master.
+    expect(
+      screen.queryByLabelText("Move subcategory Restaurants under new master"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Move subcategory Salary under new master"),
+    ).not.toBeInTheDocument();
   });
 
   it("disables submit when name is empty", async () => {

--- a/frontend/tests/components/add-master-with-subs-modal.test.tsx
+++ b/frontend/tests/components/add-master-with-subs-modal.test.tsx
@@ -231,30 +231,31 @@ describe("AddMasterWithSubsModal", () => {
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
-  it("on confirm Yes: POST master, GET previews, PATCH each move (call sequence)", async () => {
-    // Sequence: 1 POST, 2 previews, 2 moves.
+  it("on confirm Yes: POSTs master then a single atomic batch-move call", async () => {
     apiFetchMock
       .mockResolvedValueOnce(newMaster as never) // POST /categories
       .mockResolvedValueOnce({
-        category_id: 11,
-        source_master_id: 1,
-        target_master_id: 99,
-        affected_transaction_count: 12,
-        affected_recurring_count: 1,
-        affected_forecast_item_count: 0,
-        budget_actuals_shifted: true,
-      } as never) // preview sub 11
-      .mockResolvedValueOnce({
-        category_id: 21,
-        source_master_id: 2,
-        target_master_id: 99,
-        affected_transaction_count: 0,
-        affected_recurring_count: 0,
-        affected_forecast_item_count: 1,
-        budget_actuals_shifted: false,
-      } as never) // preview sub 21
-      .mockResolvedValueOnce(undefined as never) // PATCH sub 11
-      .mockResolvedValueOnce(undefined as never); // PATCH sub 21
+        moves: [
+          {
+            category_id: 11,
+            source_master_id: 1,
+            target_master_id: 99,
+            affected_transaction_count: 12,
+            affected_recurring_count: 1,
+            affected_forecast_item_count: 0,
+            budget_actuals_shifted: true,
+          },
+          {
+            category_id: 21,
+            source_master_id: 2,
+            target_master_id: 99,
+            affected_transaction_count: 0,
+            affected_recurring_count: 0,
+            affected_forecast_item_count: 1,
+            budget_actuals_shifted: false,
+          },
+        ],
+      } as never); // POST /batch-move
 
     const onCreated = vi.fn();
     render(
@@ -288,47 +289,27 @@ describe("AddMasterWithSubsModal", () => {
 
     await waitFor(() => expect(onCreated).toHaveBeenCalledWith(newMaster));
 
-    // Verify the call sequence (POST, GET, GET, PATCH, PATCH).
+    // Exactly two calls: POST master + POST batch-move (NO per-row
+    // PATCH loop, NO preview loop).
     const calls = apiFetchMock.mock.calls;
-    expect(calls).toHaveLength(5);
+    expect(calls).toHaveLength(2);
     expect(calls[0][0]).toBe("/api/v1/categories");
     expect(calls[0][1]).toMatchObject({ method: "POST" });
-    expect(calls[1][0]).toBe(
-      "/api/v1/categories/11/move/preview?target_parent_id=99",
-    );
-    expect(calls[2][0]).toBe(
-      "/api/v1/categories/21/move/preview?target_parent_id=99",
-    );
-    expect(calls[3][0]).toBe("/api/v1/categories/11/move");
-    expect(calls[3][1]).toMatchObject({
-      method: "PATCH",
-      body: JSON.stringify({ target_parent_id: 99 }),
+    expect(calls[1][0]).toBe("/api/v1/categories/batch-move");
+    expect(calls[1][1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({
+        moves: [
+          { subcategory_id: 11, target_parent_id: 99 },
+          { subcategory_id: 21, target_parent_id: 99 },
+        ],
+      }),
     });
-    expect(calls[4][0]).toBe("/api/v1/categories/21/move");
   });
 
-  it("partial-success: surfaces failed sub with retry affordance and keeps master", async () => {
+  it("atomic failure (409 name_collision) keeps master and surfaces error; no per-row retry/skip UI", async () => {
     apiFetchMock
-      .mockResolvedValueOnce(newMaster as never) // POST master
-      .mockResolvedValueOnce({
-        category_id: 11,
-        source_master_id: 1,
-        target_master_id: 99,
-        affected_transaction_count: 12,
-        affected_recurring_count: 0,
-        affected_forecast_item_count: 0,
-        budget_actuals_shifted: false,
-      } as never) // preview sub 11
-      .mockResolvedValueOnce({
-        category_id: 12,
-        source_master_id: 1,
-        target_master_id: 99,
-        affected_transaction_count: 5,
-        affected_recurring_count: 0,
-        affected_forecast_item_count: 0,
-        budget_actuals_shifted: false,
-      } as never) // preview sub 12
-      .mockResolvedValueOnce(undefined as never) // PATCH 11 ok
+      .mockResolvedValueOnce(newMaster as never) // POST master ok
       .mockRejectedValueOnce(
         new ApiResponseError(
           409,
@@ -336,7 +317,7 @@ describe("AddMasterWithSubsModal", () => {
           undefined,
           { detail: "name_collision" },
         ),
-      ); // PATCH 12 -> 409
+      ); // POST /batch-move -> 409
 
     const onCreated = vi.fn();
     render(
@@ -358,6 +339,7 @@ describe("AddMasterWithSubsModal", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /Create master and move/i }),
     );
+
     const confirmDialog = await screen.findByRole("alertdialog");
     fireEvent.click(
       within(confirmDialog).getByRole("button", {
@@ -365,40 +347,100 @@ describe("AddMasterWithSubsModal", () => {
       }),
     );
 
-    // Wait for the failed sub to render.
-    await screen.findByTestId("sub-failed-12");
-    expect(screen.getByTestId("sub-failed-12")).toHaveTextContent(
-      /name conflicts in target master/i,
+    // Wait for error alert.
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /name conflicts|already has a subcategory|Rename one/i,
+      ),
     );
 
-    // onCreated should NOT have fired yet because we still have a
-    // failure outstanding.
+    // Atomic semantics: onCreated is NOT called (no master returned to
+    // parent) because nothing moved.
     expect(onCreated).not.toHaveBeenCalled();
 
-    // Primary button should now read "Retry failed moves" and the
-    // master input is locked.
-    expect(
-      screen.getByRole("button", { name: /Retry failed moves/i }),
-    ).toBeInTheDocument();
+    // Master input is locked, button switches to retry.
     expect(
       (screen.getByLabelText(/Master name/i) as HTMLInputElement).disabled,
     ).toBe(true);
+    expect(
+      screen.getByRole("button", { name: /Retry move/i }),
+    ).toBeInTheDocument();
 
-    // Successful sub should be unselected (not in the still-selected
-    // set), failed sub should remain selected.
+    // No per-row failed marker, no "Retry failed moves" / "skip"
+    // affordance; the contract is all-or-nothing.
+    expect(screen.queryByTestId("sub-failed-12")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Retry failed moves/i }),
+    ).not.toBeInTheDocument();
+
+    // Both checkboxes remain selected (nothing moved).
     const restaurantsCheckbox = screen.getByLabelText(
       "Move subcategory Restaurants under new master",
     ) as HTMLInputElement;
     const groceriesCheckbox = screen.getByLabelText(
       "Move subcategory Groceries under new master",
     ) as HTMLInputElement;
-    expect(restaurantsCheckbox.checked).toBe(false);
+    expect(restaurantsCheckbox.checked).toBe(true);
     expect(groceriesCheckbox.checked).toBe(true);
+  });
 
-    // Done button (replaces Cancel) calls onCreated with the master so
-    // the parent page refreshes.
-    fireEvent.click(screen.getByRole("button", { name: /^Done$/i }));
-    expect(onCreated).toHaveBeenCalledWith(newMaster);
+  it("retry path: user adjusts selection and the second batch-move succeeds", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(newMaster as never) // POST master ok
+      .mockRejectedValueOnce(
+        new ApiResponseError(409, "name_collision detail", undefined, {
+          detail: "name_collision",
+        }),
+      ) // first batch-move -> 409
+      .mockResolvedValueOnce({ moves: [] } as never); // second batch-move ok
+
+    const onCreated = vi.fn();
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={onCreated}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Restaurants under new master"),
+    );
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Groceries under new master"),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /Create master and move/i }),
+    );
+
+    const confirmDialog = await screen.findByRole("alertdialog");
+    fireEvent.click(
+      within(confirmDialog).getByRole("button", {
+        name: /Yes, create and move/i,
+      }),
+    );
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+
+    // User unchecks Groceries (the colliding one) and clicks Retry move.
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Groceries under new master"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Retry move/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(newMaster));
+
+    // 3 calls total: POST master, batch-move (failed), batch-move (ok).
+    const calls = apiFetchMock.mock.calls;
+    expect(calls).toHaveLength(3);
+    expect(calls[2][0]).toBe("/api/v1/categories/batch-move");
+    expect(calls[2][1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({
+        moves: [{ subcategory_id: 11, target_parent_id: 99 }],
+      }),
+    });
   });
 
   it("surfaces 409 from POST master without committing any moves", async () => {
@@ -425,7 +467,7 @@ describe("AddMasterWithSubsModal", () => {
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i),
     );
-    // Only the POST happened; no preview, no move.
+    // Only the POST happened; no batch-move.
     expect(apiFetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/tests/components/add-master-with-subs-modal.test.tsx
+++ b/frontend/tests/components/add-master-with-subs-modal.test.tsx
@@ -581,6 +581,46 @@ describe("AddMasterWithSubsModal", () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
+  it("awaits async onCreated; reload errors surface inline with retry-refresh", async () => {
+    apiFetchMock.mockResolvedValueOnce(newMaster as never);
+    let onCreatedCallCount = 0;
+    const onCreated = vi.fn(async () => {
+      onCreatedCallCount += 1;
+      if (onCreatedCallCount === 1) {
+        throw new Error("network blip");
+      }
+    });
+
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={onCreated}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Create master$/i }));
+
+    // Reload error surfaces in the alert region with a Retry-refresh
+    // button. The modal awaits onCreated rather than dropping the
+    // promise on the floor.
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /failed to refresh/i,
+      ),
+    );
+    expect(screen.getByTestId("retry-refresh")).toBeInTheDocument();
+    expect(onCreated).toHaveBeenCalledTimes(1);
+
+    // Clicking Retry refresh re-invokes onCreated; the second call
+    // resolves and clears the error.
+    fireEvent.click(screen.getByTestId("retry-refresh"));
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(2));
+  });
+
   it("confirm dialog autofocuses its confirm button so keyboard users can reach it", async () => {
     render(
       <AddMasterWithSubsModal

--- a/frontend/tests/components/add-master-with-subs-modal.test.tsx
+++ b/frontend/tests/components/add-master-with-subs-modal.test.tsx
@@ -1,0 +1,458 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import AddMasterWithSubsModal from "@/components/ui/AddMasterWithSubsModal";
+import { ApiResponseError, apiFetch } from "@/lib/api";
+import type { Category } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const cats: Category[] = [
+  // Masters.
+  {
+    id: 1,
+    name: "Food",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "food_dining",
+    is_system: true,
+    transaction_count: 0,
+  },
+  {
+    id: 2,
+    name: "Lifestyle",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "lifestyle",
+    is_system: true,
+    transaction_count: 0,
+  },
+  {
+    id: 3,
+    name: "Income",
+    type: "income",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "income",
+    is_system: true,
+    transaction_count: 0,
+  },
+  // Subcategories.
+  {
+    id: 11,
+    name: "Restaurants",
+    type: "expense",
+    parent_id: 1,
+    parent_name: "Food",
+    description: null,
+    slug: null,
+    is_system: false,
+    transaction_count: 12,
+  },
+  {
+    id: 12,
+    name: "Groceries",
+    type: "expense",
+    parent_id: 1,
+    parent_name: "Food",
+    description: null,
+    slug: null,
+    is_system: false,
+    transaction_count: 5,
+  },
+  {
+    id: 21,
+    name: "Hobbies",
+    type: "expense",
+    parent_id: 2,
+    parent_name: "Lifestyle",
+    description: null,
+    slug: null,
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 31,
+    name: "Salary",
+    type: "income",
+    parent_id: 3,
+    parent_name: "Income",
+    description: null,
+    slug: null,
+    is_system: false,
+    transaction_count: 3,
+  },
+];
+
+const newMaster: Category = {
+  id: 99,
+  name: "Dining out",
+  type: "expense",
+  parent_id: null,
+  parent_name: null,
+  description: null,
+  slug: null,
+  is_system: false,
+  transaction_count: 0,
+};
+
+describe("AddMasterWithSubsModal", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("renders the modal with name field, type selector, and grouped sub list", async () => {
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(
+      await screen.findByLabelText(/Master name/i),
+    ).toBeInTheDocument();
+
+    // Type radios.
+    expect(screen.getByRole("radio", { name: /expense/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /income/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /both/i })).toBeInTheDocument();
+
+    // Default type is expense, so Food + Lifestyle groups should be
+    // present, Income group should not (its sub Salary is income-only).
+    expect(screen.getByTestId("group-1-label")).toHaveTextContent("Food");
+    expect(screen.getByTestId("group-2-label")).toHaveTextContent("Lifestyle");
+    expect(screen.queryByTestId("group-3-label")).not.toBeInTheDocument();
+
+    // Each compatible sub renders a checkbox.
+    expect(
+      screen.getByLabelText("Move subcategory Restaurants under new master"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Move subcategory Groceries under new master"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Move subcategory Hobbies under new master"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Move subcategory Salary under new master"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("regroups when the user switches type to income (only income subs visible)", async () => {
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /income/i }));
+    expect(screen.getByTestId("group-3-label")).toHaveTextContent("Income");
+    expect(screen.queryByTestId("group-1-label")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("group-2-label")).not.toBeInTheDocument();
+  });
+
+  it("disables submit when name is empty", async () => {
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /Create master/i }),
+    ).toBeDisabled();
+  });
+
+  it("creates master with no subs selected (no confirm dialog)", async () => {
+    apiFetchMock.mockResolvedValueOnce(newMaster as never);
+    const onCreated = vi.fn();
+
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={onCreated}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Create master$/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(newMaster));
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/v1/categories",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Dining out", type: "expense" }),
+      }),
+    );
+  });
+
+  it("opens a confirm dialog when one or more subs are selected", async () => {
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Restaurants under new master"),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Create master and move/i }),
+    );
+
+    // Confirm dialog appears with generic copy (no preview yet because
+    // the master hasn't been created).
+    const confirmMsg = await screen.findByTestId("confirm-message");
+    expect(confirmMsg).toHaveTextContent(/Create master "Dining out"/);
+    expect(confirmMsg).toHaveTextContent(/Affected transactions and forecast items/);
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("on confirm Yes: POST master, GET previews, PATCH each move (call sequence)", async () => {
+    // Sequence: 1 POST, 2 previews, 2 moves.
+    apiFetchMock
+      .mockResolvedValueOnce(newMaster as never) // POST /categories
+      .mockResolvedValueOnce({
+        category_id: 11,
+        source_master_id: 1,
+        target_master_id: 99,
+        affected_transaction_count: 12,
+        affected_recurring_count: 1,
+        affected_forecast_item_count: 0,
+        budget_actuals_shifted: true,
+      } as never) // preview sub 11
+      .mockResolvedValueOnce({
+        category_id: 21,
+        source_master_id: 2,
+        target_master_id: 99,
+        affected_transaction_count: 0,
+        affected_recurring_count: 0,
+        affected_forecast_item_count: 1,
+        budget_actuals_shifted: false,
+      } as never) // preview sub 21
+      .mockResolvedValueOnce(undefined as never) // PATCH sub 11
+      .mockResolvedValueOnce(undefined as never); // PATCH sub 21
+
+    const onCreated = vi.fn();
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={onCreated}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Restaurants under new master"),
+    );
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Hobbies under new master"),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Create master and move/i }),
+    );
+
+    const confirmDialog = await screen.findByRole("alertdialog");
+    fireEvent.click(
+      within(confirmDialog).getByRole("button", {
+        name: /Yes, create and move/i,
+      }),
+    );
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(newMaster));
+
+    // Verify the call sequence (POST, GET, GET, PATCH, PATCH).
+    const calls = apiFetchMock.mock.calls;
+    expect(calls).toHaveLength(5);
+    expect(calls[0][0]).toBe("/api/v1/categories");
+    expect(calls[0][1]).toMatchObject({ method: "POST" });
+    expect(calls[1][0]).toBe(
+      "/api/v1/categories/11/move/preview?target_parent_id=99",
+    );
+    expect(calls[2][0]).toBe(
+      "/api/v1/categories/21/move/preview?target_parent_id=99",
+    );
+    expect(calls[3][0]).toBe("/api/v1/categories/11/move");
+    expect(calls[3][1]).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({ target_parent_id: 99 }),
+    });
+    expect(calls[4][0]).toBe("/api/v1/categories/21/move");
+  });
+
+  it("partial-success: surfaces failed sub with retry affordance and keeps master", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(newMaster as never) // POST master
+      .mockResolvedValueOnce({
+        category_id: 11,
+        source_master_id: 1,
+        target_master_id: 99,
+        affected_transaction_count: 12,
+        affected_recurring_count: 0,
+        affected_forecast_item_count: 0,
+        budget_actuals_shifted: false,
+      } as never) // preview sub 11
+      .mockResolvedValueOnce({
+        category_id: 12,
+        source_master_id: 1,
+        target_master_id: 99,
+        affected_transaction_count: 5,
+        affected_recurring_count: 0,
+        affected_forecast_item_count: 0,
+        budget_actuals_shifted: false,
+      } as never) // preview sub 12
+      .mockResolvedValueOnce(undefined as never) // PATCH 11 ok
+      .mockRejectedValueOnce(
+        new ApiResponseError(
+          409,
+          'Lifestyle already has a subcategory named "Groceries". Rename one before moving.',
+          undefined,
+          { detail: "name_collision" },
+        ),
+      ); // PATCH 12 -> 409
+
+    const onCreated = vi.fn();
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={onCreated}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Restaurants under new master"),
+    );
+    fireEvent.click(
+      screen.getByLabelText("Move subcategory Groceries under new master"),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /Create master and move/i }),
+    );
+    const confirmDialog = await screen.findByRole("alertdialog");
+    fireEvent.click(
+      within(confirmDialog).getByRole("button", {
+        name: /Yes, create and move/i,
+      }),
+    );
+
+    // Wait for the failed sub to render.
+    await screen.findByTestId("sub-failed-12");
+    expect(screen.getByTestId("sub-failed-12")).toHaveTextContent(
+      /name conflicts in target master/i,
+    );
+
+    // onCreated should NOT have fired yet because we still have a
+    // failure outstanding.
+    expect(onCreated).not.toHaveBeenCalled();
+
+    // Primary button should now read "Retry failed moves" and the
+    // master input is locked.
+    expect(
+      screen.getByRole("button", { name: /Retry failed moves/i }),
+    ).toBeInTheDocument();
+    expect(
+      (screen.getByLabelText(/Master name/i) as HTMLInputElement).disabled,
+    ).toBe(true);
+
+    // Successful sub should be unselected (not in the still-selected
+    // set), failed sub should remain selected.
+    const restaurantsCheckbox = screen.getByLabelText(
+      "Move subcategory Restaurants under new master",
+    ) as HTMLInputElement;
+    const groceriesCheckbox = screen.getByLabelText(
+      "Move subcategory Groceries under new master",
+    ) as HTMLInputElement;
+    expect(restaurantsCheckbox.checked).toBe(false);
+    expect(groceriesCheckbox.checked).toBe(true);
+
+    // Done button (replaces Cancel) calls onCreated with the master so
+    // the parent page refreshes.
+    fireEvent.click(screen.getByRole("button", { name: /^Done$/i }));
+    expect(onCreated).toHaveBeenCalledWith(newMaster);
+  });
+
+  it("surfaces 409 from POST master without committing any moves", async () => {
+    apiFetchMock.mockRejectedValueOnce(
+      new ApiResponseError(
+        409,
+        "A master category named Dining out already exists.",
+      ),
+    );
+
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Master name/i), {
+      target: { value: "Dining out" },
+    });
+    // No subs selected so we skip the confirm dialog.
+    fireEvent.click(screen.getByRole("button", { name: /Create master$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i),
+    );
+    // Only the POST happened; no preview, no move.
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape closes the modal when not submitting and no master created yet", async () => {
+    const onCancel = vi.fn();
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    await screen.findByLabelText(/Master name/i);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("Cancel button calls onCancel when no master created yet", async () => {
+    const onCancel = vi.fn();
+    render(
+      <AddMasterWithSubsModal
+        categories={cats}
+        onCreated={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Punch list item C1 (Categories rework): the user can already create a master category, and they can already create subcategories under a master, but they cannot create a master and tell the system "move these existing subcategories under it" in a single flow. Today the workaround is "create the master, then go subcategory by subcategory, delete-and-recreate under the new master, hope no transactions get orphaned." That workaround does not work because deletion of a category that holds transactions is rejected with 409, and even if it weren't, recreating a sub by name loses the transaction history.

C0 (PR #194) added the backend primitives this PR drives: `POST /api/v1/categories/batch-move` for atomic multi-row re-parenting (all-or-nothing per spec section 3.C), plus `PATCH /api/v1/categories/{id}/move` for single moves and the `400 type_mismatch` and `409 name_collision` error shapes the frontend surfaces inline.

## Implementation summary

A new modal `AddMasterWithSubsModal` opens from the "+ Add Master" button on the Categories page. The flow:

1. User types a master name and picks a type (income, expense, or both).
2. Below the type, a scrollable list shows every existing subcategory grouped by its current master, filtered by strict type equality. Per `category_service.move_subcategory`, the backend rejects any move where `sub.type != target.type` with `400 type_mismatch`. The UI mirrors the rule:
   - target=INCOME shows only INCOME subs.
   - target=EXPENSE shows only EXPENSE subs.
   - target=BOTH shows only BOTH subs.
3. User checkboxes which subs (zero or more) they want to move.
4. Submit:
   - Zero subs selected: directly POSTs to create the master, then closes.
   - At least one sub selected: a confirm dialog (the project's canonical `ConfirmModal`) opens with generic copy ("Affected transactions and forecast items will be reassigned. Planned budgets are not changed."). On Yes:
     - POST creates the master.
     - A single POST to `/api/v1/categories/batch-move` runs all selected moves atomically.
5. Atomic-failure path: if the batch-move returns a non-2xx (e.g. `409 name_collision`), nothing moved. The master remains (it was created in a separate POST that already committed), the error message surfaces inline, the master input is locked, and the primary button switches to "Retry move". The user adjusts the selection and reruns the same atomic batch-move. There is no per-row retry/skip flow; the contract is all-or-nothing.

UI requirements met:

- Tokenized overlay (`bg-bg/80`).
- Tokenized colors only, no raw hex.
- Confirm dialog before submit when at least one sub is selected.
- Submit disabled when name is empty or invalid.
- Surfaces 409 on POST master (master name collision) and on POST batch-move (name collision in target master).
- Escape closes the parent modal when the confirm dialog is closed; `ConfirmModal` owns its own Escape and Tab when open.
- `ConfirmModal` autofocuses its confirm button on open and traps Tab inside its own dialog so keyboard users can reach Confirm and Cancel.
- `onCreated` is awaited; reload errors surface inline with a Retry-refresh button so a failed post-mutation refresh does not silently leave the UI stale.

## Files changed

C1 owns the "+ Add Master" entry point and the new modal flow. Per the file-ownership coordination with the parallel "Categories C2 UI" team (Edit-mode toggle and batch-select chrome), this PR specifically touched:

- `frontend/components/ui/AddMasterWithSubsModal.tsx` (new): the modal component itself.
- `frontend/app/categories/page.tsx`:
  - Replaced the "+ Custom Category" button and the inline `New Master Category` form (`handleAddMaster`, `newMasterName`, `newMasterType`, `newMasterDesc`, `showAddMaster`) with a single "+ Add Master" button that mounts `AddMasterWithSubsModal`.
  - Removed the now-unused `cardTitle` import.
  - Reload-then-close on `onCreated` so the modal can present the retry-refresh affordance before the page closes it.
  - **Did not touch** the Edit/Cancel-Edit buttons, the per-row Edit/Delete actions, the Add-Sub form, or any C2-owned chrome.
- `frontend/tests/components/add-master-with-subs-modal.test.tsx` (new): vitest + @testing-library/react coverage.

## Tests run and results

`docker compose exec frontend npx vitest run tests/components/add-master-with-subs-modal.test.tsx tests/components/add-category-modal.test.tsx tests/app/categories-mobile-pass.test.tsx`

Result: 3 files passed, 33 tests passed (14 new + 14 existing add-category-modal + 5 categories-mobile-pass).

New test coverage in `add-master-with-subs-modal.test.tsx`:

- Modal renders with name field, type radios, and grouped sub list.
- EXPENSE master picker hides INCOME and BOTH subs (default-type render).
- INCOME master picker hides EXPENSE and BOTH subs.
- BOTH master picker hides INCOME and EXPENSE subs.
- Submit disabled when name is empty.
- Empty selection still creates the master (no confirm dialog).
- Confirm dialog opens when subs are selected, with generic copy.
- Confirm Yes: asserts POST master + a single POST `/batch-move` call sequence (not per-row PATCH).
- Atomic 409 keeps master, surfaces inline error, no per-row retry/skip UI, both checkboxes remain checked.
- Retry path: user adjusts selection, second batch-move POST succeeds, exactly 3 total calls.
- 409 on POST master surfaces inline without committing any moves.
- Async `onCreated` is awaited; reload error surfaces with retry-refresh button.
- Confirm dialog autofocuses its confirm button and Cancel buttons remain reachable.
- Escape closes when no master is created yet.
- Cancel button calls `onCancel` when no master is created yet.

`docker compose exec frontend npx tsc --noEmit` is clean.

## Screenshot

Not captured. The dev container is bind-mounted from the user's main worktree on a different branch; switching the running stack to this branch to capture a screenshot would interfere with parallel work. The modal's structure is fully exercised by the test suite (14 cases) and matches the project's modal aesthetic (same `card`, `bg-bg/80` overlay, `btnPrimary`/`btnSecondary` actions, focus trap, Escape handling).

## Merge gate

C0 backend (PR #194) is merged. Merge order recommendation: this PR (#192) lands first; the parallel C2 PR (#191) rebases on top after.

## Internal reviewers

Frontend dev (self), UI designer (self), QA reviewer (self). Patterns matched against `AddCategoryModal.tsx` (modal aesthetic, focus trap, portal mounting, tokenized colors) and `ConfirmModal` (canonical confirm widget). Backend contract matched against the C0 spec sections 4.1, 4.2, 4.5, 4.6 and `category_service.move_subcategory` / `batch_move_subcategories`.

External review required before merge.
