### PR TITLE
fix(dashboard): paint Forecast by Category actual bar red when over plan

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -892,7 +892,7 @@ export default function DashboardPage() {
                 const expenseItems = forecast?.items.filter((it) => it.type === "expense") ?? [];
                 if (forecast && expenseItems.length > 0) {
                   const chartRows = expenseItems.slice(0, 8).map((it) => ({
-                    name: it.category_name.length > 12 ? it.category_name.slice(0, 12) + "…" : it.category_name,
+                    name: it.category_name.length > 12 ? it.category_name.slice(0, 12) + "..." : it.category_name,
                     planned: Number(it.planned_amount),
                     actual: Number(it.actual_amount),
                   }));

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -891,25 +891,37 @@ export default function DashboardPage() {
               {(() => {
                 const expenseItems = forecast?.items.filter((it) => it.type === "expense") ?? [];
                 if (forecast && expenseItems.length > 0) {
+                  const chartRows = expenseItems.slice(0, 8).map((it) => ({
+                    name: it.category_name.length > 12 ? it.category_name.slice(0, 12) + "…" : it.category_name,
+                    planned: Number(it.planned_amount),
+                    actual: Number(it.actual_amount),
+                  }));
                   return (
                     <div className="w-full min-w-0" style={{ height: Math.max(Math.min(expenseItems.length, 8) * 32, 100) }}>
                       <ResponsiveContainer width="100%" height="100%" initialDimension={{ width: 1, height: 1 }}>
                         <BarChart
-                          data={expenseItems.slice(0, 8).map((it) => ({
-                            name: it.category_name.length > 12 ? it.category_name.slice(0, 12) + "…" : it.category_name,
-                            planned: Number(it.planned_amount),
-                            actual: Number(it.actual_amount),
-                          }))}
+                          data={chartRows}
                           layout="vertical"
                           margin={{ left: 0, right: 20, top: 0, bottom: 0 }}
                         >
                           <XAxis type="number" hide />
                           <YAxis type="category" dataKey="name" width={90} tick={{ fill: chartColor.axisTick, fontSize: 10 }} />
                           <Tooltip
-                            formatter={(v, name) => [
-                              formatAmount(Number(v)),
-                              name === "planned" ? <span style={{ color: chartColor.planned }}>Planned</span> : <span style={{ color: chartColor.actual }}>Actual</span>,
-                            ]}
+                            formatter={(v, name, item) => {
+                              if (name === "planned") {
+                                return [
+                                  formatAmount(Number(v)),
+                                  <span style={{ color: chartColor.planned }}>Planned</span>,
+                                ];
+                              }
+                              const row = (item as { payload?: { planned: number; actual: number } } | undefined)?.payload;
+                              const isOver = row ? row.actual > row.planned : false;
+                              const labelColor = isOver ? chartColor.over : chartColor.actual;
+                              return [
+                                formatAmount(Number(v)),
+                                <span style={{ color: labelColor }}>Actual</span>,
+                              ];
+                            }}
                             contentStyle={{ fontSize: "11px" }}
                           />
                           <Bar dataKey="planned" fill={chartColor.planned} radius={[4, 4, 4, 4]} animationDuration={600}
@@ -919,7 +931,14 @@ export default function DashboardPage() {
                               if (name) setChartFilter(chartFilter === name ? null : name);
                             }}
                           />
-                          <Bar dataKey="actual" fill={chartColor.actual} radius={[4, 4, 4, 4]} animationDuration={600} />
+                          <Bar dataKey="actual" fill={chartColor.actual} radius={[4, 4, 4, 4]} animationDuration={600}>
+                            {chartRows.map((d, i) => (
+                              <Cell
+                                key={i}
+                                fill={d.actual > d.planned ? chartColor.over : chartColor.actual}
+                              />
+                            ))}
+                          </Bar>
                         </BarChart>
                       </ResponsiveContainer>
                     </div>
@@ -936,9 +955,10 @@ export default function DashboardPage() {
                   </p>
                 );
               })()}
-              <div className="mt-2 flex gap-3 text-[10px] text-text-muted">
+              <div className="mt-2 flex flex-wrap gap-3 text-[10px] text-text-muted">
                 <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.planned }} /> Planned</span>
-                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.actual }} /> Actual</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.actual }} /> Under plan</span>
+                <span className="flex items-center gap-1"><span className="inline-block h-2 w-2 rounded-full" style={{ background: chartColor.over }} /> Over plan</span>
               </div>
             </div>
           </div>

