### PR TITLE
feat(transactions): rebalance edit row + expose settled_date for pending

### DIFF
--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class TransactionCreate(BaseModel):
@@ -15,6 +15,14 @@ class TransactionCreate(BaseModel):
     type: Literal["income", "expense"]
     status: Literal["settled", "pending"] = "settled"
     date: datetime.date
+    # Optional expected settlement date for pending rows. When status=pending
+    # and the user provides this, it surfaces in the period bucket
+    # (effective_period_date_expr) so forecasts and period filters see the
+    # row in its expected month rather than its purchase month. Stored
+    # as-is for SETTLED rows when explicitly supplied; the service layer
+    # falls back to the transaction date if omitted on SETTLED creates so
+    # the SETTLED-implies-settled_date invariant holds.
+    settled_date: Optional[datetime.date] = None
 
     @field_validator("description")
     @classmethod
@@ -22,6 +30,12 @@ class TransactionCreate(BaseModel):
         if not v.strip():
             raise ValueError("Description is required")
         return v.strip()
+
+    @model_validator(mode="after")
+    def _settled_date_not_before_date(self) -> "TransactionCreate":
+        if self.settled_date is not None and self.settled_date < self.date:
+            raise ValueError("settled_date must be on or after date")
+        return self
 
 
 class TransferCreate(BaseModel):

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -267,6 +267,16 @@ async def _create_transaction_no_commit(
         acct = await get_account_for_update(db, body.account_id, org_id)
         apply_balance(acct, body.amount, tx_type)
 
+    # settled_date resolution:
+    # - SETTLED: prefer caller-supplied settled_date, else fall back to date
+    #   (matches the SETTLED-implies-settled_date model invariant).
+    # - PENDING: pass through caller-supplied settled_date as-is. Treated as
+    #   "expected settlement date" by the period bucketing in
+    #   effective_period_date_expr; None falls back to date there.
+    if tx_status == TransactionStatus.SETTLED:
+        resolved_settled_date = body.settled_date or body.date
+    else:
+        resolved_settled_date = body.settled_date
     tx = Transaction(
         org_id=org_id,
         account_id=body.account_id,
@@ -276,7 +286,7 @@ async def _create_transaction_no_commit(
         type=tx_type,
         status=tx_status,
         date=body.date,
-        settled_date=body.date if tx_status == TransactionStatus.SETTLED else None,
+        settled_date=resolved_settled_date,
         is_imported=is_imported,
         is_manual_adjustment=is_manual_adjustment,
     )
@@ -455,21 +465,31 @@ async def update_transaction(
             tx.account_id = body.account_id
         if body.status is not None:
             tx.status = new_status
-        # settled_date semantics (§5.2):
-        # - status pending → settled_date = None
-        # - status settled with body.settled_date → use it
-        # - transition to settled with no settled_date → today
-        if body.status is not None and new_status == TransactionStatus.PENDING:
-            tx.settled_date = None
-        elif new_status == TransactionStatus.SETTLED:
+        # settled_date semantics:
+        # - SETTLED rows: settled_date is required (model + DB invariant).
+        #   Use body.settled_date if provided, else stamp today on transition,
+        #   else leave existing value alone.
+        # - PENDING rows: settled_date is now an "expected settlement date"
+        #   for forecast/period bucketing. Body.settled_date sets it; if the
+        #   caller transitions a settled row to pending without supplying a
+        #   settled_date we clear it to avoid leaking the historical actual.
+        if new_status == TransactionStatus.SETTLED:
             if body.settled_date is not None:
                 tx.settled_date = body.settled_date
             elif old_status != TransactionStatus.SETTLED:
                 tx.settled_date = datetime.date.today()
-        elif body.settled_date is not None:
-            # Status unchanged but settled_date provided
-            if tx.status == TransactionStatus.SETTLED:
+        else:
+            # Pending after this update.
+            if body.settled_date is not None:
                 tx.settled_date = body.settled_date
+            elif body.status is not None and old_status == TransactionStatus.SETTLED:
+                tx.settled_date = None
+
+        # Validate date ordering after the partial update is applied. Use
+        # the resolved date+settled_date pair so a request that touches
+        # only one of them is still checked against the persisted other.
+        if tx.settled_date is not None and tx.settled_date < tx.date:
+            raise ValidationError("settled_date must be on or after date")
 
         # 4d: amount mirror to partner
         if partner is not None and amount_was_changed:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -478,7 +478,7 @@ async def update_transaction(
         #   silently no-op against the persisted value.
         settled_date_supplied = "settled_date" in body.model_fields_set
         if new_status == TransactionStatus.SETTLED:
-            # SETTLED rows must have a settled_date — clearing is illegal.
+            # SETTLED rows must have a settled_date (clearing is illegal).
             # An explicit null on transition gets the today fallback below.
             if body.settled_date is not None:
                 tx.settled_date = body.settled_date
@@ -490,7 +490,7 @@ async def update_transaction(
             if settled_date_supplied:
                 tx.settled_date = body.settled_date
             elif body.status is not None and old_status == TransactionStatus.SETTLED:
-                # Transitioning settled→pending without a supplied settled_date:
+                # Transitioning settled to pending without a supplied settled_date:
                 # clear the historical actual so it doesn't leak as an
                 # "expected" date for the now-pending row.
                 tx.settled_date = None

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -469,20 +469,30 @@ async def update_transaction(
         # - SETTLED rows: settled_date is required (model + DB invariant).
         #   Use body.settled_date if provided, else stamp today on transition,
         #   else leave existing value alone.
-        # - PENDING rows: settled_date is now an "expected settlement date"
-        #   for forecast/period bucketing. Body.settled_date sets it; if the
-        #   caller transitions a settled row to pending without supplying a
-        #   settled_date we clear it to avoid leaking the historical actual.
+        # - PENDING rows: settled_date is an "expected settlement date" for
+        #   forecast/period bucketing. The caller can SET it (non-null), CLEAR
+        #   it (explicit null), or LEAVE it alone (key omitted from body). We
+        #   distinguish "explicit null" from "key omitted" via model_fields_set
+        #   because Pydantic v2 collapses both to attribute value None
+        #   otherwise. Without this, clearing the field via the edit form would
+        #   silently no-op against the persisted value.
+        settled_date_supplied = "settled_date" in body.model_fields_set
         if new_status == TransactionStatus.SETTLED:
+            # SETTLED rows must have a settled_date — clearing is illegal.
+            # An explicit null on transition gets the today fallback below.
             if body.settled_date is not None:
                 tx.settled_date = body.settled_date
             elif old_status != TransactionStatus.SETTLED:
                 tx.settled_date = datetime.date.today()
         else:
-            # Pending after this update.
-            if body.settled_date is not None:
+            # Pending after this update. Honor explicit null (clear) and
+            # explicit value (set); leave alone when the key is omitted.
+            if settled_date_supplied:
                 tx.settled_date = body.settled_date
             elif body.status is not None and old_status == TransactionStatus.SETTLED:
+                # Transitioning settled→pending without a supplied settled_date:
+                # clear the historical actual so it doesn't leak as an
+                # "expected" date for the now-pending row.
                 tx.settled_date = None
 
         # Validate date ordering after the partial update is applied. Use

--- a/backend/tests/schemas/test_transfer_schemas.py
+++ b/backend/tests/schemas/test_transfer_schemas.py
@@ -57,3 +57,53 @@ def test_transaction_update_settled_date_optional():
     from app.schemas.transaction import TransactionUpdate
     body = TransactionUpdate(description="x")
     assert body.settled_date is None
+
+
+def test_transaction_create_accepts_settled_date_for_pending():
+    """TransactionCreate must accept settled_date so callers can stamp an
+    expected settlement date on pending rows at creation time (Item 13).
+    """
+    from app.schemas.transaction import TransactionCreate
+    import datetime
+    from decimal import Decimal
+    body = TransactionCreate(
+        account_id=1, category_id=1,
+        description="cc", amount=Decimal("1.00"),
+        type="expense", status="pending",
+        date=datetime.date(2026, 5, 1),
+        settled_date=datetime.date(2026, 6, 1),
+    )
+    assert body.settled_date == datetime.date(2026, 6, 1)
+
+
+def test_transaction_create_settled_date_optional():
+    """settled_date defaults to None — settled rows fall back to date in
+    the service layer, pending rows just don't have an expected date.
+    """
+    from app.schemas.transaction import TransactionCreate
+    import datetime
+    from decimal import Decimal
+    body = TransactionCreate(
+        account_id=1, category_id=1,
+        description="x", amount=Decimal("1.00"),
+        type="expense", status="settled",
+        date=datetime.date(2026, 5, 1),
+    )
+    assert body.settled_date is None
+
+
+def test_transaction_create_rejects_settled_date_before_date():
+    """Cross-field validator: settled_date < date is invalid at the schema."""
+    from app.schemas.transaction import TransactionCreate
+    from pydantic import ValidationError
+    import datetime
+    from decimal import Decimal
+    import pytest as _pytest
+    with _pytest.raises(ValidationError):
+        TransactionCreate(
+            account_id=1, category_id=1,
+            description="x", amount=Decimal("1.00"),
+            type="expense", status="pending",
+            date=datetime.date(2026, 5, 10),
+            settled_date=datetime.date(2026, 5, 1),
+        )

--- a/backend/tests/schemas/test_transfer_schemas.py
+++ b/backend/tests/schemas/test_transfer_schemas.py
@@ -77,7 +77,7 @@ def test_transaction_create_accepts_settled_date_for_pending():
 
 
 def test_transaction_create_settled_date_optional():
-    """settled_date defaults to None — settled rows fall back to date in
+    """settled_date defaults to None. Settled rows fall back to date in
     the service layer, pending rows just don't have an expected date.
     """
     from app.schemas.transaction import TransactionCreate

--- a/backend/tests/services/test_transaction_settled_date_pending.py
+++ b/backend/tests/services/test_transaction_settled_date_pending.py
@@ -1,0 +1,212 @@
+"""Pending-row settled_date semantics (Punch-list Item 13).
+
+PR #163 enforced SETTLED ⇒ settled_date set. This file exercises the new
+contract that PENDING rows MAY carry a non-null settled_date as the
+"expected settlement date" used by ``effective_period_date_expr`` for
+period bucketing in forecasts/filters.
+
+Coverage:
+- Create with status=pending and settled_date persists the date.
+- Create with status=settled and explicit settled_date persists it
+  (caller-supplied wins over the date fallback).
+- Create with status=pending and no settled_date keeps it None.
+- Create rejects settled_date < date at the schema layer.
+- Update a pending row to set settled_date later.
+- Update rejects settled_date < date.
+- Update flipping settled→pending without an explicit settled_date
+  clears the actual settled_date (we don't want to leak the historical
+  actual into the "expected" slot).
+"""
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from pydantic import ValidationError as PydanticValidationError
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.schemas.transaction import TransactionCreate, TransactionUpdate
+from app.services import transaction_service
+from app.services.exceptions import ValidationError
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_org_with_account(session: AsyncSession):
+    org = Organization(name="T", billing_cycle_day=1)
+    session.add(org)
+    await session.flush()
+    at = AccountType(org_id=org.id, name="CC", slug="credit_card", is_system=True)
+    session.add(at)
+    await session.flush()
+    acct = Account(
+        org_id=org.id, name="CC", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    session.add(acct)
+    cat = Category(org_id=org.id, name="Shopping", slug="shopping", type=CategoryType.EXPENSE, is_system=False)
+    session.add(cat)
+    await session.commit()
+    return org, acct, cat
+
+
+async def test_create_pending_with_settled_date_persists(db_session):
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Pending CC charge", amount=Decimal("42.00"),
+        type="expense", status="pending",
+        date=dt.date(2026, 5, 1), settled_date=dt.date(2026, 6, 15),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+    assert tx.status == TransactionStatus.PENDING
+    assert tx.settled_date == dt.date(2026, 6, 15)
+    # Pending row → balance NOT applied.
+    await db_session.refresh(acct)
+    assert acct.balance == Decimal("0")
+
+
+async def test_create_settled_with_explicit_settled_date(db_session):
+    """Caller-supplied settled_date on SETTLED creates wins over the date fallback."""
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Settled with explicit date", amount=Decimal("10.00"),
+        type="expense", status="settled",
+        date=dt.date(2026, 5, 1), settled_date=dt.date(2026, 5, 3),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+    assert tx.settled_date == dt.date(2026, 5, 3)
+
+
+async def test_create_pending_without_settled_date_remains_none(db_session):
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="No expectation", amount=Decimal("5.00"),
+        type="expense", status="pending",
+        date=dt.date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+    assert tx.settled_date is None
+
+
+def test_create_rejects_settled_date_before_date():
+    """Schema-level guard: settled_date earlier than date is invalid."""
+    with pytest.raises(PydanticValidationError):
+        TransactionCreate(
+            account_id=1, category_id=1,
+            description="bad", amount=Decimal("1.00"),
+            type="expense", status="pending",
+            date=dt.date(2026, 5, 10),
+            settled_date=dt.date(2026, 5, 1),
+        )
+
+
+async def test_update_pending_row_set_settled_date(db_session):
+    """Setting settled_date on a previously-pending row persists the value."""
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Pending", amount=Decimal("20.00"),
+        type="expense", status="pending",
+        date=dt.date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+    assert tx.settled_date is None
+
+    update = TransactionUpdate(settled_date=dt.date(2026, 6, 1))
+    result = await transaction_service.update_transaction(
+        db_session, org.id, tx.id, update,
+    )
+    assert result.status == TransactionStatus.PENDING
+    assert result.settled_date == dt.date(2026, 6, 1)
+
+
+async def test_update_rejects_settled_date_before_date(db_session):
+    """Service-layer guard against expected-settle < transaction-date."""
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Pending", amount=Decimal("20.00"),
+        type="expense", status="pending",
+        date=dt.date(2026, 5, 10),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+
+    update = TransactionUpdate(settled_date=dt.date(2026, 5, 1))
+    with pytest.raises(ValidationError):
+        await transaction_service.update_transaction(
+            db_session, org.id, tx.id, update,
+        )
+
+
+async def test_update_settled_to_pending_clears_settled_date_without_explicit(db_session):
+    """Flipping settled→pending without supplying a new settled_date clears the
+    historical actual; we don't repurpose a past actual as a future expectation.
+    """
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Was settled", amount=Decimal("30.00"),
+        type="expense", status="settled",
+        date=dt.date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+    assert tx.settled_date == dt.date(2026, 5, 1)
+
+    # Flip without providing a new settled_date.
+    update = TransactionUpdate(status="pending")
+    result = await transaction_service.update_transaction(
+        db_session, org.id, tx.id, update,
+    )
+    assert result.status == TransactionStatus.PENDING
+    assert result.settled_date is None
+
+
+async def test_update_settled_to_pending_with_explicit_settled_date_keeps_it(db_session):
+    """If the caller flips to pending AND supplies a new settled_date, treat
+    the value as the new expected-settlement date (don't drop it on the floor).
+    """
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Was settled", amount=Decimal("30.00"),
+        type="expense", status="settled",
+        date=dt.date(2026, 5, 1),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+
+    update = TransactionUpdate(status="pending", settled_date=dt.date(2026, 6, 1))
+    result = await transaction_service.update_transaction(
+        db_session, org.id, tx.id, update,
+    )
+    assert result.status == TransactionStatus.PENDING
+    assert result.settled_date == dt.date(2026, 6, 1)

--- a/backend/tests/services/test_transaction_settled_date_pending.py
+++ b/backend/tests/services/test_transaction_settled_date_pending.py
@@ -1,6 +1,6 @@
 """Pending-row settled_date semantics (Punch-list Item 13).
 
-PR #163 enforced SETTLED ⇒ settled_date set. This file exercises the new
+PR #163 enforced SETTLED implies settled_date set. This file exercises the new
 contract that PENDING rows MAY carry a non-null settled_date as the
 "expected settlement date" used by ``effective_period_date_expr`` for
 period bucketing in forecasts/filters.
@@ -13,7 +13,7 @@ Coverage:
 - Create rejects settled_date < date at the schema layer.
 - Update a pending row to set settled_date later.
 - Update rejects settled_date < date.
-- Update flipping settled→pending without an explicit settled_date
+- Update flipping settled to pending without an explicit settled_date
   clears the actual settled_date (we don't want to leak the historical
   actual into the "expected" slot).
 """
@@ -88,7 +88,7 @@ async def test_create_pending_with_settled_date_persists(db_session):
     tx = await transaction_service.create_transaction(db_session, org.id, body)
     assert tx.status == TransactionStatus.PENDING
     assert tx.settled_date == dt.date(2026, 6, 15)
-    # Pending row → balance NOT applied.
+    # Pending row -> balance NOT applied.
     await db_session.refresh(acct)
     assert acct.balance == Decimal("0")
 
@@ -169,7 +169,7 @@ async def test_update_rejects_settled_date_before_date(db_session):
 
 
 async def test_update_settled_to_pending_clears_settled_date_without_explicit(db_session):
-    """Flipping settled→pending without supplying a new settled_date clears the
+    """Flipping settled to pending without supplying a new settled_date clears the
     historical actual; we don't repurpose a past actual as a future expectation.
     """
     org, acct, cat = await _seed_org_with_account(db_session)

--- a/backend/tests/services/test_transaction_settled_date_pending.py
+++ b/backend/tests/services/test_transaction_settled_date_pending.py
@@ -210,3 +210,53 @@ async def test_update_settled_to_pending_with_explicit_settled_date_keeps_it(db_
     )
     assert result.status == TransactionStatus.PENDING
     assert result.settled_date == dt.date(2026, 6, 1)
+
+
+async def test_update_pending_clears_settled_date_via_explicit_null(db_session):
+    """Frontend's edit form clears the expected-settlement field by sending
+    settled_date=null. The service must distinguish this from "key omitted"
+    and actually wipe the persisted value (regression: prior code only
+    updated when ``body.settled_date is not None``, silently no-opping).
+    """
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Pending CC", amount=Decimal("99.00"),
+        type="expense", status="pending",
+        date=dt.date(2026, 5, 1), settled_date=dt.date(2026, 6, 15),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+    assert tx.settled_date == dt.date(2026, 6, 15)
+
+    # Caller supplies an explicit null. Pydantic v2 records it in
+    # model_fields_set so the service can tell this from a missing key.
+    update = TransactionUpdate.model_validate({"settled_date": None})
+    result = await transaction_service.update_transaction(
+        db_session, org.id, tx.id, update,
+    )
+    assert result.status == TransactionStatus.PENDING
+    assert result.settled_date is None
+
+
+async def test_update_pending_without_settled_date_key_preserves_value(db_session):
+    """A PUT body that omits ``settled_date`` entirely must NOT touch the
+    persisted value. This is the contrast case to the explicit-null test
+    above and is what protects unrelated edits (e.g. description-only)
+    from accidentally wiping the expected-settlement date.
+    """
+    org, acct, cat = await _seed_org_with_account(db_session)
+    body = TransactionCreate(
+        account_id=acct.id, category_id=cat.id,
+        description="Pending CC", amount=Decimal("99.00"),
+        type="expense", status="pending",
+        date=dt.date(2026, 5, 1), settled_date=dt.date(2026, 6, 15),
+    )
+    tx = await transaction_service.create_transaction(db_session, org.id, body)
+
+    # No settled_date key in the body.
+    update = TransactionUpdate.model_validate({"description": "Renamed"})
+    result = await transaction_service.update_transaction(
+        db_session, org.id, tx.id, update,
+    )
+    assert result.description == "Renamed"
+    assert result.settled_date == dt.date(2026, 6, 15)

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -115,10 +115,10 @@ function TransactionsPageContent() {
   const [formType, setFormType] = useState<"income" | "expense">("expense");
   const [formStatus, setFormStatus] = useState<"settled" | "pending">("settled");
   const [formDate, setFormDate] = useState(todayISO());
-  // Expected settlement date for pending creates. Pre-filled with the
-  // transaction date so the field is always populated when revealed
-  // (status=pending). Users can shift it forward for credit-card-style
-  // settlement lag without first having to discover the field is empty.
+  // Expected settlement date for pending creates. Left empty by default so
+  // the user explicitly picks a settlement date when status=pending; this
+  // keeps credit-card-style settlement lag a deliberate choice instead of
+  // silently inheriting the transaction date.
   const [formSettledDate, setFormSettledDate] = useState("");
   const [formRecurring, setFormRecurring] = useState(false);
   const [formFrequency, setFormFrequency] = useState("monthly");
@@ -507,8 +507,8 @@ function TransactionsPageContent() {
       }
       // Send settled_date only on pending edits. Settled rows keep their
       // existing settled_date untouched (the backend stamps it from the
-      // transition transition); piggy-backing the field would risk
-      // overwriting the server's authoritative value.
+      // transition); piggy-backing the field would risk overwriting the
+      // server's authoritative value.
       if (editStatus === "pending") {
         body.settled_date = editSettledDate || null;
       }

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1186,8 +1186,13 @@ function TransactionsPageContent() {
                             </div>
                           )}
                           <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border-subtle pt-3">
-                            <button onClick={handleSaveEdit} className="min-h-[36px] rounded-md bg-accent px-4 text-sm font-medium text-accent-text hover:bg-accent-hover">Save</button>
-                            <button onClick={closeEdit} className="min-h-[36px] rounded-md border border-border px-4 text-sm text-text-secondary hover:bg-surface-raised">Cancel</button>
+                            {/* 44px touch-target floor matches the mobile edit
+                                form and the project a11y baseline (per PRs
+                                #173/#174). md+ tablet width also lands here, so
+                                36px would land below WCAG 2.5.8 AA (24px) and
+                                comfortably below the project's stricter floor. */}
+                            <button onClick={handleSaveEdit} className="min-h-[44px] rounded-md bg-accent px-4 text-sm font-medium text-accent-text hover:bg-accent-hover">Save</button>
+                            <button onClick={closeEdit} className="min-h-[44px] rounded-md border border-border px-4 text-sm text-text-secondary hover:bg-surface-raised">Cancel</button>
                           </div>
                         </div>
                       ) : (

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -72,6 +72,11 @@ function TransactionsPageContent() {
   const [editType, setEditType] = useState<"income" | "expense">("expense");
   const [editStatus, setEditStatus] = useState<"settled" | "pending">("settled");
   const [editDate, setEditDate] = useState("");
+  // Expected settlement date for pending rows. Empty string means "not set"
+  // and the field is only shown when editStatus === "pending". For settled
+  // rows the backend stamps settled_date itself; surfacing it here would
+  // confuse the spreadsheet/forecast model.
+  const [editSettledDate, setEditSettledDate] = useState("");
   const [editAccountId, setEditAccountId] = useState<number | "">("");
   const [editCategoryId, setEditCategoryId] = useState<number | "">("");
   // Edit-time promote-to-recurring (L3.12). Hidden on rows that are already
@@ -110,6 +115,11 @@ function TransactionsPageContent() {
   const [formType, setFormType] = useState<"income" | "expense">("expense");
   const [formStatus, setFormStatus] = useState<"settled" | "pending">("settled");
   const [formDate, setFormDate] = useState(todayISO());
+  // Expected settlement date for pending creates. Pre-filled with the
+  // transaction date so the field is always populated when revealed
+  // (status=pending) — users can shift it forward for credit-card-style
+  // settlement lag without first having to discover the field is empty.
+  const [formSettledDate, setFormSettledDate] = useState("");
   const [formRecurring, setFormRecurring] = useState(false);
   const [formFrequency, setFormFrequency] = useState("monthly");
   const [formAutoSettle, setFormAutoSettle] = useState(false);
@@ -216,6 +226,18 @@ function TransactionsPageContent() {
   async function handleAdd(e: FormEvent) {
     e.preventDefault();
     setError("");
+    // Inline validation for the optional pending settled-date field. The
+    // backend repeats the check, but matching the message client-side
+    // keeps the form-submit experience snappy and mirror-consistent.
+    if (
+      formMode === "transaction" &&
+      formStatus === "pending" &&
+      formSettledDate &&
+      formSettledDate < formDate
+    ) {
+      setError("Expected settlement date must be on or after the transaction date");
+      return;
+    }
     try {
       if (formMode === "transfer") {
         await apiFetch("/api/v1/transactions/transfer", {
@@ -241,6 +263,11 @@ function TransactionsPageContent() {
             type: formType,
             status: formStatus,
             date: formDate,
+            // settled_date only travels on pending creates; SETTLED rows
+            // get their settled_date stamped server-side from `date`.
+            ...(formStatus === "pending" && formSettledDate
+              ? { settled_date: formSettledDate }
+              : {}),
           }),
         });
         // Promote the new tx to recurring if repeat is enabled. Using
@@ -278,6 +305,7 @@ function TransactionsPageContent() {
       setFormRecurring(false);
       setFormAutoSettle(false);
       setFormDate(todayISO());
+      setFormSettledDate("");
       setShowForm(false);
       await loadTransactions(page);
     } catch (err) {
@@ -399,6 +427,11 @@ function TransactionsPageContent() {
     setEditType(tx.type);
     setEditStatus(tx.status);
     setEditDate(tx.date);
+    // Pre-fill from server settled_date if present (pending rows can carry
+    // an "expected settlement date"); otherwise blank so the user can opt
+    // in. SETTLED rows hide the field entirely so the existing value is
+    // preserved server-side without the form touching it.
+    setEditSettledDate(tx.status === "pending" && tx.settled_date ? tx.settled_date : "");
     setEditAccountId(tx.account_id);
     setEditCategoryId(tx.category_id);
     setEditPromoteRecurring(false);
@@ -432,6 +465,16 @@ function TransactionsPageContent() {
   async function handleSaveEdit() {
     if (editingId === null) return;
     if (!editDesc.trim()) { setError("Description is required"); return; }
+    // Settled-date sanity check matches backend. Only enforced when the
+    // user surfaced the field (pending status with a value entered).
+    if (
+      editStatus === "pending" &&
+      editSettledDate &&
+      editSettledDate < editDate
+    ) {
+      setError("Expected settlement date must be on or after the transaction date");
+      return;
+    }
     setError("");
     // Capture the row pre-save so we can decide whether the promote step
     // applies (transfer legs and already-recurring rows are excluded).
@@ -461,6 +504,13 @@ function TransactionsPageContent() {
       };
       if (!isLinked) {
         body.type = editType;
+      }
+      // Send settled_date only on pending edits. Settled rows keep their
+      // existing settled_date untouched (the backend stamps it from the
+      // transition transition); piggy-backing the field would risk
+      // overwriting the server's authoritative value.
+      if (editStatus === "pending") {
+        body.settled_date = editSettledDate || null;
       }
       await apiFetch(`/api/v1/transactions/${editingId}`, {
         method: "PUT",
@@ -746,6 +796,24 @@ function TransactionsPageContent() {
               <label htmlFor="tx-date" className={label}>Date</label>
               <input id="tx-date" type="date" required value={formDate} onChange={(e) => setFormDate(e.target.value)} className={input} />
             </div>
+            {formMode === "transaction" && formStatus === "pending" && (
+              <div>
+                <label htmlFor="tx-settled-date" className={label}>
+                  Expected settlement date
+                </label>
+                <input
+                  id="tx-settled-date"
+                  type="date"
+                  min={formDate}
+                  value={formSettledDate}
+                  onChange={(e) => setFormSettledDate(e.target.value)}
+                  className={input}
+                />
+                <p className="mt-1 text-[10px] text-text-muted">
+                  Optional. When the bank actually charges the card.
+                </p>
+              </div>
+            )}
             {formMode === "transaction" && (
               <div className="flex items-end gap-4">
                 <label className="flex items-center gap-2 text-sm text-text-secondary">
@@ -953,26 +1021,49 @@ function TransactionsPageContent() {
                       const isTransfer = tx.linked_transaction_id !== null;
                       const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
                       return editingId === tx.id ? (
-                        <div key={tx.id} className="bg-surface-raised">
+                        // Desktop edit mode: switched from a single 12-col row
+                        // (Item 7 audit — Status/Amount cols ~42px clipped both
+                        // the select label and the type/amount split) to a
+                        // labeled stacked form. Fields lay out 4-up so each
+                        // input gets ~22% of the row width — wide enough for
+                        // the descriptive option labels ("Settled"/"Pending",
+                        // "Expense"/"Income") that previously had to be hidden
+                        // behind a !w-14 override.
+                        <div
+                          key={tx.id}
+                          className="bg-surface-raised px-6 py-4"
+                          data-testid={`edit-row-desktop-${tx.id}`}
+                        >
                           {editPartner && (
-                            <div className="px-6 pt-2 pb-1 text-xs text-accent" data-testid={`edit-mirror-notice-${tx.id}`}>
+                            <div className="mb-3 text-xs text-accent" data-testid={`edit-mirror-notice-${tx.id}`}>
                               Editing a transfer leg. Changes to amount apply to both rows.
                             </div>
                           )}
-                          <div className="grid grid-cols-12 items-center gap-2 px-6 py-2">
-                            <span className="col-span-1 flex items-center">
-                              <input
-                                type="checkbox"
-                                aria-label={`Select transaction ${tx.id}`}
-                                checked={selectedIds.has(tx.id)}
-                                onChange={() => toggleOne(tx.id)}
-                                className="h-4 w-4"
-                              />
+                          <div className="flex items-center gap-3 mb-3">
+                            <input
+                              type="checkbox"
+                              aria-label={`Select transaction ${tx.id}`}
+                              checked={selectedIds.has(tx.id)}
+                              onChange={() => toggleOne(tx.id)}
+                              className="h-4 w-4"
+                            />
+                            <span className="text-xs uppercase tracking-wider text-text-muted">
+                              Editing transaction
                             </span>
-                            <span className="col-span-2 min-w-0"><input aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm w-full ${input}`} /></span>
-                            <span className="col-span-2"><input aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} /></span>
-                            <span className="col-span-2">
+                          </div>
+                          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                            <div>
+                              <label htmlFor={`edit-date-${tx.id}`} className={label}>Date</label>
+                              <input id={`edit-date-${tx.id}`} aria-label="Date" type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className={`text-sm ${input}`} />
+                            </div>
+                            <div className="lg:col-span-2">
+                              <label htmlFor={`edit-desc-${tx.id}`} className={label}>Description</label>
+                              <input id={`edit-desc-${tx.id}`} aria-label="Description" type="text" required value={editDesc} onChange={(e) => setEditDesc(e.target.value)} className={`text-sm ${input}`} />
+                            </div>
+                            <div>
+                              <label htmlFor={`edit-account-${tx.id}`} className={label}>Account</label>
                               <select
+                                id={`edit-account-${tx.id}`}
                                 aria-label="Account"
                                 value={editAccountId}
                                 onChange={(e) => setEditAccountId(e.target.value === "" ? "" : Number(e.target.value))}
@@ -987,42 +1078,61 @@ function TransactionsPageContent() {
                                   })
                                   .map((a) => <option key={a.id} value={a.id}>{a.name}{!a.is_active ? " (inactive)" : ""}</option>)}
                               </select>
-                            </span>
-                            <span className="col-span-1 min-w-0">
+                            </div>
+                            <div>
+                              <label htmlFor={`edit-cat-${tx.id}`} className={label}>Category</label>
                               <CategorySelect aria-label="Category" id={`edit-cat-${tx.id}`} categories={categories} value={editCategoryId} onChange={setEditCategoryId} filterType={editType} className={`text-sm ${input}`} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
-                            </span>
-                            <span className="col-span-1">
-                              <select aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-[11px] ${input}`}>
+                            </div>
+                            <div>
+                              <label htmlFor={`edit-status-${tx.id}`} className={label}>Status</label>
+                              <select id={`edit-status-${tx.id}`} aria-label="Status" value={editStatus} onChange={(e) => setEditStatus(e.target.value as "settled" | "pending")} className={`text-sm ${input}`}>
                                 <option value="settled">Settled</option>
                                 <option value="pending">Pending</option>
                               </select>
-                            </span>
-                            <span className="col-span-1 flex gap-1 min-w-0">
+                            </div>
+                            <div>
+                              <label htmlFor={`edit-type-${tx.id}`} className={label}>Type</label>
                               {editPartner ? (
                                 <span
+                                  id={`edit-type-${tx.id}`}
                                   aria-label="Type"
                                   title="Type is fixed for transfer legs."
-                                  className={`text-[11px] !w-10 shrink-0 inline-flex items-center justify-center rounded border border-border bg-surface px-1 text-text-muted`}
+                                  className="text-sm flex items-center px-3 rounded border border-border bg-surface text-text-muted h-10"
                                 >
-                                  {editType === "expense" ? "-" : "+"}
+                                  {editType === "expense" ? "Expense" : "Income"}
                                 </span>
                               ) : (
-                                <select aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-[11px] !w-10 shrink-0 ${input}`}>
-                                  <option value="expense">-</option>
-                                  <option value="income">+</option>
+                                <select id={`edit-type-${tx.id}`} aria-label="Type" value={editType} onChange={(e) => { setEditType(e.target.value as "income" | "expense"); setEditCategoryId(""); }} className={`text-sm ${input}`}>
+                                  <option value="expense">Expense</option>
+                                  <option value="income">Income</option>
                                 </select>
                               )}
-                              <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm flex-1 min-w-0 ${input}`} />
-                            </span>
-                            <span className="col-span-2 flex flex-wrap justify-end gap-x-2 gap-y-1">
-                              <button onClick={handleSaveEdit} className="whitespace-nowrap text-xs text-accent hover:text-accent-hover">Save</button>
-                              <button onClick={closeEdit} className="whitespace-nowrap text-xs text-text-muted hover:text-text-secondary">Cancel</button>
-                            </span>
+                            </div>
+                            <div>
+                              <label htmlFor={`edit-amount-${tx.id}`} className={label}>Amount</label>
+                              <input id={`edit-amount-${tx.id}`} aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm ${input}`} />
+                            </div>
+                            {editStatus === "pending" && (
+                              <div data-testid={`edit-settled-date-cell-${tx.id}`}>
+                                <label htmlFor={`edit-settled-${tx.id}`} className={label}>
+                                  Expected settlement
+                                </label>
+                                <input
+                                  id={`edit-settled-${tx.id}`}
+                                  aria-label="Expected settlement date"
+                                  type="date"
+                                  min={editDate}
+                                  value={editSettledDate}
+                                  onChange={(e) => setEditSettledDate(e.target.value)}
+                                  className={`text-sm ${input}`}
+                                />
+                              </div>
+                            )}
                           </div>
                           {/* Promote-to-recurring (L3.12). Hidden for transfer legs;
                               shown as a static chip when the row is already recurring. */}
                           {!editPartner && (
-                            <div className="px-6 pb-3 pt-1" data-testid={`edit-recurring-row-${tx.id}`}>
+                            <div className="mt-3" data-testid={`edit-recurring-row-${tx.id}`}>
                               {tx.recurring_id !== null ? (
                                 <span
                                   className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-0.5 text-[11px] text-text-muted"
@@ -1075,6 +1185,10 @@ function TransactionsPageContent() {
                               )}
                             </div>
                           )}
+                          <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border-subtle pt-3">
+                            <button onClick={handleSaveEdit} className="min-h-[36px] rounded-md bg-accent px-4 text-sm font-medium text-accent-text hover:bg-accent-hover">Save</button>
+                            <button onClick={closeEdit} className="min-h-[36px] rounded-md border border-border px-4 text-sm text-text-secondary hover:bg-surface-raised">Cancel</button>
+                          </div>
                         </div>
                       ) : (
                         <div
@@ -1101,7 +1215,22 @@ function TransactionsPageContent() {
                               className="h-4 w-4"
                             />
                           </span>
-                          <span className="col-span-2 text-sm tabular-nums text-text-secondary">{tx.date}</span>
+                          <span className="col-span-2 text-sm tabular-nums text-text-secondary">
+                            {tx.date}
+                            {/* Expected settlement subtext (Item 13). Surfaces
+                                only when the row is pending AND the user set a
+                                custom settlement date that differs from the
+                                transaction date — otherwise the subtext would
+                                be redundant noise. */}
+                            {tx.status === "pending" && tx.settled_date && tx.settled_date !== tx.date && (
+                              <span
+                                className="block text-[10px] text-text-muted"
+                                data-testid={`expected-settled-${tx.id}`}
+                              >
+                                expected settled {tx.settled_date}
+                              </span>
+                            )}
+                          </span>
                           <span className="col-span-2 text-sm text-text-primary">{tx.description}</span>
                           <span className="col-span-2 text-sm text-text-secondary truncate">
                             {isTransfer && linkedTx
@@ -1233,6 +1362,19 @@ function TransactionsPageContent() {
                                 <label className={label}>Amount</label>
                                 <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm ${input}`} />
                               </div>
+                              {editStatus === "pending" && (
+                                <div className="sm:col-span-2" data-testid={`edit-settled-date-cell-mobile-${tx.id}`}>
+                                  <label className={label}>Expected settlement date</label>
+                                  <input
+                                    aria-label="Expected settlement date"
+                                    type="date"
+                                    min={editDate}
+                                    value={editSettledDate}
+                                    onChange={(e) => setEditSettledDate(e.target.value)}
+                                    className={`text-sm ${input}`}
+                                  />
+                                </div>
+                              )}
                             </div>
                             {/* Promote-to-recurring (L3.12) — mobile layout. Hidden on
                                 transfer legs; static chip when already recurring. */}
@@ -1334,6 +1476,14 @@ function TransactionsPageContent() {
                               <div className="mt-0.5 text-xs text-text-muted tabular-nums">
                                 {tx.date} · {isTransfer && linkedTx ? <>{tx.account_name} &rarr; {linkedTx.account_name}</> : tx.account_name}
                               </div>
+                              {tx.status === "pending" && tx.settled_date && tx.settled_date !== tx.date && (
+                                <div
+                                  className="mt-0.5 text-[10px] text-text-muted"
+                                  data-testid={`expected-settled-mobile-${tx.id}`}
+                                >
+                                  expected settled {tx.settled_date}
+                                </div>
+                              )}
                             </div>
                             <div className={`shrink-0 text-right text-sm font-semibold tabular-nums ${isTransfer ? "text-accent" : tx.type === "income" ? "text-success" : "text-danger"}`}>
                               {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -117,7 +117,7 @@ function TransactionsPageContent() {
   const [formDate, setFormDate] = useState(todayISO());
   // Expected settlement date for pending creates. Pre-filled with the
   // transaction date so the field is always populated when revealed
-  // (status=pending) — users can shift it forward for credit-card-style
+  // (status=pending). Users can shift it forward for credit-card-style
   // settlement lag without first having to discover the field is empty.
   const [formSettledDate, setFormSettledDate] = useState("");
   const [formRecurring, setFormRecurring] = useState(false);
@@ -1022,10 +1022,10 @@ function TransactionsPageContent() {
                       const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
                       return editingId === tx.id ? (
                         // Desktop edit mode: switched from a single 12-col row
-                        // (Item 7 audit — Status/Amount cols ~42px clipped both
+                        // (Item 7 audit: Status/Amount cols ~42px clipped both
                         // the select label and the type/amount split) to a
                         // labeled stacked form. Fields lay out 4-up so each
-                        // input gets ~22% of the row width — wide enough for
+                        // input gets ~22% of the row width, wide enough for
                         // the descriptive option labels ("Settled"/"Pending",
                         // "Expense"/"Income") that previously had to be hidden
                         // behind a !w-14 override.
@@ -1225,7 +1225,7 @@ function TransactionsPageContent() {
                             {/* Expected settlement subtext (Item 13). Surfaces
                                 only when the row is pending AND the user set a
                                 custom settlement date that differs from the
-                                transaction date — otherwise the subtext would
+                                transaction date. Otherwise the subtext would
                                 be redundant noise. */}
                             {tx.status === "pending" && tx.settled_date && tx.settled_date !== tx.date && (
                               <span

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -164,6 +164,32 @@ describe("TransactionsPage — edit row layout (Punch-list Item 7)", () => {
     const typeLabels = Array.from(desktopType!.options).map((o) => o.textContent);
     expect(typeLabels).toEqual(["Expense", "Income"]);
   });
+
+  it("desktop edit form Save/Cancel meet the 44px touch-target floor", async () => {
+    // Tablet portrait (md+) still receives the desktop layout, so a 36px
+    // tap target would fall below the project a11y baseline shipped in
+    // PRs #173/#174. Mirror the mobile-form action floor here.
+    const tx = makeTx({ id: 71, description: "Touch me" });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Touch me");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    const editRow = await screen.findByTestId("edit-row-desktop-71");
+    const saves = screen.getAllByRole("button", { name: /^Save$/ });
+    const desktopSave = saves.find((el) => editRow.contains(el));
+    expect(desktopSave).toBeTruthy();
+    expect(desktopSave!.className).toMatch(/min-h-\[44px\]/);
+
+    const cancels = screen.getAllByRole("button", { name: /^Cancel$/ });
+    const desktopCancel = cancels.find((el) => editRow.contains(el));
+    expect(desktopCancel).toBeTruthy();
+    expect(desktopCancel!.className).toMatch(/min-h-\[44px\]/);
+  });
 });
 
 describe("TransactionsPage — settled_date (Punch-list Item 13)", () => {

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -1,0 +1,457 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT_A = {
+  id: 100, name: "Checking A", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const CATEGORY_GROCERIES = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+type Tx = {
+  id: number;
+  account_id: number;
+  account_name: string;
+  category_id: number;
+  category_name: string;
+  description: string;
+  amount: number;
+  type: "income" | "expense";
+  status: "settled" | "pending";
+  linked_transaction_id: number | null;
+  recurring_id: number | null;
+  date: string;
+  settled_date: string | null;
+  is_imported: boolean;
+};
+
+function makeTx(over: Partial<Tx> = {}): Tx {
+  return {
+    id: 1,
+    account_id: ACCT_A.id,
+    account_name: ACCT_A.name,
+    category_id: CATEGORY_GROCERIES.id,
+    category_name: CATEGORY_GROCERIES.name,
+    description: "Coffee",
+    amount: 12.5,
+    type: "expense",
+    status: "settled",
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-01",
+    settled_date: null,
+    is_imported: false,
+    ...over,
+  };
+}
+
+function setupApiFetch(txs: Tx[]) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    if (url.startsWith("/api/v1/accounts")) return [ACCT_A] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY_GROCERIES] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) return [] as never;
+    if (url.startsWith("/api/v1/transactions") && method === "GET") return txs as never;
+    if (url === "/api/v1/transactions" && method === "POST") {
+      return { ...makeTx(), id: 999 } as never;
+    }
+    return null as never;
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: USER as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+});
+
+describe("TransactionsPage — edit row layout (Punch-list Item 7)", () => {
+  it("desktop edit form renders all 7 inputs as labeled fields, not a clipped 12-col row", async () => {
+    // Item 7 audit: in the legacy 12-col grid, Status was col-span-1 (~42px)
+    // and Amount was col-span-1, both visibly clipping their inputs. The
+    // rebalanced layout uses a labeled stacked grid (2-up on sm, 4-up on lg)
+    // so each input gets ≥22% of the row width. This test asserts the cell
+    // containers exist and are NOT the legacy single-col-span elements.
+    const tx = makeTx({ id: 70, description: "Edit me", status: "settled" });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Edit me");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    // The new desktop edit row has the data-testid we added.
+    const editRow = await screen.findByTestId("edit-row-desktop-70");
+    expect(editRow).toBeTruthy();
+
+    // Every required edit field is reachable by aria-label and is not a
+    // clipped span — they are <input>/<select> inside their own cell.
+    // Multiple matches expected (desktop + mobile renders both in jsdom).
+    expect(screen.getAllByLabelText("Date").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Description").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Account").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Category").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Status").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Type").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Amount").length).toBeGreaterThan(0);
+
+    // Status select shows full word labels (not glyphs) — this regressed
+    // pre-fix because the col-span-1 width forced abbreviations.
+    const statuses = screen.getAllByLabelText("Status");
+    const desktopStatus = statuses.find((el) =>
+      editRow.contains(el),
+    ) as HTMLSelectElement | undefined;
+    expect(desktopStatus?.tagName).toBe("SELECT");
+    const optionLabels = Array.from(desktopStatus!.options).map((o) => o.textContent);
+    expect(optionLabels).toEqual(["Settled", "Pending"]);
+
+    // Type select shows "Expense"/"Income" full words instead of "-"/"+".
+    const types = screen.getAllByLabelText("Type");
+    const desktopType = types.find((el) => editRow.contains(el)) as
+      | HTMLSelectElement
+      | undefined;
+    expect(desktopType?.tagName).toBe("SELECT");
+    const typeLabels = Array.from(desktopType!.options).map((o) => o.textContent);
+    expect(typeLabels).toEqual(["Expense", "Income"]);
+  });
+});
+
+describe("TransactionsPage — settled_date (Punch-list Item 13)", () => {
+  it("create form: settled date field shown ONLY when status=pending", async () => {
+    setupApiFetch([]);
+    render(<TransactionsPage />);
+
+    // Default status=settled → field hidden.
+    fireEvent.click(await screen.findByRole("button", { name: /\+ New Transaction/i }));
+    expect(screen.queryByLabelText(/Expected settlement/i)).toBeNull();
+
+    // Switch to pending → field appears.
+    const status = screen.getByLabelText("Status") as HTMLSelectElement;
+    fireEvent.change(status, { target: { value: "pending" } });
+    expect(screen.getByLabelText(/Expected settlement/i)).toBeTruthy();
+
+    // Back to settled → hidden again.
+    fireEvent.change(status, { target: { value: "settled" } });
+    expect(screen.queryByLabelText(/Expected settlement/i)).toBeNull();
+  });
+
+  it("create form: posts settled_date when pending + value entered", async () => {
+    setupApiFetch([]);
+    render(<TransactionsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /\+ New Transaction/i }));
+
+    await waitFor(() => {
+      const acct = screen.getByLabelText(/^Account$/i) as HTMLSelectElement;
+      expect(acct.value).not.toBe("");
+    });
+
+    // Fill required fields (account is auto-selected from the default).
+    fireEvent.change(screen.getByLabelText(/Description/i), {
+      target: { value: "CC purchase" },
+    });
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "42" },
+    });
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "pending" },
+    });
+    fireEvent.change(screen.getByLabelText("Date"), {
+      target: { value: "2026-05-01" },
+    });
+    const expectedField = screen.getByLabelText(/Expected settlement/i);
+    fireEvent.change(expectedField, { target: { value: "2026-06-15" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Transaction/i }));
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    await waitFor(() => {
+      const post = apiFetchMock.mock.calls.find(
+        (c) =>
+          c[0] === "/api/v1/transactions" &&
+          (c[1] as RequestInit | undefined)?.method === "POST",
+      );
+      expect(post).toBeTruthy();
+    });
+    const post = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions" &&
+        (c[1] as RequestInit | undefined)?.method === "POST",
+    )!;
+    const body = JSON.parse((post[1] as RequestInit).body as string);
+    expect(body.settled_date).toBe("2026-06-15");
+    expect(body.status).toBe("pending");
+  });
+
+  it("create form: rejects settled_date earlier than transaction date inline", async () => {
+    setupApiFetch([]);
+    render(<TransactionsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /\+ New Transaction/i }));
+
+    // Wait for the default-account auto-fill effect to run so the required
+    // Account select is populated. Without this, jsdom's native HTML5
+    // validation blocks form submit before our handler runs.
+    await waitFor(() => {
+      const acct = screen.getByLabelText(/^Account$/i) as HTMLSelectElement;
+      expect(acct.value).not.toBe("");
+    });
+
+    fireEvent.change(screen.getByLabelText(/Description/i), {
+      target: { value: "Bad date" },
+    });
+    fireEvent.change(screen.getByLabelText("Amount"), { target: { value: "10" } });
+    fireEvent.change(screen.getByLabelText("Date"), {
+      target: { value: "2026-05-10" },
+    });
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "pending" },
+    });
+    fireEvent.change(screen.getByLabelText(/Expected settlement/i), {
+      target: { value: "2026-05-01" }, // before the date
+    });
+
+    // Submit the form directly. jsdom's HTML5 validation on the form's
+    // required fields runs on click-submit and can pre-empt our handler;
+    // dispatching `submit` exercises the same code path React listens to.
+    const form = screen.getByRole("button", { name: /Add Transaction/i }).closest("form")!;
+    fireEvent.submit(form);
+
+    // Inline error renders. The submit must NOT have called POST.
+    expect(
+      await screen.findByText(/must be on or after the transaction date/i),
+    ).toBeTruthy();
+    const apiFetchMock = vi.mocked(apiFetch);
+    const post = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions" &&
+        (c[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(post).toBeUndefined();
+  });
+
+  it("edit form: settled date pre-fills from server when pending row already has one", async () => {
+    const tx = makeTx({
+      id: 80,
+      description: "Pending CC",
+      status: "pending",
+      date: "2026-05-01",
+      settled_date: "2026-06-10",
+    });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending CC");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
+        0,
+      );
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    const inputs = await screen.findAllByLabelText(/Expected settlement/i);
+    expect((inputs[0] as HTMLInputElement).value).toBe("2026-06-10");
+  });
+
+  it("edit form: PUT body includes settled_date when status=pending and value set", async () => {
+    const tx = makeTx({
+      id: 81,
+      description: "Pending CC",
+      status: "pending",
+      date: "2026-05-01",
+      settled_date: null,
+    });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending CC");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
+        0,
+      );
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    const expectedFields = await screen.findAllByLabelText(/Expected settlement/i);
+    fireEvent.change(expectedFields[0], { target: { value: "2026-06-15" } });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Save$/i })[0]);
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    await waitFor(() => {
+      const put = apiFetchMock.mock.calls.find(
+        (c) =>
+          c[0] === "/api/v1/transactions/81" &&
+          (c[1] as RequestInit | undefined)?.method === "PUT",
+      );
+      expect(put).toBeTruthy();
+    });
+    const put = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions/81" &&
+        (c[1] as RequestInit | undefined)?.method === "PUT",
+    )!;
+    const body = JSON.parse((put[1] as RequestInit).body as string);
+    expect(body.settled_date).toBe("2026-06-15");
+    expect(body.status).toBe("pending");
+  });
+
+  it("edit form: settled_date NOT sent when row stays settled", async () => {
+    const tx = makeTx({
+      id: 82,
+      description: "Plain settled",
+      status: "settled",
+      date: "2026-05-01",
+      settled_date: "2026-05-01",
+    });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Plain settled");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
+        0,
+      );
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    // Field is hidden when settled.
+    expect(screen.queryByLabelText(/Expected settlement/i)).toBeNull();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Save$/i })[0]);
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    await waitFor(() => {
+      const put = apiFetchMock.mock.calls.find(
+        (c) =>
+          c[0] === "/api/v1/transactions/82" &&
+          (c[1] as RequestInit | undefined)?.method === "PUT",
+      );
+      expect(put).toBeTruthy();
+    });
+    const put = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions/82" &&
+        (c[1] as RequestInit | undefined)?.method === "PUT",
+    )!;
+    const body = JSON.parse((put[1] as RequestInit).body as string);
+    expect(body).not.toHaveProperty("settled_date");
+  });
+
+  it("view row: shows 'expected settled YYYY-MM-DD' subtext on pending rows", async () => {
+    const tx = makeTx({
+      id: 90,
+      description: "Pending CC",
+      status: "pending",
+      date: "2026-05-01",
+      settled_date: "2026-06-15",
+    });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending CC");
+    // Subtext renders in both desktop + mobile views.
+    const subtexts = await screen.findAllByText(/expected settled 2026-06-15/);
+    expect(subtexts.length).toBeGreaterThan(0);
+  });
+
+  it("view row: subtext hidden when settled_date matches transaction date (would be redundant)", async () => {
+    const tx = makeTx({
+      id: 91,
+      description: "Pending same date",
+      status: "pending",
+      date: "2026-05-01",
+      settled_date: "2026-05-01",
+    });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending same date");
+    expect(screen.queryByText(/expected settled/i)).toBeNull();
+  });
+
+  it("edit form: rejects settled_date earlier than transaction date inline", async () => {
+    const tx = makeTx({
+      id: 92,
+      description: "Pending edit bad",
+      status: "pending",
+      date: "2026-05-10",
+      settled_date: null,
+    });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending edit bad");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
+        0,
+      );
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    const expectedFields = await screen.findAllByLabelText(/Expected settlement/i);
+    fireEvent.change(expectedFields[0], { target: { value: "2026-05-01" } });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Save$/i })[0]);
+
+    expect(
+      await screen.findByText(/must be on or after the transaction date/i),
+    ).toBeTruthy();
+    // No PUT should have fired.
+    const apiFetchMock = vi.mocked(apiFetch);
+    const put = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions/92" &&
+        (c[1] as RequestInit | undefined)?.method === "PUT",
+    );
+    expect(put).toBeUndefined();
+  });
+});

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import TransactionsPage from "@/app/transactions/page";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
+import { waitForStableTxList } from "../utils/wait-for-stable-tx-list";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -124,10 +125,7 @@ describe("TransactionsPage - edit row layout (Punch-list Item 7)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Edit me");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     // The new desktop edit row has the data-testid we added.
@@ -173,10 +171,7 @@ describe("TransactionsPage - edit row layout (Punch-list Item 7)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Touch me");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     const editRow = await screen.findByTestId("edit-row-desktop-71");
@@ -315,12 +310,7 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Pending CC");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
-        0,
-      );
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     const inputs = await screen.findAllByLabelText(/Expected settlement/i);
@@ -338,12 +328,7 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Pending CC");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
-        0,
-      );
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     const expectedFields = await screen.findAllByLabelText(/Expected settlement/i);
@@ -381,12 +366,7 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Plain settled");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
-        0,
-      );
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     // Field is hidden when settled.
@@ -460,10 +440,7 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Pending CC clearable");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     // Pre-fill confirms the wired-from-server path.
@@ -508,12 +485,7 @@ describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Pending edit bad");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(
-        0,
-      );
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     const expectedFields = await screen.findAllByLabelText(/Expected settlement/i);

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -418,6 +418,59 @@ describe("TransactionsPage — settled_date (Punch-list Item 13)", () => {
     expect(screen.queryByText(/expected settled/i)).toBeNull();
   });
 
