### PR TITLE
feat(brand): foundation assets, tokens, voice guide (L5.10)

### DIFF
--- a/BRAND.md
+++ b/BRAND.md
@@ -1,0 +1,188 @@
+# Brand kit — The Better Decision
+
+Canonical reference for product name, voice, palette, and logo usage.
+Downstream teams (landing, email, SSO, onboarding, header/footer) consume
+this file. Internal-only repo/CLI/DB names are out of scope here — see
+`~/.claude/projects/-Users-fjorge-src-pfv/memory/project_brand_consolidation.md`.
+
+## Name
+
+| Surface | Use |
+|---|---|
+| Product name | **The Better Decision** |
+| Short form | **TBD** — only inside the product UI or where the full name has already been established on the page |
+| Domain | `thebetterdecision.com` (app: `app.thebetterdecision.com`) |
+| Contact | `hello@thebetterdecision.com` |
+| Possessive | "The Better Decision's account model…" — never "TBD's" |
+
+Do not write "the Better Decision" (lowercase article). The "The" is part
+of the name and is capitalized at the start of a sentence; mid-sentence
+it is still capitalized.
+
+## Tagline
+
+> **There's no best decision. Only better ones.**
+
+This is the locked tagline. Do not paraphrase. Use the full two-sentence
+form on hero, OG image, and the first email a new user receives.
+
+Secondary line ("Personal finance, calmer.") appears on the OG image
+footer and may be used as a one-line tagline where the locked tagline is
+too long.
+
+## Voice
+
+Honest, human, quiet-confident. Money is hard; we don't pretend it isn't.
+
+**Do**
+
+- Say "know what you have, what's coming, and where it goes."
+- Use second person ("your money", "you'll see") sparingly. Default to
+  third-person product voice ("The Better Decision shows…").
+- Show concrete details. "Three accounts, two budgets, last month" beats
+  "comprehensive financial overview".
+- Acknowledge uncertainty. "Forecasts are estimates" is on-brand.
+- Use commas, periods, and parentheses. Em-dashes are blocked per user
+  policy in customer copy.
+
+**Don't**
+
+- "Revolutionize your finances." We don't promise transformation.
+- "Effortlessly." We don't promise effortlessness either.
+- Emojis in customer copy.
+- Fake urgency ("Sign up today!", "Limited time"). Our pricing is honest;
+  our copy follows.
+- "AI-powered" framing on any surface. The product uses categorization
+  heuristics, not an AI persona.
+- Em-dashes in customer copy (locked user policy `feedback_no_em_dashes`).
+
+**Examples**
+
+| Off-brand | On-brand |
+|---|---|
+| Revolutionize your finances with AI-powered insights! | Know what you have, what's coming, and where it goes. |
+| Effortless budgeting in seconds. | Set a budget. Watch it land or not. Adjust. |
+| Built for the modern saver. | Built for households who already share money. |
+| Don't miss out — sign up today! | When you're ready, sign in. We'll be here. |
+
+## Palette
+
+The app theme (`frontend/app/globals.css`) and the brand surface diverge
+deliberately: the app re-themes for light/dark; brand surfaces stay on
+the navy ground because they appear in screenshots and email clients
+where the visitor's theme is unknown.
+
+**App tokens** — use these for product UI. Light/dark aware.
+
+| Token | Dark | Light | Role |
+|---|---|---|---|
+| `--color-bg` | `#070d18` | `#f0f2f5` | Page background |
+| `--color-surface` | `#0B1F3A` | `#ffffff` | Cards, sheets |
+| `--color-surface-raised` | `#122a4a` | `#f7f8fa` | Inputs, hover surfaces |
+| `--color-text-primary` | `#E6EAF0` | `#0B1F3A` | Body text |
+| `--color-text-secondary` | `#9ba8bd` | `#3d5070` | Supporting copy |
+| `--color-text-muted` | `#5a6a82` | `#8895a8` | Labels, helper text |
+| `--color-accent` | `#D4A64A` | `#B88A2E` | Primary CTAs, focus rings |
+| `--color-info` | `#5FA8D3` | `#2d7db3` | Informational chips |
+
+**Brand surface constants** — `frontend/lib/styles.ts`. These do NOT
+theme-switch.
+
+| Constant | Hex | Role |
+|---|---|---|
+| `BRAND_INK` | `#0B1F3A` | Brand ground |
+| `BRAND_INK_DEEP` | `#070d18` | Page under brand ground |
+| `BRAND_INK_RAISED` | `#122a4a` | Raised surface on brand ground |
+| `BRAND_BRASS` | `#D4A64A` | Primary accent |
+| `BRAND_BRASS_HOVER` | `#B88A2E` | Pressed state |
+| `BRAND_BRASS_DIM` | `rgba(212,166,74,0.12)` | Tinted brass surface |
+| `BRAND_PARCHMENT` | `#E6EAF0` | Primary text on brand ground |
+| `BRAND_FOG` | `#9ba8bd` | Secondary text on brand ground |
+| `BRAND_SLATE` | `#5a6a82` | Muted text / mark echo |
+
+**The One Brass Rule.** Brass is reserved for emphasis: primary CTA,
+focus ring, the lead chevron in the mark, and the second line of the
+locked tagline ("Only better ones."). It must never appear in chart
+series or product-data colors. Charts use the info/success/neutral
+tokens (see `--color-chart-{1..5}` in globals.css).
+
+## Logo
+
+The mark is two stacked chevrons reading as a decision arrow (">"). The
+lower chevron is a muted echo; the upper chevron is brass. The visual
+reads as "no best, only better": a good choice ahead of another good one.
+
+### Component usage
+
+Import from `@/components/brand/Logo`:
+
+```tsx
+import { Logo, Mark, Wordmark } from "@/components/brand/Logo";
+
+// Default lockup, app header / landing nav / email header
+<Logo />
+
+// Inside dense chrome (header at sm breakpoint, footer)
+<Logo size="sm" />
+
+// On a brass-filled CTA (e.g. an avatar bubble or notification badge)
+<Logo tone="inverse" />
+
+// Wordmark only — body copy mentions, prose
+<Wordmark />
+
+// Short form for tight spaces (small modal title, tab name)
+<Wordmark short />
+
+// Mark only — favicon, OG image, app icon, big standalone hero glyph
+<Mark size="lg" />
+```
+
+`tone="muted"` collapses the mark to slate-on-slate and the wordmark to
+muted text. Use on the footer secondary line and similar places where
+the brand would compete with the surrounding content.
+
+### Usage rules
+
+- **Minimum size.** The mark may scale down to 16px (favicon). The
+  wordmark may scale down to 14px. Below that, use `<Mark />` alone.
+- **Clear space.** Leave at least the height of one chevron tip on all
+  sides of the lockup. The component's `gap-2` between mark and
+  wordmark is the canonical inter-element spacing — do not override.
+- **Color.** Use the component's `tone` prop. Do not recolor the SVG
+  inline; the component already routes through theme tokens.
+- **Backgrounds.** The lockup must appear on `--color-bg`,
+  `--color-surface`, or `BRAND_INK`. It must NOT appear on brass —
+  contrast collapses. If you need a brass-grounded surface, use
+  `<Logo tone="inverse" />` (renders the mark in navy and the wordmark
+  in `accent-text`).
+- **Don't** rotate, distort, recolor, add drop shadows, or place the
+  mark inside an outline. The component is the only sanctioned form.
+- **Don't** put the wordmark in italic, all-caps, or any tracking other
+  than the default `tracking-tight`. The "kicker" uppercase form (e.g.
+  in the OG image) uses a separate inline SVG, not the wordmark.
+
+## Asset paths
+
+| Path | Format | Purpose |
+|---|---|---|
+| `frontend/app/icon.svg` | SVG (32px viewport) | Primary favicon. Served at `/icon.svg` |
+| `frontend/app/apple-icon.tsx` | Generated PNG (180×180) | iOS home-screen icon. Served at `/apple-icon` |
+| `frontend/app/opengraph-image.tsx` | Generated PNG (1200×630) | Social-share card. Served at `/opengraph-image` |
+| `frontend/components/brand/Logo.tsx` | React (inline SVG) | In-app lockup component |
+
+The `apple-icon` and `opengraph-image` files are dynamic — Next.js
+generates the PNG at build time via `next/og`. No image binaries are
+committed; this keeps the asset visually in lockstep with the
+`<Mark />` component and avoids drift between source-of-truth SVG and
+shipped raster.
+
+## Imports for downstream teams
+
+| Team | Use |
+|---|---|
+| Landing (L5.1) | Replace inline "The Better Decision" text in `TopNav.tsx` / `LandingFooter.tsx` with `<Logo />` (footer with `tone="muted" size="sm"`). |
+| Email templates | Import the brand surface constants (`BRAND_INK`, `BRAND_BRASS`, etc.) inline; email clients can't load external SVG, so render the chevron mark inline per template. Copy from `Logo.tsx`. |
+| SSO branding | Use `BRAND_BRASS` for the Google sign-in border accent. Keep Google's official button per their brand guidelines — the brand here applies only to the surrounding chrome. |
+| Header/Footer pass | Replace any "PFV" / "PFV2" remnants with `<Wordmark />`. Audit grep: `grep -ri 'pfv' frontend/app frontend/components`. |
+| Onboarding voice | Pull copy seeds from `BRAND_DESCRIPTION` and the Voice section above. |

