### PR TITLE
fix(a11y): mobile drawer keyboard + focus trap + reduced motion

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -28,13 +28,17 @@
   --theme-accent-text: #0B1F3A;
 
   --theme-danger: #f87171;
+  --theme-danger-hover: #ef4444;
   --theme-danger-dim: rgba(248, 113, 113, 0.12);
+  --theme-danger-text: #0B1F3A;
   --theme-success: #4ade80;
   --theme-success-dim: rgba(74, 222, 128, 0.12);
   --theme-info: #5FA8D3;
   --theme-info-dim: rgba(95, 168, 211, 0.12);
   --theme-warning: #f59e0b;
+  --theme-warning-hover: #d97706;
   --theme-warning-dim: rgba(245, 158, 11, 0.16);
+  --theme-warning-text: #0B1F3A;
 
   --theme-sidebar-bg: #06101e;
   --theme-sidebar-text: #7a8da6;
@@ -65,13 +69,17 @@
   --theme-accent-text: #ffffff;
 
   --theme-danger: #dc2626;
+  --theme-danger-hover: #b91c1c;
   --theme-danger-dim: rgba(220, 38, 38, 0.06);
+  --theme-danger-text: #ffffff;
   --theme-success: #16a34a;
   --theme-success-dim: rgba(22, 163, 74, 0.06);
   --theme-info: #2d7db3;
   --theme-info-dim: rgba(45, 125, 179, 0.08);
   --theme-warning: #b45309;
+  --theme-warning-hover: #92400e;
   --theme-warning-dim: rgba(180, 83, 9, 0.10);
+  --theme-warning-text: #ffffff;
 
   --theme-sidebar-bg: #0B1F3A;
   --theme-sidebar-text: #7a8da6;
@@ -101,13 +109,17 @@
   --color-accent-text: var(--theme-accent-text);
 
   --color-danger: var(--theme-danger);
+  --color-danger-hover: var(--theme-danger-hover);
   --color-danger-dim: var(--theme-danger-dim);
+  --color-danger-text: var(--theme-danger-text);
   --color-success: var(--theme-success);
   --color-success-dim: var(--theme-success-dim);
   --color-info: var(--theme-info);
   --color-info-dim: var(--theme-info-dim);
   --color-warning: var(--theme-warning);
+  --color-warning-hover: var(--theme-warning-hover);
   --color-warning-dim: var(--theme-warning-dim);
+  --color-warning-text: var(--theme-warning-text);
 
   --color-sidebar-bg: var(--theme-sidebar-bg);
   --color-sidebar-text: var(--theme-sidebar-text);

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -189,3 +189,18 @@ a, button { transition: all 0.15s ease; }
 .recharts-tooltip-wrapper .recharts-default-tooltip .recharts-tooltip-item {
   color: var(--theme-text-primary) !important;
 }
