### PR TITLE
feat(admin): superadmin org member management (L4.4 slice)

### DIFF
--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -694,12 +694,17 @@ async def get_feature_state(
 
 
 def _audit_event_type_for_member_update(changes: list[str], after: dict) -> Optional[str]:
-    """Pick the single most specific event type for a member PATCH.
+    """Pick the single event type for a member PATCH.
 
-    Order of specificity (most → least): activation/deactivation,
-    role change. If both changed in one PATCH we emit both; if only
-    one changed we emit one; if nothing changed we emit none (the
-    route returns 200 with the same body but writes no audit row).
+    Emits one event type per request; the UI sends one field at a
+    time, so role and is_active changes never combine in a single
+    PATCH today. If a future caller sends both in one body, the
+    activation/deactivation flip takes precedence (it's the more
+    operationally significant signal — a deactivated member can't
+    use any role), and the role change is still captured in the
+    ``before`` / ``after`` / ``changed_fields`` detail of the same
+    audit row. If nothing actually changed the route returns 200
+    without writing an audit row.
     """
     if "is_active" in changes:
         return (

--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -13,6 +13,8 @@ message client-side, full detail server-side.
 """
 
 from datetime import datetime
+from typing import Optional
+
 from app._time import utcnow_naive
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
@@ -27,12 +29,22 @@ from app.database import get_db
 from app.deps import get_current_user, get_session_factory
 from app.models.feature_override import OrgFeatureOverride
 from app.models.subscription import Plan, Subscription, SubscriptionStatus
-from app.models.user import Organization, User
+from app.models.user import Organization, Role, User
 from app.rate_limit import get_client_ip
-from app.schemas.admin_orgs import OrgDeleteRequest, SubscriptionUpdateRequest
+from app.schemas.admin_orgs import (
+    AdminMemberResponse,
+    AdminMemberUpdateRequest,
+    OrgDeleteRequest,
+    SubscriptionUpdateRequest,
+)
 from app.schemas.feature_override import FeatureOverrideUpsert, OrgFeatureOverrideResponse
 from app.schemas.feature_state import FeatureStateResponse
-from app.services import admin_orgs_service, audit_service, feature_service
+from app.services import (
+    admin_org_members_service,
+    admin_orgs_service,
+    audit_service,
+    feature_service,
+)
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 logger = structlog.stdlib.get_logger()
@@ -676,3 +688,234 @@ async def get_feature_state(
         })
 
     return {"plan": plan_summary, "features": feature_rows}
+
+
+# ── Org members (L4.4 — superadmin escape hatch) ─────────────────────────
+
+
+def _audit_event_type_for_member_update(changes: list[str], after: dict) -> Optional[str]:
+    """Pick the single most specific event type for a member PATCH.
+
+    Order of specificity (most → least): activation/deactivation,
+    role change. If both changed in one PATCH we emit both; if only
+    one changed we emit one; if nothing changed we emit none (the
+    route returns 200 with the same body but writes no audit row).
+    """
+    if "is_active" in changes:
+        return (
+            "admin.org.member.reactivated"
+            if after["is_active"]
+            else "admin.org.member.deactivated"
+        )
+    if "role" in changes:
+        return "admin.org.member.role_changed"
+    return None
+
+
+async def _ensure_target_org(db: AsyncSession, org_id: int) -> Organization:
+    org = (
+        await db.execute(select(Organization).where(Organization.id == org_id))
+    ).scalar_one_or_none()
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+    return org
+
+
+@router.get(
+    "/{org_id}/members",
+    response_model=list[AdminMemberResponse],
+    dependencies=[Depends(require_permission("orgs.view"))],
+)
+async def list_org_members(
+    org_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await admin_org_members_service.list_members(db, org_id=org_id)
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+
+
+@router.patch(
+    "/{org_id}/members/{user_id}",
+    response_model=AdminMemberResponse,
+)
+async def update_org_member(
+    org_id: int,
+    user_id: int,
+    body: AdminMemberUpdateRequest,
+    request: Request,
+    current_user: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    org = await _ensure_target_org(db, org_id)
+    target_org_name = org.name
+
+    role_arg: Optional[Role] = None
+    if body.role is not None:
+        try:
+            role_arg = Role(body.role)
+        except ValueError:
+            # Pydantic Literal already constrains to the three roles,
+            # but a defensive translation keeps the contract honest.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown role {body.role!r}",
+            )
+
+    try:
+        target, before, after, changes = await admin_org_members_service.update_member(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            actor=current_user,
+            role=role_arg,
+            is_active=body.is_active,
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Member not found",
+        )
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except ConflictError as e:
+        # The "platform superadmin" guard surfaces here as a
+        # ConflictError; HTTP-wise it belongs at 403 because the
+        # superadmin status is an authorization boundary, not a
+        # transient conflict. Detect by message.
+        msg = str(e)
+        if "superadmin" in msg.lower():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail=msg
+            )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=msg
+        )
+
+    event_type = _audit_event_type_for_member_update(changes, after)
+
+    await db.commit()
+
+    member_payload = {
+        "id": target.id,
+        "username": target.username,
+        "email": target.email,
+        "role": target.role.value,
+        "is_active": target.is_active,
+        "email_verified": target.email_verified,
+        "is_superadmin": target.is_superadmin,
+        "created_at": target.created_at.isoformat() if target.created_at else None,
+    }
+
+    if event_type is not None:
+        detail: dict[str, object] = {
+            "target_user_id": target.id,
+            "target_username": target.username,
+            "target_email": target.email,
+            "before": before,
+            "after": after,
+            "changed_fields": changes,
+        }
+        await logger.ainfo(
+            event_type,
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=target_org_name,
+            target_user_id=target.id,
+            before=before,
+            after=after,
+            changed_fields=changes,
+        )
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type=event_type,
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=target_org_name,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail=detail,
+        )
+
+    return member_payload
+
+
+@router.delete(
+    "/{org_id}/members/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_org_member(
+    org_id: int,
+    user_id: int,
+    request: Request,
+    current_user: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    org = await _ensure_target_org(db, org_id)
+    target_org_name = org.name
+
+    try:
+        target, snapshot = await admin_org_members_service.remove_member(
+            db,
+            org_id=org_id,
+            user_id=user_id,
+            actor=current_user,
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Member not found",
+        )
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except ConflictError as e:
+        msg = str(e)
+        if "superadmin" in msg.lower():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail=msg
+            )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=msg
+        )
+
+    await db.commit()
+
+    # Idempotent on already-inactive targets — no audit row to avoid
+    # phantom "removed" events for a member who was already removed
+    # previously. The structlog signal is enough for the trace.
+    if snapshot["was_active"]:
+        await logger.ainfo(
+            "admin.org.member.removed",
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=target_org_name,
+            target_user_id=target.id,
+            snapshot=snapshot,
+        )
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.org.member.removed",
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=target_org_name,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail={"snapshot": snapshot},
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/admin_orgs.py
+++ b/backend/app/schemas/admin_orgs.py
@@ -16,3 +16,34 @@ class SubscriptionUpdateRequest(BaseModel):
 
 class OrgDeleteRequest(BaseModel):
     confirm_name: str = Field(min_length=1, max_length=200)
