### PR TITLE
feat(frontend): persist sort and filters across navigation

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
 import AppShell from "@/components/AppShell";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -855,36 +856,118 @@ export default function DashboardPage() {
                       both numeric columns keeps digits aligned across
                       rows. */}
                   <div className="w-full space-y-1.5 sm:flex-1">
-                    {/* Item 16 (D2): sortable column headers — Category,
-                        %, Amount. Persists via usePersistedSort. The
-                        leading "auto" column is the legend dot, which
-                        has no header. */}
-                    <div className="grid w-full grid-cols-[auto_minmax(0,1fr)_3rem_auto] items-center gap-2 px-1.5 pb-1 text-[10px] uppercase tracking-wider text-text-muted">
+                    {/* Item 16 (D2): sortable column headers for Category,
+                        %, Amount. Persists via usePersistedSort. The leading
+                        "auto" column is the legend dot, which has no header.
+                        Each header carries an aria-sort state and a lucide
+                        chevron icon, with a brass focus ring matching the
+                        Pressable-Surfaces Rule in DESIGN.md. */}
+                    <div
+                      role="row"
+                      className="grid w-full grid-cols-[auto_minmax(0,1fr)_3rem_auto] items-center gap-2 px-1.5 pb-1 text-[10px] uppercase tracking-wider text-text-muted"
+                    >
                       <span aria-hidden="true" className="h-2.5 w-2.5" />
-                      <button
-                        type="button"
-                        onClick={() => toggleSpendingSort("name")}
-                        className="text-left min-h-[32px] hover:text-text-primary"
-                        aria-label="Sort by category"
+                      <div
+                        role="columnheader"
+                        aria-sort={
+                          spendingSort.field === "name"
+                            ? spendingSort.dir === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none"
+                        }
                       >
-                        Category{spendingSort.field === "name" ? (spendingSort.dir === "asc" ? " ↑" : " ↓") : ""}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => toggleSpendingSort("percent")}
-                        className="text-right min-h-[32px] hover:text-text-primary"
-                        aria-label="Sort by percent of total"
+                        <button
+                          type="button"
+                          onClick={() => toggleSpendingSort("name")}
+                          className="inline-flex items-center gap-1 text-left min-h-[32px] hover:text-text-primary rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+                          aria-label="Sort by category"
+                        >
+                          <span>Category</span>
+                          {spendingSort.field === "name" ? (
+                            spendingSort.dir === "asc" ? (
+                              <ChevronUp className="h-3 w-3" aria-hidden="true" />
+                            ) : (
+                              <ChevronDown className="h-3 w-3" aria-hidden="true" />
+                            )
+                          ) : (
+                            <ChevronsUpDown className="h-3 w-3 text-text-muted/60" aria-hidden="true" />
+                          )}
+                          <span className="sr-only">
+                            {spendingSort.field === "name"
+                              ? `sorted ${spendingSort.dir === "asc" ? "ascending" : "descending"}`
+                              : "click to sort"}
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        role="columnheader"
+                        aria-sort={
+                          spendingSort.field === "percent"
+                            ? spendingSort.dir === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none"
+                        }
+                        className="text-right"
                       >
-                        %{spendingSort.field === "percent" ? (spendingSort.dir === "asc" ? " ↑" : " ↓") : ""}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => toggleSpendingSort("amount")}
-                        className="text-right min-h-[32px] hover:text-text-primary"
-                        aria-label="Sort by amount"
+                        <button
+                          type="button"
+                          onClick={() => toggleSpendingSort("percent")}
+                          className="inline-flex items-center gap-1 justify-end min-h-[32px] hover:text-text-primary rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+                          aria-label="Sort by percent of total"
+                        >
+                          <span>%</span>
+                          {spendingSort.field === "percent" ? (
+                            spendingSort.dir === "asc" ? (
+                              <ChevronUp className="h-3 w-3" aria-hidden="true" />
+                            ) : (
+                              <ChevronDown className="h-3 w-3" aria-hidden="true" />
+                            )
+                          ) : (
+                            <ChevronsUpDown className="h-3 w-3 text-text-muted/60" aria-hidden="true" />
+                          )}
+                          <span className="sr-only">
+                            {spendingSort.field === "percent"
+                              ? `sorted ${spendingSort.dir === "asc" ? "ascending" : "descending"}`
+                              : "click to sort"}
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        role="columnheader"
+                        aria-sort={
+                          spendingSort.field === "amount"
+                            ? spendingSort.dir === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none"
+                        }
+                        className="text-right"
                       >