+
+/* Honor user's reduced-motion preference. WCAG 2.2 AA + PRODUCT.md
+   commitment. Disables animations, transitions, and smooth-scroll for
+   anyone with the OS-level preference set. Placed last so it wins
+   over earlier transition rules (a, button) and library overrides. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -10,13 +10,14 @@ import AppShellAddTransactionCta, {
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import TrialBanner from "@/components/ui/TrialBanner";
 import { hasPlatformPermission } from "@/lib/auth";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 
 const navItems = [
   {
     href: "/dashboard",
     label: "Dashboard",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
       </svg>
     ),
@@ -25,7 +26,7 @@ const navItems = [
     href: "/transactions",
     label: "Transactions",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
       </svg>
     ),
@@ -34,7 +35,7 @@ const navItems = [
     href: "/accounts",
     label: "Accounts",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
       </svg>
     ),
@@ -43,7 +44,7 @@ const navItems = [
     href: "/recurring",
     label: "Recurring",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182M21.015 4.356v4.992" />
       </svg>
     ),
@@ -52,7 +53,7 @@ const navItems = [
     href: "/budgets",
     label: "Budgets",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
         <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
       </svg>
@@ -62,7 +63,7 @@ const navItems = [
     href: "/forecast-plans",
     label: "Forecast Plans",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
       </svg>
     ),
@@ -71,7 +72,7 @@ const navItems = [
     href: "/categories",
     label: "Categories",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
         <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6Z" />
       </svg>
@@ -97,7 +98,7 @@ const systemItems: readonly SystemNavItem[] = [
     label: "Admin",
     permission: "admin.view",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
         <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
       </svg>
@@ -108,7 +109,7 @@ const systemItems: readonly SystemNavItem[] = [
     label: "Organizations",
     permission: "orgs.view",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
       </svg>
     ),
@@ -118,7 +119,7 @@ const systemItems: readonly SystemNavItem[] = [
     label: "Audit log",
     permission: "audit.view",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2Z" />
       </svg>
     ),
@@ -128,7 +129,7 @@ const systemItems: readonly SystemNavItem[] = [
     label: "Plans",
     permission: "plans.manage",
     icon: (
-      <svg className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <svg aria-hidden="true" className="h-[18px] w-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z" />
       </svg>
     ),
@@ -141,6 +142,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const [userExpanded, setUserExpanded] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const sidebarRef = useRef<HTMLElement | null>(null);
+
+  useFocusTrap({ active: sidebarOpen, containerRef: sidebarRef });
 
   useEffect(() => {
     if (!loading && !user) router.replace("/login");
@@ -152,6 +156,17 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     document.addEventListener("click", close);
     return () => document.removeEventListener("click", close);
   }, [userExpanded]);
+
+  // Escape closes the mobile drawer. useFocusTrap doesn't handle this
+  // itself; it only manages Tab cycling and focus restore.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSidebarOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [sidebarOpen]);
 
   if (loading || !user) {
     return (
@@ -189,19 +204,24 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex h-screen overflow-hidden">
-      {/* Mobile overlay backdrop */}
+      {/* Mobile overlay backdrop — real <button> so keyboard users can dismiss */}
       {sidebarOpen && (
-        <div className="fixed inset-0 z-40 bg-bg/80 lg:hidden" onClick={() => setSidebarOpen(false)} />
+        <button
+          type="button"
+          aria-label="Close menu"
+          onClick={() => setSidebarOpen(false)}
+          className="fixed inset-0 z-40 bg-bg/80 lg:hidden"
+        />
       )}
 
       {/* Dark sidebar — fixed height, never scrolls */}
-      <aside className={`fixed inset-y-0 left-0 z-50 flex w-56 flex-col bg-sidebar-bg transition-transform duration-200 lg:relative lg:translate-x-0 ${sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}`}>
+      <aside ref={sidebarRef} className={`fixed inset-y-0 left-0 z-50 flex w-56 flex-col bg-sidebar-bg transition-transform duration-200 lg:relative lg:translate-x-0 ${sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"}`}>
         <div className="flex items-center justify-between px-5 pt-5 pb-6">
           <Link href="/dashboard" className="font-display text-lg font-semibold text-sidebar-text-bright">
             TBD
           </Link>
           <button onClick={() => setSidebarOpen(false)} aria-label="Close menu" className="rounded-md p-1 text-sidebar-muted hover:text-sidebar-text-bright lg:hidden">
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg aria-hidden="true" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
             </svg>
           </button>
@@ -267,6 +287,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               <p className="truncate text-[11px] text-sidebar-muted">{user.org_name}</p>
             </div>
             <svg
+              aria-hidden="true"
               className={`h-3.5 w-3.5 text-sidebar-muted transition-transform ${userExpanded ? "rotate-180" : ""}`}
               fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
             >
@@ -281,7 +302,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 onClick={() => setSidebarOpen(false)}
                 className="flex items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
               >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
                   <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
                 </svg>
