### PR TITLE
feat(help): in-app contextual help anchors (L5.3)

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -199,7 +200,10 @@ export default function AccountsPage() {
 
   return (
     <AppShell>
-      <h1 className={pageTitle}>Accounts</h1>
+      <div className="mb-8 flex items-center gap-1">
+        <h1 className={`${pageTitle} mb-0`}>Accounts</h1>
+        <HelpAnchor section="accounts" label="Accounts" />
+      </div>
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
 

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -13,6 +13,7 @@ import {
   XCircle,
 } from "lucide-react";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { hasPlatformPermission } from "@/lib/auth";
@@ -353,7 +354,10 @@ export default function AdminDashboardPage() {
       <div className="space-y-6">
         <header className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="font-display text-2xl text-text-primary">Admin</h1>
+            <div className="flex items-center gap-1">
+              <h1 className="font-display text-2xl text-text-primary">Admin</h1>
+              <HelpAnchor section="admin" label="Admin" />
+            </div>
             <p className="mt-1 text-sm text-text-muted">
               Platform ops hub, totals and shortcuts across all organizations.
             </p>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -205,7 +206,10 @@ export default function BudgetsPage() {
   return (
     <AppShell>
       <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className={`${pageTitle} mb-0`}>Budgets</h1>
+        <div className="flex items-center gap-1">
+          <h1 className={`${pageTitle} mb-0`}>Budgets</h1>
+          <HelpAnchor section="budgets" label="Budgets" />
+        </div>
         <div className="flex flex-wrap gap-2">
           {isCurrentPeriod && (
             <button

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -203,7 +204,10 @@ export default function CategoriesPage() {
   return (
     <AppShell>
       <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className={`${pageTitle} mb-0`}>Categories</h1>
+        <div className="flex items-center gap-1">
+          <h1 className={`${pageTitle} mb-0`}>Categories</h1>
+          <HelpAnchor section="categories" label="Categories" />
+        </div>
         <div className="flex flex-wrap items-center gap-2">
           {/* C2a: Edit-mode toggle. Owned by Team Categories C2 UI. */}
           <button

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -598,7 +599,10 @@ export default function DashboardPage() {
   return (
     <AppShell>
       <div className="mb-6 flex items-center justify-between">
-        <h1 className={`${pageTitle} mb-0`}>Dashboard</h1>
+        <div className="flex items-center gap-1">
+          <h1 className={`${pageTitle} mb-0`}>Dashboard</h1>
+          <HelpAnchor section="dashboard" label="Dashboard" />
+        </div>
         <div className="flex items-center gap-2">
           <Link href="/import" className={btnSecondary}>
             Import

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -27,6 +27,13 @@ const sections = [
   { id: "forecasts", label: "Forecasts: planning vs projecting" },
   { id: "admin-workflows", label: "Admin workflows" },
   { id: "system-health", label: "System health" },
+  { id: "dashboard", label: "Dashboard" },
+  { id: "transactions", label: "Transactions" },
+  { id: "accounts", label: "Accounts" },
+  { id: "categories", label: "Categories" },
+  { id: "budgets", label: "Budgets" },
+  { id: "forecast-plans", label: "Forecast Plans" },
+  { id: "admin", label: "Admin" },
   { id: "whats-next", label: "What's next" },
 ];
 
@@ -386,6 +393,118 @@ export default function DocsPage() {
               status of the database and Redis, including latency.
               Failures there usually explain whatever the rest of the
               app is doing.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="dashboard">Dashboard</h2>
+            <p>
+              The Dashboard is the household summary screen. The On Track
+              hero tile reads from what has actually settled in the
+              current billing period, so it stays calm even when pending
+              charges or upcoming recurring bills make the projection
+              jumpy. Below the hero, the Accounts strip shows balance
+              plus pending per account, and a Forecast card shows the
+              expected month-end balance for each account. Three cards
+              underneath summarize spending by category, budget
+              progress, and forecast by category. Use the period nav at
+              the top to step through past or future periods; the donut
+              and bars are filterable by category. For variance numbers,
+              source attribution, and the planned-vs-actual chart, open
+              Forecast Plans and turn on Show details.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="transactions">Transactions</h2>
+            <p>
+              The Transactions page lists every booked row in the
+              selected billing period. Click a row to expand the inline
+              editor, where you can change description, amount, dates,
+              category, status, and notes without leaving the list. From
+              the same row you can promote a transaction to a recurring
+              template, convert it into a transfer leg by selecting its
+              counterparty account, or attach tags. Use the toolbar to
+              filter by status, account, or category, and to sort the
+              columns. Imports land here as a preview first, so nothing
+              is committed until you confirm.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="accounts">Accounts</h2>
+            <p>
+              Accounts represent your real-world money containers: bank
+              accounts, credit cards, cash, savings. Each account has a
+              type, a currency, and a balance derived from its
+              transactions plus pending items. Credit-card accounts also
+              carry a close day, which drives the billing period for
+              charges on that card. From here you can add new accounts,
+              set the default one (it shows first on the Dashboard
+              strip), close an account, or post a manual balance
+              adjustment when the in-app total drifts from the bank's.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="categories">Categories</h2>
+            <p>
+              Categories are the backbone of budgets and forecasts. They
+              are hierarchical: master categories group related
+              subcategories, and each category has a type (income,
+              expense, or both) that constrains where it can be used.
+              Edit mode unlocks batch selection so you can move or
+              delete multiple subcategories at once. Renaming is
+              live-reference, so existing transactions update
+              automatically. Deleting a category that is in use prompts
+              you to migrate its rows to another category in the same
+              type. Master categories cannot be removed while they have
+              children.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="budgets">Budgets</h2>
+            <p>
+              Budgets are the current-period control surface: a number
+              per category that represents the cap you want to spend
+              against for this period. The bar chart on the Budgets page
+              colors each row by utilization (under, near, over), and
+              the Dashboard's Budget Progress card pulls the same
+              numbers. Budgets are scoped to the open billing period.
+              For future periods, use Forecast Plans instead, and click
+              From Forecast to seed the current period's budgets from
+              the matching plan.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="forecast-plans">Forecast Plans</h2>
+            <p>
+              Forecast Plans is where you build and adjust the wish list
+              of what you expect to spend and earn per category for a
+              billing period. Auto-populate fills the plan from
+              recurring bills, your last 3 months of activity, and
+              anything already booked in the period. The Show details
+              toggle reveals variance, source attribution, the planned
+              vs actual chart, and Refresh from sources, which re-runs
+              auto-population while preserving rows you typed yourself.
+              See the Forecasts section above for the full mental model
+              of plan vs projected vs variance.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="admin">Admin</h2>
+            <p>
+              The Admin area is the platform-ops hub, visible only to
+              users with platform permissions. The header summarizes
+              live database and Redis health; the totals strip tracks
+              orgs, users, active subscriptions, and recent signups. The
+              tiles below open the Organizations browser, the Audit log,
+              and the Roles editor. Most destructive actions
+              (subscription overrides, org deletes, tenant resets) are
+              captured in the audit log automatically.
             </p>
           </section>
 

--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "re
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import CategorySelect from "@/components/ui/CategorySelect";
@@ -595,7 +596,10 @@ export default function ForecastPlansClient({
     <AppShell>
       {/* Header */}
       <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
-        <h1 className={`${pageTitle} mb-0`}>Forecast Plans</h1>
+        <div className="flex items-center gap-1">
+          <h1 className={`${pageTitle} mb-0`}>Forecast Plans</h1>
+          <HelpAnchor section="forecast-plans" label="Forecast Plans" />
+        </div>
         <div className="flex flex-wrap items-center gap-2">
           {/* Show/hide details toggle. Hides variance/source/chart/refresh
               and the technical (?) help markers when off. */}

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, Suspense, useCallback, useEffect, useMemo, useState } from "
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -837,7 +838,10 @@ function TransactionsPageContent() {
         </div>
       )}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className={`${pageTitle} mb-0`}>Transactions</h1>
+        <div className="flex items-center gap-1">
+          <h1 className={`${pageTitle} mb-0`}>Transactions</h1>
+          <HelpAnchor section="transactions" label="Transactions" />
+        </div>
         <div className="flex items-center gap-2">
           {activeAccounts.length > 0 && categories.length > 0 && (
             <button onClick={() => setShowForm(!showForm)} className={btnPrimary}>

--- a/frontend/components/HelpAnchor.tsx
+++ b/frontend/components/HelpAnchor.tsx
@@ -1,0 +1,50 @@
+import { HelpCircle } from "lucide-react";
+
+/**
+ * HelpAnchor — small "?" icon that links to a section of the in-app
+ * `/docs` user manual. Sits next to a page title (or other prominent
+ * heading) and opens the matching anchor in a new tab so the user keeps
+ * their context.
+ *
+ * Convention: `section` must match a real `id=` on a heading inside
+ * `frontend/app/docs/page.tsx`. A broken anchor here is a bug, not a
+ * design choice — the L5.3 contract is "every help marker resolves to
+ * a real section."
+ *
+ * Token-clean per `scripts/check-design-tokens.sh`: muted by default,
+ * accent on hover/focus. Touch target ≥44px on mobile (WCAG 2.5.8) and
+ * compact 28px at desktop where the cursor is precise.
+ */
+type HelpAnchorProps = {
+  /** /docs section id, e.g. "dashboard". Must exist in the docs page. */
+  section: string;
+  /** Optional extra context for screen readers. Falls back to the section name. */
+  label?: string;
+  /** Optional class overrides for layout fit (margin, alignment). */
+  className?: string;
+};
+
+export default function HelpAnchor({
+  section,
+  label,
+  className = "",
+}: HelpAnchorProps) {
+  const ariaLabel = `Help: ${label ?? section}`;
+  return (
+    <a
+      href={`/docs#${section}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={ariaLabel}
+      data-testid="help-anchor"
+      data-section={section}
+      className={`inline-flex min-h-[44px] min-w-[44px] md:min-h-7 md:min-w-7 items-center justify-center rounded-full text-text-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${className}`}
+    >
+      <HelpCircle
+        aria-hidden="true"
+        className="h-4 w-4"
+        strokeWidth={1.75}
+      />
+    </a>
+  );
+}

--- a/frontend/tests/app/dashboard-help-anchor.test.tsx
+++ b/frontend/tests/app/dashboard-help-anchor.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/dashboard",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+function mockEmptyDashboard() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/accounts") return Promise.resolve([]);
+    if (url === "/api/v1/categories") return Promise.resolve([]);
+    if (url === "/api/v1/budgets") return Promise.resolve([]);
+    if (url === "/api/v1/settings/billing-cycle")
+      return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period")
+      return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings/billing-periods")
+      return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve([]);
+    if (url.startsWith("/api/v1/forecast-plans/current"))
+      return Promise.resolve(null);
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("DashboardPage — contextual help anchor (L5.3)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    window.history.pushState({}, "", "/dashboard");
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockEmptyDashboard();
+  });
+
+  it("mounts a HelpAnchor next to the page title pointing at /docs#dashboard", async () => {
+    render(<DashboardPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("help-anchor")).toBeInTheDocument();
+    });
+    const anchor = screen.getByTestId("help-anchor");
+    expect(anchor).toHaveAttribute("href", "/docs#dashboard");
+    expect(anchor).toHaveAttribute("target", "_blank");
+  });
+});

--- a/frontend/tests/components/HelpAnchor.test.tsx
+++ b/frontend/tests/components/HelpAnchor.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import HelpAnchor from "@/components/HelpAnchor";
+
+describe("HelpAnchor", () => {
+  it("renders an anchor pointing at the given /docs section", () => {
+    render(<HelpAnchor section="dashboard" />);
+
+    const anchor = screen.getByTestId("help-anchor");
+    expect(anchor).toBeInTheDocument();
+    expect(anchor).toHaveAttribute("href", "/docs#dashboard");
+    expect(anchor).toHaveAttribute("data-section", "dashboard");
+  });
+
+  it("opens in a new tab with secure rel attributes", () => {
+    render(<HelpAnchor section="transactions" />);
+
+    const anchor = screen.getByTestId("help-anchor");
+    expect(anchor).toHaveAttribute("target", "_blank");
+    expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("uses the section as the aria-label fallback", () => {
+    render(<HelpAnchor section="accounts" />);
+
+    expect(
+      screen.getByRole("link", { name: "Help: accounts" }),
+    ).toBeInTheDocument();
+  });
+
+  it("prefers the explicit label in the aria-label when provided", () => {
+    render(<HelpAnchor section="forecast-plans" label="Forecast Plans" />);
+
+    expect(
+      screen.getByRole("link", { name: "Help: Forecast Plans" }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks the inner icon as decorative for screen readers", () => {
+    const { container } = render(<HelpAnchor section="budgets" />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+});


### PR DESCRIPTION
## Summary

Adds in-app contextual help anchors that link to matching sections in `/docs`. A small `?` button appears next to the page title on seven high-value pages and opens the corresponding docs section in a new tab.

Recovers L5.3 PARTIAL → SHIPPED per the 2026-05-11 roadmap reconciliation.

## Component

`frontend/components/HelpAnchor.tsx` — renders a small `?` icon button with `aria-label="Help: <label or section>"`, links to `/docs#<section>` in a new tab (`target="_blank"`, `rel="noopener noreferrer"`). Token-clean (`text-text-muted hover:text-accent` + focus-visible accent ring). Touch target ≥44px on mobile, compact at `md+`. Decorative icon has `aria-hidden="true"`.

## Injection points

- `/dashboard` → `section="dashboard"`
- `/transactions` → `section="transactions"`
- `/accounts` → `section="accounts"`
- `/categories` → `section="categories"`
- `/budgets` → `section="budgets"`
- `/forecast-plans` → `section="forecast-plans"` (in client component, not RSC shell)
- `/admin` → `section="admin"`

## /docs sections added

Expanded `frontend/app/docs/page.tsx` by ~119 lines with anchored content matching the seven injection points.

## Tests

- `frontend/tests/components/HelpAnchor.test.tsx` — component render, href, aria-label, new-tab attrs.
- `frontend/tests/app/dashboard-help-anchor.test.tsx` — integration smoke on /dashboard.

Suite: 497 → 503 (+6 tests, +2 files).

## Quality gates

- Token check: pass
- tsc --noEmit: pass
- lint --quiet: pass
- Tests: 503/503 pass
- Build: pass

## Out of scope

No videos/GIFs (deferred), no L3.3 onboarding tour integration (separate dispatch), no backend changes.

## Risk notes

Each `section=` value resolves to a real `id=` in `/docs/page.tsx`. No new dependencies. Backend untouched.