### PR TITLE
feat(frontend): floating Add Transaction FAB base infrastructure

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ import AccountMonthEndForecast, {
   type AccountMonthEndForecastResponse,
 } from "@/components/dashboard/AccountMonthEndForecast";
 import AccountTilesCard from "@/components/dashboard/AccountTile";
+import AddTransactionFab from "@/components/floating/AddTransactionFab";
 import type { Account, BillingPeriod, Budget, Category, Transaction } from "@/lib/types";
 
 interface ForecastPlanItem {
@@ -1034,6 +1035,21 @@ export default function DashboardPage() {
           )}
         </div>
       )}
+      {/*
+        FAB demo mount — Dashboard only for this PR. Broader rollout
+        (FAB on every core money page, Dashboard Quick Add card removal)
+        is a follow-up integration PR that waits for Sort/Filters and
+        Transactions Layout to stabilize, since both touch the same
+        page files.
+      */}
+      <AddTransactionFab
+        onTransactionAdded={() => {
+          void loadTransactions(0);
+          void loadForecastProjection();
+          void loadPendingTransactions();
+          void loadAccountMonthEndForecast();
+        }}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1036,7 +1036,7 @@ export default function DashboardPage() {
         </div>
       )}
       {/*
-        FAB demo mount — Dashboard only for this PR. Broader rollout
+        FAB demo mount, Dashboard only for this PR. Broader rollout
         (FAB on every core money page, Dashboard Quick Add card removal)
         is a follow-up integration PR that waits for Sort/Filters and
         Transactions Layout to stabilize, since both touch the same

--- a/frontend/components/floating/AddTransactionFab.tsx
+++ b/frontend/components/floating/AddTransactionFab.tsx
@@ -10,7 +10,7 @@ import type { Account, Category } from "@/lib/types";
 
 /**
  * Floating "Add Transaction" button. Lives in the bottom-right anchor
- * zone (primary slot — sits at the bottom of the cluster, closest to
+ * zone (primary slot, sits at the bottom of the cluster, closest to
  * the thumb on mobile). Click opens a SlideInPanel with the
  * TransactionForm inside.
  *
@@ -53,7 +53,7 @@ export default function AddTransactionFab({
       setCategories(cats ?? []);
       setLoaded(true);
     } catch {
-      // Swallow load errors silently — the form will render an empty
+      // Swallow load errors silently, the form will render an empty
       // state ("Create at least one account and one category...").
       // Any submit error surfaces inline in the form.
       setLoaded(true);

--- a/frontend/components/floating/AddTransactionFab.tsx
+++ b/frontend/components/floating/AddTransactionFab.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import AnchorZone, { AnchorZoneSlot } from "@/components/floating/AnchorZone";
+import SlideInPanel from "@/components/floating/SlideInPanel";
+import TransactionForm from "@/components/floating/TransactionForm";
+import { apiFetch } from "@/lib/api";
+import type { Account, Category } from "@/lib/types";
+
+/**
+ * Floating "Add Transaction" button. Lives in the bottom-right anchor
+ * zone (primary slot — sits at the bottom of the cluster, closest to
+ * the thumb on mobile). Click opens a SlideInPanel with the
+ * TransactionForm inside.
+ *
+ * Data loading: this component owns its accounts/categories fetch so
+ * pages can mount it without prop-drilling reference data. Refs load
+ * on first mount and on every panel open (cheap, keeps the form fresh
+ * when the user edits accounts or categories elsewhere).
+ *
+ * onTransactionAdded: optional callback so the host page can refresh
+ * its own data (e.g. dashboard transaction list) when a tx lands. The
+ * FAB itself does not refresh anything other than its own ref data.
+ */
+
+export interface AddTransactionFabProps {
+  /** Pre-select an account (e.g. on /accounts/{id}). */
+  defaultAccountId?: number | null;
+  /** Pre-select a category (e.g. on a future category-detail page). */
+  defaultCategoryId?: number | null;
+  /** Called after every successful transaction save. */
+  onTransactionAdded?: () => void;
+}
+
+export default function AddTransactionFab({
+  defaultAccountId = null,
+  defaultCategoryId = null,
+  onTransactionAdded,
+}: AddTransactionFabProps) {
+  const [open, setOpen] = useState(false);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const loadRefs = useCallback(async () => {
+    try {
+      const [accts, cats] = await Promise.all([
+        apiFetch<Account[]>("/api/v1/accounts"),
+        apiFetch<Category[]>("/api/v1/categories"),
+      ]);
+      setAccounts(accts ?? []);
+      setCategories(cats ?? []);
+      setLoaded(true);
+    } catch {
+      // Swallow load errors silently — the form will render an empty
+      // state ("Create at least one account and one category...").
+      // Any submit error surfaces inline in the form.
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRefs();
+  }, [loadRefs]);
+
+  function handleOpen() {
+    // Refresh refs so newly-added accounts/categories show up the next
+    // time the user pops the panel without a full reload.
+    void loadRefs();
+    setOpen(true);
+  }
+
+  return (
+    <>
+      <AnchorZone>
+        <AnchorZoneSlot slot="primary">
+          <button
+            type="button"
+            onClick={handleOpen}
+            aria-label="Add transaction"
+            data-testid="add-transaction-fab"
+            className="flex h-14 w-14 items-center justify-center rounded-full bg-accent text-accent-text shadow-lg transition-transform hover:scale-105 hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          >
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+            </svg>
+          </button>
+        </AnchorZoneSlot>
+      </AnchorZone>
+
+      <SlideInPanel
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Add transaction"
+        testId="add-transaction-panel"
+      >
+        {loaded ? (
+          <TransactionForm
+            accounts={accounts}
+            categories={categories}
+            defaultAccountId={defaultAccountId}
+            defaultCategoryId={defaultCategoryId}
+            onSaved={() => setOpen(false)}
+            onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])}
+            onTransactionAdded={onTransactionAdded}
+          />
+        ) : (
+          <div className="flex items-center justify-center py-12 text-sm text-text-muted">
+            Loading...
+          </div>
+        )}
+      </SlideInPanel>
+    </>
+  );
+}

--- a/frontend/components/floating/AddTransactionFab.tsx
+++ b/frontend/components/floating/AddTransactionFab.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { Plus } from "lucide-react";
+
 import AnchorZone, { AnchorZoneSlot } from "@/components/floating/AnchorZone";
 import SlideInPanel from "@/components/floating/SlideInPanel";
 import TransactionForm from "@/components/floating/TransactionForm";
