### PR TITLE
fix(dashboard): deep-link uses settled_date so CC rows match

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -80,11 +80,18 @@ interface ForecastProjection {
 const PAGE_SIZE = 10;
 
 function transactionHighlightHref(tx: Transaction) {
+  // The transactions list filters by `effective_period_date_expr =
+  // COALESCE(settled_date, date)`, so a deep link built from `tx.date`
+  // misses any row whose settled_date differs from its purchase date —
+  // notably every credit-card transaction settling on a later statement
+  // close. Use the same coalesce here so the row we want highlighted
+  // actually lands inside the queried window.
+  const effectiveDate = tx.settled_date ?? tx.date;
   const params = new URLSearchParams({
     account_id: String(tx.account_id),
     transaction_id: String(tx.id),
-    date_from: tx.date,
-    date_to: tx.date,
+    date_from: effectiveDate,
+    date_to: effectiveDate,
   });
 
   return `/transactions?${params.toString()}`;

--- a/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
+++ b/frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx
@@ -198,4 +198,49 @@ describe("DashboardPage — pending refetch on status toggle (L3.4)", () => {
       "/transactions?account_id=10&transaction_id=999&date_from=2026-05-01&date_to=2026-05-01",
     );
   });
+
+  it("uses settled_date in the deep link when it differs from purchase date (CC row)", async () => {
+    // A credit-card purchase on 2026-05-01 that doesn't post to the
+    // statement until 2026-05-15. The transactions list filters by
+    // COALESCE(settled_date, date), so a deep link built from `tx.date`
+    // would query for [2026-05-01, 2026-05-01] and skip this row
+    // entirely. The href must use settled_date instead.
+    const CC_TX = {
+      ...SETTLED_TX,
+      id: 482,
+      account_id: 15,
+      date: "2026-05-01",
+      settled_date: "2026-05-15",
+      description: "Restaurant",
+      account_name: "Amex Gold",
+    };
+
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([]);
+      if (url === "/api/v1/categories") return Promise.resolve([]);
+      if (url === "/api/v1/budgets" || url.startsWith("/api/v1/budgets?"))
+        return Promise.resolve([]);
+      if (url === "/api/v1/settings/billing-cycle")
+        return Promise.resolve({ billing_cycle_day: 1 });
+      if (url === "/api/v1/settings/billing-period")
+        return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      if (url === "/api/v1/settings/billing-periods")
+        return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+      if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
+      if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
+      if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+      if (url.startsWith("/api/v1/transactions?limit=200")) return Promise.resolve([CC_TX]);
+      if (url.startsWith("/api/v1/transactions?limit=11&offset=0"))
+        return Promise.resolve([CC_TX]);
+      return Promise.resolve({});
+    }) as never);
+
+    render(<DashboardPage />);
+
+    const link = await screen.findByRole("link", { name: /Restaurant Amex Gold/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/transactions?account_id=15&transaction_id=482&date_from=2026-05-15&date_to=2026-05-15",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Hot-fix on top of #218: the dashboard's "highlight transaction" deep link built `date_from` / `date_to` from `tx.date`, but the transactions list filters by `COALESCE(settled_date, date)`. For credit-card rows whose `settled_date` lands on a later statement close, the deep link's `[tx.date, tx.date]` window does not contain the target row, so the page renders empty.

Symptom: clicking a recent CC transaction on `/dashboard` lands on `/transactions?...&date_from=YYYY-MM-DD&date_to=YYYY-MM-DD` with zero rows. Same-day-settled rows happened to match because `date == settled_date`.

## Fix

One file, six-line change in `frontend/app/dashboard/page.tsx` — `transactionHighlightHref` now coalesces `tx.settled_date ?? tx.date`, mirroring the backend's `effective_period_date_expr()` in `backend/app/services/transaction_filters.py:31`.

## Tests

New regression in `frontend/tests/app/dashboard-pending-toggle-refresh.test.tsx`: a CC fixture with `date=2026-05-01` + `settled_date=2026-05-15` asserts the link's date params come from `settled_date`. The existing same-day assertion still passes (both fields resolve to the same value in that fixture).

Suite: 80 files / 543 tests (was 79 / 542). +1 test.

## Quality gates

- Design token check: pass
- tsc --noEmit: pass
- eslint --quiet: pass
- Tests: 543/543 pass
- Build: pass

## Out of scope

The separate "account_id filter doesn't work locally" report appears to be a stale-node_modules / stale-dev-server symptom — `@dnd-kit/core` (added by #215) was missing from local `node_modules`, which suggests the dev container was not rebuilt. After merging this fix, also: `docker compose up --build -d frontend` to refresh the container's baked deps.

## Risk notes

- Behavioral change is scoped to the dashboard recent-transaction link target. No backend changes, no schema changes.
- Pending rows without an estimated `settled_date` continue to use `tx.date` (the existing fallback the backend uses too).