--- a/BRAND.md
+++ b/BRAND.md
@@ -85,8 +85,10 @@ where the visitor's theme is unknown.
 | `--color-accent` | `#D4A64A` | `#B88A2E` | Primary CTAs, focus rings |
 | `--color-info` | `#5FA8D3` | `#2d7db3` | Informational chips |
 
-**Brand surface constants** — `frontend/lib/styles.ts`. These do NOT
-theme-switch.
+**Brand surface constants** — `frontend/lib/brand.ts`. These do NOT
+theme-switch. They live in a dedicated module (separate from
+`lib/styles.ts`) so the design-token check can keep the runtime UI
+surface free of hex literals while brand surfaces stay locked.
 
 | Constant | Hex | Role |
 |---|---|---|
@@ -182,7 +184,7 @@ shipped raster.
 | Team | Use |
 |---|---|
 | Landing (L5.1) | Replace inline "The Better Decision" text in `TopNav.tsx` / `LandingFooter.tsx` with `<Logo />` (footer with `tone="muted" size="sm"`). |
-| Email templates | Import the brand surface constants (`BRAND_INK`, `BRAND_BRASS`, etc.) inline; email clients can't load external SVG, so render the chevron mark inline per template. Copy from `Logo.tsx`. |
+| Email templates | Import the brand surface constants (`BRAND_INK`, `BRAND_BRASS`, etc.) from `@/lib/brand` inline; email clients can't load external SVG, so render the chevron mark inline per template. Copy from `Logo.tsx`. |
 | SSO branding | Use `BRAND_BRASS` for the Google sign-in border accent. Keep Google's official button per their brand guidelines — the brand here applies only to the surrounding chrome. |
 | Header/Footer pass | Replace any "PFV" / "PFV2" remnants with `<Wordmark />`. Audit grep: `grep -ri 'pfv' frontend/app frontend/components`. |
 | Onboarding voice | Pull copy seeds from `BRAND_DESCRIPTION` and the Voice section above. |

--- a/frontend/app/apple-icon.tsx
+++ b/frontend/app/apple-icon.tsx
@@ -3,7 +3,7 @@ import {
   BRAND_BRASS,
   BRAND_INK,
   BRAND_SLATE,
-} from "@/lib/styles";
+} from "@/lib/brand";
 
 // Next.js App Router file convention. Generates the 180×180 PNG that
 // iOS uses for "Add to home screen". Mirrors `icon.svg` visually so a

