### PR TITLE
feat(admin): system usage analytics counts slice (L4.6)

### DIFF
--- a/backend/alembic/versions/039_seed_analytics_view_permission.py
+++ b/backend/alembic/versions/039_seed_analytics_view_permission.py
@@ -1,0 +1,80 @@
+"""Seed analytics.view permission into the superadmin role (L4.6).
+
+Revision ID: 039_analytics_view_perm
+Revises: 038_tags_and_dictionary
+Create Date: 2026-05-11
+
+L4.6 ships the system-usage analytics surface. It is gated by a new
+``analytics.view`` permission key (added to
+``app/auth/permissions.py``'s ``Permission`` literal + ``ALL_PERMISSIONS``).
+
+The runtime resolver short-circuits via ``is_superadmin``, so the seed
+below is for parity with future non-superadmin roles and to keep the
+``/admin/roles`` UI's permission editor accurate. We INSERT-IGNORE
+(via existence check) so re-running the migration after manual seeding
+doesn't fail.
+
+This follows the pattern documented in migration ``033_add_roles_and_role_permissions``:
+"If new permissions are added later, ship a follow-up data migration
+that inserts the new keys into role_permissions for the superadmin row."
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "039_analytics_view_perm"
+down_revision = "038_tags_and_dictionary"
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_KEY = "analytics.view"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Locate the superadmin role; if the row is missing (e.g. someone
+    # ran the downgrade for 033 manually), bail silently — the runtime
+    # short-circuit still covers superadmins, and this seed is purely
+    # for UI parity.
+    row = bind.execute(
+        sa.text("SELECT id FROM roles WHERE slug = :slug"),
+        {"slug": "superadmin"},
+    ).first()
+    if row is None:
+        return
+    role_id = row[0]
+
+    # Idempotent insert: skip if the (role_id, permission_key) row
+    # already exists. Composite PK means a plain INSERT would explode
+    # on rerun under MySQL.
+    exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM role_permissions "
+            "WHERE role_id = :role_id AND permission_key = :key"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    ).first()
+    if exists is not None:
+        return
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO role_permissions (role_id, permission_key) "
+            "VALUES (:role_id, :key)"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "DELETE FROM role_permissions WHERE permission_key = :key"
+        ),
+        {"key": PERMISSION_KEY},
+    )

--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -26,6 +26,7 @@ Permission = Literal[
     "orgs.manage",
     "audit.view",
     "roles.manage",
+    "analytics.view",
 ]
 
 
@@ -39,6 +40,7 @@ ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "orgs.manage",
     "audit.view",
     "roles.manage",
+    "analytics.view",
 })
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_audit, admin_orgs, admin_roles, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_analytics, admin_audit, admin_orgs, admin_roles, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -380,6 +380,7 @@ app.include_router(plans.router)
 app.include_router(admin.router)
 app.include_router(admin_orgs.router)
 app.include_router(admin_audit.router)
+app.include_router(admin_analytics.router)
 app.include_router(admin_roles.router)
 app.include_router(org_members.router)
 app.include_router(org_data.router)

--- a/backend/app/routers/admin_analytics.py
+++ b/backend/app/routers/admin_analytics.py
@@ -1,0 +1,45 @@
+"""Admin system-usage analytics read API (L4.6).
+
+Mounted at ``/api/v1/admin/analytics``. Gated by the platform
+``analytics.view`` permission (superadmin short-circuits, fine-grained
+roles via L4.8 layer in later without touching this file).
+
+Read-only counts-only first slice. No third-party SDK; no per-user
+event stream; no charts (follow-up). All numbers are derived from
+existing tables (``audit_events`` for logins, ``transactions`` for
+write/import volume, ``organizations`` for the org leaderboard and
+dormancy list).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.permissions import require_permission
+from app.database import get_db
+from app.schemas.admin_analytics import AnalyticsResponse
+from app.services import admin_analytics_service
+
+
+router = APIRouter(prefix="/api/v1/admin/analytics", tags=["admin-analytics"])
+
+
+@router.get(
+    "",
+    response_model=AnalyticsResponse,
+    dependencies=[Depends(require_permission("analytics.view"))],
+)
+async def get_analytics(
+    days: int = Query(default=30, ge=1, le=365),
+    top_orgs_limit: int = Query(default=10, ge=1, le=100),
+    dormant_threshold_days: int = Query(default=30, ge=0, le=365),
+    db: AsyncSession = Depends(get_db),
+) -> AnalyticsResponse:
+    """System-usage analytics envelope. One round-trip per page render."""
+    payload = await admin_analytics_service.build_analytics_payload(
+        db,
+        days=days,
+        top_orgs_limit=top_orgs_limit,
+        dormant_threshold_days=dormant_threshold_days,
+    )
+    return AnalyticsResponse.model_validate(payload)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -5,13 +5,14 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import httpx
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response, Cookie, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy import func, or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models.account import AccountType, SYSTEM_ACCOUNT_TYPES
 from app.models.settings import OrgSetting
 from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
@@ -59,7 +60,8 @@ from app.security import (
     token_cutoff,
     verify_password,
 )
