### PR TITLE
fix(accounts): stack list cards vertically at all viewports

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -179,7 +179,7 @@ export default function AccountsPage() {
       {fetching ? (
         <Spinner />
       ) : (
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2">
+        <div className="flex flex-col gap-6">
           {/* Account Types */}
           <div className={card}>
             <div className={cardHeader}>


### PR DESCRIPTION
## Problem

User-reported screenshot showed the Accounts page badly cramped at desktop (1280 px). Account names broke word-by-word (\"Credit Card - closes day 25\" stacked vertically across four lines), the DEFAULT badge mashed against the balance, and the rightmost actions (Deactivate, Delete) clipped past the card edge.

Root cause: the wrapper at `frontend/app/accounts/page.tsx:182` set `grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2`, splitting the page into two equal columns from md (768 px) upward. After PR #188 added a fifth action and PR #190 introduced per-row column headers (and added the `md:grid-cols-2` breakpoint), the Accounts list could no longer fit in half the page width. The Account Types card on the left is small (5 system rows on a fresh org) and gained nothing from sitting beside the much wider Accounts list.

## Implementation

One-line wrapper class swap:

```diff
-        <div className=\"grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-2\">
+        <div className=\"flex flex-col gap-6\">
```

The inner cards use the `card` token from `frontend/lib/styles.ts` (`rounded-lg border border-border bg-surface`) which has no width constraints, so they fill the flex container at full content width.

## Files changed

- `frontend/app/accounts/page.tsx` (1 line)

## Tests

- `npx vitest run accounts`: 14/14 pass across 4 files (`adjust-balance-modal`, `accounts-pending-visibility`, `accounts-adjust-balance-button`, `accounts-list-headers`).
- `npx tsc --noEmit`: clean.

## Screenshots

Saved to `/Users/fjorge/src/pfv/.claude/worktrees/agent-ae82fd0630c8c3ec0/screenshots/` on the local machine.

Desktop (1280 x 900):
- `before-desktop-1280.png`: Accounts list squeezed into the right column. \"Credit Card - closes day 25\" wraps word-by-word, DEFAULT badge butted against the balance, Deactivate / Delete clipped past the card edge.
- `after-desktop-1280.png`: Accounts list spans the full content width. Each row renders on a single line: account name, type, close-day, balance, all five actions.

Tablet portrait (768 x 1024):
- `before-tablet-768.png`: 2-column layout from PR #190 (Account Types card sat side-by-side with the Accounts list at md+ width).
- `after-tablet-768.png`: This PR removes both `md:grid-cols-2` and `lg:grid-cols-2` from the wrapper, so tablet portrait (768-1023) is now single-column, same as mobile. Trade-off: the Account Types card no longer sits side-by-side with the Accounts list at this width. Benefit: the Accounts list spans full content width on desktop instead of being squeezed into half the page.

## Known risks / follow-ups

The Account Types card now sits alone above the Accounts list at full width. With 5 system rows it can feel visually orphaned at very wide viewports. If that bothers anyone, tightening its `max-w-*` is a future polish, intentionally not addressed here.

## Merge gate

Merge gate: independent. Visual regression fix; can land any time.

## Internal reviewers

- @flamarion

External review required before merge.