@@ -292,7 +313,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 onClick={logout}
                 className="flex w-full items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
               >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
                 </svg>
                 Sign Out
@@ -305,7 +326,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       <div className="flex flex-1 flex-col overflow-hidden">
         <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-surface px-4 sm:px-8">
           <button onClick={() => setSidebarOpen(true)} className="rounded-md p-2 text-text-muted hover:text-text-primary lg:hidden" aria-label="Open menu">
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg aria-hidden="true" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
             </svg>
           </button>
@@ -319,7 +340,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               aria-label="Docs"
               title="Docs"
             >
-              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <svg aria-hidden="true" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
               </svg>
             </Link>

--- a/frontend/lib/styles.ts
+++ b/frontend/lib/styles.ts
@@ -13,8 +13,11 @@ export const btnSecondary =
 export const btnDanger =
   "text-xs text-text-muted hover:text-danger";
 
+export const btnDangerSolid =
+  "rounded-md bg-danger px-4 py-2 text-sm font-medium text-danger-text hover:bg-danger-hover disabled:opacity-50";
+
 export const btnWarning =
-  "rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50";
+  "rounded-md bg-warning px-4 py-2 text-sm font-medium text-warning-text hover:bg-warning-hover disabled:opacity-50";
 
 export const btnLink =
   "text-xs text-text-muted hover:text-accent";
@@ -36,3 +39,24 @@ export const success =
 
 export const pageTitle =
   "mb-8 font-display text-2xl text-text-primary";
+
+export const badgeBase =
+  "inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium";
+
+export const badgeWarning =
+  `${badgeBase} bg-warning-dim text-warning`;
+
+export const badgeError =
+  `${badgeBase} bg-danger-dim text-danger`;
+
+export const badgeInfo =
+  `${badgeBase} bg-info-dim text-info`;
+
+export const badgeSuccess =
+  `${badgeBase} bg-success-dim text-success`;
+
+export const badgeNeutral =
+  `${badgeBase} bg-surface-raised text-text-secondary`;
+
+export const stickyBar =
+  "sticky top-0 z-20 -mx-4 sm:-mx-8 border-b border-border bg-surface-raised px-4 sm:px-8";