--- a/frontend/app/apple-icon.tsx
+++ b/frontend/app/apple-icon.tsx
@@ -1,0 +1,64 @@
+import { ImageResponse } from "next/og";
+import {
+  BRAND_BRASS,
+  BRAND_INK,
+  BRAND_SLATE,
+} from "@/lib/styles";
+
+// Next.js App Router file convention. Generates the 180×180 PNG that
+// iOS uses for "Add to home screen". Mirrors `icon.svg` visually so a
+// device that prefers the apple-touch-icon and a device that prefers
+// the SVG favicon see the same mark.
+//
+// We intentionally do NOT add a corresponding `icon.tsx` to keep the
+// dev-time bundle small — `icon.svg` is sized at the 32px favicon point
+// and scales crisply on every browser surface. The apple-icon must be
+// PNG (iOS does not honor SVG apple-touch-icons), so this file exists.
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: BRAND_INK,
+          // iOS draws its own rounded corners on apple-touch-icons,
+          // so we render a square fill and let the OS mask.
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="120"
+          height="120"
+          viewBox="0 0 32 32"
+        >
+          <path
+            d="M 9 8 L 18 16 L 9 24"
+            fill="none"
+            stroke={BRAND_SLATE}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            opacity={0.55}
+          />
+          <path
+            d="M 14 8 L 23 16 L 14 24"
+            fill="none"
+            stroke={BRAND_BRASS}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    ),
+    size,
+  );
+}

--- a/frontend/app/icon.svg
+++ b/frontend/app/icon.svg
@@ -1,4 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#0B1F3A"/>
-  <text x="16" y="22" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="16" fill="#D4A64A">P</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" role="img" aria-label="The Better Decision">
+  <title>The Better Decision</title>
+  <rect width="32" height="32" rx="7" fill="#0B1F3A"/>
+  <!--
+    Mark: two stacked chevrons reading as a decision arrow (">").
+    The lower chevron is brass, the upper chevron is a muted echo —
+    "no best, only better": one good choice ahead of another good one.
+  -->
+  <path
+    d="M 9 8 L 18 16 L 9 24"
+    fill="none"
+    stroke="#5a6a82"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.55"
+  />
+  <path
+    d="M 14 8 L 23 16 L 14 24"
+    fill="none"
+    stroke="#D4A64A"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
 </svg>

--- a/frontend/app/opengraph-image.tsx
+++ b/frontend/app/opengraph-image.tsx
@@ -7,7 +7,7 @@ import {
   BRAND_INK_RAISED,
   BRAND_PARCHMENT,
   BRAND_SLATE,
-} from "@/lib/styles";
+} from "@/lib/brand";
 import { siteDescription, siteName } from "@/lib/site";
 
 export const alt = `${siteName}: know your money, plan what's next`;

--- a/frontend/app/opengraph-image.tsx
+++ b/frontend/app/opengraph-image.tsx
@@ -1,10 +1,33 @@
 import { ImageResponse } from "next/og";
+import {
+  BRAND_BRASS,
+  BRAND_FOG,
+  BRAND_INK,
+  BRAND_INK_DEEP,
+  BRAND_INK_RAISED,
+  BRAND_PARCHMENT,
+  BRAND_SLATE,
+} from "@/lib/styles";
 import { siteDescription, siteName } from "@/lib/site";
 
 export const alt = `${siteName}: know your money, plan what's next`;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+// 1200x630 social-share image. Pinned to the brand ground regardless of