--- a/frontend/tests/app/dashboard-forecast-by-category-colors.test.tsx
+++ b/frontend/tests/app/dashboard-forecast-by-category-colors.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/dashboard",
+}));
+
+// Lightweight recharts mock that renders <Bar> children so <Cell> elements
+// land in the DOM with their fill attribute. The dashboard's Forecast by
+// Category bar passes a list of Cell children whose fills encode the
+// over/under-plan classification — that's what this test asserts.
+vi.mock("recharts", () => {
+  return {
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+    BarChart: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="bar-chart">{children}</div>
+    ),
+    Bar: ({
+      dataKey,
+      fill,
+      children,
+    }: {
+      dataKey?: string;
+      fill?: string;
+      children?: React.ReactNode;
+    }) => (
+      <div data-testid={`bar-${dataKey}`} data-fill={fill}>
+        {children}
+      </div>
+    ),
+    Cell: ({ fill }: { fill?: string }) => (
+      <div data-testid="cell" data-fill={fill} />
+    ),
+    XAxis: () => null,
+    YAxis: () => null,
+    Tooltip: () => null,
+    PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Pie: () => null,
+  };
+});
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+// Plan with two expense lines:
+// - Housing: planned 20.00, actual 39.50 (OVER plan, +19.50) → red Cell
+// - Groceries: planned 500.00, actual 200.00 (UNDER plan) → green Cell
+// Mirrors the user-reported repro on 2026-05-10.
+const PLAN_OVER_AND_UNDER = {
+  id: 1,
+  billing_period_id: 1,
+  period_start: "2026-05-01",
+  period_end: null,
+  status: "active",
+  total_planned_income: "0",
+  total_planned_expense: "520.00",
+  total_actual_income: "0",
+  total_actual_expense: "239.50",
+  items: [
+    {
+      id: 1,
+      plan_id: 1,
+      category_id: 100,
+      category_name: "Housing",
+      parent_id: null,
+      type: "expense",
+      planned_amount: "20.00",
+      source: "manual",
+      actual_amount: "39.50",
+      variance: "19.50",
+    },
+    {
+      id: 2,
+      plan_id: 1,
+      category_id: 101,
+      category_name: "Groceries",
+      parent_id: null,
+      type: "expense",
+      planned_amount: "500.00",
+      source: "manual",
+      actual_amount: "200.00",
+      variance: "-300.00",
+    },
+  ],
+};
+
+function setupApiMocks() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/accounts") return Promise.resolve([]);
+    if (url === "/api/v1/categories") return Promise.resolve([]);
+    if (url === "/api/v1/budgets" || url.startsWith("/api/v1/budgets?"))
+      return Promise.resolve([]);
+    if (url === "/api/v1/settings/billing-cycle")
+      return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period")
+      return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings/billing-periods")
+      return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+    if (url.startsWith("/api/v1/forecast-plans/current"))
+      return Promise.resolve(PLAN_OVER_AND_UNDER);
+    if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
+    if (url.startsWith("/api/v1/forecast/account-balances"))
+      return Promise.resolve({ accounts: [], period_start: "2026-05-01", period_end: "2026-05-31" });
+    if (url.startsWith("/api/v1/transactions?status=pending"))
+      return Promise.resolve([]);
+    if (url.startsWith("/api/v1/transactions"))
+      return Promise.resolve([]);
+    return Promise.resolve(null);
+  }) as never);
+}
+
+describe("DashboardPage — Forecast by Category over/under-plan colors", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    window.history.pushState({}, "", "/dashboard");
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    setupApiMocks();
+  });
+
+  it("paints actual-bar Cells red when actual > planned and green otherwise", async () => {
+    render(<DashboardPage />);
+
+    // Wait for the Forecast by Category card to render (it's gated on
+    // forecast?.items being non-empty).
+    await waitFor(() => {
+      expect(screen.getByText("Forecast by Category")).toBeTruthy();
+    });
+
+    // The actual <Bar dataKey="actual"> in the Forecast by Category chart
+    // wraps the per-row <Cell> children with the over/under-plan fills.
+    // There's only one chart on the page that mounts a Bar with
+    // dataKey="actual" today (Forecast by Category). Find it by walking
+    // every actual-bar and picking the one whose Cell count matches the
+    // expense-line count (2 in this fixture).
+    const allActualBars = await screen.findAllByTestId("bar-actual");
+    const forecastBar = allActualBars.find(
+      (b) => b.querySelectorAll('[data-testid="cell"]').length === 2,
+    );
+    expect(forecastBar).toBeTruthy();
+
+    const cells = forecastBar!.querySelectorAll('[data-testid="cell"]');
+    expect(cells.length).toBe(2);
+
+    // Order in the chart data follows the order of expenseItems passed
+    // into the chart, which mirrors plan.items: Housing then Groceries.
+    // Housing: actual 39.50 > planned 20 → over (red, var(--color-danger))
+    expect(cells[0].getAttribute("data-fill")).toBe("var(--color-danger)");
+    // Groceries: actual 200 < planned 500 → under (green, var(--color-success))
+    expect(cells[1].getAttribute("data-fill")).toBe("var(--color-success)");
+  });
+
+  it("legend lists Planned, Under plan, and Over plan", async () => {
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Forecast by Category")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Planned")).toBeTruthy();
+    expect(screen.getByText("Under plan")).toBeTruthy();
+    expect(screen.getByText("Over plan")).toBeTruthy();
+  });
+});

