### PR TITLE
feat(auth): server-side auth helpers for RSC migrations (foundation)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -169,6 +169,13 @@ services:
       - key: HOSTNAME
         scope: RUN_AND_BUILD_TIME
         value: "0.0.0.0"
+      # Server-side (RSC) reach to the backend. Browser requests use the App
+      # Platform ingress (relative URLs); server-side fetches must hit the
+      # backend component via its private URL. RUN_TIME scope only — the
+      # value isn't needed at build time and isn't resolvable then either.
+      - key: BACKEND_INTERNAL_URL
+        scope: RUN_TIME
+        value: ${backend.PRIVATE_URL}
 
 # Pre-deploy job: run Alembic migrations exactly once before any backend
 # replica starts. This is the canonical "init container" pattern for App

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,6 +51,10 @@ services:
     environment:
       - NEXT_PUBLIC_API_URL=
       - HOSTNAME=0.0.0.0
+      # Server-side (RSC) reach to the backend. Browser requests use the
+      # nginx ingress (relative URLs); server-side fetches must hit the
+      # backend service directly inside the compose network.
+      - BACKEND_INTERNAL_URL=http://backend:8000
     depends_on:
       - backend
     volumes: []  # Override dev volume mounts — immutable container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,10 @@ services:
       - "3000"
     environment:
       - NEXT_PUBLIC_API_URL=
+      # Server-side (RSC) reach to the backend. Browser requests use the
+      # nginx ingress (relative URLs); server-side fetches must hit the
+      # backend service directly inside the compose network.
+      - BACKEND_INTERNAL_URL=http://backend:8000
     depends_on:
       - backend
     volumes:

--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -1,0 +1,72 @@
+import { cookies } from "next/headers";
+import { cache } from "react";
+import type { User } from "./types";
+
+// Foundation for Server Component migrations. The client-side `apiFetch` in
+// lib/api.ts cannot run in an RSC: the access token lives in an in-memory
+// module variable, and `next/headers` cookies are only available server-side.
+//
+// This module reads the refresh cookie that the backend sets at login time
+// (`refresh_token`, HTTP-only, Path=/) and forwards it to a purpose-built
+// backend endpoint that validates the cookie WITHOUT rotation, then returns
+// `{ user, access_token, token_type }` in one round-trip. See backend PR #211
+// for the endpoint contract and the latent FastAPI cookie-merge bug it
+// documented along the way.
+//
+// Results are cached per request via React's `cache` so multiple RSCs in a
+// single render only pay the network cost once.
+//
+// URL resolution. The browser uses relative URLs and nginx routes them. The
+// server (this module) needs an absolute URL to reach the backend. In
+// docker-compose dev and prod, BACKEND_INTERNAL_URL points at the backend
+// service (`http://backend:8000`). On DO App Platform it resolves to the
+// inter-service private URL. Fallback chain ends at `http://localhost:8000`
+// so a developer running the backend directly outside docker can still
+// import this module and have it work.
+
+const SERVER_API_URL =
+  process.env.BACKEND_INTERNAL_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8000";
+
+const REFRESH_COOKIE_NAME = "refresh_token";
+
+export type ServerSession = {
+  user: User;
+  accessToken: string;
+};
+
+export const getServerSession = cache(
+  async (): Promise<ServerSession | null> => {
+    const cookieStore = await cookies();
+    const refresh = cookieStore.get(REFRESH_COOKIE_NAME);
+    if (!refresh) return null;
+
+    const res = await fetch(`${SERVER_API_URL}/api/v1/auth/verify`, {
+      method: "POST",
+      headers: {
+        Cookie: `${refresh.name}=${refresh.value}`,
+      },
+      // No credentials: 'include' on server-side fetch — we forward the
+      // cookie explicitly via the Cookie header above. The endpoint does not
+      // issue a Set-Cookie response, so there's nothing to propagate back.
+      cache: "no-store",
+    });
+
+    if (!res.ok) return null;
+
+    const payload = (await res.json()) as {
+      user: User;
+      access_token: string;
+      token_type: string;
+    };
+    if (!payload.access_token || !payload.user) return null;
+
+    return { user: payload.user, accessToken: payload.access_token };
+  },
+);
+
+export const getServerUser = async (): Promise<User | null> => {
+  const session = await getServerSession();
+  return session?.user ?? null;
+};


### PR DESCRIPTION
Foundation for the planned `/forecast-plans` → `/transactions` → `/dashboard` Server Component migrations (architecture note: `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-10-server-component-split.md`).

Consumes the new `POST /api/v1/auth/verify` endpoint shipped in #211 — single round-trip, no rotation, no Set-Cookie. Reviewer found three blockers on the first draft; all fixed in #211 + this update:

- `getServerSession()` is now a single `POST /api/v1/auth/verify` call (was two-step `refresh + me`, which would have discarded backend rotation Set-Cookie headers).
- `BACKEND_INTERNAL_URL` wired at every place the frontend server runs: `docker-compose.yml`, `docker-compose.prod.yml`, and `.do/app.yaml` (DO binding via `${backend.PRIVATE_URL}`, RUN_TIME scope — not needed at build).
- Existing client-side auth (`lib/api.ts`, `AuthProvider`) unchanged.
- Zero backend changes in this PR (those landed in #211).
- React `cache()` de-duplicates per render.

Followups outside this PR:
- First RSC consumer (`/forecast-plans` → RSC shell + `<ForecastPlansClient>`).
- Optional `<AuthProvider initialUser>` seeding from `app/layout.tsx` to skip the on-mount client refresh — deferred until the first consumer validates the pattern in practice.
- `${backend.PRIVATE_URL}` exact resolution on App Platform is the typical DO binding form; if the first deploy reveals a different syntax, that's a one-line fix in `.do/app.yaml`.