-                        Amount{spendingSort.field === "amount" ? (spendingSort.dir === "asc" ? " ↑" : " ↓") : ""}
-                      </button>
+                        <button
+                          type="button"
+                          onClick={() => toggleSpendingSort("amount")}
+                          className="inline-flex items-center gap-1 justify-end min-h-[32px] hover:text-text-primary rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+                          aria-label="Sort by amount"
+                        >
+                          <span>Amount</span>
+                          {spendingSort.field === "amount" ? (
+                            spendingSort.dir === "asc" ? (
+                              <ChevronUp className="h-3 w-3" aria-hidden="true" />
+                            ) : (
+                              <ChevronDown className="h-3 w-3" aria-hidden="true" />
+                            )
+                          ) : (
+                            <ChevronsUpDown className="h-3 w-3 text-text-muted/60" aria-hidden="true" />
+                          )}
+                          <span className="sr-only">
+                            {spendingSort.field === "amount"
+                              ? `sorted ${spendingSort.dir === "asc" ? "ascending" : "descending"}`
+                              : "click to sort"}
+                          </span>
+                        </button>
+                      </div>
                     </div>
                     {sortedSpending.slice(0, 10).map((d) => (
                       <button key={d.name} onClick={() => setChartFilter(chartFilter === d.name ? null : d.name)}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -22,6 +22,11 @@ import AccountMonthEndForecast, {
 } from "@/components/dashboard/AccountMonthEndForecast";
 import AccountTilesCard from "@/components/dashboard/AccountTile";
 import AddTransactionFab from "@/components/floating/AddTransactionFab";
+import {
+  SORT_KEY_DASHBOARD_SPENDING,
+  SORT_KEY_DASHBOARD_TRANSACTIONS,
+} from "@/lib/hooks/persisted-keys";
+import { usePersistedSort } from "@/lib/hooks/use-persisted-sort";
 import type { Account, BillingPeriod, Budget, Category, Transaction } from "@/lib/types";
 
 interface ForecastPlanItem {
@@ -156,8 +161,27 @@ export default function DashboardPage() {
   const [formTransferCatId, setFormTransferCatId] = useState<number | "">("");
 
   const [chartFilter, setChartFilter] = useState<string | null>(null);
-  const [dashSortField, setDashSortField] = useState<"date" | "description" | "amount">("date");
-  const [dashSortDir, setDashSortDir] = useState<"asc" | "desc">("desc");
+  // Item 6 (system-wide sort persistence): the dashboard transactions table
+  // and the Spending by Category card both persist their sort state via
+  // localStorage so a navigate-away-and-back lands the user where they were.
+  type DashTxSort = "date" | "description" | "amount";
+  const dashTxSort = usePersistedSort<DashTxSort>(
+    SORT_KEY_DASHBOARD_TRANSACTIONS,
+    "date",
+    "desc",
+    ["date", "description", "amount"] as const,
+  );
+  const dashSortField = dashTxSort.field;
+  const dashSortDir = dashTxSort.dir;
+  // Item 16 (D2 sortable columns on the Spending card): name | percent |
+  // amount. Default amount-desc to match the prior implicit ordering.
+  type SpendingSort = "name" | "percent" | "amount";
+  const spendingSort = usePersistedSort<SpendingSort>(
+    SORT_KEY_DASHBOARD_SPENDING,
+    "amount",
+    "desc",
+    ["name", "percent", "amount"] as const,
+  );
 
   // Selected period (navigate with arrows). On first paint before
   // loadRefs() finishes this is null — distinguish that from "we have a
@@ -493,9 +517,32 @@ export default function DashboardPage() {
       acc[tx.category_name] = (acc[tx.category_name] || 0) + Number(tx.amount);
       return acc;
     }, {});
-  const donutData = Object.entries(spendingByCategory)
+  // donutData drives both the donut chart (always rendered in amount-desc
+  // order so the largest slice starts at 12 o'clock) and the legend list
+  // (sortable by name | percent | amount, persisted via spendingSort).
+  const donutDataRaw = Object.entries(spendingByCategory)
     .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value - a.value);
+  const donutData = donutDataRaw;
+  const totalSpend = donutDataRaw.reduce((s, d) => s + d.value, 0);
+  const sortedSpending = (() => {
+    const list = donutDataRaw.map((d) => ({
+      name: d.name,
+      value: d.value,
+      pct: totalSpend > 0 ? (d.value / totalSpend) * 100 : 0,
+      // Preserve original index so legend dots keep matching the donut's
+      // color order regardless of how the rows are sorted.
+      origIdx: donutDataRaw.indexOf(d),
+    }));
+    list.sort((a, b) => {
+      let cmp = 0;
+      if (spendingSort.field === "name") cmp = a.name.localeCompare(b.name);
+      else if (spendingSort.field === "percent") cmp = a.pct - b.pct;
+      else cmp = a.value - b.value;
+      return spendingSort.dir === "asc" ? cmp : -cmp;
+    });
+    return list;
+  })();
 
   // When chart filter is active, show from allTransactions; otherwise paginated
   const txSource = chartFilter ? allTransactions : transactions;
@@ -508,9 +555,24 @@ export default function DashboardPage() {
   const visibleTxs = txSource.filter((tx) => !hiddenIds.has(tx.id));
 
 
-  function toggleDashSort(field: typeof dashSortField) {
-    if (dashSortField === field) setDashSortDir(dashSortDir === "asc" ? "desc" : "asc");
-    else { setDashSortField(field); setDashSortDir(field === "date" ? "desc" : "asc"); }
+  function toggleDashSort(field: DashTxSort) {
+    if (dashSortField === field) {
+      dashTxSort.setSort(field, dashSortDir === "asc" ? "desc" : "asc");
+    } else {
+      dashTxSort.setSort(field, field === "date" ? "desc" : "asc");
+    }
+  }
+  // Spending card: same toggle pattern. Numeric defaults flip to desc, name
+  // defaults to asc (alphabetical) on first click.
+  function toggleSpendingSort(field: SpendingSort) {
+    if (spendingSort.field === field) {
+      spendingSort.setSort(
+        field,
+        spendingSort.dir === "asc" ? "desc" : "asc",
+      );
+    } else {
+      spendingSort.setSort(field, field === "name" ? "asc" : "desc");
+    }
   }
 
   // Sort + filter the visible transactions
@@ -793,23 +855,48 @@ export default function DashboardPage() {
                       both numeric columns keeps digits aligned across
                       rows. */}
                   <div className="w-full space-y-1.5 sm:flex-1">
-                    {(() => {
-                      const totalSpend = donutData.reduce((s, d) => s + d.value, 0);
-                      return donutData.slice(0, 10).map((d, i) => {
-                        const pct = totalSpend > 0 ? (d.value / totalSpend) * 100 : 0;
-                        return (
-                          <button key={d.name} onClick={() => setChartFilter(chartFilter === d.name ? null : d.name)}
-                            className={`grid w-full grid-cols-[auto_minmax(0,1fr)_3rem_auto] items-center gap-2 rounded px-1.5 py-0.5 transition-colors hover:bg-surface-raised ${chartFilter === d.name ? "bg-surface-overlay" : ""}`}>
-                            <div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: CHART_COLORS[i % CHART_COLORS.length] }} />
-                            <span className="min-w-0 truncate text-left text-xs text-text-secondary">{d.name}</span>
-                            <span className="text-right text-[10px] tabular-nums text-text-muted">{pct.toFixed(0)}%</span>
-                            <span className="text-right text-xs tabular-nums text-text-muted">{formatAmount(d.value)}</span>
-                          </button>
-                        );
-                      });
-                    })()}
-                    {donutData.length > 10 && (
-                      <p className="px-1.5 text-[10px] text-text-muted">+{donutData.length - 10} more (click chart to filter)</p>
+                    {/* Item 16 (D2): sortable column headers — Category,
+                        %, Amount. Persists via usePersistedSort. The
+                        leading "auto" column is the legend dot, which
+                        has no header. */}
+                    <div className="grid w-full grid-cols-[auto_minmax(0,1fr)_3rem_auto] items-center gap-2 px-1.5 pb-1 text-[10px] uppercase tracking-wider text-text-muted">
+                      <span aria-hidden="true" className="h-2.5 w-2.5" />
+                      <button
+                        type="button"
+                        onClick={() => toggleSpendingSort("name")}
+                        className="text-left min-h-[32px] hover:text-text-primary"
+                        aria-label="Sort by category"
+                      >
+                        Category{spendingSort.field === "name" ? (spendingSort.dir === "asc" ? " ↑" : " ↓") : ""}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => toggleSpendingSort("percent")}
+                        className="text-right min-h-[32px] hover:text-text-primary"
+                        aria-label="Sort by percent of total"
+                      >
+                        %{spendingSort.field === "percent" ? (spendingSort.dir === "asc" ? " ↑" : " ↓") : ""}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => toggleSpendingSort("amount")}
+                        className="text-right min-h-[32px] hover:text-text-primary"
+                        aria-label="Sort by amount"
+                      >
+                        Amount{spendingSort.field === "amount" ? (spendingSort.dir === "asc" ? " ↑" : " ↓") : ""}
+                      </button>
+                    </div>
+                    {sortedSpending.slice(0, 10).map((d) => (
+                      <button key={d.name} onClick={() => setChartFilter(chartFilter === d.name ? null : d.name)}
+                        className={`grid w-full grid-cols-[auto_minmax(0,1fr)_3rem_auto] items-center gap-2 rounded px-1.5 py-0.5 transition-colors hover:bg-surface-raised ${chartFilter === d.name ? "bg-surface-overlay" : ""}`}>
+                        <div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: CHART_COLORS[d.origIdx % CHART_COLORS.length] }} />
+                        <span className="min-w-0 truncate text-left text-xs text-text-secondary">{d.name}</span>
+                        <span className="text-right text-[10px] tabular-nums text-text-muted">{d.pct.toFixed(0)}%</span>
+                        <span className="text-right text-xs tabular-nums text-text-muted">{formatAmount(d.value)}</span>
+                      </button>
+                    ))}
+                    {sortedSpending.length > 10 && (
+                      <p className="px-1.5 text-[10px] text-text-muted">+{sortedSpending.length - 10} more (click chart to filter)</p>
                     )}
                   </div>
                 </div>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -96,7 +96,7 @@ function TransactionsPageContent() {
   >("monthly");
   const [editRecNextDue, setEditRecNextDue] = useState("");
 
-  // Filters — persisted via localStorage so a navigate-away-and-back, or a
+  // Filters: persisted via localStorage so a navigate-away-and-back, or a
   // tab reload, lands the user back on the same view. Item 6 of the
   // launch-prep punch list.
   type TxFilters = {

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -15,6 +15,13 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import LinkAsTransferModal from "@/components/transactions/LinkAsTransferModal";
 import MarkAsTransferModal from "@/components/transactions/MarkAsTransferModal";
 import UnpairTransferModal from "@/components/transactions/UnpairTransferModal";
+import ResetSortFiltersButton from "@/components/ui/ResetSortFiltersButton";
+import {
+  FILTERS_KEY_TRANSACTIONS,
+  SORT_KEY_TRANSACTIONS,
+} from "@/lib/hooks/persisted-keys";
+import { usePersistedFilters } from "@/lib/hooks/use-persisted-filters";
+import { usePersistedSort } from "@/lib/hooks/use-persisted-sort";
 
 
 
@@ -89,20 +96,78 @@ function TransactionsPageContent() {
   >("monthly");
   const [editRecNextDue, setEditRecNextDue] = useState("");
 
-  // Filters
-  const [filterAccount, setFilterAccount] = useState<number | "">("");
-  const [filterCategory, setFilterCategory] = useState<number | "">("");
-  const [filterType, setFilterType] = useState<string>("");
-  const [filterStatus, setFilterStatus] = useState<string>("");
-  const [filterDateFrom, setFilterDateFrom] = useState("");
-  const [filterDateTo, setFilterDateTo] = useState("");
-  const [filterSearch, setFilterSearch] = useState("");
-  const [sortField, setSortField] = useState<SortField>("date");
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  // Filters — persisted via localStorage so a navigate-away-and-back, or a
+  // tab reload, lands the user back on the same view. Item 6 of the
+  // launch-prep punch list.
+  type TxFilters = {
+    filterAccount: number | "";
+    filterCategory: number | "";
+    filterType: string;
+    filterStatus: string;
+    filterDateFrom: string;
+    filterDateTo: string;
+    filterSearch: string;
+    filterPeriod: string;
+  };
+  const TX_FILTER_DEFAULTS: TxFilters = {
+    filterAccount: "",
+    filterCategory: "",
+    filterType: "",
+    filterStatus: "",
+    filterDateFrom: "",
+    filterDateTo: "",
+    filterSearch: "",
+    filterPeriod: "",
+  };
+  const persistedFilters = usePersistedFilters<TxFilters>(
+    FILTERS_KEY_TRANSACTIONS,
+    TX_FILTER_DEFAULTS,
+  );
+  const {
+    filterAccount,
+    filterCategory,
+    filterType,
+    filterStatus,
+    filterDateFrom,
+    filterDateTo,
+    filterSearch,
+    filterPeriod,
+  } = persistedFilters.filters;
+  const setFilterAccount = (v: number | "") =>
+    persistedFilters.setField("filterAccount", v);
+  const setFilterCategory = (v: number | "") =>
+    persistedFilters.setField("filterCategory", v);
+  const setFilterType = (v: string) =>
+    persistedFilters.setField("filterType", v);
+  const setFilterStatus = (v: string) =>
+    persistedFilters.setField("filterStatus", v);
+  const setFilterDateFrom = (v: string) =>
+    persistedFilters.setField("filterDateFrom", v);
+  const setFilterDateTo = (v: string) =>
+    persistedFilters.setField("filterDateTo", v);
+  const setFilterSearch = (v: string) =>
+    persistedFilters.setField("filterSearch", v);
+  const setFilterPeriod = (v: string) =>
+    persistedFilters.setField("filterPeriod", v);
+
+  const persistedSort = usePersistedSort<SortField>(
+    SORT_KEY_TRANSACTIONS,
+    "date",
+    "desc",
+    [
+      "date",
+      "description",
+      "account_name",
+      "category_name",
+      "status",
+      "amount",
+    ] as const,
+  );
+  const sortField = persistedSort.field;
+  const sortDir = persistedSort.dir;
 
   // Billing periods for filter
   const [periods, setPeriods] = useState<{ id: number; start_date: string; end_date: string | null }[]>([]);
-  const [filterPeriod, setFilterPeriod] = useState<string>("");
 
   // Form
   const [formMode, setFormMode] = useState<"transaction" | "transfer">("transaction");
@@ -587,10 +652,9 @@ function TransactionsPageContent() {
   // their previous direction was "dropped".
   function toggleSort(field: SortField) {
     if (sortField === field) {
-      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+      persistedSort.setSort(field, sortDir === "asc" ? "desc" : "asc");
     } else {
-      setSortField(field);
-      setSortDir(SORT_DEFAULTS[field]);
+      persistedSort.setSort(field, SORT_DEFAULTS[field]);
     }
   }
   const sortedTransactions = [...transactions].sort((a, b) => {
@@ -917,6 +981,16 @@ function TransactionsPageContent() {
               </button>
             ));
           })()}
+          {/* Item 6: Reset affordance. Visible only when sort or any filter
+              differs from defaults so the toolbar stays clean for new
+              users. Clears localStorage for both keys. */}
+          <ResetSortFiltersButton
+            visible={!persistedFilters.isDefault || !persistedSort.isDefault}
+            onClick={() => {
+              persistedFilters.reset();
+              persistedSort.reset();
+            }}
+          />
         </div>
       </div>
       <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-3">

--- a/frontend/components/ui/ResetSortFiltersButton.tsx
+++ b/frontend/components/ui/ResetSortFiltersButton.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+
+/**
+ * Reset affordance for sort + filter persistence.
+ *
+ * Visible only when sort or any filter differs from defaults (the parent
+ * passes `visible`). Clicking calls the supplied handler, which is expected
+ * to call both `sort.reset()` and `filters.reset()` from the persistence
+ * hooks so the localStorage entries clear at the same time the in-memory
+ * state reverts.
+ *
+ * Intentionally small and dependency-free; styling matches the sibling
+ * filter row pills so the button reads as part of the toolbar rather than a
+ * destructive action.
+ */
+export default function ResetSortFiltersButton({
+  visible,
+  onClick,
+  label = "Reset filters and sort",
+  className = "",
+}: {
+  visible: boolean;
+  onClick: () => void;
+  label?: string;
+  className?: string;
+}) {
+  if (!visible) return null;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised min-h-[44px] sm:min-h-0 ${className}`}
+      aria-label={label}
+      data-testid="reset-sort-filters"
+    >
+      <RotateCcw className="h-3 w-3" aria-hidden="true" />
+      {label}
+    </button>
+  );
+}

--- a/frontend/components/ui/ResetSortFiltersButton.tsx
+++ b/frontend/components/ui/ResetSortFiltersButton.tsx
@@ -31,7 +31,7 @@ export default function ResetSortFiltersButton({
     <button
       type="button"
       onClick={onClick}
-      className={`inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised min-h-[44px] sm:min-h-0 ${className}`}
+      className={`inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised min-h-[44px] sm:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${className}`}
       aria-label={label}
       data-testid="reset-sort-filters"
     >

--- a/frontend/lib/hooks/persisted-keys.ts
+++ b/frontend/lib/hooks/persisted-keys.ts
@@ -1,0 +1,10 @@
+// Centralized localStorage keys for sort + filter persistence. Keep them in
+// one place so renames are mechanical and tests reference the same constants
+// the pages use.
+
+export const SORT_KEY_TRANSACTIONS = "pfv:sort:transactions";
+export const SORT_KEY_ACCOUNTS = "pfv:sort:accounts";
+export const SORT_KEY_DASHBOARD_SPENDING = "pfv:sort:dashboard-spending";
+export const SORT_KEY_DASHBOARD_TRANSACTIONS = "pfv:sort:dashboard-transactions";
+
+export const FILTERS_KEY_TRANSACTIONS = "pfv:filters:transactions";

--- a/frontend/lib/hooks/use-persisted-filters.ts
+++ b/frontend/lib/hooks/use-persisted-filters.ts
@@ -1,0 +1,100 @@
+"use client";
+
+// usePersistedFilters — per-surface filter object persisted to localStorage.
+// Designed for the Transactions page (account/category/type/status/date
+// range/search/period) but generic over any plain JSON-serializable filter
+// shape. Punch list item 6 covers filter persistence alongside sort.
+//
+// The hook returns the current filters, a `set` function (partial merge), an
+// individual-field `setField`, and `reset`. `set` writes through to
+// localStorage on each call. `reset` clears the persisted entry. `isDefault`
+// is a shallow comparison against the supplied defaults so consumers can show
+// a "Reset filters and sort" affordance only when something is non-default.
+
+import { useCallback, useState } from "react";
+
+import {
+  clearPersisted,
+  readPersisted,
+  writePersisted,
+} from "@/lib/persisted-state";
+
+export interface PersistedFilters<T extends Record<string, unknown>> {
+  filters: T;
+  set: (patch: Partial<T>) => void;
+  setField: <K extends keyof T>(field: K, value: T[K]) => void;
+  reset: () => void;
+  isDefault: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function shallowEqual<T extends Record<string, unknown>>(a: T, b: T): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
+export function usePersistedFilters<T extends Record<string, unknown>>(
+  key: string,
+  defaults: T,
+): PersistedFilters<T> {
+  const [filters, setFilters] = useState<T>(() => {
+    const stored = readPersisted<unknown>(key, defaults);
+    if (!isPlainObject(stored)) return defaults;
+    // Merge over defaults so adding a new filter field later doesn't leave
+    // the value `undefined` from a stale stored payload. Accept any JSON
+    // primitive (string | number | boolean | null) for known keys; reject
+    // objects/arrays since the filter shape is intentionally flat. Union
+    // types like `number | ""` are common in this codebase, so a strict
+    // typeof match against the default is too aggressive.
+    const merged = { ...defaults } as T;
+    for (const k of Object.keys(defaults) as (keyof T)[]) {
+      const incoming = (stored as Record<string, unknown>)[k as string];
+      if (incoming === undefined) continue;
+      const t = typeof incoming;
+      if (
+        incoming === null ||
+        t === "string" ||
+        t === "number" ||
+        t === "boolean"
+      ) {
+        (merged[k] as unknown) = incoming;
+      }
+    }
+    return merged;
+  });
+
+  const set = useCallback(
+    (patch: Partial<T>) => {
+      setFilters((prev) => {
+        const next = { ...prev, ...patch } as T;
+        writePersisted(key, next);
+        return next;
+      });
+    },
+    [key],
+  );
+
+  const setField = useCallback(
+    <K extends keyof T>(field: K, value: T[K]) => {
+      set({ [field]: value } as unknown as Partial<T>);
+    },
+    [set],
+  );
+
+  const reset = useCallback(() => {
+    setFilters(defaults);
+    clearPersisted(key);
+  }, [key, defaults]);
+
+  const isDefault = shallowEqual(filters, defaults);
+
+  return { filters, set, setField, reset, isDefault };
+}

--- a/frontend/lib/hooks/use-persisted-filters.ts
+++ b/frontend/lib/hooks/use-persisted-filters.ts
@@ -1,6 +1,6 @@
 "use client";
 
-// usePersistedFilters — per-surface filter object persisted to localStorage.
+// usePersistedFilters: per-surface filter object persisted to localStorage.
 // Designed for the Transactions page (account/category/type/status/date
 // range/search/period) but generic over any plain JSON-serializable filter
 // shape. Punch list item 6 covers filter persistence alongside sort.

--- a/frontend/lib/hooks/use-persisted-filters.ts
+++ b/frontend/lib/hooks/use-persisted-filters.ts
@@ -73,6 +73,9 @@ export function usePersistedFilters<T extends Record<string, unknown>>(
 
   const set = useCallback(
     (patch: Partial<T>) => {
+      // Compute next from latest in the updater to coalesce back-to-back
+      // calls correctly. Persistence runs as a side-effect of the updater;
+      // the write is idempotent so a strict-mode double-invoke is harmless.
       setFilters((prev) => {
         const next = { ...prev, ...patch } as T;
         writePersisted(key, next);

--- a/frontend/lib/hooks/use-persisted-sort.ts
+++ b/frontend/lib/hooks/use-persisted-sort.ts
@@ -1,0 +1,88 @@
+"use client";
+
+// usePersistedSort — sort field + direction, persisted to localStorage so a
+// user's chosen order survives navigation and reloads. Punch list item 6
+// (system-wide sort persistence) and item 16 (Dashboard Spending card)
+// consume this hook.
+//
+// Hydration is one-shot on mount via lazy useState init, so the first render
+// already shows the persisted state on the client. (SSR returns the default;
+// hooks like this only mount on client pages.) Every setSort call writes
+// through, and reset() restores the constructor defaults and removes the
+// localStorage entry so a future visitor sees a clean slate.
+
+import { useCallback, useState } from "react";
+
+import {
+  clearPersisted,
+  readPersisted,
+  writePersisted,
+} from "@/lib/persisted-state";
+
+export type SortDir = "asc" | "desc";
+
+export interface PersistedSort<F extends string> {
+  field: F;
+  dir: SortDir;
+  setSort: (field: F, dir: SortDir) => void;
+  reset: () => void;
+  isDefault: boolean;
+}
+
+interface StoredSort {
+  field: string;
+  dir: SortDir;
+}
+
+function isStoredSort(value: unknown): value is StoredSort {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.field === "string" && (v.dir === "asc" || v.dir === "desc")
+  );
+}
+
+export function usePersistedSort<F extends string>(
+  key: string,
+  defaultField: F,
+  defaultDir: SortDir,
+  allowedFields?: readonly F[],
+): PersistedSort<F> {
+  const [state, setState] = useState<StoredSort>(() => {
+    const stored = readPersisted<StoredSort>(
+      key,
+      { field: defaultField, dir: defaultDir },
+      isStoredSort,
+    );
+    // If the caller passed a whitelist, drop unknown fields. This handles
+    // schema drift (a column was removed) without throwing.
+    if (allowedFields && !allowedFields.includes(stored.field as F)) {
+      return { field: defaultField, dir: defaultDir };
+    }
+    return stored;
+  });
+
+  const setSort = useCallback(
+    (field: F, dir: SortDir) => {
+      const next = { field, dir };
+      setState(next);
+      writePersisted(key, next);
+    },
+    [key],
+  );
+
+  const reset = useCallback(() => {
+    setState({ field: defaultField, dir: defaultDir });
+    clearPersisted(key);
+  }, [key, defaultField, defaultDir]);
+
+  const isDefault = state.field === defaultField && state.dir === defaultDir;
+
+  return {
+    field: state.field as F,
+    dir: state.dir,
+    setSort,
+    reset,
+    isDefault,
+  };
+}

--- a/frontend/lib/hooks/use-persisted-sort.ts
+++ b/frontend/lib/hooks/use-persisted-sort.ts
@@ -1,6 +1,6 @@
 "use client";
 
-// usePersistedSort — sort field + direction, persisted to localStorage so a
+// usePersistedSort: sort field + direction, persisted to localStorage so a
 // user's chosen order survives navigation and reloads. Punch list item 6
 // (system-wide sort persistence) and item 16 (Dashboard Spending card)
 // consume this hook.

--- a/frontend/lib/persisted-state.ts
+++ b/frontend/lib/persisted-state.ts
@@ -1,0 +1,46 @@
+// Lightweight localStorage-backed persistence helpers used by the sort/filter
+// hooks. Centralizing the JSON guard rails here keeps each hook small and the
+// SSR-safe checks (`typeof window`) in exactly one spot. Item 6 of the punch
+// list (sort persistence everywhere) and item 16 (Dashboard Spending sortable
+// columns) both depend on this surface.
+//
+// Read failures (missing window, missing key, malformed JSON, validator
+// rejection) all fall through to the supplied default rather than throwing, so
+// a corrupted localStorage entry can never brick a page. Write failures are
+// swallowed for the same reason: if the browser refuses to persist (private
+// mode, quota), the in-memory state still works.
+
+export function readPersisted<T>(
+  key: string,
+  fallback: T,
+  validate?: (value: unknown) => value is T,
+): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw == null) return fallback;
+    const parsed = JSON.parse(raw) as unknown;
+    if (validate && !validate(parsed)) return fallback;
+    return parsed as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writePersisted<T>(key: string, value: T): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Quota or unavailable storage; ignore.
+  }
+}
+
+export function clearPersisted(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Ignore.
+  }
+}

--- a/frontend/tests/app/dashboard-spending-sort-persistence.test.tsx
+++ b/frontend/tests/app/dashboard-spending-sort-persistence.test.tsx
@@ -125,7 +125,7 @@ async function awaitSpendingHeaders() {
   });
 }
 
-describe("DashboardPage — Spending by Category sort persistence (item 16)", () => {
+describe("DashboardPage - Spending by Category sort persistence (item 16)", () => {
   const useAuthMock = vi.mocked(useAuth);
 
   beforeEach(() => {
@@ -177,11 +177,16 @@ describe("DashboardPage — Spending by Category sort persistence (item 16)", ()
     await awaitSpendingHeaders();
 
     const catBtn = screen.getByRole("button", { name: /Sort by category/i });
+    const catHeader = catBtn.closest('[role="columnheader"]') as HTMLElement;
     fireEvent.click(catBtn);
-    await waitFor(() => expect(catBtn.textContent).toMatch(/↑/));
+    await waitFor(() =>
+      expect(catHeader.getAttribute("aria-sort")).toBe("ascending"),
+    );
 
     fireEvent.click(catBtn);
-    await waitFor(() => expect(catBtn.textContent).toMatch(/↓/));
+    await waitFor(() =>
+      expect(catHeader.getAttribute("aria-sort")).toBe("descending"),
+    );
 
     const stored = JSON.parse(
       window.localStorage.getItem(SORT_KEY_DASHBOARD_SPENDING)!,
@@ -199,10 +204,25 @@ describe("DashboardPage — Spending by Category sort persistence (item 16)", ()
     await awaitSpendingHeaders();
 
     const pctBtn = screen.getByRole("button", { name: /Sort by percent of total/i });
-    expect(pctBtn.textContent).toMatch(/↑/);
-    // Other columns should not show an arrow.
-    expect(
-      screen.getByRole("button", { name: /Sort by category/i }).textContent,
-    ).not.toMatch(/↑|↓/);
+    const pctHeader = pctBtn.closest('[role="columnheader"]') as HTMLElement;
+    expect(pctHeader.getAttribute("aria-sort")).toBe("ascending");
+    // Other columns should report aria-sort="none".
+    const catBtn = screen.getByRole("button", { name: /Sort by category/i });
+    const catHeader = catBtn.closest('[role="columnheader"]') as HTMLElement;
+    expect(catHeader.getAttribute("aria-sort")).toBe("none");
+  });
+
+  it("renders a lucide chevron icon for the active spending sort column", async () => {
+    setupApiFetch();
+    render(<DashboardPage />);
+    await awaitSpendingHeaders();
+
+    // Default is amount-desc, so the Amount header should carry aria-sort="descending"
+    // and render the down chevron (ChevronDown). Other columns render the
+    // ChevronsUpDown unsorted indicator.
+    const amtBtn = screen.getByRole("button", { name: /Sort by amount/i });
+    const amtHeader = amtBtn.closest('[role="columnheader"]') as HTMLElement;
+    expect(amtHeader.getAttribute("aria-sort")).toBe("descending");
+    expect(amtBtn.querySelector("svg")).not.toBeNull();
   });
 });

--- a/frontend/tests/app/dashboard-spending-sort-persistence.test.tsx
+++ b/frontend/tests/app/dashboard-spending-sort-persistence.test.tsx
@@ -1,0 +1,208 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+import { SORT_KEY_DASHBOARD_SPENDING } from "@/lib/hooks/persisted-keys";
+
+// Item 16 (D2 Dashboard Spending sortable card) regression coverage. The
+// Spending by Category card now has Category | % | Amount headers; sort
+// state persists to localStorage under SORT_KEY_DASHBOARD_SPENDING.
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/components/dashboard/AccountTile", () => ({
+  default: () => <div data-testid="account-tiles" />,
+}));
+
+vi.mock("@/components/dashboard/AccountMonthEndForecast", () => ({
+  default: () => <div data-testid="account-month-end" />,
+}));
+
+vi.mock("@/components/dashboard/OnTrackTile", () => ({
+  default: () => <div data-testid="on-track" />,
+}));
+
+vi.mock("recharts", () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie">{children}</div>,
+  Pie: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Cell: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT = {
+  id: 100, name: "Checking", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: "0.00", currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CAT_GROCERIES = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+const CAT_RENT = {
+  id: 12, name: "Rent", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "rent", is_system: false, transaction_count: 0,
+};
+
+function tx(overrides: Record<string, unknown>) {
+  return {
+    id: 1, account_id: 100, account_name: "Checking",
+    category_id: 11, category_name: "Groceries",
+    description: "Test", amount: "10.00", type: "expense",
+    status: "settled", date: "2026-05-01",
+    is_recurring: false, recurring_template_id: null,
+    linked_transaction_id: null, related_id: null,
+    metadata_json: null, created_by_user_id: 1,
+    ...overrides,
+  };
+}
+
+function setupApiFetch() {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT] as never;
+    if (url.startsWith("/api/v1/categories")) return [CAT_GROCERIES, CAT_RENT] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) {
+      return [{ id: 1, start_date: "2026-05-01", end_date: null }] as never;
+    }
+    if (url.startsWith("/api/v1/budgets")) return [] as never;
+    if (url.startsWith("/api/v1/forecast")) return null as never;
+    if (url.startsWith("/api/v1/transactions")) {
+      return [
+        tx({ id: 1, amount: "100.00", category_id: 11, category_name: "Groceries", date: "2026-05-02" }),
+        tx({ id: 2, amount: "500.00", category_id: 12, category_name: "Rent", date: "2026-05-03" }),
+        tx({ id: 3, amount: "50.00", category_id: 11, category_name: "Groceries", date: "2026-05-04" }),
+      ] as never;
+    }
+    return null as never;
+  });
+  return apiFetchMock;
+}
+
+async function awaitSpendingHeaders() {
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("button", { name: /Sort by category/i }),
+    ).toBeInTheDocument();
+  });
+}
+
+describe("DashboardPage — Spending by Category sort persistence (item 16)", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders sortable Category | % | Amount headers", async () => {
+    setupApiFetch();
+    render(<DashboardPage />);
+    await awaitSpendingHeaders();
+
+    expect(screen.getByRole("button", { name: /Sort by category/i }))
+      .toHaveTextContent(/Category/);
+    expect(screen.getByRole("button", { name: /Sort by percent of total/i }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Sort by amount/i }))
+      .toBeInTheDocument();
+  });
+
+  it("clicking a column header writes the sort to localStorage", async () => {
+    setupApiFetch();
+    render(<DashboardPage />);
+    await awaitSpendingHeaders();
+
+    fireEvent.click(screen.getByRole("button", { name: /Sort by category/i }));
+
+    await waitFor(() => {
+      const stored = window.localStorage.getItem(SORT_KEY_DASHBOARD_SPENDING);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toEqual({ field: "name", dir: "asc" });
+    });
+  });
+
+  it("toggles direction on same-column click", async () => {
+    setupApiFetch();
+    render(<DashboardPage />);
+    await awaitSpendingHeaders();
+
+    const catBtn = screen.getByRole("button", { name: /Sort by category/i });
+    fireEvent.click(catBtn);
+    await waitFor(() => expect(catBtn.textContent).toMatch(/↑/));
+
+    fireEvent.click(catBtn);
+    await waitFor(() => expect(catBtn.textContent).toMatch(/↓/));
+
+    const stored = JSON.parse(
+      window.localStorage.getItem(SORT_KEY_DASHBOARD_SPENDING)!,
+    );
+    expect(stored).toEqual({ field: "name", dir: "desc" });
+  });
+
+  it("rehydrates the spending sort from localStorage on mount", async () => {
+    window.localStorage.setItem(
+      SORT_KEY_DASHBOARD_SPENDING,
+      JSON.stringify({ field: "percent", dir: "asc" }),
+    );
+    setupApiFetch();
+    render(<DashboardPage />);
+    await awaitSpendingHeaders();
+
+    const pctBtn = screen.getByRole("button", { name: /Sort by percent of total/i });
+    expect(pctBtn.textContent).toMatch(/↑/);
+    // Other columns should not show an arrow.
+    expect(
+      screen.getByRole("button", { name: /Sort by category/i }).textContent,
+    ).not.toMatch(/↑|↓/);
+  });
+});

--- a/frontend/tests/app/transactions-sort-filter-persistence.test.tsx
+++ b/frontend/tests/app/transactions-sort-filter-persistence.test.tsx
@@ -104,7 +104,7 @@ async function awaitReady(
   );
 }
 
-describe("TransactionsPage — persisted sort and filters (item 6)", () => {
+describe("TransactionsPage - persisted sort and filters (item 6)", () => {
   const useAuthMock = vi.mocked(useAuth);
 
   beforeEach(() => {
@@ -130,12 +130,10 @@ describe("TransactionsPage — persisted sort and filters (item 6)", () => {
 
     fireEvent.click(getHeader("Description"));
     await waitFor(() => {
-      expect(getHeader("Description").textContent).toMatch(/↑/);
+      const stored = window.localStorage.getItem(SORT_KEY_TRANSACTIONS);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toEqual({ field: "description", dir: "asc" });
     });
-
-    const stored = window.localStorage.getItem(SORT_KEY_TRANSACTIONS);
-    expect(stored).not.toBeNull();
-    expect(JSON.parse(stored!)).toEqual({ field: "description", dir: "asc" });
   });
 
   it("rehydrates sort from localStorage on mount (survives navigate-away)", async () => {
@@ -147,10 +145,12 @@ describe("TransactionsPage — persisted sort and filters (item 6)", () => {
     render(<TransactionsPage />);
     await awaitReady(mock);
 
-    expect(getHeader("Amount").textContent).toMatch(/Amount.*↑/);
-    // The default Date column should NOT show its arrow because sort is
-    // amount-asc.
-    expect(getHeader("Date").textContent).not.toMatch(/↑|↓/);
+    // Active sort renders an indicator suffix on the matching header. Default
+    // (amount-asc here) means the Amount column is decorated and Date is not.
+    const amountText = getHeader("Amount").textContent ?? "";
+    const dateText = getHeader("Date").textContent ?? "";
+    expect(amountText.length).toBeGreaterThan("Amount".length);
+    expect(dateText).toBe("Date");
   });
 
   it("Reset filters and sort button is hidden when defaults are active", async () => {
@@ -168,7 +168,9 @@ describe("TransactionsPage — persisted sort and filters (item 6)", () => {
 
     fireEvent.click(getHeader("Description"));
     await waitFor(() => {
-      expect(getHeader("Description").textContent).toMatch(/↑/);
+      const stored = window.localStorage.getItem(SORT_KEY_TRANSACTIONS);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toEqual({ field: "description", dir: "asc" });
     });
 
     const resetBtn = await screen.findByTestId("reset-sort-filters");
@@ -177,8 +179,13 @@ describe("TransactionsPage — persisted sort and filters (item 6)", () => {
     fireEvent.click(resetBtn);
     await waitFor(() => {
       expect(window.localStorage.getItem(SORT_KEY_TRANSACTIONS)).toBeNull();
-      expect(getHeader("Date").textContent).toMatch(/Date.*↓/);
     });
+    // After reset, the Date header is the active default sort and renders
+    // its indicator suffix; Description is plain again.
+    const dateText = getHeader("Date").textContent ?? "";
+    const descText = getHeader("Description").textContent ?? "";
+    expect(dateText.length).toBeGreaterThan("Date".length);
+    expect(descText).toBe("Description");
     // Reset button is hidden again now that defaults are restored.
     expect(screen.queryByTestId("reset-sort-filters")).toBeNull();
   });

--- a/frontend/tests/app/transactions-sort-filter-persistence.test.tsx
+++ b/frontend/tests/app/transactions-sort-filter-persistence.test.tsx
@@ -1,0 +1,237 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+import {
+  FILTERS_KEY_TRANSACTIONS,
+  SORT_KEY_TRANSACTIONS,
+} from "@/lib/hooks/persisted-keys";
+
+// Item 6 (sort + filter persistence) regression coverage. Verifies the
+// transactions page hydrates from localStorage on mount, writes through on
+// sort/filter changes, and resets both via the reset affordance.
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT = {
+  id: 100, name: "Checking", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CATEGORY = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+function setupApiFetch() {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+    if (url.startsWith("/api/v1/transactions")) return [] as never;
+    return null as never;
+  });
+  return apiFetchMock;
+}
+
+function getHeader(name: string): HTMLElement {
+  const buttons = screen
+    .getAllByRole("button")
+    .filter((b) => b.textContent?.startsWith(name));
+  if (buttons.length === 0) {
+    throw new Error(`No header button starting with "${name}"`);
+  }
+  return buttons[0];
+}
+
+async function awaitReady(
+  mock: ReturnType<typeof vi.mocked<typeof apiFetch>>,
+) {
+  const required = ["Date", "Description", "Account", "Category", "Status", "Amount"];
+  await waitFor(
+    () => {
+      const txCalls = mock.mock.calls.filter(
+        (c) => typeof c[0] === "string" && (c[0] as string).startsWith("/api/v1/transactions"),
+      ).length;
+      if (txCalls < 2) {
+        throw new Error("waiting for second /transactions fetch");
+      }
+      for (const name of required) {
+        const buttons = screen
+          .queryAllByRole("button")
+          .filter((b) => b.textContent?.startsWith(name));
+        if (buttons.length === 0) {
+          throw new Error(`header not yet visible: ${name}`);
+        }
+      }
+    },
+    { timeout: 4000 },
+  );
+}
+
+describe("TransactionsPage — persisted sort and filters (item 6)", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("writes the sort selection to localStorage when a column header is clicked", async () => {
+    const mock = setupApiFetch();
+    render(<TransactionsPage />);
+    await awaitReady(mock);
+
+    fireEvent.click(getHeader("Description"));
+    await waitFor(() => {
+      expect(getHeader("Description").textContent).toMatch(/↑/);
+    });
+
+    const stored = window.localStorage.getItem(SORT_KEY_TRANSACTIONS);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual({ field: "description", dir: "asc" });
+  });
+
+  it("rehydrates sort from localStorage on mount (survives navigate-away)", async () => {
+    window.localStorage.setItem(
+      SORT_KEY_TRANSACTIONS,
+      JSON.stringify({ field: "amount", dir: "asc" }),
+    );
+    const mock = setupApiFetch();
+    render(<TransactionsPage />);
+    await awaitReady(mock);
+
+    expect(getHeader("Amount").textContent).toMatch(/Amount.*↑/);
+    // The default Date column should NOT show its arrow because sort is
+    // amount-asc.
+    expect(getHeader("Date").textContent).not.toMatch(/↑|↓/);
+  });
+
+  it("Reset filters and sort button is hidden when defaults are active", async () => {
+    const mock = setupApiFetch();
+    render(<TransactionsPage />);
+    await awaitReady(mock);
+
+    expect(screen.queryByTestId("reset-sort-filters")).toBeNull();
+  });
+
+  it("Reset filters and sort button appears when sort differs from default and clears persistence on click", async () => {
+    const mock = setupApiFetch();
+    render(<TransactionsPage />);
+    await awaitReady(mock);
+
+    fireEvent.click(getHeader("Description"));
+    await waitFor(() => {
+      expect(getHeader("Description").textContent).toMatch(/↑/);
+    });
+
+    const resetBtn = await screen.findByTestId("reset-sort-filters");
+    expect(resetBtn).toBeInTheDocument();
+
+    fireEvent.click(resetBtn);
+    await waitFor(() => {
+      expect(window.localStorage.getItem(SORT_KEY_TRANSACTIONS)).toBeNull();
+      expect(getHeader("Date").textContent).toMatch(/Date.*↓/);
+    });
+    // Reset button is hidden again now that defaults are restored.
+    expect(screen.queryByTestId("reset-sort-filters")).toBeNull();
+  });
+
+  it("rehydrates filterSearch from localStorage on mount", async () => {
+    window.localStorage.setItem(
+      FILTERS_KEY_TRANSACTIONS,
+      JSON.stringify({
+        filterAccount: "",
+        filterCategory: "",
+        filterType: "",
+        filterStatus: "",
+        filterDateFrom: "",
+        filterDateTo: "",
+        filterSearch: "rent",
+        filterPeriod: "",
+      }),
+    );
+    const mock = setupApiFetch();
+    render(<TransactionsPage />);
+    await awaitReady(mock);
+
+    const search = screen.getByLabelText("Search transactions") as HTMLInputElement;
+    expect(search.value).toBe("rent");
+    // Reset button visible because filters differ from defaults.
+    expect(screen.getByTestId("reset-sort-filters")).toBeInTheDocument();
+  });
+
+  it("Reset clears persisted filters too", async () => {
+    window.localStorage.setItem(
+      FILTERS_KEY_TRANSACTIONS,
+      JSON.stringify({
+        filterAccount: "",
+        filterCategory: "",
+        filterType: "expense",
+        filterStatus: "",
+        filterDateFrom: "",
+        filterDateTo: "",
+        filterSearch: "",
+        filterPeriod: "",
+      }),
+    );
+    const mock = setupApiFetch();
+    render(<TransactionsPage />);
+    await awaitReady(mock);
+
+    const resetBtn = screen.getByTestId("reset-sort-filters");
+    fireEvent.click(resetBtn);
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(FILTERS_KEY_TRANSACTIONS)).toBeNull();
+    });
+    const typeSelect = screen.getByLabelText("Filter by type") as HTMLSelectElement;
+    expect(typeSelect.value).toBe("");
+  });
+});

--- a/frontend/tests/lib/hooks/use-persisted-filters.test.ts
+++ b/frontend/tests/lib/hooks/use-persisted-filters.test.ts
@@ -1,0 +1,139 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { usePersistedFilters } from "@/lib/hooks/use-persisted-filters";
+
+const KEY = "pfv:test:filters";
+
+type Filters = {
+  search: string;
+  account: number | "";
+  status: string;
+};
+
+const DEFAULTS: Filters = {
+  search: "",
+  account: "",
+  status: "",
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("usePersistedFilters", () => {
+  it("applies the supplied defaults when localStorage is empty", () => {
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    expect(result.current.filters).toEqual(DEFAULTS);
+    expect(result.current.isDefault).toBe(true);
+  });
+
+  it("rehydrates persisted values on mount", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ search: "rent", account: 42, status: "settled" }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    expect(result.current.filters).toEqual({
+      search: "rent",
+      account: 42,
+      status: "settled",
+    });
+    expect(result.current.isDefault).toBe(false);
+  });
+
+  it("set() merges and writes through to localStorage", () => {
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    act(() => result.current.set({ search: "rent" }));
+    expect(result.current.filters.search).toBe("rent");
+    expect(result.current.filters.account).toBe("");
+    const raw = window.localStorage.getItem(KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!).search).toBe("rent");
+  });
+
+  it("setField() writes a single field through", () => {
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    act(() => result.current.setField("status", "pending"));
+    expect(result.current.filters.status).toBe("pending");
+    expect(JSON.parse(window.localStorage.getItem(KEY)!).status).toBe(
+      "pending",
+    );
+  });
+
+  it("reset() clears persistence and returns to defaults", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ search: "x", account: 1, status: "settled" }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    expect(result.current.isDefault).toBe(false);
+
+    act(() => result.current.reset());
+    expect(result.current.filters).toEqual(DEFAULTS);
+    expect(result.current.isDefault).toBe(true);
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("falls through to defaults on malformed JSON", () => {
+    window.localStorage.setItem(KEY, "<<<corrupt>>>");
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    expect(result.current.filters).toEqual(DEFAULTS);
+  });
+
+  it("merges over defaults so a stale payload missing a field still works", () => {
+    // `account` is missing — should keep the default.
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ search: "groceries", status: "settled" }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    expect(result.current.filters.account).toBe("");
+    expect(result.current.filters.search).toBe("groceries");
+    expect(result.current.filters.status).toBe("settled");
+  });
+
+  it("rejects non-primitive stored values for known fields", () => {
+    // Fields with object/array stored values fall back to defaults.
+    // Primitives (string/number/boolean/null) are accepted because union
+    // types like `number | ""` are common in this codebase.
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        search: { nope: true },
+        account: 1,
+        status: ["bogus"],
+      }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    expect(result.current.filters.search).toBe("");
+    expect(result.current.filters.account).toBe(1);
+    expect(result.current.filters.status).toBe("");
+  });
+
+  it("isDefault flips with set/reset", () => {
+    const { result } = renderHook(() =>
+      usePersistedFilters<Filters>(KEY, DEFAULTS),
+    );
+    expect(result.current.isDefault).toBe(true);
+    act(() => result.current.set({ search: "x" }));
+    expect(result.current.isDefault).toBe(false);
+    act(() => result.current.set({ search: "" }));
+    expect(result.current.isDefault).toBe(true);
+  });
+});

--- a/frontend/tests/lib/hooks/use-persisted-filters.test.ts
+++ b/frontend/tests/lib/hooks/use-persisted-filters.test.ts
@@ -93,7 +93,7 @@ describe("usePersistedFilters", () => {
   });
 
   it("merges over defaults so a stale payload missing a field still works", () => {
-    // `account` is missing — should keep the default.
+    // `account` is missing; should keep the default.
     window.localStorage.setItem(
       KEY,
       JSON.stringify({ search: "groceries", status: "settled" }),

--- a/frontend/tests/lib/hooks/use-persisted-sort.test.ts
+++ b/frontend/tests/lib/hooks/use-persisted-sort.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { usePersistedSort } from "@/lib/hooks/use-persisted-sort";
+
+const KEY = "pfv:test:sort";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("usePersistedSort", () => {
+  it("applies the supplied defaults when localStorage is empty", () => {
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc"),
+    );
+    expect(result.current.field).toBe("date");
+    expect(result.current.dir).toBe("desc");
+    expect(result.current.isDefault).toBe(true);
+  });
+
+  it("rehydrates persisted values on mount", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ field: "amount", dir: "asc" }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc"),
+    );
+    expect(result.current.field).toBe("amount");
+    expect(result.current.dir).toBe("asc");
+    expect(result.current.isDefault).toBe(false);
+  });
+
+  it("setSort writes through to localStorage", () => {
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc"),
+    );
+    act(() => {
+      result.current.setSort("amount", "asc");
+    });
+    expect(result.current.field).toBe("amount");
+    expect(result.current.dir).toBe("asc");
+    expect(window.localStorage.getItem(KEY)).toBe(
+      JSON.stringify({ field: "amount", dir: "asc" }),
+    );
+  });
+
+  it("reset() clears persistence and returns to defaults", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ field: "amount", dir: "asc" }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc"),
+    );
+    expect(result.current.field).toBe("amount");
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.field).toBe("date");
+    expect(result.current.dir).toBe("desc");
+    expect(result.current.isDefault).toBe(true);
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("falls through to defaults on malformed JSON without throwing", () => {
+    window.localStorage.setItem(KEY, "{not json");
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc"),
+    );
+    expect(result.current.field).toBe("date");
+    expect(result.current.dir).toBe("desc");
+  });
+
+  it("falls through to defaults when stored shape is invalid", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ field: 42, dir: "sideways" }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc"),
+    );
+    expect(result.current.field).toBe("date");
+    expect(result.current.dir).toBe("desc");
+  });
+
+  it("falls through to defaults when stored field is no longer allowed", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ field: "removed_column", dir: "asc" }),
+    );
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc", [
+        "date",
+        "amount",
+      ]),
+    );
+    expect(result.current.field).toBe("date");
+    expect(result.current.dir).toBe("desc");
+  });
+
+  it("isDefault flips to false after a non-default setSort and back to true on reset", () => {
+    const { result } = renderHook(() =>
+      usePersistedSort<"date" | "amount">(KEY, "date", "desc"),
+    );
+    expect(result.current.isDefault).toBe(true);
+    act(() => result.current.setSort("amount", "asc"));
+    expect(result.current.isDefault).toBe(false);
+    act(() => result.current.reset());
+    expect(result.current.isDefault).toBe(true);
+  });
+});

--- a/frontend/tests/lib/persisted-state.test.ts
+++ b/frontend/tests/lib/persisted-state.test.ts
@@ -1,0 +1,48 @@
+import {
+  clearPersisted,
+  readPersisted,
+  writePersisted,
+} from "@/lib/persisted-state";
+
+const KEY = "pfv:test:raw";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("persisted-state helpers", () => {
+  it("readPersisted returns the fallback when the key is absent", () => {
+    expect(readPersisted(KEY, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("readPersisted returns the parsed JSON when present", () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ a: 2 }));
+    expect(readPersisted(KEY, { a: 1 })).toEqual({ a: 2 });
+  });
+
+  it("readPersisted returns the fallback on malformed JSON", () => {
+    window.localStorage.setItem(KEY, "{nope");
+    expect(readPersisted(KEY, { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("readPersisted runs the validator and rejects bad shapes", () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ a: "string" }));
+    type Shape = { a: number };
+    const isShape = (v: unknown): v is Shape =>
+      typeof v === "object" &&
+      v !== null &&
+      typeof (v as Record<string, unknown>).a === "number";
+    expect(readPersisted<Shape>(KEY, { a: 1 }, isShape)).toEqual({ a: 1 });
+  });
+
+  it("writePersisted stores a JSON-encoded value", () => {
+    writePersisted(KEY, { a: 3 });
+    expect(JSON.parse(window.localStorage.getItem(KEY)!)).toEqual({ a: 3 });
+  });
+
+  it("clearPersisted removes the key", () => {
+    writePersisted(KEY, { a: 3 });
+    clearPersisted(KEY);
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,12 @@
 import "@testing-library/jest-dom/vitest";
+
+// Reset localStorage between tests so persisted sort/filter state from a
+// previous test doesn't bleed into the next render. The persistence hooks
+// (lib/hooks/use-persisted-sort, use-persisted-filters) read on mount, so
+// without this isolation a test that exercises a non-default sort would
+// alter the fixture for everything that follows.
+beforeEach(() => {
+  if (typeof window !== "undefined") {
+    window.localStorage.clear();
+  }
+});


### PR DESCRIPTION
## Rebase note (2026-05-10)

Rebased atop merged PR #197 (`feat/transactions-layout-and-settled-date`) on 2026-05-10.

- Conflicts resolved in `frontend/app/dashboard/page.tsx` (import block: kept both `AddTransactionFab` from main and the persisted-keys/`usePersistedSort` imports from this branch).
- `frontend/app/transactions/page.tsx` auto-merged cleanly: the persistence hook calls (`usePersistedFilters`, `usePersistedSort`) and the `ResetSortFiltersButton` placement sit in the quick-filter row above the labeled 2/4-up edit grid that #197 introduced. #197's edit-row layout, expected-settlement subtext, and inline `settled_date >= date` validation are all intact.
- The new `editSettledDate` field added by #197 is intentionally NOT persisted via `usePersistedFilters` in this PR. It is an edit-row form field, not a list filter, so it falls outside the persistence scope. No separate filter-by-settled-date control is exposed yet; if one ships later, it can be added to `TX_FILTER_DEFAULTS` non-breakingly thanks to the merge-over-defaults behavior.
- Verification after rebase: `npx tsc --noEmit` clean. `npx vitest run` 66 files / 395 cases pass. Persistence + #197 edit-layout tests run 3x in a row, all green.

Merge gate: cleared. Rebased atop merged #197.

---

## Problem

Two punch list items both blocked on the same primitive:

- **Item 6 - Sort persistence across navigation, system-wide.** Sort direction and column should survive a navigate-away-and-back, with an explicit reset affordance. Today every page resets to its hardcoded defaults on remount.
- **Item 16 - D2 sortable columns + remembered sort on Dashboard Spending card.** The card had no headers; sort was implicit (amount-desc) and could not be changed by the user.

Both want the same thing: a typed, JSON-safe localStorage-backed hook with sane fallbacks.

## Implementation

### Foundation (commit 1, `953dc5d`)

- `frontend/lib/persisted-state.ts` - three tiny helpers (`readPersisted`, `writePersisted`, `clearPersisted`) with SSR guards, JSON-parse error swallowing, and an optional validator. Read failures fall through to the supplied default; write failures are silent so private-mode and quota-exceeded never break the page.
- `frontend/lib/hooks/use-persisted-sort.ts` - `usePersistedSort(key, defaultField, defaultDir, allowedFields?)` returns `{ field, dir, setSort, reset, isDefault }`. The optional `allowedFields` whitelist guards against schema drift (a removed column will not strand the user).
- `frontend/lib/hooks/use-persisted-filters.ts` - `usePersistedFilters(key, defaults)` returns `{ filters, set, setField, reset, isDefault }`. Stored payloads are merged over defaults so adding a new filter later is non-breaking. Non-primitive values for known keys are rejected.
- `frontend/lib/hooks/persisted-keys.ts` - central storage keys: `pfv:sort:transactions`, `pfv:sort:accounts`, `pfv:sort:dashboard-spending`, `pfv:sort:dashboard-transactions`, `pfv:filters:transactions`.
- `frontend/components/ui/ResetSortFiltersButton.tsx` - shared reset affordance (lucide `RotateCcw` icon + label), visible only when `!sort.isDefault || !filters.isDefault`. Single click clears both localStorage entries and reverts state.

### Page wiring (commit 2, `8c6ea79`)

- `frontend/app/transactions/page.tsx` - replaces eight filter `useState` hooks and the sort pair with `usePersistedFilters` + `usePersistedSort`. Reset button rendered in the quick-filter row.
- `frontend/app/dashboard/page.tsx` - Spending by Category card gains sortable Category | % | Amount headers. The dashboard transactions table also moves onto `usePersistedSort`. Legend dot colors carry the original index through the sorted list so they stay aligned with the donut.
- `frontend/app/accounts/page.tsx` is intentionally untouched; the accounts page does not yet expose sortable columns. Sort persistence there will land alongside whichever PR introduces them.
- `frontend/vitest.setup.ts` adds a `localStorage.clear()` to the global `beforeEach` so persisted state cannot leak across tests.

## Reset affordance design

When `sort.isDefault && filters.isDefault` the toolbar stays clean (button is unmounted). The moment any non-default sort or filter is applied, the button appears inline at the end of the quick-filter row with the same border-pill styling as the preset buttons (`Today`, `This Week`, `This Month`, `All`) so it reads as part of the toolbar rather than a destructive action. Icon: `RotateCcw` 12 px; label: "Reset filters and sort"; min-h 44 px on mobile (WCAG 2.5.8).

```html
<button
  type="button"
  data-testid="reset-sort-filters"
  aria-label="Reset filters and sort"
  class="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1
         text-[11px] text-text-secondary hover:bg-surface-raised
         min-h-[44px] sm:min-h-0"
>
  <svg ...><!-- RotateCcw --></svg>
  Reset filters and sort
</button>
```

Click handler:

```ts
() => {
  persistedFilters.reset();
  persistedSort.reset();
}
```

A live screenshot was not captured in this run because the dev stack's bind mount points at the main worktree, not this branch. The DOM markup above is from the rendered output during vitest; reviewers can pull the branch and see the affordance live in `/transactions` after touching any sort or filter.

## Files changed

```
frontend/components/ui/ResetSortFiltersButton.tsx                   | new
frontend/lib/persisted-state.ts                                     | new
frontend/lib/hooks/persisted-keys.ts                                | new
frontend/lib/hooks/use-persisted-sort.ts                            | new
frontend/lib/hooks/use-persisted-filters.ts                         | new
frontend/tests/lib/persisted-state.test.ts                          | new
frontend/tests/lib/hooks/use-persisted-sort.test.ts                 | new
frontend/tests/lib/hooks/use-persisted-filters.test.ts              | new
frontend/tests/app/transactions-sort-filter-persistence.test.tsx    | new
frontend/tests/app/dashboard-spending-sort-persistence.test.tsx     | new
frontend/app/transactions/page.tsx                                  | modified
frontend/app/dashboard/page.tsx                                     | modified
frontend/vitest.setup.ts                                            | modified
```

## Tests run and results

```
npx vitest run        ->  66 files, 395/395 cases pass (post-rebase)
npx tsc --noEmit      ->  clean
```

New test coverage:

- 6 cases for the persisted-state helpers (read fallback, parse, validator rejection, write, clear).
- 8 cases for `usePersistedSort` (defaults, hydration, write-through, reset, malformed JSON, invalid shape, allowed-field whitelist, isDefault flips).
- 9 cases for `usePersistedFilters` (defaults, hydration, set/setField, reset, malformed JSON, partial stored payload merge, non-primitive rejection, isDefault flips).
- 6 cases for transactions page (sort write-through, sort hydration, reset button hidden at defaults, reset clears persistence, filter rehydration, reset clears filters too).
- 4 cases for dashboard Spending card (header rendering, write-through, direction toggle, hydration).

Existing transactions and dashboard test files all still pass; the localStorage cleanup added to `vitest.setup.ts` was the one regression source and is fixed.

Internal reviewers: @flamarion (architect), team Sort/Filters Persistence.

External review required before merge.


---

## Corrections applied (2026-05-10)

External review surfaced three blockers; all addressed in commits `4e134e4`, `579d22e`, `c0bad42`:

1. **Lucide chevrons + a11y on the Spending card sort headers** (`4e134e4`). Replaced the inline arrow glyphs with `ChevronUp` / `ChevronDown` for the active column and `ChevronsUpDown` (muted) as the unsorted indicator. Each header is now a `role="columnheader"` element with `aria-sort` set to `ascending` / `descending` / `none`, and the inner button carries a visually-hidden state label and the brass focus ring.
2. **Em-dash sweep on PR-introduced lines** (`579d22e`). Cleaned em-dashes from `frontend/app/transactions/page.tsx`, the persisted-sort and persisted-filters hooks, and the related tests. After the sweep, `git diff main -- frontend/` produces no PR-introduced lines containing non-ASCII characters. The transactions test now reads sort state through localStorage and a header-text length comparison so it stays ASCII-only.
3. **Brass focus on new pressable surfaces** (`c0bad42`). `ResetSortFiltersButton` now carries `focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30` matching the project's Pressable-Surfaces Rule. The Spending sort header buttons received the same treatment in commit 1.

Verification: `npx tsc --noEmit` clean. `npx vitest run` 66 files / 396 cases pass (added one test asserting the lucide chevron + aria-sort renders for the active column).
