### PR TITLE
fix(admin): snapshot actor before commit/rollback in users merge

### DIFF
--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -55,6 +55,15 @@ async def merge_users(
     audit event on success and ``admin.user.merge.failed`` on
     failure.
     """
+    # Snapshot actor identity BEFORE any commit/rollback. SQLAlchemy
+    # expires ORM attributes on commit/rollback; subsequent
+    # ``actor.id`` / ``actor.email`` access would trigger a lazy
+    # load, which raises ``MissingGreenlet`` outside the greenlet
+    # context the audit-write opens — turning every error path into
+    # a 500 and breaking the success-path audit row too.
+    actor_id = actor.id
+    actor_email = actor.email
+
     try:
         counts = await user_merge_service.merge_users(
             db,
@@ -67,8 +76,8 @@ async def merge_users(
         await audit_service.record_audit_event(
             session_factory,
             event_type="admin.user.merge.failed",
-            actor_user_id=actor.id,
-            actor_email=actor.email,
+            actor_user_id=actor_id,
+            actor_email=actor_email,
             target_org_id=None,
             target_org_name=None,
             request_id=_request_id(),
@@ -93,8 +102,8 @@ async def merge_users(
         await audit_service.record_audit_event(
             session_factory,
             event_type="admin.user.merge.failed",
-            actor_user_id=actor.id,
-            actor_email=actor.email,
+            actor_user_id=actor_id,
+            actor_email=actor_email,
             target_org_id=None,
             target_org_name=None,
             request_id=_request_id(),
@@ -118,8 +127,8 @@ async def merge_users(
         await audit_service.record_audit_event(
             session_factory,
             event_type="admin.user.merge.failed",
-            actor_user_id=actor.id,
-            actor_email=actor.email,
+            actor_user_id=actor_id,
+            actor_email=actor_email,
             target_org_id=None,
             target_org_name=None,
             request_id=_request_id(),
@@ -139,8 +148,8 @@ async def merge_users(
     await audit_service.record_audit_event(
         session_factory,
         event_type="admin.user.merged",
-        actor_user_id=actor.id,
-        actor_email=actor.email,
+        actor_user_id=actor_id,
+        actor_email=actor_email,
         target_org_id=None,
         target_org_name=None,
         request_id=_request_id(),

--- a/backend/tests/routers/test_admin_users_merge.py
+++ b/backend/tests/routers/test_admin_users_merge.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -245,3 +245,203 @@ async def test_merge_cross_org_returns_409(session_factory) -> None:
             json={"source_user_id": s_id, "target_user_id": t_id},
         )
     assert res.status_code == 409
+
+
+# ── actor-snapshot regression coverage (post-#222) ────────────────────────
+#
+# In production, ``get_current_user`` resolves ``actor`` through the same
+# ``AsyncSession`` the request handler uses as ``db``. SQLAlchemy expires
+# every instance attached to a session on ``rollback()`` regardless of the
+# ``expire_on_commit`` flag, so any later ``actor.id`` / ``actor.email``
+# access triggers a lazy load — and in async that needs the greenlet
+# context the audit-write does not provide, raising ``MissingGreenlet``
+# and turning every error path into a 500. The router fix snapshots
+# ``actor_id`` / ``actor_email`` into locals before the first commit or
+# rollback. These tests share the actor's session with the request to
+# mirror production and prove the snapshot keeps the audit-write path
+# happy on the 400 / 409 / 200 branches.
+
+
+def _make_app_shared_session(session_factory, actor_user_id: int) -> FastAPI:
+    """Like ``_make_app`` but the actor is loaded through the SAME
+    session that the request handler uses as ``db``. This reproduces
+    production where ``get_current_user`` and the route share one
+    session, so a ``db.rollback()`` expires ``actor`` in place."""
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    async def override_current_user(
+        db: AsyncSession = Depends(get_db),
+    ) -> User:
+        # Pull the actor through the same session FastAPI will pass to
+        # the route as ``db``. FastAPI caches sub-dependency results
+        # per request by callable identity — depending on ``get_db``
+        # (which is overridden to ``override_get_db``) shares the
+        # cache key with the route's own ``Depends(get_db)``, so
+        # both see the same AsyncSession. Matches production where
+        # ``get_current_user`` and the route share one session.
+        user = await db.get(User, actor_user_id)
+        assert user is not None
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_users_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_merge_same_user_returns_400_with_shared_session(
+    session_factory,
+) -> None:
+    """Reproducer for the merged-#222 bug: same-user merge with a shared
+    actor/request session must return 400, not 500 (MissingGreenlet)."""
+    org_id = await _seed_org(session_factory)
+    actor_id = await _seed_user(
+        session_factory,
+        org_id=org_id,
+        username="root",
+        email="root@x.io",
+        is_superadmin=True,
+    )
+
+    app = _make_app_shared_session(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": actor_id, "target_user_id": actor_id},
+        )
+    assert res.status_code == 400, res.text
+    assert "different" in res.json()["detail"].lower()
+
+    # And the failure audit row landed with the snapshotted actor.
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.user.merge.failed"
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].actor_user_id == actor_id
+        assert rows[0].actor_email == "root@x.io"
+        assert rows[0].detail["reason"] == "validation"
+
+
+@pytest.mark.asyncio
+async def test_merge_last_active_owner_returns_409_with_shared_session(
+    session_factory,
+) -> None:
+    """The last-active-owner guard fires ``ConflictError`` → 409. The
+    rollback path must not crash on a lazy-loaded ``actor.id``, and the
+    failure audit row must still carry the snapshotted actor."""
+    # The actor sits in a DIFFERENT org so it does not count toward
+    # the "active OWNER" tally of source's org. Superadmin short-
+    # circuits the orgs.manage permission gate regardless of org
+    # membership, so the request still hits the merge service.
+    actor_org_id = await _seed_org(session_factory, name="Actor Org")
+    actor_id = await _seed_user(
+        session_factory,
+        org_id=actor_org_id,
+        username="root",
+        email="root@x.io",
+        is_superadmin=True,
+    )
+    # Target org has exactly one active OWNER (``source``). Target
+    # is a MEMBER, so it cannot preserve the invariant. Deleting
+    # source would leave the org without an active owner → 409.
+    target_org_id = await _seed_org(session_factory, name="Target Org")
+    source_id = await _seed_user(
+        session_factory, org_id=target_org_id, username="solo", email="solo@x.io"
+    )
+    target_id = await _seed_user(
+        session_factory, org_id=target_org_id, username="tgt", email="tgt@x.io"
+    )
+    async with session_factory() as db:
+        target = await db.get(User, target_id)
+        assert target is not None
+        target.role = Role.MEMBER
+        await db.commit()
+
+    app = _make_app_shared_session(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": source_id, "target_user_id": target_id},
+        )
+    assert res.status_code == 409, res.text
+    assert "only active owner" in res.json()["detail"]
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.user.merge.failed"
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].actor_user_id == actor_id
+        assert rows[0].actor_email == "root@x.io"
+        assert rows[0].detail["reason"] == "conflict"
+
+
+@pytest.mark.asyncio
+async def test_merge_success_with_shared_session_writes_snapshotted_audit(
+    session_factory,
+) -> None:
+    """Happy path with shared actor/request session. The success audit
+    row must carry the snapshotted actor id/email even though the
+    request-scoped commit fired between actor resolution and the
+    audit-write call."""
+    org_id = await _seed_org(session_factory)
+    actor_id = await _seed_user(
+        session_factory,
+        org_id=org_id,
+        username="root",
+        email="root@x.io",
+        is_superadmin=True,
+    )
+    # Owner that survives the merge (preserves last-active-owner
+    # invariant on the source org).
+    await _seed_user(
+        session_factory, org_id=org_id, username="keeper", email="keeper@x.io"
+    )
+    s_id = await _seed_user(
+        session_factory, org_id=org_id, username="s", email="s@x.io"
+    )
+    t_id = await _seed_user(
+        session_factory, org_id=org_id, username="t", email="t@x.io"
+    )
+
+    app = _make_app_shared_session(session_factory, actor_user_id=actor_id)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/admin/users/merge",
+            json={"source_user_id": s_id, "target_user_id": t_id},
+        )
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        # Source deleted.
+        assert (await db.scalar(select(User).where(User.id == s_id))) is None
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.user.merged"
+                )
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].actor_user_id == actor_id
+        assert rows[0].actor_email == "root@x.io"
+        assert rows[0].detail["source_user_id"] == s_id
+        assert rows[0].detail["target_user_id"] == t_id


### PR DESCRIPTION
## Summary

`POST /api/v1/admin/users/merge` returned **500 MissingGreenlet** for every guard path (same-user 400, missing-user 404, cross-org 409, last-active-owner 409, internal-error 500) and the success-path audit write was equally exposed.

Local repro:
```
POST /api/v1/admin/users/merge  { "source_user_id": 1, "target_user_id": 1 }
Expected: 400 "cannot merge user with itself"
Actual:   500 MissingGreenlet
```

## Root cause

The router read `actor.id` / `actor.email` for the audit-event write AFTER `db.rollback()` (failure branches) or `db.commit()` (success branch). `Session.rollback()` expires every attached instance regardless of `expire_on_commit=False`, so the subsequent attribute access triggered a lazy load. In async that lazy load needs the greenlet context the `record_audit_event` task does not provide, so SQLAlchemy raised `MissingGreenlet` and the response collapsed to 500.

`get_current_user` resolves `actor` through the same `AsyncSession` the request handler uses as `db`, so the actor and the rolled-back session share fate. The existing tests masked the bug by overriding `get_current_user` to load `actor` from a SEPARATE session.

## Fix scope

Single file: `backend/app/routers/admin_users.py`.

- Snapshot `actor_id = actor.id` and `actor_email = actor.email` at the TOP of `merge_users`, before any service call, commit, or rollback.
- Replace every later `actor.id` / `actor.email` reference (success audit-write + 3 failure audit-writes) with the local snapshots.
- No behavioural change otherwise: same status codes, same error messages, same audit-event shape. No `source.*` / `target.*` access in the router post-commit, so nothing else to snapshot.

## Tests

Added to `backend/tests/routers/test_admin_users_merge.py`. All three share the actor's session with the request handler to mirror production, where `get_current_user` and the route resolve `db` to the same session.

- `test_merge_same_user_returns_400_with_shared_session` — direct reproducer of the user's bug report. Without the fix this raises `MissingGreenlet` and returns 500.
- `test_merge_last_active_owner_returns_409_with_shared_session` — exercises the `ConflictError` rollback path through the last-active-owner guard (#222 fix-up). Asserts 409 + audit-row carries the snapshotted actor.
- `test_merge_success_with_shared_session_writes_snapshotted_audit` — happy path, asserts 200 + audit row with `actor_user_id` and `actor_email` from the snapshots.

Existing tests untouched. 22/22 passing (19 router + service unchanged, 3 new).

## Quality gates

```
docker compose -p team-merge-actor-snapshot up -d backend mysql redis
docker compose -p team-merge-actor-snapshot exec backend pytest \
  tests/routers/test_admin_users_merge.py \
  tests/services/test_user_merge_service.py
# 22 passed
docker compose -p team-merge-actor-snapshot down -v
```

Sanity check: temporarily reverting the snapshot in `admin_users.py` re-broke the two failure-path tests with `MissingGreenlet`, confirming the new coverage characterises the production bug.

## Risk notes

Pure additive locals at the top of one handler; no schema change, no permission change, no audit-event shape change. The only externally observable difference is that the four code paths now return their intended status code (400/404/409/500) instead of 500. No backend rebuild risk beyond the single router import path.