### PR TITLE
fix(dashboard): link accounts and transactions to filtered ledger

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -79,6 +79,17 @@ interface ForecastProjection {
 
 const PAGE_SIZE = 10;
 
+function transactionHighlightHref(tx: Transaction) {
+  const params = new URLSearchParams({
+    account_id: String(tx.account_id),
+    transaction_id: String(tx.id),
+    date_from: tx.date,
+    date_to: tx.date,
+  });
+
+  return `/transactions?${params.toString()}`;
+}
+
 export default function DashboardPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
@@ -1059,7 +1070,10 @@ export default function DashboardPage() {
                 const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
                 return (
                   <div key={tx.id} className="flex items-center justify-between px-5 py-2.5">
-                    <div className="flex items-center gap-3 min-w-0">
+                    <Link
+                      href={transactionHighlightHref(tx)}
+                      className="-mx-2 -my-1.5 flex min-w-0 items-center gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+                    >
                       <span className="text-xs tabular-nums text-text-muted w-16 shrink-0">{tx.date.slice(5)}</span>
                       <div className="min-w-0">
                         <p className="text-sm text-text-primary truncate">{tx.description}</p>
@@ -1067,7 +1081,7 @@ export default function DashboardPage() {
                           {isTransfer && linkedTx ? <>{tx.account_name} &rarr; {linkedTx.account_name}</> : <>{tx.account_name} · {tx.category_name}</>}
                         </p>
                       </div>
-                    </div>
+                    </Link>
                     <div className="flex items-center gap-2 shrink-0">
                       <span className={`text-sm font-medium tabular-nums ${isTransfer ? "text-info" : tx.type === "income" ? "text-success" : "text-danger"}`}>
                         {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}

--- a/frontend/components/dashboard/AccountTile.tsx
+++ b/frontend/components/dashboard/AccountTile.tsx
@@ -13,7 +13,7 @@ export interface AccountTilesCardProps {
 // Compact identity/status/navigation column for the dashboard. ONE
 // shared card with internal divider rows, mirroring the Forecast card
 // idiom on the right side of the row. Each row is a click-through to
-// /accounts. The Forecast card is the numeric authority; the muted
+// /transactions filtered by account. The Forecast card is the numeric authority; the muted
 // balance hint here is secondary text only, NOT the primary visual
 // anchor of the row.
 export default function AccountTilesCard({
@@ -52,7 +52,7 @@ export function AccountTileRow({ account, pendingAmount }: AccountTileRowProps) 
 
   return (
     <Link
-      href="/accounts"
+      href={`/transactions?account_id=${account.id}`}
       data-testid="account-tile"
       data-account-id={account.id}
       className="flex items-center justify-between gap-3 px-3 py-2.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -168,4 +168,34 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
     // refetch.
     await waitFor(() => expect(pendingCalls).toBeGreaterThan(pendingCallsBeforeToggle));
   });
+
+  it("links recent transaction identity to the filtered transaction highlight target", async () => {
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([]);
+      if (url === "/api/v1/categories") return Promise.resolve([]);
+      if (url === "/api/v1/budgets" || url.startsWith("/api/v1/budgets?"))
+        return Promise.resolve([]);
+      if (url === "/api/v1/settings/billing-cycle")
+        return Promise.resolve({ billing_cycle_day: 1 });
+      if (url === "/api/v1/settings/billing-period")
+        return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      if (url === "/api/v1/settings/billing-periods")
+        return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+      if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
+      if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve([SETTLED_TX]);
+      if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
+        return Promise.resolve([SETTLED_TX]);
+      return Promise.resolve({});
+    }) as never);
+
+    render(<DashboardPage />);
+
+    const link = await screen.findByRole("link", { name: /Coffee Amex Primary/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/transactions?account_id=10&transaction_id=999&date_from=2026-05-01&date_to=2026-05-01",
+    );
+  });
 });

--- a/frontend/tests/components/dashboard/account-tile.test.tsx
+++ b/frontend/tests/components/dashboard/account-tile.test.tsx
@@ -99,11 +99,11 @@ describe("AccountTileRow — identity/status/navigation surface", () => {
     expect(screen.getByText(/Pending: 200\.00/)).toBeInTheDocument();
   });
 
-  it("renders as a link to /accounts (click-through navigation)", () => {
+  it("renders as a link to transactions filtered by account", () => {
     render(<AccountTileRow account={PRIMARY_CHECKING} pendingAmount={0} />);
     const link = screen.getByTestId("account-tile");
     expect(link.tagName).toBe("A");
-    expect(link).toHaveAttribute("href", "/accounts");
+    expect(link).toHaveAttribute("href", "/transactions?account_id=1");
   });
 
   it("balance text is muted (forecast card is the numeric authority, tile is secondary)", () => {


### PR DESCRIPTION
## Summary
- Point dashboard account tiles at `/transactions?account_id=<accountId>`
- Link recent transaction identity text to the Team A transaction highlight URL
- Keep the dashboard status toggle as a separate button outside the link

## Dependency
Depends on the transactions URL-param PR from Team A. This PR should not be treated as standalone mergeable until `/transactions` supports `account_id`, `transaction_id`, `date_from`, and `date_to` from query params on main, unless it is restacked onto Team A's branch.

## Tests
- `npm test -- tests/components/dashboard/account-tile.test.tsx tests/app/dashboard-pending-toggle-refresh.test.tsx`
- `npm run lint` (0 errors, existing warnings)
- `npx tsc --noEmit`