-from app.rate_limit import limiter
+from app.rate_limit import get_client_ip, limiter
+from app.services import audit_service
 from app.services.email_service import send_mfa_email_code, send_password_reset_email, send_verification_email
 from app.services.mfa_service import (
     MfaConfigError,
@@ -234,7 +236,11 @@ async def register(
 @router.post("/login", response_model=TokenResponse | MfaChallengeResponse)
 @limiter.limit("10/minute")
 async def login(
-    request: Request, body: LoginRequest, response: Response, db: AsyncSession = Depends(get_db)
+    request: Request,
+    body: LoginRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     # Accept username or email
     result = await db.execute(
@@ -265,7 +271,10 @@ async def login(
             },
         )
 
-    # If MFA is enabled, return a challenge token instead of access tokens
+    # If MFA is enabled, return a challenge token instead of access tokens.
+    # The login.success audit fires AFTER MFA completes (in /mfa/*), not
+    # here, so the analytics count reflects "user actually signed in" not
+    # "user passed first factor".
     if user.mfa_enabled:
         mfa_token = create_mfa_challenge_token(user.id)
         return MfaChallengeResponse(mfa_token=mfa_token)
@@ -281,6 +290,10 @@ async def login(
         samesite="lax",
         max_age=7 * 24 * 60 * 60,
         path="/",
+    )
+
+    await _record_login_success(
+        session_factory, user=user, request=request, method="password"
     )
 
     return TokenResponse(access_token=access_token)
@@ -699,6 +712,38 @@ def _issue_tokens(user: User, response: Response) -> TokenResponse:
     return TokenResponse(access_token=access_token)
 
 
+async def _record_login_success(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    user: User,
+    request: Request,
+    method: str,
+) -> None:
+    """Persist a ``user.login.success`` audit event.
+
+    Fire-and-forget contract — ``record_audit_event`` swallows DB
+    errors so a transient audit write failure can never block a
+    successful sign-in. ``method`` distinguishes ``password``,
+    ``mfa_totp``, ``mfa_recovery``, ``mfa_email``, and ``google_sso``
+    so the L4.6 analytics surface can disaggregate later without a
+    schema change. PII (e.g. password, TOTP code) is never recorded;
+    only the actor identity, request id, and IP travel into the row.
+    """
+    request_id = structlog.contextvars.get_contextvars().get("request_id")
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="user.login.success",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=user.org_id,
+        target_org_name=None,
+        request_id=request_id,
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"method": method},
+    )
+
+
 @router.post("/mfa/setup", response_model=MfaSetupResponse)
 async def mfa_setup(
     current_user: User = Depends(get_current_user),
@@ -795,6 +840,7 @@ async def mfa_verify(
     body: MfaVerifyRequest,
     response: Response,
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     """Verify TOTP code during login to complete authentication."""
     user = await _resolve_mfa_user(body.mfa_token, db)
@@ -809,7 +855,11 @@ async def mfa_verify(
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=401, detail="Invalid TOTP code")
 
-    return _issue_tokens(user, response)
+    tokens = _issue_tokens(user, response)
+    await _record_login_success(
+        session_factory, user=user, request=request, method="mfa_totp"
+    )
+    return tokens
 
 
 @router.post("/mfa/recovery", response_model=TokenResponse)
@@ -819,6 +869,7 @@ async def mfa_recovery(
     body: MfaRecoveryRequest,
     response: Response,
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     """Use a recovery code during login to complete authentication."""
     user = await _resolve_mfa_user(body.mfa_token, db)
@@ -836,7 +887,11 @@ async def mfa_recovery(
     user.recovery_codes = ",".join(hashed_codes) if hashed_codes else None
     await db.commit()
 
-    return _issue_tokens(user, response)
+    tokens = _issue_tokens(user, response)
+    await _record_login_success(
+        session_factory, user=user, request=request, method="mfa_recovery"
+    )
+    return tokens
 
 
 @router.post("/mfa/email-code")
@@ -883,6 +938,7 @@ async def mfa_email_verify(
     body: MfaEmailVerifyRequest,
     response: Response,
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     """Verify an email-based MFA code to complete authentication."""
     user = await _resolve_mfa_user(body.mfa_token, db)
@@ -925,7 +981,11 @@ async def mfa_email_verify(
         if not consumed:
             raise HTTPException(status_code=401, detail="Invalid or expired email code")
 
-    return _issue_tokens(user, response)
+    tokens = _issue_tokens(user, response)
+    await _record_login_success(
+        session_factory, user=user, request=request, method="mfa_email"
+    )
+    return tokens
 
 
 # ── Google SSO ───────────────────────────────────────────────────────────────
@@ -986,9 +1046,11 @@ async def google_login(response: Response):
 
 @router.get("/google/callback")
 async def google_callback(
+    request: Request,
     code: str,
     state: str,
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
     oauth_state: str | None = Cookie(default=None),
 ):
     """Handle Google OAuth callback — exchange code for tokens, create or login user.
@@ -1160,6 +1222,9 @@ async def google_callback(
         samesite="lax",
         max_age=7 * 24 * 60 * 60,
         path="/",
+    )
+    await _record_login_success(
+        session_factory, user=user, request=request, method="google_sso"
     )
     return resp
 

--- a/backend/app/schemas/admin_analytics.py
+++ b/backend/app/schemas/admin_analytics.py
@@ -1,0 +1,63 @@
+"""Pydantic schemas for the L4.6 system-usage analytics API.
+
+Counts-only first slice — no PII, no per-user series, no charts. The
+envelope is intentionally flat so a follow-up PR can drop in a charts
+client without re-shaping existing fields.
+"""
+from __future__ import annotations
+
+import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class DailyCount(BaseModel):
+    """One bucket in a daily activity series. ``date`` is an ISO date
+    (UTC). Missing days carry ``count=0`` so the frontend can render
+    sparkline-style strips without re-walking the window."""
+
+    date: datetime.date
+    count: int
+
+
+class OrgTxVolume(BaseModel):
+    """Org ranked by transactions created in the window. ``rank`` is
+    1-based to match the way humans read leaderboards."""
+
+    rank: int
+    org_id: int
+    org_name: str
+    tx_count: int
+
+
+class DormantOrg(BaseModel):
+    """Org with no transactions created within the dormancy window.
+
+    ``last_tx_at`` is None when an org has never recorded a transaction
+    (newly-created shells). ``days_since_last_activity`` is None in the
+    same case — UI renders that as ``no activity yet`` rather than
+    ``Infinity days``.
+    """
+
+    org_id: int
+    org_name: str
+    last_tx_at: Optional[datetime.datetime] = None
+    days_since_last_activity: Optional[int] = None
+
+
+class AnalyticsResponse(BaseModel):
+    """One round-trip payload for ``/admin/analytics``.
+
+    ``window_days`` is echoed so the frontend doesn't need to track the
+    backend default separately. ``generated_at`` lets the UI render a
+    "as of …" timestamp without trusting client clocks.
+    """
+
+    window_days: int
+    generated_at: datetime.datetime
+    logins_by_day: list[DailyCount]
+    tx_writes_by_day: list[DailyCount]
+    imports_by_day: list[DailyCount]
+    top_orgs_by_tx_volume: list[OrgTxVolume]
+    dormant_orgs: list[DormantOrg]

--- a/backend/app/services/admin_analytics_service.py
+++ b/backend/app/services/admin_analytics_service.py
@@ -1,0 +1,386 @@
+"""System-usage analytics aggregations (L4.6 — counts-only slice).
+
+Pure SQL aggregates over existing tables. No third-party analytics
+SDK; no per-user/per-event PII; no real-time streams. The shape is
+deliberately small (six functions) so each can be evolved into a
+charts source later without breaking the envelope.
+
+Data sources:
+
+- ``logins_by_day``  → ``audit_events`` filtered by
+  ``event_type = 'user.login.success'``. The login endpoint emits
+  this event on every successful sign-in (see PR L4.6).
+- ``tx_writes_by_day`` / ``imports_by_day`` / ``top_orgs_by_tx_volume``
+  / ``dormant_orgs`` → ``transactions`` table, grouped by
+  ``DATE(created_at)`` (creation time, not transaction_date — the
+  spec wants write activity).
+- ``imports_by_day`` → counts ``transactions`` rows with
+  ``is_imported = TRUE``. The product does not persist an
+  ``import_sessions`` table, so this is "imported rows per day",
+  not "import sessions per day". A single CSV import may contribute
+  dozens of rows; document this when surfacing.
+
+Cross-org isolation:
+
+- ``logins_by_day`` is platform-global by design (it's a system-usage
+  signal). The route is platform-only (``analytics.view`` permission)
+  so there's no tenant context to scope against.
+- ``tx_writes_by_day`` and ``imports_by_day`` are platform-global
+  (sum across all orgs) — again, the system view.
+- ``top_orgs_by_tx_volume`` and ``dormant_orgs`` are cross-org by
+  necessity; rank is over all orgs.
+
+Performance note:
+
+- All queries are single-pass aggregates over indexed columns
+  (``transactions.created_at`` is indexed via the org_id+created_at
+  pattern used throughout the app; ``audit_events.created_at`` is
+  indexed by 030). For dev/PR-1 scale this is sub-millisecond. Watch
+  cardinality if the dataset crosses ~10M rows — at that point cache
+  the response or pre-aggregate into a daily-rollup table.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_event import AuditEvent
+from app.models.transaction import Transaction
+from app.models.user import Organization
+
+
+LOGIN_AUDIT_EVENT_TYPE = "user.login.success"
+
+
+def _normalize_days(days: int) -> int:
+    """Clamp the window to a sane range. The route surfaces the value
+    so an obvious upper bound matters for latency budgeting more than
+    for correctness."""
+    if days <= 0:
+        return 30
+    if days > 365:
+        return 365
+    return days
+
+
+def _window_start(days: int, *, now: datetime | None = None) -> datetime:
+    """UTC midnight ``days`` days ago. We pin to midnight so the same
+    request issued twice on the same day returns the same buckets."""
+    base = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    midnight = base.replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight - timedelta(days=days - 1)
+
+
+def _coerce_to_date(value: Any) -> date | None:
+    """Normalize ``func.date()`` output across drivers.
+
+    MySQL returns ``date`` objects. SQLite returns ISO date strings.
+    Some configurations return ``datetime``. Anything else is treated
+    as malformed and dropped (caller's responsibility to skip None).
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        # ISO date string (SQLite default for DATE()).
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            return None
+    return None
+
+
+def _fill_daily_series(
+    rows: list[tuple[Any, int]],
+    *,
+    window_days: int,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Convert a ``(date_value, count)`` rowset into a contiguous series
+    with zero-fill for missing days. The frontend assumes ``window_days``
+    points; emitting fewer would force per-render gap-filling there."""
+    counts: dict[date, int] = {}
+    for raw_d, c in rows:
+        d = _coerce_to_date(raw_d)
+        if d is None:
+            continue
+        counts[d] = int(c or 0)
+
+    base = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    today = base.date()
+    series: list[dict[str, Any]] = []
+    for i in range(window_days):
+        the_day = today - timedelta(days=window_days - 1 - i)
+        series.append({"date": the_day, "count": counts.get(the_day, 0)})
+    return series
+
+
+async def login_counts_by_day(
+    db: AsyncSession,
+    days: int = 30,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Daily count of successful logins across the platform.
+
+    Source: ``audit_events`` rows with
+    ``event_type = 'user.login.success'``. Days with zero logins are
+    emitted with ``count = 0`` so the series is always ``days`` long.
+    """
+    window_days = _normalize_days(days)
+    start = _window_start(window_days, now=now)
+    # ``func.date()`` is supported by both MySQL and SQLite and yields
+    # a date/iso-string the row mapper can ingest without a typed cast.
+    day_col = func.date(AuditEvent.created_at).label("day")
+    stmt = (
+        select(day_col, func.count().label("c"))
+        .where(AuditEvent.event_type == LOGIN_AUDIT_EVENT_TYPE)
+        .where(AuditEvent.created_at >= start)
+        .group_by(day_col)
+        .order_by(day_col)
+    )
+    rows = (await db.execute(stmt)).all()
+    return _fill_daily_series(
+        [(r.day, r.c) for r in rows],
+        window_days=window_days,
+        now=now,
+    )
+
+
+async def tx_writes_by_day(
+    db: AsyncSession,
+    days: int = 30,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Daily count of transactions created across the platform.
+
+    Uses ``transactions.created_at`` (write time), NOT
+    ``transaction_date`` (purchase / accounting date) — the spec
+    wants write activity for the system-usage view.
+    """
+    window_days = _normalize_days(days)
+    start = _window_start(window_days, now=now)
+    day_col = func.date(Transaction.created_at).label("day")
+    stmt = (
+        select(day_col, func.count().label("c"))
+        .where(Transaction.created_at >= start)
+        .group_by(day_col)
+        .order_by(day_col)
+    )
+    rows = (await db.execute(stmt)).all()
+    return _fill_daily_series(
+        [(r.day, r.c) for r in rows],
+        window_days=window_days,
+        now=now,
+    )
+
+
+async def imports_by_day(
+    db: AsyncSession,
+    days: int = 30,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Daily count of imported transactions across the platform.
+
+    We do not persist an ``import_sessions`` table, so this returns
+    "imported rows per day" rather than "import sessions per day".
+    Surfaces should label accordingly. Filter: ``is_imported = TRUE``.
+    """
+    window_days = _normalize_days(days)
+    start = _window_start(window_days, now=now)
+    day_col = func.date(Transaction.created_at).label("day")
+    stmt = (
+        select(day_col, func.count().label("c"))
+        .where(Transaction.created_at >= start)
+        .where(Transaction.is_imported.is_(True))
+        .group_by(day_col)
+        .order_by(day_col)
+    )
+    rows = (await db.execute(stmt)).all()
+    return _fill_daily_series(
+        [(r.day, r.c) for r in rows],
+        window_days=window_days,
+        now=now,
+    )
+
+
+async def top_orgs_by_tx_volume(
+    db: AsyncSession,
+    limit: int = 10,
+    days: int = 30,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Top N orgs by transactions created in the window. Newest orgs
+    surface here too — the join key is ``transactions.org_id``, so an
+    org with zero transactions is not represented (intentional; that's
+    what ``dormant_orgs`` is for).
+
+    Tie-break: secondary sort by ``org_id`` ascending so the result is
+    deterministic when two orgs have identical counts.
+    """
+    window_days = _normalize_days(days)
+    if limit <= 0:
+        return []
+    if limit > 100:
+        limit = 100
+    start = _window_start(window_days, now=now)
+    stmt = (
+        select(
+            Organization.id.label("org_id"),
+            Organization.name.label("org_name"),
+            func.count(Transaction.id).label("tx_count"),
+        )
+        .join(Transaction, Transaction.org_id == Organization.id)
+        .where(Transaction.created_at >= start)
+        .group_by(Organization.id, Organization.name)
+        .order_by(func.count(Transaction.id).desc(), Organization.id.asc())
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        {
+            "rank": i + 1,
+            "org_id": r.org_id,
+            "org_name": r.org_name,
+            "tx_count": int(r.tx_count or 0),
+        }
+        for i, r in enumerate(rows)
+    ]
+
+
+async def dormant_orgs(
+    db: AsyncSession,
+    threshold_days: int = 30,
+    *,
+    now: datetime | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Orgs whose most recent transaction is older than the threshold
+    (or that have never recorded a transaction at all).
+
+    Sorted by oldest-last-activity first so the most-stale orgs lead.
+    Orgs with ``last_tx_at = NULL`` (no transactions ever) appear at
+    the top — ``ORDER BY last_tx_at NULLS FIRST`` semantics emulated
+    via a sentinel column (MySQL has no NULLS FIRST, so we compute a
+    boolean ``has_any_tx`` and order by it).
+    """
+    if threshold_days < 0:
+        threshold_days = 0
+    if limit <= 0:
+        return []
+    if limit > 500:
+        limit = 500
+    base = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    cutoff = base - timedelta(days=threshold_days)
+
+    last_tx_subq = (
+        select(
+            Transaction.org_id.label("org_id"),
+            func.max(Transaction.created_at).label("last_tx_at"),
+        )
+        .group_by(Transaction.org_id)
+        .subquery()
+    )
+
+    has_any_tx = last_tx_subq.c.last_tx_at.isnot(None)
+    stmt = (
+        select(
+            Organization.id.label("org_id"),
+            Organization.name.label("org_name"),
+            last_tx_subq.c.last_tx_at,
+        )
+        .join(
+            last_tx_subq,
+            last_tx_subq.c.org_id == Organization.id,
+            isouter=True,
+        )
+        .where(
+            # Either no transactions at all, or last write before the
+            # cutoff. Both indicate dormancy.
+            (last_tx_subq.c.last_tx_at.is_(None))
+            | (last_tx_subq.c.last_tx_at < cutoff)
+        )
+        # Stable order: never-active orgs first (has_any_tx = False),
+        # then oldest-last-activity. Ties broken by org_id ASC.
+        .order_by(
+            has_any_tx.asc(),
+            last_tx_subq.c.last_tx_at.asc(),
+            Organization.id.asc(),
+        )
+        .limit(limit)
+    )
+
+    rows = (await db.execute(stmt)).all()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        last_at = r.last_tx_at
+        if last_at is None:
+            days_since: int | None = None
+        else:
+            # Some MySQL drivers return naive datetimes for TIMESTAMP/
+            # DATETIME columns; normalize to UTC-aware before subtraction.
+            if last_at.tzinfo is None:
+                last_at_aware = last_at.replace(tzinfo=timezone.utc)
+            else:
+                last_at_aware = last_at.astimezone(timezone.utc)
+            delta = base - last_at_aware
+            days_since = max(0, delta.days)
+        out.append(
+            {
+                "org_id": r.org_id,
+                "org_name": r.org_name,
+                "last_tx_at": last_at,
+                "days_since_last_activity": days_since,
+            }
+        )
+    return out
+
+
+async def build_analytics_payload(
+    db: AsyncSession,
+    *,
+    days: int = 30,
+    top_orgs_limit: int = 10,
+    dormant_threshold_days: int = 30,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Single round-trip composition of the analytics page payload.
+
+    Sequential aggregates rather than ``asyncio.gather`` — SQLAlchemy's
+    ``AsyncSession`` is not safe under concurrent task access (same
+    rationale as ``admin_dashboard_service.build_dashboard_payload``).
+    Each aggregate is sub-millisecond at dev scale; if this ever shows
+    up in flame graphs, collapse into a single SELECT with scalar
+    subqueries before reintroducing concurrent session use.
+    """
+    base_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    window_days = _normalize_days(days)
+
+    logins = await login_counts_by_day(db, days=window_days, now=base_now)
+    tx_writes = await tx_writes_by_day(db, days=window_days, now=base_now)
+    imports = await imports_by_day(db, days=window_days, now=base_now)
+    top_orgs = await top_orgs_by_tx_volume(
+        db, limit=top_orgs_limit, days=window_days, now=base_now
+    )
+    dormant = await dormant_orgs(
+        db, threshold_days=dormant_threshold_days, now=base_now
+    )
+
+    return {
+        "window_days": window_days,
+        "generated_at": base_now,
+        "logins_by_day": logins,
+        "tx_writes_by_day": tx_writes,
+        "imports_by_day": imports,
+        "top_orgs_by_tx_volume": top_orgs,
+        "dormant_orgs": dormant,
+    }

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -52,6 +52,7 @@ def test_all_permissions_contains_known_platform_permissions() -> None:
         "orgs.manage",
         "audit.view",
         "roles.manage",
+        "analytics.view",
     })
 
 

--- a/backend/tests/routers/test_admin_analytics.py
+++ b/backend/tests/routers/test_admin_analytics.py
@@ -1,0 +1,174 @@
+"""Router tests for L4.6 GET /api/v1/admin/analytics.
+
+Pins:
+- The auth gate (``analytics.view`` → superadmin short-circuits;
+  non-superadmin gets 403).
+- Response envelope shape (one round-trip).
+- Window length echoed (``window_days``) and series are zero-filled
+  to length ``window_days``.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.routers.admin_analytics import router as admin_analytics_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_analytics_router)
+    return app
+
+
+async def _seed_users(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Platform", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        sa = User(
+            org_id=org.id,
+            username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=org.id,
+            username="member",
+            email="m@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+        await db.commit()
+        return {"org_id": org.id, "sa_id": sa.id, "plain_id": plain.id}
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+@pytest.mark.asyncio
+async def test_get_analytics_forbidden_for_non_superadmin(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/analytics")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_analytics_returns_envelope_for_superadmin(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/analytics?days=14")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["window_days"] == 14
+    assert "generated_at" in body
+    # All three series are zero-filled to window length even when empty.
+    assert len(body["logins_by_day"]) == 14
+    assert len(body["tx_writes_by_day"]) == 14
+    assert len(body["imports_by_day"]) == 14
+    assert body["top_orgs_by_tx_volume"] == []
+    # The Platform org has no transactions → it's dormant by default.
+    dormant_names = {d["org_name"] for d in body["dormant_orgs"]}
+    assert "Platform" in dormant_names
+
+
+@pytest.mark.asyncio
+async def test_get_analytics_rejects_out_of_range_days(session_factory):
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        # FastAPI Query(le=365) rejects above-range; route returns 422.
+        res = client.get("/api/v1/admin/analytics?days=1000")
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_analytics_clamps_limit_params(session_factory):
+    """top_orgs_limit and dormant_threshold_days are bounded; out-of-range
+    values return 422 rather than silently clipping."""
+    await _seed_users(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/analytics?top_orgs_limit=0")
+    assert res.status_code == 422
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/analytics?dormant_threshold_days=-1")
+    assert res.status_code == 422

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -1,0 +1,238 @@
+"""Auth router tests for L4.6 login audit emission.
+
+Pins:
+- ``POST /api/v1/auth/login`` writes a ``user.login.success`` audit row
+  with ``detail.method == "password"`` for the actor.
+- ``POST /api/v1/auth/mfa/recovery`` writes a ``user.login.success``
+  audit row with ``detail.method == "mfa_recovery"`` once the second
+  factor clears.
+
+These tests are the only guard against a future refactor silently
+dropping the audit-event emission that the L4.6 analytics
+``logins_by_day`` series depends on.
+
+Pattern:
+- An in-memory SQLite session factory backs both the request session
+  AND the independent audit-write session — ``get_session_factory``
+  is overridden onto the same factory so the audit row lands in the
+  DB the test queries.
+- The audit write opens its OWN session (``record_audit_event``), so
+  we must flush by closing that session and re-querying with the test
+  factory. ``record_audit_event`` calls ``commit`` internally on the
+  audit session, so the row is visible to a subsequent ``factory()``
+  open without further work.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import router as auth_router
+from app.security import (
+    create_mfa_challenge_token,
+    hash_password,
+)
+from app.services.mfa_service import (
+    generate_recovery_codes,
+    hash_recovery_code,
+)
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    """SlowAPI ``Limiter`` is a module-level singleton; without a reset
+    the per-IP counter from one test bleeds into the next (a 429 on a
+    perfectly good login)."""
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    # SlowAPI handler chain — without these the @limiter.limit decorator
+    # raises an AttributeError on request.state.limiter.
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        # Returns the factory itself (FastAPI invokes the dependency to
+        # produce the value; the value is the factory we hand out).
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    email: str = "alice@acme.io",
+    username: str = "alice",
+    password: str = "starting-password-1",
+    mfa_enabled: bool = False,
+    recovery_codes_plaintext: list[str] | None = None,
+) -> dict:
+    """Create org + user. Optionally set MFA state and pre-issued
+    recovery codes (returned plaintext for the test to send back).
+    """
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        recovery_field: str | None = None
+        if recovery_codes_plaintext is not None:
+            recovery_field = ",".join(
+                hash_recovery_code(c) for c in recovery_codes_plaintext
+            )
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=email,
+            password_hash=hash_password(password),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+            mfa_enabled=mfa_enabled,
+            recovery_codes=recovery_field,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id, "email": email}
+
+
+async def _login_success_rows(factory) -> list[AuditEvent]:
+    """Pull every ``user.login.success`` row from the test DB. The audit
+    write commits on a session opened by ``record_audit_event``; opening
+    a new session here is sufficient to observe it (no extra flush)."""
+    async with factory() as db:
+        result = await db.execute(
+            select(AuditEvent).where(
+                AuditEvent.event_type == "user.login.success"
+            )
+        )
+        return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_password_login_writes_user_login_success_audit(
+    session_factory,
+) -> None:
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": "starting-password-1"},
+        )
+    assert res.status_code == 200, res.json()
+    assert "access_token" in res.json()
+
+    rows = await _login_success_rows(session_factory)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.event_type == "user.login.success"
+    assert row.outcome.value == "success"
+    assert row.actor_user_id == seed["user_id"]
+    assert row.actor_email == seed["email"]
+    # The discriminator is what the analytics service will eventually
+    # split on. Pin the spelling.
+    assert row.detail is not None
+    assert row.detail.get("method") == "password"
+
+
+@pytest.mark.asyncio
+async def test_invalid_password_does_not_write_audit(session_factory) -> None:
+    """Failed login must NOT leave a success row behind. (We don't
+    currently emit a failure row either — this test pins the
+    today-behavior so a future regression to "success on every POST"
+    is caught.)"""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": "wrong-password"},
+        )
+    assert res.status_code == 401
+
+    rows = await _login_success_rows(session_factory)
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_mfa_recovery_writes_user_login_success_audit(
+    session_factory,
+) -> None:
+    """``/auth/mfa/recovery`` is the second-factor completion path for
+    users who lost their authenticator. Successfully consuming a
+    recovery code is a login completion event and must emit the audit
+    row with ``method=mfa_recovery``."""
+    codes = generate_recovery_codes(count=3)
+    seed = await _seed_user(
+        session_factory,
+        mfa_enabled=True,
+        recovery_codes_plaintext=codes,
+    )
+    app = _make_app(session_factory)
+
+    mfa_token = create_mfa_challenge_token(seed["user_id"])
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/mfa/recovery",
+            json={"mfa_token": mfa_token, "code": codes[0]},
+        )
+    assert res.status_code == 200, res.json()
+    assert "access_token" in res.json()
+
+    rows = await _login_success_rows(session_factory)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.actor_user_id == seed["user_id"]
+    assert row.detail is not None
+    assert row.detail.get("method") == "mfa_recovery"

--- a/backend/tests/services/test_admin_analytics_service.py
+++ b/backend/tests/services/test_admin_analytics_service.py
@@ -1,0 +1,385 @@
+"""Service-layer tests for L4.6 admin_analytics_service.
+
+Pins:
+- Each aggregate emits a contiguous day series (zero-filled).
+- Empty datasets yield all-zero series of the right length.
+- Window is anchored on UTC midnight (request issued twice on the same
+  day returns identical buckets).
+- Cross-org isolation in ``top_orgs_by_tx_volume``: rows from org A do
+  not inflate org B's count.
+- ``dormant_orgs`` includes orgs with no transactions, sorted before
+  stale-but-not-silent orgs.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.category import Category, CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization
+from app.services import admin_analytics_service
+
+
+# We use status=PENDING in test fixtures because the SETTLED invariant
+# (migration 036) requires a settled_date; the analytics service does
+# not filter on status, so PENDING is the simpler shape.
+
+
+# Pin the clock so every assertion lines up against a known date.
+# 2026-05-11 14:00 UTC sits comfortably in the test data window below.
+FIXED_NOW = datetime(2026, 5, 11, 14, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _make_org(db: AsyncSession, name: str) -> Organization:
+    org = Organization(name=name, billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _make_account_and_category(
+    db: AsyncSession, org: Organization
+) -> tuple[Account, Category]:
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True
+    )
+    db.add(at)
+    await db.flush()
+    acct = Account(
+        org_id=org.id,
+        name="Main",
+        account_type_id=at.id,
+        currency="EUR",
+        balance=Decimal("0.00"),
+    )
+    cat = Category(
+        org_id=org.id,
+        name="Misc",
+        slug="misc",
+        type=CategoryType.EXPENSE,
+        is_system=False,
+    )
+    db.add_all([acct, cat])
+    await db.flush()
+    return acct, cat
+
+
+def _make_tx(
+    *,
+    org: Organization,
+    account: Account,
+    category: Category,
+    created_at: datetime,
+    is_imported: bool = False,
+    amount: str = "10.00",
+) -> Transaction:
+    return Transaction(
+        org_id=org.id,
+        account_id=account.id,
+        category_id=category.id,
+        description="Test tx",
+        amount=Decimal(amount),
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.PENDING,
+        date=created_at.date(),
+        created_at=created_at,
+        is_imported=is_imported,
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_counts_by_day_zero_fills_empty_window(db_session) -> None:
+    series = await admin_analytics_service.login_counts_by_day(
+        db_session, days=7, now=FIXED_NOW
+    )
+    assert len(series) == 7
+    assert all(row["count"] == 0 for row in series)
+    # Newest day is "today" (UTC of FIXED_NOW).
+    assert series[-1]["date"] == FIXED_NOW.date()
+    # Series is contiguous and ascending.
+    for i in range(1, len(series)):
+        assert (series[i]["date"] - series[i - 1]["date"]).days == 1
+
+
+@pytest.mark.asyncio
+async def test_login_counts_by_day_counts_login_events_only(db_session) -> None:
+    org = await _make_org(db_session, "Org A")
+    db_session.add_all(
+        [
+            # actor_user_id / target_org_id left None to avoid the FK
+            # constraint dance — the analytics service filters only on
+            # event_type and created_at.
+            AuditEvent(
+                event_type="user.login.success",
+                actor_user_id=None,
+                actor_email="a@x.io",
+                target_org_id=None,
+                target_org_name=None,
+                request_id=None,
+                ip_address=None,
+                outcome=AuditOutcome.SUCCESS,
+                detail={"method": "password"},
+                created_at=FIXED_NOW - timedelta(days=1, hours=1),
+            ),
+            AuditEvent(
+                event_type="user.login.success",
+                actor_user_id=None,
+                actor_email="b@x.io",
+                target_org_id=None,
+                target_org_name=None,
+                request_id=None,
+                ip_address=None,
+                outcome=AuditOutcome.SUCCESS,
+                detail={"method": "password"},
+                created_at=FIXED_NOW - timedelta(days=1, hours=2),
+            ),
+            # Non-login event must be ignored.
+            AuditEvent(
+                event_type="org.rename",
+                actor_user_id=None,
+                actor_email="a@x.io",
+                target_org_id=None,
+                target_org_name="Org A",
+                request_id=None,
+                ip_address=None,
+                outcome=AuditOutcome.SUCCESS,
+                detail={},
+                created_at=FIXED_NOW - timedelta(days=1, hours=3),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    series = await admin_analytics_service.login_counts_by_day(
+        db_session, days=3, now=FIXED_NOW
+    )
+    counts_by_date = {row["date"]: row["count"] for row in series}
+    yesterday = (FIXED_NOW - timedelta(days=1)).date()
+    assert counts_by_date[yesterday] == 2
+    # No login events on the other days.
+    assert sum(counts_by_date.values()) == 2
+
+
+@pytest.mark.asyncio
+async def test_tx_writes_by_day_uses_created_at_not_transaction_date(
+    db_session,
+) -> None:
+    org = await _make_org(db_session, "Org A")
+    acct, cat = await _make_account_and_category(db_session, org)
+    # ``date`` (purchase date) is far in the past; created_at (write time)
+    # is yesterday. The analytics service must bucket by created_at.
+    tx = _make_tx(
+        org=org,
+        account=acct,
+        category=cat,
+        created_at=FIXED_NOW - timedelta(days=1),
+    )
+    tx.date = (FIXED_NOW - timedelta(days=200)).date()
+    db_session.add(tx)
+    await db_session.commit()
+
+    series = await admin_analytics_service.tx_writes_by_day(
+        db_session, days=5, now=FIXED_NOW
+    )
+    counts_by_date = {row["date"]: row["count"] for row in series}
+    yesterday = (FIXED_NOW - timedelta(days=1)).date()
+    assert counts_by_date[yesterday] == 1
+    assert sum(counts_by_date.values()) == 1
+
+
+@pytest.mark.asyncio
+async def test_imports_by_day_filters_on_is_imported(db_session) -> None:
+    org = await _make_org(db_session, "Org A")
+    acct, cat = await _make_account_and_category(db_session, org)
+    db_session.add_all(
+        [
+            _make_tx(
+                org=org, account=acct, category=cat,
+                created_at=FIXED_NOW - timedelta(days=1),
+                is_imported=True,
+            ),
+            _make_tx(
+                org=org, account=acct, category=cat,
+                created_at=FIXED_NOW - timedelta(days=1),
+                is_imported=True,
+            ),
+            _make_tx(
+                org=org, account=acct, category=cat,
+                created_at=FIXED_NOW - timedelta(days=1),
+                is_imported=False,  # not imported — must NOT count.
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    series = await admin_analytics_service.imports_by_day(
+        db_session, days=3, now=FIXED_NOW
+    )
+    counts_by_date = {row["date"]: row["count"] for row in series}
+    yesterday = (FIXED_NOW - timedelta(days=1)).date()
+    assert counts_by_date[yesterday] == 2
+
+
+@pytest.mark.asyncio
+async def test_top_orgs_by_tx_volume_isolates_per_org(db_session) -> None:
+    org_a = await _make_org(db_session, "Org Alpha")
+    org_b = await _make_org(db_session, "Org Bravo")
+    acct_a, cat_a = await _make_account_and_category(db_session, org_a)
+    acct_b, cat_b = await _make_account_and_category(db_session, org_b)
+
+    # Org A: 3 txs in window. Org B: 1 tx in window + 1 outside.
+    for _ in range(3):
+        db_session.add(
+            _make_tx(
+                org=org_a, account=acct_a, category=cat_a,
+                created_at=FIXED_NOW - timedelta(days=2),
+            )
+        )
+    db_session.add(
+        _make_tx(
+            org=org_b, account=acct_b, category=cat_b,
+            created_at=FIXED_NOW - timedelta(days=2),
+        )
+    )
+    db_session.add(
+        _make_tx(
+            org=org_b, account=acct_b, category=cat_b,
+            # Outside the 7-day window we'll query for.
+            created_at=FIXED_NOW - timedelta(days=60),
+        )
+    )
+    await db_session.commit()
+
+    rows = await admin_analytics_service.top_orgs_by_tx_volume(
+        db_session, limit=10, days=7, now=FIXED_NOW
+    )
+    assert [r["org_name"] for r in rows] == ["Org Alpha", "Org Bravo"]
+    assert rows[0]["rank"] == 1
+    assert rows[0]["tx_count"] == 3
+    assert rows[1]["rank"] == 2
+    assert rows[1]["tx_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_top_orgs_by_tx_volume_empty_dataset(db_session) -> None:
+    rows = await admin_analytics_service.top_orgs_by_tx_volume(
+        db_session, limit=10, days=30, now=FIXED_NOW
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_dormant_orgs_lists_silent_and_never_active(db_session) -> None:
+    # Three orgs, three states:
+    # - Org Active: tx within threshold → NOT dormant.
+    # - Org Stale: tx older than threshold → dormant.
+    # - Org Empty: no transactions at all → dormant (never-active first).
+    org_active = await _make_org(db_session, "Org Active")
+    org_stale = await _make_org(db_session, "Org Stale")
+    org_empty = await _make_org(db_session, "Org Empty")
+
+    acct_a, cat_a = await _make_account_and_category(db_session, org_active)
+    acct_s, cat_s = await _make_account_and_category(db_session, org_stale)
+
+    db_session.add(
+        _make_tx(
+            org=org_active, account=acct_a, category=cat_a,
+            created_at=FIXED_NOW - timedelta(days=5),
+        )
+    )
+    db_session.add(
+        _make_tx(
+            org=org_stale, account=acct_s, category=cat_s,
+            created_at=FIXED_NOW - timedelta(days=90),
+        )
+    )
+    await db_session.commit()
+
+    rows = await admin_analytics_service.dormant_orgs(
+        db_session, threshold_days=30, now=FIXED_NOW
+    )
+    names = [r["org_name"] for r in rows]
+    assert "Org Active" not in names
+    assert names[0] == "Org Empty"  # never-active orgs lead.
+    assert "Org Stale" in names
+    # Org Empty has no last_tx_at.
+    empty_row = next(r for r in rows if r["org_name"] == "Org Empty")
+    assert empty_row["last_tx_at"] is None
+    assert empty_row["days_since_last_activity"] is None
+    # Org Stale's last activity was ~90 days ago.
+    stale_row = next(r for r in rows if r["org_name"] == "Org Stale")
+    assert stale_row["days_since_last_activity"] is not None
+    assert 89 <= stale_row["days_since_last_activity"] <= 91
+
+
+@pytest.mark.asyncio
+async def test_build_analytics_payload_assembles_full_envelope(db_session) -> None:
+    org = await _make_org(db_session, "Single Org")
+    acct, cat = await _make_account_and_category(db_session, org)
+    db_session.add(
+        _make_tx(
+            org=org, account=acct, category=cat,
+            created_at=FIXED_NOW - timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+
+    payload = await admin_analytics_service.build_analytics_payload(
+        db_session, days=7, top_orgs_limit=5, dormant_threshold_days=30,
+        now=FIXED_NOW,
+    )
+    assert payload["window_days"] == 7
+    assert payload["generated_at"] == FIXED_NOW
+    assert len(payload["logins_by_day"]) == 7
+    assert len(payload["tx_writes_by_day"]) == 7
+    assert len(payload["imports_by_day"]) == 7
+    # One org has activity → it appears in top_orgs. No org is dormant
+    # under the 30d threshold because the only tx is 1 day old.
+    assert payload["top_orgs_by_tx_volume"][0]["org_name"] == "Single Org"
+    assert payload["dormant_orgs"] == []
+
+
+@pytest.mark.asyncio
+async def test_normalize_days_clamps_out_of_range_values() -> None:
+    assert admin_analytics_service._normalize_days(0) == 30
+    assert admin_analytics_service._normalize_days(-5) == 30
+    assert admin_analytics_service._normalize_days(400) == 365
+    assert admin_analytics_service._normalize_days(45) == 45

--- a/frontend/app/admin/analytics/page.tsx
+++ b/frontend/app/admin/analytics/page.tsx
@@ -71,7 +71,7 @@ function MetricRow({ label, total, avg, series }: MetricRowProps) {
             {label}
           </div>
           <div className="mt-1 flex items-baseline gap-3">
-            <span className="font-display text-2xl text-text-primary tabular-nums">
+            <span className="text-2xl font-semibold tabular-nums text-text-primary">
               {total.toLocaleString()}
             </span>
             <span className="text-xs text-text-muted">
@@ -83,7 +83,7 @@ function MetricRow({ label, total, avg, series }: MetricRowProps) {
           <div className="text-xs uppercase tracking-wider text-text-muted">
             avg/day
           </div>
-          <div className="font-display text-lg text-text-secondary tabular-nums">
+          <div className="text-lg font-semibold tabular-nums text-text-primary">
             {formatAvg(avg)}
           </div>
         </div>
@@ -304,7 +304,9 @@ export default function AdminAnalyticsPage() {
                     {formatLastActivity(row.last_tx_at)}
                   </td>
                   <td className="px-6 py-3 text-right font-mono text-text-secondary tabular-nums">
-                    {row.days_since_last_activity ?? "—"}
+                    {row.days_since_last_activity ?? (
+                      <span className="text-text-muted">never</span>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/frontend/app/admin/analytics/page.tsx
+++ b/frontend/app/admin/analytics/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { hasPlatformPermission } from "@/lib/auth";
+import type { AnalyticsResponse, DailyCount } from "@/lib/types";
+import {
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  pageTitle,
+} from "@/lib/styles";
+
+const dtFmt = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function sum(series: DailyCount[]): number {
+  return series.reduce((acc, row) => acc + (row.count ?? 0), 0);
+}
+
+function average(series: DailyCount[]): number {
+  if (series.length === 0) return 0;
+  return sum(series) / series.length;
+}
+
+function formatAvg(value: number): string {
+  // The aggregates are integer counts, so an average like 12.4 is honest;
+  // anything > 10 rounds to the whole number for legibility.
+  if (!Number.isFinite(value)) return "0";
+  if (value >= 10) return value.toFixed(0);
+  return value.toFixed(1);
+}
+
+function formatLastActivity(value: string | null): string {
+  if (!value) return "never";
+  try {
+    return dtFmt.format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+type MetricRowProps = {
+  label: string;
+  total: number;
+  avg: number;
+  series: DailyCount[];
+};
+
+function MetricRow({ label, total, avg, series }: MetricRowProps) {
+  // Mini sparkline-strip: render a row of fixed-width dots, each cell's
+  // height scaled to its proportion of the day-max. No chart library;
+  // pure CSS so it stays token-clean.
+  const dayMax = series.reduce((acc, row) => Math.max(acc, row.count ?? 0), 0);
+  return (
+    <div className="border-b border-border-subtle px-6 py-4 last:border-b-0">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wider text-text-muted">
+            {label}
+          </div>
+          <div className="mt-1 flex items-baseline gap-3">
+            <span className="font-display text-2xl text-text-primary tabular-nums">
+              {total.toLocaleString()}
+            </span>
+            <span className="text-xs text-text-muted">
+              total in window
+            </span>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-xs uppercase tracking-wider text-text-muted">
+            avg/day
+          </div>
+          <div className="font-display text-lg text-text-secondary tabular-nums">
+            {formatAvg(avg)}
+          </div>
+        </div>
+      </div>
+      <div
+        className="mt-3 flex items-end gap-[2px] h-8"
+        aria-hidden="true"
+      >
+        {series.map((row) => {
+          const ratio = dayMax > 0 ? (row.count ?? 0) / dayMax : 0;
+          const heightPct = Math.max(4, ratio * 100);
+          return (
+            <div
+              key={row.date}
+              title={`${row.date}: ${row.count}`}
+              className="flex-1 min-w-[2px] rounded-sm bg-accent/30"
+              style={{ height: `${heightPct}%` }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default function AdminAnalyticsPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<AnalyticsResponse | null>(null);
+  const [error, setError] = useState("");
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!hasPlatformPermission(user, "analytics.view")) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "analytics.view")) {
+      return;
+    }
+    setFetching(true);
+    apiFetch<AnalyticsResponse>("/api/v1/admin/analytics?days=30")
+      .then((d) => setData(d))
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
+      .finally(() => setFetching(false));
+  }, [loading, user]);
+
+  if (loading || !user || !hasPlatformPermission(user, "analytics.view")) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <h1 className={pageTitle}>System usage analytics</h1>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className="mb-2 text-xs text-text-muted">
+        {data
+          ? `Last ${data.window_days} days, as of ${formatLastActivity(data.generated_at)}`
+          : fetching
+            ? "Loading…"
+            : ""}
+      </div>
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Activity (last 30 days)</h2>
+        </div>
+        {fetching && !data && (
+          <div className="px-6 py-6 text-center text-text-muted">
+            Loading…
+          </div>
+        )}
+        {data && (
+          <>
+            <MetricRow
+              label="Successful logins"
+              total={sum(data.logins_by_day)}
+              avg={average(data.logins_by_day)}
+              series={data.logins_by_day}
+            />
+            <MetricRow
+              label="Transactions created"
+              total={sum(data.tx_writes_by_day)}
+              avg={average(data.tx_writes_by_day)}
+              series={data.tx_writes_by_day}
+            />
+            <MetricRow
+              label="Rows imported"
+              total={sum(data.imports_by_day)}
+              avg={average(data.imports_by_day)}
+              series={data.imports_by_day}
+            />
+          </>
+        )}
+      </div>
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Top organizations</h2>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3 w-16">Rank</th>
+                <th className="px-6 py-3">Organization</th>
+                <th className="px-6 py-3 text-right">Transactions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && !data && (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {data && data.top_orgs_by_tx_volume.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    No transaction activity in the window.
+                  </td>
+                </tr>
+              )}
+              {data?.top_orgs_by_tx_volume.map((row) => (
+                <tr
+                  key={row.org_id}
+                  className="border-b border-border-subtle last:border-b-0"
+                >
+                  <td className="px-6 py-3 font-mono text-text-muted tabular-nums">
+                    {row.rank}
+                  </td>
+                  <td className="px-6 py-3 text-text-primary">
+                    {row.org_name}
+                    <span className="ml-1 text-text-muted">
+                      (#{row.org_id})
+                    </span>
+                  </td>
+                  <td className="px-6 py-3 text-right font-mono text-text-secondary tabular-nums">
+                    {row.tx_count.toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Dormant organizations</h2>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3">Organization</th>
+                <th className="px-6 py-3">Last activity</th>
+                <th className="px-6 py-3 text-right">Days since</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && !data && (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {data && data.dormant_orgs.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    All organizations are active.
+                  </td>
+                </tr>
+              )}
+              {data?.dormant_orgs.map((row) => (
+                <tr
+                  key={row.org_id}
+                  className="border-b border-border-subtle last:border-b-0"
+                >
+                  <td className="px-6 py-3 text-text-primary">
+                    {row.org_name}
+                    <span className="ml-1 text-text-muted">
+                      (#{row.org_id})
+                    </span>
+                  </td>
+                  <td className="px-6 py-3 text-text-secondary tabular-nums">
+                    {formatLastActivity(row.last_tx_at)}
+                  </td>
+                  <td className="px-6 py-3 text-right font-mono text-text-secondary tabular-nums">
+                    {row.days_since_last_activity ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -110,6 +110,12 @@ const systemItems: readonly SystemNavItem[] = [
     icon: <FileText {...NAV_ICON_PROPS} />,
   },
   {
+    href: "/admin/analytics",
+    label: "Analytics",
+    permission: "analytics.view",
+    icon: <BarChart3 {...NAV_ICON_PROPS} />,
+  },
+  {
     href: "/system/plans",
     label: "Plans",
     permission: "plans.manage",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -441,3 +441,34 @@ export interface PermissionCatalogResponse {
   namespaces: Record<string, string[]>;
   keys: string[];
 }
+
+// L4.6 — System usage analytics (counts-only first slice).
+
+export interface DailyCount {
+  date: string; // ISO date (YYYY-MM-DD).
+  count: number;
+}
+
+export interface OrgTxVolume {
+  rank: number;
+  org_id: number;
+  org_name: string;
+  tx_count: number;
+}
+
+export interface DormantOrg {
+  org_id: number;
+  org_name: string;
+  last_tx_at: string | null;
+  days_since_last_activity: number | null;
+}
+
+export interface AnalyticsResponse {
+  window_days: number;
+  generated_at: string;
+  logins_by_day: DailyCount[];
+  tx_writes_by_day: DailyCount[];
+  imports_by_day: DailyCount[];
+  top_orgs_by_tx_volume: OrgTxVolume[];
+  dormant_orgs: DormantOrg[];
+}

--- a/frontend/tests/app/admin-analytics-page.test.tsx
+++ b/frontend/tests/app/admin-analytics-page.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AdminAnalyticsPage from "@/app/admin/analytics/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/analytics",
+}));
+
+const SUPERADMIN = {
+  id: 1,
+  username: "root",
+  email: "root@platform.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Platform",
+  billing_cycle_day: 1,
+  is_superadmin: true,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const POPULATED_RESPONSE = {
+  window_days: 30,
+  generated_at: "2026-05-11T14:00:00Z",
+  logins_by_day: [
+    { date: "2026-05-10", count: 3 },
+    { date: "2026-05-11", count: 5 },
+  ],
+  tx_writes_by_day: [
+    { date: "2026-05-10", count: 12 },
+    { date: "2026-05-11", count: 14 },
+  ],
+  imports_by_day: [
+    { date: "2026-05-10", count: 1 },
+    { date: "2026-05-11", count: 0 },
+  ],
+  top_orgs_by_tx_volume: [
+    { rank: 1, org_id: 42, org_name: "Acme", tx_count: 26 },
+  ],
+  dormant_orgs: [
+    {
+      org_id: 99,
+      org_name: "Silent Co",
+      last_tx_at: null,
+      days_since_last_activity: null,
+    },
+  ],
+};
+
+const EMPTY_RESPONSE = {
+  window_days: 30,
+  generated_at: "2026-05-11T14:00:00Z",
+  logins_by_day: [{ date: "2026-05-11", count: 0 }],
+  tx_writes_by_day: [{ date: "2026-05-11", count: 0 }],
+  imports_by_day: [{ date: "2026-05-11", count: 0 }],
+  top_orgs_by_tx_volume: [],
+  dormant_orgs: [],
+};
+
+describe("AdminAnalyticsPage", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders the analytics envelope for a superadmin", async () => {
+    apiFetchMock.mockResolvedValueOnce(POPULATED_RESPONSE as never);
+
+    render(<AdminAnalyticsPage />);
+
+    await screen.findByText(/Successful logins/i);
+    expect(screen.getByText(/Transactions created/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rows imported/i)).toBeInTheDocument();
+    expect(screen.getByText(/Acme/)).toBeInTheDocument();
+    expect(screen.getByText(/Silent Co/)).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("renders empty-state copy when no activity is present", async () => {
+    apiFetchMock.mockResolvedValueOnce(EMPTY_RESPONSE as never);
+
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No transaction activity in the window\./i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/All organizations are active\./i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("redirects non-superadmin users without analytics.view away from the page", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("renders for a non-superadmin who carries analytics.view in permissions", async () => {
+    apiFetchMock.mockResolvedValueOnce(POPULATED_RESPONSE as never);
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["analytics.view"],
+      } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminAnalyticsPage />);
+
+    await screen.findByText(/Successful logins/i);
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+});


### PR DESCRIPTION
## Summary

Counts-only first slice of the L4.6 system usage analytics surface. Aggregates over existing tables only (`audit_events`, `transactions`, `organizations`); no third-party SDK, no per-user event stream, no charts.

## Backend changes

- New service `app/services/admin_analytics_service.py` with five aggregates:
  - `login_counts_by_day` reads `audit_events` filtered by `event_type='user.login.success'`.
  - `tx_writes_by_day` / `imports_by_day` group `transactions` by `DATE(created_at)` (write time, not `date`).
  - `top_orgs_by_tx_volume` joins orgs ↔ transactions and ranks.
  - `dormant_orgs` returns orgs with no activity inside the threshold window, never-active orgs first.
- New router `GET /api/v1/admin/analytics` returning a single envelope; gated by `analytics.view`.
- New Pydantic schemas at `app/schemas/admin_analytics.py`.
- Login endpoints (`/login`, `/mfa/verify`, `/mfa/recovery`, `/mfa/email-verify`, `/google/callback`) now emit `user.login.success` audit events via a shared `_record_login_success` helper. PII never travels; only actor identity, request id, IP, and a `method` discriminator (`password`, `mfa_totp`, `mfa_recovery`, `mfa_email`, `google_sso`).

## Frontend changes

- New page `/admin/analytics` with three pulse-strip rows (logins/day, tx writes/day, imports/day) + Top organizations table + Dormant organizations table. No charts.
- AppShell sidebar gains an `Analytics` entry visible to anyone with `analytics.view`.
- All styling uses token primitives from `lib/styles.ts` and existing theme tokens (no raw palette utilities, no hex literals).

## Permission added

- `analytics.view`
- Registered in `app/auth/permissions.py` (`Permission` literal + `ALL_PERMISSIONS`).
- Seeded into the superadmin role row via migration `039_seed_analytics_view_permission` (idempotent: skips if the row already exists).
- Frontend gate via `hasPlatformPermission(user, 'analytics.view')` (superadmin short-circuits client-side; backend gate is authoritative).

## Quality gates

- Backend: 45 new + touched tests pass (9 service + 4 router + 32 auth). Broader suite (`pytest tests/`) green: 796 + 13 = 809 passed, 2 skipped.
- Frontend: 501 tests pass (4 new); `npm run lint -- --quiet` clean; `tsc --noEmit` clean; `npm run build` succeeds; `frontend/scripts/check-design-tokens.sh` passes.
- Tests run under isolated compose project `team-l4-6-analytics`; volume torn down with `down -v`. Main checkout left clean.

## Out of scope

- Charts (Phase 2 will layer a charts client on top of the same envelope).
- Real-time polling / WebSocket push.
- Third-party analytics SDK (Segment / PostHog / Mixpanel) — policy constraint.
- Persistent `import_sessions` table; `imports_by_day` counts imported rows per day, not sessions.

## Risk notes

- **Cross-org isolation in queries.** The analytics surface is platform-global by design (`analytics.view` is a platform permission, no tenant context). `top_orgs_by_tx_volume` and `dormant_orgs` are cross-org reads gated only by the permission check. Verified via `test_top_orgs_by_tx_volume_isolates_per_org` (rows from Org A do not inflate Org B's count) and `test_dormant_orgs_lists_silent_and_never_active` (sorting + state separation).
- **MySQL/SQLite date portability.** `func.date()` returns a `date` on MySQL but an ISO string on SQLite; the service has a `_coerce_to_date` helper that normalizes both before zero-filling. Covered by service tests, which run on in-memory SQLite.
- **Login audit-event volume.** Every successful sign-in now writes to `audit_events`. At dev scale this is sub-millisecond; at production scale watch the index on `(event_type, created_at)` if the table grows past ~10M rows.