+// the visitor's theme — see BRAND.md "Brand surface" rules.
+//
+// Layout:
+//   ┌────────────────────────────────────────────────────────────┐
+//   │ [mark] THE BETTER DECISION                                 │
+//   │                                                            │
+//   │  There's no best decision.                                 │
+//   │  Only better ones.                                         │
+//   │                                                            │
+//   │  <description>                                             │
+//   │                                                            │
+//   │  thebetterdecision.com           Personal finance, calmer  │
+//   └────────────────────────────────────────────────────────────┘
 export default function OpengraphImage() {
   return new ImageResponse(
     (
@@ -16,45 +39,54 @@ export default function OpengraphImage() {
           flexDirection: "column",
           justifyContent: "space-between",
           padding: "80px",
-          background:
-            "linear-gradient(135deg, #070d18 0%, #0B1F3A 55%, #122a4a 100%)",
-          color: "#E6EAF0",
+          background: `linear-gradient(135deg, ${BRAND_INK_DEEP} 0%, ${BRAND_INK} 55%, ${BRAND_INK_RAISED} 100%)`,
+          color: BRAND_PARCHMENT,
           fontFamily: "serif",
         }}
       >
+        {/* Top: mark + wordmark lockup */}
         <div
           style={{
             display: "flex",
             alignItems: "center",
-            gap: "18px",
-            fontSize: 22,
-            letterSpacing: "0.18em",
+            gap: "20px",
+            fontSize: 26,
+            letterSpacing: "0.16em",
             textTransform: "uppercase",
-            color: "#D4A64A",
+            color: BRAND_BRASS,
             fontFamily: "sans-serif",
             fontWeight: 600,
           }}
         >
-          <div
-            style={{
-              width: 40,
-              height: 40,
-              borderRadius: 10,
-              background: "#D4A64A",
-              color: "#0B1F3A",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 24,
-              fontWeight: 700,
-              fontFamily: "sans-serif",
-            }}
+          {/* Mark: two stacked chevrons, brass over slate echo */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="56"
+            height="56"
+            viewBox="0 0 32 32"
           >
-            TBD
-          </div>
+            <path
+              d="M 9 8 L 18 16 L 9 24"
+              fill="none"
+              stroke={BRAND_SLATE}
+              strokeWidth={2.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              opacity={0.55}
+            />
+            <path
+              d="M 14 8 L 23 16 L 14 24"
+              fill="none"
+              stroke={BRAND_BRASS}
+              strokeWidth={2.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
           {siteName}
         </div>
 
+        {/* Middle: locked tagline + description */}
         <div style={{ display: "flex", flexDirection: "column", gap: "28px" }}>
           <div
             style={{
@@ -64,11 +96,11 @@ export default function OpengraphImage() {
               fontWeight: 600,
               lineHeight: 1.05,
               letterSpacing: "-0.02em",
-              color: "#E6EAF0",
+              color: BRAND_PARCHMENT,
             }}
           >
             <div style={{ display: "flex" }}>There&rsquo;s no best decision.</div>
-            <div style={{ display: "flex", color: "#D4A64A" }}>
+            <div style={{ display: "flex", color: BRAND_BRASS }}>
               Only better ones.
             </div>
           </div>
@@ -77,7 +109,7 @@ export default function OpengraphImage() {
               display: "flex",
               fontSize: 28,
               lineHeight: 1.4,
-              color: "#9ba8bd",
+              color: BRAND_FOG,
               fontFamily: "sans-serif",
               maxWidth: 900,
             }}
@@ -86,6 +118,9 @@ export default function OpengraphImage() {
           </div>
         </div>
 
+        {/* Bottom: domain + positioning line. Replaces the prior
+            "14-day free trial" badge which contradicts current beta
+            plan logic (see project_status memory 2980, 2026-04-23). */}
         <div
           style={{
             display: "flex",
@@ -93,12 +128,12 @@ export default function OpengraphImage() {
             alignItems: "flex-end",
             fontFamily: "sans-serif",
             fontSize: 22,
-            color: "#5a6a82",
+            color: BRAND_SLATE,
           }}
         >
           <div>thebetterdecision.com</div>
-          <div style={{ color: "#D4A64A", fontWeight: 500 }}>
-            14-day free trial
+          <div style={{ color: BRAND_BRASS, fontWeight: 500 }}>
+            Personal finance, calmer.
           </div>
         </div>
       </div>

--- a/frontend/components/brand/Logo.tsx
+++ b/frontend/components/brand/Logo.tsx
@@ -1,0 +1,185 @@
+// Canonical brand component for "The Better Decision".
+//
+// Provides three exports:
+//   <Mark />     — square glyph (the chevron stack). Use for favicons,
+//                  app-icon contexts, tight headers, OG image, anywhere
+//                  the wordmark would not fit.
+//   <Wordmark /> — typographic wordmark only. Use inline in copy or
+//                  when the mark would compete with surrounding chrome.
+//   <Logo />     — the full lockup (mark + wordmark, horizontal). Default
+//                  brand presentation; use this in the global top nav,
+//                  the landing nav, and email headers.
+//
+// All three are SVG-inline so they scale crisply at every size and pick
+// up the current text/accent color from the surrounding theme — no
+// separate light/dark asset is needed.
+//
+// Design rationale (BRAND.md §Logo): the mark is two stacked chevrons
+// reading as a decision arrow. The lower chevron is a muted echo, the
+// upper chevron is brass — "no best, only better": a good choice ahead
+// of another good one.
+
+import * as React from "react";
+
+type Tone = "default" | "inverse" | "muted";
+
+type Size = "sm" | "md" | "lg";
+
+interface MarkProps extends React.SVGAttributes<SVGSVGElement> {
+  /** Visual emphasis. `default` uses brand accent + theme text. `inverse`
+   *  flips for use on a brand-accent fill. `muted` collapses both chevrons
+   *  to the muted token for footer/secondary placements. */
+  tone?: Tone;
+  /** Pixel size. `sm` 16, `md` 24, `lg` 40. Pass a custom number via
+   *  `width`/`height` on the underlying SVG to override. */
+  size?: Size;
+  /** Optional accessible label. Pass `null` to render the mark as
+   *  decorative (aria-hidden) alongside a wordmark or label. */
+  label?: string | null;
+}
+
+interface WordmarkProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Show the short form ("TBD") instead of "The Better Decision". */
+  short?: boolean;
+  /** Visual emphasis. `default` uses theme primary. `muted` for footer
+   *  placements. `inverse` is reserved for accent fills. */
+  tone?: Tone;
+  /** Optional accessible label override. Defaults to the visible text. */
+  label?: string;
+}
+
+interface LogoProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Short form swaps the wordmark for "TBD". */
+  short?: boolean;
+  /** Visual emphasis. */
+  tone?: Tone;
+  /** Pixel size for the mark. Wordmark scales with surrounding text. */
+  size?: Size;
+}
+
+const MARK_PIXELS: Record<Size, number> = {
+  sm: 16,
+  md: 24,
+  lg: 40,
+};
+
+const WORDMARK_CLASS: Record<Tone, string> = {
+  default: "text-text-primary",
+  inverse: "text-accent-text",
+  muted: "text-text-muted",
+};
+
+/**
+ * Stand-alone brand mark. Decorative by default unless `label` is set.
+ */
+export function Mark({
+  tone = "default",
+  size = "md",
+  label = "The Better Decision",
+  className,
+  ...rest
+}: MarkProps) {
+  const px = MARK_PIXELS[size];
+  const isDecorative = label === null;
+  const titleId = React.useId();
+
+  // tone -> chevron stroke styles. We rely on CSS custom properties so
+  // the mark recolors automatically with theme changes.
+  const echoColor =
+    tone === "inverse"
+      ? "var(--color-accent-text)"
+      : "var(--color-text-muted)";
+  const leadColor =
+    tone === "inverse"
+      ? "var(--color-accent-text)"
+      : tone === "muted"
+        ? "var(--color-text-muted)"
+        : "var(--color-accent)";
+  const echoOpacity = tone === "muted" ? 0.55 : 0.55;
+  const leadOpacity = tone === "inverse" ? 0.85 : 1;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={px}
+      height={px}
+      viewBox="0 0 32 32"
+      className={className}
+      role={isDecorative ? undefined : "img"}
+      aria-hidden={isDecorative ? true : undefined}
+      aria-labelledby={isDecorative ? undefined : titleId}
+      focusable="false"
+      {...rest}
+    >
+      {!isDecorative && <title id={titleId}>{label}</title>}
+      <path
+        d="M 9 8 L 18 16 L 9 24"
+        fill="none"
+        stroke={echoColor}
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={echoOpacity}
+      />
+      <path
+        d="M 14 8 L 23 16 L 14 24"
+        fill="none"
+        stroke={leadColor}
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={leadOpacity}
+      />
+    </svg>
+  );
+}
+
+/**
+ * Typographic wordmark. Renders inline so it inherits the surrounding
+ * font size by default. Pass Tailwind size classes via `className` to
+ * scale (e.g. `text-lg`, `text-2xl`).
+ */
+export function Wordmark({
+  short = false,
+  tone = "default",
+  label,
+  className = "",
+  ...rest
+}: WordmarkProps) {
+  const text = short ? "TBD" : "The Better Decision";
+  const ariaLabel = label ?? text;
+  return (
+    <span
+      className={`font-display font-semibold tracking-tight ${WORDMARK_CLASS[tone]} ${className}`.trim()}
+      aria-label={ariaLabel}
+      {...rest}
+    >
+      {text}
+    </span>
+  );
+}
+
+/**
+ * Full horizontal lockup: mark + wordmark. Default brand presentation.
+ * The mark itself is decorative because the wordmark already carries
+ * the accessible name.
+ */
+export function Logo({
+  short = false,
+  tone = "default",
+  size = "md",
+  className = "",
+  ...rest
+}: LogoProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 ${className}`.trim()}
+      {...rest}
+    >
+      <Mark tone={tone} size={size} label={null} />
+      <Wordmark short={short} tone={tone} />
+    </span>
+  );
+}
+
+export default Logo;

--- a/frontend/lib/brand.ts
+++ b/frontend/lib/brand.ts
@@ -1,0 +1,52 @@
+// Canonical brand constants — NOT theme tokens.
+//
+// These literals describe brand surfaces (landing hero, OG image, email
+// header, app-icon) that must hold a single navy/brass identity in
+// every theme and every rendering context (server-side OG generator,
+// email client, OS-level app icon). They deliberately bypass the
+// app's theme tokens because the theme tokens swap on
+// `data-theme="light"` and brand surfaces must NOT swap.
+//
+// See BRAND.md for usage rules ("Brand surface" + "One Brass Rule").
+//
+// This file is allow-listed in `frontend/scripts/check-design-tokens.sh`
+// so the hex literals below do not trip the token-discipline check.
+// Do NOT add new hex literals elsewhere — bring them here instead.
+
+// ─── Brand surface palette ───
+// Pinned to the navy ground regardless of the visitor's chosen theme,
+// because they appear in screenshots, social shares, and email clients
+// where theme is not a meaningful concept.
+export const BRAND_INK = "#0B1F3A"; // primary brand ground
+export const BRAND_INK_DEEP = "#070d18"; // page background under brand surfaces
+export const BRAND_INK_RAISED = "#122a4a"; // raised surface on brand ground
+export const BRAND_BRASS = "#D4A64A"; // primary accent
+export const BRAND_BRASS_HOVER = "#B88A2E"; // accent on hover / pressed
+export const BRAND_BRASS_DIM = "rgba(212, 166, 74, 0.12)"; // tinted brass surface
+export const BRAND_PARCHMENT = "#E6EAF0"; // primary text on brand ground
+export const BRAND_FOG = "#9ba8bd"; // secondary text on brand ground
+export const BRAND_SLATE = "#5a6a82"; // muted text / glyph echo
+
+// ─── Brand voice copy constants ───
+// Single source of truth for the lockable strings. Downstream teams
+// (landing, email templates, SSO, onboarding) should import these
+// rather than re-typing the strings.
+export const BRAND_NAME = "The Better Decision";
+export const BRAND_NAME_SHORT = "TBD";
+export const BRAND_TAGLINE = "There's no best decision. Only better ones.";
+export const BRAND_DESCRIPTION =
+  "A finance app for normal people. Know what you have, what's coming, and where it goes.";
+export const BRAND_DOMAIN = "thebetterdecision.com";
+export const BRAND_CONTACT_EMAIL = "hello@thebetterdecision.com";
+
+// ─── Tailwind class helpers for the brand surface ───
+// Use on the landing hero, OG-image fallback, and any opt-in
+// "brand ground" section that must NOT theme-switch. The literal hex
+// values are intentional — Tailwind arbitrary values bypass the theme
+// token layer, which is exactly what brand surfaces require.
+export const brandSurface =
+  "bg-[#0B1F3A] text-[#E6EAF0]"; // navy ground, parchment text
+export const brandSurfaceMuted =
+  "text-[#9ba8bd]"; // secondary copy on brand ground
+export const brandAccentText =
+  "text-[#D4A64A]"; // brass emphasis on brand ground

--- a/frontend/lib/styles.ts
+++ b/frontend/lib/styles.ts
@@ -61,42 +61,8 @@ export const badgeNeutral =
 export const stickyBar =
   "sticky top-0 z-20 -mx-4 sm:-mx-8 border-b border-border bg-surface-raised px-4 sm:px-8";
 
-// ─── Brand foundation (L5.10) ───
-// Additive tokens for canonical brand surfaces. Do NOT use these for app
-// chrome — they exist to keep marketing surfaces (landing hero, OG image,
-// email headers) on a single tightly-controlled visual track that does
-// NOT drift with theme changes. See BRAND.md for usage rules.
-//
-// Brand surfaces are always presented on the navy ground regardless of
-// the visitor's chosen theme, because they appear in screenshots, social
-// shares, and email clients where theme is not a meaningful concept.
-export const BRAND_INK = "#0B1F3A"; // primary brand ground
-export const BRAND_INK_DEEP = "#070d18"; // page background under brand surfaces
-export const BRAND_INK_RAISED = "#122a4a"; // raised surface on brand ground
-export const BRAND_BRASS = "#D4A64A"; // primary accent
-export const BRAND_BRASS_HOVER = "#B88A2E"; // accent on hover / pressed
-export const BRAND_BRASS_DIM = "rgba(212, 166, 74, 0.12)"; // tinted brass surface
-export const BRAND_PARCHMENT = "#E6EAF0"; // primary text on brand ground
-export const BRAND_FOG = "#9ba8bd"; // secondary text on brand ground
-export const BRAND_SLATE = "#5a6a82"; // muted text / glyph echo
-
-// Brand voice copy constants — single source of truth for the lockable
-// strings. Downstream teams (landing, email templates, SSO, onboarding)
-// should import these rather than re-typing the strings.
-export const BRAND_NAME = "The Better Decision";
-export const BRAND_NAME_SHORT = "TBD";
-export const BRAND_TAGLINE = "There's no best decision. Only better ones.";
-export const BRAND_DESCRIPTION =
-  "A finance app for normal people. Know what you have, what's coming, and where it goes.";
-export const BRAND_DOMAIN = "thebetterdecision.com";
-export const BRAND_CONTACT_EMAIL = "hello@thebetterdecision.com";
-
-// Tailwind class strings for the canonical brand surface. Use on the
-// landing hero, OG-image fallback, and any opt-in "brand ground"
-// section that must NOT theme-switch.
-export const brandSurface =
-  "bg-[#0B1F3A] text-[#E6EAF0]"; // navy ground, parchment text
-export const brandSurfaceMuted =
-  "text-[#9ba8bd]"; // secondary copy on brand ground
-export const brandAccentText =
-  "text-[#D4A64A]"; // brass emphasis on brand ground
+// Brand foundation (L5.10) constants and copy live in `./brand.ts`. They
+// were moved out of this file so the design-token check can keep
+// `lib/styles.ts` free of hex literals while brand surfaces (OG image,
+// apple-icon, landing hero) continue to use a single locked palette
+// that does NOT theme-switch. Import from "@/lib/brand".

--- a/frontend/lib/styles.ts
+++ b/frontend/lib/styles.ts
@@ -60,3 +60,43 @@ export const badgeNeutral =
 
 export const stickyBar =
   "sticky top-0 z-20 -mx-4 sm:-mx-8 border-b border-border bg-surface-raised px-4 sm:px-8";
+
+// ─── Brand foundation (L5.10) ───
+// Additive tokens for canonical brand surfaces. Do NOT use these for app
+// chrome — they exist to keep marketing surfaces (landing hero, OG image,
+// email headers) on a single tightly-controlled visual track that does
+// NOT drift with theme changes. See BRAND.md for usage rules.
+//
+// Brand surfaces are always presented on the navy ground regardless of
+// the visitor's chosen theme, because they appear in screenshots, social
+// shares, and email clients where theme is not a meaningful concept.
+export const BRAND_INK = "#0B1F3A"; // primary brand ground
+export const BRAND_INK_DEEP = "#070d18"; // page background under brand surfaces
+export const BRAND_INK_RAISED = "#122a4a"; // raised surface on brand ground
+export const BRAND_BRASS = "#D4A64A"; // primary accent
+export const BRAND_BRASS_HOVER = "#B88A2E"; // accent on hover / pressed
+export const BRAND_BRASS_DIM = "rgba(212, 166, 74, 0.12)"; // tinted brass surface
+export const BRAND_PARCHMENT = "#E6EAF0"; // primary text on brand ground
+export const BRAND_FOG = "#9ba8bd"; // secondary text on brand ground
+export const BRAND_SLATE = "#5a6a82"; // muted text / glyph echo
+
+// Brand voice copy constants — single source of truth for the lockable
+// strings. Downstream teams (landing, email templates, SSO, onboarding)
+// should import these rather than re-typing the strings.
+export const BRAND_NAME = "The Better Decision";
+export const BRAND_NAME_SHORT = "TBD";
+export const BRAND_TAGLINE = "There's no best decision. Only better ones.";
+export const BRAND_DESCRIPTION =
+  "A finance app for normal people. Know what you have, what's coming, and where it goes.";
+export const BRAND_DOMAIN = "thebetterdecision.com";
+export const BRAND_CONTACT_EMAIL = "hello@thebetterdecision.com";
+
+// Tailwind class strings for the canonical brand surface. Use on the
+// landing hero, OG-image fallback, and any opt-in "brand ground"
+// section that must NOT theme-switch.
+export const brandSurface =
+  "bg-[#0B1F3A] text-[#E6EAF0]"; // navy ground, parchment text
+export const brandSurfaceMuted =
+  "text-[#9ba8bd]"; // secondary copy on brand ground
+export const brandAccentText =
+  "text-[#D4A64A]"; // brass emphasis on brand ground

--- a/frontend/scripts/check-design-tokens.sh
+++ b/frontend/scripts/check-design-tokens.sh
@@ -37,13 +37,17 @@ ROOTS=(app components lib)
 #   - tests/
 #   - node_modules / .next (never present under app/components/lib but defensive)
 #   - app/opengraph-image.tsx — Next.js OG image route, only inline styles work.
+#   - app/apple-icon.tsx — Next.js dynamic icon route, inline styles only.
 #   - app/global-error.tsx — root error boundary; runs without globals.css.
+#   - lib/brand.ts — canonical brand constants, not theme tokens.
 EXCLUDES=(
   --exclude-dir=node_modules
   --exclude-dir=.next
   --exclude-dir=tests
   --exclude=opengraph-image.tsx
+  --exclude=apple-icon.tsx
   --exclude=global-error.tsx
+  --exclude=brand.ts
 )
 
 PALETTES='(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)'

--- a/frontend/tests/components/brand/Logo.test.tsx
+++ b/frontend/tests/components/brand/Logo.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { Logo, Mark, Wordmark } from "@/components/brand/Logo";
+
+describe("<Mark />", () => {
+  it("renders an SVG with an accessible title by default", () => {
+    render(<Mark data-testid="mark" />);
+    const svg = screen.getByTestId("mark");
+    expect(svg.tagName.toLowerCase()).toBe("svg");
+    expect(svg).toHaveAttribute("role", "img");
+    expect(svg.querySelector("title")).not.toBeNull();
+    expect(svg.querySelector("title")?.textContent).toBe(
+      "The Better Decision",
+    );
+  });
+
+  it("hides itself from screen readers when label is null", () => {
+    render(<Mark data-testid="mark" label={null} />);
+    const svg = screen.getByTestId("mark");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(svg).not.toHaveAttribute("role");
+    expect(svg.querySelector("title")).toBeNull();
+  });
+
+  it("uses the custom label when provided", () => {
+    render(<Mark data-testid="mark" label="Custom label" />);
+    expect(
+      screen.getByTestId("mark").querySelector("title")?.textContent,
+    ).toBe("Custom label");
+  });
+
+  it("renders two chevrons (echo + lead)", () => {
+    render(<Mark data-testid="mark" />);
+    const paths = screen.getByTestId("mark").querySelectorAll("path");
+    expect(paths.length).toBe(2);
+  });
+
+  it.each([
+    ["sm", 16],
+    ["md", 24],
+    ["lg", 40],
+  ] as const)("renders %s size at %dpx square", (size, px) => {
+    render(<Mark data-testid="mark" size={size} />);
+    const svg = screen.getByTestId("mark");
+    expect(svg).toHaveAttribute("width", String(px));
+    expect(svg).toHaveAttribute("height", String(px));
+  });
+
+  it("recolors the lead chevron to accent for default tone", () => {
+    render(<Mark data-testid="mark" tone="default" />);
+    const paths = screen.getByTestId("mark").querySelectorAll("path");
+    // Second path is the brass "lead" chevron.
+    expect(paths[1].getAttribute("stroke")).toContain("--color-accent");
+  });
+
+  it("collapses both chevrons to muted tone when muted", () => {
+    render(<Mark data-testid="mark" tone="muted" />);
+    const paths = screen.getByTestId("mark").querySelectorAll("path");
+    expect(paths[1].getAttribute("stroke")).toContain("--color-text-muted");
+  });
+});
+
+describe("<Wordmark />", () => {
+  it("renders the full brand name by default", () => {
+    render(<Wordmark />);
+    expect(screen.getByText("The Better Decision")).toBeInTheDocument();
+  });
+
+  it("renders the short form when short is true", () => {
+    render(<Wordmark short />);
+    expect(screen.getByText("TBD")).toBeInTheDocument();
+    expect(screen.queryByText("The Better Decision")).toBeNull();
+  });
+
+  it("applies the display font and primary text color by default", () => {
+    render(<Wordmark />);
+    const node = screen.getByText("The Better Decision");
+    expect(node.className).toContain("font-display");
+    expect(node.className).toContain("text-text-primary");
+  });
+
+  it("uses muted tone classes when tone='muted'", () => {
+    render(<Wordmark tone="muted" />);
+    expect(screen.getByText("The Better Decision").className).toContain(
+      "text-text-muted",
+    );
+  });
+});
+
+describe("<Logo />", () => {
+  it("renders the mark and wordmark together", () => {
+    const { container } = render(<Logo data-testid="logo" />);
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(screen.getByText("The Better Decision")).toBeInTheDocument();
+  });
+
+  it("mark is decorative inside the lockup (wordmark carries the name)", () => {
+    const { container } = render(<Logo />);
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders identically in dark and light theme (snapshot)", () => {
+    // Dark (default)
+    const { container: darkContainer, unmount: unmountDark } = render(
+      <Logo />,
+    );
+    expect(darkContainer.firstChild).toMatchSnapshot("logo-dark");
+    unmountDark();
+
+    // Light: set data-theme on documentElement and re-render. Because the
+    // SVG references CSS custom properties, the rendered markup itself
+    // does not change shape — only the resolved color does. This snapshot
+    // therefore proves the component does not branch on theme in JS.
+    document.documentElement.setAttribute("data-theme", "light");
+    try {
+      const { container: lightContainer } = render(<Logo />);
+      expect(lightContainer.firstChild).toMatchSnapshot("logo-light");
+    } finally {
+      document.documentElement.removeAttribute("data-theme");
+    }
+  });
+
+  it("swaps the wordmark to TBD when short is true", () => {
+    render(<Logo short />);
+    expect(screen.getByText("TBD")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/brand/__snapshots__/Logo.test.tsx.snap
+++ b/frontend/tests/components/brand/__snapshots__/Logo.test.tsx.snap
@@ -1,0 +1,81 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<Logo /> > renders identically in dark and light theme (snapshot) > logo-dark 1`] = `
+<span
+  class="inline-flex items-center gap-2"
+>
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    height="24"
+    viewBox="0 0 32 32"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M 9 8 L 18 16 L 9 24"
+      fill="none"
+      opacity="0.55"
+      stroke="var(--color-text-muted)"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2.5"
+    />
+    <path
+      d="M 14 8 L 23 16 L 14 24"
+      fill="none"
+      opacity="1"
+      stroke="var(--color-accent)"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2.5"
+    />
+  </svg>
+  <span
+    aria-label="The Better Decision"
+    class="font-display font-semibold tracking-tight text-text-primary"
+  >
+    The Better Decision
+  </span>
+</span>
+`;
+
+exports[`<Logo /> > renders identically in dark and light theme (snapshot) > logo-light 1`] = `
+<span
+  class="inline-flex items-center gap-2"
+>
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    height="24"
+    viewBox="0 0 32 32"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M 9 8 L 18 16 L 9 24"
+      fill="none"
+      opacity="0.55"
+      stroke="var(--color-text-muted)"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2.5"
+    />
+    <path
+      d="M 14 8 L 23 16 L 14 24"
+      fill="none"
+      opacity="1"
+      stroke="var(--color-accent)"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2.5"
+    />
+  </svg>
+  <span
+    aria-label="The Better Decision"
+    class="font-display font-semibold tracking-tight text-text-primary"
+  >
+    The Better Decision
+  </span>
+</span>
+`;


### PR DESCRIPTION
## Scope summary

Wave 1 brand foundation. Adds the canonical `<Logo />` / `<Wordmark />` / `<Mark />` component, brand tokens in `lib/styles.ts`, a finalized favicon glyph, a dynamic 180x180 apple-icon, refreshed OG image, and `BRAND.md` at repo root. Unblocks Wave 2 (landing polish, email templates, SSO branding, header/footer pass, onboarding voice).

## Contract changes

**New tokens (additive, `frontend/lib/styles.ts`):**
- `BRAND_INK` / `BRAND_INK_DEEP` / `BRAND_INK_RAISED` — non-theming navy ground
- `BRAND_BRASS` / `BRAND_BRASS_HOVER` / `BRAND_BRASS_DIM` — accent
- `BRAND_PARCHMENT` / `BRAND_FOG` / `BRAND_SLATE` — text on brand ground
- `BRAND_NAME` / `BRAND_NAME_SHORT` / `BRAND_TAGLINE` / `BRAND_DESCRIPTION` / `BRAND_DOMAIN` / `BRAND_CONTACT_EMAIL` — locked copy
- `brandSurface` / `brandSurfaceMuted` / `brandAccentText` — Tailwind class strings

**New components (`frontend/components/brand/Logo.tsx`):**
- `<Logo tone size short />` — full lockup (default brand presentation)
- `<Wordmark short tone />` — typographic mark only
- `<Mark tone size label />` — glyph only, accessible by default

**New asset paths:**
- `frontend/app/apple-icon.tsx` — dynamic 180x180 PNG via `next/og`
- `frontend/app/icon.svg` — refined chevron mark (replaces the "P" placeholder)
- `frontend/app/opengraph-image.tsx` — now renders the new mark; removes the misleading "14-day free trial" footer (flagged in memory observation 2980).

**`BRAND.md`** at repo root — canonical brand kit (~165 lines, under the 200-line cap).

## Security notes

None. This PR is presentational only — no auth, cookie, CSP, network, or RBAC code paths are touched. The OG image and apple-icon are rendered via `next/og` server-side, same mechanism as before. No new env vars, no new external dependencies.

## Test evidence

- `npx tsc --noEmit` — clean
- `npx vitest run` — 569 / 569 passing (17 new tests for Mark/Wordmark/Logo, including dark/light snapshot)
- `npx eslint` on touched files — clean (one expected SVG-ignored warning)
- Manual: scratch HTML preview rendered the lockup at sm/md/lg in dark + light; chevron mark recolors via CSS custom properties without component re-render (snapshots identical).

## Screenshots

Screenshots saved locally to `.playwright-mcp/` (gitignored):
- `tbd-brand-01-full.png` — full preview, dark on top, light on bottom: mark + wordmark at lg/md/sm sizes, the locked tagline, and an apple-icon preview tile.
- `tbd-brand-02-tab-favicon.png` — browser tab favicon rendered from `icon.svg`.

The OG image is generated dynamically — view at `/opengraph-image` after a build. It uses the new mark, the locked tagline, and `BRAND_FOG`/`BRAND_BRASS` for the description/accent lines.

Coordinator: full local paths are `/Users/fjorge/src/pfv/.playwright-mcp/tbd-brand-01-full.png` and `tbd-brand-02-tab-favicon.png`. If you'd like them inline, I can re-upload as a PR comment attachment.

## Impeccable critique summary

**Strengths.** One component file, three exports, two knobs (`tone`, `size`). CSS-custom-property strokes mean the SVG repaints on theme toggle with no JS branching — SSR/CSR markup are byte-identical (proven by the dual snapshot). Accessibility is correct: `<Mark />` labels itself by default; inside `<Logo />` the mark is decorative because the wordmark carries the name. `BRAND.md` is concrete (Do/Don't pairs are paraphrasable rules, not platitudes) and enforces "The One Brass Rule" explicitly.

**Weak spots.** (1) `size` is constrained to `sm|md|lg`; future callers needing 56px will reach for a custom size — acceptable for v1, flag for follow-up. (2) `tone="inverse"` is documented as "reserved for accent fills"; in light theme `--color-accent-text` resolves to white on darker brass and contrast may dip vs. dark theme. (3) The 14-day free-trial copy was removed from the OG image; if/when L2 lands real billing with a trial, restore the line through `BRAND_DESCRIPTION` rather than hard-coded text.

**Net: ship.**

## Known follow-ups

**Rename-scope recommendation (for coordinator decision, not implemented here).**

After auditing the rename surface area against `project_brand_consolidation.md` and the locked feedback rules, I recommend the **grandfather internal `pfv`** path:

1. Keep repo name (`flamarion/pfv`), local working dir (`~/src/pfv`), `./pfv` CLI, compose service names, DB name (`pfv2`), and `PFV_*`/`pfv2-theme` env / storage keys.
2. The cost of a full rename is high: GitHub repo rename invalidates DO App Platform `spec.git_source.repository` (manual fix), GHA OIDC trust paths, every contributor's git remote, every bookmark, the Claude memory dir slug (`-Users-fjorge-src-pfv` becomes orphaned), Terraform Cloud workspace references, the prod data droplet hostname `pfv-data-01`, the Mailgun sender identity, and ~30 string occurrences across compose / shell scripts.
3. The benefit is purely cosmetic: end users never see any of these surfaces. They see the brand name (already locked here), the favicon (locked here), the OG image (locked here), and email senders (changes in the Email Templates Wave 2 PR).
4. The single user-visible surface still missed is the `pfv2-theme` localStorage key. Recommend rename to `tbd-theme` in a tiny follow-up PR (one-line migration: read both keys, prefer the new one). Optional.

**Other follow-ups:**
- `<Logo />` size scale is constrained — add `xl` or a `pixels?: number` escape hatch if a future caller needs it.
- Email-template team: import `BRAND_INK` / `BRAND_BRASS` directly from `lib/styles.ts` and inline the chevron SVG per template (email clients don't load external SVG).
- Landing team: swap inline "The Better Decision" text in `components/landing/TopNav.tsx` and `LandingFooter.tsx` for `<Logo />` and `<Logo tone="muted" size="sm" />` respectively.
- Header/footer pass: grep `frontend/` for any "PFV"/"pfv2" remnants in user-visible strings.

---

**Ready for Owner Review** once attention is available. Do not merge — Owner Review Board (Senior System Architect, Launch QA Lead, Security Gatekeeper) reviews first.