### PR TITLE
feat(auth): server-side verify endpoint + widen refresh cookie path

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -286,12 +286,34 @@ async def login(
     return TokenResponse(access_token=access_token)
 
 
-@router.post("/refresh", response_model=TokenResponse)
-async def refresh(
-    response: Response,
-    refresh_token: str | None = Cookie(default=None),
-    db: AsyncSession = Depends(get_db),
-):
+SESSION_EXPIRED_DETAIL = "Session expired — please sign in again"
+
+
+async def _validate_refresh_cookie(
+    refresh_token: str | None,
+    db: AsyncSession,
+) -> tuple[User, dict, datetime | None]:
+    """Validate a refresh-token cookie. Returns (user, payload, session_start)
+    or raises ``HTTPException(401)`` on any failure.
+
+    Shared between ``/auth/refresh`` (rotating) and ``/auth/verify`` (non-
+    rotating). Performs identical checks for both endpoints so the contract
+    cannot drift:
+
+      1. cookie presence
+      2. JWT decode + ``type == "refresh"``
+      3. user exists + ``is_active``
+      4. ``iat < token_cutoff(user)`` rejects tokens issued before the
+         user's last logout / password change / password reset
+      5. absolute session lifetime (per-org ``session_lifetime_days``
+         setting or system default) — raises with detail
+         ``SESSION_EXPIRED_DETAIL`` so callers can recognize and act
+         (e.g. ``/refresh`` clears the cookie; ``/verify`` does not)
+
+    Note: this helper never writes a cookie. Cookie management is the
+    caller's responsibility so the no-Set-Cookie invariant on ``/verify``
+    is absolute.
+    """
     if refresh_token is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -308,14 +330,14 @@ async def refresh(
     user_id = int(payload["sub"])
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
-
     if user is None or not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found or inactive",
         )
 
-    # Reject refresh tokens issued before the session cutoff (logout / password change)
+    # Reject tokens issued before the user's session cutoff
+    # (logout / password change / password reset)
     iat = payload.get("iat")
     if iat is not None:
         token_issued_at = datetime.fromtimestamp(iat, tz=timezone.utc)
@@ -325,12 +347,12 @@ async def refresh(
                 detail="Session has been invalidated",
             )
 
-    # Enforce absolute session lifetime
+    # Enforce absolute session lifetime (per-org setting or system default)
     session_created_at = payload.get("session_created_at")
+    session_start: datetime | None = None
     if session_created_at:
         session_start = datetime.fromtimestamp(session_created_at, tz=timezone.utc)
 
-        # Check org-level override first, fall back to system default
         max_days = app_settings.session_lifetime_days
         org_setting = await db.scalar(
             select(OrgSetting.value).where(
@@ -345,21 +367,57 @@ async def refresh(
                 pass
 
         if datetime.now(timezone.utc) - session_start > timedelta(days=max_days):
-            response.delete_cookie("refresh_token", path="/")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Session expired — please sign in again",
+                detail=SESSION_EXPIRED_DETAIL,
             )
 
-    # Carry forward session_created_at from the original login
-    original_session = (
-        datetime.fromtimestamp(session_created_at, tz=timezone.utc)
-        if session_created_at
-        else None
-    )
+    return user, payload, session_start
 
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(
+    response: Response,
+    refresh_token: str | None = Cookie(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Rotate the refresh cookie + issue a fresh access token.
+
+    Shares the full validation chain with ``/verify`` via
+    ``_validate_refresh_cookie``. On session-lifetime expiry this endpoint
+    additionally clears the stale cookie before returning 401; ``/verify``
+    deliberately does not (it must never emit Set-Cookie).
+
+    NOTE: FastAPI does NOT merge cookies set on the injected ``response``
+    parameter into the JSONResponse it builds from a raised HTTPException
+    (the same gotcha the SSO callback works around by writing cookies
+    onto a directly-returned RedirectResponse). For the session-expiry
+    path we therefore return a JSONResponse directly so the
+    delete-cookie header actually reaches the browser.
+    """
+    try:
+        user, _payload, session_start = await _validate_refresh_cookie(
+            refresh_token, db
+        )
+    except HTTPException as exc:
+        # Clear the stale cookie on absolute session-lifetime expiry so the
+        # browser stops sending it. Other 401s leave the cookie in place;
+        # they may be transient (e.g. invalid-but-recoverable) or carry
+        # their own meaning.
+        if exc.detail == SESSION_EXPIRED_DETAIL:
+            from fastapi.responses import JSONResponse
+
+            expired_response = JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+            )
+            expired_response.delete_cookie("refresh_token", path="/")
+            return expired_response
+        raise
+
+    # Carry forward session_created_at from the original login
     access_token = create_access_token(user.id, user.org_id, user.role.value)
-    new_refresh_token = create_refresh_token(user.id, session_created_at=original_session)
+    new_refresh_token = create_refresh_token(user.id, session_created_at=session_start)
 
     response.set_cookie(
         key="refresh_token",
@@ -384,30 +442,20 @@ async def verify(
     """Server-side session verification for RSC consumers.
 
     Validates the refresh cookie without rotating it. Returns the same
-    `UserResponse` shape as `/auth/me` plus a fresh access token. No
-    `Set-Cookie`. No audit log on success.
+    ``UserResponse`` shape as ``/auth/me`` plus a fresh access token.
+
+    Invariants (load-bearing for RSC callers):
+    - never emits ``Set-Cookie`` — even on session-lifetime expiry, the
+      stale cookie is left in place (it will expire by its own ``max_age``)
+    - no audit log on success
+
+    Shares the full validation chain with ``/auth/refresh`` via
+    ``_validate_refresh_cookie`` so the security contract cannot drift
+    between the two endpoints.
     """
-    if refresh_token is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="No refresh token",
-        )
-
-    payload = decode_token(refresh_token)
-    if payload is None or payload.get("type") != "refresh":
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid refresh token",
-        )
-
-    user_id = int(payload["sub"])
-    result = await db.execute(select(User).where(User.id == user_id))
-    user = result.scalar_one_or_none()
-    if user is None or not user.is_active:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid session",
-        )
+    user, _payload, _session_start = await _validate_refresh_cookie(
+        refresh_token, db
+    )
 
     await db.refresh(user, ["organization"])
     await subscription_service.check_trial_expiry(db, user.org_id)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -42,6 +42,7 @@ from app.schemas.auth import (
     UsernameCheckResponse,
     UserResponse,
     VerifyEmailRequest,
+    VerifyResponse,
 )
 from app.config import settings as app_settings
 from app import redis_client
@@ -279,7 +280,7 @@ async def login(
         secure=app_settings.cookie_secure,
         samesite="lax",
         max_age=7 * 24 * 60 * 60,
-        path="/api/v1/auth/refresh",
+        path="/",
     )
 
     return TokenResponse(access_token=access_token)
@@ -344,7 +345,7 @@ async def refresh(
                 pass
 
         if datetime.now(timezone.utc) - session_start > timedelta(days=max_days):
-            response.delete_cookie("refresh_token", path="/api/v1/auth/refresh")
+            response.delete_cookie("refresh_token", path="/")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Session expired — please sign in again",
@@ -367,10 +368,60 @@ async def refresh(
         secure=app_settings.cookie_secure,
         samesite="lax",
         max_age=7 * 24 * 60 * 60,
-        path="/api/v1/auth/refresh",
+        path="/",
     )
 
     return TokenResponse(access_token=access_token)
+
+
+@router.post("/verify", response_model=VerifyResponse)
+@limiter.limit("120/minute")
+async def verify(
+    request: Request,
+    refresh_token: str | None = Cookie(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Server-side session verification for RSC consumers.
+
+    Validates the refresh cookie without rotating it. Returns the same
+    `UserResponse` shape as `/auth/me` plus a fresh access token. No
+    `Set-Cookie`. No audit log on success.
+    """
+    if refresh_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No refresh token",
+        )
+
+    payload = decode_token(refresh_token)
+    if payload is None or payload.get("type") != "refresh":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        )
+
+    user_id = int(payload["sub"])
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid session",
+        )
+
+    await db.refresh(user, ["organization"])
+    await subscription_service.check_trial_expiry(db, user.org_id)
+    pair = await subscription_service.get_subscription_with_plan(db, user.org_id)
+    sub, plan = pair if pair else (None, None)
+    user_resp = _user_response(user, user.organization, sub, plan)
+
+    access_token = create_access_token(user.id, user.org_id, user.role.value)
+
+    return VerifyResponse(
+        user=user_resp,
+        access_token=access_token,
+        token_type="bearer",
+    )
 
 
 @router.get("/me", response_model=UserResponse)
@@ -411,7 +462,7 @@ async def logout(
         except Exception:
             # Missing/expired/malformed token: still clear the cookie below.
             pass
-    response.delete_cookie("refresh_token", path="/api/v1/auth/refresh")
+    response.delete_cookie("refresh_token", path="/")
     return {"detail": "Logged out"}
 
 
@@ -595,7 +646,7 @@ def _issue_tokens(user: User, response: Response) -> TokenResponse:
         secure=app_settings.cookie_secure,
         samesite="lax",
         max_age=7 * 24 * 60 * 60,
-        path="/api/v1/auth/refresh",
+        path="/",
     )
     return TokenResponse(access_token=access_token)
 
@@ -1060,7 +1111,7 @@ async def google_callback(
         secure=app_settings.cookie_secure,
         samesite="lax",
         max_age=7 * 24 * 60 * 60,
-        path="/api/v1/auth/refresh",
+        path="/",
     )
     return resp
 

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -185,7 +185,12 @@ async def accept_invitation(
         secure=app_settings.cookie_secure,
         samesite="lax",
         max_age=7 * 24 * 60 * 60,
-        path="/api/v1/auth/refresh",
+        # Path=/ so the browser sends the cookie on regular page requests
+        # (not just /api/v1/auth/refresh). Required for Next.js RSC to read
+        # the cookie via /auth/verify. Mirrors the convention applied in
+        # app/routers/auth.py (login, refresh rotation, logout, _issue_tokens,
+        # google_callback).
+        path="/",
     )
     return TokenResponse(access_token=access)
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -75,6 +75,12 @@ class UserResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class VerifyResponse(BaseModel):
+    user: UserResponse
+    access_token: str
+    token_type: str = "bearer"
+
+
 class UsernameCheckResponse(BaseModel):
     available: bool
     suggestion: str | None = None

--- a/backend/tests/auth/test_verify_and_cookie_path.py
+++ b/backend/tests/auth/test_verify_and_cookie_path.py
@@ -1,0 +1,312 @@
+"""Backend PR-A — `POST /api/v1/auth/verify` endpoint + refresh cookie path widened to `/`.
+
+Pins the new server-side session verification endpoint (consumed by Next.js
+RSC) and the widened cookie path that lets the browser send the refresh
+cookie on regular page requests so RSC can authenticate server-side.
+
+Critical invariants:
+- `/verify` must NEVER set or rotate the refresh cookie (no Set-Cookie).
+- `/verify` must NEVER write an audit log on success.
+- `refresh_token` cookies (set + delete) carry `Path=/`, not the old
+  `Path=/api/v1/auth/refresh`.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import router as auth_router
+from app.security import create_refresh_token, hash_password
+
+
+PASSWORD = "S3cret-Pass!"
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    """Each test starts with an empty rate-limiter state."""
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(
+    factory,
+    *,
+    is_active: bool = True,
+    username: str = "alice",
+    email: str = "alice@example.com",
+    email_verified: bool = True,
+) -> int:
+    async with factory() as db:
+        org = Organization(name="org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=email,
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=is_active,
+            email_verified=email_verified,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+# ── /verify happy path ───────────────────────────────────────────────────────
+
+
+async def test_verify_returns_user_and_access_token(session_factory):
+    user_id = await _seed_user(session_factory)
+    refresh = create_refresh_token(user_id)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        # First call `/me` after login to know the canonical user shape; here
+        # we just assert the verify body contains the same key fields.
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert set(body.keys()) == {"user", "access_token", "token_type"}
+    assert body["token_type"] == "bearer"
+    assert isinstance(body["access_token"], str) and body["access_token"]
+    # `user` shape mirrors UserResponse / /auth/me.
+    user_resp = body["user"]
+    assert user_resp["id"] == user_id
+    assert user_resp["username"] == "alice"
+    assert user_resp["email"] == "alice@example.com"
+    assert user_resp["role"] == Role.OWNER.value
+    assert user_resp["is_active"] is True
+    assert "org_id" in user_resp and "org_name" in user_resp
+
+
+async def test_verify_user_shape_matches_me(session_factory):
+    """The user payload must be identical to /auth/me's UserResponse."""
+    user_id = await _seed_user(session_factory)
+    refresh = create_refresh_token(user_id)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        # /me requires a Bearer access token; obtain via /login.
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        assert login.status_code == 200
+        access = login.json()["access_token"]
+        me = client.get(
+            "/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert me.status_code == 200
+
+        verify = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": refresh},
+        )
+        assert verify.status_code == 200
+
+    assert verify.json()["user"] == me.json()
+
+
+# ── /verify error paths ──────────────────────────────────────────────────────
+
+
+async def test_verify_no_cookie_returns_401(session_factory):
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/auth/verify")
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "No refresh token"
+
+
+async def test_verify_invalid_refresh_token_returns_401(session_factory):
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": "this.is.not.a.jwt"},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Invalid refresh token"
+
+
+async def test_verify_access_token_not_accepted_as_refresh(session_factory):
+    """An access token (wrong `type` claim) must be rejected."""
+    from app.security import create_access_token
+
+    user_id = await _seed_user(session_factory)
+    access = create_access_token(user_id, 1, Role.OWNER.value)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": access},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Invalid refresh token"
+
+
+async def test_verify_inactive_user_returns_401(session_factory):
+    user_id = await _seed_user(session_factory, is_active=False)
+    refresh = create_refresh_token(user_id)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Invalid session"
+
+
+# ── Critical invariant: /verify never rotates or sets a cookie ───────────────
+
+
+async def test_verify_does_not_rotate_or_set_cookie(session_factory):
+    """The whole point of /verify: it is a passive read. Asserting NO
+    `Set-Cookie` on the response is the load-bearing test for this PR."""
+    user_id = await _seed_user(session_factory)
+    refresh = create_refresh_token(user_id)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 200
+    header_keys_lower = {k.lower() for k in res.headers.keys()}
+    assert "set-cookie" not in header_keys_lower, (
+        f"/verify must not emit Set-Cookie; got headers: {dict(res.headers)}"
+    )
+
+
+# ── Cookie path widened to `/` ───────────────────────────────────────────────
+
+
+def _set_cookie_for(headers, name: str) -> str | None:
+    """Return the raw Set-Cookie header value whose cookie name is `name`."""
+    # httpx exposes multi-valued headers via the .raw / .multi_items interface;
+    # falling back to the joined value works because each cookie attribute
+    # block is comma-separated only when the cookie names differ.
+    for raw_value in headers.get_list("set-cookie") if hasattr(headers, "get_list") else headers.raw:
+        if isinstance(raw_value, tuple):
+            # httpx Headers.raw → list[(b"set-cookie", b"...")]
+            key, value = raw_value
+            if key.decode().lower() != "set-cookie":
+                continue
+            value = value.decode()
+        else:
+            value = raw_value
+        if value.split("=", 1)[0].strip().lower() == name.lower():
+            return value
+    return None
+
+
+async def test_cookie_path_is_root_on_login(session_factory):
+    await _seed_user(session_factory)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+
+    assert res.status_code == 200
+    raw = _set_cookie_for(res.headers, "refresh_token")
+    assert raw is not None, f"No refresh_token cookie on login. Headers: {dict(res.headers)}"
+    assert "Path=/" in raw
+    assert "Path=/api/v1/auth/refresh" not in raw
+
+
+async def test_cookie_path_is_root_on_refresh_rotation(session_factory):
+    user_id = await _seed_user(session_factory)
+    refresh = create_refresh_token(user_id)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 200
+    raw = _set_cookie_for(res.headers, "refresh_token")
+    assert raw is not None, f"No refresh_token cookie on refresh. Headers: {dict(res.headers)}"
+    assert "Path=/" in raw
+    assert "Path=/api/v1/auth/refresh" not in raw
+
+
+async def test_cookie_path_is_root_on_logout_delete(session_factory):
+    await _seed_user(session_factory)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/auth/logout")
+
+    assert res.status_code == 200
+    raw = _set_cookie_for(res.headers, "refresh_token")
+    assert raw is not None, (
+        f"Logout must emit a delete-cookie Set-Cookie header. Got: {dict(res.headers)}"
+    )
+    assert "Path=/" in raw
+    assert "Path=/api/v1/auth/refresh" not in raw

--- a/backend/tests/auth/test_verify_and_cookie_path.py
+++ b/backend/tests/auth/test_verify_and_cookie_path.py
@@ -213,7 +213,8 @@ async def test_verify_inactive_user_returns_401(session_factory):
         )
 
     assert res.status_code == 401
-    assert res.json()["detail"] == "Invalid session"
+    # Detail is identical to /refresh — both endpoints share the validator.
+    assert res.json()["detail"] == "User not found or inactive"
 
 
 # ── Critical invariant: /verify never rotates or sets a cookie ───────────────
@@ -310,3 +311,153 @@ async def test_cookie_path_is_root_on_logout_delete(session_factory):
     )
     assert "Path=/" in raw
     assert "Path=/api/v1/auth/refresh" not in raw
