### PR TITLE
fix(frontend): Number Voice + State-Only Shadow compliance

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -66,7 +66,7 @@ function KpiCard({ label, value }: { label: string; value: number }) {
       <p className="text-xs font-medium uppercase tracking-[0.08em] text-text-muted">
         {label}
       </p>
-      <p className="mt-2 font-display text-3xl text-text-primary">{nf.format(value)}</p>
+      <p className="mt-2 text-3xl font-semibold tabular-nums text-text-primary">{nf.format(value)}</p>
     </div>
   );
 }

--- a/frontend/app/recurring/page.tsx
+++ b/frontend/app/recurring/page.tsx
@@ -145,7 +145,7 @@ export default function RecurringPage() {
               {activeItems.map((r) => (
                 <article
                   key={r.id}
-                  className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 shadow-sm"
+                  className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4"
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
@@ -225,7 +225,7 @@ export default function RecurringPage() {
                 {pausedItems.map((r) => (
                   <article
                     key={r.id}
-                    className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 shadow-sm opacity-60"
+                    className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 opacity-60"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0 flex-1">

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1453,7 +1453,7 @@ function TransactionsPageContent() {
                       const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
                       if (editingId === tx.id) {
                         return (
-                          <article key={tx.id} className="flex flex-col gap-3 rounded-lg border border-border bg-surface-raised p-4 shadow-sm">
+                          <article key={tx.id} className="flex flex-col gap-3 rounded-lg border border-border bg-surface-raised p-4">
                             {editPartner && (
                               <div className="text-xs text-accent" data-testid={`edit-mirror-notice-mobile-${tx.id}`}>
                                 Editing a transfer leg. Changes to amount apply to both rows.
@@ -1604,7 +1604,7 @@ function TransactionsPageContent() {
                       return (
                         <article
                           key={tx.id}
-                          className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 shadow-sm"
+                          className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4"
                         >
                           {/* Pending rows dim the row contents but keep the
                               status pill at full opacity. CSS opacity composites

--- a/frontend/components/landing/HeroDashboard.tsx
+++ b/frontend/components/landing/HeroDashboard.tsx
@@ -2,7 +2,7 @@ export default function HeroDashboard() {
   return (
     <div
       aria-hidden
-      className="rounded-xl border border-border bg-surface-raised p-6 shadow-2xl"
+      className="rounded-xl border border-border bg-surface-raised p-6"
     >
       <div className="mb-1 text-[10px] font-medium uppercase tracking-[0.12em] text-text-muted">
         April balance

--- a/frontend/components/landing/HeroDashboard.tsx
+++ b/frontend/components/landing/HeroDashboard.tsx
@@ -7,7 +7,7 @@ export default function HeroDashboard() {
       <div className="mb-1 text-[10px] font-medium uppercase tracking-[0.12em] text-text-muted">
         April balance
       </div>
-      <div className="mb-5 font-display text-3xl font-semibold text-text-primary">
+      <div className="mb-5 text-3xl font-semibold tabular-nums text-text-primary">
         €4,283.12
       </div>
 


### PR DESCRIPTION
## Summary

- Admin KPI numbers: drop Fraunces and use Outfit (body) with `tabular-nums` + `font-semibold`. Currency and counts read as data, not branding (DESIGN.md §3 Number Voice Rule). Page title `h1` keeps Fraunces.
- Strip `shadow-sm` from four resting cards in `transactions` and `recurring` mobile layouts; depth now comes from `surface` / `surface-raised` plus the existing `border-border` (DESIGN.md §4 State-Only Shadow Rule).
- Drop `shadow-2xl` from the static `HeroDashboard` preview block. Border + raised surface keeps the container outline without breaking the rule on a non-state element.
- Stacked on `fix/touch-targets-and-modal-widths` (Phase C2). No layout changes; no modals, popovers, or dropdowns touched.