+
+
+# ── L4.4 member management ────────────────────────────────────────────────
+
+
+class AdminMemberResponse(BaseModel):
+    """Member row returned by /admin/orgs/{id}/members. Superset of the
+    org-side `MemberResponse`: includes `email_verified` (operator
+    diagnostics) and `is_superadmin` (so the UI can disable mutation
+    affordances)."""
+
+    id: int
+    username: str
+    email: str
+    role: Literal["owner", "admin", "member"]
+    is_active: bool
+    email_verified: bool
+    is_superadmin: bool
+    created_at: Optional[str] = None
+
+
+class AdminMemberUpdateRequest(BaseModel):
+    """Partial update for /admin/orgs/{id}/members/{user_id}.
+
+    Both fields optional; the service rejects an all-None body with
+    400. The role enum here intentionally omits platform-level roles
+    (e.g. "superadmin") — they're not assignable through this
+    surface."""
+
+    role: Optional[Literal["owner", "admin", "member"]] = None
+    is_active: Optional[bool] = None

--- a/backend/app/services/admin_org_members_service.py
+++ b/backend/app/services/admin_org_members_service.py
@@ -1,0 +1,234 @@
+"""Superadmin org-member management (L4.4 slice).
+
+Escape-hatch endpoints for editing membership of any org. Mirrors the
+owner-only ``invitation_service`` member ops but with the caller's
+identity decoupled from the target org (the actor's ``org_id`` is the
+superadmin's home org, not necessarily ``target_org_id``).
+
+All mutations are caller-commit; the router owns the ``db.commit()``
+boundary and the audit-event write (so the audit row sits in the same
+transaction as the business write for org-delete-style guarantees,
+and is also re-emitted on the independent session for failure paths).
+
+Safety guards (every mutation enforces all that apply):
+
+- Cannot operate on yourself via this endpoint. Footgun prevention;
+  superadmins still manage their own user via /me / /admin/users.
+- Cannot deactivate / demote / remove the LAST OWNER of the target
+  org (count includes only active owners). The org would be left
+  without an owner and the org-side admin tooling would have nothing
+  to recover with — that's the inverse of the escape hatch.
+- Cannot remove or deactivate a superadmin via this endpoint.
+  Superadmin status is platform-level; their org membership is for
+  data locality, not auth, and yanking it via the org sub-resource
+  is the wrong control surface (use platform user admin when L4.4-B
+  ships).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app._time import utcnow_naive
+from app.models.user import Organization, Role, User
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+# Roles a superadmin can assign through this endpoint. Restricted to
+# the org-scoped set; platform roles (e.g. superadmin) are managed on
+# a different surface.
+_ASSIGNABLE_ROLES = frozenset({Role.OWNER, Role.ADMIN, Role.MEMBER})
+
+
+async def _load_target_member(
+    db: AsyncSession, *, org_id: int, user_id: int
+) -> User:
+    target = (
+        await db.execute(
+            select(User).where(User.id == user_id, User.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+    if target is None:
+        raise NotFoundError("Member")
+    return target
+
+
+async def _active_owner_count(db: AsyncSession, *, org_id: int) -> int:
+    return (
+        await db.scalar(
+            select(func.count())
+            .select_from(User)
+            .where(
+                User.org_id == org_id,
+                User.role == Role.OWNER,
+                User.is_active.is_(True),
+            )
+        )
+    ) or 0
+
+
+async def list_members(db: AsyncSession, *, org_id: int) -> list[dict]:
+    """Every member of the org (active and inactive), stable order.
+
+    Superadmin-visibility shape — includes ``is_active`` and
+    ``email_verified`` so the admin UI can render correctly without a
+    second roundtrip.
+    """
+    org_exists = await db.scalar(
+        select(Organization.id).where(Organization.id == org_id)
+    )
+    if org_exists is None:
+        raise NotFoundError("Organization")
+
+    rows = (
+        await db.execute(
+            select(User).where(User.org_id == org_id).order_by(User.username)
+        )
+    ).scalars().all()
+    return [
+        {
+            "id": u.id,
+            "username": u.username,
+            "email": u.email,
+            "role": u.role.value,
+            "is_active": u.is_active,
+            "email_verified": u.email_verified,
+            "is_superadmin": u.is_superadmin,
+            "created_at": u.created_at.isoformat() if u.created_at else None,
+        }
+        for u in rows
+    ]
+
+
+async def update_member(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    user_id: int,
+    actor: User,
+    role: Optional[Role] = None,
+    is_active: Optional[bool] = None,
+) -> tuple[User, dict, dict, list[str]]:
+    """Apply a partial update to a member of ``org_id``.
+
+    Returns ``(target, before, after, changes)`` where ``changes`` is
+    the list of fields that actually changed (so the router emits one
+    audit event per real change and skips audit/log noise for no-op
+    PATCHes).
+
+    Caller commits.
+    """
+    if role is None and is_active is None:
+        raise ValidationError("No fields to update")
+
+    if user_id == actor.id:
+        raise ValidationError("You cannot modify your own membership here")
+
+    if role is not None and role not in _ASSIGNABLE_ROLES:
+        raise ValidationError(f"Cannot assign role {role.value!r}")
+
+    target = await _load_target_member(db, org_id=org_id, user_id=user_id)
+
+    if target.is_superadmin:
+        raise ConflictError(
+            "Cannot modify a platform superadmin via org-member admin"
+        )
+
+    before = {
+        "role": target.role.value,
+        "is_active": target.is_active,
+    }
+
+    # Determine which fields are actually changing and run the safety
+    # guards against the effective post-update state. Counting only
+    # active owners excludes already-removed accounts from "last
+    # owner" arithmetic (a dormant inactive owner can't recover an
+    # org by themselves).
+    changes: list[str] = []
+    will_become_inactive = (
+        is_active is False and target.is_active is True
+    )
+    will_be_demoted = (
+        role is not None and target.role == Role.OWNER and role != Role.OWNER
+    )
+
+    if (will_become_inactive or will_be_demoted) and target.role == Role.OWNER:
+        active_owners = await _active_owner_count(db, org_id=org_id)
+        if active_owners <= 1:
+            raise ConflictError(
+                "Cannot remove the last active owner of the organization"
+            )
+
+    if role is not None and role != target.role:
+        target.role = role
+        changes.append("role")
+    if is_active is not None and is_active != target.is_active:
+        target.is_active = is_active
+        if is_active is False:
+            # Force a token re-issue check on next request, so the
+            # deactivated user can't continue an active session.
+            target.sessions_invalidated_at = utcnow_naive()
+        changes.append("is_active")
+
+    after = {
+        "role": target.role.value,
+        "is_active": target.is_active,
+    }
+
+    if changes:
+        await db.flush()
+
+    return target, before, after, changes
+
+
+async def remove_member(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    user_id: int,
+    actor: User,
+) -> tuple[User, dict]:
+    """Soft-delete a member from ``org_id`` (mirrors the org-side
+    ``invitation_service.remove_member`` semantics — sets
+    ``is_active=False`` and bumps ``sessions_invalidated_at``).
+
+    Returns ``(target, snapshot)`` where ``snapshot`` is the
+    pre-removal identifying fields for the audit detail. Caller
+    commits.
+    """
+    if user_id == actor.id:
+        raise ValidationError("You cannot remove yourself")
+
+    target = await _load_target_member(db, org_id=org_id, user_id=user_id)
+
+    if target.is_superadmin:
+        raise ConflictError(
+            "Cannot remove a platform superadmin via org-member admin"
+        )
+
+    snapshot = {
+        "user_id": target.id,
+        "username": target.username,
+        "email": target.email,
+        "role": target.role.value,
+        "was_active": target.is_active,
+    }
+
+    if not target.is_active:
+        # Already removed — idempotent. Returning the snapshot lets
+        # the router emit a no-op audit event if it wants.
+        return target, snapshot
+
+    if target.role == Role.OWNER:
+        active_owners = await _active_owner_count(db, org_id=org_id)
+        if active_owners <= 1:
+            raise ConflictError(
+                "Cannot remove the last active owner of the organization"
+            )
+
+    target.is_active = False
+    target.sessions_invalidated_at = utcnow_naive()
+    await db.flush()
+    return target, snapshot

--- a/backend/tests/routers/test_admin_org_members.py
+++ b/backend/tests/routers/test_admin_org_members.py
@@ -1,0 +1,552 @@
+"""Router tests for L4.4 superadmin org member management.
+
+Pins:
+- Auth gate: 401 unauthenticated, 403 without `orgs.manage`.
+- Listing returns the superset shape (`is_active`, `email_verified`,
+  `is_superadmin`).
+- PATCH guards: last-owner (deactivate / demote), self-target,
+  superadmin target, no-op body.
+- DELETE guards: last-owner, self-target, superadmin target.
+- Audit events: one row per real change, no row for no-op PATCH or
+  already-inactive DELETE.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.routers.admin_orgs import router as admin_orgs_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await resolver(session_factory)
+
+    def override_get_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_get_session_factory
+    app.include_router(admin_orgs_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """Two orgs, the second populated so we can test member admin.
+
+    Admin Org: one superadmin owner ("root").
+    Target Inc: one OWNER ("t_owner"), one ADMIN ("t_admin"), one
+    MEMBER ("t_member"), and one INACTIVE MEMBER ("t_ghost") so the
+    list endpoint exercises the active/inactive split.
+    """
+    async with factory() as db:
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target = Organization(name="Target Inc", billing_cycle_day=1)
+        db.add_all([admin_org, target])
+        await db.commit()
+
+        sa = User(
+            org_id=admin_org.id,
+            username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        owner = User(
+            org_id=target.id,
+            username="t_owner",
+            email="t_owner@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        admin = User(
+            org_id=target.id,
+            username="t_admin",
+            email="t_admin@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.ADMIN,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        member = User(
+            org_id=target.id,
+            username="t_member",
+            email="t_member@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=False,
+        )
+        ghost = User(
+            org_id=target.id,
+            username="t_ghost",
+            email="t_ghost@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER,
+            is_superadmin=False,
+            is_active=False,
+            email_verified=True,
+        )
+        # A second org-hosted superadmin so the "superadmin guard"
+        # branch has a target that lives inside `target` and not
+        # inside `admin_org`.
+        embedded_sa = User(
+            org_id=target.id,
+            username="t_sa",
+            email="t_sa@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.ADMIN,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, owner, admin, member, ghost, embedded_sa])
+        await db.commit()
+
+        return {
+            "admin_user_id": sa.id,
+            "admin_org_id": admin_org.id,
+            "target_id": target.id,
+            "owner_id": owner.id,
+            "admin_id": admin.id,
+            "member_id": member.id,
+            "ghost_id": ghost.id,
+            "embedded_sa_id": embedded_sa.id,
+        }
+
+
+def _superadmin_resolver():
+    async def resolve(factory):
+        async with factory() as db:
+            return (
+                await db.execute(
+                    select(User).where(
+                        User.is_superadmin.is_(True),
+                        User.email == "root@platform.io",
+                    )
+                )
+            ).scalar_one()
+
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(factory):
+        async with factory() as db:
+            return (
+                await db.execute(
+                    select(User).where(User.username == "t_owner")
+                )
+            ).scalar_one()
+
+    return resolve
+
+
+async def _audit_events(factory, event_type: str | None = None) -> list[AuditEvent]:
+    async with factory() as db:
+        q = select(AuditEvent)
+        if event_type:
+            q = q.where(AuditEvent.event_type == event_type)
+        result = await db.execute(q)
+        return list(result.scalars().all())
+
+
+# ── auth gates ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_members_403_for_non_superadmin(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get(f"/api/v1/admin/orgs/{seed['target_id']}/members")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_patch_member_403_for_non_superadmin(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['member_id']}",
+            json={"role": "admin"},
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_member_403_for_non_superadmin(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['member_id']}"
+        )
+    assert res.status_code == 403
+
+
+# ── list ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_members_returns_full_shape(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(f"/api/v1/admin/orgs/{seed['target_id']}/members")
+    assert res.status_code == 200
+    body = res.json()
+    usernames = sorted(m["username"] for m in body)
+    assert usernames == ["t_admin", "t_ghost", "t_member", "t_owner", "t_sa"]
+    # Shape check: every member row has the required keys.
+    for m in body:
+        assert set(m.keys()) >= {
+            "id", "username", "email", "role",
+            "is_active", "email_verified", "is_superadmin", "created_at",
+        }
+    by_user = {m["username"]: m for m in body}
+    assert by_user["t_ghost"]["is_active"] is False
+    assert by_user["t_member"]["email_verified"] is False
+    assert by_user["t_sa"]["is_superadmin"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_members_404_for_missing_org(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/orgs/99999/members")
+    assert res.status_code == 404
+
+
+# ── PATCH success paths ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_member_role_changed_writes_audit(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['member_id']}",
+            json={"role": "admin"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["role"] == "admin"
+
+    rows = await _audit_events(session_factory, "admin.org.member.role_changed")
+    assert len(rows) == 1
+    assert rows[0].target_org_id == seed["target_id"]
+    assert rows[0].detail["before"]["role"] == "member"
+    assert rows[0].detail["after"]["role"] == "admin"
+    assert "role" in rows[0].detail["changed_fields"]
+
+
+@pytest.mark.asyncio
+async def test_patch_member_deactivate_writes_audit(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['admin_id']}",
+            json={"is_active": False},
+        )
+    assert res.status_code == 200
+    assert res.json()["is_active"] is False
+    rows = await _audit_events(session_factory, "admin.org.member.deactivated")
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_member_reactivate_writes_audit(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['ghost_id']}",
+            json={"is_active": True},
+        )
+    assert res.status_code == 200
+    assert res.json()["is_active"] is True
+    rows = await _audit_events(session_factory, "admin.org.member.reactivated")
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_member_no_change_writes_no_audit(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        # Apply role=admin to a user who is already admin.
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['admin_id']}",
+            json={"role": "admin"},
+        )
+    assert res.status_code == 200
+    rows = await _audit_events(session_factory)
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_patch_member_empty_body_400(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['member_id']}",
+            json={},
+        )
+    assert res.status_code == 400
+
+
+# ── PATCH safety guards ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_cannot_target_self(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['admin_org_id']}/members/{seed['admin_user_id']}",
+            json={"is_active": False},
+        )
+    assert res.status_code == 400
+    assert "your own" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_cannot_demote_last_owner(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['owner_id']}",
+            json={"role": "admin"},
+        )
+    assert res.status_code == 409
+    assert "last active owner" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_cannot_deactivate_last_owner(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['owner_id']}",
+            json={"is_active": False},
+        )
+    assert res.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_patch_can_demote_owner_when_second_owner_exists(session_factory):
+    """Inverse pin: with a second active OWNER, demoting the first is
+    allowed. Confirms the guard is "last" not "any"."""
+    seed = await _seed(session_factory)
+    # Promote t_admin to OWNER first (legal — still 1 active owner
+    # plus 1 demotable promotion target). Then demote t_owner.
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        # Promote t_admin → owner.
+        promote = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['admin_id']}",
+            json={"role": "owner"},
+        )
+        assert promote.status_code == 200
+        # Now demote t_owner → admin (legal — t_admin is the second owner).
+        demote = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['owner_id']}",
+            json={"role": "admin"},
+        )
+    assert demote.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_patch_cannot_target_superadmin(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['embedded_sa_id']}",
+            json={"is_active": False},
+        )
+    assert res.status_code == 403
+    assert "superadmin" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_patch_member_404_for_missing_user(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/99999",
+            json={"role": "admin"},
+        )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_member_404_for_missing_org(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/99999/members/{seed['member_id']}",
+            json={"role": "admin"},
+        )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_member_in_wrong_org_404(session_factory):
+    """User exists, but not in the path org. Treated as not-found,
+    matching the org-scoped contract used elsewhere."""
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.patch(
+            f"/api/v1/admin/orgs/{seed['admin_org_id']}/members/{seed['member_id']}",
+            json={"role": "admin"},
+        )
+    assert res.status_code == 404
+
+
+# ── DELETE success + safety ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_member_204_writes_audit(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['member_id']}"
+        )
+    assert res.status_code == 204
+    rows = await _audit_events(session_factory, "admin.org.member.removed")
+    assert len(rows) == 1
+    assert rows[0].detail["snapshot"]["user_id"] == seed["member_id"]
+    assert rows[0].detail["snapshot"]["was_active"] is True
+
+    # is_active flipped to False in the DB.
+    async with session_factory() as db:
+        u = await db.scalar(select(User).where(User.id == seed["member_id"]))
+        assert u.is_active is False
+        assert u.sessions_invalidated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_already_inactive_member_is_idempotent_no_audit(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['ghost_id']}"
+        )
+    assert res.status_code == 204
+    # No audit row for the no-op delete.
+    rows = await _audit_events(session_factory, "admin.org.member.removed")
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_delete_cannot_target_self(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['admin_org_id']}/members/{seed['admin_user_id']}"
+        )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_cannot_remove_last_owner(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['owner_id']}"
+        )
+    assert res.status_code == 409
+    assert "last active owner" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_cannot_target_superadmin(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['embedded_sa_id']}"
+        )
+    assert res.status_code == 403
+    assert "superadmin" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_member_404_for_missing_user(session_factory):
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.delete(
+            f"/api/v1/admin/orgs/{seed['target_id']}/members/99999"
+        )
+    assert res.status_code == 404

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -384,7 +384,7 @@ export default function AdminOrgDetailPage() {
                 const lockedReason = isSelf
                   ? "You cannot modify your own membership here."
                   : isPlatformSuperadmin
-                  ? "Platform superadmin — managed elsewhere."
+                  ? "Platform superadmin, managed elsewhere."
                   : null;
                 const busy = memberBusyId === m.id;
                 return (
@@ -489,19 +489,19 @@ export default function AdminOrgDetailPage() {
         <div className="grid grid-cols-2 gap-4 px-6 py-5 sm:grid-cols-4">
           <div>
             <p className="text-xs text-text-muted">Transactions</p>
-            <p className="font-display text-2xl text-text-primary">{detail.counts.transactions}</p>
+            <p className="text-2xl font-semibold tabular-nums text-text-primary">{detail.counts.transactions}</p>
           </div>
           <div>
             <p className="text-xs text-text-muted">Accounts</p>
-            <p className="font-display text-2xl text-text-primary">{detail.counts.accounts}</p>
+            <p className="text-2xl font-semibold tabular-nums text-text-primary">{detail.counts.accounts}</p>
           </div>
           <div>
             <p className="text-xs text-text-muted">Budgets</p>
-            <p className="font-display text-2xl text-text-primary">{detail.counts.budgets}</p>
+            <p className="text-2xl font-semibold tabular-nums text-text-primary">{detail.counts.budgets}</p>
           </div>
           <div>
             <p className="text-xs text-text-muted">Forecast plans</p>
-            <p className="font-display text-2xl text-text-primary">{detail.counts.forecast_plans}</p>
+            <p className="text-2xl font-semibold tabular-nums text-text-primary">{detail.counts.forecast_plans}</p>
           </div>
         </div>
       </section>

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -8,6 +8,7 @@ import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import ChangePlanModal from "@/components/admin/ChangePlanModal";
 import FeatureOverridesCard from "@/components/admin/FeatureOverridesCard";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { hasPlatformPermission } from "@/lib/auth";
 import {
@@ -43,7 +44,13 @@ type Member = {
   is_active: boolean;
   email_verified: boolean;
   created_at: string | null;
+  // Optional in the legacy /api/v1/admin/orgs/{id} payload; the
+  // dedicated /members endpoint includes it. Default `false` if
+  // absent so existing call sites still narrow correctly.
+  is_superadmin?: boolean;
 };
+
+const ROLE_OPTIONS = ["owner", "admin", "member"] as const;
 
 type OrgDetail = {
   id: number;
@@ -85,6 +92,11 @@ export default function AdminOrgDetailPage() {
   const [confirmName, setConfirmName] = useState("");
   const [deleting, setDeleting] = useState(false);
 
+  // Member management state (L4.4 slice).
+  const [memberBusyId, setMemberBusyId] = useState<number | null>(null);
+  const [memberError, setMemberError] = useState("");
+  const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
+
   useEffect(() => {
     if (loading) return;
     if (!user) {
@@ -98,11 +110,19 @@ export default function AdminOrgDetailPage() {
 
   async function refresh() {
     try {
-      const [d, planList] = await Promise.all([
+      const [d, planList, members] = await Promise.all([
         apiFetch<OrgDetail>(`/api/v1/admin/orgs/${orgId}`),
         apiFetch<PlanOption[]>("/api/v1/plans"),
+        // The dedicated members endpoint carries the superset shape
+        // (is_superadmin in particular) so admin affordances render
+        // correctly. Falls back gracefully to d.members if it errors
+        // or returns a non-array shape (older API / mocks).
+        apiFetch<Member[]>(`/api/v1/admin/orgs/${orgId}/members`).catch(
+          () => null,
+        ),
       ]);
-      setDetail(d);
+      const useMembers = Array.isArray(members) ? members : d.members;
+      setDetail({ ...d, members: useMembers });
       setPlans(planList ?? []);
       const sub = d.subscription as Subscription;
       setSubStatus(sub.status ?? "");
@@ -143,6 +163,44 @@ export default function AdminOrgDetailPage() {
       await refresh();
     } catch (err) {
       setError(extractErrorMessage(err, "Update failed"));
+    }
+  }
+
+  async function patchMember(
+    member: Member,
+    body: { role?: string; is_active?: boolean },
+  ) {
+    setMemberError("");
+    setMemberBusyId(member.id);
+    try {
+      await apiFetch(
+        `/api/v1/admin/orgs/${orgId}/members/${member.id}`,
+        { method: "PATCH", body: JSON.stringify(body) },
+      );
+      await refresh();
+    } catch (err) {
+      setMemberError(extractErrorMessage(err, "Update failed"));
+    } finally {
+      setMemberBusyId(null);
+    }
+  }
+
+  async function confirmRemoveMember() {
+    if (!removeTarget) return;
+    const member = removeTarget;
+    setMemberError("");
+    setMemberBusyId(member.id);
+    try {
+      await apiFetch(
+        `/api/v1/admin/orgs/${orgId}/members/${member.id}`,
+        { method: "DELETE" },
+      );
+      setRemoveTarget(null);
+      await refresh();
+    } catch (err) {
+      setMemberError(extractErrorMessage(err, "Remove failed"));
+    } finally {
+      setMemberBusyId(null);
     }
   }
 
@@ -299,6 +357,11 @@ export default function AdminOrgDetailPage() {
         <div className={cardHeader}>
           <h2 className={cardTitle}>Members ({detail.members.length})</h2>
         </div>
+        {memberError && (
+          <div className="px-6 pt-4">
+            <div className={errorCls} role="alert">{memberError}</div>
+          </div>
+        )}
         <div className="overflow-x-auto px-6 py-4">
           <table className="w-full text-sm">
             <thead>
@@ -307,23 +370,116 @@ export default function AdminOrgDetailPage() {
                 <th className="py-2 pr-4">Email</th>
                 <th className="py-2 pr-4">Role</th>
                 <th className="py-2 pr-4">Active</th>
-                <th className="py-2">Verified</th>
+                <th className="py-2 pr-4">Verified</th>
+                <th className="py-2">Actions</th>
               </tr>
             </thead>
             <tbody>
-              {detail.members.map((m) => (
-                <tr key={m.id} className="border-b border-border-subtle">
-                  <td className="py-2 pr-4 text-text-primary">{m.username}</td>
-                  <td className="py-2 pr-4 text-text-secondary">{m.email}</td>
-                  <td className="py-2 pr-4 text-text-secondary">{m.role}</td>
-                  <td className="py-2 pr-4 text-text-secondary">{m.is_active ? "yes" : "no"}</td>
-                  <td className="py-2 text-text-secondary">{m.email_verified ? "yes" : "no"}</td>
-                </tr>
-              ))}
+              {detail.members.map((m) => {
+                const isSelf = m.id === user?.id;
+                const isPlatformSuperadmin = m.is_superadmin === true;
+                // Locking actions for self + platform superadmin
+                // matches the backend guard semantics so the UI
+                // doesn't dangle affordances that would 400/403.
+                const lockedReason = isSelf
+                  ? "You cannot modify your own membership here."
+                  : isPlatformSuperadmin
+                  ? "Platform superadmin — managed elsewhere."
+                  : null;
+                const busy = memberBusyId === m.id;
+                return (
+                  <tr key={m.id} className="border-b border-border-subtle align-middle">
+                    <td className="py-2 pr-4 text-text-primary">{m.username}</td>
+                    <td className="py-2 pr-4 text-text-secondary">{m.email}</td>
+                    <td className="py-2 pr-4 text-text-secondary">
+                      {lockedReason ? (
+                        <span>{m.role}</span>
+                      ) : (
+                        <label className="sr-only" htmlFor={`role-${m.id}`}>
+                          Role for {m.username}
+                        </label>
+                      )}
+                      {!lockedReason && (
+                        <select
+                          id={`role-${m.id}`}
+                          aria-label={`Role for ${m.username}`}
+                          value={m.role}
+                          disabled={busy}
+                          onChange={(e) => {
+                            if (e.target.value !== m.role) {
+                              patchMember(m, { role: e.target.value });
+                            }
+                          }}
+                          className={`${input} max-w-[10rem]`}
+                        >
+                          {ROLE_OPTIONS.map((r) => (
+                            <option key={r} value={r}>{r}</option>
+                          ))}
+                        </select>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4 text-text-secondary">
+                      {m.is_active ? "yes" : "no"}
+                    </td>
+                    <td className="py-2 pr-4 text-text-secondary">
+                      {m.email_verified ? "yes" : "no"}
+                    </td>
+                    <td className="py-2">
+                      {lockedReason ? (
+                        <span className="text-xs text-text-muted">
+                          {lockedReason}
+                        </span>
+                      ) : (
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() =>
+                              patchMember(m, { is_active: !m.is_active })
+                            }
+                            className={`${btnSecondary} min-h-[44px]`}
+                            aria-label={
+                              m.is_active
+                                ? `Deactivate ${m.username}`
+                                : `Reactivate ${m.username}`
+                            }
+                          >
+                            {m.is_active ? "Deactivate" : "Reactivate"}
+                          </button>
+                          <button
+                            type="button"
+                            disabled={busy || !m.is_active}
+                            onClick={() => setRemoveTarget(m)}
+                            className={`${btnDangerSolid} min-h-[44px]`}
+                            aria-label={`Remove ${m.username} from org`}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
       </section>
+
+      <ConfirmModal
+        open={removeTarget !== null}
+        title="Remove member from organization"
+        message={
+          removeTarget
+            ? `Remove ${removeTarget.username} (${removeTarget.email}) from ${detail.name}? They will lose access immediately. This action is recorded in the audit log.`
+            : ""
+        }
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={confirmRemoveMember}
+        onCancel={() => setRemoveTarget(null)}
+      />
 
       {/* Counts card */}
       <section className={`${card} mb-6`}>

--- a/frontend/tests/app/admin-org-detail-members.test.tsx
+++ b/frontend/tests/app/admin-org-detail-members.test.tsx
@@ -1,0 +1,316 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import AdminOrgDetailPage from "@/app/admin/orgs/[id]/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useParams: () => ({ id: "42" }),
+  usePathname: () => "/admin/orgs/42",
+}));
+
+const SUPERADMIN = {
+  id: 1, username: "root", email: "root@platform.io",
+  first_name: null, last_name: null, phone: null, avatar_url: null,
+  email_verified: true, role: "owner", org_id: 1, org_name: "Platform",
+  billing_cycle_day: 1, is_superadmin: true, is_active: true,
+  mfa_enabled: false, subscription_status: null, subscription_plan: null,
+  trial_end: null,
+};
+
+const DETAIL = {
+  id: 42, name: "Acme", billing_cycle_day: 1,
+  created_at: "2026-04-15T10:00:00",
+  subscription: {
+    status: "trialing", plan_id: 1, plan_slug: "free",
+    trial_start: "2026-04-15", trial_end: "2026-05-15",
+    current_period_start: null, current_period_end: null,
+    created_at: "2026-04-15T10:00:00", updated_at: "2026-04-15T10:00:00",
+  },
+  members: [],
+  counts: { transactions: 5, accounts: 1, budgets: 0, forecast_plans: 0 },
+};
+
+const MEMBERS = [
+  {
+    id: 9, username: "owner", email: "o@a.io", role: "owner",
+    is_active: true, email_verified: true, is_superadmin: false,
+    created_at: null,
+  },
+  {
+    id: 10, username: "alice", email: "a@a.io", role: "member",
+    is_active: true, email_verified: true, is_superadmin: false,
+    created_at: null,
+  },
+  {
+    id: 11, username: "ghost", email: "g@a.io", role: "member",
+    is_active: false, email_verified: false, is_superadmin: false,
+    created_at: null,
+  },
+  {
+    id: 12, username: "platformsa", email: "psa@a.io", role: "admin",
+    is_active: true, email_verified: true, is_superadmin: true,
+    created_at: null,
+  },
+];
+
+const FEATURE_STATE = {
+  plan: { id: 1, name: "Free", slug: "free" },
+  features: [
+    { key: "ai.budget", plan_default: true, effective: true, override: null },
+    { key: "ai.forecast", plan_default: false, effective: false, override: null },
+    { key: "ai.smart_plan", plan_default: false, effective: false, override: null },
+    { key: "ai.autocategorize", plan_default: false, effective: false, override: null },
+  ],
+};
+
+function installMocks(membersOverride?: typeof MEMBERS) {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+    if (url === "/api/v1/admin/orgs/42") {
+      return Promise.resolve({ ...DETAIL, members: [] });
+    }
+    if (url === "/api/v1/admin/orgs/42/members" && (!opts || opts.method === undefined)) {
+      return Promise.resolve(membersOverride ?? MEMBERS);
+    }
+    if (url === "/api/v1/admin/orgs/42/feature-state") {
+      return Promise.resolve(FEATURE_STATE);
+    }
+    if (url === "/api/v1/plans") {
+      return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
+    }
+    return Promise.resolve(undefined);
+  }) as never);
+  return apiFetchMock;
+}
+
+describe("AdminOrgDetailPage — member management (L4.4)", () => {
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders the member section with role select and Remove buttons for editable rows", async () => {
+    installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByRole("heading", { name: "Acme" });
+    await screen.findByLabelText(/Role for alice/i);
+
+    // Editable rows get a role-combobox + Remove button.
+    expect(screen.getByLabelText(/Role for owner/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Remove alice from org/i }),
+    ).toBeInTheDocument();
+
+    // Platform superadmin shows the locked-reason copy, not actions.
+    expect(screen.getByText(/Platform superadmin/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Remove platformsa from org/i }),
+    ).toBeNull();
+  });
+
+  it("hides member section actions and shows hint when user is not orgs.manage-capable", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+    installMocks();
+    render(<AdminOrgDetailPage />);
+    // Page redirects entirely without permission; member section never
+    // renders, which is the correct gate behavior.
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("PATCHes role on dropdown change and refreshes the list", async () => {
+    const apiFetchMock = installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("alice");
+    const roleSelect = screen.getByLabelText(/Role for alice/i) as HTMLSelectElement;
+    fireEvent.change(roleSelect, { target: { value: "admin" } });
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/42/members/10",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ role: "admin" }),
+        }),
+      );
+    });
+  });
+
+  it("PATCHes is_active=false when Deactivate is clicked", async () => {
+    const apiFetchMock = installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("alice");
+    fireEvent.click(screen.getByRole("button", { name: /Deactivate alice/i }));
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/42/members/10",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ is_active: false }),
+        }),
+      );
+    });
+  });
+
+  it("Reactivate appears on inactive rows and PATCHes is_active=true", async () => {
+    const apiFetchMock = installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("ghost");
+    fireEvent.click(screen.getByRole("button", { name: /Reactivate ghost/i }));
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/42/members/11",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ is_active: true }),
+        }),
+      );
+    });
+  });
+
+  it("Remove opens the confirm modal and DELETEs on confirm", async () => {
+    const apiFetchMock = installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("alice");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Remove alice from org/i }),
+    );
+
+    // Confirm modal opens.
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/Remove member from organization/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Remove$/i }));
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/orgs/42/members/10",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+  });
+
+  it("Cancel on the remove modal closes without calling DELETE", async () => {
+    const apiFetchMock = installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("alice");
+    fireEvent.click(
+      screen.getByRole("button", { name: /Remove alice from org/i }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /Cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    const deleteCalls = apiFetchMock.mock.calls.filter(
+      ([, opts]) => (opts as RequestInit | undefined)?.method === "DELETE",
+    );
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("surfaces a 409 last-owner error from the backend in the member-error banner", async () => {
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url === "/api/v1/admin/orgs/42") {
+        return Promise.resolve({ ...DETAIL, members: [] });
+      }
+      if (url === "/api/v1/admin/orgs/42/members" && (!opts || opts.method === undefined)) {
+        return Promise.resolve(MEMBERS);
+      }
+      if (url === "/api/v1/admin/orgs/42/feature-state") {
+        return Promise.resolve(FEATURE_STATE);
+      }
+      if (url === "/api/v1/plans") {
+        return Promise.resolve([{ id: 1, slug: "free", name: "Free" }]);
+      }
+      if (
+        url === "/api/v1/admin/orgs/42/members/9" &&
+        (opts as RequestInit | undefined)?.method === "PATCH"
+      ) {
+        // Simulate the 409 last-owner shape from the backend.
+        return Promise.reject(
+          new Error("Cannot remove the last active owner of the organization"),
+        );
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByLabelText(/Role for owner/i);
+    const ownerRoleSelect = screen.getByLabelText(/Role for owner/i) as HTMLSelectElement;
+    fireEvent.change(ownerRoleSelect, { target: { value: "admin" } });
+
+    await screen.findByText(/last active owner/i);
+  });
+
+  it("does not render role select or Remove for the actor's own row", async () => {
+    // Inject the actor into the member list so the locked-reason
+    // path renders.
+    const membersWithSelf = [
+      ...MEMBERS,
+      {
+        id: 1, username: "root", email: "root@platform.io", role: "owner",
+        is_active: true, email_verified: true, is_superadmin: true,
+        created_at: null,
+      },
+    ];
+    installMocks(membersWithSelf);
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("root");
+    // Two rows are locked: the platform superadmin AND the actor.
+    expect(
+      screen.queryByLabelText(/Role for root/i),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Remove root from org/i }),
+    ).toBeNull();
+  });
+});

