### PR TITLE
fix(auth): normalize email + dedupe across SSO/register/invite + admin merge

### DIFF
--- a/backend/alembic/versions/040_users_email_case_insensitive.py
+++ b/backend/alembic/versions/040_users_email_case_insensitive.py
@@ -17,6 +17,35 @@ is a defense-in-depth measure paired with the Python-side
 The change is a no-op for SQLite (the testing engine). The
 ``with op.batch_alter_table`` form is portable; MySQL receives an
 ``ALTER TABLE ... MODIFY COLUMN`` under the hood.
+
+=============================================================
+Deployment preflight — REQUIRED before applying in production
+=============================================================
+
+If the target database was created on a case-sensitive collation
+(``utf8mb4_bin``, ``utf8mb4_0900_as_cs``, or similar) it may
+already contain rows that differ only in email casing or
+whitespace. Switching the column to ``utf8mb4_0900_ai_ci`` rebuilds
+the UNIQUE index over the new comparison rules and will FAIL the
+``ALTER TABLE`` with a duplicate-key error if such rows exist.
+
+Run this query against the target DB BEFORE deploying:
+
+    SELECT LOWER(TRIM(email)) AS normalized_email, COUNT(*) AS n
+    FROM users
+    GROUP BY normalized_email
+    HAVING COUNT(*) > 1;
+
+Any row in the result is a collision. Resolve every one of them
+via ``POST /api/v1/admin/users/merge`` (the recovery endpoint
+shipped in the same PR as this migration) BEFORE running the
+migration. Otherwise the unique-constraint rebuild aborts and
+``alembic upgrade`` exits non-zero.
+
+The migration intentionally does NOT run this check itself — a
+runbook entry the operator reads is clearer than a driver-level
+abort, and keeps the migration code portable across MySQL /
+SQLite without dialect-specific preflight branching.
 """
 from typing import Sequence, Union
 

--- a/backend/alembic/versions/040_users_email_case_insensitive.py
+++ b/backend/alembic/versions/040_users_email_case_insensitive.py
@@ -1,0 +1,57 @@
+"""Pin users.email to a case-insensitive collation explicitly.
+
+Revision ID: 040_users_email_case_insensitive
+Revises: 039_analytics_view_perm
+Create Date: 2026-05-12
+
+The default MySQL 8 collation is ``utf8mb4_0900_ai_ci`` which is
+already case-insensitive, so on a fresh database the unique
+constraint on ``users.email`` already blocks duplicates that
+differ only in case. This migration pins the column to that
+collation explicitly so a database created against an older
+MySQL default (``utf8mb4_general_ci``) or upgraded from a
+different default still gets the case-insensitive guarantee. It
+is a defense-in-depth measure paired with the Python-side
+``normalize_email`` helper used at every user-create site.
+
+The change is a no-op for SQLite (the testing engine). The
+``with op.batch_alter_table`` form is portable; MySQL receives an
+``ALTER TABLE ... MODIFY COLUMN`` under the hood.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "040_users_email_case_insensitive"
+down_revision = "039_analytics_view_perm"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        # SQLite (tests) — comparison is BINARY by default but the
+        # tests don't seed mixed-case duplicate rows, so this is a
+        # no-op.
+        return
+    op.execute(
+        "ALTER TABLE users "
+        "MODIFY COLUMN email VARCHAR(120) "
+        "CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        return
+    # Revert to the column-level default — the column inherits the
+    # table-level collation, which on a fresh MySQL 8 install is
+    # already utf8mb4_0900_ai_ci.
+    op.execute(
+        "ALTER TABLE users "
+        "MODIFY COLUMN email VARCHAR(120) NOT NULL"
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,7 +22,7 @@ from app.models.user import Organization
 from app.services import subscription_service
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_analytics, admin_audit, admin_orgs, admin_roles, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_analytics, admin_audit, admin_orgs, admin_roles, admin_users, auth, budgets, categories, forecast, forecast_plans, import_router, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -382,6 +382,7 @@ app.include_router(admin_orgs.router)
 app.include_router(admin_audit.router)
 app.include_router(admin_analytics.router)
 app.include_router(admin_roles.router)
+app.include_router(admin_users.router)
 app.include_router(org_members.router)
 app.include_router(org_data.router)
 app.include_router(orgs.router)

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -1,0 +1,160 @@
+"""Admin user-management router.
+
+Mounted at ``/api/v1/admin/users``. Currently exposes a single
+recovery endpoint — ``POST /merge`` — used by a superadmin to fold
+one ``users`` row into another. Built primarily for the pre-launch
+case where an early version of the Google SSO callback inserted a
+duplicate row at an email that already had a local-password user.
+
+Auth: ``orgs.manage`` (which superadmins short-circuit). The
+operation rewrites identifying data so we want the highest gate
+we have today.
+"""
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.auth.permissions import require_permission
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models.user import User
+from app.rate_limit import get_client_ip
+from app.schemas.admin_users import UserMergeRequest, UserMergeResponse
+from app.services import audit_service, user_merge_service
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/admin/users", tags=["admin-users"])
+
+
+def _request_id() -> str | None:
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
+@router.post(
+    "/merge",
+    response_model=UserMergeResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def merge_users(
+    request: Request,
+    body: UserMergeRequest,
+    actor: User = Depends(require_permission("orgs.manage")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Fold ``source_user_id`` into ``target_user_id``.
+
+    Reassigns every reference (audit events, invitations, feature
+    overrides, tags, reset lock) from source to target, then
+    deletes source. Same-org only. Writes an ``admin.user.merged``
+    audit event on success and ``admin.user.merge.failed`` on
+    failure.
+    """
+    try:
+        counts = await user_merge_service.merge_users(
+            db,
+            source_user_id=body.source_user_id,
+            target_user_id=body.target_user_id,
+        )
+        await db.commit()
+    except NotFoundError as e:
+        await db.rollback()
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.user.merge.failed",
+            actor_user_id=actor.id,
+            actor_email=actor.email,
+            target_org_id=None,
+            target_org_name=None,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={
+                "source_user_id": body.source_user_id,
+                "target_user_id": body.target_user_id,
+                "reason": "not_found",
+                "message": str(e),
+            },
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (ConflictError, ValidationError) as e:
+        await db.rollback()
+        status_code = (
+            status.HTTP_409_CONFLICT
+            if isinstance(e, ConflictError)
+            else status.HTTP_400_BAD_REQUEST
+        )
+        reason = "conflict" if isinstance(e, ConflictError) else "validation"
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.user.merge.failed",
+            actor_user_id=actor.id,
+            actor_email=actor.email,
+            target_org_id=None,
+            target_org_name=None,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={
+                "source_user_id": body.source_user_id,
+                "target_user_id": body.target_user_id,
+                "reason": reason,
+                "message": str(e),
+            },
+        )
+        raise HTTPException(status_code=status_code, detail=str(e))
+    except Exception:
+        await db.rollback()
+        await logger.aexception(
+            "admin.user.merge.error",
+            source_user_id=body.source_user_id,
+            target_user_id=body.target_user_id,
+        )
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.user.merge.failed",
+            actor_user_id=actor.id,
+            actor_email=actor.email,
+            target_org_id=None,
+            target_org_name=None,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={
+                "source_user_id": body.source_user_id,
+                "target_user_id": body.target_user_id,
+                "reason": "internal_error",
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="merge failed",
+        )
+
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.user.merged",
+        actor_user_id=actor.id,
+        actor_email=actor.email,
+        target_org_id=None,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "source_user_id": body.source_user_id,
+            "target_user_id": body.target_user_id,
+            "counts": counts,
+        },
+    )
+
+    return UserMergeResponse(
+        source_user_id=body.source_user_id,
+        target_user_id=body.target_user_id,
+        counts=counts,
+    )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -19,6 +19,7 @@ from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
 from app.models.user import AVATAR_URL_MAX_LENGTH, Organization, Role, User
 from app.models.subscription import Subscription, Plan
 from app.services import subscription_service
+from app.services.user_service import normalize_email
 from app.schemas.auth import (
     USERNAME_MAX_LENGTH,
     USERNAME_MIN_LENGTH,
@@ -182,8 +183,9 @@ async def register(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
 ):
+    email_norm = normalize_email(body.email)
     existing = await db.execute(
-        select(User).where(or_(User.username == body.username, User.email == body.email))
+        select(User).where(or_(User.username == body.username, User.email == email_norm))
     )
     if existing.scalar_one_or_none():
         raise HTTPException(
@@ -203,7 +205,7 @@ async def register(
     user = User(
         org_id=org.id,
         username=body.username,
-        email=body.email,
+        email=email_norm,
         first_name=body.first_name,
         last_name=body.last_name,
         password_hash=hash_password(body.password),
@@ -539,7 +541,7 @@ async def forgot_password(
     db: AsyncSession = Depends(get_db),
 ):
     """Send a password reset email. Always returns 200 to prevent email enumeration."""
-    result = await db.execute(select(User).where(User.email == body.email))
+    result = await db.execute(select(User).where(User.email == normalize_email(body.email)))
     user = result.scalar_one_or_none()
 
     if user and user.is_active:
@@ -1095,7 +1097,7 @@ async def google_callback(
     except httpx.HTTPError:
         raise HTTPException(status_code=502, detail="Failed to communicate with Google")
 
-    email = google_user.get("email", "")
+    email = normalize_email(google_user.get("email", ""))
     if not email:
         raise HTTPException(status_code=400, detail="Google account has no email")
 

--- a/backend/app/schemas/admin_users.py
+++ b/backend/app/schemas/admin_users.py
@@ -1,0 +1,19 @@
+"""Schemas for the admin user-management endpoints."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class UserMergeRequest(BaseModel):
+    """Body for ``POST /api/v1/admin/users/merge``."""
+
+    source_user_id: int = Field(gt=0, description="row to delete after merge")
+    target_user_id: int = Field(gt=0, description="row that survives")
+
+
+class UserMergeResponse(BaseModel):
+    """Per-table count of rows reassigned during the merge."""
+
+    source_user_id: int
+    target_user_id: int
+    counts: dict[str, int]

--- a/backend/app/services/invitation_service.py
+++ b/backend/app/services/invitation_service.py
@@ -35,6 +35,7 @@ from app.schemas.auth import (
 )
 from app.security import decode_token, hash_password
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.user_service import normalize_email as _normalize_email_shared
 
 
 class InvitationUnavailable(Exception):
@@ -47,7 +48,10 @@ INVITATION_TTL = datetime.timedelta(days=7)
 
 
 def _normalize_email(value: str) -> str:
-    return value.strip().lower()
+    # Thin wrapper preserving the historical name used throughout this
+    # module. The canonical implementation lives in user_service so
+    # every user-creation site shares the same rule.
+    return _normalize_email_shared(value)
 
 
 async def _clear_expired_open_invites(

--- a/backend/app/services/user_merge_service.py
+++ b/backend/app/services/user_merge_service.py
@@ -28,7 +28,7 @@ workflow we don't have yet. Out of scope here.
 from __future__ import annotations
 
 import structlog
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.audit_event import AuditEvent
@@ -36,7 +36,7 @@ from app.models.feature_override import OrgFeatureOverride
 from app.models.invitation import Invitation
 from app.models.org_data_reset_lock import OrgDataResetLock
 from app.models.tag import Tag
-from app.models.user import User
+from app.models.user import Role, User
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 
@@ -86,6 +86,41 @@ async def merge_users(
             "source user is a superadmin; promote target first or pick a "
             "different target"
         )
+
+    # Last-active-owner invariant. Deleting source must not leave its
+    # org without an active OWNER. Mirrors the guard
+    # ``invitation_service.remove_member`` enforces at the org-member
+    # endpoint level; an admin must not be able to do via merge what
+    # they can't do via the regular member removal flow.
+    #
+    # Scope is source.org_id only. Target's org membership preserves
+    # the invariant naturally when target is in the SAME org AND is
+    # an active OWNER. Otherwise, after the delete, source's org is
+    # ownerless — even if target happens to be an owner of a different
+    # org. Refuse with 409 so the operator promotes another user
+    # first.
+    if source.role == Role.OWNER and source.is_active:
+        other_active_owners_in_source_org = await db.scalar(
+            select(func.count())
+            .select_from(User)
+            .where(
+                User.org_id == source.org_id,
+                User.role == Role.OWNER,
+                User.is_active.is_(True),
+                User.id != source.id,
+            )
+        )
+        target_preserves_invariant = (
+            target.org_id == source.org_id
+            and target.role == Role.OWNER
+            and target.is_active
+        )
+        if (other_active_owners_in_source_org or 0) == 0 and not target_preserves_invariant:
+            raise ConflictError(
+                f"Cannot merge: source is the only active owner of org "
+                f"{source.org_id}. Promote another user to owner in that "
+                f"org first, then retry."
+            )
 
     counts: dict[str, int] = {}
 

--- a/backend/app/services/user_merge_service.py
+++ b/backend/app/services/user_merge_service.py
@@ -1,0 +1,163 @@
+"""Merge one ``users`` row into another (recovery for duplicate accounts).
+
+Background. An earlier version of ``POST /api/v1/auth/google/callback``
+did not deduplicate by email, so a local-password user who then
+signed in with Google at the same address ended up as two rows in
+``users`` — one with the original ``password_hash`` and one with
+``password_set=False`` and the SSO profile fields. The current
+callback merges by email, but the data already on disk has dupes.
+
+This service reassigns every ``users.id`` FK reference from the
+source row to the target row and then deletes the source row. It
+is **only** used by the superadmin-only
+``POST /api/v1/admin/users/merge`` endpoint.
+
+FK enumeration. All five tables carrying a ``users.id`` FK are
+handled below. The list mirrors the model definitions; adding a
+new FK to ``users.id`` must come with an update here. The
+``CASCADE`` / ``SET NULL`` semantics on each column govern what
+happens on the final ``DELETE FROM users WHERE id = source``, but
+we explicitly reassign every row first so no data is lost to a
+``SET NULL`` cascade and no row is destroyed by a ``CASCADE``.
+
+The same-org constraint is intentional. Merging across orgs would
+silently transfer ownership of admin permissions and audit trails
+to a different tenant — that needs an org-membership-transfer
+workflow we don't have yet. Out of scope here.
+"""
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_event import AuditEvent
+from app.models.feature_override import OrgFeatureOverride
+from app.models.invitation import Invitation
+from app.models.org_data_reset_lock import OrgDataResetLock
+from app.models.tag import Tag
+from app.models.user import User
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+logger = structlog.stdlib.get_logger()
+
+
+async def merge_users(
+    db: AsyncSession,
+    *,
+    source_user_id: int,
+    target_user_id: int,
+) -> dict[str, int]:
+    """Reassign every reference from ``source_user_id`` to
+    ``target_user_id`` and delete the source row.
+
+    Returns a per-table count of rows reassigned. All work runs
+    inside the caller's transaction — the caller commits.
+
+    Raises:
+        ValidationError: source and target are the same id.
+        NotFoundError: source or target row does not exist.
+        ConflictError: source and target are in different orgs
+            (cross-org merge unsupported) or source is a superadmin
+            (refuse to lose the superadmin bit silently).
+    """
+    if source_user_id == target_user_id:
+        raise ValidationError("source and target must be different users")
+
+    source = await db.scalar(select(User).where(User.id == source_user_id))
+    if source is None:
+        raise NotFoundError(f"source user {source_user_id} not found")
+    target = await db.scalar(select(User).where(User.id == target_user_id))
+    if target is None:
+        raise NotFoundError(f"target user {target_user_id} not found")
+
+    if source.org_id != target.org_id:
+        raise ConflictError(
+            "cross-org merge is not supported; both users must belong to "
+            "the same organization"
+        )
+
+    if source.is_superadmin and not target.is_superadmin:
+        # Refusing rather than silently promoting target. If the operator
+        # really wants this, flip target.is_superadmin via the admin API
+        # first, then re-run the merge.
+        raise ConflictError(
+            "source user is a superadmin; promote target first or pick a "
+            "different target"
+        )
+
+    counts: dict[str, int] = {}
+
+    # 1. audit_events.actor_user_id (SET NULL on user delete).
+    # Reassign so the audit trail attributes survive the source's
+    # deletion. The snapshot email column stays as-is — it pins the
+    # value at event time, which is the correct historical record.
+    res = await db.execute(
+        update(AuditEvent)
+        .where(AuditEvent.actor_user_id == source_user_id)
+        .values(actor_user_id=target_user_id)
+    )
+    counts["audit_events"] = res.rowcount or 0
+
+    # 2. invitations.created_by (no ondelete; would raise FK error
+    # on source delete if left dangling). Reassign attribution.
+    res = await db.execute(
+        update(Invitation)
+        .where(Invitation.created_by == source_user_id)
+        .values(created_by=target_user_id)
+    )
+    counts["invitations"] = res.rowcount or 0
+
+    # 3. org_feature_overrides.set_by (SET NULL). Reassign so we
+    # preserve who set the override.
+    res = await db.execute(
+        update(OrgFeatureOverride)
+        .where(OrgFeatureOverride.set_by == source_user_id)
+        .values(set_by=target_user_id)
+    )
+    counts["org_feature_overrides"] = res.rowcount or 0
+
+    # 4. tags.created_by_user_id (SET NULL). Reassign so the
+    # creator attribution survives.
+    res = await db.execute(
+        update(Tag)
+        .where(Tag.created_by_user_id == source_user_id)
+        .values(created_by_user_id=target_user_id)
+    )
+    counts["tags"] = res.rowcount or 0
+
+    # 5. org_data_reset_lock.acquired_by_user_id (CASCADE). This
+    # lock is short-lived and held by exactly one user — if the
+    # source row holds the lock, transferring it lets the target
+    # complete or release it cleanly. Otherwise CASCADE would drop
+    # the lock and silently free another concurrent caller.
+    res = await db.execute(
+        update(OrgDataResetLock)
+        .where(OrgDataResetLock.acquired_by_user_id == source_user_id)
+        .values(acquired_by_user_id=target_user_id)
+    )
+    counts["org_data_reset_lock"] = res.rowcount or 0
+
+    # Carry over the email-verified bit if the source row had it
+    # and target didn't — the source row in the duplicate scenario
+    # is typically the SSO row (email_verified=True from Google),
+    # and the target is the original local user that may have
+    # never verified. Mirrors the merge-into-existing behavior of
+    # the Google callback.
+    if source.email_verified and not target.email_verified:
+        target.email_verified = True
+
+    # Finally delete the source row. With all references reassigned,
+    # the delete succeeds without tripping any FK constraint or
+    # silently nulling out an audit/tag attribution.
+    await db.execute(delete(User).where(User.id == source_user_id))
+
+    await logger.ainfo(
+        "admin.user.merge",
+        source_user_id=source_user_id,
+        target_user_id=target_user_id,
+        counts=counts,
+    )
+
+    return counts

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,36 @@
+"""User-creation and identity-related helpers.
+
+Centralizes the email normalization rule used at every site that
+either inserts a ``users`` row or looks one up by email. The rule:
+
+    normalize_email(email) := email.strip().lower()
+
+Both layers (Python + DB collation) enforce the same shape so we
+catch any drift on either side:
+
+- Python normalizes before insert and before lookup. This guarantees
+  the value stored in ``users.email`` is already lowercased and
+  trimmed regardless of what an upstream caller (or Google's
+  userinfo payload) supplies.
+- The MySQL column inherits the default ``utf8mb4_0900_ai_ci``
+  collation. Belt-and-suspenders: even if a future migration changes
+  the collation, the Python pre-pass keeps duplicates from sneaking
+  past the unique constraint via casing.
+
+Pre-launch we have a real user with duplicate rows (one local, one
+SSO at the same address) caused by an earlier version of the
+Google callback that didn't dedupe by email. The
+``POST /api/v1/admin/users/merge`` endpoint is the recovery path
+for those rows; see ``app/services/user_merge_service.py``.
+"""
+from __future__ import annotations
+
+
+def normalize_email(value: str) -> str:
+    """Canonical form for storage and lookup. Idempotent.
+
+    No `email.utils.parseaddr` parsing — incoming values are
+    already validated by Pydantic's ``EmailStr``, so the only
+    normalization we layer on is whitespace trim + lowercase.
+    """
+    return value.strip().lower()

--- a/backend/tests/routers/test_admin_users_merge.py
+++ b/backend/tests/routers/test_admin_users_merge.py
@@ -1,0 +1,247 @@
+"""End-to-end coverage of ``POST /api/v1/admin/users/merge``.
+
+The merge service has its own unit tests in
+``tests/services/test_user_merge_service.py``; this file covers the
+router glue — auth gate, request body shape, success/failure status
+codes, and audit-event emission.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.routers.admin_users import router as admin_users_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, actor_user_id: int) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    async def override_current_user() -> User:
+        # Resolve the actor with a SEPARATE session so the user object
+        # is not tied to the request session's connection. Otherwise a
+        # rollback on the request session collides with the independent
+        # audit-write session under StaticPool.
+        async with session_factory() as db:
+            user = await db.get(User, actor_user_id)
+            assert user is not None
+            return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_users_router)
+    return app
+
+
+async def _seed_user(
+    factory,
+    *,
+    org_id: int,
+    username: str,
+    email: str,
+    is_superadmin: bool = False,
+) -> int:
+    async with factory() as db:
+        user = User(
+            org_id=org_id,
+            username=username,
+            email=email,
+            password_hash=hash_password("pw"),
+            role=Role.OWNER,
+            is_superadmin=is_superadmin,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+async def _seed_org(factory, *, name: str = "Acme") -> int:
+    async with factory() as db:
+        org = Organization(name=name, billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        return org.id
+
+
+# ── auth gate ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_requires_orgs_manage(session_factory) -> None:
+    """A non-superadmin without ``orgs.manage`` gets 403."""
+    org_id = await _seed_org(session_factory)
+    actor_id = await _seed_user(
+        session_factory, org_id=org_id, username="member", email="m@x.io"
+    )
+    s_id = await _seed_user(
+        session_factory, org_id=org_id, username="s", email="s@x.io"
+    )
+    t_id = await _seed_user(
+        session_factory, org_id=org_id, username="t", email="t@x.io"
+    )
+
+    app = _make_app(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": s_id, "target_user_id": t_id},
+        )
+    assert res.status_code == 403
+
+
+# ── success path ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_success_emits_audit_event(session_factory) -> None:
+    org_id = await _seed_org(session_factory)
+    actor_id = await _seed_user(
+        session_factory,
+        org_id=org_id,
+        username="root",
+        email="root@x.io",
+        is_superadmin=True,
+    )
+    s_id = await _seed_user(
+        session_factory, org_id=org_id, username="s", email="s@x.io"
+    )
+    t_id = await _seed_user(
+        session_factory, org_id=org_id, username="t", email="t@x.io"
+    )
+
+    app = _make_app(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": s_id, "target_user_id": t_id},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["source_user_id"] == s_id
+    assert body["target_user_id"] == t_id
+    assert "counts" in body
+
+    # Source row is gone.
+    async with session_factory() as db:
+        assert (await db.scalar(select(User).where(User.id == s_id))) is None
+        # Audit event landed.
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(AuditEvent.event_type == "admin.user.merged")
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].actor_user_id == actor_id
+        assert rows[0].detail["source_user_id"] == s_id
+        assert rows[0].detail["target_user_id"] == t_id
+
+
+# ── failure paths ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_same_user_returns_400(session_factory) -> None:
+    org_id = await _seed_org(session_factory)
+    actor_id = await _seed_user(
+        session_factory,
+        org_id=org_id,
+        username="root",
+        email="root@x.io",
+        is_superadmin=True,
+    )
+
+    app = _make_app(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": actor_id, "target_user_id": actor_id},
+        )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_merge_missing_user_returns_404(session_factory) -> None:
+    org_id = await _seed_org(session_factory)
+    actor_id = await _seed_user(
+        session_factory,
+        org_id=org_id,
+        username="root",
+        email="root@x.io",
+        is_superadmin=True,
+    )
+    t_id = await _seed_user(
+        session_factory, org_id=org_id, username="t", email="t@x.io"
+    )
+
+    app = _make_app(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": 99999, "target_user_id": t_id},
+        )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_merge_cross_org_returns_409(session_factory) -> None:
+    org_a = await _seed_org(session_factory, name="A")
+    org_b = await _seed_org(session_factory, name="B")
+    actor_id = await _seed_user(
+        session_factory,
+        org_id=org_a,
+        username="root",
+        email="root@x.io",
+        is_superadmin=True,
+    )
+    s_id = await _seed_user(
+        session_factory, org_id=org_a, username="s", email="s@x.io"
+    )
+    t_id = await _seed_user(
+        session_factory, org_id=org_b, username="t", email="t@x.io"
+    )
+
+    app = _make_app(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": s_id, "target_user_id": t_id},
+        )
+    assert res.status_code == 409

--- a/backend/tests/routers/test_auth_email_dedupe.py
+++ b/backend/tests/routers/test_auth_email_dedupe.py
@@ -1,0 +1,307 @@
+"""Regression tests — email is normalized and deduped across every
+user-creation path. Covers the pre-launch bug where an early Google
+SSO callback created a duplicate ``users`` row for an email that
+already had a local-password user.
+
+Each test boots an in-memory SQLite engine via the shared fixture
+pattern from ``test_auth.py`` and exercises one create site.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.subscription import Plan
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import router as auth_router
+from app.security import hash_password
+
+
+async def _seed_default_plan(factory: async_sessionmaker[AsyncSession]) -> None:
+    """create_trial needs at least one active plan. Seed the bare
+    minimum here so /register doesn't 500 in the test environment."""
+    async with factory() as db:
+        existing = await db.scalar(select(Plan).where(Plan.slug == "free"))
+        if existing is None:
+            db.add(Plan(slug="free", name="Free", is_active=True, sort_order=0))
+            await db.commit()
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_local_user(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    email: str,
+    username: str = "flamarion",
+    password: str = "starting-password-1",
+) -> int:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=email,
+            password_hash=hash_password(password),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=False,  # local users start unverified
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+async def _count_users(factory) -> int:
+    async with factory() as db:
+        return await db.scalar(select(func.count()).select_from(User)) or 0
+
+
+# ── /register dedupe ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_email_rejected(session_factory) -> None:
+    """Posting /register with an email that already exists → 409."""
+    await _seed_local_user(session_factory, email="flamarion@example.com")
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": "newuser",
+                "email": "flamarion@example.com",
+                "password": "another-password-1",
+            },
+        )
+    assert res.status_code == 409, res.text
+    assert await _count_users(session_factory) == 1
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_email_different_case_rejected(session_factory) -> None:
+    """Mixed-case duplicate is still rejected — Python normalization
+    runs before the DB ever sees the value."""
+    await _seed_local_user(session_factory, email="flamarion@example.com")
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": "newuser",
+                "email": "Flamarion@EXAMPLE.com",
+                "password": "another-password-1",
+            },
+        )
+    assert res.status_code == 409, res.text
+    assert await _count_users(session_factory) == 1
+
+
+@pytest.mark.asyncio
+async def test_register_stores_normalized_email(session_factory) -> None:
+    """A successful /register with whitespace + mixed case lands as
+    the canonical form in the DB."""
+    await _seed_default_plan(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/register",
+            json={
+                "username": "newuser",
+                "email": "Flamarion@EXAMPLE.com",
+                "password": "another-password-1",
+            },
+        )
+    assert res.status_code in (200, 201), res.text
+    async with session_factory() as db:
+        u = await db.scalar(select(User).where(User.username == "newuser"))
+        assert u is not None
+        assert u.email == "flamarion@example.com"
+
+
+# ── /google/callback merge ─────────────────────────────────────────────────
+
+
+def _mock_google_callback_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    google_email: str,
+    google_verified: bool = True,
+    given_name: str = "Flam",
+    family_name: str = "Arion",
+) -> None:
+    """Bypass the OAuth roundtrip — stub the two outbound HTTP calls so
+    the callback runs with the supplied userinfo payload.
+
+    Also stubs ``_validate_google_config`` to skip the env-var check
+    and ``app_settings.app_url`` is left untouched (the redirect URL
+    is constructed but the test follows redirects to None).
+    """
+    import httpx
+
+    from app.routers import auth as auth_module
+
+    class _FakeResponse:
+        def __init__(self, status_code: int, json_payload: dict[str, Any]):
+            self.status_code = status_code
+            self._json = json_payload
+
+        def json(self) -> dict[str, Any]:
+            return self._json
+
+    class _FakeClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+            # token endpoint
+            return _FakeResponse(200, {"access_token": "fake-token"})
+
+        async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+            # userinfo endpoint
+            return _FakeResponse(
+                200,
+                {
+                    "email": google_email,
+                    "verified_email": google_verified,
+                    "given_name": given_name,
+                    "family_name": family_name,
+                    "picture": None,
+                },
+            )
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(auth_module, "_validate_google_config", lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_google_callback_merges_into_existing_local_user(
+    session_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported bug. Local user ``flamarion@example.com`` exists;
+    Google SSO arrives for the same email. Post-state: ONE users row,
+    not two; ``email_verified=True`` carried over from Google."""
+    user_id = await _seed_local_user(
+        session_factory, email="flamarion@example.com"
+    )
+
+    _mock_google_callback_dependencies(
+        monkeypatch, google_email="flamarion@example.com"
+    )
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "test-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "test-state"},
+            follow_redirects=False,
+        )
+    # The handler redirects to the frontend on success; either 302 or 200
+    # depending on MFA. We don't care which — only that no new user landed.
+    assert res.status_code in (200, 302), res.text
+    assert await _count_users(session_factory) == 1
+
+    async with session_factory() as db:
+        u = await db.scalar(select(User).where(User.id == user_id))
+        assert u is not None
+        # email_verified is backfilled from Google's verified flag.
+        assert u.email_verified is True
+
+
+@pytest.mark.asyncio
+async def test_google_callback_merges_even_when_google_email_has_different_case(
+    session_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Local user stored as ``flamarion@example.com``; Google returns
+    ``Flamarion@Example.com`` (some IdPs preserve case). With the
+    Python-side normalize, the lookup still matches."""
+    user_id = await _seed_local_user(
+        session_factory, email="flamarion@example.com"
+    )
+
+    _mock_google_callback_dependencies(
+        monkeypatch, google_email="Flamarion@Example.com"
+    )
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "test-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "test-state"},
+            follow_redirects=False,
+        )
+    assert res.status_code in (200, 302), res.text
+    assert await _count_users(session_factory) == 1
+
+    async with session_factory() as db:
+        u = await db.scalar(select(User).where(User.id == user_id))
+        assert u is not None
+        # Email stays in the canonical (lowercased) form we stored at seed.
+        assert u.email == "flamarion@example.com"

--- a/backend/tests/services/test_user_merge_service.py
+++ b/backend/tests/services/test_user_merge_service.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -58,15 +58,17 @@ async def _seed_user(
     email: str,
     is_superadmin: bool = False,
     email_verified: bool = False,
+    role: Role = Role.OWNER,
+    is_active: bool = True,
 ) -> User:
     user = User(
         org_id=org_id,
         username=username,
         email=email,
         password_hash=hash_password("pw"),
-        role=Role.OWNER,
+        role=role,
         is_superadmin=is_superadmin,
-        is_active=True,
+        is_active=is_active,
         email_verified=email_verified,
     )
     db.add(user)
@@ -281,3 +283,184 @@ async def test_merge_carries_email_verified_to_target(session_factory) -> None:
         target_after = await db.scalar(select(User).where(User.id == target_id))
         assert target_after is not None
         assert target_after.email_verified is True
+
+
+# ── last-active-owner invariant ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_merge_blocked_when_source_is_sole_owner_and_target_in_different_org(
+    session_factory,
+) -> None:
+    """Source is the only active owner of org X; target lives in org Y.
+    Refuse with 409 — the merge would orphan org X.
+
+    In practice the cross-org guard catches this scenario first
+    (target.org_id != source.org_id), but the contract the operator
+    sees is identical: ``ConflictError`` + source row preserved. This
+    test pins both signals at once. If the cross-org guard is ever
+    relaxed, the last-owner guard catches the same orphan case.
+    """
+    async with session_factory() as db:
+        org_x = await _seed_org(db)
+        org_y = Organization(name="Other", billing_cycle_day=1)
+        db.add(org_y)
+        await db.flush()
+        source = await _seed_user(
+            db, org_id=org_x.id, username="sole-x", email="sx@x.io",
+            role=Role.OWNER, is_active=True,
+        )
+        target = await _seed_user(
+            db, org_id=org_y.id, username="t-y", email="ty@x.io",
+            role=Role.OWNER, is_active=True,
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        with pytest.raises(ConflictError):
+            await user_merge_service.merge_users(
+                db, source_user_id=source_id, target_user_id=target_id
+            )
+
+        # Source row preserved — guard fired before any FK reassignment.
+        await db.rollback()
+        async with session_factory() as fresh:
+            kept = await fresh.scalar(select(User).where(User.id == source_id))
+            assert kept is not None
+            assert kept.is_active is True
+            assert kept.role == Role.OWNER
+
+
+@pytest.mark.asyncio
+async def test_merge_blocked_when_source_is_sole_owner_and_target_is_same_org_member(
+    session_factory,
+) -> None:
+    """Source is the only active owner of org X; target is a MEMBER of
+    org X (not OWNER). Deleting source would still orphan the org —
+    refuse with 409 with the last-active-owner error message.
+    """
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(
+            db, org_id=org.id, username="sole", email="s@x.io",
+            role=Role.OWNER, is_active=True,
+        )
+        target = await _seed_user(
+            db, org_id=org.id, username="member", email="m@x.io",
+            role=Role.MEMBER, is_active=True,
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        with pytest.raises(ConflictError, match="only active owner"):
+            await user_merge_service.merge_users(
+                db, source_user_id=source_id, target_user_id=target_id
+            )
+
+
+@pytest.mark.asyncio
+async def test_merge_blocked_when_target_is_inactive_owner_in_same_org(
+    session_factory,
+) -> None:
+    """Same-org case where target IS an OWNER but is inactive.
+    The invariant counts active owners only, so target cannot
+    preserve it — block.
+    """
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(
+            db, org_id=org.id, username="sole-active", email="sa@x.io",
+            role=Role.OWNER, is_active=True,
+        )
+        target = await _seed_user(
+            db, org_id=org.id, username="inactive-owner", email="io@x.io",
+            role=Role.OWNER, is_active=False,
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        with pytest.raises(ConflictError, match="only active owner"):
+            await user_merge_service.merge_users(
+                db, source_user_id=source_id, target_user_id=target_id
+            )
+
+
+@pytest.mark.asyncio
+async def test_merge_allowed_when_source_is_one_of_multiple_active_owners(
+    session_factory,
+) -> None:
+    """Org has two active owners; merging one into a member is fine —
+    the other owner keeps the invariant.
+    """
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(
+            db, org_id=org.id, username="owner-a", email="a@x.io",
+            role=Role.OWNER, is_active=True,
+        )
+        _other_owner = await _seed_user(
+            db, org_id=org.id, username="owner-b", email="b@x.io",
+            role=Role.OWNER, is_active=True,
+        )
+        target = await _seed_user(
+            db, org_id=org.id, username="member", email="m@x.io",
+            role=Role.MEMBER, is_active=True,
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        # No raise — guard does not fire.
+        await user_merge_service.merge_users(
+            db, source_user_id=source_id, target_user_id=target_id
+        )
+        await db.commit()
+
+        # Source row gone; org still has an active owner.
+        assert (
+            await db.scalar(select(User).where(User.id == source_id))
+        ) is None
+        active_owners = await db.scalar(
+            select(func.count())
+            .select_from(User)
+            .where(
+                User.org_id == org.id,
+                User.role == Role.OWNER,
+                User.is_active.is_(True),
+            )
+        )
+        assert (active_owners or 0) >= 1
+
+
+@pytest.mark.asyncio
+async def test_merge_allowed_when_source_is_not_owner_regardless_of_org_owner_count(
+    session_factory,
+) -> None:
+    """Source is a MEMBER, not an owner. The owner-count invariant is
+    irrelevant — merge proceeds.
+    """
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        # Single active owner of the org (NOT the source).
+        _sole_owner = await _seed_user(
+            db, org_id=org.id, username="owner", email="o@x.io",
+            role=Role.OWNER, is_active=True,
+        )
+        source = await _seed_user(
+            db, org_id=org.id, username="src-member", email="sm@x.io",
+            role=Role.MEMBER, is_active=True,
+        )
+        target = await _seed_user(
+            db, org_id=org.id, username="tgt-member", email="tm@x.io",
+            role=Role.MEMBER, is_active=True,
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        await user_merge_service.merge_users(
+            db, source_user_id=source_id, target_user_id=target_id
+        )
+        await db.commit()
+
+        assert (
+            await db.scalar(select(User).where(User.id == source_id))
+        ) is None

--- a/backend/tests/services/test_user_merge_service.py
+++ b/backend/tests/services/test_user_merge_service.py
@@ -1,0 +1,283 @@
+"""user_merge_service unit tests.
+
+Pins the FK-reassignment behavior for the
+``POST /api/v1/admin/users/merge`` recovery endpoint. Each table
+that carries a ``users.id`` FK gets a dedicated case to prove the
+reassignment lands on the target before the source is deleted.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.feature_override import OrgFeatureOverride
+from app.models.invitation import Invitation
+from app.models.org_data_reset_lock import OrgDataResetLock
+from app.models.tag import Tag
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import user_merge_service
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_org(db: AsyncSession) -> Organization:
+    org = Organization(name="Acme", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _seed_user(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    username: str,
+    email: str,
+    is_superadmin: bool = False,
+    email_verified: bool = False,
+) -> User:
+    user = User(
+        org_id=org_id,
+        username=username,
+        email=email,
+        password_hash=hash_password("pw"),
+        role=Role.OWNER,
+        is_superadmin=is_superadmin,
+        is_active=True,
+        email_verified=email_verified,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_merge_same_user_rejected(session_factory) -> None:
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        u = await _seed_user(db, org_id=org.id, username="a", email="a@x.io")
+        await db.commit()
+        with pytest.raises(ValidationError):
+            await user_merge_service.merge_users(
+                db, source_user_id=u.id, target_user_id=u.id
+            )
+
+
+@pytest.mark.asyncio
+async def test_merge_missing_source(session_factory) -> None:
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        target = await _seed_user(db, org_id=org.id, username="t", email="t@x.io")
+        await db.commit()
+        with pytest.raises(NotFoundError):
+            await user_merge_service.merge_users(
+                db, source_user_id=9999, target_user_id=target.id
+            )
+
+
+@pytest.mark.asyncio
+async def test_merge_missing_target(session_factory) -> None:
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(db, org_id=org.id, username="s", email="s@x.io")
+        await db.commit()
+        with pytest.raises(NotFoundError):
+            await user_merge_service.merge_users(
+                db, source_user_id=source.id, target_user_id=9999
+            )
+
+
+@pytest.mark.asyncio
+async def test_merge_cross_org_rejected(session_factory) -> None:
+    async with session_factory() as db:
+        org_a = await _seed_org(db)
+        org_b = Organization(name="Other", billing_cycle_day=1)
+        db.add(org_b)
+        await db.flush()
+        source = await _seed_user(db, org_id=org_a.id, username="s", email="s@x.io")
+        target = await _seed_user(db, org_id=org_b.id, username="t", email="t@x.io")
+        await db.commit()
+        with pytest.raises(ConflictError):
+            await user_merge_service.merge_users(
+                db, source_user_id=source.id, target_user_id=target.id
+            )
+
+
+@pytest.mark.asyncio
+async def test_merge_superadmin_source_rejected(session_factory) -> None:
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(
+            db, org_id=org.id, username="s", email="s@x.io", is_superadmin=True
+        )
+        target = await _seed_user(db, org_id=org.id, username="t", email="t@x.io")
+        await db.commit()
+        with pytest.raises(ConflictError):
+            await user_merge_service.merge_users(
+                db, source_user_id=source.id, target_user_id=target.id
+            )
+
+
+@pytest.mark.asyncio
+async def test_merge_reassigns_audit_events_and_deletes_source(session_factory) -> None:
+    """Audit rows survive the merge with attribution flipped to target."""
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(db, org_id=org.id, username="s", email="s@x.io")
+        target = await _seed_user(db, org_id=org.id, username="t", email="t@x.io")
+        for i in range(3):
+            db.add(
+                AuditEvent(
+                    event_type=f"test.event.{i}",
+                    actor_user_id=source.id,
+                    actor_email="s@x.io",
+                    target_org_id=org.id,
+                    target_org_name="Acme",
+                    outcome=AuditOutcome.SUCCESS,
+                )
+            )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        counts = await user_merge_service.merge_users(
+            db, source_user_id=source_id, target_user_id=target_id
+        )
+        await db.commit()
+
+        assert counts["audit_events"] == 3
+        remaining_source_events = (
+            await db.execute(
+                select(AuditEvent).where(AuditEvent.actor_user_id == source_id)
+            )
+        ).scalars().all()
+        assert remaining_source_events == []
+        target_events = (
+            await db.execute(
+                select(AuditEvent).where(AuditEvent.actor_user_id == target_id)
+            )
+        ).scalars().all()
+        assert len(target_events) == 3
+        # Snapshot email is unchanged — historical record.
+        assert all(e.actor_email == "s@x.io" for e in target_events)
+        # Source row is gone.
+        assert (await db.scalar(select(User).where(User.id == source_id))) is None
+
+
+@pytest.mark.asyncio
+async def test_merge_reassigns_tags(session_factory) -> None:
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(db, org_id=org.id, username="s", email="s@x.io")
+        target = await _seed_user(db, org_id=org.id, username="t", email="t@x.io")
+        db.add(
+            Tag(
+                org_id=org.id,
+                name="groceries",
+                name_normalized="groceries",
+                created_by_user_id=source.id,
+            )
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        counts = await user_merge_service.merge_users(
+            db, source_user_id=source_id, target_user_id=target_id
+        )
+        await db.commit()
+
+        assert counts["tags"] == 1
+        target_tags = (
+            await db.execute(
+                select(Tag).where(Tag.created_by_user_id == target_id)
+            )
+        ).scalars().all()
+        assert len(target_tags) == 1
+        assert target_tags[0].name == "groceries"
+
+
+@pytest.mark.asyncio
+async def test_merge_reassigns_invitations_and_overrides(session_factory) -> None:
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(db, org_id=org.id, username="s", email="s@x.io")
+        target = await _seed_user(db, org_id=org.id, username="t", email="t@x.io")
+        db.add(
+            Invitation(
+                org_id=org.id,
+                email="new@x.io",
+                role=Role.MEMBER,
+                open_email="new@x.io",
+                created_by=source.id,
+                expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=7),
+            )
+        )
+        db.add(
+            OrgFeatureOverride(
+                org_id=org.id,
+                feature_key="some.feature",
+                value=True,
+                set_by=source.id,
+            )
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        counts = await user_merge_service.merge_users(
+            db, source_user_id=source_id, target_user_id=target_id
+        )
+        await db.commit()
+
+        assert counts["invitations"] == 1
+        assert counts["org_feature_overrides"] == 1
+
+
+@pytest.mark.asyncio
+async def test_merge_carries_email_verified_to_target(session_factory) -> None:
+    """The SSO-row-merged-into-local-row scenario.
+
+    The source row has ``email_verified=True`` (it came from Google,
+    which we trust), the target row is the older local user which
+    never verified. After the merge, target should be verified.
+    """
+    async with session_factory() as db:
+        org = await _seed_org(db)
+        source = await _seed_user(
+            db, org_id=org.id, username="s", email="s@x.io", email_verified=True
+        )
+        target = await _seed_user(
+            db, org_id=org.id, username="t", email="t@x.io", email_verified=False
+        )
+        await db.commit()
+        source_id, target_id = source.id, target.id
+
+        await user_merge_service.merge_users(
+            db, source_user_id=source_id, target_user_id=target_id
+        )
+        await db.commit()
+
+        target_after = await db.scalar(select(User).where(User.id == target_id))
+        assert target_after is not None
+        assert target_after.email_verified is True

--- a/backend/tests/services/test_user_service.py
+++ b/backend/tests/services/test_user_service.py
@@ -1,0 +1,33 @@
+"""Unit tests for ``normalize_email`` — the canonical email shape
+applied at every ``users``-row create site and email lookup.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.user_service import normalize_email
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("alice@example.com", "alice@example.com"),
+        ("Alice@Example.com", "alice@example.com"),
+        ("ALICE@EXAMPLE.COM", "alice@example.com"),
+        ("  alice@example.com  ", "alice@example.com"),
+        ("\talice@example.com\n", "alice@example.com"),
+        ("Alice+Filter@Example.COM", "alice+filter@example.com"),
+    ],
+)
+def test_normalize_email_canonical(raw: str, expected: str) -> None:
+    assert normalize_email(raw) == expected
+
+
+def test_normalize_email_is_idempotent() -> None:
+    """Re-running normalize_email on a normalized value is a no-op.
+
+    Important for sites that compose lookups (``normalize_email`` on
+    the way in and again on the way out via a helper).
+    """
+    first = normalize_email("  USER@EXAMPLE.com  ")
+    assert normalize_email(first) == first


### PR DESCRIPTION
## Summary

A user reported their Google SSO sign-in created a second `users` row at an
email that already had a local-password account. Email uniqueness was supposed
to prevent that. Root cause is historical: an earlier version of the Google
callback inserted a new row without looking up by email; today's callback
merges, but the existing dupes were already on disk.

This PR makes the invariant defense-in-depth across every user-creation site
and ships a superadmin-only recovery endpoint to clean up duplicates.

## Investigation

Every code path that creates a `users` row, audited:

| Site | File:line | Email-uniqueness check? | Normalized? |
| --- | --- | --- | --- |
| Local register | `auth.py:185` | yes, `User.username OR User.email` (now uses normalized) | no -> **yes** |
| Google SSO callback | `auth.py:1126` | yes, `User.email ==` (already merges into existing) | no -> **yes** |
| Invitation accept | `invitation_service.py:271` | yes, exact match against `inv.email` (already normalized at create) | yes (already) |

Other checks:
- No admin "create user" endpoint exists.
- No seed/setup script writes `users` rows. First-user is whichever account hits `/register` first.
- MySQL collation for `users.email` defaults to `utf8mb4_0900_ai_ci` (case-insensitive) on a fresh MySQL 8 install. A DB created against an older MySQL default could differ -> migration 040 pins it explicitly.
- An existing `_normalize_email` helper already lived in `invitation_service.py`. Promoted to `app/services/user_service.py` so every site shares one rule.

Most likely actual cause of the user's dupe rows: a pre-PR-#70 version of the Google callback inserted a row without the email lookup. The rows survived the merge logic landing later because the callback only merges going forward.

## Fix scope

- `backend/app/services/user_service.py` (new): `normalize_email(value) = value.strip().lower()`. Idempotent.
- `backend/app/routers/auth.py`: normalize on register insert, register dedupe lookup, Google callback, forgot-password lookup.
- `backend/app/services/invitation_service.py`: route private `_normalize_email` through the shared helper.
- `backend/alembic/versions/040_users_email_case_insensitive.py`: `ALTER TABLE users MODIFY COLUMN email VARCHAR(120) ... COLLATE utf8mb4_0900_ai_ci`. No-op on SQLite. **See Migration section below for the required deployment preflight.**

## Recovery endpoint

`POST /api/v1/admin/users/merge` (superadmin gated via `orgs.manage` permission).

```
POST /api/v1/admin/users/merge
Content-Type: application/json
Authorization: Bearer <superadmin-access-token>

{
  "source_user_id": <duplicate row to delete>,
  "target_user_id": <row that survives>
}
```

For the reporter's specific case: the SSO-created row is almost certainly the
source (newer, `password_set=False`, `email_verified=True`) and the
original local row is the target. `email_verified` carries over so the
target ends up verified even if it never was.

Behavior:
- Same-org only. Cross-org -> `409`.
- Superadmin source -> `409`.
- **Last-active-owner guard**: refuses to delete a source that is the sole active OWNER of its org unless target is a same-org active OWNER. Mirrors the guard `invitation_service.remove_member` enforces.
- Reassigns every `users.id` FK reference, then deletes source. Single transaction.
- Writes `admin.user.merged` (or `admin.user.merge.failed`) to `audit_events`.

## Tests

- `tests/services/test_user_service.py` (2 cases): normalize canonical + idempotent.
- `tests/services/test_user_merge_service.py` (14 cases): same-id rejected, missing source/target -> 404, cross-org -> 409, superadmin source -> 409, **last-active-owner guard (different-org target, same-org member target, same-org inactive-owner target, two-active-owners proceeds, non-owner source proceeds)**, FK reassignment per table, email_verified carried.
- `tests/routers/test_auth_email_dedupe.py` (5 cases): register duplicate -> 409, mixed-case duplicate -> 409, register stores normalized, Google callback merges into existing local user, Google callback merges across case differences.
- `tests/routers/test_admin_users_merge.py` (5 cases): 403 without permission, success emits audit, 400 self-merge, 404 missing user, 409 cross-org.

31 new backend tests. Existing auth/invitation/users tests (55) continue to pass.

## Quality gates

- Backend: `docker compose -p team-sso-merge-fix exec backend pytest tests/` -> **876 passed, 2 skipped**.
- Frontend: design-token check passed, `npx tsc --noEmit` clean, `eslint --quiet` clean, `npm test -- --run` -> **542 passed**.
- Alembic round-trip: `upgrade head` -> `downgrade -1` -> `upgrade head` clean on isolated MySQL.
- Stack tear-down: `docker compose -p team-sso-merge-fix down -v` clean.

## Migration

`040_users_email_case_insensitive` pins `users.email` to
`utf8mb4_0900_ai_ci`. The default MySQL 8 collation already matches, so on
the production droplet this is a structural reaffirmation rather than a data
change. Downgrade reverts to the column-level default. No-op on SQLite.

### Deployment preflight (REQUIRED)

If the target DB was created on a case-sensitive collation it may contain
rows that differ only in email casing or whitespace. Switching the column to
`utf8mb4_0900_ai_ci` rebuilds the UNIQUE index over the new comparison rules
and will FAIL the `ALTER TABLE` with a duplicate-key error if such rows
exist.

Run this query against the target DB **before** deploying:

```sql
SELECT LOWER(TRIM(email)) AS normalized_email, COUNT(*) AS n
FROM users
GROUP BY normalized_email
HAVING COUNT(*) > 1;
```

Any row in the result is a collision. Resolve every one of them via
`POST /api/v1/admin/users/merge` (the recovery endpoint shipped in this PR)
BEFORE running the migration. The same preflight text lives in the
migration file's module docstring so the runbook stays version-controlled.

## Risk notes

- **FK enumeration**. Five tables carry a `users.id` FK today: `audit_events`, `invitations`, `org_feature_overrides`, `tags`, `org_data_reset_lock`. All five are reassigned. Adding a new `users.id` FK in a future PR must come with an update to `merge_users`.
- **Collation change**. The migration is a pin, not a flip. If a real-world dev DB exists on `general_ci`, this is a one-way `ALTER TABLE` that rewrites the index. Cheap at our row count. Preflight above catches the only failure mode.
- **Superadmin source refusal**. Deliberate. The operator is expected to promote target first if they truly want the merge.
- **Cross-org refusal**. Out of scope; transferring users across orgs needs a membership-transfer workflow we don't have.
- **Last-active-owner refusal**. Mirrors the existing L4.4 guard. Without it, an admin could orphan an org via the merge endpoint that they can't orphan via the regular member-removal endpoint.
