### PR TITLE
feat(settings): polish MFA setup + billing period config (L5.5)

### DIFF
--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -9,6 +9,11 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import { Loader2 } from "lucide-react";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  mapBillingCycleError,
+  mapBillingPeriodCloseError,
+  validateBillingCycleDay,
+} from "@/lib/formErrors";
 import { projectedPeriodEnd } from "@/lib/format";
 import { isAdmin } from "@/lib/auth";
 import MembersSection from "@/components/settings/MembersSection";
@@ -54,6 +59,15 @@ export default function OrganizationSettingsPage() {
   // resurrect a stale value right after a fast Save.
   const userEditedCycleDayRef = useRef(false);
   const [savingCycle, setSavingCycle] = useState(false);
+  // Inline error for the billing-cycle field. Surfaced under the input
+  // (not the page-level error banner) so the admin sees exactly which
+  // field needs fixing.
+  const [cycleFieldError, setCycleFieldError] = useState<string | null>(null);
+  // Cached server-confirmed value used to disable Save when nothing
+  // changed. Updated after a successful save or a successful GET.
+  const [savedCycleDay, setSavedCycleDay] = useState<string>(
+    user?.billing_cycle_day != null ? String(user.billing_cycle_day) : ""
+  );
   const [currentPeriod, setCurrentPeriod] = useState<{
     id: number;
     start_date: string;
@@ -170,8 +184,10 @@ export default function OrganizationSettingsPage() {
       ).then(setCurrentPeriod).catch(() => {});
       apiFetch<{ billing_cycle_day: number }>("/api/v1/settings/billing-cycle")
         .then((r) => {
+          const next = String(r.billing_cycle_day);
+          setSavedCycleDay(next);
           if (!userEditedCycleDayRef.current) {
-            setBillingCycleDay(String(r.billing_cycle_day));
+            setBillingCycleDay(next);
           }
         })
         .catch(() => {
@@ -234,29 +250,39 @@ export default function OrganizationSettingsPage() {
 
   async function handleSaveCycle(e: FormEvent) {
     e.preventDefault();
+    if (savingCycle) return;
     setError("");
-    const day = Number(billingCycleDay);
-    if (!Number.isInteger(day) || day < 1 || day > 28) {
-      setError("Billing cycle day must be a whole number between 1 and 28");
+    const fieldErr = validateBillingCycleDay(billingCycleDay);
+    if (fieldErr) {
+      setCycleFieldError(fieldErr);
       return;
     }
+    setCycleFieldError(null);
+    const day = Number(billingCycleDay);
     setSavingCycle(true);
     try {
       await apiFetch("/api/v1/settings/billing-cycle", {
         method: "PUT",
         body: JSON.stringify({ billing_cycle_day: day }),
       });
-      // Server now matches local state — clear the dirty flag so a future GET
-      // (e.g., on revisit) can re-sync without being treated as a stale overwrite.
+      // Server now matches local state. Clear the dirty flag so a future
+      // GET (e.g., on revisit) can re-sync without being treated as a
+      // stale overwrite, and update the cached server value so the Save
+      // button correctly disables again until the next edit.
       userEditedCycleDayRef.current = false;
+      setSavedCycleDay(String(day));
       const period = await apiFetch<{ id: number; start_date: string; end_date: string | null }>(
         "/api/v1/settings/billing-period"
       );
       setCurrentPeriod(period);
-      setSuccessMsg("Billing cycle updated");
-      setTimeout(() => setSuccessMsg(""), 3000);
+      setSuccessMsg(`Billing cycle saved. Periods now start on day ${day} of each month.`);
+      setTimeout(() => setSuccessMsg(""), 4000);
     } catch (err) {
-      setError(extractErrorMessage(err));
+      // Map known status codes to friendly copy; the raw server message
+      // is only kept when it is already a safe sentence.
+      setError(mapBillingCycleError(err));
+      // Leave the form filled with the admin's input so they can correct
+      // it without re-typing.
     } finally {
       setSavingCycle(false);
     }
@@ -264,10 +290,13 @@ export default function OrganizationSettingsPage() {
 
   function handleClosePeriod() {
     setConfirmAction({
-      title: "Close Billing Period",
-      message: `Close the current billing period starting ${currentPeriod?.start_date}?\nA new period will open automatically.`,
+      title: "Close billing period",
+      message:
+        `Close the current billing period starting ${currentPeriod?.start_date}? ` +
+        "A new period will open automatically. Closing a period cannot be undone.",
       variant: "warning",
       action: async () => {
+        if (closingPeriod) return;
         setClosingPeriod(true);
         try {
           await apiFetch("/api/v1/settings/billing-period/close", { method: "POST" });
@@ -275,10 +304,14 @@ export default function OrganizationSettingsPage() {
             "/api/v1/settings/billing-period"
           );
           setCurrentPeriod(p);
-          setSuccessMsg("Period closed");
-          setTimeout(() => setSuccessMsg(""), 3000);
+          setSuccessMsg(
+            p?.start_date
+              ? `Previous period closed. New period opened on ${p.start_date}.`
+              : "Previous period closed. A new period is now open.",
+          );
+          setTimeout(() => setSuccessMsg(""), 4000);
         } catch (err) {
-          setError(extractErrorMessage(err));
+          setError(mapBillingPeriodCloseError(err));
         } finally {
           setClosingPeriod(false);
         }
@@ -347,8 +380,16 @@ export default function OrganizationSettingsPage() {
 
   return (
     <SettingsLayout activeTab="/settings/organization">
-      {error && <p className={errorCls}>{error}</p>}
-      {successMsg && <p className={successCls}>{successMsg}</p>}
+      {error && (
+        <p role="alert" aria-live="polite" className={errorCls}>
+          {error}
+        </p>
+      )}
+      {successMsg && (
+        <p role="status" aria-live="polite" className={successCls}>
+          {successMsg}
+        </p>
+      )}
 
       <div className="space-y-6">
         {/* Organization Name */}
@@ -431,48 +472,97 @@ export default function OrganizationSettingsPage() {
         {/* Billing Period */}
         <div className={card}>
           <div className={cardHeader}>
-            <h2 className={cardTitle}>Billing Period</h2>
+            <h2 className={cardTitle}>Billing period</h2>
           </div>
           <div className="p-6 space-y-4">
             {currentPeriod && (
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-sm text-text-primary">
                     Current: {currentPeriod.start_date}
-                    {currentPeriodEndDisplay ? ` — ${currentPeriodEndDisplay}` : " — open"}
+                    {currentPeriodEndDisplay ? `, ${currentPeriodEndDisplay}` : ", open"}
                   </p>
                   <p className="text-xs text-text-muted">
-                    {currentPeriod.end_date ? "Closed" : "Open, transactions are being recorded"}
+                    {currentPeriod.end_date
+                      ? "Closed. Transactions in this range are locked from period rollover."
+                      : "Open. New transactions are being recorded in this period."}
                   </p>
                 </div>
                 {!currentPeriod.end_date && (
                   <button
+                    type="button"
                     onClick={handleClosePeriod}
                     disabled={closingPeriod}
-                    className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                    aria-busy={closingPeriod}
+                    className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
                   >
-                    {closingPeriod ? "Closing..." : "Close Period"}
+                    {closingPeriod && (
+                      <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                    )}
+                    {closingPeriod ? "Closing..." : "Close period"}
                   </button>
                 )}
               </div>
             )}
 
-            <form onSubmit={handleSaveCycle} className="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-3">
-              <div>
-                <label className={label}>Billing cycle day</label>
+            <form
+              onSubmit={handleSaveCycle}
+              className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-3"
+              aria-busy={savingCycle}
+            >
+              <div className="flex-1">
+                <label htmlFor="billing-cycle-day" className={label}>
+                  Billing cycle day
+                </label>
                 <input
+                  id="billing-cycle-day"
                   type="number"
                   min={1}
                   max={28}
+                  inputMode="numeric"
                   value={billingCycleDay}
                   onChange={(e) => {
                     userEditedCycleDayRef.current = true;
                     setBillingCycleDay(e.target.value);
+                    // Re-validate live so the error clears the moment the
+                    // value becomes valid (and surfaces on the first
+                    // out-of-range keystroke).
+                    setCycleFieldError(validateBillingCycleDay(e.target.value));
                   }}
                   className={`${input} w-full sm:w-24`}
+                  aria-describedby={
+                    cycleFieldError ? "billing-cycle-day-err billing-cycle-day-hint" : "billing-cycle-day-hint"
+                  }
+                  aria-invalid={cycleFieldError ? true : undefined}
                 />
+                <p id="billing-cycle-day-hint" className="mt-1.5 text-xs text-text-muted">
+                  Day of the month each new period starts. Days 1 to 28 only, so every month has it.
+                </p>
+                {cycleFieldError && (
+                  <p
+                    id="billing-cycle-day-err"
+                    role="alert"
+                    aria-live="polite"
+                    className="mt-1.5 text-xs text-danger"
+                  >
+                    {cycleFieldError}
+                  </p>
+                )}
               </div>
-              <button type="submit" disabled={savingCycle} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+              <button
+                type="submit"
+                disabled={
+                  savingCycle ||
+                  cycleFieldError !== null ||
+                  billingCycleDay.trim() === "" ||
+                  billingCycleDay === savedCycleDay
+                }
+                aria-busy={savingCycle}
+                className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2 sm:mt-[26px]`}
+              >
+                {savingCycle && (
+                  <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                )}
                 {savingCycle ? "Saving..." : "Save"}
               </button>
             </form>

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
 import SettingsLayout from "@/components/SettingsLayout";
 import PasswordInput from "@/components/ui/PasswordInput";
 import { useAuth, MfaRequiredError } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { isAdmin } from "@/lib/auth";
+import {
+  mapMfaSetupError,
+  mapMfaDisableError,
+  mapMfaRegenerateError,
+} from "@/lib/formErrors";
 import {
   input,
   label,
@@ -195,6 +201,7 @@ export default function SecurityPage() {
   }
 
   async function handleSetup() {
+    if (mfaLoading) return; // guard against double-submit on rapid clicks
     setMfaErr(""); setMfaLoading(true);
     try {
       const data = await apiFetch<MfaSetupResponse>("/api/v1/auth/mfa/setup", {
@@ -202,12 +209,19 @@ export default function SecurityPage() {
       });
       setSetupData(data);
       setMfaStep("qr");
-    } catch (err) { setMfaErr(extractErrorMessage(err)); }
+    } catch (err) { setMfaErr(mapMfaSetupError(err)); }
     finally { setMfaLoading(false); }
   }
 
   async function handleVerifyCode(e: FormEvent) {
     e.preventDefault();
+    if (mfaLoading) return;
+    if (totpCode.length !== 6) {
+      // Should be unreachable because the submit button is disabled, but
+      // belt-and-suspenders for the keyboard-Enter path.
+      setMfaErr("Code must be 6 digits.");
+      return;
+    }
     setMfaErr(""); setMfaLoading(true);
     try {
       const data = await apiFetch<MfaEnableResponse>("/api/v1/auth/mfa/enable", {
@@ -216,7 +230,12 @@ export default function SecurityPage() {
       });
       setRecoveryCodes(data.recovery_codes);
       setMfaStep("codes");
-    } catch (err) { setMfaErr(extractErrorMessage(err)); }
+      setTotpCode(""); // wipe the code now that it's been accepted
+    } catch (err) {
+      setMfaErr(mapMfaSetupError(err));
+      // Keep the input filled so the user can correct it; the code may
+      // simply be one tick stale.
+    }
     finally { setMfaLoading(false); }
   }
 
@@ -226,7 +245,9 @@ export default function SecurityPage() {
     setTotpCode("");
     setRecoveryCodes([]);
     setCodesSaved(false);
-    setMfaMsg("Two-factor authentication enabled");
+    setMfaMsg(
+      "Two-factor authentication is on. You will need your authenticator app the next time you sign in.",
+    );
     refreshMe();
   }
 
@@ -247,6 +268,11 @@ export default function SecurityPage() {
 
   async function handleDisable(e: FormEvent) {
     e.preventDefault();
+    if (disabling) return;
+    if (!disablePassword) {
+      setDisableErr("Enter your password to confirm.");
+      return;
+    }
     setDisableErr(""); setDisabling(true);
     try {
       await apiFetch("/api/v1/auth/mfa/disable", {
@@ -255,14 +281,25 @@ export default function SecurityPage() {
       });
       setShowDisable(false);
       setDisablePassword("");
-      setMfaMsg("Two-factor authentication disabled");
+      setMfaMsg(
+        "Two-factor authentication is off. Your account is now protected by your password only.",
+      );
       refreshMe();
-    } catch (err) { setDisableErr(extractErrorMessage(err)); }
+    } catch (err) {
+      // Keep the password field filled so the user can retry. Only the
+      // server can decide whether the password was wrong.
+      setDisableErr(mapMfaDisableError(err));
+    }
     finally { setDisabling(false); }
   }
 
   async function handleRegenerate(e: FormEvent) {
     e.preventDefault();
+    if (regenerating) return;
+    if (!regenPassword) {
+      setRegenErr("Enter your password to confirm.");
+      return;
+    }
     setRegenErr(""); setRegenerating(true);
     try {
       const data = await apiFetch<MfaEnableResponse>("/api/v1/auth/mfa/recovery-codes", {
@@ -271,7 +308,11 @@ export default function SecurityPage() {
       });
       setRegenCodes(data.recovery_codes);
       setRegenPassword("");
-    } catch (err) { setRegenErr(extractErrorMessage(err)); }
+    } catch (err) {
+      // Preserve the typed password on error so the user can correct
+      // and resubmit without re-typing.
+      setRegenErr(mapMfaRegenerateError(err));
+    }
     finally { setRegenerating(false); }
   }
 
@@ -346,8 +387,16 @@ export default function SecurityPage() {
         <div className={`${card} p-6`}>
           <h2 className={`mb-5 ${cardTitle}`}>Two-Factor Authentication</h2>
 
-          {mfaMsg && <div className={`mb-4 ${successCls}`}>{mfaMsg}</div>}
-          {mfaErr && <div className={`mb-4 ${errorCls}`}>{mfaErr}</div>}
+          {mfaMsg && (
+            <div role="status" aria-live="polite" className={`mb-4 ${successCls}`}>
+              {mfaMsg}
+            </div>
+          )}
+          {mfaErr && (
+            <div role="alert" aria-live="polite" className={`mb-4 ${errorCls}`}>
+              {mfaErr}
+            </div>
+          )}
 
           {/* ── Idle: Not enabled ─────────────────────────────────── */}
           {!mfaEnabled && mfaStep === "idle" && (
@@ -355,7 +404,15 @@ export default function SecurityPage() {
               <p className="mb-4 text-sm text-text-muted">
                 Add an extra layer of security to your account by requiring a verification code when you sign in.
               </p>
-              <button onClick={handleSetup} disabled={mfaLoading} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+              <button
+                onClick={handleSetup}
+                disabled={mfaLoading}
+                aria-busy={mfaLoading}
+                className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+              >
+                {mfaLoading && (
+                  <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                )}
                 {mfaLoading ? "Setting up..." : "Set Up Two-Factor Authentication"}
               </button>
             </div>
@@ -395,7 +452,7 @@ export default function SecurityPage() {
 
           {/* ── Step 2: Verify code ───────────────────────────────── */}
           {mfaStep === "verify" && (
-            <form onSubmit={handleVerifyCode} className="space-y-4">
+            <form onSubmit={handleVerifyCode} className="space-y-4" aria-busy={mfaLoading}>
               <p className="text-sm text-text-muted">
                 Enter the 6-digit code from your authenticator app to confirm it&apos;s working.
               </p>
@@ -413,14 +470,35 @@ export default function SecurityPage() {
                   className={`${input} text-center text-lg tracking-[0.3em]`}
                   placeholder="000000"
                   autoFocus
+                  aria-describedby="mfa-setup-code-hint"
+                  aria-invalid={mfaErr ? true : undefined}
                 />
+                <p id="mfa-setup-code-hint" className="mt-1.5 text-xs text-text-muted">
+                  Codes refresh every 30 seconds. If one fails, wait for the next one.
+                </p>
               </div>
               <div className="flex flex-col gap-3 sm:flex-row">
-                <button type="button" onClick={() => setMfaStep("qr")} className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+                <button
+                  type="button"
+                  onClick={() => setMfaStep("qr")}
+                  disabled={mfaLoading}
+                  className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                >
                   Back
                 </button>
-                <button type="submit" disabled={mfaLoading || totpCode.length !== 6} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
-                  {mfaLoading ? "Verifying..." : "Verify & Enable"}
+                <button
+                  type="submit"
+                  disabled={mfaLoading || totpCode.length !== 6}
+                  aria-busy={mfaLoading}
+                  aria-describedby={
+                    totpCode.length !== 6 && !mfaLoading ? "mfa-setup-code-hint" : undefined
+                  }
+                  className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                >
+                  {mfaLoading && (
+                    <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                  )}
+                  {mfaLoading ? "Verifying..." : "Verify and Enable"}
                 </button>
               </div>
             </form>
@@ -433,7 +511,7 @@ export default function SecurityPage() {
                 Save your recovery codes
               </p>
               <p className="text-sm text-text-muted">
-                If you lose access to your authenticator app, you can use these codes to sign in. Each code can only be used once.
+                If you lose access to your authenticator app, you can use these codes to sign in. Each code can only be used once. We will not show them again.
               </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 rounded-lg bg-surface-raised p-4">
                 {recoveryCodes.map((code, i) => (
@@ -442,14 +520,33 @@ export default function SecurityPage() {
                   </code>
                 ))}
               </div>
-              <button onClick={() => downloadCodes(recoveryCodes)} className={`w-full ${btnSecondary}`}>
-                Download Codes
+              <button
+                type="button"
+                onClick={() => downloadCodes(recoveryCodes)}
+                className={`w-full ${btnSecondary}`}
+              >
+                Download codes
               </button>
               <label className="flex items-center gap-2 text-sm text-text-muted">
-                <input type="checkbox" checked={codesSaved} onChange={(e) => setCodesSaved(e.target.checked)} className="rounded border-border" />
-                I&apos;ve saved these recovery codes
+                <input
+                  type="checkbox"
+                  checked={codesSaved}
+                  onChange={(e) => setCodesSaved(e.target.checked)}
+                  className="rounded border-border"
+                  aria-describedby="codes-saved-hint"
+                />
+                I have saved these recovery codes
               </label>
-              <button onClick={handleFinishSetup} disabled={!codesSaved} className={`w-full ${btnPrimary}`}>
+              <p id="codes-saved-hint" className="text-xs text-text-muted">
+                Check the box to confirm. The Done button stays disabled until you do.
+              </p>
+              <button
+                type="button"
+                onClick={handleFinishSetup}
+                disabled={!codesSaved}
+                aria-describedby={!codesSaved ? "codes-saved-hint" : undefined}
+                className={`w-full ${btnPrimary}`}
+              >
                 Done
               </button>
             </div>
@@ -468,21 +565,61 @@ export default function SecurityPage() {
 
               {/* Regenerate recovery codes */}
               {!showRegen && regenCodes.length === 0 && (
-                <button onClick={() => setShowRegen(true)} className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
-                  Regenerate Recovery Codes
+                <button
+                  type="button"
+                  onClick={() => setShowRegen(true)}
+                  className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                >
+                  Regenerate recovery codes
                 </button>
               )}
               {showRegen && regenCodes.length === 0 && (
-                <form onSubmit={handleRegenerate} className="space-y-3 rounded-lg border border-border p-4">
-                  <p className="text-xs text-text-muted">This will invalidate your existing recovery codes.</p>
-                  {regenErr && <div className={errorCls}>{regenErr}</div>}
+                <form
+                  onSubmit={handleRegenerate}
+                  className="space-y-3 rounded-lg border border-border p-4"
+                  aria-busy={regenerating}
+                >
+                  <p className="text-sm text-text-primary font-medium">
+                    Regenerating will invalidate your existing recovery codes.
+                  </p>
+                  <p className="text-xs text-text-muted">
+                    Any codes you saved before will stop working as soon as new ones are generated. Save the new set before leaving this page.
+                  </p>
+                  {regenErr && (
+                    <div id="regen-err" role="alert" aria-live="polite" className={errorCls}>
+                      {regenErr}
+                    </div>
+                  )}
                   <div>
-                    <label htmlFor="regen-pwd" className={label}>Confirm Password</label>
-                    <PasswordInput id="regen-pwd" required value={regenPassword} onChange={(e) => setRegenPassword(e.target.value)} className={input} />
+                    <label htmlFor="regen-pwd" className={label}>Confirm password</label>
+                    <PasswordInput
+                      id="regen-pwd"
+                      required
+                      value={regenPassword}
+                      onChange={(e) => setRegenPassword(e.target.value)}
+                      className={input}
+                      aria-describedby={regenErr ? "regen-err" : undefined}
+                      aria-invalid={regenErr ? true : undefined}
+                    />
                   </div>
                   <div className="flex flex-col gap-2 sm:flex-row">
-                    <button type="button" onClick={() => { setShowRegen(false); setRegenPassword(""); }} className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>Cancel</button>
-                    <button type="submit" disabled={regenerating} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+                    <button
+                      type="button"
+                      onClick={() => { setShowRegen(false); setRegenPassword(""); setRegenErr(""); }}
+                      disabled={regenerating}
+                      className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={regenerating || !regenPassword}
+                      aria-busy={regenerating}
+                      className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                    >
+                      {regenerating && (
+                        <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                      )}
                       {regenerating ? "Generating..." : "Regenerate"}
                     </button>
                   </div>
@@ -490,7 +627,10 @@ export default function SecurityPage() {
               )}
               {regenCodes.length > 0 && (
                 <div className="space-y-3">
-                  <p className="text-sm font-medium text-text-primary">New Recovery Codes</p>
+                  <p className="text-sm font-medium text-text-primary">New recovery codes</p>
+                  <p className="text-xs text-text-muted">
+                    These replace any codes you saved before. Old codes will not work anymore.
+                  </p>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 rounded-lg bg-surface-raised p-4">
                     {regenCodes.map((code, i) => (
                       <code key={i} className="text-sm text-text-primary font-mono">
@@ -498,10 +638,18 @@ export default function SecurityPage() {
                       </code>
                     ))}
                   </div>
-                  <button onClick={() => downloadCodes(regenCodes)} className={`w-full ${btnSecondary}`}>
-                    Download Codes
+                  <button
+                    type="button"
+                    onClick={() => downloadCodes(regenCodes)}
+                    className={`w-full ${btnSecondary}`}
+                  >
+                    Download codes
                   </button>
-                  <button onClick={() => { setRegenCodes([]); setShowRegen(false); }} className={`w-full ${btnPrimary}`}>
+                  <button
+                    type="button"
+                    onClick={() => { setRegenCodes([]); setShowRegen(false); }}
+                    className={`w-full ${btnPrimary}`}
+                  >
                     Done
                   </button>
                 </div>
@@ -510,21 +658,57 @@ export default function SecurityPage() {
               {/* Disable MFA */}
               <div className="border-t border-border pt-4">
                 {!showDisable ? (
-                  <button onClick={() => setShowDisable(true)} className={`${btnDanger} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
-                    Disable Two-Factor Authentication
+                  <button
+                    type="button"
+                    onClick={() => setShowDisable(true)}
+                    className={`${btnDanger} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                  >
+                    Disable two-factor authentication
                   </button>
                 ) : (
-                  <form onSubmit={handleDisable} className="space-y-3">
-                    <p className="text-xs text-text-muted">Enter your password to disable two-factor authentication.</p>
-                    {disableErr && <div className={errorCls}>{disableErr}</div>}
+                  <form onSubmit={handleDisable} className="space-y-3" aria-busy={disabling}>
+                    <p className="text-sm text-text-primary font-medium">
+                      Confirm with your password to turn off two-factor.
+                    </p>
+                    <p className="text-xs text-text-muted">
+                      Your account will be protected by your password only. You can turn it back on at any time.
+                    </p>
+                    {disableErr && (
+                      <div id="disable-err" role="alert" aria-live="polite" className={errorCls}>
+                        {disableErr}
+                      </div>
+                    )}
                     <div>
                       <label htmlFor="disable-pwd" className={label}>Password</label>
-                      <PasswordInput id="disable-pwd" required value={disablePassword} onChange={(e) => setDisablePassword(e.target.value)} className={input} />
+                      <PasswordInput
+                        id="disable-pwd"
+                        required
+                        value={disablePassword}
+                        onChange={(e) => setDisablePassword(e.target.value)}
+                        className={input}
+                        aria-describedby={disableErr ? "disable-err" : undefined}
+                        aria-invalid={disableErr ? true : undefined}
+                      />
                     </div>
                     <div className="flex flex-col gap-2 sm:flex-row">
-                      <button type="button" onClick={() => { setShowDisable(false); setDisablePassword(""); }} className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>Cancel</button>
-                      <button type="submit" disabled={disabling} className={`${btnPrimary} !bg-danger hover:!bg-danger/80 w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
-                        {disabling ? "Disabling..." : "Disable MFA"}
+                      <button
+                        type="button"
+                        onClick={() => { setShowDisable(false); setDisablePassword(""); setDisableErr(""); }}
+                        disabled={disabling}
+                        className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="submit"
+                        disabled={disabling || !disablePassword}
+                        aria-busy={disabling}
+                        className={`${btnPrimary} !bg-danger hover:!bg-danger/80 w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                      >
+                        {disabling && (
+                          <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                        )}
+                        {disabling ? "Disabling..." : "Disable two-factor"}
                       </button>
                     </div>
                   </form>
@@ -537,9 +721,9 @@ export default function SecurityPage() {
         {/* ── Email Fallback Info ──────────────────────────────────────── */}
         {mfaEnabled && mfaStep === "idle" && (
           <div className={`${card} p-6`}>
-            <h2 className={`mb-3 ${cardTitle}`}>Email Fallback</h2>
+            <h2 className={`mb-3 ${cardTitle}`}>Email fallback</h2>
             <p className="text-sm text-text-muted">
-              If you can&apos;t access your authenticator app or recovery codes, a verification code can be sent to <span className="font-medium text-text-primary">{user?.email}</span>.
+              If you cannot access your authenticator app or recovery codes, a verification code can be sent to <span className="font-medium text-text-primary">{user?.email}</span>.
             </p>
           </div>
         )}
@@ -547,15 +731,23 @@ export default function SecurityPage() {
         {/* ── Session Lifetime (admin only) ────────────────────────────── */}
         {admin && (
           <div className={`${card} p-6`}>
-            <h2 className={`mb-5 ${cardTitle}`}>Session Lifetime</h2>
+            <h2 className={`mb-5 ${cardTitle}`}>Session lifetime</h2>
             <p className="mb-4 text-sm text-text-muted">
               Maximum number of days a user can stay signed in before being required to re-authenticate. Applies to all users in your organization.
             </p>
-            <form onSubmit={handleSessionSubmit} className="space-y-4">
-              {sessionMsg && <div className={successCls}>{sessionMsg}</div>}
-              {sessionErr && <div className={errorCls}>{sessionErr}</div>}
+            <form onSubmit={handleSessionSubmit} className="space-y-4" aria-busy={savingSession}>
+              {sessionMsg && (
+                <div role="status" aria-live="polite" className={successCls}>
+                  {sessionMsg}
+                </div>
+              )}
+              {sessionErr && (
+                <div id="session-err" role="alert" aria-live="polite" className={errorCls}>
+                  {sessionErr}
+                </div>
+              )}
               <div>
-                <label htmlFor="session-days" className={label}>Maximum Session Duration (days)</label>
+                <label htmlFor="session-days" className={label}>Maximum session duration (days)</label>
                 <input
                   id="session-days"
                   type="number"
@@ -565,9 +757,22 @@ export default function SecurityPage() {
                   value={sessionDays}
                   onChange={(e) => setSessionDays(e.target.value)}
                   className={`${input} w-full sm:max-w-[200px]`}
+                  aria-describedby={sessionErr ? "session-err session-hint" : "session-hint"}
+                  aria-invalid={sessionErr ? true : undefined}
                 />
+                <p id="session-hint" className="mt-1.5 text-xs text-text-muted">
+                  Between 1 and 365 days.
+                </p>
               </div>
-              <button type="submit" disabled={savingSession} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+              <button
+                type="submit"
+                disabled={savingSession}
+                aria-busy={savingSession}
+                className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+              >
+                {savingSession && (
+                  <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                )}
                 {savingSession ? "Saving..." : "Save"}
               </button>
             </form>

--- a/frontend/lib/formErrors.ts
+++ b/frontend/lib/formErrors.ts
@@ -1,0 +1,188 @@
+/**
+ * User-friendly error mapping for settings forms.
+ *
+ * Backend MFA and settings endpoints return HTTPException(status, detail)
+ * with plain text. Surfacing raw detail strings ("Invalid TOTP code",
+ * "Invalid or expired MFA token") works but is inconsistent in tone and
+ * occasionally leaks shape (e.g. "MFA configuration error, contact
+ * support"). This helper maps `ApiResponseError` instances to short,
+ * friendly, recoverable sentences without ever revealing auth-sensitive
+ * state (account existence, secret state, exact reuse history).
+ *
+ * Pattern: status-first, with the raw detail used only when the server
+ * already chose a safe, customer-facing message we want to keep. Anything
+ * unrecognised falls through to the supplied fallback.
+ *
+ * Keep all messages free of em-dashes per user copy policy
+ * (feedback_no_em_dashes).
+ */
+
+import { ApiResponseError } from "@/lib/api";
+
+export interface ErrorMapOptions {
+  fallback?: string;
+}
+
+/**
+ * MFA setup / verify / enable errors.
+ *
+ * Endpoints covered:
+ *   POST /auth/mfa/setup
+ *   POST /auth/mfa/enable
+ */
+export function mapMfaSetupError(
+  err: unknown,
+  { fallback = "Something went wrong. Try again." }: ErrorMapOptions = {},
+): string {
+  if (!(err instanceof ApiResponseError)) {
+    return err instanceof Error ? err.message : fallback;
+  }
+  switch (err.status) {
+    case 400:
+      // Server may say "Invalid TOTP code" (verify), "MFA is already
+      // enabled" (race), or "Call /mfa/setup first" (state drift).
+      if (/already enabled/i.test(err.message)) {
+        return "Two-factor authentication is already on. Refresh the page.";
+      }
+      if (/totp/i.test(err.message) || /code/i.test(err.message)) {
+        return "That code did not match. Codes refresh every 30 seconds, so use the latest one.";
+      }
+      return "We could not start setup. Try again in a moment.";
+    case 401:
+      return "That code did not match. Try the next code your app shows.";
+    case 429:
+      return "Too many attempts. Wait a minute and try again.";
+    case 503:
+      return "Two-factor setup is temporarily unavailable. Try again later.";
+    default:
+      return fallback;
+  }
+}
+
+/**
+ * MFA disable errors.
+ *
+ * Endpoint: POST /auth/mfa/disable
+ * Treat 401/403 the same way (bad password) without distinguishing.
+ */
+export function mapMfaDisableError(
+  err: unknown,
+  { fallback = "We could not disable two-factor. Try again." }: ErrorMapOptions = {},
+): string {
+  if (!(err instanceof ApiResponseError)) {
+    return err instanceof Error ? err.message : fallback;
+  }
+  switch (err.status) {
+    case 400:
+      if (/not enabled/i.test(err.message)) {
+        return "Two-factor authentication is not on. Refresh the page.";
+      }
+      return fallback;
+    case 401:
+    case 403:
+      return "That password did not match. Check it and try again.";
+    case 429:
+      return "Too many attempts. Wait a minute and try again.";
+    default:
+      return fallback;
+  }
+}
+
+/**
+ * MFA recovery-code regeneration errors.
+ *
+ * Endpoint: POST /auth/mfa/recovery-codes
+ */
+export function mapMfaRegenerateError(
+  err: unknown,
+  { fallback = "We could not generate new codes. Try again." }: ErrorMapOptions = {},
+): string {
+  if (!(err instanceof ApiResponseError)) {
+    return err instanceof Error ? err.message : fallback;
+  }
+  switch (err.status) {
+    case 400:
+      if (/not enabled/i.test(err.message)) {
+        return "Two-factor authentication is not on. Turn it on first.";
+      }
+      return fallback;
+    case 401:
+    case 403:
+      return "That password did not match. Check it and try again.";
+    case 429:
+      return "Too many attempts. Wait a minute and try again.";
+    default:
+      return fallback;
+  }
+}
+
+/**
+ * Billing-cycle save errors.
+ *
+ * Endpoint: PUT /settings/billing-cycle
+ */
+export function mapBillingCycleError(
+  err: unknown,
+  { fallback = "We could not save the billing cycle. Try again." }: ErrorMapOptions = {},
+): string {
+  if (!(err instanceof ApiResponseError)) {
+    return err instanceof Error ? err.message : fallback;
+  }
+  switch (err.status) {
+    case 400:
+    case 422:
+      return "Pick a whole number between 1 and 28.";
+    case 403:
+      return "You do not have permission to change the billing cycle.";
+    case 429:
+      return "Too many save attempts. Wait a moment and try again.";
+    default:
+      return fallback;
+  }
+}
+
+/**
+ * Billing-period close errors.
+ *
+ * Endpoint: POST /settings/billing-period/close
+ */
+export function mapBillingPeriodCloseError(
+  err: unknown,
+  { fallback = "We could not close the period. Try again." }: ErrorMapOptions = {},
+): string {
+  if (!(err instanceof ApiResponseError)) {
+    return err instanceof Error ? err.message : fallback;
+  }
+  switch (err.status) {
+    case 400:
+      if (/already.*closed/i.test(err.message) || /no.*open/i.test(err.message)) {
+        return "This period is already closed. Refresh the page to see the next one.";
+      }
+      return fallback;
+    case 403:
+      return "You do not have permission to close the period.";
+    case 429:
+      return "Too many attempts. Wait a moment and try again.";
+    default:
+      return fallback;
+  }
+}
+
+/**
+ * Client-side billing-cycle-day validation. Returns null when the value
+ * is acceptable, or a short reason string otherwise. Mirrors server
+ * constraint (whole number, 1 to 28 inclusive).
+ *
+ * Days 29 to 31 are rejected because they do not exist in every month;
+ * the billing period rollover needs a day that always lands.
+ */
+export function validateBillingCycleDay(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return "Enter a day between 1 and 28.";
+  if (!/^\d+$/.test(trimmed)) return "Use digits only.";
+  const day = Number(trimmed);
+  if (!Number.isInteger(day) || day < 1 || day > 28) {
+    return "Pick a whole number between 1 and 28.";
+  }
+  return null;
+}

--- a/frontend/tests/app/settings-security-mfa-polish.test.tsx
+++ b/frontend/tests/app/settings-security-mfa-polish.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import SecurityPage from "@/app/settings/security/page";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/settings/security",
+}));
+
+function makeUser(mfaEnabled: boolean) {
+  return {
+    id: 1,
+    username: "alice",
+    email: "alice@acme.io",
+    first_name: null,
+    last_name: null,
+    phone: null,
+    avatar_url: null,
+    email_verified: true,
+    role: "owner" as const,
+    org_id: 1,
+    org_name: "Acme",
+    billing_cycle_day: 1,
+    is_superadmin: false,
+    is_active: true,
+    mfa_enabled: mfaEnabled,
+    password_set: true,
+    subscription_status: null,
+    subscription_plan: null,
+    trial_end: null,
+  };
+}
+
+function mockUser(mfaEnabled: boolean) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: makeUser(mfaEnabled) as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
+
+describe("Security page MFA polish: copy, validation, error mapping", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(apiFetch).mockResolvedValue([] as never);
+  });
+
+  it("disables the Set Up button while in flight and shows a spinner", async () => {
+    mockUser(false);
+    // Hang the setup call so we can observe the busy state.
+    let resolve: (v: unknown) => void = () => {};
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/setup") {
+        return new Promise((r) => { resolve = r; });
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    render(<SecurityPage />);
+    const setupBtn = await screen.findByRole("button", {
+      name: /Set Up Two-Factor Authentication/i,
+    });
+    fireEvent.click(setupBtn);
+
+    const busyBtn = await screen.findByRole("button", { name: /Setting up/i });
+    expect(busyBtn).toBeDisabled();
+    expect(busyBtn).toHaveAttribute("aria-busy", "true");
+
+    resolve({ qr_code: "Zm9v", secret: "S" });
+    await waitFor(() => {
+      expect(screen.getByText(/Scan this QR code/i)).toBeInTheDocument();
+    });
+  });
+
+  it("maps a 401 TOTP error to a friendly message and keeps the user's code filled", async () => {
+    mockUser(false);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/setup") {
+        return Promise.resolve({ qr_code: "Zm9v", secret: "SECRET" });
+      }
+      if (url === "/api/v1/auth/mfa/enable") {
+        return Promise.reject(new ApiResponseError(401, "Invalid TOTP code"));
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    render(<SecurityPage />);
+    const setupBtn = await screen.findByRole("button", {
+      name: /Set Up Two-Factor Authentication/i,
+    });
+    fireEvent.click(setupBtn);
+
+    // Advance to the verify step.
+    fireEvent.click(await screen.findByRole("button", { name: /^Continue$/i }));
+
+    const codeInput = await screen.findByLabelText(/Verification Code/i);
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Verify and Enable/i }));
+
+    const err = await screen.findByRole("alert");
+    expect(err.textContent).toMatch(/did not match/i);
+    // Raw server detail must not leak through.
+    expect(err.textContent).not.toMatch(/Invalid TOTP code/i);
+    // The code stays filled so the admin can correct it.
+    expect((codeInput as HTMLInputElement).value).toBe("123456");
+  });
+
+  it("renders the 6-digit hint and ties it to the input via aria-describedby", async () => {
+    mockUser(false);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/setup") {
+        return Promise.resolve({ qr_code: "Zm9v", secret: "SECRET" });
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    render(<SecurityPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Set Up Two-Factor Authentication/i }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /^Continue$/i }));
+
+    const codeInput = await screen.findByLabelText(/Verification Code/i);
+    const describedBy = codeInput.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const hint = document.getElementById(describedBy!);
+    expect(hint?.textContent).toMatch(/30 seconds/i);
+  });
+
+  it("recovery codes screen makes Done depend on the confirmation checkbox", async () => {
+    mockUser(false);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/setup") {
+        return Promise.resolve({ qr_code: "Zm9v", secret: "SECRET" });
+      }
+      if (url === "/api/v1/auth/mfa/enable") {
+        return Promise.resolve({ recovery_codes: ["A1B2C3D4", "E5F6G7H8"] });
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    render(<SecurityPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Set Up Two-Factor Authentication/i }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /^Continue$/i }));
+    const codeInput = await screen.findByLabelText(/Verification Code/i);
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Verify and Enable/i }));
+
+    const done = await screen.findByRole("button", { name: /^Done$/i });
+    expect(done).toBeDisabled();
+    // Hint must be present and reachable from the disabled button.
+    const describedBy = done.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText(/I have saved these recovery codes/i));
+    expect(done).toBeEnabled();
+  });
+
+  it("regenerate flow keeps the password filled on error and maps the 401", async () => {
+    mockUser(true);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/recovery-codes") {
+        return Promise.reject(new ApiResponseError(401, "Invalid password"));
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    render(<SecurityPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Regenerate recovery codes/i }),
+    );
+    const pwd = await screen.findByLabelText(/Confirm password/i);
+    fireEvent.change(pwd, { target: { value: "wrongPassword" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Regenerate$/i }));
+
+    const err = await screen.findByRole("alert");
+    expect(err.textContent).toMatch(/password did not match/i);
+    expect(err.textContent).not.toMatch(/Invalid password/);
+    expect((pwd as HTMLInputElement).value).toBe("wrongPassword");
+  });
+});

--- a/frontend/tests/formErrors.test.ts
+++ b/frontend/tests/formErrors.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { ApiResponseError } from "@/lib/api";
+import {
+  mapBillingCycleError,
+  mapBillingPeriodCloseError,
+  mapMfaDisableError,
+  mapMfaRegenerateError,
+  mapMfaSetupError,
+  validateBillingCycleDay,
+} from "@/lib/formErrors";
+
+describe("validateBillingCycleDay", () => {
+  it("accepts integer days 1 through 28", () => {
+    for (const day of [1, 5, 15, 28]) {
+      expect(validateBillingCycleDay(String(day))).toBeNull();
+    }
+  });
+
+  it("rejects days outside 1-28", () => {
+    expect(validateBillingCycleDay("0")).toMatch(/1 and 28/);
+    expect(validateBillingCycleDay("29")).toMatch(/1 and 28/);
+    expect(validateBillingCycleDay("31")).toMatch(/1 and 28/);
+    expect(validateBillingCycleDay("-3")).toMatch(/digits only|1 and 28/);
+  });
+
+  it("rejects non-numeric and empty input with field-specific copy", () => {
+    expect(validateBillingCycleDay("")).toMatch(/between 1 and 28/);
+    expect(validateBillingCycleDay("abc")).toMatch(/digits only/);
+    expect(validateBillingCycleDay("1.5")).toMatch(/digits only/);
+  });
+
+  it("contains no em-dashes", () => {
+    const msgs = [
+      validateBillingCycleDay(""),
+      validateBillingCycleDay("0"),
+      validateBillingCycleDay("abc"),
+    ];
+    for (const m of msgs) {
+      expect(m).not.toMatch(/—|–/);
+    }
+  });
+});
+
+describe("mapMfaSetupError", () => {
+  it("maps 401 to a friendly retry message without revealing details", () => {
+    const err = new ApiResponseError(401, "Invalid TOTP code");
+    const msg = mapMfaSetupError(err);
+    expect(msg).toMatch(/did not match/i);
+    expect(msg).not.toContain("Invalid TOTP code");
+  });
+
+  it("maps 400 with code language to a refresh hint", () => {
+    const err = new ApiResponseError(400, "Invalid TOTP code");
+    expect(mapMfaSetupError(err)).toMatch(/30 seconds/);
+  });
+
+  it("maps 400 'already enabled' to a refresh hint", () => {
+    const err = new ApiResponseError(400, "MFA is already enabled");
+    expect(mapMfaSetupError(err)).toMatch(/already on/i);
+  });
+
+  it("maps 429 to a wait message", () => {
+    const err = new ApiResponseError(429, "Too many requests");
+    expect(mapMfaSetupError(err)).toMatch(/wait a minute/i);
+  });
+
+  it("maps 503 to a temporary-unavailable message", () => {
+    const err = new ApiResponseError(503, "anything");
+    expect(mapMfaSetupError(err)).toMatch(/temporarily unavailable/i);
+  });
+
+  it("falls back to the supplied fallback for unrecognised statuses", () => {
+    const err = new ApiResponseError(418, "I am a teapot");
+    expect(mapMfaSetupError(err, { fallback: "Custom" })).toBe("Custom");
+  });
+
+  it("handles non-ApiResponseError gracefully", () => {
+    expect(mapMfaSetupError(new Error("boom"))).toBe("boom");
+    expect(mapMfaSetupError({ weird: true })).toMatch(/Something went wrong/);
+  });
+
+  it("never contains em-dashes", () => {
+    const samples = [
+      mapMfaSetupError(new ApiResponseError(400, "Invalid TOTP code")),
+      mapMfaSetupError(new ApiResponseError(401, "x")),
+      mapMfaSetupError(new ApiResponseError(429, "x")),
+      mapMfaSetupError(new ApiResponseError(503, "x")),
+    ];
+    for (const m of samples) {
+      expect(m).not.toMatch(/—|–/);
+    }
+  });
+});
+
+describe("mapMfaDisableError", () => {
+  it("maps 401 and 403 to the same friendly password-mismatch message", () => {
+    expect(mapMfaDisableError(new ApiResponseError(401, "x"))).toMatch(/password did not match/i);
+    expect(mapMfaDisableError(new ApiResponseError(403, "Invalid password"))).toMatch(
+      /password did not match/i,
+    );
+  });
+
+  it("maps 400 'not enabled' to a refresh hint", () => {
+    expect(mapMfaDisableError(new ApiResponseError(400, "MFA is not enabled"))).toMatch(
+      /not on/i,
+    );
+  });
+
+  it("never reveals whether the password reuse vs bad-password caused failure", () => {
+    const msgs = [
+      mapMfaDisableError(new ApiResponseError(401, "Invalid password")),
+      mapMfaDisableError(new ApiResponseError(403, "Invalid password")),
+    ];
+    // Both paths must produce the exact same user-facing string.
+    expect(msgs[0]).toBe(msgs[1]);
+  });
+});
+
+describe("mapMfaRegenerateError", () => {
+  it("maps 401 to a password-mismatch message", () => {
+    expect(mapMfaRegenerateError(new ApiResponseError(401, "x"))).toMatch(
+      /password did not match/i,
+    );
+  });
+
+  it("maps 400 'not enabled' to a helpful next step", () => {
+    expect(mapMfaRegenerateError(new ApiResponseError(400, "MFA is not enabled"))).toMatch(
+      /not on/i,
+    );
+  });
+});
+
+describe("mapBillingCycleError", () => {
+  it("maps 422 to a clear field-rule sentence", () => {
+    expect(mapBillingCycleError(new ApiResponseError(422, "validation"))).toMatch(
+      /between 1 and 28/,
+    );
+  });
+
+  it("maps 403 to a permission message", () => {
+    expect(mapBillingCycleError(new ApiResponseError(403, "x"))).toMatch(/do not have permission/);
+  });
+
+  it("maps 429 to a rate-limit message", () => {
+    expect(mapBillingCycleError(new ApiResponseError(429, "x"))).toMatch(/wait a moment/i);
+  });
+});
+
+describe("mapBillingPeriodCloseError", () => {
+  it("maps already-closed 400 to a refresh hint", () => {
+    expect(
+      mapBillingPeriodCloseError(new ApiResponseError(400, "Period already closed")),
+    ).toMatch(/already closed/i);
+  });
+
+  it("maps 403 to a permission message", () => {
+    expect(mapBillingPeriodCloseError(new ApiResponseError(403, "x"))).toMatch(
+      /do not have permission/,
+    );
+  });
+});

--- a/frontend/tests/settings/organization-billing-period-polish.test.tsx
+++ b/frontend/tests/settings/organization-billing-period-polish.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import OrganizationSettingsPage from "@/app/settings/organization/page";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("swr", async () => {
+  const actual = await vi.importActual<typeof import("swr")>("swr");
+  return { ...actual, mutate: vi.fn(() => Promise.resolve()) };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => "/settings/organization",
+}));
+
+function makeUser() {
+  return {
+    id: 1, username: "u", email: "u@x.io",
+    first_name: null, last_name: null, phone: null, avatar_url: null,
+    email_verified: true,
+    role: "owner" as const,
+    org_id: 42, org_name: "Acme", billing_cycle_day: 1,
+    is_superadmin: false, is_active: true, mfa_enabled: false,
+    password_set: true,
+    subscription_status: null, subscription_plan: null, trial_end: null,
+  };
+}
+
+function baseFixtures() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/settings/billing-cycle") {
+      return Promise.resolve({ billing_cycle_day: 1 });
+    }
+    if (url === "/api/v1/settings/billing-period") {
+      return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    }
+    if (url === "/api/v1/settings") return Promise.resolve([]);
+    if (url === "/api/v1/orgs/members") return Promise.resolve([]);
+    if (url === "/api/v1/orgs/invitations") return Promise.resolve([]);
+    if (url === "/api/v1/category-rules") return Promise.resolve([]);
+    return Promise.resolve({});
+  }) as never);
+}
+
+function mockUser() {
+  vi.mocked(useAuth).mockReturnValue({
+    user: makeUser() as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
+
+describe("Billing period polish: inline validation, busy state, error mapping", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    baseFixtures();
+    mockUser();
+  });
+
+  it("disables Save when the value matches what the server already has", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = (await screen.findByLabelText(
+      /Billing cycle day/i,
+    )) as HTMLInputElement;
+    // billing-cycle GET resolves to 1 from baseFixtures.
+    await waitFor(() => expect(input.value).toBe("1"));
+    const saveBtn = screen.getAllByRole("button", { name: /^Save$/i })[0];
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it("surfaces inline error and disables Save for out-of-range input", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = await screen.findByLabelText(/Billing cycle day/i);
+    fireEvent.change(input, { target: { value: "31" } });
+    const err = await screen.findByRole("alert");
+    expect(err.textContent).toMatch(/between 1 and 28/);
+    const saveBtn = screen.getAllByRole("button", { name: /^Save$/i })[0];
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it("clears the inline error once the value becomes valid", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = await screen.findByLabelText(/Billing cycle day/i);
+    fireEvent.change(input, { target: { value: "31" } });
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "15" } });
+    await waitFor(() =>
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+    );
+    const saveBtn = screen.getAllByRole("button", { name: /^Save$/i })[0];
+    expect(saveBtn).toBeEnabled();
+  });
+
+  it("renders the day-rule hint and ties it to the input", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = await screen.findByLabelText(/Billing cycle day/i);
+    const ids = (input.getAttribute("aria-describedby") || "").split(/\s+/);
+    expect(ids.some((id) => /hint/.test(id))).toBe(true);
+    const hint = document.getElementById(
+      ids.find((id) => /hint/.test(id)) || "",
+    );
+    expect(hint?.textContent).toMatch(/Day of the month/i);
+  });
+
+  it("maps a 422 save error to friendly copy without echoing raw body", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = await screen.findByLabelText(/Billing cycle day/i);
+    fireEvent.change(input, { target: { value: "15" } });
+
+    vi.mocked(apiFetch).mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url === "/api/v1/settings/billing-cycle" && opts?.method === "PUT") {
+        return Promise.reject(
+          new ApiResponseError(422, "billing_cycle_day: ensure this value is less than or equal to 28"),
+        );
+      }
+      if (url === "/api/v1/settings/billing-cycle") {
+        return Promise.resolve({ billing_cycle_day: 1 });
+      }
+      if (url === "/api/v1/settings/billing-period") {
+        return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    const saveBtn = screen.getAllByRole("button", { name: /^Save$/i })[0];
+    fireEvent.click(saveBtn);
+
+    const pageError = await screen.findByRole("alert");
+    expect(pageError.textContent).toMatch(/between 1 and 28/);
+    // Raw server detail must not bleed through.
+    expect(pageError.textContent).not.toMatch(/ensure this value/i);
+    // Value is preserved for retry.
+    expect((input as HTMLInputElement).value).toBe("15");
+  });
+});


### PR DESCRIPTION
## Scope summary
UI/copy/state polish on the MFA setup, recovery codes, MFA disable, MFA recovery-code regeneration, and billing-period config (day picker, save, close period) screens. No endpoint, schema, or security semantics changed.

## Contract changes
None (UI/copy only; no endpoint changes).

## Security notes
- No auth or MFA semantics changed. Password re-prompt still required to disable MFA and to regenerate recovery codes. TOTP secret handling unchanged. Rate limits unchanged.
- Confirmed: error copy never reveals account existence, secret state, code reuse, or password-vs-MFA distinction. 401 and 403 on the disable/regenerate paths collapse to the same user-facing string ("That password did not match. Check it and try again.").
- Backend continues to be the authority on validation. Client-side `validateBillingCycleDay` is a UX assist; the server still rejects out-of-range values.
- Errors from unrecognised status codes fall back to generic copy instead of echoing raw bodies.

## What changed
**New: `frontend/lib/formErrors.ts`** maps `ApiResponseError` to friendly, recoverable sentences for MFA setup/enable, MFA disable, recovery-code regeneration, billing-cycle save, and billing-period close. Plus a `validateBillingCycleDay` rule used live in the form.

**MFA setup flows** (`frontend/app/settings/security/page.tsx`):
- Inline TOTP hint ("Codes refresh every 30 seconds. If one fails, wait for the next one.") with `aria-describedby` linking the input to the hint and surfacing the disabled-button reason.
- `Loader2` spinner with `motion-reduce:animate-none` on every submit button (setup, verify, regen, disable, session). `aria-busy` on forms and buttons while submitting.
- Double-submit guard on every async handler.
- Recovery codes screen: explicit "We will not show them again." + the Done button's disabled reason exposed via `aria-describedby`.
- Regenerate warning promoted from muted footnote to primary copy ("Regenerating will invalidate your existing recovery codes."). Old-codes warning repeated on the new-codes panel.
- Disable warning clarified ("Your account will be protected by your password only. You can turn it back on at any time.").
- Top-of-card success/error banners now use `role="status"` and `role="alert"` with `aria-live="polite"`. Inline errors on regen/disable forms tied to inputs via `aria-describedby` + `aria-invalid`.
- Error messages mapped through `mapMfaSetupError`/`mapMfaDisableError`/`mapMfaRegenerateError`. Raw server detail (e.g. "Invalid TOTP code") no longer reaches the UI.
- Friendlier success copy: "Two-factor authentication is on. You will need your authenticator app the next time you sign in." instead of "Two-factor authentication enabled".

**Billing period config** (`frontend/app/settings/organization/page.tsx` billing-period card only):
- Inline validation on the day field. Out-of-range values (0, 29 to 31, non-integer, empty) show a field-specific error tied via `aria-describedby` and `aria-invalid`, and disable Save until corrected.
- Save is also disabled when the value matches the server-confirmed value (no-op submit prevention).
- Day-rule hint ("Day of the month each new period starts. Days 1 to 28 only, so every month has it.") tied via `aria-describedby`.
- Spinner + `aria-busy` on Save and Close period.
- Close-period confirm copy now says "Closing a period cannot be undone."
- Success copy on save names the new behaviour ("Billing cycle saved. Periods now start on day N of each month."), and on close names the new period start date.
- On save error, the admin's input is preserved.

## Test evidence
- `npx tsc --noEmit` clean.
- `npm test` clean: 584 tests pass, 32 new (`tests/formErrors.test.ts` x22, `tests/app/settings-security-mfa-polish.test.tsx` x5, `tests/settings/organization-billing-period-polish.test.tsx` x5).
- New tests assert: error mappings, live validation, hint-link via `aria-describedby`, raw server detail does not leak, password/input preservation on error, no em-dashes in mapped strings.
- Reduced motion: every new `animate-spin` is paired with `motion-reduce:animate-none` so `prefers-reduced-motion` users see a static icon.

## /impeccable critique notes
Captured during the design pass (no separate `/impeccable` invocation produced an artefact, the critique is summarised here for review):

*MFA setup before*: page-level alert banner only, no aria-live, raw server text, no hint on TOTP input, no spinner. Loading state was a text swap. Verify button had no contextual help when disabled.
*MFA setup after*: inline + aria-live alerts, mapped copy, hint + 30s explainer, spinner + aria-busy, the disabled Verify button announces why via `aria-describedby`.

*Billing period before*: single page-level error, validation only on submit, the Save button stayed enabled at all values, no hint, no spinner, ambiguous confirm copy.
*Billing period after*: inline field-level error with live revalidation, Save disabled until valid and changed, day-rule hint always visible, spinner + aria-busy, confirm copy spells out irreversibility, success copy names the next state.

## Known follow-ups
- A future pass could move the page-level error banners into a dedicated `<FormBanner>` component shared across settings cards. Out of scope here (would touch `lib/styles.ts` adjacent territory; Brand Foundation owns the tokens).
- Password-change flow inside the same security page kept its existing copy and error handling. Could receive the same polish in a follow-up if desired.
- Session-lifetime card received light polish (label case, aria-describedby, spinner) but its validation rule and error path are unchanged; could be deepened in a follow-up.