--- a/frontend/tests/app/admin-org-detail-page.test.tsx
+++ b/frontend/tests/app/admin-org-detail-page.test.tsx
@@ -197,13 +197,14 @@ describe("AdminOrgDetailPage — Danger zone gating", () => {
     // Modal opens; wait for the modal heading to confirm it mounted, then for
     // the Pro option to load (modal fetches /api/v1/plans/all asynchronously).
     await screen.findByRole("heading", { name: /Change plan/i });
-    await screen.findByRole("option", { name: /Pro \(pro\)/i });
+    const proOption = await screen.findByRole("option", { name: /Pro \(pro\)/i });
 
-    // Pick the Pro plan via the modal's select. The page also has a Status
-    // <select>, so grab all comboboxes and pick the modal's (rendered last).
-    const comboboxes = screen.getAllByRole("combobox");
-    const planSelect = comboboxes[comboboxes.length - 1];
-    fireEvent.change(planSelect, { target: { value: "2" } });
+    // Pick the Pro plan via the modal's select. The page has multiple
+    // <select> elements (Status, per-member Role, modal Plan), so find
+    // the one containing the Pro option rather than indexing.
+    const planSelect = proOption.closest("select");
+    expect(planSelect).not.toBeNull();
+    fireEvent.change(planSelect as HTMLSelectElement, { target: { value: "2" } });
 
     // Submit: there are now two "Save" buttons (the page's + the modal's).
     // The modal's submit button is the last one rendered.


### PR DESCRIPTION
## Summary

Adds a superadmin escape hatch for managing membership inside any org. Lets superadmins change a member's role, deactivate/reactivate, or remove them — addressing the case where an org admin can't (locked-out owner, abandoned account, etc.). Slice of L4.4; non-goals listed below.

## Backend changes

- New service `app/services/admin_org_members_service.py` with `list_members`, `update_member`, `remove_member`. Service is caller-commit so the router owns the transaction boundary and the audit-row write.
- Three new endpoints on `app/routers/admin_orgs.py` (same router family as L4.3):
  - `GET  /api/v1/admin/orgs/{org_id}/members` — full member list incl. `is_active`, `email_verified`, `is_superadmin`, `created_at`.
  - `PATCH /api/v1/admin/orgs/{org_id}/members/{user_id}` — partial update of `{role, is_active}`. Empty body 400. No-op PATCH returns 200 without writing an audit row.
  - `DELETE /api/v1/admin/orgs/{org_id}/members/{user_id}` — soft-delete (`is_active=False` + bump `sessions_invalidated_at`), mirrors org-side `invitation_service.remove_member`.
- New Pydantic schemas in `app/schemas/admin_orgs.py`: `AdminMemberResponse`, `AdminMemberUpdateRequest`.

## Frontend changes

- `frontend/app/admin/orgs/[id]/page.tsx`: Members section now carries per-row Role dropdown, Deactivate/Reactivate toggle, and Remove button. Remove flows through the shared `ConfirmModal` (focus trap, ESC, restore-focus baked in). Surface uses design tokens, 44px touch targets on actions, no em dashes.
- Page fetches the dedicated `/members` endpoint on refresh for the superset shape and falls back to the legacy `detail.members` when the list isn't an array (mocks / older callers).
- Updated `tests/app/admin-org-detail-page.test.tsx` so the plan-select lookup finds the modal's `<select>` by option content (the page now has Status + per-member Role + modal Plan comboboxes).

## Permission added

- None new — the slice reuses the existing `orgs.manage` permission (superadmin short-circuit). Adding `org_members.manage` would have duplicated the same gating without an L4.8 distinction yet; tracked as a follow-up when role admin UI lands.

## Safety guards

| Guard | HTTP | Test |
|---|---|---|
| Cannot target self (PATCH or DELETE) | 400 | `test_patch_cannot_target_self`, `test_delete_cannot_target_self` |
| Cannot demote last active OWNER | 409 | `test_patch_cannot_demote_last_owner` (+ `test_patch_can_demote_owner_when_second_owner_exists` for the inverse) |
| Cannot deactivate last active OWNER | 409 | `test_patch_cannot_deactivate_last_owner` |
| Cannot remove last active OWNER | 409 | `test_delete_cannot_remove_last_owner` |
| Cannot operate on platform superadmin via this surface | 403 | `test_patch_cannot_target_superadmin`, `test_delete_cannot_target_superadmin` |
| Empty PATCH body | 400 | `test_patch_member_empty_body_400` |
| Member not in path org / missing user / missing org | 404 | `test_patch_member_in_wrong_org_404`, `test_patch_member_404_for_missing_user`, `test_list_members_404_for_missing_org` |

## Audit events

All written via `audit_service.record_audit_event` (independent session), `event_type` column ceiling is 80 chars (all new types fit):

- `admin.org.member.role_changed`
- `admin.org.member.deactivated`
- `admin.org.member.reactivated`
- `admin.org.member.removed`

No-op PATCH (role unchanged, is_active unchanged) and already-inactive DELETE write no audit row — kept idempotent without spawning phantom history. structlog signal still emitted in both cases. Each audit row carries `before`, `after`, `changed_fields`, and a target-user snapshot in `detail`.

## Quality gates

- Backend: 24 new tests + 32 regression tests in adjacent files all green (69 in the cluster sweep). Ran via isolated `docker compose -p team-admin-org-members`.
- Frontend: 9 new tests, full suite 551/551 green. `tsc --noEmit` clean, `npm run lint --quiet` clean, design-token check clean, `npm run build` clean.

## Out of scope

- No admin-side "create user" endpoint.
- No admin invite-to-org endpoint (org-side `invitation_service` covers the invite path).
- No password/email/MFA reset from admin.
- No impersonate / read-only impersonate.
- No cross-org user search.
- No new docs/help anchor in `/docs`.

## Risk notes

- New endpoints sit on `orgs.manage`; superadmin short-circuit means platform superadmins reach them today. If/when L4.8 splits org-management from member-management, swap the dep in two route lines.
- `is_active=False` + `sessions_invalidated_at` matches the org-side semantics. JWTs already check `sessions_invalidated_at`, so the deactivated user is locked out on next request without an explicit token-revocation pass.
- The platform-superadmin guard maps to HTTP 403 by message inspection ("superadmin" in `ConflictError`). If a future last-owner message ever contains the substring "superadmin", that check would misroute the status — pinned by tests but worth a structural cleanup (typed error class) if the surface grows.