### PR TITLE
chore(auth): mark auth-server.ts as server-only

### DIFF
--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { cookies } from "next/headers";
 import { cache } from "react";
 import type { User } from "./types";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "recharts": "^3.8.1",
+        "server-only": "^0.0.1",
         "swr": "^2.3.3"
       },
       "devDependencies": {
@@ -7793,6 +7794,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "recharts": "^3.8.1",
+    "server-only": "^0.0.1",
     "swr": "^2.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Tiny follow-up to #210 per Next data-security guidance.

- Adds the `server-only` package as a dependency.
- Imports its marker at the top of `frontend/lib/auth-server.ts`.

If anything client-side ever imports the module (directly or transitively), the Next bundler now fails the build with a clear error message instead of letting the module slip into the client bundle. Net change: 3 files, +10/-0. Build still passes locally, so no current client code imports it.