--- a/frontend/tests/app/dashboard-forecast-by-category-colors.test.tsx
+++ b/frontend/tests/app/dashboard-forecast-by-category-colors.test.tsx
@@ -29,7 +29,7 @@ vi.mock("next/navigation", () => ({
 // Lightweight recharts mock that renders <Bar> children so <Cell> elements
 // land in the DOM with their fill attribute. The dashboard's Forecast by
 // Category bar passes a list of Cell children whose fills encode the
-// over/under-plan classification — that's what this test asserts.
+// over/under-plan classification, that's what this test asserts.
 vi.mock("recharts", () => {
   return {
     ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
@@ -84,8 +84,8 @@ const USER = {
 };
 
 // Plan with two expense lines:
-// - Housing: planned 20.00, actual 39.50 (OVER plan, +19.50) → red Cell
-// - Groceries: planned 500.00, actual 200.00 (UNDER plan) → green Cell
+// - Housing: planned 20.00, actual 39.50 (OVER plan, +19.50) -> red Cell
+// - Groceries: planned 500.00, actual 200.00 (UNDER plan) -> green Cell
 // Mirrors the user-reported repro on 2026-05-10.
 const PLAN_OVER_AND_UNDER = {
   id: 1,
@@ -150,7 +150,7 @@ function setupApiMocks() {
   }) as never);
 }
 
-describe("DashboardPage — Forecast by Category over/under-plan colors", () => {
+describe("DashboardPage - Forecast by Category over/under-plan colors", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
     window.history.pushState({}, "", "/dashboard");
@@ -192,9 +192,9 @@ describe("DashboardPage — Forecast by Category over/under-plan colors", () => 
 
     // Order in the chart data follows the order of expenseItems passed
     // into the chart, which mirrors plan.items: Housing then Groceries.
-    // Housing: actual 39.50 > planned 20 → over (red, var(--color-danger))
+    // Housing: actual 39.50 > planned 20 -> over (red, var(--color-danger))
     expect(cells[0].getAttribute("data-fill")).toBe("var(--color-danger)");
-    // Groceries: actual 200 < planned 500 → under (green, var(--color-success))
+    // Groceries: actual 200 < planned 500 -> under (green, var(--color-success))
     expect(cells[1].getAttribute("data-fill")).toBe("var(--color-success)");
   });
 


### PR DESCRIPTION
## Problem

User-reported on 2026-05-10: same forecast data, two surfaces, two different colors.

- Forecast Plans page (`/forecast-plans`): Housing planned 20.00, actual 39.50 renders the actual bar in **red** (over plan, +19.50 variance), with a three-token legend (Planned / Under plan / Over plan).
- Dashboard `Forecast by Category` card: same Housing row renders the actual bar in **green**, with a two-token legend (Planned / Actual). The variance is 100% over and the dashboard is silently telling the user everything is fine.

Root cause: `frontend/app/dashboard/page.tsx` renders the actual `<Bar>` with a single static `fill={chartColor.actual}` and no per-row classification. The dedicated forecasts page at `frontend/app/forecast-plans/page.tsx` already does the right thing: it wraps the actual `<Bar>` with `<Cell>` children whose fills are computed per row from `d.actual > d.planned`.

## Implementation

Mirror the forecasts-page pattern on the dashboard.

1. **Per-row Cell fills.** The dashboard's actual `<Bar>` now wraps `<Cell>` children, one per chart row, with fill `d.actual > d.planned ? chartColor.over : chartColor.actual`. The chart data array is hoisted so the same array drives both `BarChart.data` and the `<Cell>` children, so the fills cannot drift from the data.
2. **Legend updated.** The dashboard legend now shows three tokens (Planned / Under plan / Over plan) instead of two (Planned / Actual). Same color tokens as the forecasts page.
3. **Tooltip color matches the bar.** The Tooltip formatter previously colored the "Actual" label with `chartColor.actual` unconditionally. It now reads the row payload from the formatter's third argument and switches to `chartColor.over` when `actual > planned`, so hovering an over-plan bar surfaces the same red in the tooltip label.

No changes to Forecast Plans (it was already correct). No changes to other dashboard charts. Color tokens are reused from `frontend/lib/chart-colors.ts`; no new colors introduced.

## Files changed

- `frontend/app/dashboard/page.tsx`: Cell-based per-row fill, three-token legend, over/under tooltip.
- `frontend/tests/app/dashboard-forecast-by-category-colors.test.tsx`: new Vitest spec.

## Tests

- New test mounts `DashboardPage` with a forecast plan containing one over-plan line (Housing 39.50/20.00) and one under-plan line (Groceries 200/500). Asserts the two `<Cell>` elements inside the actual `<Bar>` carry `var(--color-danger)` and `var(--color-success)` respectively, and that the legend renders all three labels.
- `cd frontend && npx vitest run` -- 61 files / 352 tests pass, including the new spec.
- `cd frontend && npx tsc --noEmit` -- clean.

## Screenshots

Live before/after screenshots were not captured because reproducing them requires authenticating into the local seeded user, which I'm not in a position to do from this session. The new Vitest test is the deterministic regression evidence: it would have caught the bug had it existed before this fix.

## Risks

- Visual change to the dashboard only. Pre-launch app, no compat concerns.
- Tooltip formatter now reads the third positional argument from Recharts (`item.payload`). The Recharts type for the formatter is loose, so the access is typed defensively with a local payload shape. Behavior is unchanged when the payload is missing (falls back to under-plan / green).

## Reviewers

Internal: me. **External review required before merge.**