+  it("edit form: clearing the expected-settlement input sends settled_date: null (not omitted)", async () => {
+    // Regression: the frontend used to send the field when set, but on clear
+    // the empty-string -> ?? -> undefined path made the JSON body OMIT the
+    // key. Combined with a backend that only updated on non-null, clearing
+    // was a silent no-op. The frontend now sends explicit null on clear so
+    // the backend can wipe the persisted value.
+    const tx = makeTx({
+      id: 95,
+      description: "Pending CC clearable",
+      status: "pending",
+      date: "2026-05-01",
+      settled_date: "2026-06-15",
+    });
+    setupApiFetch([tx]);
+    render(<TransactionsPage />);
+
+    await screen.findAllByText("Pending CC clearable");
+    await waitFor(() => {
+      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
+
+    // Pre-fill confirms the wired-from-server path.
+    const expectedFields = await screen.findAllByLabelText(/Expected settlement/i);
+    expect((expectedFields[0] as HTMLInputElement).value).toBe("2026-06-15");
+
+    // Clear the field.
+    fireEvent.change(expectedFields[0], { target: { value: "" } });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Save$/i })[0]);
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    await waitFor(() => {
+      const put = apiFetchMock.mock.calls.find(
+        (c) =>
+          c[0] === "/api/v1/transactions/95" &&
+          (c[1] as RequestInit | undefined)?.method === "PUT",
+      );
+      expect(put).toBeTruthy();
+    });
+    const put = apiFetchMock.mock.calls.find(
+      (c) =>
+        c[0] === "/api/v1/transactions/95" &&
+        (c[1] as RequestInit | undefined)?.method === "PUT",
+    )!;
+    const body = JSON.parse((put[1] as RequestInit).body as string);
+    // The key MUST be present and explicitly null. Asserting "in" plus a
+    // strict-null check guards against a future regression where the
+    // frontend silently drops the key when the input is empty.
+    expect("settled_date" in body).toBe(true);
+    expect(body.settled_date).toBeNull();
+  });
+
   it("edit form: rejects settled_date earlier than transaction date inline", async () => {
     const tx = makeTx({
       id: 92,

--- a/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
+++ b/frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx
@@ -113,12 +113,12 @@ beforeEach(() => {
   });
 });
 
-describe("TransactionsPage — edit row layout (Punch-list Item 7)", () => {
+describe("TransactionsPage - edit row layout (Punch-list Item 7)", () => {
   it("desktop edit form renders all 7 inputs as labeled fields, not a clipped 12-col row", async () => {
     // Item 7 audit: in the legacy 12-col grid, Status was col-span-1 (~42px)
     // and Amount was col-span-1, both visibly clipping their inputs. The
     // rebalanced layout uses a labeled stacked grid (2-up on sm, 4-up on lg)
-    // so each input gets ≥22% of the row width. This test asserts the cell
+    // so each input gets >=22% of the row width. This test asserts the cell
     // containers exist and are NOT the legacy single-col-span elements.
     const tx = makeTx({ id: 70, description: "Edit me", status: "settled" });
     setupApiFetch([tx]);
@@ -135,7 +135,7 @@ describe("TransactionsPage — edit row layout (Punch-list Item 7)", () => {
     expect(editRow).toBeTruthy();
 
     // Every required edit field is reachable by aria-label and is not a
-    // clipped span — they are <input>/<select> inside their own cell.
+    // clipped span. They are <input>/<select> inside their own cell.
     // Multiple matches expected (desktop + mobile renders both in jsdom).
     expect(screen.getAllByLabelText("Date").length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Description").length).toBeGreaterThan(0);
@@ -145,7 +145,7 @@ describe("TransactionsPage — edit row layout (Punch-list Item 7)", () => {
     expect(screen.getAllByLabelText("Type").length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Amount").length).toBeGreaterThan(0);
 
-    // Status select shows full word labels (not glyphs) — this regressed
+    // Status select shows full word labels (not glyphs); this regressed
     // pre-fix because the col-span-1 width forced abbreviations.
     const statuses = screen.getAllByLabelText("Status");
     const desktopStatus = statuses.find((el) =>
@@ -192,21 +192,21 @@ describe("TransactionsPage — edit row layout (Punch-list Item 7)", () => {
   });
 });
 
-describe("TransactionsPage — settled_date (Punch-list Item 13)", () => {
+describe("TransactionsPage - settled_date (Punch-list Item 13)", () => {
   it("create form: settled date field shown ONLY when status=pending", async () => {
     setupApiFetch([]);
     render(<TransactionsPage />);
 
-    // Default status=settled → field hidden.
+    // Default status=settled -> field hidden.
     fireEvent.click(await screen.findByRole("button", { name: /\+ New Transaction/i }));
     expect(screen.queryByLabelText(/Expected settlement/i)).toBeNull();
 
-    // Switch to pending → field appears.
+    // Switch to pending -> field appears.
     const status = screen.getByLabelText("Status") as HTMLSelectElement;
     fireEvent.change(status, { target: { value: "pending" } });
     expect(screen.getByLabelText(/Expected settlement/i)).toBeTruthy();
 
-    // Back to settled → hidden again.
+    // Back to settled -> hidden again.
     fireEvent.change(status, { target: { value: "settled" } });
     expect(screen.queryByLabelText(/Expected settlement/i)).toBeNull();
   });

--- a/frontend/tests/app/transactions-promote-recurring.test.tsx
+++ b/frontend/tests/app/transactions-promote-recurring.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import TransactionsPage from "@/app/transactions/page";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
+import { waitForStableTxList } from "../utils/wait-for-stable-tx-list";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -112,33 +113,6 @@ beforeEach(() => {
     refreshMe: vi.fn(),
   });
 });
-
-// The transactions page issues two fetches at mount: loadRefs (which
-// updates `periods`) and loadTransactions. Because loadTransactions
-// depends on `periods`, the second setPeriods call (even to the same
-// empty array) re-triggers loadTransactions, briefly flipping the
-// `fetching` flag back to true and replacing the table with a Spinner.
-// Tests that race past the spinner can land between Edit-button clicks
-// and the post-spinner re-render, dropping the just-set editingId.
-// This helper waits for the GET /api/v1/transactions call to have
-// happened at least twice (initial + post-loadRefs re-fetch) AND for
-// the Edit buttons to be present, so subsequent clicks aren't clobbered.
-async function waitForStableTxList() {
-  const apiFetchMock = vi.mocked(apiFetch);
-  await waitFor(() => {
-    const txGetCalls = apiFetchMock.mock.calls.filter(
-      (c) =>
-        typeof c[0] === "string" &&
-        (c[0] as string).startsWith("/api/v1/transactions") &&
-        ((c[1] as RequestInit | undefined)?.method ?? "GET") === "GET",
-    );
-    expect(txGetCalls.length).toBeGreaterThanOrEqual(2);
-    expect(screen.queryByRole("status", { name: /loading/i })).toBeNull();
-    expect(
-      screen.queryAllByRole("button", { name: /^Edit:/ }).length,
-    ).toBeGreaterThan(0);
-  });
-}
 
 describe("TransactionsPage — promote to recurring (L3.12)", () => {
   it("non-recurring row: toggle reveals frequency + next-due-date inputs", async () => {

--- a/frontend/tests/app/transactions-promote-recurring.test.tsx
+++ b/frontend/tests/app/transactions-promote-recurring.test.tsx
@@ -113,16 +113,40 @@ beforeEach(() => {
   });
 });
 
+// The transactions page issues two fetches at mount: loadRefs (which
+// updates `periods`) and loadTransactions. Because loadTransactions
+// depends on `periods`, the second setPeriods call (even to the same
+// empty array) re-triggers loadTransactions, briefly flipping the
+// `fetching` flag back to true and replacing the table with a Spinner.
+// Tests that race past the spinner can land between Edit-button clicks
+// and the post-spinner re-render, dropping the just-set editingId.
+// This helper waits for the GET /api/v1/transactions call to have
+// happened at least twice (initial + post-loadRefs re-fetch) AND for
+// the Edit buttons to be present, so subsequent clicks aren't clobbered.
+async function waitForStableTxList() {
+  const apiFetchMock = vi.mocked(apiFetch);
+  await waitFor(() => {
+    const txGetCalls = apiFetchMock.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).startsWith("/api/v1/transactions") &&
+        ((c[1] as RequestInit | undefined)?.method ?? "GET") === "GET",
+    );
+    expect(txGetCalls.length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByRole("status", { name: /loading/i })).toBeNull();
+    expect(
+      screen.queryAllByRole("button", { name: /^Edit:/ }).length,
+    ).toBeGreaterThan(0);
+  });
+}
+
 describe("TransactionsPage — promote to recurring (L3.12)", () => {
   it("non-recurring row: toggle reveals frequency + next-due-date inputs", async () => {
     const tx = makeTx({ id: 70, description: "Promo me" });
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Promo me");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     // Toggle present, frequency + date hidden by default.
@@ -148,10 +172,7 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
     });
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Save me");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     // Tick the recurring toggle on the desktop layout (first match).
@@ -226,10 +247,7 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
 
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Partial save");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     fireEvent.click(screen.getAllByLabelText("Make recurring")[0]);
@@ -261,10 +279,7 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
     });
     render(<TransactionsPage />);
 
-    await screen.findAllByText("No promote");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
     fireEvent.click(screen.getAllByRole("button", { name: /^Save$/i })[0]);
 
@@ -291,10 +306,7 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
     setupApiFetch([tx]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Already promo");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     // Chip rendered (desktop + mobile each render once).
@@ -463,10 +475,7 @@ describe("TransactionsPage — promote to recurring (L3.12)", () => {
     setupApiFetch([expenseLeg, incomeLeg]);
     render(<TransactionsPage />);
 
-    await screen.findAllByText("Linked out");
-    await waitFor(() => {
-      expect(screen.queryAllByRole("button", { name: /^Edit:/ }).length).toBeGreaterThan(0);
-    });
+    await waitForStableTxList();
     fireEvent.click(screen.getAllByRole("button", { name: /^Edit:/ })[0]);
 
     // Mirror notice present (sanity: we are in the linked edit path).

--- a/frontend/tests/utils/wait-for-stable-tx-list.ts
+++ b/frontend/tests/utils/wait-for-stable-tx-list.ts
@@ -1,0 +1,36 @@
+import { screen, waitFor } from "@testing-library/react";
+
+import { apiFetch } from "@/lib/api";
+
+/**
+ * The transactions page issues two fetches at mount: loadRefs (which
+ * updates `periods`) and loadTransactions. Because loadTransactions
+ * depends on `periods`, the second setPeriods call (even to the same
+ * empty array) re-triggers loadTransactions, briefly flipping the
+ * `fetching` flag back to true and replacing the table with a Spinner.
+ * Tests that race past the spinner can land between Edit-button clicks
+ * and the post-spinner re-render, dropping the just-set editingId.
+ *
+ * This helper waits for the GET /api/v1/transactions call to have
+ * happened at least twice (initial + post-loadRefs re-fetch) AND for
+ * the Edit buttons to be present, so subsequent clicks aren't clobbered.
+ *
+ * Callers must have `vi.mock("@/lib/api", ...)` in scope so that the
+ * imported `apiFetch` here is the same mocked function the test wires up.
+ */
+export async function waitForStableTxList(): Promise<void> {
+  const apiFetchMock = vi.mocked(apiFetch);
+  await waitFor(() => {
+    const txGetCalls = apiFetchMock.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).startsWith("/api/v1/transactions") &&
+        ((c[1] as RequestInit | undefined)?.method ?? "GET") === "GET",
+    );
+    expect(txGetCalls.length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByRole("status", { name: /loading/i })).toBeNull();
+    expect(
+      screen.queryAllByRole("button", { name: /^Edit:/ }).length,
+    ).toBeGreaterThan(0);
+  });
+}


### PR DESCRIPTION
## Problem

**Punch-list Item 7 - Edit row column widths.** The 12-column grid that powers the transactions list reuses the same template for view AND edit modes. Edit-control widths (date inputs, status selects, amount fields) are wider than view-mode text, so the cramped 1/12 cells (~42 px) clip Status, Amount, and Type. The Type select was hacked around with `!w-14` and showed only `-` / `+` glyphs because there was no room for "Expense" / "Income". The 2026-05-09 screenshot review confirmed the regression.

**Punch-list Item 13 - Expected settlement date for pending.** PR #163 enforced the SETTLED implies settled_date invariant and PR #157 used `effective_period_date_expr` (= `coalesce(settled_date, date)`) to bucket rows into billing periods. The backend was therefore already prepared to use `settled_date` as an "expected settlement date" for PENDING rows, but the create + edit form UIs never exposed the field, so users couldn't tell the system when a credit-card charge would settle.

## Implementation summary

### Item 7 - desktop edit row rebalance
- Replaced the cramped single-row grid with a labeled stacked form (2-up on `sm`, 4-up on `lg`). Every input gets at least 22% of the row width.
- Status select now shows full word labels (Settled / Pending); was forced to abbreviate.
- Type select now shows Expense / Income; was a `!w-14` glyph hack.
- Description spans 2/4 columns on `lg` so it never clips at typical merchant-name widths.
- Save / Cancel pinned to a dedicated action bar with 44 px touch-target floor (matches mobile + the project a11y baseline shipped in PRs #173/#174).
- View mode: untouched. Mobile edit form: extended to surface settled_date but otherwise unchanged.

### Item 13 - settled_date wiring
**Backend**
- `TransactionCreate` accepts an optional `settled_date` with a cross-field validator (`settled_date >= date`).
- `_create_transaction_no_commit` resolves settled_date as: SETTLED -> caller value or `date` fallback; PENDING -> caller value or `None`.
- `update_transaction` distinguishes "field omitted" from "explicit null" via Pydantic v2's `model_fields_set` so the edit form can clear the expected-settlement value (regression fix; previously the clear was a silent no-op). Preserves explicit `settled_date` on pending rows and validates `settled_date >= date` against the post-update row.

**Frontend**
- Create form: shows "Expected settlement date" only when `status === "pending"`; the `min` attribute is bound to the transaction date.
- Edit form: same field, pre-fills from server when set, hides on settled rows so the form doesn't accidentally overwrite the historical actual. Sends explicit `null` on clear so the backend can wipe the value.
- View row: pending rows show `expected settled YYYY-MM-DD` muted subtext under the date when settled_date differs from date (suppressed when equal, which would be redundant noise).
- Inline validation on both forms: rejects settled_date earlier than the transaction date with a clear message.

## Files changed

```
backend/app/schemas/transaction.py
backend/app/services/transaction_service.py
backend/tests/schemas/test_transfer_schemas.py
backend/tests/services/test_transaction_settled_date_pending.py     (new)
frontend/app/transactions/page.tsx
frontend/tests/app/transactions-edit-layout-and-settled-date.test.tsx (new)
frontend/tests/app/transactions-promote-recurring.test.tsx          (race fix)
```

## Tests run

- `docker compose -p team-197-correct exec backend pytest tests/services/test_transaction_settled_date_pending.py tests/schemas/test_transfer_schemas.py tests/services/test_transaction_service_edit_linked.py tests/services/test_transaction_service_pair.py tests/test_settled_invariant.py`: **70 passed**.
- `docker compose -p team-tx-layout exec frontend npx vitest run`: **323 passed** (full suite, 3 consecutive runs all green).
- `docker compose -p team-tx-layout exec frontend npx vitest run transactions-promote-recurring`: **8 passed** (15 consecutive runs, post race fix).
- `docker compose exec frontend npx tsc --noEmit` on `app/transactions/page.tsx`: clean.

## Before / After screenshots

Captured against a fresh local stack with three test rows (settled, pending with custom expected settlement, pending without).

| Viewport | State | File |
|----------|-------|------|
| Desktop (1280x900) | Edit pending - BEFORE (main) | `.playwright-mcp/team-tx-layout/before-desktop-edit-pending.png` |
| Desktop (1280x900) | Edit pending - AFTER  | `.playwright-mcp/team-tx-layout/after-desktop-edit-pending.png` |
| Desktop (1280x900) | Edit settled - AFTER (settled_date hidden) | `.playwright-mcp/team-tx-layout/after-desktop-edit-settled.png` |
| Desktop (1280x900) | Create pending - AFTER (settled_date visible) | `.playwright-mcp/team-tx-layout/after-desktop-create-pending.png` |
| Desktop (1280x900) | View mode - AFTER (Amazon row shows "expected settled 2026-06-15") | `.playwright-mcp/team-tx-layout/after-desktop-view-mode.png` |
| Mobile (390x844)  | Edit pending - BEFORE (main) | `.playwright-mcp/team-tx-layout/before-mobile-edit-pending.png` |
| Mobile (390x844)  | Edit pending - AFTER | `.playwright-mcp/team-tx-layout/after-mobile-edit-pending.png` |
| Mobile (390x844)  | View mode - AFTER | `.playwright-mcp/team-tx-layout/after-mobile-view-mode.png` |

Before-desktop visually demonstrates the audit findings: Description clipped to "Amazon CC purchas", Category to "Debt Re", Type select reduced to a stray dropdown arrow with no glyph visible, Amount field empty (the `129.99` is invisible inside its 1/12 column).

## Corrections applied (review round 1)

External review surfaced four blocking findings on the initial push. Each is now addressed:

1. **Frontend CI flake on `transactions-promote-recurring.test.tsx`** -> root-caused to a fetch-cycle race. The page re-runs `loadTransactions` after `loadRefs` updates `periods` (deps change), briefly swapping the row list for a Spinner. Tests that polled `queryAllByRole(Edit:)` could land between the spinner and steady state. Added a `waitForStableTxList()` helper that gates on (a) `apiFetch` having been invoked at least twice for `/api/v1/transactions` and (b) no `role="status"` Spinner in the DOM. 15 consecutive isolated runs + 3 consecutive full-suite runs all green.

2. **Expected settlement date could not be cleared.** The edit form sent `settled_date: null` on clear, but the backend only updated when `body.settled_date is not None`, so explicit-null was a silent no-op. Switched to Pydantic v2's `model_fields_set` to distinguish "omitted" from "explicit null" while preserving the existing semantics for omitted-key edits (so unrelated PUTs don't accidentally wipe the field). Two new backend tests pin both behaviors; one new frontend test asserts the request body includes `settled_date: null` (key present, value null) on clear.

3. **44 px touch-target floor on Save/Cancel.** Desktop edit-form action buttons used `min-h-[36px]` which fell below the project a11y baseline (PRs #173/#174). Tablet portrait (md+) sees this layout, so 36 px was a regression there. Bumped to `min-h-[44px]` to match mobile + project standard. New class-presence test on the desktop Save and Cancel buttons.

4. **Non-ASCII sweep on PR-introduced content.** Replaced em-dashes with hyphens/commas/parens, smart-quote variants with straight, and arrow glyphs with `->` in the new comments and docstrings introduced by this PR. PR body cleaned in this same edit. Existing non-ASCII in untouched lines was left alone per scope.

## Merge gate

Merge gate: independent. Sort/Filters Persistence and FAB teams will rebase onto this PR after it lands.

## Internal reviewers

@flamarion (architect)

External review required before merge.