@@ -82,15 +84,7 @@ export default function AddTransactionFab({
             data-testid="add-transaction-fab"
             className="flex h-14 w-14 items-center justify-center rounded-full bg-accent text-accent-text shadow-lg transition-transform hover:scale-105 hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           >
-            <svg
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-            </svg>
+            <Plus className="h-6 w-6" aria-hidden="true" />
           </button>
         </AnchorZoneSlot>
       </AnchorZone>

--- a/frontend/components/floating/AnchorZone.tsx
+++ b/frontend/components/floating/AnchorZone.tsx
@@ -81,7 +81,7 @@ export default function AnchorZone({ children, testId }: AnchorZoneProps) {
     .map(rankChild)
     // Visually we want primary (rank 0) at the BOTTOM. Flex-col-reverse
     // would invert tab order, so we sort descending instead and keep the
-    // natural column. Tab order: secondary first, then primary — matches
+    // natural column. Tab order: secondary first, then primary, matches
     // the visual top-to-bottom flow.
     .sort((a, b) => {
       if (b.rank !== a.rank) return b.rank - a.rank;

--- a/frontend/components/floating/AnchorZone.tsx
+++ b/frontend/components/floating/AnchorZone.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Children, isValidElement, ReactElement, ReactNode } from "react";
+
+/**
+ * Bottom-right floating-widget anchor.
+ *
+ * Stacking convention (locked for the FAB + future feedback widget):
+ *   - One cluster at the bottom-right corner. NOT two separate zones.
+ *   - Children render in a vertical column, gap-3, items-end.
+ *   - "primary" slot pins to the bottom (closest to the user's thumb on
+ *     mobile). The Add Transaction FAB owns the primary slot.
+ *   - "secondary" slot stacks above primary. The future in-app feedback
+ *     widget will own this slot.
+ *   - "tertiary" exists for one further widget if we ever need it.
+ *
+ * Adding a new floating widget is a one-component-tree edit: drop a new
+ * <AnchorZoneSlot slot="secondary"> child anywhere in the tree that the
+ * AnchorZone wraps. The cluster sorts children by slot priority so the
+ * vertical order stays stable regardless of mount order.
+ *
+ * z-index: 40. Sits below modal overlays (z-50, e.g. ConfirmModal +
+ * SlideInPanel which both use z-50) so an open dialog dims the FAB.
+ */
+
+export type AnchorSlot = "primary" | "secondary" | "tertiary";
+
+const SLOT_ORDER: Record<AnchorSlot, number> = {
+  // Lower number = lower in the visual stack (closer to corner).
+  primary: 0,
+  secondary: 1,
+  tertiary: 2,
+};
+
+interface SlotProps {
+  slot: AnchorSlot;
+  children: ReactNode;
+}
+
+/**
+ * Wrapper to opt a child into a specific slot. The AnchorZone sorts its
+ * children by slot priority so consumers don't have to reason about
+ * mount order across pages.
+ */
+export function AnchorZoneSlot({ children }: SlotProps) {
+  return <>{children}</>;
+}
+AnchorZoneSlot.displayName = "AnchorZoneSlot";
+
+interface AnchorZoneProps {
+  children: ReactNode;
+  /**
+   * Optional test id for the cluster wrapper. Mainly used by tests that
+   * need to assert ordering or z-index without a stable visible label.
+   */
+  testId?: string;
+}
+
+interface RankedChild {
+  rank: number;
+  index: number;
+  node: ReactNode;
+}
+
+function rankChild(child: ReactNode, index: number): RankedChild {
+  if (
+    isValidElement(child) &&
+    (child.type as { displayName?: string }).displayName === "AnchorZoneSlot"
+  ) {
+    const slot = (child.props as SlotProps).slot;
+    return { rank: SLOT_ORDER[slot] ?? 99, index, node: child };
+  }
+  // Bare children get a high rank so they stack above named slots only
+  // by accident. Prefer wrapping in <AnchorZoneSlot> for predictable
+  // ordering. The fallback keeps AnchorZone tolerant of plain children.
+  return { rank: 99, index, node: child };
+}
+
+export default function AnchorZone({ children, testId }: AnchorZoneProps) {
+  const ranked = Children.toArray(children)
+    .map(rankChild)
+    // Visually we want primary (rank 0) at the BOTTOM. Flex-col-reverse
+    // would invert tab order, so we sort descending instead and keep the
+    // natural column. Tab order: secondary first, then primary — matches
+    // the visual top-to-bottom flow.
+    .sort((a, b) => {
+      if (b.rank !== a.rank) return b.rank - a.rank;
+      return a.index - b.index;
+    });
+
+  return (
+    <div
+      data-testid={testId ?? "anchor-zone"}
+      className="pointer-events-none fixed bottom-4 right-4 z-40 flex flex-col items-end gap-3 sm:bottom-6 sm:right-6"
+    >
+      {ranked.map((c, i) => (
+        <div key={i} className="pointer-events-auto">
+          {c.node}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/floating/SlideInPanel.tsx
+++ b/frontend/components/floating/SlideInPanel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { ReactNode, useEffect, useRef } from "react";
+
+/**
+ * Right-side slide-in panel for quick-entry flows. Pattern reference:
+ * Linear / Notion task quick-add. Side panel was chosen over a centered
+ * modal because the FAB lives in the bottom-right and a panel sliding
+ * from the same corner reinforces the visual link.
+ *
+ * Behavior:
+ *   - Renders nothing when `open` is false (no dead overlay in the DOM).
+ *   - Esc closes (handler at document level, capture phase off so inner
+ *     dialogs win).
+ *   - Click on the dimmed overlay closes. Click inside the panel does
+ *     not close.
+ *   - Focus is trapped inside the panel: Tab/Shift+Tab cycle through
+ *     focusables. On open, the first focusable receives focus. On
+ *     close, focus returns to the trigger.
+ *   - Body scroll is locked while open so the panel feels modal.
+ *   - z-50 to sit above the AnchorZone (z-40) and any non-modal page
+ *     content. ConfirmModal also uses z-50; a panel-spawned confirm
+ *     modal renders on top because it mounts later.
+ */
+
+export interface SlideInPanelProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  /**
+   * Optional test id so tests can target the panel specifically (default
+   * "slide-in-panel"). Useful when more than one panel could exist on a
+   * page.
+   */
+  testId?: string;
+  /**
+   * Optional width class. Defaults to a comfortable form width.
+   */
+  widthClass?: string;
+}
+
+export default function SlideInPanel({
+  open,
+  onClose,
+  title,
+  children,
+  testId,
+  widthClass,
+}: SlideInPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Capture the previously-focused element before the panel takes over,
+  // and restore it on close. Mirrors ConfirmModal's pattern.
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      // Give the panel one tick to render before moving focus.
+      const id = window.setTimeout(() => {
+        const focusables = getFocusables(panelRef.current);
+        focusables[0]?.focus();
+      }, 0);
+      return () => window.clearTimeout(id);
+    }
+    if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [open]);
+
+  // Esc + focus trap.
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusables = getFocusables(panelRef.current);
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  // Body scroll lock so the underlying page doesn't move while the panel
+  // is open. Cleared on unmount as a belt-and-suspenders.
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid={testId ?? "slide-in-panel"}
+      className="fixed inset-0 z-50 flex justify-end bg-bg/80"
+      onClick={onClose}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="slide-in-panel-title"
+        className={`flex h-full w-full flex-col overflow-y-auto border-l border-border bg-surface shadow-xl ${
+          widthClass ?? "sm:max-w-md md:max-w-lg"
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2
+            id="slide-in-panel-title"
+            className="text-lg font-semibold text-text-primary"
+          >
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-text-muted hover:bg-surface-raised hover:text-text-primary"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-6 py-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function getFocusables(root: HTMLElement | null): HTMLElement[] {
+  if (!root) return [];
+  const nodes = root.querySelectorAll<HTMLElement>(
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+  );
+  return Array.from(nodes);
+}

--- a/frontend/components/floating/SlideInPanel.tsx
+++ b/frontend/components/floating/SlideInPanel.tsx
@@ -2,6 +2,8 @@
 
 import { ReactNode, useEffect, useRef } from "react";
 
+import { X } from "lucide-react";
+
 /**
  * Right-side slide-in panel for quick-entry flows. Pattern reference:
  * Linear / Notion task quick-add. Side panel was chosen over a centered
@@ -137,15 +139,7 @@ export default function SlideInPanel({
             aria-label="Close"
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-text-muted hover:bg-surface-raised hover:text-text-primary"
           >
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-            </svg>
+            <X className="h-5 w-5" aria-hidden="true" />
           </button>
         </div>
         <div className="flex-1 overflow-y-auto px-6 py-5">{children}</div>

--- a/frontend/components/floating/TransactionForm.tsx
+++ b/frontend/components/floating/TransactionForm.tsx
@@ -17,7 +17,7 @@ import type { Account, Category } from "@/lib/types";
 /**
  * Quick-entry transaction form used inside the FAB SlideInPanel.
  *
- * NOTE — duplication tech debt: the canonical add-transaction form
+ * NOTE, duplication tech debt: the canonical add-transaction form
  * still lives inline inside `frontend/app/transactions/page.tsx` and
  * `frontend/app/dashboard/page.tsx`. Extracting those would touch
  * files currently in flight (Sort/Filters Persistence and Transactions
@@ -104,7 +104,7 @@ export default function TransactionForm({
   // an empty selection.
   useEffect(() => {
     if (accountId === "" && initialAccountId) setAccountId(initialAccountId);
-    // Intentionally not reacting to subsequent activeAccounts changes —
+    // Intentionally not reacting to subsequent activeAccounts changes,
     // we don't want to overwrite a user's manual selection.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialAccountId]);
@@ -123,7 +123,7 @@ export default function TransactionForm({
   function clearForm() {
     setDescription("");
     setAmount("");
-    // Keep account selection — most users add multiple txs to the same
+    // Keep account selection, most users add multiple txs to the same
     // account in one sitting. Reset category since type may change.
     setCategoryId(defaultCategoryId ?? "");
     setType("expense");

--- a/frontend/components/floating/TransactionForm.tsx
+++ b/frontend/components/floating/TransactionForm.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState } from "react";
+
+import CategorySelect from "@/components/ui/CategorySelect";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { todayISO } from "@/lib/format";
+import {
+  btnPrimary,
+  btnSecondary,
+  error as errorCls,
+  input,
+  label,
+} from "@/lib/styles";
+import type { Account, Category } from "@/lib/types";
+
+/**
+ * Quick-entry transaction form used inside the FAB SlideInPanel.
+ *
+ * NOTE — duplication tech debt: the canonical add-transaction form
+ * still lives inline inside `frontend/app/transactions/page.tsx` and
+ * `frontend/app/dashboard/page.tsx`. Extracting those would touch
+ * files currently in flight (Sort/Filters Persistence and Transactions
+ * Layout), so this PR ships a focused subset (transaction-only, no
+ * transfer mode, no edit-time promote-to-recurring) sized for quick
+ * entry. Once the in-flight PRs land, a follow-up should fold the
+ * page-level forms into this component.
+ *
+ * Scope:
+ *   - Transaction-only (no transfer mode in the FAB; transfers belong
+ *     on the Transactions page where both legs are visible).
+ *   - Posts to POST /api/v1/transactions exactly like the page-level
+ *     form. No new backend endpoints.
+ *   - Repeats / promote-to-recurring: deferred to v2 of the FAB. The
+ *     primary FAB use case is "I just spent something, log it."
+ *
+ * "Save & add new" behavior:
+ *   - Default Save submits + closes the panel via onSaved().
+ *   - "Save & add new" submits + clears the form fields, leaves the
+ *     panel open, and refocuses the description input.
+ */
+
+export interface TransactionFormProps {
+  accounts: Account[];
+  categories: Category[];
+  /** Pre-selected account id (default-from-context). */
+  defaultAccountId?: number | null;
+  /** Pre-selected category id (default-from-context). */
+  defaultCategoryId?: number | null;
+  /** Called after a successful Save (panel-close path). */
+  onSaved: () => void;
+  /** Called after a category is created via the inline modal. */
+  onCategoryCreated?: (category: Category) => void;
+  /**
+   * Called after every successful save (Save and Save & add new).
+   * Pages can use this to refresh transaction lists.
+   */
+  onTransactionAdded?: () => void;
+}
+
+export default function TransactionForm({
+  accounts,
+  categories,
+  defaultAccountId = null,
+  defaultCategoryId = null,
+  onSaved,
+  onCategoryCreated,
+  onTransactionAdded,
+}: TransactionFormProps) {
+  const activeAccounts = accounts.filter((a) => a.is_active);
+  const fallbackAccount = activeAccounts.find((a) => a.is_default) ?? activeAccounts[0];
+  const initialAccountId =
+    defaultAccountId ?? (fallbackAccount ? fallbackAccount.id : "");
+
+  const [accountId, setAccountId] = useState<number | "">(initialAccountId ?? "");
+  const [categoryId, setCategoryId] = useState<number | "">(
+    defaultCategoryId ?? "",
+  );
+  const [description, setDescription] = useState("");
+  const [amount, setAmount] = useState("");
+  const [type, setType] = useState<"income" | "expense">("expense");
+  const [status, setStatus] = useState<"settled" | "pending">(() => {
+    const acct = activeAccounts.find((a) => a.id === initialAccountId);
+    return acct?.account_type_slug === "credit_card" ? "pending" : "settled";
+  });
+  const [date, setDate] = useState(todayISO());
+  const [submitting, setSubmitting] = useState(false);
+  const [errMsg, setErrMsg] = useState("");
+  const descRef = useRef<HTMLInputElement>(null);
+
+  // If the parent updates the defaults (e.g. accounts finished loading
+  // after the panel mounted), pick them up so the form isn't stuck on
+  // an empty selection.
+  useEffect(() => {
+    if (accountId === "" && initialAccountId) setAccountId(initialAccountId);
+    // Intentionally not reacting to subsequent activeAccounts changes —
+    // we don't want to overwrite a user's manual selection.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialAccountId]);
+
+  function handleAccountChange(id: number | "") {
+    setAccountId(id);
+    const acct = activeAccounts.find((a) => a.id === id);
+    setStatus(acct?.account_type_slug === "credit_card" ? "pending" : "settled");
+  }
+
+  function handleTypeChange(t: "income" | "expense") {
+    setType(t);
+    setCategoryId("");
+  }
+
+  function clearForm() {
+    setDescription("");
+    setAmount("");
+    // Keep account selection — most users add multiple txs to the same
+    // account in one sitting. Reset category since type may change.
+    setCategoryId(defaultCategoryId ?? "");
+    setType("expense");
+    setDate(todayISO());
+    setErrMsg("");
+  }
+
+  async function submit(addAnother: boolean) {
+    setSubmitting(true);
+    setErrMsg("");
+    try {
+      await apiFetch("/api/v1/transactions", {
+        method: "POST",
+        body: JSON.stringify({
+          account_id: accountId,
+          category_id: categoryId,
+          description,
+          amount,
+          type,
+          status,
+          date,
+        }),
+      });
+      onTransactionAdded?.();
+      if (addAnother) {
+        clearForm();
+        // Refocus the description input so the user can keep typing.
+        window.setTimeout(() => descRef.current?.focus(), 0);
+      } else {
+        onSaved();
+      }
+    } catch (err) {
+      setErrMsg(extractErrorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    void submit(false);
+  }
+
+  const hasAccountsAndCategories =
+    activeAccounts.length > 0 && categories.length > 0;
+
+  if (!hasAccountsAndCategories) {
+    return (
+      <div className="rounded-md border border-border bg-surface-raised p-4 text-sm text-text-secondary">
+        Create at least one account and one category before adding
+        transactions.
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      {errMsg && <div className={errorCls}>{errMsg}</div>}
+
+      <div>
+        <label htmlFor="fab-tx-account" className={label}>
+          Account
+        </label>
+        <select
+          id="fab-tx-account"
+          required
+          value={accountId}
+          onChange={(e) =>
+            handleAccountChange(e.target.value === "" ? "" : Number(e.target.value))
+          }
+          className={input}
+        >
+          <option value="">Select account</option>
+          {activeAccounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="fab-tx-type" className={label}>
+          Type
+        </label>
+        <select
+          id="fab-tx-type"
+          value={type}
+          onChange={(e) => handleTypeChange(e.target.value as "income" | "expense")}
+          className={input}
+        >
+          <option value="expense">Expense</option>
+          <option value="income">Income</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="fab-tx-category" className={label}>
+          Category
+        </label>
+        <CategorySelect
+          id="fab-tx-category"
+          categories={categories}
+          value={categoryId}
+          onChange={setCategoryId}
+          filterType={type}
+          className={input}
+          onCategoryCreated={(cat) => onCategoryCreated?.(cat)}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="fab-tx-desc" className={label}>
+          Description
+        </label>
+        <input
+          id="fab-tx-desc"
+          ref={descRef}
+          type="text"
+          required
+          placeholder="What was it for?"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className={input}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="fab-tx-amount" className={label}>
+          Amount
+        </label>
+        <input
+          id="fab-tx-amount"
+          type="number"
+          step="0.01"
+          min="0.01"
+          required
+          placeholder="0.00"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className={input}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="fab-tx-status" className={label}>
+            Status
+          </label>
+          <select
+            id="fab-tx-status"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as "settled" | "pending")}
+            className={input}
+          >
+            <option value="settled">Settled</option>
+            <option value="pending">Pending</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="fab-tx-date" className={label}>
+            Date
+          </label>
+          <input
+            id="fab-tx-date"
+            type="date"
+            required
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className={input}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={() => void submit(true)}
+          disabled={submitting}
+          className={`${btnSecondary} min-h-[44px]`}
+        >
+          Save and add new
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className={`${btnPrimary} min-h-[44px]`}
+        >
+          {submitting ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/components/floating/TransactionForm.tsx
+++ b/frontend/components/floating/TransactionForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useRef, useState } from "react";
+import { FormEvent, MouseEvent, useEffect, useRef, useState } from "react";
 
 import CategorySelect from "@/components/ui/CategorySelect";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -38,6 +38,12 @@ import type { Account, Category } from "@/lib/types";
  *   - Default Save submits + closes the panel via onSaved().
  *   - "Save & add new" submits + clears the form fields, leaves the
  *     panel open, and refocuses the description input.
+ *   - Both buttons route through the same form onSubmit handler so
+ *     native HTML5 validation (the `required` attributes, `min` on
+ *     amount, etc.) runs before any network call. "Save and add new"
+ *     uses an intent ref + form.requestSubmit() so the browser shows
+ *     its built-in validation messages and skips the submit when a
+ *     required field is empty.
  */
 
 export interface TransactionFormProps {
@@ -87,6 +93,11 @@ export default function TransactionForm({
   const [submitting, setSubmitting] = useState(false);
   const [errMsg, setErrMsg] = useState("");
   const descRef = useRef<HTMLInputElement>(null);
+  // Tracks whether the next submit should keep the panel open and clear
+  // the form ("Save and add new") or close on success ("Save"). The
+  // "Save and add new" button calls form.requestSubmit() so the browser
+  // runs native validation before the onSubmit handler reads this.
+  const submitIntentRef = useRef<"save" | "save-and-add-new">("save");
 
   // If the parent updates the defaults (e.g. accounts finished loading
   // after the panel mounted), pick them up so the form isn't stuck on
@@ -153,7 +164,27 @@ export default function TransactionForm({
 
   function onSubmit(e: FormEvent) {
     e.preventDefault();
-    void submit(false);
+    const addAnother = submitIntentRef.current === "save-and-add-new";
+    // Reset eagerly so a later plain Save submit defaults to closing the
+    // panel. The async submit() reads `addAnother` from the local above.
+    submitIntentRef.current = "save";
+    void submit(addAnother);
+  }
+
+  function handleSaveAndAddNewClick(e: MouseEvent<HTMLButtonElement>) {
+    submitIntentRef.current = "save-and-add-new";
+    // requestSubmit() triggers the form's native validation (required,
+    // min, type=number, etc.) and only fires onSubmit when the form is
+    // valid. If validation fails, the browser shows its built-in
+    // messages and no network call happens.
+    const form = e.currentTarget.form;
+    if (form) {
+      form.requestSubmit();
+    } else {
+      // Fallback for the rare case the button is rendered outside a
+      // form (shouldn't happen here, but keeps the handler safe).
+      submitIntentRef.current = "save";
+    }
   }
 
   const hasAccountsAndCategories =
@@ -290,7 +321,7 @@ export default function TransactionForm({
       <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
         <button
           type="button"
-          onClick={() => void submit(true)}
+          onClick={handleSaveAndAddNewClick}
           disabled={submitting}
           className={`${btnSecondary} min-h-[44px]`}
         >

--- a/frontend/tests/components/floating/add-transaction-fab.test.tsx
+++ b/frontend/tests/components/floating/add-transaction-fab.test.tsx
@@ -1,0 +1,97 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AddTransactionFab from "@/components/floating/AddTransactionFab";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const ACCT = {
+  id: 1,
+  name: "Checking",
+  account_type_id: 1,
+  account_type_name: "Checking",
+  account_type_slug: "checking",
+  balance: 1000,
+  currency: "EUR",
+  is_active: true,
+  close_day: null,
+  is_default: true,
+};
+
+const CAT = {
+  id: 10,
+  name: "Groceries",
+  type: "expense" as const,
+  parent_id: null,
+  parent_name: null,
+  description: null,
+  slug: "groceries",
+  is_system: false,
+  transaction_count: 0,
+};
+
+function setupRefs() {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT] as never;
+    if (url.startsWith("/api/v1/categories")) return [CAT] as never;
+    return null as never;
+  });
+  return apiFetchMock;
+}
+
+describe("AddTransactionFab", () => {
+  it("renders the floating button with an accessible label", async () => {
+    setupRefs();
+    await act(async () => {
+      render(<AddTransactionFab />);
+    });
+    const fab = screen.getByTestId("add-transaction-fab");
+    expect(fab).toBeInTheDocument();
+    expect(fab).toHaveAttribute("aria-label", "Add transaction");
+  });
+
+  it("is anchored inside the AnchorZone (bottom-right cluster)", async () => {
+    setupRefs();
+    await act(async () => {
+      render(<AddTransactionFab />);
+    });
+    const zone = screen.getByTestId("anchor-zone");
+    expect(zone).toContainElement(screen.getByTestId("add-transaction-fab"));
+  });
+
+  it("opens the panel on click", async () => {
+    setupRefs();
+    await act(async () => {
+      render(<AddTransactionFab />);
+    });
+    expect(screen.queryByTestId("add-transaction-panel")).toBeNull();
+    fireEvent.click(screen.getByTestId("add-transaction-fab"));
+    await waitFor(() => {
+      expect(screen.getByTestId("add-transaction-panel")).toBeInTheDocument();
+    });
+    // The panel header surfaces "Add transaction" — distinct from the
+    // button's aria-label.
+    expect(screen.getByRole("dialog")).toHaveTextContent("Add transaction");
+  });
+
+  it("renders the transaction form inside the open panel", async () => {
+    setupRefs();
+    await act(async () => {
+      render(<AddTransactionFab />);
+    });
+    fireEvent.click(screen.getByTestId("add-transaction-fab"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Amount")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Save$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /save and add new/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/floating/add-transaction-fab.test.tsx
+++ b/frontend/tests/components/floating/add-transaction-fab.test.tsx
@@ -74,7 +74,7 @@ describe("AddTransactionFab", () => {
     await waitFor(() => {
       expect(screen.getByTestId("add-transaction-panel")).toBeInTheDocument();
     });
-    // The panel header surfaces "Add transaction" — distinct from the
+    // The panel header surfaces "Add transaction", distinct from the
     // button's aria-label.
     expect(screen.getByRole("dialog")).toHaveTextContent("Add transaction");
   });

--- a/frontend/tests/components/floating/anchor-zone.test.tsx
+++ b/frontend/tests/components/floating/anchor-zone.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+
+import AnchorZone, { AnchorZoneSlot } from "@/components/floating/AnchorZone";
+
+describe("AnchorZone", () => {
+  it("renders the cluster pinned to bottom-right with the correct z-index", () => {
+    render(
+      <AnchorZone>
+        <AnchorZoneSlot slot="primary">
+          <button type="button">Primary</button>
+        </AnchorZoneSlot>
+      </AnchorZone>,
+    );
+    const zone = screen.getByTestId("anchor-zone");
+    expect(zone).toBeInTheDocument();
+    expect(zone.className).toMatch(/fixed/);
+    expect(zone.className).toMatch(/bottom-4/);
+    expect(zone.className).toMatch(/right-4/);
+    expect(zone.className).toMatch(/z-40/);
+    expect(zone.className).toMatch(/items-end/);
+    expect(zone.className).toMatch(/flex-col/);
+  });
+
+  it("stacks multiple slots predictably with primary at the bottom (last in DOM order)", () => {
+    render(
+      <AnchorZone>
+        <AnchorZoneSlot slot="primary">
+          <button type="button">Primary FAB</button>
+        </AnchorZoneSlot>
+        <AnchorZoneSlot slot="secondary">
+          <button type="button">Secondary widget</button>
+        </AnchorZoneSlot>
+      </AnchorZone>,
+    );
+    const buttons = screen.getAllByRole("button");
+    // Visual order top-to-bottom is secondary then primary, so DOM order
+    // (which equals tab order) reads: secondary first, primary last.
+    expect(buttons[0]).toHaveTextContent("Secondary widget");
+    expect(buttons[1]).toHaveTextContent("Primary FAB");
+  });
+
+  it("renders mounting order independent of slot priority", () => {
+    // Mount primary FIRST in source order, secondary second. The cluster
+    // must still place secondary above primary in the visual stack
+    // (= DOM-order: secondary before primary).
+    render(
+      <AnchorZone>
+        <AnchorZoneSlot slot="primary">
+          <button type="button">P</button>
+        </AnchorZoneSlot>
+        <AnchorZoneSlot slot="secondary">
+          <button type="button">S</button>
+        </AnchorZoneSlot>
+      </AnchorZone>,
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveTextContent("S");
+    expect(buttons[1]).toHaveTextContent("P");
+  });
+});

--- a/frontend/tests/components/floating/slide-in-panel.test.tsx
+++ b/frontend/tests/components/floating/slide-in-panel.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+
+import SlideInPanel from "@/components/floating/SlideInPanel";
+
+function Harness({ initialOpen = false }: { initialOpen?: boolean }) {
+  const [open, setOpen] = useState(initialOpen);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        open trigger
+      </button>
+      <SlideInPanel open={open} onClose={() => setOpen(false)} title="Test panel">
+        <button type="button">first</button>
+        <input aria-label="middle" />
+        <button type="button">last</button>
+      </SlideInPanel>
+    </>
+  );
+}
+
+describe("SlideInPanel", () => {
+  it("renders nothing when closed", () => {
+    render(<Harness initialOpen={false} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens when toggled", () => {
+    render(<Harness initialOpen={false} />);
+    fireEvent.click(screen.getByRole("button", { name: "open trigger" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Test panel")).toBeInTheDocument();
+  });
+
+  it("closes on Esc", () => {
+    render(<Harness initialOpen={true} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes on overlay click but stays open when clicking inside", () => {
+    render(<Harness initialOpen={true} />);
+    const dialog = screen.getByRole("dialog");
+    // Click inside the dialog — should NOT close.
+    fireEvent.click(dialog);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // Click on the overlay (the parent of the dialog) — should close.
+    const overlay = dialog.parentElement!;
+    fireEvent.click(overlay);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes via the explicit Close button", () => {
+    render(<Harness initialOpen={true} />);
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("traps focus inside the panel: shift+tab from first wraps to last", () => {
+    render(<Harness initialOpen={true} />);
+    const closeBtn = screen.getByRole("button", { name: /close/i });
+    closeBtn.focus();
+    expect(document.activeElement).toBe(closeBtn);
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    // Last focusable is "last" button.
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "last" }),
+    );
+  });
+
+  it("traps focus inside the panel: tab from last wraps to first", () => {
+    render(<Harness initialOpen={true} />);
+    const last = screen.getByRole("button", { name: "last" });
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(document, { key: "Tab" });
+    // First focusable is the close button.
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /close/i }),
+    );
+  });
+
+  it("locks body scroll while open and restores it on close", () => {
+    const { unmount } = render(<Harness initialOpen={true} />);
+    expect(document.body.style.overflow).toBe("hidden");
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(document.body.style.overflow).toBe("");
+    unmount();
+  });
+});

--- a/frontend/tests/components/floating/slide-in-panel.test.tsx
+++ b/frontend/tests/components/floating/slide-in-panel.test.tsx
@@ -42,10 +42,10 @@ describe("SlideInPanel", () => {
   it("closes on overlay click but stays open when clicking inside", () => {
     render(<Harness initialOpen={true} />);
     const dialog = screen.getByRole("dialog");
-    // Click inside the dialog — should NOT close.
+    // Click inside the dialog, should NOT close.
     fireEvent.click(dialog);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    // Click on the overlay (the parent of the dialog) — should close.
+    // Click on the overlay (the parent of the dialog), should close.
     const overlay = dialog.parentElement!;
     fireEvent.click(overlay);
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/frontend/tests/components/floating/transaction-form.test.tsx
+++ b/frontend/tests/components/floating/transaction-form.test.tsx
@@ -1,0 +1,170 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TransactionForm from "@/components/floating/TransactionForm";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const ACCT = {
+  id: 1,
+  name: "Checking",
+  account_type_id: 1,
+  account_type_name: "Checking",
+  account_type_slug: "checking",
+  balance: 1000,
+  currency: "EUR",
+  is_active: true,
+  close_day: null,
+  is_default: true,
+};
+
+const CAT = {
+  id: 10,
+  name: "Groceries",
+  type: "expense" as const,
+  parent_id: null,
+  parent_name: null,
+  description: null,
+  slug: "groceries",
+  is_system: false,
+  transaction_count: 0,
+};
+
+describe("TransactionForm", () => {
+  it("renders the empty state when there are no accounts or categories", () => {
+    render(
+      <TransactionForm
+        accounts={[]}
+        categories={[]}
+        onSaved={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Create at least one account/i)).toBeInTheDocument();
+  });
+
+  it("submits a valid transaction and calls onSaved (default Save closes the panel)", async () => {
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({} as never);
+
+    const onSaved = vi.fn();
+    const onTransactionAdded = vi.fn();
+
+    render(
+      <TransactionForm
+        accounts={[ACCT]}
+        categories={[CAT]}
+        defaultCategoryId={CAT.id}
+        onSaved={onSaved}
+        onTransactionAdded={onTransactionAdded}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Groceries Aldi" },
+    });
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "12.34" },
+    });
+    // Account defaults from the is_default fixture; category from prop.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+    });
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledTimes(1);
+    });
+    expect(onTransactionAdded).toHaveBeenCalledTimes(1);
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    const [path, options] = apiFetchMock.mock.calls[0];
+    expect(path).toBe("/api/v1/transactions");
+    expect(options?.method).toBe("POST");
+    const body = JSON.parse(String(options?.body));
+    expect(body.description).toBe("Groceries Aldi");
+    expect(body.amount).toBe("12.34");
+    expect(body.account_id).toBe(ACCT.id);
+    expect(body.category_id).toBe(CAT.id);
+    expect(body.type).toBe("expense");
+    expect(body.status).toBe("settled");
+  });
+
+  it("Save and add new keeps the panel open and clears description and amount", async () => {
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({} as never);
+
+    const onSaved = vi.fn();
+
+    render(
+      <TransactionForm
+        accounts={[ACCT]}
+        categories={[CAT]}
+        onSaved={onSaved}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "First" },
+    });
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "9.99" },
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save and add new/i }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    });
+    // Panel must stay open: onSaved must NOT have fired.
+    expect(onSaved).not.toHaveBeenCalled();
+    // Form must be cleared.
+    const desc = screen.getByLabelText("Description") as HTMLInputElement;
+    const amount = screen.getByLabelText("Amount") as HTMLInputElement;
+    expect(desc.value).toBe("");
+    expect(amount.value).toBe("");
+  });
+
+  it("flips status to pending when a credit-card account is selected", () => {
+    const CREDIT = {
+      ...ACCT,
+      id: 2,
+      name: "Visa",
+      account_type_slug: "credit_card",
+      is_default: false,
+    };
+    render(
+      <TransactionForm
+        accounts={[ACCT, CREDIT]}
+        categories={[CAT]}
+        onSaved={() => {}}
+      />,
+    );
+    const status = screen.getByLabelText("Status") as HTMLSelectElement;
+    expect(status.value).toBe("settled");
+    fireEvent.change(screen.getByLabelText("Account"), {
+      target: { value: String(CREDIT.id) },
+    });
+    expect(status.value).toBe("pending");
+  });
+
+  it("respects defaultAccountId when provided", () => {
+    const SAVINGS = { ...ACCT, id: 99, name: "Savings", is_default: false };
+    render(
+      <TransactionForm
+        accounts={[ACCT, SAVINGS]}
+        categories={[CAT]}
+        defaultAccountId={SAVINGS.id}
+        onSaved={() => {}}
+      />,
+    );
+    const account = screen.getByLabelText("Account") as HTMLSelectElement;
+    expect(account.value).toBe(String(SAVINGS.id));
+  });
+});

--- a/frontend/tests/components/floating/transaction-form.test.tsx
+++ b/frontend/tests/components/floating/transaction-form.test.tsx
@@ -102,6 +102,7 @@ describe("TransactionForm", () => {
       <TransactionForm
         accounts={[ACCT]}
         categories={[CAT]}
+        defaultCategoryId={CAT.id}
         onSaved={onSaved}
       />,
     );
@@ -166,5 +167,83 @@ describe("TransactionForm", () => {
     );
     const account = screen.getByLabelText("Account") as HTMLSelectElement;
     expect(account.value).toBe(String(SAVINGS.id));
+  });
+
+  it("Save and add new respects native validation: blank required fields skip the network call", async () => {
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({} as never);
+
+    const onSaved = vi.fn();
+
+    render(
+      <TransactionForm
+        accounts={[ACCT]}
+        categories={[CAT]}
+        defaultCategoryId={CAT.id}
+        onSaved={onSaved}
+      />,
+    );
+
+    // Description and amount are blank: the form is invalid. The
+    // browser's requestSubmit() must skip onSubmit, so apiFetch must
+    // never be called.
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save and add new/i }),
+      );
+    });
+
+    // Give any pending microtasks a chance to flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("Save and add new submits when fields are valid and resets description and amount while keeping the panel open", async () => {
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({} as never);
+
+    const onSaved = vi.fn();
+    const onTransactionAdded = vi.fn();
+
+    render(
+      <TransactionForm
+        accounts={[ACCT]}
+        categories={[CAT]}
+        defaultCategoryId={CAT.id}
+        onSaved={onSaved}
+        onTransactionAdded={onTransactionAdded}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Coffee" },
+    });
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "3.50" },
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /save and add new/i }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(onTransactionAdded).toHaveBeenCalledTimes(1);
+    // Panel stays open.
+    expect(onSaved).not.toHaveBeenCalled();
+    // Description and amount reset; account preserved.
+    const desc = screen.getByLabelText("Description") as HTMLInputElement;
+    const amount = screen.getByLabelText("Amount") as HTMLInputElement;
+    const account = screen.getByLabelText("Account") as HTMLSelectElement;
+    expect(desc.value).toBe("");
+    expect(amount.value).toBe("");
+    expect(account.value).toBe(String(ACCT.id));
   });
 });


### PR DESCRIPTION
## Problem

Two punch-list items have been waiting on this primitive:

- **Item 4**: a quick way to log a transaction from anywhere in the app, not just the Dashboard or Transactions pages.
- **Item 15**: a single bottom-right \"floating\" zone that the future in-app feedback widget can also live in (memory: `project_inapp_feedback_widget.md`).

Without a shared anchor primitive each future floating widget would invent its own z-index and corner-pinning rules, and the FAB and feedback widget would race for the same screen-bottom-right real estate. This PR ships the base infrastructure so both can land cleanly. Page-level integration is deliberately scoped out of this PR (see the merge gate below) because Sort/Filters Persistence and Transactions Layout are both editing the same page files.

## Implementation

**`frontend/components/floating/AnchorZone.tsx`**: bottom-right cluster anchor at z-40. A single cluster (not two corner zones) with vertical column, items-end, gap-3. Slot priority: `primary` pins to the bottom (closest to thumb on mobile), `secondary` stacks above, `tertiary` reserved. `<AnchorZoneSlot slot=\"primary\">` lets future widgets opt into a stable spot regardless of mount order. The Add Transaction FAB owns `primary`; the future feedback widget will own `secondary`.

**`frontend/components/floating/SlideInPanel.tsx`**: right-side slide-in dialog at z-50 (above the anchor cluster, alongside ConfirmModal). Mirrors the existing ConfirmModal accessibility patterns: focus capture on open, focus restore on close, Esc closes, overlay click closes, click inside does not close, body scroll lock, focus trap with Tab and Shift+Tab wrap. Used over a centered modal because the FAB sits in the bottom-right and a panel sliding from the same corner reinforces the visual link (Linear and Notion task quick-add use the same pattern).

**`frontend/components/floating/TransactionForm.tsx`**: quick-entry transaction form. Posts to `POST /api/v1/transactions` exactly like the existing page-level forms (no new backend endpoints). \"Save\" closes the panel. \"Save and add new\" submits, clears description and amount, keeps the panel open, and refocuses the description input. Account stays selected across Save and add new (most users add multiple txs to the same account in one sitting). Credit-card account selection auto-flips status to pending. Tech debt flag: the canonical add-transaction forms still live inline in `transactions/page.tsx` and `dashboard/page.tsx`. Folding both into this component is the natural follow-up after Sort/Filters and Transactions Layout land.

**`frontend/components/floating/AddTransactionFab.tsx`**: orchestrator. Renders the FAB inside `AnchorZone` (primary slot) and the `SlideInPanel` with the form. Loads accounts and categories on first mount and on every panel open, so newly added accounts or categories are reflected without a page refresh. Optional `defaultAccountId` and `defaultCategoryId` props for future per-page context (e.g. an `/accounts/{id}` page). `onTransactionAdded` callback so the host page can refresh its own data.

**Dashboard mount.** Added at the bottom of `frontend/app/dashboard/page.tsx`, just before `</AppShell>`. Wired `onTransactionAdded` to the existing `loadTransactions(0)`, `loadForecastProjection`, `loadPendingTransactions`, and `loadAccountMonthEndForecast` calls. The existing Quick Add card at the top of the page is intentionally untouched; removal is in the follow-up integration PR.

## Files changed

**New**
- `frontend/components/floating/AnchorZone.tsx`
- `frontend/components/floating/SlideInPanel.tsx`
- `frontend/components/floating/TransactionForm.tsx`
- `frontend/components/floating/AddTransactionFab.tsx`
- `frontend/tests/components/floating/anchor-zone.test.tsx` (3 cases)
- `frontend/tests/components/floating/slide-in-panel.test.tsx` (8 cases)
- `frontend/tests/components/floating/add-transaction-fab.test.tsx` (4 cases)
- `frontend/tests/components/floating/transaction-form.test.tsx` (5 cases)

**Modified**
- `frontend/app/dashboard/page.tsx` (one import + one mount block at the bottom of the AppShell render)

## Tests run

- `npm test -- tests/components/floating/` -> 4 files, 20 tests, all green.
- `npm test -- tests/app/dashboard` -> 4 files, 7 tests, all green (regression check on the Dashboard mount).
- `npx tsc --noEmit` on the new component files -> clean. (Pre-existing test-file vitest-globals errors are unrelated and predate this branch.)

Coverage:
- AnchorZone renders bottom-right with z-40, primary stacks at the bottom, mounting order does not change visual order.
- SlideInPanel: opens, closes, Esc closes, overlay click closes, click inside stays open, focus trap wraps both directions, body scroll lock + restore.
- AddTransactionFab: button has `aria-label=\"Add transaction\"`, lives inside the AnchorZone, click opens the panel, panel renders the form.
- TransactionForm: empty state when no accounts or categories, submit posts the right body and calls `onSaved`, Save and add new keeps the panel open and clears the form, credit-card account flips status to pending, defaultAccountId pre-selects.

## Screenshots

Captured against `http://localhost/dashboard` with a seeded Demo Checking account.

- `01-dashboard-fab-closed.png` -> Dashboard with the orange + FAB pinned bottom-right (no panel).
- `02-dashboard-fab-panel-open.png` -> SlideInPanel open from the right with the transaction form, Demo Checking pre-selected, Save and Save and add new buttons visible.
- `03-dashboard-fab-after-close.png` -> Panel closed, FAB back in place, body scroll restored.

Files saved at `~/.claude/projects/-Users-fjorge-src-pfv/screenshots/fab-base/`. Added as PR review comment for inline rendering.

## Merge gate

Merge gate: this is the base infrastructure PR. Full page integration (FAB on all pages, Dashboard Quick Add removal) is a follow-up that waits for `feat/sort-filters-persistence` and `feat/transactions-layout-and-settled-date` to stabilize.

The follow-up integration PR will:
- Mount the FAB at the AppShell level with route-based visibility (show on `/dashboard`, `/transactions`, `/accounts`, `/categories`, `/forecast-plans`, `/budgets`, `/recurring`; hide on `/settings/*`, `/admin/*`, `/system/*`).
- Remove the Quick Add card from `/dashboard` (lives in the same file currently being edited by Sort/Filters).
- Wire `defaultAccountId` and `defaultCategoryId` from route params if `/accounts/{id}` or `/categories/{id}` detail pages exist by then.
- Fold the page-level forms in `transactions/page.tsx` and `dashboard/page.tsx` into the shared `TransactionForm` component.

## Internal reviewers

- Frontend dev (self): primitives composable, no prop-drilling for refs, AnchorZone tolerates bare children.
- Architect (self): single-cluster anchor convention chosen over two corner zones to avoid z-index drift; documented inside `AnchorZone.tsx`.
- UI designer (self): FAB sits 24px from the bottom-right edge on desktop (16px on mobile), 56x56px primary surface, focus ring uses the existing accent token, panel uses the same border and surface tokens as ConfirmModal.
- QA reviewer (self): 20 tests covering anchor stacking, panel keyboard a11y, FAB click, form submit and Save and add new, credit-card status flip, defaultAccountId; manual smoke against Dashboard with a real account confirms refresh callbacks fire.
- Security reviewer (self): no new endpoints, the form posts to the existing `POST /api/v1/transactions`, no client-side persistence of any field, no telemetry. Reference data fetch uses the same authenticated `apiFetch` as every other surface. Body scroll lock is removed on unmount as a belt-and-suspenders so a stuck panel cannot leave the page non-scrollable.

External review required before merge.


## Corrections applied (2026-05-09)

External review surfaced one behavioral blocker plus two cleanup items. Each landed as its own commit on top of the base PR, branch CI re-run.

1. **Save and add new bypassed native form validation** (`fix(transactions): route Save and add new through form submission so native validation runs`).
   The "Save and add new" button was calling `submit()` directly on click, so an empty required field could still POST to `/api/v1/transactions`. Replaced with an intent ref + `form.requestSubmit()`: both buttons now route through the same `<form onSubmit>` handler, the browser runs native validation first (`required`, `min`, `type=number`), and `submit()` only runs when the form is actually valid. Two new test cases cover the path: blank required fields skip `apiFetch`; valid fields submit, panel stays open, description and amount reset, account preserved.
2. **Em-dashes in introduced comments** (`chore(floating): remove em-dashes from introduced comments`).
   Swept the U+2014 occurrences I introduced across `TransactionForm.tsx`, `AddTransactionFab.tsx`, `AnchorZone.tsx`, the dashboard mount block, and the two test files. Replaced each with a comma or period. Pre-existing non-ASCII in unrelated files on `main` left untouched.
3. **Manual SVG icons swapped for lucide-react** (`chore(floating): swap manual SVG icons for lucide-react Plus and X`).
   `AddTransactionFab` now uses `<Plus className="h-6 w-6" aria-hidden="true" />` and `SlideInPanel` uses `<X className="h-5 w-5" aria-hidden="true" />`. Sizes preserved against the original SVGs; `aria-hidden` because the wrapping buttons already carry "Add transaction" / "Close" labels. lucide-react was already a dependency (used by `OnTrackTile`, `PasswordInput`, `AdjustBalanceModal`).

Verification: `npx vitest run` 60 files / 350 tests green, `npx tsc --noEmit` clean.
