### PR TITLE
chore(dev): harden migration paths against worktree shared-state drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,25 @@ docker compose exec frontend npm test -- tests/...
 docker compose exec frontend npx tsc --noEmit
 ```
 
+### Running backend tests in parallel agent sessions
+
+When dispatched as a parallel agent, NEVER run backend tests against the user's
+default `pfv` docker compose stack. Always use an isolated compose project:
+
+```bash
+docker compose -p team-<unique-name> up -d backend mysql redis
+docker compose -p team-<unique-name> exec backend pytest tests/...
+```
+
+Every `compose` and `docker exec` call must carry the same `-p team-<name>`
+flag, on every command in the session. A single command that omits it falls
+back to the default `pfv` project name and will write to the user's MySQL
+volume. See `~/.claude/projects/-Users-fjorge-src-pfv/memory/reference_shared_mysql_volume_trap.md`
+for the 2026-05-09 incident this rule prevents.
+
+`./pfv migrate` is for the user's local stack only. Do not invoke it from an
+agent session; it has no `-p` flag and always targets the default project.
+
 ## Seeding
 
 For a repeatable local dataset (accounts, transactions, budgets, recurring templates), run `./pfv seed`. See the Seeding Mock Data section of CONTRIBUTING.md for the full workflow and the `SEED_*` environment variables that let you customize the seeded user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,17 @@ for the 2026-05-09 incident this rule prevents.
 `./pfv migrate` is for the user's local stack only. Do not invoke it from an
 agent session; it has no `-p` flag and always targets the default project.
 
+### Lifespan migration branch guard
+
+`./pfv start`, `./pfv restart`, and `./pfv rebuild` boot the backend, whose
+FastAPI lifespan calls `_run_migrations()` against the shared MySQL volume in
+dev. To prevent the same drift class `./pfv migrate`'s CLI guard catches, the
+lifespan reads `/app/.git/HEAD` and refuses to migrate when the host checkout
+is on a non-main branch (or is detached / unreadable). If you genuinely need
+to run lifespan migrations from a feature branch in dev, set
+`PFV_MIGRATE_OK_OFF_MAIN=1` in `.env` or the shell. Default is to refuse,
+since the same env var name pairs with `./pfv migrate`'s CLI guard.
+
 ## Seeding
 
 For a repeatable local dataset (accounts, transactions, budgets, recurring templates), run `./pfv seed`. See the Seeding Mock Data section of CONTRIBUTING.md for the full workflow and the `SEED_*` environment variables that let you customize the seeded user.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,9 +46,102 @@ async def _backfill_subscriptions() -> None:
             await logger.ainfo("backfilled subscriptions", count=len(org_ids))
 
 
-def _run_migrations() -> None:
+_ALEMBIC_INI_PATH = "/app/alembic.ini"
+
+
+def _resolve_alembic_head() -> str:
+    """Return the head revision recorded in the alembic versions tree.
+
+    Uses the alembic Python API directly (no subprocess) so this stays
+    cheap enough to call on every dev boot. Returns "unknown" if anything
+    goes wrong; we never want diagnostic logging to gate startup.
+    """
+    try:
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        cfg = Config(_ALEMBIC_INI_PATH)
+        script = ScriptDirectory.from_config(cfg)
+        heads = script.get_heads()
+        if len(heads) == 1:
+            return heads[0]
+        # Multi-head or no heads: surface the raw shape rather than guess.
+        return ",".join(heads) if heads else "unknown"
+    except Exception:
+        return "unknown"
+
+
+async def _resolve_alembic_current() -> str:
+    """Return the alembic_version row from the live DB.
+
+    Direct SQL via the existing async engine, far cheaper than spinning
+    up a separate alembic context. Returns "unknown" on any error so a
+    log line is still emitted; the actual upgrade run will surface real
+    failures. Returns "none" if alembic_version is empty (fresh DB).
+    """
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                text("SELECT version_num FROM alembic_version LIMIT 1")
+            )
+            row = result.first()
+            if row is None:
+                return "none"
+            return str(row[0])
+    except Exception:
+        return "unknown"
+
+
+def _resolve_git_branch() -> str:
+    """Best-effort current git branch for diagnostic logging.
+
+    The dev container is bind-mounted from the host worktree, so
+    /app/.git resolves to the user's checkout. Falls back to "unknown"
+    if git isn't available or the repo can't be read.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or "unknown"
+    except Exception:
+        pass
+    return "unknown"
+
+
+async def _run_migrations() -> None:
     """Run Alembic migrations on startup. Idempotent — alembic upgrade head
-    is a no-op when already at the latest revision."""
+    is a no-op when already at the latest revision.
+
+    Logs the resolved head + current revision (and best-effort git branch)
+    before invoking alembic so the next drift incident has a breadcrumb
+    pointing at exactly which revision the lifespan was targeting. Skips
+    the subprocess entirely when current == head.
+    """
+    head = _resolve_alembic_head()
+    current = await _resolve_alembic_current()
+    branch = _resolve_git_branch()
+
+    if current == head and head != "unknown":
+        logger.info(
+            "migrate.dev.no_op",
+            current_revision=current,
+            head_revision=head,
+            branch=branch,
+        )
+        return
+
+    logger.info(
+        "migrate.dev.target",
+        current_revision=current,
+        head_revision=head,
+        branch=branch,
+    )
+
     result = subprocess.run(
         ["alembic", "upgrade", "head"],
         capture_output=True,
@@ -67,7 +160,7 @@ async def lifespan(app: FastAPI):
     # equivalent — the alternative is a manual `./pfv migrate` after every
     # rebuild.
     if app_settings.app_env != "production":
-        _run_migrations()
+        await _run_migrations()
     await _backfill_subscriptions()
     await logger.ainfo("starting", app=app_settings.app_name, env=app_settings.app_env)
     yield

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -108,7 +108,7 @@ def _detect_branch() -> str | None:
         or anything else goes wrong (worktree gitdir indirection,
         permissions, etc.)
 
-    Callers MUST treat None as "couldn't tell" — the lifespan guard
+    Callers MUST treat None as "couldn't tell" - the lifespan guard
     refuses to migrate in that case so we fail closed, not open.
     """
     try:
@@ -132,14 +132,14 @@ def _resolve_git_branch() -> str:
 
 def _migrate_off_main_override_set() -> bool:
     """True when the operator has opted in to lifespan migrations from
-    a non-main checkout. Mirrors the CLI guard in `./pfv migrate` — same
+    a non-main checkout. Mirrors the CLI guard in `./pfv migrate`. Same
     env var name on purpose so a single export covers both surfaces.
     """
     return os.environ.get("PFV_MIGRATE_OK_OFF_MAIN", "").strip() == "1"
 
 
 async def _run_migrations() -> None:
-    """Run Alembic migrations on startup. Idempotent — alembic upgrade head
+    """Run Alembic migrations on startup. Idempotent: alembic upgrade head
     is a no-op when already at the latest revision.
 
     Refuses to run when the host checkout is on a non-main branch unless
@@ -208,7 +208,7 @@ async def lifespan(app: FastAPI):
     # PRE_DEPLOY job in .do/app.yaml; initContainer in k8s/templates/
     # backend.yaml) so they don't gate uvicorn's port-bind. Dev runs them
     # inline because the dev orchestrator (docker-compose) has no PRE_DEPLOY
-    # equivalent — the alternative is a manual `./pfv migrate` after every
+    # equivalent. The alternative is a manual `./pfv migrate` after every
     # rebuild.
     if app_settings.app_env != "production":
         await _run_migrations()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from contextlib import asynccontextmanager
 
@@ -92,46 +93,96 @@ async def _resolve_alembic_current() -> str:
         return "unknown"
 
 
-def _resolve_git_branch() -> str:
-    """Best-effort current git branch for diagnostic logging.
+_GIT_HEAD_PATH = "/app/.git/HEAD"
 
-    The dev container is bind-mounted from the host worktree, so
-    /app/.git resolves to the user's checkout. Falls back to "unknown"
-    if git isn't available or the repo can't be read.
+
+def _detect_branch() -> str | None:
+    """Read the current branch directly from /app/.git/HEAD.
+
+    docker-compose mounts the host repo's .git directory read-only into
+    /app/.git, so this is a file read with no subprocess and no git
+    binary required in the container. Returns:
+
+      * the branch name, when HEAD is a symbolic ref (the normal case)
+      * None, when HEAD is detached (a raw SHA), the file is missing,
+        or anything else goes wrong (worktree gitdir indirection,
+        permissions, etc.)
+
+    Callers MUST treat None as "couldn't tell" — the lifespan guard
+    refuses to migrate in that case so we fail closed, not open.
     """
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip() or "unknown"
-    except Exception:
-        pass
-    return "unknown"
+        with open(_GIT_HEAD_PATH) as f:
+            head = f.read().strip()
+    except (OSError, ValueError):
+        return None
+    prefix = "ref: refs/heads/"
+    if head.startswith(prefix):
+        return head[len(prefix):] or None
+    return None
+
+
+def _resolve_git_branch() -> str:
+    """String-returning wrapper around `_detect_branch()` for diagnostic
+    logging. Returns "unknown" rather than None so structured log fields
+    stay typed.
+    """
+    return _detect_branch() or "unknown"
+
+
+def _migrate_off_main_override_set() -> bool:
+    """True when the operator has opted in to lifespan migrations from
+    a non-main checkout. Mirrors the CLI guard in `./pfv migrate` — same
+    env var name on purpose so a single export covers both surfaces.
+    """
+    return os.environ.get("PFV_MIGRATE_OK_OFF_MAIN", "").strip() == "1"
 
 
 async def _run_migrations() -> None:
     """Run Alembic migrations on startup. Idempotent — alembic upgrade head
     is a no-op when already at the latest revision.
 
+    Refuses to run when the host checkout is on a non-main branch unless
+    `PFV_MIGRATE_OK_OFF_MAIN=1` is set. A migrate from a feature branch
+    can leave alembic_version pointing at a revision that only exists on
+    that branch, which then breaks the next `./pfv start` on main until
+    the version row is hand-patched. Same drift class the 2026-05-09
+    incident demonstrated. Detached HEAD / unreadable HEAD also refuses
+    (fail closed). See
+    ~/.claude/projects/-Users-fjorge-src-pfv/memory/reference_shared_mysql_volume_trap.md.
+
     Logs the resolved head + current revision (and best-effort git branch)
     before invoking alembic so the next drift incident has a breadcrumb
     pointing at exactly which revision the lifespan was targeting. Skips
     the subprocess entirely when current == head.
     """
+    branch = _detect_branch()
+    if branch != "main" and not _migrate_off_main_override_set():
+        logger.error(
+            "migrate.dev.refused",
+            branch=branch if branch is not None else "unknown",
+            reason=(
+                "branch_not_main" if branch is not None else "branch_undetectable"
+            ),
+            override_env_var="PFV_MIGRATE_OK_OFF_MAIN",
+        )
+        raise RuntimeError(
+            "Refusing to run dev lifespan migrations from non-main branch "
+            f"({'detached/unknown' if branch is None else branch!r}). "
+            "Set PFV_MIGRATE_OK_OFF_MAIN=1 in .env or the shell to override. "
+            "See reference_shared_mysql_volume_trap.md."
+        )
+
     head = _resolve_alembic_head()
     current = await _resolve_alembic_current()
-    branch = _resolve_git_branch()
+    branch_for_log = branch or "unknown"
 
     if current == head and head != "unknown":
         logger.info(
             "migrate.dev.no_op",
             current_revision=current,
             head_revision=head,
-            branch=branch,
+            branch=branch_for_log,
         )
         return
 
@@ -139,7 +190,7 @@ async def _run_migrations() -> None:
         "migrate.dev.target",
         current_revision=current,
         head_revision=head,
-        branch=branch,
+        branch=branch_for_log,
     )
 
     result = subprocess.run(

--- a/backend/tests/test_lifespan_migrate_logging.py
+++ b/backend/tests/test_lifespan_migrate_logging.py
@@ -1,0 +1,175 @@
+"""Tests for the dev-mode lifespan migration logging.
+
+Asserts that `_run_migrations()` emits a `migrate.dev.target` (or
+`migrate.dev.no_op`) structured event before invoking alembic, with the
+current + head revisions and best-effort branch attached. The breadcrumb
+exists so the next alembic drift incident has a log line pointing at
+exactly which revision the lifespan was targeting.
+
+Unit tests only; alembic subprocess and DB lookups are mocked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import structlog
+from structlog.testing import LogCapture
+
+from app import main as app_main
+
+
+@pytest.fixture
+def cap_logs():
+    """Reroute structlog through LogCapture; restore on teardown."""
+    capture = LogCapture()
+
+    structlog.configure(
+        processors=[capture],
+        wrapper_class=structlog.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+
+    # Re-bind the module-level logger so it picks up the new config.
+    original_logger = app_main.logger
+    app_main.logger = structlog.stdlib.get_logger()
+
+    yield capture
+
+    app_main.logger = original_logger
+    structlog.reset_defaults()
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_emits_target_event_with_revisions(cap_logs, monkeypatch):
+    """When current != head, we log migrate.dev.target then run alembic."""
+    monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
+    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "feat/something")
+
+    async def _fake_current() -> str:
+        return "current_xyz"
+
+    monkeypatch.setattr(app_main, "_resolve_alembic_current", _fake_current)
+
+    class _FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    monkeypatch.setattr(
+        app_main.subprocess, "run", lambda *a, **kw: _FakeResult()
+    )
+
+    await app_main._run_migrations()
+
+    events = [e["event"] for e in cap_logs.entries]
+    assert "migrate.dev.target" in events
+
+    target_event = next(
+        e for e in cap_logs.entries if e["event"] == "migrate.dev.target"
+    )
+    assert target_event["current_revision"] == "current_xyz"
+    assert target_event["head_revision"] == "head_abc"
+    assert target_event["branch"] == "feat/something"
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_emits_no_op_when_current_equals_head(cap_logs, monkeypatch):
+    """When current == head, we log migrate.dev.no_op and skip subprocess."""
+    monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
+    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "main")
+
+    async def _fake_current() -> str:
+        return "head_abc"
+
+    monkeypatch.setattr(app_main, "_resolve_alembic_current", _fake_current)
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise AssertionError("subprocess should not be called on no-op")
+
+    monkeypatch.setattr(app_main.subprocess, "run", _boom)
+
+    await app_main._run_migrations()
+
+    events = [e["event"] for e in cap_logs.entries]
+    assert events == ["migrate.dev.no_op"]
+    entry = cap_logs.entries[0]
+    assert entry["current_revision"] == "head_abc"
+    assert entry["head_revision"] == "head_abc"
+    assert entry["branch"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_runs_alembic_when_head_unknown(cap_logs, monkeypatch):
+    """If head resolution fails, we still log + run alembic (the upgrade
+    will then either succeed or surface the real failure)."""
+    monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "unknown")
+    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "main")
+
+    async def _fake_current() -> str:
+        return "unknown"
+
+    monkeypatch.setattr(app_main, "_resolve_alembic_current", _fake_current)
+
+    calls: list[tuple[Any, ...]] = []
+
+    class _FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def _record(args, **_kw):
+        calls.append(tuple(args))
+        return _FakeResult()
+
+    monkeypatch.setattr(app_main.subprocess, "run", _record)
+
+    await app_main._run_migrations()
+
+    # Even with both unknown we still emit a target event (no_op only
+    # fires when both equal AND head is a real revision).
+    events = [e["event"] for e in cap_logs.entries]
+    assert "migrate.dev.target" in events
+    assert calls == [("alembic", "upgrade", "head")]
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_raises_on_alembic_failure(monkeypatch):
+    monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
+    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "main")
+
+    async def _fake_current() -> str:
+        return "current_xyz"
+
+    monkeypatch.setattr(app_main, "_resolve_alembic_current", _fake_current)
+
+    class _FakeResult:
+        returncode = 1
+        stderr = "boom"
+        stdout = ""
+
+    monkeypatch.setattr(
+        app_main.subprocess, "run", lambda *a, **kw: _FakeResult()
+    )
+
+    with pytest.raises(RuntimeError, match="Migration failed"):
+        await app_main._run_migrations()
+
+
+def test_resolve_git_branch_returns_string():
+    """Best-effort branch resolution must always return a string, even
+    when git is unavailable or times out."""
+    branch = app_main._resolve_git_branch()
+    assert isinstance(branch, str)
+    assert branch  # non-empty
+
+
+def test_resolve_alembic_head_returns_string():
+    """Head resolution must never raise; returns 'unknown' on failure."""
+    with patch.object(app_main, "_ALEMBIC_INI_PATH", "/nonexistent/alembic.ini"):
+        result = app_main._resolve_alembic_head()
+        assert result == "unknown"

--- a/backend/tests/test_lifespan_migrate_logging.py
+++ b/backend/tests/test_lifespan_migrate_logging.py
@@ -1,10 +1,12 @@
-"""Tests for the dev-mode lifespan migration logging.
+"""Tests for the dev-mode lifespan migration logging + branch guard.
 
-Asserts that `_run_migrations()` emits a `migrate.dev.target` (or
-`migrate.dev.no_op`) structured event before invoking alembic, with the
-current + head revisions and best-effort branch attached. The breadcrumb
-exists so the next alembic drift incident has a log line pointing at
-exactly which revision the lifespan was targeting.
+Covers two layers of `_run_migrations()` behavior:
+
+  1. Branch guard — refuses to run when the host checkout is off main
+     unless `PFV_MIGRATE_OK_OFF_MAIN=1` is set. Mirrors `./pfv migrate`.
+  2. Logging breadcrumb — emits `migrate.dev.target` /
+     `migrate.dev.no_op` with current + head revisions and branch so the
+     next alembic drift incident has a structured pointer.
 
 Unit tests only; alembic subprocess and DB lookups are mocked.
 """
@@ -44,11 +46,22 @@ def cap_logs():
     structlog.reset_defaults()
 
 
+@pytest.fixture
+def on_main(monkeypatch):
+    """Default the environment to a main-branch checkout with no override
+    so individual tests only have to override what they exercise. Tests
+    that need off-main behavior re-patch `_detect_branch` themselves.
+    """
+    monkeypatch.setattr(app_main, "_detect_branch", lambda: "main")
+    monkeypatch.delenv("PFV_MIGRATE_OK_OFF_MAIN", raising=False)
+
+
 @pytest.mark.asyncio
-async def test_run_migrations_emits_target_event_with_revisions(cap_logs, monkeypatch):
+async def test_run_migrations_emits_target_event_with_revisions(
+    cap_logs, monkeypatch, on_main
+):
     """When current != head, we log migrate.dev.target then run alembic."""
     monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
-    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "feat/something")
 
     async def _fake_current() -> str:
         return "current_xyz"
@@ -74,14 +87,15 @@ async def test_run_migrations_emits_target_event_with_revisions(cap_logs, monkey
     )
     assert target_event["current_revision"] == "current_xyz"
     assert target_event["head_revision"] == "head_abc"
-    assert target_event["branch"] == "feat/something"
+    assert target_event["branch"] == "main"
 
 
 @pytest.mark.asyncio
-async def test_run_migrations_emits_no_op_when_current_equals_head(cap_logs, monkeypatch):
+async def test_run_migrations_emits_no_op_when_current_equals_head(
+    cap_logs, monkeypatch, on_main
+):
     """When current == head, we log migrate.dev.no_op and skip subprocess."""
     monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
-    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "main")
 
     async def _fake_current() -> str:
         return "head_abc"
@@ -104,11 +118,12 @@ async def test_run_migrations_emits_no_op_when_current_equals_head(cap_logs, mon
 
 
 @pytest.mark.asyncio
-async def test_run_migrations_runs_alembic_when_head_unknown(cap_logs, monkeypatch):
+async def test_run_migrations_runs_alembic_when_head_unknown(
+    cap_logs, monkeypatch, on_main
+):
     """If head resolution fails, we still log + run alembic (the upgrade
     will then either succeed or surface the real failure)."""
     monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "unknown")
-    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "main")
 
     async def _fake_current() -> str:
         return "unknown"
@@ -138,9 +153,8 @@ async def test_run_migrations_runs_alembic_when_head_unknown(cap_logs, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_run_migrations_raises_on_alembic_failure(monkeypatch):
+async def test_run_migrations_raises_on_alembic_failure(monkeypatch, on_main):
     monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
-    monkeypatch.setattr(app_main, "_resolve_git_branch", lambda: "main")
 
     async def _fake_current() -> str:
         return "current_xyz"
@@ -173,3 +187,180 @@ def test_resolve_alembic_head_returns_string():
     with patch.object(app_main, "_ALEMBIC_INI_PATH", "/nonexistent/alembic.ini"):
         result = app_main._resolve_alembic_head()
         assert result == "unknown"
+
+
+# ----------------------------------------------------------------------
+# Branch guard tests — the lifespan must refuse to migrate when the
+# host checkout is off main unless PFV_MIGRATE_OK_OFF_MAIN=1 is set.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_refuses_when_branch_is_not_main(
+    cap_logs, monkeypatch
+):
+    """Off-main branch + no override => RuntimeError, no alembic invoked."""
+    monkeypatch.setattr(app_main, "_detect_branch", lambda: "feat/some-thing")
+    monkeypatch.delenv("PFV_MIGRATE_OK_OFF_MAIN", raising=False)
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise AssertionError("subprocess must not run when the guard refuses")
+
+    monkeypatch.setattr(app_main.subprocess, "run", _boom)
+
+    with pytest.raises(RuntimeError, match="Refusing to run dev lifespan migrations"):
+        await app_main._run_migrations()
+
+    refused = [e for e in cap_logs.entries if e["event"] == "migrate.dev.refused"]
+    assert len(refused) == 1
+    assert refused[0]["branch"] == "feat/some-thing"
+    assert refused[0]["reason"] == "branch_not_main"
+    assert refused[0]["override_env_var"] == "PFV_MIGRATE_OK_OFF_MAIN"
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_proceeds_when_branch_is_main(
+    cap_logs, monkeypatch
+):
+    """main branch + no override => proceeds, alembic invoked."""
+    monkeypatch.setattr(app_main, "_detect_branch", lambda: "main")
+    monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
+    monkeypatch.delenv("PFV_MIGRATE_OK_OFF_MAIN", raising=False)
+
+    async def _fake_current() -> str:
+        return "current_xyz"
+
+    monkeypatch.setattr(app_main, "_resolve_alembic_current", _fake_current)
+
+    calls: list[tuple[Any, ...]] = []
+
+    class _FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def _record(args, **_kw):
+        calls.append(tuple(args))
+        return _FakeResult()
+
+    monkeypatch.setattr(app_main.subprocess, "run", _record)
+
+    await app_main._run_migrations()
+
+    assert calls == [("alembic", "upgrade", "head")]
+    events = [e["event"] for e in cap_logs.entries]
+    assert "migrate.dev.refused" not in events
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_proceeds_off_main_when_override_set(
+    cap_logs, monkeypatch
+):
+    """Off-main + PFV_MIGRATE_OK_OFF_MAIN=1 => proceeds (escape hatch)."""
+    monkeypatch.setattr(app_main, "_detect_branch", lambda: "feat/something")
+    monkeypatch.setattr(app_main, "_resolve_alembic_head", lambda: "head_abc")
+    monkeypatch.setenv("PFV_MIGRATE_OK_OFF_MAIN", "1")
+
+    async def _fake_current() -> str:
+        return "current_xyz"
+
+    monkeypatch.setattr(app_main, "_resolve_alembic_current", _fake_current)
+
+    calls: list[tuple[Any, ...]] = []
+
+    class _FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def _record(args, **_kw):
+        calls.append(tuple(args))
+        return _FakeResult()
+
+    monkeypatch.setattr(app_main.subprocess, "run", _record)
+
+    await app_main._run_migrations()
+
+    assert calls == [("alembic", "upgrade", "head")]
+    events = [e["event"] for e in cap_logs.entries]
+    assert "migrate.dev.refused" not in events
+    target = next(e for e in cap_logs.entries if e["event"] == "migrate.dev.target")
+    assert target["branch"] == "feat/something"
+
+
+@pytest.mark.asyncio
+async def test_run_migrations_refuses_on_undetectable_branch(
+    cap_logs, monkeypatch
+):
+    """Detached HEAD / unreadable HEAD => fail closed (refuse).
+
+    Tradeoff: this catches detached-HEAD checkouts (rare in dev) at the
+    cost of a noisy error. The override env var is the documented
+    escape hatch; the alternative (proceed when undetectable) would
+    silently re-open the exact drift class the guard exists to close.
+    """
+    monkeypatch.setattr(app_main, "_detect_branch", lambda: None)
+    monkeypatch.delenv("PFV_MIGRATE_OK_OFF_MAIN", raising=False)
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise AssertionError("subprocess must not run when the guard refuses")
+
+    monkeypatch.setattr(app_main.subprocess, "run", _boom)
+
+    with pytest.raises(RuntimeError, match="detached/unknown"):
+        await app_main._run_migrations()
+
+    refused = [e for e in cap_logs.entries if e["event"] == "migrate.dev.refused"]
+    assert len(refused) == 1
+    assert refused[0]["branch"] == "unknown"
+    assert refused[0]["reason"] == "branch_undetectable"
+
+
+# ----------------------------------------------------------------------
+# Direct unit tests for the new helpers.
+# ----------------------------------------------------------------------
+
+
+def test_detect_branch_reads_symbolic_ref(tmp_path, monkeypatch):
+    """_detect_branch returns the branch name for a normal HEAD file."""
+    head = tmp_path / "HEAD"
+    head.write_text("ref: refs/heads/feat/sample\n")
+    monkeypatch.setattr(app_main, "_GIT_HEAD_PATH", str(head))
+
+    assert app_main._detect_branch() == "feat/sample"
+
+
+def test_detect_branch_returns_none_for_detached_head(tmp_path, monkeypatch):
+    """A raw SHA in HEAD (detached) returns None — fail closed."""
+    head = tmp_path / "HEAD"
+    head.write_text("a1b2c3d4e5f6\n")
+    monkeypatch.setattr(app_main, "_GIT_HEAD_PATH", str(head))
+
+    assert app_main._detect_branch() is None
+
+
+def test_detect_branch_returns_none_when_file_missing(tmp_path, monkeypatch):
+    """Missing /app/.git/HEAD => None (e.g. .git not bind-mounted)."""
+    monkeypatch.setattr(
+        app_main, "_GIT_HEAD_PATH", str(tmp_path / "does-not-exist")
+    )
+    assert app_main._detect_branch() is None
+
+
+def test_migrate_off_main_override_only_truthy_for_exact_one(monkeypatch):
+    """The override is opt-in: only the literal string '1' counts."""
+    monkeypatch.delenv("PFV_MIGRATE_OK_OFF_MAIN", raising=False)
+    assert app_main._migrate_off_main_override_set() is False
+
+    monkeypatch.setenv("PFV_MIGRATE_OK_OFF_MAIN", "")
+    assert app_main._migrate_off_main_override_set() is False
+
+    monkeypatch.setenv("PFV_MIGRATE_OK_OFF_MAIN", "true")
+    assert app_main._migrate_off_main_override_set() is False
+
+    monkeypatch.setenv("PFV_MIGRATE_OK_OFF_MAIN", "1")
+    assert app_main._migrate_off_main_override_set() is True
+
+    # Whitespace stripped so "  1  " also counts (handy for .env files).
+    monkeypatch.setenv("PFV_MIGRATE_OK_OFF_MAIN", " 1 ")
+    assert app_main._migrate_off_main_override_set() is True

--- a/backend/tests/test_lifespan_migrate_logging.py
+++ b/backend/tests/test_lifespan_migrate_logging.py
@@ -2,9 +2,9 @@
 
 Covers two layers of `_run_migrations()` behavior:
 
-  1. Branch guard — refuses to run when the host checkout is off main
+  1. Branch guard: refuses to run when the host checkout is off main
      unless `PFV_MIGRATE_OK_OFF_MAIN=1` is set. Mirrors `./pfv migrate`.
-  2. Logging breadcrumb — emits `migrate.dev.target` /
+  2. Logging breadcrumb: emits `migrate.dev.target` /
      `migrate.dev.no_op` with current + head revisions and branch so the
      next alembic drift incident has a structured pointer.
 
@@ -190,7 +190,7 @@ def test_resolve_alembic_head_returns_string():
 
 
 # ----------------------------------------------------------------------
-# Branch guard tests — the lifespan must refuse to migrate when the
+# Branch guard tests: the lifespan must refuse to migrate when the
 # host checkout is off main unless PFV_MIGRATE_OK_OFF_MAIN=1 is set.
 # ----------------------------------------------------------------------
 
@@ -331,7 +331,7 @@ def test_detect_branch_reads_symbolic_ref(tmp_path, monkeypatch):
 
 
 def test_detect_branch_returns_none_for_detached_head(tmp_path, monkeypatch):
-    """A raw SHA in HEAD (detached) returns None — fail closed."""
+    """A raw SHA in HEAD (detached) returns None: fail closed."""
     head = tmp_path / "HEAD"
     head.write_text("a1b2c3d4e5f6\n")
     monkeypatch.setattr(app_main, "_GIT_HEAD_PATH", str(head))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,11 @@ services:
       # repo-root .github/workflows/deploy.yml and .do/app.yaml.
       - ./.github:/app/.github:ro
       - ./.do:/app/.do:ro
+      # Read-only .git so the lifespan branch guard in app.main can
+      # detect the host checkout's branch and refuse to migrate from
+      # a non-main feature branch (the same drift class PFV_MIGRATE_OK_OFF_MAIN
+      # protects on the CLI side).
+      - ./.git:/app/.git:ro
 
   frontend:
     build:

--- a/pfv
+++ b/pfv
@@ -86,6 +86,29 @@ cmd_reset() {
 }
 
 cmd_migrate() {
+  # Guard: refuse to run migrations from a non-main checkout unless the
+  # operator opts in via PFV_MIGRATE_OK_OFF_MAIN=1. A migration run from a
+  # feature branch can leave alembic_version pointing at a revision that
+  # only exists on that branch, which then breaks `./pfv start` on main
+  # until the version row is hand-patched. See
+  # ~/.claude/projects/-Users-fjorge-src-pfv/memory/reference_shared_mysql_volume_trap.md
+  # for the 2026-05-09 incident this guard prevents.
+  local branch
+  branch="$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+  if [[ "$branch" != "main" && "${PFV_MIGRATE_OK_OFF_MAIN:-}" != "1" ]]; then
+    cat >&2 <<EOF
+WARNING: ./pfv migrate is about to run migrations against the local dev DB
+while the repo is on branch '${branch}'. Migrations from feature branches
+can leave alembic_version pointing at revisions that do not exist on main,
+breaking ./pfv start until repaired (see reference_shared_mysql_volume_trap.md).
+
+If you intend to migrate from this branch, re-run with:
+  PFV_MIGRATE_OK_OFF_MAIN=1 ./pfv migrate
+
+Aborting.
+EOF
+    exit 1
+  fi
   docker compose exec backend python /app/scripts/migrate.py
 }
 


### PR DESCRIPTION
## Problem

On 2026-05-09 a parallel-agent dispatch advanced the local dev MySQL volume to alembic revision `037_tags_and_dictionary`, a revision that only exists on the `feat/tags-pr-a-backend` feature branch (PR #196). When the user's `./pfv start` next ran on `main`, the FastAPI lifespan tried `alembic upgrade head`, could not locate the revision file, and the backend exited with a 502 from nginx until the `alembic_version` row was hand-patched.

Full incident write-up:
`~/.claude/projects/-Users-fjorge-src-pfv/memory/reference_shared_mysql_volume_trap.md`

This PR adds dev-safety guards across both entry points that touch the shared MySQL volume in dev. None change production behaviour.

## Corrections applied

External review flagged that the original scope was insufficient: the `./pfv migrate` CLI guard alone does not protect `./pfv start`, `./pfv restart`, or `./pfv rebuild`, which all spin up the backend whose lifespan calls `_run_migrations()` against the same shared MySQL volume. From a feature-branch checkout, that lifespan migration runs `alembic upgrade head` and re-introduces the exact same drift class the 2026-05-09 incident demonstrated. The guard had to be in the lifespan, not just the CLI.

The latest commit closes that gap: the lifespan now reads `/app/.git/HEAD` directly and refuses to migrate when the host checkout is on a non-main branch. Same env var name (`PFV_MIGRATE_OK_OFF_MAIN`) covers both surfaces with a single export.

## Implementation summary

1. **`./pfv migrate` CLI branch guard.** `cmd_migrate` refuses when the current branch is not `main`, with an explicit `PFV_MIGRATE_OK_OFF_MAIN=1` escape hatch.
2. **Lifespan branch guard.** `_run_migrations` reads `/app/.git/HEAD` directly (no subprocess, no git binary required in the container) and refuses to migrate when the host checkout is off-main. Detached HEAD or unreadable HEAD also refuses (fail closed). The `PFV_MIGRATE_OK_OFF_MAIN=1` env var is the documented escape hatch and shares the same name as the CLI guard.
3. **`docker-compose.yml` mounts `./.git:/app/.git:ro`** so the lifespan can read HEAD inside the container. Read-only; no other behaviour changes.
4. **Lifespan migration logs the resolved revisions.** `_run_migrations` reads the script-tree head (via the alembic Python API) and the live `alembic_version.version_num` (via a single SQL read on the existing async engine), then emits a `migrate.dev.target` event with `current_revision`, `head_revision`, and best-effort `branch` BEFORE invoking `alembic upgrade`. When `current == head`, emits `migrate.dev.no_op` and skips the subprocess entirely. Production unchanged (the lifespan path is gated on `APP_ENV != "production"`).
5. **CLAUDE.md compose-project rule + lifespan guard doc.** Promotes the `-p team-<name>` discipline from informal guidance to checked-in repo doc, plus a new section documenting the lifespan branch guard and the `PFV_MIGRATE_OK_OFF_MAIN` override.

## Files changed

- `pfv` (+23 lines): branch guard at top of `cmd_migrate`.
- `backend/app/main.py`: new helpers (`_detect_branch`, `_migrate_off_main_override_set`, `_resolve_alembic_head`, `_resolve_alembic_current`, `_resolve_git_branch`); `_run_migrations` now async, refuses off-main without override, emits structured events; lifespan await updated.
- `backend/tests/test_lifespan_migrate_logging.py`: 14 unit tests covering target event, no-op, unknown-head fallback, alembic failure propagation, the four guard cases (off-main refuses, on-main proceeds, override allows off-main, undetectable refuses), the helper return-shape contracts, the HEAD-file parser, and the override-env-var semantics.
- `docker-compose.yml`: `./.git:/app/.git:ro` bind mount on backend.
- `CLAUDE.md`: parallel-agent compose-project rule + lifespan-guard subsection.

## Tests run and results

Full backend suite in an isolated compose project (per the new rule):

```
docker compose -p team-198-fix up -d backend mysql redis
docker compose -p team-198-fix exec backend pytest tests/ -q
```

Result: **704 passed, 2 skipped, 0 failures (114s)**. `test_lifespan_migrate_logging.py`: 14/14 passed in 0.46s.

`./pfv migrate` was manually exercised on this branch:
- Without override: aborts with the warning, exit 1.
- With `PFV_MIGRATE_OK_OFF_MAIN=1`: proceeds.

`bash -n pfv` passes (script syntax-clean).

## Known risks / follow-ups

- The lifespan guard fail-closes on detached HEAD / unreadable HEAD. The override env var is the documented escape. The alternative (proceed when undetectable) would silently re-open the exact drift class the guard exists to close.
- This PR does NOT modify `backend/scripts/migrate.py` (the production-ish wrapper used by K8s init / DO PRE_DEPLOY / `./pfv migrate`). That wrapper already emits structured `migrate.start` / `migrate.step.*` / `migrate.complete` events; adding the same `branch` field there is a possible follow-up but out of scope for this dev-safety PR.

## Internal reviewers

@flamarion

External review required before merge.