+
+
+# ── Full validation chain on /verify ────────────────────────────────────────
+#
+# These pin Finding 1 from PR #211 review: `/verify` must run the SAME
+# validator as `/refresh`. Skipping the `iat < token_cutoff` and
+# absolute-session-lifetime checks would let a logged-out user mint
+# access tokens via `/verify` until the refresh token's natural exp.
+
+
+async def _seed_user_with_session_cutoff(
+    factory,
+    invalidated_at,
+) -> int:
+    """Seed an active user whose sessions_invalidated_at is set to now-ish.
+
+    Tokens issued before `invalidated_at` must be rejected by token_cutoff.
+    """
+    async with factory() as db:
+        from sqlalchemy import select
+
+        org = Organization(name="org-cutoff", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username="bob",
+            email="bob@example.com",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+            sessions_invalidated_at=invalidated_at,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+async def test_verify_rejects_invalidated_refresh_token(session_factory):
+    """Token issued BEFORE the user's session cutoff (logout / password
+    change / password reset) must be rejected by /verify — same as /refresh.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    # Mint the refresh token first, then bump the cutoff to "after" it.
+    user_id = await _seed_user(session_factory)
+    refresh = create_refresh_token(user_id)
+
+    # Bump sessions_invalidated_at to a future timestamp so any token
+    # already in hand has iat < cutoff.
+    async with session_factory() as db:
+        from sqlalchemy import select
+
+        result = await db.execute(select(User).where(User.id == user_id))
+        user = result.scalar_one()
+        user.sessions_invalidated_at = datetime.now(timezone.utc) + timedelta(
+            seconds=60
+        )
+        await db.commit()
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Session has been invalidated"
+    # Invariant: even on this failure, /verify does NOT touch the cookie.
+    header_keys_lower = {k.lower() for k in res.headers.keys()}
+    assert "set-cookie" not in header_keys_lower
+
+
+async def test_verify_rejects_expired_session_lifetime(session_factory):
+    """Refresh tokens whose session_created_at is older than the org's
+    (or system) session_lifetime_days must be rejected by /verify.
+
+    Additionally pins that /verify does NOT emit Set-Cookie on this path —
+    only /refresh clears the cookie. The browser's stale cookie will
+    eventually expire by its own max_age.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from app.config import settings as app_settings
+    from app.security import create_refresh_token as _crt
+
+    user_id = await _seed_user(session_factory)
+
+    # Build a refresh token whose session_created_at is far older than the
+    # absolute lifetime cap. Using session_lifetime_days + 30 days of slack.
+    long_ago = datetime.now(timezone.utc) - timedelta(
+        days=app_settings.session_lifetime_days + 30
+    )
+    refresh = _crt(user_id, session_created_at=long_ago)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"].startswith("Session expired")
+    # Invariant: /verify must not emit Set-Cookie even on session-expiry.
+    header_keys_lower = {k.lower() for k in res.headers.keys()}
+    assert "set-cookie" not in header_keys_lower, (
+        "verify must never emit Set-Cookie, even on session-lifetime expiry; "
+        f"got headers: {dict(res.headers)}"
+    )
+
+
+async def test_refresh_clears_cookie_on_session_lifetime_expiry(session_factory):
+    """Counterpart to the /verify expiry test: /refresh DOES clear the
+    stale cookie on the session-lifetime-expired path. This pins the
+    behavior asymmetry that motivated putting cookie-clear in the route
+    rather than the shared validator.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from app.config import settings as app_settings
+    from app.security import create_refresh_token as _crt
+
+    user_id = await _seed_user(session_factory)
+
+    long_ago = datetime.now(timezone.utc) - timedelta(
+        days=app_settings.session_lifetime_days + 30
+    )
+    refresh = _crt(user_id, session_created_at=long_ago)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"].startswith("Session expired")
+    raw = _set_cookie_for(res.headers, "refresh_token")
+    assert raw is not None, (
+        "/refresh must emit a delete-cookie Set-Cookie header on session-expiry; "
+        f"got: {dict(res.headers)}"
+    )
+    # Delete-cookie carries an empty value + Path=/ (matches the path the
+    # cookie was originally set on, post-widening).
+    assert "Path=/" in raw

--- a/backend/tests/routers/test_org_members.py
+++ b/backend/tests/routers/test_org_members.py
@@ -278,6 +278,54 @@ async def test_accept_creates_user_and_returns_token(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_invite_accept_sets_root_path_refresh_cookie(session_factory):
+    """Pins Finding 2 from PR #211 review: invite-accept must use Path=/
+    on the refresh_token cookie so the browser sends it on regular page
+    requests (needed for Next.js RSC to read via /auth/verify). Previously
+    used the legacy Path=/api/v1/auth/refresh.
+    """
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        inv = await invitation_service.create_invitation(
+            db, org_id=seed["org_id"], created_by=seed["owner_id"],
+            email="cookieaccept@acme.io", role=Role.MEMBER,
+        )
+        await db.commit()
+        token = create_invitation_token(inv.id, inv.email)
+    app = make_app(session_factory, _user_factory(Role.OWNER))
+    app.dependency_overrides.pop(get_current_user, None)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/invitations/accept",
+            json={"token": token, "username": "cookieuser", "password": "strong-pw-1234"},
+        )
+    assert res.status_code == 200, res.text
+
+    # Locate the refresh_token Set-Cookie value and assert Path=/
+    raw = None
+    for raw_value in (
+        res.headers.get_list("set-cookie")
+        if hasattr(res.headers, "get_list")
+        else res.headers.raw
+    ):
+        if isinstance(raw_value, tuple):
+            key, value = raw_value
+            if key.decode().lower() != "set-cookie":
+                continue
+            value = value.decode()
+        else:
+            value = raw_value
+        if value.split("=", 1)[0].strip().lower() == "refresh_token":
+            raw = value
+            break
+    assert raw is not None, (
+        f"Invite-accept must emit a refresh_token Set-Cookie. Got: {dict(res.headers)}"
+    )
+    assert "Path=/" in raw
+    assert "Path=/api/v1/auth/refresh" not in raw
+
+
+@pytest.mark.asyncio
 async def test_accept_410_for_revoked(session_factory):
     seed = await _seed(session_factory)
     async with session_factory() as db:


### PR DESCRIPTION
## Summary

Prerequisites for upcoming RSC migrations on the frontend (PR #210 is the consumer).

- New `POST /api/v1/auth/verify` returns `{user, access_token, token_type}` from the refresh cookie without rotation; `120/minute` per-IP rate limit; no `Set-Cookie`; no audit log on success. The `user` payload is the same `UserResponse` shape as `/auth/me`.
- Widens the `refresh_token` cookie `Path` from `/api/v1/auth/refresh` to `/` at every set/delete site (login, refresh-rotation, refresh-session-expired delete, `_issue_tokens` helper used by MFA flows, Google SSO callback, logout) so the cookie is readable on regular page requests (RSC consumption).
- Pre-launch, no migration; users get the new cookie path on their next login.