--- a/frontend/scripts/check-design-tokens.sh
+++ b/frontend/scripts/check-design-tokens.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# check-design-tokens.sh — enforce the design system token discipline.
+#
+# Forbidden in app/, components/, lib/ (the runtime UI surface):
+#   - Raw Tailwind palette utilities (bg-red-500, text-amber-600, etc.).
+#   - text-white / text-black in .ts/.tsx (legitimate inline-style escape
+#     hatches `app/opengraph-image.tsx` and `app/global-error.tsx` are
+#     excluded — they cannot rely on Tailwind theme tokens at runtime).
+#   - Hard-coded hex literals in .ts/.tsx.
+#
+# This script is EXPECTED TO FAIL today (Phase A): the foundation PR adds
+# the missing primitives but does not migrate call sites. Phase B will
+# replace the offending utilities at the call sites and, once green, this
+# check will be wired into CI. Until then, do not gate CI on it.
+#
+# Tracked Phase B fix targets (non-exhaustive):
+#   - app/transactions/page.tsx (sticky bar + amber/red utilities)
+#   - components/categories/BatchActionBar.tsx (sticky bar)
+#   - any component still using bg-amber-* / bg-red-* / text-white / text-black
+#
+# Usage:
+#   bash frontend/scripts/check-design-tokens.sh
+#
+# Exits 0 when clean, 1 when any forbidden pattern is found.
+
+set -uo pipefail
+
+# Resolve frontend dir relative to this script so it works from any cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${FRONTEND_DIR}"
+
+# Roots we scan.
+ROOTS=(app components lib)
+
+# Files / directories to exclude:
+#   - tests/
+#   - node_modules / .next (never present under app/components/lib but defensive)
+#   - app/opengraph-image.tsx — Next.js OG image route, only inline styles work.
+#   - app/global-error.tsx — root error boundary; runs without globals.css.
+EXCLUDES=(
+  --exclude-dir=node_modules
+  --exclude-dir=.next
+  --exclude-dir=tests
+  --exclude=opengraph-image.tsx
+  --exclude=global-error.tsx
+)
+
+PALETTES='(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)'
+PROPS='(bg|text|border|ring|fill|stroke|from|to|via|outline|divide|placeholder|caret|accent|shadow|decoration|hover:bg|hover:text|hover:border)'
+
+PALETTE_RE="${PROPS}-${PALETTES}-[0-9]+"
+WHITE_BLACK_RE='\b(text-white|text-black)\b'
+# Match 6-char hex literals only. The 3-char shorthand is too easily
+# confused with GitHub PR references (e.g. "PR #197") that pepper our
+# comments. If you ever need to catch shorthand, tighten this in Phase B
+# after the loud violations are gone.
+HEX_RE='#[0-9a-fA-F]{6}\b'
+
+fail=0
+
+run_check() {
+  local label="$1"
+  local pattern="$2"
+  shift 2
+  local includes=("$@")
+
+  local matches
+  matches=$(grep -rEnH "${pattern}" "${includes[@]}" "${EXCLUDES[@]}" "${ROOTS[@]}" 2>/dev/null || true)
+  if [ -n "${matches}" ]; then
+    echo "── ${label} ─────────────────────────────"
+    echo "${matches}"
+    echo
+    fail=1
+  fi
+}
+
+run_check "Raw Tailwind palette utilities" "${PALETTE_RE}" \
+  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx'
+
+run_check "text-white / text-black (use tokens)" "${WHITE_BLACK_RE}" \
+  --include='*.ts' --include='*.tsx'
+
+run_check "Hard-coded hex literals" "${HEX_RE}" \
+  --include='*.ts' --include='*.tsx'
+
+if [ "${fail}" -ne 0 ]; then
+  echo "Design-token check failed. Replace the offenders with theme tokens"
+  echo "from app/globals.css (e.g. bg-warning, text-danger, etc.) or with"
+  echo "primitives from lib/styles.ts (btnPrimary, badgeWarning, stickyBar...)."
+  exit 1
+fi
+
+echo "Design-token check passed."
+exit 0


### PR DESCRIPTION
## Summary
- Mobile sidebar overlay is now a real `<button aria-label="Close menu">`, reachable by keyboard (Enter/Space dismiss).
- `useFocusTrap` applied to the drawer `<aside>`; Tab/Shift+Tab cycles within, focus restores to the hamburger on close. A sibling effect handles Escape-to-close (the hook only owns Tab cycling + restore).
- Decorative SVG icons in `AppShell.tsx` (nav items, system nav, hamburger, close X, user chevron, Settings, Sign Out, Docs) all marked `aria-hidden="true"` so screen readers do not double-announce their adjacent labels.
- Global `@media (prefers-reduced-motion: reduce)` block added in `globals.css`, neutralizing animations, transitions, and smooth scroll. Honors WCAG 2.2 AA + PRODUCT.md commitment.

## Scope
Touches only `frontend/components/AppShell.tsx` and `frontend/app/globals.css`. No new deps. No new raw Tailwind palette utilities (design-token check still at 33 lines, same as A1 baseline).

## Disabled-state parity audit
All `disabled:opacity-50` usages across `app/`, `components/`, `lib/` use the Tailwind modifier prefix, which only fires when the element actually has `disabled`. No mismatches to fix. The only bare `opacity-50` lives on a `<div>` row in `app/recurring/page.tsx:207` (inactive recurring template row) — not a button/input, so not a parity issue.

Stacks on top of #203 (A1 primitives). PR base set to `feat/design-system-primitives`.