### PR TITLE
chore(stabilization): token check + lint gate in CI, fix dashboard react/jsx-key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,14 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Check design tokens
+        working-directory: frontend
+        run: bash scripts/check-design-tokens.sh
+
+      - name: Run frontend lint
+        working-directory: frontend
+        run: npm run lint -- --quiet
+
       - name: Run frontend tests
         working-directory: frontend
         run: npm test

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -984,7 +984,7 @@ export default function DashboardPage() {
                               if (name === "planned") {
                                 return [
                                   formatAmount(Number(v)),
-                                  <span style={{ color: chartColor.planned }}>Planned</span>,
+                                  <span key="planned" style={{ color: chartColor.planned }}>Planned</span>,
                                 ];
                               }
                               const row = (item as { payload?: { planned: number; actual: number } } | undefined)?.payload;
@@ -992,7 +992,7 @@ export default function DashboardPage() {
                               const labelColor = isOver ? chartColor.over : chartColor.actual;
                               return [
                                 formatAmount(Number(v)),
-                                <span style={{ color: labelColor }}>Actual</span>,
+                                <span key="actual" style={{ color: labelColor }}>Actual</span>,
                               ];
                             }}
                             contentStyle={{ fontSize: "11px" }}


### PR DESCRIPTION
Post-merge stabilization after the design-system + a11y + perf wave (#203-#208).

- Wire `frontend/scripts/check-design-tokens.sh` into Frontend Checks, ahead of tests/build.
- Add `npm run lint -- --quiet` (errors only) to Frontend Checks now that the two pre-existing dashboard `react/jsx-key` errors are fixed.
- Fix `frontend/app/dashboard/page.tsx:987,995` by giving the Recharts tooltip-formatter `<span>` labels static keys.
- `lucide-react@^1.7.0` verified: lockfile and installed match; named exports used by the AppShell swap all resolve. No change.