### PR TITLE
feat(categories): drag-and-drop subcategory move (C2b)

### DIFF
--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -15,6 +15,7 @@ import BatchMoveModal from "@/components/categories/BatchMoveModal";
 import BatchDeleteModal from "@/components/categories/BatchDeleteModal";
 import DraggableSubcategoryRow from "@/components/categories/DraggableSubcategoryRow";
 import MasterDropZone from "@/components/categories/MasterDropZone";
+import DragMoveConfirmModal from "@/components/categories/DragMoveConfirmModal";
 import { buildMoveErrorMessage, classifyDrop } from "@/components/categories/dragMoveHelpers";
 import {
   DndContext,
@@ -651,88 +652,18 @@ export default function CategoriesPage() {
         }}
       />
 
-      {pendingDrag !== null && (
-        <div
-          data-testid="drag-move-confirm"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
-          onClick={handleCancelDragMove}
-        >
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="drag-move-confirm-title"
-            className="w-full max-w-[min(28rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 id="drag-move-confirm-title" className="text-lg font-semibold text-text-primary">
-              Move subcategory
-            </h3>
-            <p className="mt-2 text-sm text-text-secondary">
-              Move <strong>{pendingDrag.subcategoryName}</strong> to <strong>{pendingDrag.targetMasterName}</strong>?
-            </p>
-
-            <div
-              data-testid="drag-move-preview"
-              className="mt-4 rounded-md border border-border bg-surface-raised p-3 text-sm text-text-secondary"
-            >
-              {pendingPreviewLoading ? (
-                <span>Loading preview...</span>
-              ) : pendingPreviewError ? (
-                <span className="text-danger">{pendingPreviewError}</span>
-              ) : pendingPreview ? (
-                <>
-                  <p>
-                    Reassigns <strong>{pendingPreview.affected_transaction_count}</strong> transaction
-                    {pendingPreview.affected_transaction_count === 1 ? "" : "s"},{" "}
-                    <strong>{pendingPreview.affected_recurring_count}</strong> recurring template
-                    {pendingPreview.affected_recurring_count === 1 ? "" : "s"}, and{" "}
-                    <strong>{pendingPreview.affected_forecast_item_count}</strong> forecast plan item
-                    {pendingPreview.affected_forecast_item_count === 1 ? "" : "s"}.
-                  </p>
-                  {pendingPreview.budget_actuals_shifted && (
-                    <p className="mt-1 text-xs text-text-muted">
-                      Current-period budget actuals will shift attribution. Planned amounts are unchanged.
-                    </p>
-                  )}
-                </>
-              ) : null}
-            </div>
-
-            {dragMoveError && (
-              <div
-                data-testid="drag-move-error"
-                role="alert"
-                className="mt-4 whitespace-pre-line rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
-              >
-                {dragMoveError}
-              </div>
-            )}
-
-            <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-              <button
-                type="button"
-                onClick={handleCancelDragMove}
-                className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                data-testid="drag-move-confirm-button"
-                onClick={() => void handleConfirmDragMove()}
-                disabled={
-                  pendingMoveSubmitting
-                  || pendingPreviewLoading
-                  || pendingPreview === null
-                }
-                className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
-              >
-                {pendingMoveSubmitting ? "Moving..." : "Move"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <DragMoveConfirmModal
+        open={pendingDrag !== null}
+        subcategoryName={pendingDrag?.subcategoryName ?? ""}
+        targetMasterName={pendingDrag?.targetMasterName ?? ""}
+        preview={pendingPreview}
+        previewLoading={pendingPreviewLoading}
+        previewError={pendingPreviewError}
+        moveError={dragMoveError}
+        submitting={pendingMoveSubmitting}
+        onConfirm={() => void handleConfirmDragMove()}
+        onCancel={handleCancelDragMove}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -13,11 +13,44 @@ import AddMasterWithSubsModal from "@/components/ui/AddMasterWithSubsModal";
 import BatchActionBar from "@/components/categories/BatchActionBar";
 import BatchMoveModal from "@/components/categories/BatchMoveModal";
 import BatchDeleteModal from "@/components/categories/BatchDeleteModal";
+import DraggableSubcategoryRow from "@/components/categories/DraggableSubcategoryRow";
+import MasterDropZone from "@/components/categories/MasterDropZone";
+import { buildMoveErrorMessage, classifyDrop } from "@/components/categories/dragMoveHelpers";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
 import {
   Wallet, Home, Zap, UtensilsCrossed, Car, HeartPulse,
   Scissors, Gamepad2, Target, CreditCard, Gift, HelpCircle, Tag,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+
+interface CategoryMoveResult {
+  category_id: number;
+  source_master_id: number;
+  target_master_id: number;
+  affected_transaction_count: number;
+  affected_recurring_count: number;
+  affected_forecast_item_count: number;
+  budget_actuals_shifted: boolean;
+}
+
+interface PendingDrag {
+  subcategoryId: number;
+  subcategoryName: string;
+  subcategoryType: Category["type"];
+  sourceParentId: number;
+  targetMasterId: number;
+  targetMasterName: string;
+}
+
 
 const CATEGORY_ICONS: Record<string, LucideIcon> = {
   income: Wallet,
@@ -80,12 +113,50 @@ export default function CategoriesPage() {
   const [batchMoveOpen, setBatchMoveOpen] = useState(false);
   const [batchDeleteOpen, setBatchDeleteOpen] = useState(false);
 
+  // -- C2b: drag-and-drop subcategory move ---------------------------------
+  // Drag a subcategory onto a same-type master to move it. Two-step:
+  // (1) preview via GET .../move/preview, (2) confirm via PATCH .../move.
+  // Edit mode is the gate; outside Edit mode rows render the same as today.
+  const [activeDragSub, setActiveDragSub] = useState<{
+    id: number;
+    name: string;
+    type: Category["type"];
+    parentId: number;
+  } | null>(null);
+  const [pendingDrag, setPendingDrag] = useState<PendingDrag | null>(null);
+  const [pendingPreview, setPendingPreview] = useState<CategoryMoveResult | null>(null);
+  const [pendingPreviewLoading, setPendingPreviewLoading] = useState(false);
+  const [pendingPreviewError, setPendingPreviewError] = useState<string>("");
+  const [pendingMoveSubmitting, setPendingMoveSubmitting] = useState(false);
+  const [dragMoveError, setDragMoveError] = useState<string>("");
+
+  const sensors = useSensors(
+    // 6px activation distance keeps clicks on the grip from registering
+    // as drags accidentally. Pointer covers mouse + pen; the explicit
+    // TouchSensor with a small delay keeps the row scrollable on mobile
+    // while still allowing drag from the handle.
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
+    useSensor(KeyboardSensor),
+  );
+
+  const clearPendingDrag = useCallback(() => {
+    setPendingDrag(null);
+    setPendingPreview(null);
+    setPendingPreviewError("");
+    setPendingPreviewLoading(false);
+    setPendingMoveSubmitting(false);
+  }, []);
+
   const exitEditMode = useCallback(() => {
     setEditMode(false);
     setSelectedIds([]);
     setBatchMoveOpen(false);
     setBatchDeleteOpen(false);
-  }, []);
+    setActiveDragSub(null);
+    clearPendingDrag();
+    setDragMoveError("");
+  }, [clearPendingDrag]);
 
   const toggleSelected = useCallback((id: number) => {
     setSelectedIds((prev) =>
@@ -100,11 +171,12 @@ export default function CategoriesPage() {
       if (e.key !== "Escape") return;
       if (batchMoveOpen || batchDeleteOpen || confirmDeleteId !== null) return;
       if (editingCatId !== null || addingToMaster !== null) return;
+      if (pendingDrag !== null) return;
       exitEditMode();
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [editMode, batchMoveOpen, batchDeleteOpen, confirmDeleteId, editingCatId, addingToMaster, exitEditMode]);
+  }, [editMode, batchMoveOpen, batchDeleteOpen, confirmDeleteId, editingCatId, addingToMaster, pendingDrag, exitEditMode]);
   // -- /C2 UI ---------------------------------------------------------------
 
   const reload = useCallback(async () => {
@@ -200,6 +272,103 @@ export default function CategoriesPage() {
     } catch (err) { setError(extractErrorMessage(err)); }
   }
 
+  // -- C2b drag handlers ----------------------------------------------------
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const data = event.active.data.current as
+      | { kind?: string; subcategoryId?: number; subcategoryName?: string; subcategoryType?: Category["type"]; parentId?: number }
+      | undefined;
+    if (!data || data.kind !== "subcategory") return;
+    if (data.subcategoryId === undefined || data.subcategoryName === undefined
+        || data.subcategoryType === undefined || data.parentId === undefined) return;
+    setDragMoveError("");
+    setActiveDragSub({
+      id: data.subcategoryId,
+      name: data.subcategoryName,
+      type: data.subcategoryType,
+      parentId: data.parentId,
+    });
+  }, []);
+
+  const handleDragCancel = useCallback(() => {
+    setActiveDragSub(null);
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    setActiveDragSub(null);
+    if (!editMode) return;
+
+    const classification = classifyDrop(
+      event.active.data.current,
+      event.over?.data.current,
+    );
+    if (classification.kind !== "valid") return;
+
+    const { sub, target } = classification;
+    const targetMaster = categories.find((c) => c.id === target.masterId);
+    setPendingDrag({
+      subcategoryId: sub.subcategoryId,
+      subcategoryName: sub.subcategoryName,
+      subcategoryType: sub.subcategoryType,
+      sourceParentId: sub.parentId,
+      targetMasterId: target.masterId,
+      targetMasterName: targetMaster?.name ?? "target master",
+    });
+  }, [editMode, categories]);
+
+  // Preview fetch fires once `pendingDrag` is set.
+  useEffect(() => {
+    if (pendingDrag === null) return;
+    let cancelled = false;
+    setPendingPreviewLoading(true);
+    setPendingPreview(null);
+    setPendingPreviewError("");
+    (async () => {
+      try {
+        const result = await apiFetch<CategoryMoveResult>(
+          `/api/v1/categories/${pendingDrag.subcategoryId}/move/preview?target_parent_id=${pendingDrag.targetMasterId}`,
+        );
+        if (cancelled) return;
+        setPendingPreview(result);
+      } catch (err) {
+        if (cancelled) return;
+        setPendingPreviewError(buildMoveErrorMessage(err, pendingDrag.subcategoryName, pendingDrag.targetMasterName));
+      } finally {
+        if (!cancelled) setPendingPreviewLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [pendingDrag]);
+
+  async function handleConfirmDragMove() {
+    if (pendingDrag === null) return;
+    setPendingMoveSubmitting(true);
+    setDragMoveError("");
+    try {
+      await apiFetch<CategoryMoveResult>(
+        `/api/v1/categories/${pendingDrag.subcategoryId}/move`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ target_parent_id: pendingDrag.targetMasterId }),
+        },
+      );
+      // Reload first; if it throws, surface the error inline and keep the
+      // pending-move state so the user can dismiss. The PATCH already
+      // succeeded server-side. This mirrors the reload-before-close
+      // pattern used by BatchMoveModal.
+      await reload();
+      clearPendingDrag();
+    } catch (err) {
+      setDragMoveError(buildMoveErrorMessage(err, pendingDrag.subcategoryName, pendingDrag.targetMasterName));
+      setPendingMoveSubmitting(false);
+    }
+  }
+
+  function handleCancelDragMove() {
+    clearPendingDrag();
+    setDragMoveError("");
+  }
+  // -- /C2b drag handlers --------------------------------------------------
+
   return (
     <AppShell>
       <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -268,15 +437,37 @@ export default function CategoriesPage() {
         </div>
       )}
 
+      {editMode && (
+        <p
+          id="categories-drag-instructions"
+          data-testid="categories-drag-instructions"
+          className="mb-3 text-xs text-text-muted"
+        >
+          Drag a subcategory by its handle onto a same-type master to move it. Batch Move is still available via the selection checkboxes.
+        </p>
+      )}
+
       {fetching ? (
         <Spinner />
       ) : (
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
         <div className="space-y-4">
           {masters.map((master) => {
             const subs = childrenOf(master.id);
             const Icon = (master.slug && CATEGORY_ICONS[master.slug]) || Tag;
             return (
-              <div key={master.id} className={card}>
+              <MasterDropZone
+                key={master.id}
+                masterId={master.id}
+                masterType={master.type}
+                enabled={editMode}
+              >
+              <div className={card}>
                 <div data-testid={`master-row-${master.id}`} className={`flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between ${cardHeader}`}>
                   <div className="flex min-w-0 w-full items-center gap-2.5 sm:w-auto sm:flex-1">
                     <Icon className="h-4 w-4 flex-shrink-0 text-text-muted" />
@@ -329,7 +520,15 @@ export default function CategoriesPage() {
                   {subs.length > 0 ? (
                     <div className="space-y-0.5">
                       {subs.map((sub) => (
-                        <div key={sub.id} data-testid={`sub-row-${sub.id}`} className="flex flex-wrap items-center justify-between gap-2 rounded-md px-3 py-2 transition-colors hover:bg-surface-raised">
+                        <DraggableSubcategoryRow
+                          key={sub.id}
+                          subcategoryId={sub.id}
+                          subcategoryName={sub.name}
+                          subcategoryType={sub.type}
+                          parentId={master.id}
+                          enabled={editMode && editingCatId !== sub.id}
+                        >
+                        <div data-testid={`sub-row-${sub.id}`} className="flex flex-wrap items-center justify-between gap-2 rounded-md px-3 py-2 transition-colors hover:bg-surface-raised">
                           {editMode && editingCatId !== sub.id && (
                             <input
                               type="checkbox"
@@ -361,6 +560,7 @@ export default function CategoriesPage() {
                             </>
                           )}
                         </div>
+                        </DraggableSubcategoryRow>
                       ))}
                     </div>
                   ) : (
@@ -368,6 +568,7 @@ export default function CategoriesPage() {
                   )}
                 </div>
               </div>
+              </MasterDropZone>
             );
           })}
 
@@ -377,6 +578,17 @@ export default function CategoriesPage() {
             </div>
           )}
         </div>
+        <DragOverlay dropAnimation={null}>
+          {activeDragSub ? (
+            <div
+              data-testid="categories-drag-overlay"
+              className="pointer-events-none rounded-md border border-accent bg-surface-raised px-3 py-2 text-sm font-medium text-text-primary shadow-lg"
+            >
+              {activeDragSub.name}
+            </div>
+          ) : null}
+        </DragOverlay>
+        </DndContext>
       )}
       <ConfirmModal
         open={confirmDeleteId !== null}
@@ -438,6 +650,89 @@ export default function CategoriesPage() {
           }
         }}
       />
+
+      {pendingDrag !== null && (
+        <div
+          data-testid="drag-move-confirm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+          onClick={handleCancelDragMove}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="drag-move-confirm-title"
+            className="w-full max-w-[min(28rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="drag-move-confirm-title" className="text-lg font-semibold text-text-primary">
+              Move subcategory
+            </h3>
+            <p className="mt-2 text-sm text-text-secondary">
+              Move <strong>{pendingDrag.subcategoryName}</strong> to <strong>{pendingDrag.targetMasterName}</strong>?
+            </p>
+
+            <div
+              data-testid="drag-move-preview"
+              className="mt-4 rounded-md border border-border bg-surface-raised p-3 text-sm text-text-secondary"
+            >
+              {pendingPreviewLoading ? (
+                <span>Loading preview...</span>
+              ) : pendingPreviewError ? (
+                <span className="text-danger">{pendingPreviewError}</span>
+              ) : pendingPreview ? (
+                <>
+                  <p>
+                    Reassigns <strong>{pendingPreview.affected_transaction_count}</strong> transaction
+                    {pendingPreview.affected_transaction_count === 1 ? "" : "s"},{" "}
+                    <strong>{pendingPreview.affected_recurring_count}</strong> recurring template
+                    {pendingPreview.affected_recurring_count === 1 ? "" : "s"}, and{" "}
+                    <strong>{pendingPreview.affected_forecast_item_count}</strong> forecast plan item
+                    {pendingPreview.affected_forecast_item_count === 1 ? "" : "s"}.
+                  </p>
+                  {pendingPreview.budget_actuals_shifted && (
+                    <p className="mt-1 text-xs text-text-muted">
+                      Current-period budget actuals will shift attribution. Planned amounts are unchanged.
+                    </p>
+                  )}
+                </>
+              ) : null}
+            </div>
+
+            {dragMoveError && (
+              <div
+                data-testid="drag-move-error"
+                role="alert"
+                className="mt-4 whitespace-pre-line rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
+              >
+                {dragMoveError}
+              </div>
+            )}
+
+            <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={handleCancelDragMove}
+                className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="drag-move-confirm-button"
+                onClick={() => void handleConfirmDragMove()}
+                disabled={
+                  pendingMoveSubmitting
+                  || pendingPreviewLoading
+                  || pendingPreview === null
+                }
+                className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
+              >
+                {pendingMoveSubmitting ? "Moving..." : "Move"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </AppShell>
   );
 }

--- a/frontend/components/categories/DragMoveConfirmModal.tsx
+++ b/frontend/components/categories/DragMoveConfirmModal.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
+import { btnPrimary, btnSecondary } from "@/lib/styles";
+
+/**
+ * Two-step drag-move confirmation modal for C2b. The drag-end handler
+ * on /categories opens this modal once a valid drop has been
+ * classified; the modal renders the preview impact (or its loading /
+ * error state), the surfaced backend error if the PATCH fails, and a
+ * primary Confirm action.
+ *
+ * Modal a11y matches the rest of the codebase's modal contract (see
+ * `BatchMoveModal` + `ConfirmModal` for the original implementations):
+ *   - focus moves into the dialog on open (initial focus goes to the
+ *     Cancel button so a stray Enter from the keyboard drag does NOT
+ *     immediately submit a move the user might not have intended);
+ *   - Tab is trapped inside the dialog;
+ *   - Escape closes the modal (and routes through onCancel);
+ *   - focus restores on close;
+ *   - body scroll locks while open.
+ *
+ * Owned by Team Categories C2 UI (C2b).
+ */
+
+export interface MovePreviewSummary {
+  affected_transaction_count: number;
+  affected_recurring_count: number;
+  affected_forecast_item_count: number;
+  budget_actuals_shifted: boolean;
+}
+
+interface Props {
+  open: boolean;
+  subcategoryName: string;
+  targetMasterName: string;
+  preview: MovePreviewSummary | null;
+  previewLoading: boolean;
+  previewError: string;
+  moveError: string;
+  submitting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function DragMoveConfirmModal({
+  open,
+  subcategoryName,
+  targetMasterName,
+  preview,
+  previewLoading,
+  previewError,
+  moveError,
+  submitting,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useFocusTrap({
+    active: open,
+    containerRef: dialogRef,
+    initialFocusRef: cancelRef,
+  });
+
+  // Escape closes the modal. Stops propagation so the page-level Esc
+  // handler (which would also exit Edit mode) does not fire.
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  // Body scroll lock while open.
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="drag-move-confirm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drag-move-confirm-title"
+        className="w-full max-w-[min(28rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          id="drag-move-confirm-title"
+          className="text-lg font-semibold text-text-primary"
+        >
+          Move subcategory
+        </h3>
+        <p className="mt-2 text-sm text-text-secondary">
+          Move <strong>{subcategoryName}</strong> to{" "}
+          <strong>{targetMasterName}</strong>?
+        </p>
+
+        <div
+          data-testid="drag-move-preview"
+          className="mt-4 rounded-md border border-border bg-surface-raised p-3 text-sm text-text-secondary"
+        >
+          {previewLoading ? (
+            <span>Loading preview...</span>
+          ) : previewError ? (
+            <span className="text-danger">{previewError}</span>
+          ) : preview ? (
+            <>
+              <p>
+                Reassigns <strong>{preview.affected_transaction_count}</strong>{" "}
+                transaction
+                {preview.affected_transaction_count === 1 ? "" : "s"},{" "}
+                <strong>{preview.affected_recurring_count}</strong> recurring
+                template
+                {preview.affected_recurring_count === 1 ? "" : "s"}, and{" "}
+                <strong>{preview.affected_forecast_item_count}</strong>{" "}
+                forecast plan item
+                {preview.affected_forecast_item_count === 1 ? "" : "s"}.
+              </p>
+              {preview.budget_actuals_shifted && (
+                <p className="mt-1 text-xs text-text-muted">
+                  Current-period budget actuals will shift attribution. Planned
+                  amounts are unchanged.
+                </p>
+              )}
+            </>
+          ) : null}
+        </div>
+
+        {moveError && (
+          <div
+            data-testid="drag-move-error"
+            role="alert"
+            className="mt-4 whitespace-pre-line rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
+          >
+            {moveError}
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="drag-move-confirm-button"
+            onClick={onConfirm}
+            disabled={submitting || previewLoading || preview === null}
+            className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
+          >
+            {submitting ? "Moving..." : "Move"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/categories/DraggableSubcategoryRow.tsx
+++ b/frontend/components/categories/DraggableSubcategoryRow.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+import { GripVertical } from "lucide-react";
+
+/**
+ * Drag source for a subcategory row. The drag handle is rendered to the
+ * left of the row content and is the ONLY drag activator (using
+ * dnd-kit's `listeners` on the handle keeps the row contents clickable —
+ * checkbox, Edit/Delete buttons, the row body etc.).
+ *
+ * Owned by Team Categories C2 UI (C2b).
+ */
+interface Props {
+  subcategoryId: number;
+  subcategoryName: string;
+  subcategoryType: "income" | "expense" | "both";
+  parentId: number;
+  enabled: boolean;
+  children: ReactNode;
+}
+
+export default function DraggableSubcategoryRow({
+  subcategoryId,
+  subcategoryName,
+  subcategoryType,
+  parentId,
+  enabled,
+  children,
+}: Props) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `sub-${subcategoryId}`,
+    disabled: !enabled,
+    data: {
+      kind: "subcategory",
+      subcategoryId,
+      subcategoryName,
+      subcategoryType,
+      parentId,
+    },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`sub-draggable-${subcategoryId}`}
+      data-dragging={isDragging ? "true" : "false"}
+      className={`flex items-center gap-1 ${
+        isDragging ? "opacity-50" : ""
+      }`}
+    >
+      {enabled && (
+        <button
+          type="button"
+          data-testid={`sub-drag-handle-${subcategoryId}`}
+          aria-label={`Drag ${subcategoryName}`}
+          className="flex h-8 w-6 cursor-grab touch-none items-center justify-center text-text-muted hover:text-accent active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+      )}
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}

--- a/frontend/components/categories/DraggableSubcategoryRow.tsx
+++ b/frontend/components/categories/DraggableSubcategoryRow.tsx
@@ -55,11 +55,11 @@ export default function DraggableSubcategoryRow({
           type="button"
           data-testid={`sub-drag-handle-${subcategoryId}`}
           aria-label={`Drag ${subcategoryName}`}
-          className="flex h-8 w-6 cursor-grab touch-none items-center justify-center text-text-muted hover:text-accent active:cursor-grabbing"
+          className="flex min-h-[44px] min-w-[44px] cursor-grab touch-none items-center justify-center text-text-muted hover:text-accent active:cursor-grabbing md:min-h-8 md:min-w-6"
           {...attributes}
           {...listeners}
         >
-          <GripVertical className="h-4 w-4" />
+          <GripVertical className="h-4 w-4" aria-hidden="true" />
         </button>
       )}
       <div className="min-w-0 flex-1">{children}</div>

--- a/frontend/components/categories/MasterDropZone.tsx
+++ b/frontend/components/categories/MasterDropZone.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useDndMonitor, useDroppable } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+/**
+ * Drop target for a master category card. Highlights when a compatible
+ * subcategory is being dragged over it. Cross-type drops render a
+ * disabled state instead of an accent highlight, and dropping does
+ * nothing (the page-level `onDragEnd` short-circuits the move).
+ *
+ * Owned by Team Categories C2 UI (C2b).
+ */
+interface Props {
+  masterId: number;
+  masterType: "income" | "expense" | "both";
+  enabled: boolean;
+  children: ReactNode;
+}
+
+interface ActiveDragData {
+  kind?: string;
+  subcategoryType?: "income" | "expense" | "both";
+  parentId?: number;
+}
+
+export default function MasterDropZone({
+  masterId,
+  masterType,
+  enabled,
+  children,
+}: Props) {
+  const { setNodeRef, isOver, active } = useDroppable({
+    id: `master-${masterId}`,
+    disabled: !enabled,
+    data: {
+      kind: "master",
+      masterId,
+      masterType,
+    },
+  });
+
+  // `active.data.current` may be undefined depending on the activation
+  // path; `useDndMonitor` keeps a stable mirror updated on every drag
+  // tick which is more robust during keyboard / programmatic drags.
+  const [activeData, setActiveData] = useState<ActiveDragData | null>(null);
+  useDndMonitor({
+    onDragStart(event) {
+      const data = event.active.data.current as ActiveDragData | undefined;
+      setActiveData(data ?? null);
+    },
+    onDragEnd() {
+      setActiveData(null);
+    },
+    onDragCancel() {
+      setActiveData(null);
+    },
+  });
+
+  const dragging = active != null && enabled;
+  const dragData = activeData
+    ?? ((active?.data.current as ActiveDragData | undefined) ?? null);
+
+  const sameType = dragData?.kind === "subcategory"
+    && dragData.subcategoryType === masterType;
+  const isSourceParent = dragData?.kind === "subcategory"
+    && dragData.parentId === masterId;
+
+  // Drop state classification:
+  //   - source-parent: not a valid drop target (no-op), neutral state.
+  //   - cross-type: shown as disabled even when hovered.
+  //   - same-type: hover shows the accent-dim highlight.
+  const showAsValidTarget = dragging && sameType && !isSourceParent;
+  const showAsInvalidHover = dragging && isOver && !sameType;
+  const showAsSourceParentHover = dragging && isOver && isSourceParent;
+
+  let dropStateClass = "";
+  if (showAsInvalidHover) {
+    dropStateClass = "ring-2 ring-danger/40 cursor-not-allowed";
+  } else if (showAsValidTarget && isOver) {
+    dropStateClass = "ring-2 ring-accent bg-accent-dim";
+  } else if (showAsValidTarget) {
+    dropStateClass = "ring-1 ring-accent/40";
+  } else if (showAsSourceParentHover) {
+    // Hovering over the current parent — neutral, no API call will fire.
+    dropStateClass = "ring-1 ring-border";
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`master-dropzone-${masterId}`}
+      data-drop-valid={showAsValidTarget ? "true" : "false"}
+      data-drop-invalid={showAsInvalidHover ? "true" : "false"}
+      className={`transition-shadow ${dropStateClass}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/components/categories/dragMoveHelpers.ts
+++ b/frontend/components/categories/dragMoveHelpers.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure helpers for the C2b drag-and-drop subcategory move flow.
+ *
+ * The page's `onDragEnd` handler delegates to `classifyDrop` to decide
+ * whether a drop should:
+ *   - open the confirm modal ("valid"),
+ *   - silently no-op ("source_parent" or "cross_type"),
+ *   - or be ignored ("missing_data" / "wrong_kind").
+ *
+ * Keeping the classification pure makes the handler trivially
+ * unit-testable without simulating real pointer / keyboard events in
+ * jsdom.
+ *
+ * Owned by Team Categories C2 UI (C2b).
+ */
+
+import type { ApiResponseError } from "@/lib/api";
+
+export type CategoryType = "income" | "expense" | "both";
+
+export interface SubcategoryDragData {
+  kind: "subcategory";
+  subcategoryId: number;
+  subcategoryName: string;
+  subcategoryType: CategoryType;
+  parentId: number;
+}
+
+export interface MasterDropData {
+  kind: "master";
+  masterId: number;
+  masterType: CategoryType;
+}
+
+export type DropClassification =
+  | { kind: "valid"; sub: SubcategoryDragData; target: MasterDropData }
+  | { kind: "source_parent"; sub: SubcategoryDragData; target: MasterDropData }
+  | { kind: "cross_type"; sub: SubcategoryDragData; target: MasterDropData }
+  | { kind: "no_drop" }
+  | { kind: "wrong_kind" };
+
+interface RawData {
+  kind?: string;
+  subcategoryId?: number;
+  subcategoryName?: string;
+  subcategoryType?: CategoryType;
+  parentId?: number;
+  masterId?: number;
+  masterType?: CategoryType;
+}
+
+function asSubcategoryData(data: unknown): SubcategoryDragData | null {
+  if (!data || typeof data !== "object") return null;
+  const d = data as RawData;
+  if (d.kind !== "subcategory") return null;
+  if (
+    typeof d.subcategoryId !== "number"
+    || typeof d.subcategoryName !== "string"
+    || (d.subcategoryType !== "income" && d.subcategoryType !== "expense" && d.subcategoryType !== "both")
+    || typeof d.parentId !== "number"
+  ) {
+    return null;
+  }
+  return {
+    kind: "subcategory",
+    subcategoryId: d.subcategoryId,
+    subcategoryName: d.subcategoryName,
+    subcategoryType: d.subcategoryType,
+    parentId: d.parentId,
+  };
+}
+
+function asMasterData(data: unknown): MasterDropData | null {
+  if (!data || typeof data !== "object") return null;
+  const d = data as RawData;
+  if (d.kind !== "master") return null;
+  if (
+    typeof d.masterId !== "number"
+    || (d.masterType !== "income" && d.masterType !== "expense" && d.masterType !== "both")
+  ) {
+    return null;
+  }
+  return {
+    kind: "master",
+    masterId: d.masterId,
+    masterType: d.masterType,
+  };
+}
+
+export function classifyDrop(
+  activeData: unknown,
+  overData: unknown | undefined,
+): DropClassification {
+  if (overData === undefined || overData === null) return { kind: "no_drop" };
+  const sub = asSubcategoryData(activeData);
+  const target = asMasterData(overData);
+  if (!sub || !target) return { kind: "wrong_kind" };
+  if (target.masterId === sub.parentId) {
+    return { kind: "source_parent", sub, target };
+  }
+  if (target.masterType !== sub.subcategoryType) {
+    return { kind: "cross_type", sub, target };
+  }
+  return { kind: "valid", sub, target };
+}
+
+interface CategoryErrorDetail {
+  detail?: string;
+  conflicting_child_name?: string;
+  message?: string;
+}
+
+/**
+ * Builds a user-facing error message from an ApiResponseError surfaced
+ * by the move preview or PATCH endpoint. Handles the
+ * `name_collision` (409) and `type_mismatch` (400) cases the C0
+ * contract spells out, with sensible fallbacks for anything else.
+ */
+export function buildMoveErrorMessage(
+  err: unknown,
+  subName: string,
+  targetName: string,
+): string {
+  if (err instanceof Error) {
+    const apiErr = err as ApiResponseError;
+    const detail = apiErr.detail as CategoryErrorDetail | string | undefined;
+    if (typeof detail === "object" && detail !== null) {
+      if (detail.detail === "name_collision" && detail.conflicting_child_name) {
+        return `Cannot move "${subName}" to "${targetName}": a subcategory named "${detail.conflicting_child_name}" already exists there. Rename one before moving.`;
+      }
+      if (detail.detail === "type_mismatch") {
+        return `Cannot move "${subName}" to "${targetName}": types are incompatible.`;
+      }
+      if (typeof detail.detail === "string") {
+        return `Move failed: ${detail.detail}`;
+      }
+    }
+    return err.message || `Move failed for "${subName}".`;
+  }
+  return `Move failed for "${subName}".`;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pfv2-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "lucide-react": "^1.7.0",
         "next": "16.2.4",
         "react": "19.2.5",
@@ -459,6 +460,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "lucide-react": "^1.7.0",
     "next": "16.2.4",
     "react": "19.2.5",

--- a/frontend/tests/app/categories-drag-drop.test.tsx
+++ b/frontend/tests/app/categories-drag-drop.test.tsx
@@ -20,6 +20,7 @@ import { describe, beforeEach, it, expect, vi } from "vitest";
 import * as React from "react";
 
 import CategoriesPage from "@/app/categories/page";
+import DragMoveConfirmModal from "@/components/categories/DragMoveConfirmModal";
 import { apiFetch, ApiResponseError } from "@/lib/api";
 import { useAuth } from "@/components/auth/AuthProvider";
 import {
@@ -374,5 +375,340 @@ describe("CategoriesPage -C2b render-level gates", () => {
     const urls = vi.mocked(apiFetch).mock.calls.map((c) => String(c[0]));
     expect(urls.some((u) => u.includes("/move/preview"))).toBe(false);
     expect(urls.some((u) => /\/move(\?|$)/.test(u))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------
+// DragMoveConfirmModal — modal a11y contract.
+//
+// Asserts the modal wires the focus-trap / Escape / focus-restore /
+// scroll-lock pattern the remediation wave (PRs #203-#209)
+// standardized. Tests render the modal directly so we don't have to
+// drive a real drag to inspect its a11y behavior.
+// ---------------------------------------------------------------------
+
+describe("DragMoveConfirmModal -modal a11y", () => {
+  const NOOP = () => {};
+  const PREVIEW = {
+    affected_transaction_count: 5,
+    affected_recurring_count: 1,
+    affected_forecast_item_count: 2,
+    budget_actuals_shifted: false,
+  };
+
+  it("returns null and does not lock body scroll when closed", () => {
+    document.body.style.overflow = "";
+    const { container } = render(
+      <DragMoveConfirmModal
+        open={false}
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={null}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("renders with role=dialog + aria-modal when open and locks body scroll", () => {
+    document.body.style.overflow = "";
+    render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("drag-move-confirm-title");
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("moves focus to the Cancel button on open (avoids accidental confirm)", async () => {
+    render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    await waitFor(() => {
+      const cancel = screen.getByRole("button", { name: "Cancel" });
+      expect(document.activeElement).toBe(cancel);
+    });
+  });
+
+  it("Escape calls onCancel", () => {
+    const onCancel = vi.fn();
+    render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the backdrop calls onCancel; clicking inside the dialog does not", () => {
+    const onCancel = vi.fn();
+    render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={onCancel}
+      />,
+    );
+    // Click inside the dialog body — should not bubble to backdrop.
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onCancel).not.toHaveBeenCalled();
+
+    // Click on the backdrop wrapper (the testid container is the
+    // backdrop because it's the outer .fixed inset-0).
+    fireEvent.click(screen.getByTestId("drag-move-confirm"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores body scroll on unmount", () => {
+    document.body.style.overflow = "";
+    const { unmount } = render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("restores focus to the previously-focused element after close", async () => {
+    const prior = document.createElement("button");
+    prior.setAttribute("data-testid", "prior-focus");
+    prior.textContent = "prior";
+    document.body.appendChild(prior);
+    prior.focus();
+    expect(document.activeElement).toBe(prior);
+
+    const { rerender } = render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    // Focus moved into the dialog.
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(prior);
+    });
+
+    // Close.
+    rerender(
+      <DragMoveConfirmModal
+        open={false}
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    await waitFor(() => {
+      expect(document.activeElement).toBe(prior);
+    });
+
+    document.body.removeChild(prior);
+  });
+
+  it("Tab key is captured by the focus trap (defaultPrevented) when at a trap edge", () => {
+    // jsdom's `offsetParent === null` filter inside the focus-trap
+    // hook makes the wrap-around assertion unreliable in a unit test
+    // (every focusable element looks 'hidden' to the hook). What we
+    // can prove deterministically is that the hook is installed: a
+    // Tab keydown is observed by the document-level listener while
+    // the modal is open. The wrap-around itself is covered by the
+    // same `useFocusTrap` hook tests that ship with the rest of the
+    // modal family.
+    render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    cancel.focus();
+    const ev = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+    document.dispatchEvent(ev);
+    // The hook calls preventDefault when there are no real focusable
+    // matches (jsdom) OR when at a trap edge (real browser). Either
+    // way, the trap is engaged.
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("disables Confirm while preview is loading or absent", () => {
+    const { rerender } = render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={null}
+        previewLoading
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Move" })).toBeDisabled();
+
+    rerender(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError=""
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Move" })).not.toBeDisabled();
+  });
+
+  it("surfaces moveError in an alert region without dismissing the modal", () => {
+    render(
+      <DragMoveConfirmModal
+        open
+        subcategoryName="Restaurants"
+        targetMasterName="Lifestyle"
+        preview={PREVIEW}
+        previewLoading={false}
+        previewError=""
+        moveError="Cannot move: name collision."
+        submitting={false}
+        onConfirm={NOOP}
+        onCancel={NOOP}
+      />,
+    );
+    const err = screen.getByTestId("drag-move-error");
+    expect(err.getAttribute("role")).toBe("alert");
+    expect(err.textContent).toContain("name collision");
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------
+// Touch target — the drag handle must meet 44x44px on mobile (Edit
+// mode supports TouchSensor and the row is the only drag activator).
+// md+ may shrink to a more compact size for desktop density.
+// ---------------------------------------------------------------------
+
+describe("DraggableSubcategoryRow -touch target", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    setupApi();
+  });
+
+  it("drag handle has min-h-[44px] / min-w-[44px] for mobile touch", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    const handle = screen.getByTestId("sub-drag-handle-101");
+    const classes = handle.className;
+    expect(classes).toContain("min-h-[44px]");
+    expect(classes).toContain("min-w-[44px]");
+    // Compact density allowed at md+.
+    expect(classes).toMatch(/md:min-h-8/);
+    expect(classes).toMatch(/md:min-w-6/);
+  });
+
+  it("drag handle icon is aria-hidden (the button itself owns the label)", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    const handle = screen.getByTestId("sub-drag-handle-101");
+    const svg = handle.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
   });
 });

--- a/frontend/tests/app/categories-drag-drop.test.tsx
+++ b/frontend/tests/app/categories-drag-drop.test.tsx
@@ -1,0 +1,378 @@
+/**
+ * C2b — drag-and-drop subcategory move on /categories.
+ *
+ * Strategy:
+ *   - Unit-test the pure classifier (`classifyDrop`) and error
+ *     formatter (`buildMoveErrorMessage`) against every meaningful
+ *     drop combination + every backend error code we care about.
+ *   - Render-level tests assert the Edit-mode gate (drag handles +
+ *     drop zones + the instructions banner only appear in Edit mode)
+ *     and that Batch Move stays fully wired as the SR-accessible
+ *     fallback.
+ *
+ * Real pointer-driven drag simulation in jsdom is intentionally
+ * skipped: dnd-kit's sensors depend on layout measurements jsdom
+ * cannot provide. The contract is dnd-kit's responsibility; ours is
+ * the handler logic and the Edit-mode gate, both of which are pure.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, beforeEach, it, expect, vi } from "vitest";
+import * as React from "react";
+
+import CategoriesPage from "@/app/categories/page";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+import {
+  buildMoveErrorMessage,
+  classifyDrop,
+} from "@/components/categories/dragMoveHelpers";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/categories",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const CATEGORIES = [
+  {
+    id: 100,
+    name: "Food",
+    slug: "food_dining",
+    parent_id: null,
+    parent_name: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+  {
+    id: 101,
+    name: "Restaurants",
+    slug: null,
+    parent_id: 100,
+    parent_name: "Food",
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 5,
+  },
+  {
+    id: 200,
+    name: "Lifestyle",
+    slug: "lifestyle",
+    parent_id: null,
+    parent_name: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+  {
+    id: 300,
+    name: "Income",
+    slug: "income",
+    parent_id: null,
+    parent_name: null,
+    type: "income" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+];
+
+function setupApi(handlers: Record<string, (init?: RequestInit) => unknown> = {}) {
+  vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+    if (url === "/api/v1/categories" && (!init || init.method === undefined)) {
+      return Promise.resolve(CATEGORIES);
+    }
+    if (handlers[url]) {
+      const result = handlers[url](init);
+      return result instanceof Promise ? result : Promise.resolve(result);
+    }
+    const noQuery = url.split("?")[0];
+    if (handlers[noQuery]) {
+      const result = handlers[noQuery](init);
+      return result instanceof Promise ? result : Promise.resolve(result);
+    }
+    return Promise.resolve({});
+  }) as never);
+}
+
+// ---------------------------------------------------------------------
+// classifyDrop — pure unit tests for the drag-end handler core.
+// ---------------------------------------------------------------------
+
+describe("classifyDrop", () => {
+  const subData = {
+    kind: "subcategory" as const,
+    subcategoryId: 101,
+    subcategoryName: "Restaurants",
+    subcategoryType: "expense" as const,
+    parentId: 100,
+  };
+
+  it("returns 'valid' for a same-type cross-master drop", () => {
+    const result = classifyDrop(subData, {
+      kind: "master",
+      masterId: 200,
+      masterType: "expense",
+    });
+    expect(result.kind).toBe("valid");
+    if (result.kind === "valid") {
+      expect(result.target.masterId).toBe(200);
+      expect(result.sub.subcategoryId).toBe(101);
+    }
+  });
+
+  it("returns 'source_parent' when dropping on the current parent (no API call)", () => {
+    const result = classifyDrop(subData, {
+      kind: "master",
+      masterId: 100,
+      masterType: "expense",
+    });
+    expect(result.kind).toBe("source_parent");
+  });
+
+  it("returns 'cross_type' when dropping an expense sub on an income master", () => {
+    const result = classifyDrop(subData, {
+      kind: "master",
+      masterId: 300,
+      masterType: "income",
+    });
+    expect(result.kind).toBe("cross_type");
+  });
+
+  it("returns 'no_drop' when the drag did not land over a droppable", () => {
+    expect(classifyDrop(subData, undefined).kind).toBe("no_drop");
+    expect(classifyDrop(subData, null).kind).toBe("no_drop");
+  });
+
+  it("returns 'wrong_kind' when active is not a subcategory", () => {
+    const result = classifyDrop(
+      { kind: "master", masterId: 100, masterType: "expense" },
+      { kind: "master", masterId: 200, masterType: "expense" },
+    );
+    expect(result.kind).toBe("wrong_kind");
+  });
+
+  it("returns 'wrong_kind' when over is not a master", () => {
+    const result = classifyDrop(subData, {
+      kind: "subcategory",
+      subcategoryId: 999,
+      subcategoryName: "Other",
+      subcategoryType: "expense",
+      parentId: 200,
+    });
+    expect(result.kind).toBe("wrong_kind");
+  });
+
+  it("rejects malformed active payloads", () => {
+    expect(classifyDrop({ kind: "subcategory" }, { kind: "master", masterId: 1, masterType: "expense" }).kind).toBe("wrong_kind");
+  });
+
+  it("rejects malformed over payloads", () => {
+    expect(classifyDrop(subData, { kind: "master" }).kind).toBe("wrong_kind");
+  });
+
+  it("'both' source type only matches a 'both' master", () => {
+    const bothSub = { ...subData, subcategoryType: "both" as const };
+    expect(
+      classifyDrop(bothSub, { kind: "master", masterId: 200, masterType: "expense" }).kind,
+    ).toBe("cross_type");
+    expect(
+      classifyDrop(bothSub, { kind: "master", masterId: 200, masterType: "both" }).kind,
+    ).toBe("valid");
+  });
+});
+
+// ---------------------------------------------------------------------
+// buildMoveErrorMessage — pure unit tests for the error formatter.
+// ---------------------------------------------------------------------
+
+describe("buildMoveErrorMessage", () => {
+  it("formats a structured name_collision 409 detail", () => {
+    const err = new ApiResponseError(409, "name_collision", undefined, {
+      detail: "name_collision",
+      target_parent_id: 200,
+      conflicting_child_id: 201,
+      conflicting_child_name: "Restaurants",
+      normalized_name: "restaurants",
+    });
+    const msg = buildMoveErrorMessage(err, "Restaurants", "Lifestyle");
+    expect(msg).toContain("Restaurants");
+    expect(msg).toContain("Lifestyle");
+    expect(msg).toContain("already exists");
+  });
+
+  it("formats a structured type_mismatch 400 detail distinctly from name_collision", () => {
+    const err = new ApiResponseError(400, "type_mismatch", undefined, {
+      detail: "type_mismatch",
+      source_type: "expense",
+      target_type: "income",
+      dependent_breakdown: { income: 0, expense: 3 },
+    });
+    const msg = buildMoveErrorMessage(err, "Restaurants", "Income");
+    expect(msg).toContain("incompatible");
+    expect(msg).not.toContain("already exists");
+  });
+
+  it("falls back to err.message for unknown detail strings", () => {
+    const err = new ApiResponseError(500, "boom", undefined, { detail: "oops" });
+    const msg = buildMoveErrorMessage(err, "Restaurants", "Lifestyle");
+    expect(msg).toContain("oops");
+  });
+
+  it("returns a sensible fallback for non-Error values", () => {
+    const msg = buildMoveErrorMessage("plain string", "Restaurants", "Lifestyle");
+    expect(msg).toContain("Restaurants");
+  });
+});
+
+// ---------------------------------------------------------------------
+// Render-level: Edit-mode gate, sticky Batch Move presence.
+// ---------------------------------------------------------------------
+
+describe("CategoriesPage -C2b render-level gates", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    setupApi();
+  });
+
+  it("does not render drag handles or the instructions banner outside Edit mode", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    expect(screen.queryByTestId("sub-drag-handle-101")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("categories-drag-instructions"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("entering Edit mode adds drag handles on subcategory rows ONLY", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    expect(screen.getByTestId("sub-drag-handle-101")).toBeInTheDocument();
+    expect(screen.getByTestId("categories-drag-instructions")).toBeInTheDocument();
+    // Masters never get a drag handle.
+    expect(screen.queryByTestId("sub-drag-handle-100")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("sub-drag-handle-200")).not.toBeInTheDocument();
+  });
+
+  it("master rows render as drop zones in Edit mode", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    expect(screen.getByTestId("master-dropzone-100")).toBeInTheDocument();
+    expect(screen.getByTestId("master-dropzone-200")).toBeInTheDocument();
+    expect(screen.getByTestId("master-dropzone-300")).toBeInTheDocument();
+
+    // Initial state: no active drag, every dropzone neutral.
+    for (const id of [100, 200, 300]) {
+      const zone = screen.getByTestId(`master-dropzone-${id}`);
+      expect(zone.getAttribute("data-drop-valid")).toBe("false");
+      expect(zone.getAttribute("data-drop-invalid")).toBe("false");
+    }
+  });
+
+  it("exiting Edit mode clears drag handles and drop zones", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    expect(screen.getByTestId("sub-drag-handle-101")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    expect(screen.queryByTestId("sub-drag-handle-101")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("categories-drag-instructions"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("Batch Move remains the keyboard/SR-accessible fallback in Edit mode", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("sub-checkbox-101"));
+
+    expect(screen.getByTestId("batch-action-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("batch-move-button")).toBeInTheDocument();
+    expect(screen.getByTestId("batch-delete-button")).toBeInTheDocument();
+  });
+
+  it("the drag handle is a real, focusable button with an aria-label", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    const handle = screen.getByTestId("sub-drag-handle-101");
+    // dnd-kit assigns role=button + tabindex=0 so keyboard users can
+    // start a drag with the keyboard. Aria-label scopes it to the
+    // subcategory name so screen readers announce the target row.
+    expect(handle.getAttribute("aria-label")).toContain("Restaurants");
+    expect(handle.getAttribute("role") ?? handle.tagName.toLowerCase()).toMatch(/button/i);
+  });
+
+  it("no /move or /move/preview API call fires on mount or Edit toggle", async () => {
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+    fireEvent.click(screen.getByTestId("categories-edit-toggle"));
+
+    const urls = vi.mocked(apiFetch).mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes("/move/preview"))).toBe(false);
+    expect(urls.some((u) => /\/move(\?|$)/.test(u))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Drag-and-drop is now available on /categories as an enhancement on top of the existing Batch Move flow. Subcategories are draggable onto same-type masters; everything else (master rows, cross-type drops, dropping on the source parent) is a deliberate no-op.
- Two-step confirm: a valid drop fetches `GET /api/v1/categories/{id}/move/preview?target_parent_id=...`, shows a confirm modal with the impacted-row counts, then PATCHes `/api/v1/categories/{id}/move` on confirm. Errors (`name_collision` 409, `type_mismatch` 400) surface verbatim in the modal.
- Batch Move is preserved fully as the keyboard / screen-reader fallback. C2b is purely additive.
- New pure helper `classifyDrop` makes the drag-end handler trivially unit-testable; 20 new tests covering every drop combination, error path, and Edit-mode gate.

## Scope
- `frontend/app/categories/page.tsx` — DndContext + DragOverlay wiring, pending-drag state, preview fetch, PATCH-on-confirm, drag-confirm modal markup.
- `frontend/components/categories/DraggableSubcategoryRow.tsx` (new) — wraps each sub row with a grip-only drag activator so the rest of the row (checkbox, Edit/Delete) stays clickable.
- `frontend/components/categories/MasterDropZone.tsx` (new) — wraps each master card with a `useDroppable`. Visual states: valid (accent ring), invalid hover (danger ring), source-parent hover (neutral).
- `frontend/components/categories/dragMoveHelpers.ts` (new) — pure `classifyDrop` + `buildMoveErrorMessage`.
- `frontend/tests/app/categories-drag-drop.test.tsx` (new) — 20 tests.
- `frontend/package.json` + `frontend/package-lock.json` — adds `@dnd-kit/core ^6.3.1`.

## Behavior contract
- Edit mode gates everything: drag handles, drop zones, the instructions banner. Outside Edit mode rows render exactly as today.
- Sources: subcategories only. Masters are never draggable.
- Targets: masters only. Subcategories are never drop targets.
- Same-type rule: expense sub onto expense master only (and same for income / both). Cross-type drops are not API calls.
- No-op source drop: dropping a sub onto its current parent does nothing. No API call, no modal.
- Confirm modal mirrors Batch Move's preview shape (transactions / recurring / forecast items + budget-actuals-shift note).
- On a successful PATCH: reload categories first, then close the modal — same reload-before-close pattern that PR #191 / #192 established so a refresh failure stays visible.

## Backend touched
None. The existing `GET /api/v1/categories/{id}/move/preview` and `PATCH /api/v1/categories/{id}/move` endpoints (shipped in PR #189) cover everything this needs. Request body for PATCH is `{ \"target_parent_id\": <id> }` per `CategoryMoveRequest`.

## Dependency added
Yes — `@dnd-kit/core` ^6.3.1 (no @dnd-kit/sortable; this PR is move-across-master only, not reorder-within-parent). The bind-mounted dev frontend container needs a rebuild after merge: \`docker compose up --build -d frontend\`. (See the dev-dep-drift memory item.)

## Quality gates
- TypeScript: \`npx tsc --noEmit\` — clean.
- ESLint: \`npm run lint -- --quiet\` — clean.
- Tests: \`npm test -- --run\` — 76 files / 517 tests pass (was 496; +21 net for this PR).
- Token check: \`bash scripts/check-design-tokens.sh\` — passed.
- Build: \`npm run build\` — compiled successfully, 39 static pages.

## Manual QA
Verified in the worktree:
- Token check, lint, TS, tests, and prod build all green.
- Unit-tested `classifyDrop` against every relevant input: valid same-type drop, source-parent drop, cross-type drop, missing over-target, malformed payloads, \"both\" source/target compat.
- Unit-tested `buildMoveErrorMessage` against structured `name_collision` 409 and `type_mismatch` 400 details, plus the non-structured fallback.
- Render-level tests confirm the Edit-mode gate: drag handles + drop zones + banner only appear inside Edit mode; exiting clears them.

Deferred to the post-merge smoke pass (jsdom can't drive real pointer drags with layout measurements):
- Desktop pointer drag of a subcategory onto a same-type master → confirm → success.
- Desktop drag onto a cross-type master → visual disabled state, no API call.
- Desktop drop on the current parent → no-op (no modal).
- Forced 409 name_collision response handling visible in the confirm modal.
- Mobile touch behavior with dnd-kit's TouchSensor (150 ms activation delay, 8 px tolerance). If touch UX is awkward, Batch Move remains the recommended mobile flow.
- prefers-reduced-motion: drop animations are disabled (`dropAnimation={null}` on DragOverlay).

## Risk notes
- Batch Move is preserved verbatim — every test from `categories-c2-edit-mode.test.tsx` still passes. Drag is strictly additive.
- Drag handle is a real \`<button>\` with role=button + aria-label, and the keyboard sensor is wired, so keyboard users can start a drag from the handle with Space. But the primary keyboard / SR path is still the Batch Move checkboxes + sticky bar.
- No pointer-only critical paths: every action available via drag is also available via Batch Move.