### PR TITLE
fix(transactions): clean date presets and support dashboard deep links

### DIFF
--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { FormEvent, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
@@ -28,6 +28,7 @@ import { usePersistedSort } from "@/lib/hooks/use-persisted-sort";
 
 
 const PAGE_SIZE = 20;
+const DATE_PARAM_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 // Column-aware sort defaults. When the user clicks a different column, that
 // column's natural default direction is applied (Option B in the data-table
@@ -65,6 +66,10 @@ export default function TransactionsPage() {
 function TransactionsPageContent() {
   const { user, loading } = useAuth();
   const searchParams = useSearchParams();
+  const urlFiltersSyncedRef = useRef(false);
+  const categoryUrlSyncedRef = useRef(false);
+  const targetDesktopRowRef = useRef<HTMLDivElement | null>(null);
+  const targetMobileRowRef = useRef<HTMLElement | null>(null);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -174,6 +179,7 @@ function TransactionsPageContent() {
 
   // Billing periods for filter
   const [periods, setPeriods] = useState<{ id: number; start_date: string; end_date: string | null }[]>([]);
+  const [periodsLoaded, setPeriodsLoaded] = useState(false);
 
   // Form
   const [formMode, setFormMode] = useState<"transaction" | "transfer">("transaction");
@@ -217,6 +223,7 @@ function TransactionsPageContent() {
     setAccounts(accts ?? []);
     setCategories(cats ?? []);
     setPeriods(pers ?? []);
+    setPeriodsLoaded(true);
   }, []);
 
   const loadTransactions = useCallback(async (p: number) => {
@@ -249,16 +256,61 @@ function TransactionsPageContent() {
     if (!loading && user) loadRefs().catch(() => {});
   }, [loading, user, loadRefs]);
 
+  // Apply supported URL params once so dashboard deep links don't fight
+  // user-edited filters after initial hydration.
+  useEffect(() => {
+    if (urlFiltersSyncedRef.current) return;
+    urlFiltersSyncedRef.current = true;
+
+    const patch: Partial<TxFilters> = {};
+    const accountId = Number(searchParams.get("account_id"));
+    if (Number.isInteger(accountId) && accountId > 0) {
+      patch.filterAccount = accountId;
+    }
+
+    const dateFrom = searchParams.get("date_from");
+    const dateTo = searchParams.get("date_to");
+    if (dateFrom && DATE_PARAM_RE.test(dateFrom)) {
+      patch.filterDateFrom = dateFrom;
+      patch.filterPeriod = "";
+    }
+    if (dateTo && DATE_PARAM_RE.test(dateTo)) {
+      patch.filterDateTo = dateTo;
+      patch.filterPeriod = "";
+    }
+
+    if (Object.keys(patch).length > 0) {
+      persistedFilters.set(patch);
+    }
+  }, [persistedFilters, searchParams]);
+
   // Apply ?category= URL param once categories are loaded
   useEffect(() => {
+    if (categoryUrlSyncedRef.current) return;
     const categoryName = searchParams.get("category");
     if (categoryName && categories.length > 0) {
       const match = categories.find(
         (c) => c.name.toLowerCase() === categoryName.toLowerCase()
       );
-      if (match) setFilterCategory(match.id);
+      if (match) {
+        categoryUrlSyncedRef.current = true;
+        setFilterCategory(match.id);
+      }
     }
   }, [categories, searchParams]);
+
+  const closedPeriods = useMemo(
+    () => periods.filter((p) => p.end_date !== null),
+    [periods],
+  );
+
+  useEffect(() => {
+    if (!periodsLoaded || !filterPeriod) return;
+    const selectedClosedPeriod = closedPeriods.some(
+      (p) => String(p.id) === filterPeriod,
+    );
+    if (!selectedClosedPeriod) setFilterPeriod("");
+  }, [closedPeriods, filterPeriod, periodsLoaded]);
 
   useEffect(() => {
     if (!loading && user) {
@@ -719,6 +771,29 @@ function TransactionsPageContent() {
     () => sortedTransactions.filter((t) => !selectionHiddenIds.has(t.id)),
     [sortedTransactions, selectionHiddenIds],
   );
+  const targetTransactionId = useMemo(() => {
+    const raw = searchParams.get("transaction_id");
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (
+      targetTransactionId === null ||
+      !visibleTxs.some((tx) => tx.id === targetTransactionId)
+    ) {
+      return;
+    }
+    const prefersDesktop =
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function" ||
+      window.matchMedia("(min-width: 768px)").matches;
+    const row = prefersDesktop
+      ? targetDesktopRowRef.current ?? targetMobileRowRef.current
+      : targetMobileRowRef.current ?? targetDesktopRowRef.current;
+    row?.scrollIntoView({ block: "center", behavior: "auto" });
+  }, [targetTransactionId, visibleTxs]);
 
   // Tx lookup map for O(1) linked-row resolution. Recomputed only when the
   // transactions array itself changes.
@@ -1035,7 +1110,7 @@ function TransactionsPageContent() {
                   const now = new Date();
                   setRange(
                     formatLocalDate(new Date(now.getFullYear(), now.getMonth(), 1)),
-                    todayISO(),
+                    formatLocalDate(new Date(now.getFullYear(), now.getMonth() + 1, 0)),
                   );
                 },
               },
@@ -1044,20 +1119,6 @@ function TransactionsPageContent() {
                 fn: () => setRange("", ""),
               },
             ];
-            // Optional "Current Period" preset, only when an open billing
-            // period exists. It sets the period filter (which the URL builder
-            // already prefers) and clears any explicit date range.
-            const currentPeriod = periods.find((p) => p.end_date === null);
-            if (currentPeriod) {
-              presets.push({
-                label: "Current Period",
-                fn: () => {
-                  setFilterDateFrom("");
-                  setFilterDateTo("");
-                  setFilterPeriod(String(currentPeriod.id));
-                },
-              });
-            }
             return presets.map((p) => (
               <button key={p.label} type="button" onClick={p.fn} className="rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary hover:bg-surface-raised min-h-[44px] sm:min-h-0">
                 {p.label}
@@ -1115,14 +1176,14 @@ function TransactionsPageContent() {
           <label htmlFor="f-to" className="sr-only">To date</label>
           <input id="f-to" type="date" value={filterDateTo} onChange={(e) => { setFilterPeriod(""); setFilterDateTo(e.target.value); }} className={`w-full sm:w-32 ${input}`} placeholder="To" />
         </div>
-        {periods.length > 0 && (
+        {closedPeriods.length > 0 && (
           <div className="w-full sm:w-auto">
             <label htmlFor="f-period" className="sr-only">Billing period</label>
             <select id="f-period" value={filterPeriod} onChange={(e) => { setFilterPeriod(e.target.value); if (e.target.value) { setFilterDateFrom(""); setFilterDateTo(""); } }} className={`w-full sm:w-40 ${input}`}>
               <option value="">All periods</option>
-              {periods.map((p) => (
+              {closedPeriods.map((p) => (
                 <option key={p.id} value={String(p.id)}>
-                  {p.start_date}{p.end_date ? ` — ${p.end_date}` : " (current)"}
+                  {p.start_date} — {p.end_date}
                 </option>
               ))}
             </select>
@@ -1175,6 +1236,7 @@ function TransactionsPageContent() {
                     {visibleTxs.map((tx) => {
                       const isTransfer = tx.linked_transaction_id !== null;
                       const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
+                      const isTarget = targetTransactionId === tx.id;
                       return editingId === tx.id ? (
                         // Desktop edit mode: switched from a single 12-col row
                         // (Item 7 audit: Status/Amount cols ~42px clipped both
@@ -1353,11 +1415,14 @@ function TransactionsPageContent() {
                       ) : (
                         <div
                           key={tx.id}
+                          ref={isTarget ? targetDesktopRowRef : null}
+                          id={`transaction-${tx.id}`}
+                          data-testid={`tx-row-desktop-${tx.id}`}
                           className={`grid grid-cols-12 items-center gap-4 px-6 py-3 transition-colors hover:bg-surface-raised ${
                             tx.status === "pending"
                               ? "[&>*:not(.tx-status-cell)]:opacity-60"
                               : ""
-                          }`}
+                          } ${isTarget ? "bg-accent-dim ring-2 ring-accent ring-inset" : ""}`}
                         >
                           {/* Pending rows dim every cell except the status pill
                               via the [&>*:not(.tx-status-cell)] selector above.
@@ -1455,6 +1520,7 @@ function TransactionsPageContent() {
                     {visibleTxs.map((tx) => {
                       const isTransfer = tx.linked_transaction_id !== null;
                       const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
+                      const isTarget = targetTransactionId === tx.id;
                       if (editingId === tx.id) {
                         return (
                           <article key={tx.id} className="flex flex-col gap-3 rounded-lg border border-border bg-surface-raised p-4">
@@ -1608,7 +1674,12 @@ function TransactionsPageContent() {
                       return (
                         <article
                           key={tx.id}
-                          className="flex flex-col gap-2 rounded-lg border border-border bg-surface p-4"
+                          ref={isTarget ? targetMobileRowRef : null}
+                          id={`transaction-mobile-${tx.id}`}
+                          data-testid={`tx-row-mobile-${tx.id}`}
+                          className={`flex flex-col gap-2 rounded-lg border border-border bg-surface p-4 ${
+                            isTarget ? "bg-accent-dim ring-2 ring-accent" : ""
+                          }`}
                         >
                           {/* Pending rows dim the row contents but keep the
                               status pill at full opacity. CSS opacity composites

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -236,9 +236,9 @@ function TransactionsPageContent() {
     // Period filter overrides date_from/date_to
     if (filterPeriod) {
       const per = periods.find((p) => String(p.id) === filterPeriod);
-      if (per) {
+      if (per && per.end_date !== null) {
         url += `&date_from=${per.start_date}`;
-        if (per.end_date) url += `&date_to=${per.end_date}`;
+        url += `&date_to=${per.end_date}`;
       }
     } else {
       if (filterDateFrom) url += `&date_from=${filterDateFrom}`;

--- a/frontend/tests/app/transactions-deep-links.test.tsx
+++ b/frontend/tests/app/transactions-deep-links.test.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TransactionsPage from "@/app/transactions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+const searchParamsState = vi.hoisted(() => ({
+  value: new URLSearchParams(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/transactions",
+  useSearchParams: () => ({
+    get: (key: string) => searchParamsState.value.get(key),
+  }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1, username: "user", email: "user@example.com",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner" as const, org_id: 1, org_name: "Org",
+  billing_cycle_day: 1, is_superadmin: false, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const ACCT_A = {
+  id: 100, name: "Checking A", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: true,
+};
+
+const ACCT_B = {
+  id: 200, name: "Checking B", account_type_id: 1,
+  account_type_name: "Checking", account_type_slug: "checking",
+  balance: 0, currency: "EUR", is_active: true,
+  close_day: null, is_default: false,
+};
+
+const CATEGORY = {
+  id: 11, name: "Groceries", type: "expense" as const,
+  parent_id: null, parent_name: null, description: null,
+  slug: "groceries", is_system: false, transaction_count: 0,
+};
+
+function makeTx(over: Partial<{
+  id: number;
+  account_id: number;
+  account_name: string;
+  description: string;
+  amount: number;
+  date: string;
+}> = {}) {
+  return {
+    id: 1,
+    account_id: ACCT_A.id,
+    account_name: ACCT_A.name,
+    category_id: CATEGORY.id,
+    category_name: CATEGORY.name,
+    description: "Tx",
+    amount: 100,
+    type: "expense" as const,
+    status: "settled" as const,
+    linked_transaction_id: null,
+    recurring_id: null,
+    date: "2026-05-01",
+    settled_date: null,
+    is_imported: false,
+    ...over,
+  };
+}
+
+function setupApiFetch(txs: ReturnType<typeof makeTx>[]) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockReset();
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/v1/accounts")) return [ACCT_A, ACCT_B] as never;
+    if (url.startsWith("/api/v1/categories")) return [CATEGORY] as never;
+    if (url.startsWith("/api/v1/settings/billing-periods")) {
+      return [{ id: 9, start_date: "2026-05-01", end_date: null }] as never;
+    }
+    if (url.startsWith("/api/v1/transactions")) return txs as never;
+    return null as never;
+  });
+  return apiFetchMock;
+}
+
+function listUrls(mock: ReturnType<typeof vi.mocked<typeof apiFetch>>): string[] {
+  return mock.mock.calls
+    .map((call) => call[0])
+    .filter(
+      (url): url is string =>
+        typeof url === "string" && url.startsWith("/api/v1/transactions?"),
+    );
+}
+
+function listUrlsAfter(
+  mock: ReturnType<typeof vi.mocked<typeof apiFetch>>,
+  startIndex: number,
+): string[] {
+  return mock.mock.calls
+    .slice(startIndex)
+    .map((call) => call[0])
+    .filter(
+      (url): url is string =>
+        typeof url === "string" && url.startsWith("/api/v1/transactions?"),
+    );
+}
+
+describe("TransactionsPage — dashboard deep links", () => {
+  const useAuthMock = vi.mocked(useAuth);
+  let scrollIntoView: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    searchParamsState.value = new URLSearchParams();
+    window.localStorage.clear();
+    scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("applies account_id and explicit date URL filters once", async () => {
+    searchParamsState.value = new URLSearchParams(
+      "account_id=200&date_from=2026-05-01&date_to=2026-05-31",
+    );
+    const mock = setupApiFetch([]);
+
+    render(<TransactionsPage />);
+
+    await waitFor(() => {
+      const urls = listUrls(mock);
+      expect(urls.length).toBeGreaterThan(0);
+      const last = urls[urls.length - 1];
+      expect(last).toContain("account_id=200");
+      expect(last).toContain("date_from=2026-05-01");
+      expect(last).toContain("date_to=2026-05-31");
+    });
+
+    expect(screen.getByLabelText("Filter by account")).toHaveValue("200");
+    expect(screen.getByLabelText("From date")).toHaveValue("2026-05-01");
+    expect(screen.getByLabelText("To date")).toHaveValue("2026-05-31");
+
+    const startCount = mock.mock.calls.length;
+    fireEvent.change(screen.getByLabelText("Filter by account"), {
+      target: { value: "100" },
+    });
+
+    await waitFor(() => {
+      const after = listUrlsAfter(mock, startCount);
+      expect(after.at(-1)).toContain("account_id=100");
+    });
+  });
+
+  it("highlights and scrolls a visible transaction_id target row", async () => {
+    searchParamsState.value = new URLSearchParams("transaction_id=42");
+    setupApiFetch([
+      makeTx({ id: 41, description: "Other tx" }),
+      makeTx({ id: 42, description: "Target tx" }),
+    ]);
+
+    render(<TransactionsPage />);
+
+    const desktopRow = await screen.findByTestId("tx-row-desktop-42");
+    const mobileRow = await screen.findByTestId("tx-row-mobile-42");
+
+    expect(desktopRow.className).toContain("ring-accent");
+    expect(mobileRow.className).toContain("ring-accent");
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", behavior: "auto" });
+    });
+  });
+});

--- a/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
+++ b/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import TransactionsPage from "@/app/transactions/page";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
+import { FILTERS_KEY_TRANSACTIONS } from "@/lib/hooks/persisted-keys";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -121,7 +122,7 @@ describe("TransactionsPage — quick filter buttons", () => {
 
   it("Today button sends date_from=date_to=today and clears any prior period filter", async () => {
     const periods: Period[] = [
-      { id: 7, start_date: "2026-05-01", end_date: null }, // current/open
+      { id: 7, start_date: "2026-04-01", end_date: "2026-04-30" },
     ];
     const mock = setupApiFetch(periods);
 
@@ -132,14 +133,14 @@ describe("TransactionsPage — quick filter buttons", () => {
       expect(lastListUrl(mock)).not.toBeNull();
     });
 
-    // Pre-select "Current Period" via the dropdown to seed the state, then
+    // Pre-select a closed period via the dropdown to seed the state, then
     // confirm clicking Today swaps it to a date_from/date_to pair.
     const periodSelect = await screen.findByLabelText("Billing period");
     fireEvent.change(periodSelect, { target: { value: "7" } });
 
     await waitFor(() => {
       const url = lastListUrl(mock);
-      expect(url).toContain("date_from=2026-05-01");
+      expect(url).toContain("date_from=2026-04-01");
     });
 
     const todayBtn = screen.getByRole("button", { name: "Today" });
@@ -156,7 +157,7 @@ describe("TransactionsPage — quick filter buttons", () => {
     });
   });
 
-  it("This Month button sends date_from=first-of-month and date_to=today", async () => {
+  it("This Month button sends date_from=first-of-month and date_to=last-of-month", async () => {
     const mock = setupApiFetch();
 
     render(<TransactionsPage />);
@@ -168,13 +169,13 @@ describe("TransactionsPage — quick filter buttons", () => {
 
     const now = new Date();
     const firstOfMonth = isoLocal(new Date(now.getFullYear(), now.getMonth(), 1));
-    const today = todayLocal();
+    const lastOfMonth = isoLocal(new Date(now.getFullYear(), now.getMonth() + 1, 0));
     await waitFor(() => {
       const after = listUrlsAfter(mock, startIdx);
       expect(after.length).toBeGreaterThan(0);
       const last = after[after.length - 1];
       expect(last).toContain(`date_from=${firstOfMonth}`);
-      expect(last).toContain(`date_to=${today}`);
+      expect(last).toContain(`date_to=${lastOfMonth}`);
     });
   });
 
@@ -207,19 +208,19 @@ describe("TransactionsPage — quick filter buttons", () => {
 
   it("All button drops every date constraint, including a previously-selected period", async () => {
     const periods: Period[] = [
-      { id: 7, start_date: "2026-05-01", end_date: null },
+      { id: 7, start_date: "2026-04-01", end_date: "2026-04-30" },
     ];
     const mock = setupApiFetch(periods);
 
     render(<TransactionsPage />);
     await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
 
-    // Seed: pick the open period from the dropdown.
+    // Seed: pick a closed period from the dropdown.
     const periodSelect = await screen.findByLabelText("Billing period");
     fireEvent.change(periodSelect, { target: { value: "7" } });
     await waitFor(() => {
       const url = lastListUrl(mock);
-      expect(url).toContain("date_from=2026-05-01");
+      expect(url).toContain("date_from=2026-04-01");
     });
 
     const startIdx = mock.mock.calls.length;
@@ -234,7 +235,37 @@ describe("TransactionsPage — quick filter buttons", () => {
     });
   });
 
-  it("Current Period button is shown when an open period exists and pins the period filter", async () => {
+  it("does not expose open/current periods as quick filter or dropdown options", async () => {
+    const periods: Period[] = [
+      { id: 5, start_date: "2026-04-01", end_date: "2026-04-30" },
+      { id: 6, start_date: "2026-05-01", end_date: null },
+    ];
+    setupApiFetch(periods);
+
+    render(<TransactionsPage />);
+
+    expect(screen.queryByRole("button", { name: /current period/i })).toBeNull();
+
+    const periodSelect = await screen.findByLabelText("Billing period");
+    expect(periodSelect).toHaveTextContent("2026-04-01");
+    expect(periodSelect).not.toHaveTextContent("2026-05-01");
+    expect(periodSelect).not.toHaveTextContent("current");
+  });
+
+  it("clears a persisted open period after billing periods load", async () => {
+    window.localStorage.setItem(
+      FILTERS_KEY_TRANSACTIONS,
+      JSON.stringify({
+        filterAccount: "",
+        filterCategory: "",
+        filterType: "",
+        filterStatus: "",
+        filterDateFrom: "",
+        filterDateTo: "",
+        filterSearch: "",
+        filterPeriod: "6",
+      }),
+    );
     const periods: Period[] = [
       { id: 5, start_date: "2026-04-01", end_date: "2026-04-30" },
       { id: 6, start_date: "2026-05-01", end_date: null },
@@ -242,50 +273,29 @@ describe("TransactionsPage — quick filter buttons", () => {
     const mock = setupApiFetch(periods);
 
     render(<TransactionsPage />);
-    await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
 
-    const currentBtn = await screen.findByRole("button", { name: /current period/i });
-    const startIdx = mock.mock.calls.length;
-    fireEvent.click(currentBtn);
-
+    await screen.findByLabelText("Billing period");
     await waitFor(() => {
-      const after = listUrlsAfter(mock, startIdx);
-      expect(after.length).toBeGreaterThan(0);
-      const last = after[after.length - 1];
-      // Open period: only date_from is sent; date_to is omitted because
-      // end_date is null on the current/open billing period.
-      expect(last).toContain("date_from=2026-05-01");
-      expect(last).not.toContain("date_to=");
+      const stored = window.localStorage.getItem(FILTERS_KEY_TRANSACTIONS);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!).filterPeriod).toBe("");
+      expect(lastListUrl(mock)).not.toContain("date_from=2026-05-01");
     });
   });
 
-  it("Current Period button is NOT rendered when no open billing period exists", async () => {
-    // All periods closed (every end_date is set) — no open period to pin.
-    const periods: Period[] = [
-      { id: 5, start_date: "2026-04-01", end_date: "2026-04-30" },
-    ];
-    setupApiFetch(periods);
-
-    render(<TransactionsPage />);
-
-    // Sanity: the dropdown loads (so periods are present), but no quick button.
-    await screen.findByLabelText("Billing period");
-    expect(screen.queryByRole("button", { name: /current period/i })).toBeNull();
-  });
-
   it("Manually editing the From-date input clears any pinned period filter", async () => {
-    const periods: Period[] = [{ id: 7, start_date: "2026-05-01", end_date: null }];
+    const periods: Period[] = [{ id: 7, start_date: "2026-04-01", end_date: "2026-04-30" }];
     const mock = setupApiFetch(periods);
 
     render(<TransactionsPage />);
     await waitFor(() => expect(lastListUrl(mock)).not.toBeNull());
 
-    // Pin the open period via the dropdown first.
+    // Pin a closed period via the dropdown first.
     const periodSelect = await screen.findByLabelText("Billing period");
     fireEvent.change(periodSelect, { target: { value: "7" } });
     await waitFor(() => {
       const url = lastListUrl(mock);
-      expect(url).toContain("date_from=2026-05-01");
+      expect(url).toContain("date_from=2026-04-01");
     });
 
     // Now type a different From-date — this must drop the period and use

--- a/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
+++ b/frontend/tests/app/transactions-quick-filters-and-sort.test.tsx
@@ -276,10 +276,22 @@ describe("TransactionsPage — quick filter buttons", () => {
 
     await screen.findByLabelText("Billing period");
     await waitFor(() => {
+      const periodsCallIndex = mock.mock.calls.findIndex(
+        (call) =>
+          typeof call[0] === "string" &&
+          (call[0] as string).startsWith("/api/v1/settings/billing-periods"),
+      );
+      expect(periodsCallIndex).toBeGreaterThanOrEqual(0);
+      const txUrlsAfterPeriodsLoad = listUrlsAfter(mock, periodsCallIndex + 1);
+      expect(txUrlsAfterPeriodsLoad.length).toBeGreaterThan(0);
+      expect(
+        txUrlsAfterPeriodsLoad.filter((url) =>
+          url.includes("date_from=2026-05-01"),
+        ),
+      ).toEqual([]);
       const stored = window.localStorage.getItem(FILTERS_KEY_TRANSACTIONS);
       expect(stored).not.toBeNull();
       expect(JSON.parse(stored!).filterPeriod).toBe("");
-      expect(lastListUrl(mock)).not.toContain("date_from=2026-05-01");
     });
   });
 


### PR DESCRIPTION
## Summary
- Support /transactions deep links for account_id, explicit date_from/date_to ranges, and transaction_id row targeting.
- Remove the Current Period quick filter and hide open/current periods from the billing-period dropdown.
- Change This Month to cover the full local calendar month.
- Add focused regression coverage for dashboard deep links, closed-period filtering, persisted open-period cleanup, and month-end date presets.

## Merge dependency
This PR should merge before any dashboard-link PR that relies on account_id or transaction_id URL params.

## Verification
- npm test -- transactions-quick-filters-and-sort.test.tsx transactions-sort-filter-persistence.test.tsx transactions-page.test.tsx transactions-deep-links.test.tsx
- npm run lint (exits 0; existing warnings remain)
- npm run build