### PR TITLE
fix(deploy): pass JWT_SECRET_KEY to migrate job to unblock PRE_DEPLOY

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -199,3 +199,7 @@ jobs:
         scope: RUN_AND_BUILD_TIME
         type: SECRET
         value: EV[1:PW7zpRXasYFhIiOoqMNopBxpqujwXZCO:LB8zQbjWAG4N99+0Q3m4fwakl3DTHqrPo9PH5r+JkSVSouY4n8pTl0ISC5FLVUBMPo92zTCxPIzGnfiKKbDEq5oxbKyM1g+jyVdUoXOBgogEWvJ84R5yvWC8SQVNQrdKsplwP2YScTPlpewRMw==]
+      - key: JWT_SECRET_KEY
+        scope: RUN_AND_BUILD_TIME
+        type: SECRET
+        value: EV[1:yu+iyIxbSwoJpe7aEGuEBSJ8judQo26F:Ogb2sdGetlKniX5UaHeObIhPiYej4c4W1fccXr1By5mIGy1LI4dn8R6NPR1CGfnUAo5fslDt7qV48MNdMnGwk1A9qlp8GxCcKD2fdYcm7f8=]


### PR DESCRIPTION
## PRODUCTION INCIDENT

Prod has been stuck on commit `69089ec` since PR #181 merged on 2026-05-08. Eight subsequent merges (#194, #195, #196, #197, #198, #199, #200, #201) all failed PRE_DEPLOY and were rolled back by App Platform. No customer-visible regression yet (the rolled-back revision keeps serving), but every change since 2026-05-08 is unmerged in production.

## Root cause

PR #181 introduced `backend/scripts/migrate.py` and pointed the App Platform PRE_DEPLOY job at it (`run_command: python /app/scripts/migrate.py`). That wrapper imports the app's structured logger:

```
backend/scripts/migrate.py
  -> from app.logging import setup_logging
       -> from app.config import settings        # evaluates Settings() at module load
            -> field_validator on jwt_secret_key  # rejects placeholder default
```

`Settings.jwt_secret_key` has a `@field_validator` (`backend/app/config.py:48-57`) that raises `ValueError` if the value equals the placeholder `"change-me-generate-a-real-secret"`.

The migrate job's `envs:` block in `.do/app.yaml` only declared `APP_ENV` and `DATABASE_URL`. App Platform does not auto-inherit secrets across components, so the migrate job inherited the placeholder default for `JWT_SECRET_KEY`. The validator fired, the script exited 1 before alembic ever started, and DO rolled the deploy back.

This is a known recurring failure mode for this app: JWT_SECRET_KEY dropping to its placeholder default has been documented in the spec's comments since 2026-04-25 (PR #89). The same class of bug, different surface.

## Fix

One env addition. The migrate job now passes the same encrypted `EV[...]` value the backend service uses for `JWT_SECRET_KEY`. EV references are scoped to the app, not the component, so the same blob decrypts correctly in both places.

```yaml
jobs:
  - name: migrate
    envs:
      - key: APP_ENV
        ...
      - key: DATABASE_URL
        ...
      - key: JWT_SECRET_KEY     # <-- added
        scope: RUN_AND_BUILD_TIME
        type: SECRET
        value: EV[1:yu+iyIxb...]   # same EV value as the backend service
```

No code change. No other env changes. No other file changes.

## Verification plan

After merge:

1. Watch the next deploy run. PRE_DEPLOY job should now exit 0.
2. Backend revision flips from `69089ec` to `02ac281` (HEAD of main).
3. Confirm prod commit at `https://app.thebetterdecision.com` matches `git rev-parse origin/main`.
4. Tail the migrate job logs to confirm `migrate.complete` (or `migrate.no_op` if no pending revisions) instead of the previous `ValidationError`.

## Tech-debt follow-up (out of scope here)

`backend/scripts/migrate.py` should not depend on `app.config`. The migrate job logically only needs `DATABASE_URL`. Refactor the wrapper so it pulls `database_url` directly from the environment and uses `logging.basicConfig` (or a minimal local structlog setup) instead of importing `app.logging`. That removes the entire transitive `Settings()` evaluation from the PRE_DEPLOY hot path and prevents any future Settings validator from silently breaking deploys the same way.

Tracked separately. This PR just unblocks production.

External review required before merge.