### PR TITLE
feat(help): Tooltip primitive + tour scaffold + per-element tooltips (L5.3)

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import Tooltip from "@/components/Tooltip";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -402,8 +403,13 @@ export default function AccountsPage() {
                         <span className="text-text-muted">{a.currency}</span>
                       </span>
                       {pendingByAccount[a.id] ? (
-                        <span className="text-xs tabular-nums text-text-muted">
-                          Pending: {formatAmount(Math.abs(pendingByAccount[a.id]))}
+                        <span className="inline-flex items-center gap-1 text-xs tabular-nums text-text-muted">
+                          <span>Pending: {formatAmount(Math.abs(pendingByAccount[a.id]))}</span>
+                          <Tooltip
+                            content="Sum of transactions still marked Pending on this account. They do not move the balance yet, but they shape the end of month forecast."
+                            learnMoreSection="accounts"
+                            triggerLabel="What does Pending mean for this account?"
+                          />
                         </span>
                       ) : null}
                     </div>

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import Tooltip from "@/components/Tooltip";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -380,21 +381,37 @@ export default function CategoriesPage() {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {/* C2a: Edit-mode toggle. Owned by Team Categories C2 UI. */}
-          <button
-            type="button"
-            data-testid="categories-edit-toggle"
-            aria-pressed={editMode}
-            onClick={() => (editMode ? exitEditMode() : setEditMode(true))}
-            className={`${btnSecondary} min-h-[44px] sm:min-h-0`}
-          >
-            {editMode ? "Cancel Edit" : "Edit"}
-          </button>
-          <button
-            onClick={() => setShowAddMasterModal(true)}
-            className={btnPrimary}
-          >
-            + Add Master
-          </button>
+          <span className="inline-flex items-center gap-1">
+            <button
+              type="button"
+              data-testid="categories-edit-toggle"
+              aria-pressed={editMode}
+              onClick={() => (editMode ? exitEditMode() : setEditMode(true))}
+              className={`${btnSecondary} min-h-[44px] sm:min-h-0`}
+            >
+              {editMode ? "Cancel Edit" : "Edit"}
+            </button>
+            {!editMode && (
+              <Tooltip
+                content="Edit mode unlocks drag and drop reordering, moving subcategories between masters, and batch select for delete or move."
+                learnMoreSection="categories"
+                triggerLabel="What does Edit mode unlock?"
+              />
+            )}
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <button
+              onClick={() => setShowAddMasterModal(true)}
+              className={btnPrimary}
+            >
+              + Add Master
+            </button>
+            <Tooltip
+              content="Master categories anchor budgets. Subcategories nest under a master and act as tags on individual transactions."
+              learnMoreSection="categories"
+              triggerLabel="What is a Master category?"
+            />
+          </span>
         </div>
       </div>
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -773,7 +773,7 @@ export default function DashboardPage() {
                     />
                     <div className="absolute right-3 top-3">
                       <HelpTooltip
-                        content="Projects each account's balance to month end using settled balance plus pending transactions and any planned recurring activity."
+                        content="Each account's current balance plus its pending transactions in this billing period. Recurring activity is not factored in."
                         learnMoreSection="forecasts"
                         triggerLabel="How is the end of month forecast calculated?"
                       />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import HelpTooltip from "@/components/Tooltip";
+import TourAnchor from "@/components/tour/TourAnchor";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -616,17 +618,21 @@ export default function DashboardPage() {
 
   return (
     <AppShell>
-      <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-center gap-1">
-          <h1 className={`${pageTitle} mb-0`}>Dashboard</h1>
-          <HelpAnchor section="dashboard" label="Dashboard" />
+      <TourAnchor id="dashboard.header" as="child">
+        <div className="mb-6 flex items-center justify-between">
+          <div className="flex items-center gap-1">
+            <h1 className={`${pageTitle} mb-0`}>Dashboard</h1>
+            <HelpAnchor section="dashboard" label="Dashboard" />
+          </div>
+          <div className="flex items-center gap-2">
+            <TourAnchor id="dashboard.import-cta" as="child">
+              <Link href="/import" className={btnSecondary}>
+                Import
+              </Link>
+            </TourAnchor>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Link href="/import" className={btnSecondary}>
-            Import
-          </Link>
-        </div>
-      </div>
+      </TourAnchor>
 
       {resetBanner && (
         <div
@@ -675,6 +681,7 @@ export default function DashboardPage() {
       ) : (
         <div className="space-y-5">
           {/* ═══ BILLING PERIOD — standalone nav bar ═══ */}
+          <TourAnchor id="dashboard.period-nav" as="child">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <button onClick={() => { setPeriodIdx(Math.min(periodIdx + 1, periods.length - 1)); setChartFilter(null); }} disabled={periodIdx >= periods.length - 1} className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Previous period">
@@ -693,17 +700,31 @@ export default function DashboardPage() {
             </div>
             <Link href="/transactions" className="text-xs text-text-secondary underline underline-offset-2 hover:text-text-primary">View All Transactions</Link>
           </div>
+          </TourAnchor>
 
           {/* ═══ ROW 1: On Track hero — single full-width tile ═══ */}
-          <OnTrackTile
-            forecastPlan={forecast}
-            projection={forecastProjection}
-            projectionFailed={projectionFailed}
-            projectionLoading={projectionLoading}
-            onRetryProjection={() => void loadForecastProjection()}
-            isPastPeriod={isPastSelectedPeriod}
-            isFuturePeriod={isFutureSelectedPeriod}
-          />
+          <TourAnchor id="dashboard.on-track-tile">
+            <div className="flex items-start gap-2">
+              <div className="flex-1">
+                <OnTrackTile
+                  forecastPlan={forecast}
+                  projection={forecastProjection}
+                  projectionFailed={projectionFailed}
+                  projectionLoading={projectionLoading}
+                  onRetryProjection={() => void loadForecastProjection()}
+                  isPastPeriod={isPastSelectedPeriod}
+                  isFuturePeriod={isFutureSelectedPeriod}
+                />
+              </div>
+              <div className="pt-3">
+                <HelpTooltip
+                  content="On Track compares spent so far to your planned spending for this period. Watch warns at 95 percent, Over at 105 percent."
+                  learnMoreSection="forecasts"
+                  triggerLabel="What does On Track mean?"
+                />
+              </div>
+            </div>
+          </TourAnchor>
 
           {/* ═══ ROW 2: Accounts sidebar + Forecast card, side-by-side ═══
               Tiles share ONE card with internal divider rows; the
@@ -735,19 +756,30 @@ export default function DashboardPage() {
                   accounts={orderedAccounts}
                   pendingByAccount={pendingByAccount}
                 />
-                <AccountMonthEndForecast
-                  forecast={accountMonthEndForecast}
-                  isCurrentPeriod={isCurrentSelectedPeriod}
-                  hasAnyAccounts={activeAccounts.length > 0}
-                  hasError={accountMonthEndForecastError}
-                  onJumpToCurrent={() => {
-                    const idx = periods.findIndex((p) => p.end_date === null);
-                    if (idx >= 0) {
-                      setPeriodIdx(idx);
-                      setChartFilter(null);
-                    }
-                  }}
-                />
+                <TourAnchor id="dashboard.account-forecast" as="child">
+                  <div className="relative">
+                    <AccountMonthEndForecast
+                      forecast={accountMonthEndForecast}
+                      isCurrentPeriod={isCurrentSelectedPeriod}
+                      hasAnyAccounts={activeAccounts.length > 0}
+                      hasError={accountMonthEndForecastError}
+                      onJumpToCurrent={() => {
+                        const idx = periods.findIndex((p) => p.end_date === null);
+                        if (idx >= 0) {
+                          setPeriodIdx(idx);
+                          setChartFilter(null);
+                        }
+                      }}
+                    />
+                    <div className="absolute right-3 top-3">
+                      <HelpTooltip
+                        content="Projects each account's balance to month end using settled balance plus pending transactions and any planned recurring activity."
+                        learnMoreSection="forecasts"
+                        triggerLabel="How is the end of month forecast calculated?"
+                      />
+                    </div>
+                  </div>
+                </TourAnchor>
               </div>
             );
           })()}

--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import HelpTooltip from "@/components/Tooltip";
 import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import CategorySelect from "@/components/ui/CategorySelect";
@@ -603,6 +604,11 @@ export default function ForecastPlansClient({
         <div className="flex flex-wrap items-center gap-2">
           {/* Show/hide details toggle. Hides variance/source/chart/refresh
               and the technical (?) help markers when off. */}
+          <HelpTooltip
+            content="Show details reveals variance vs plan, source breakdowns, the chart, and refresh from sources. Hide details keeps the page light."
+            learnMoreSection="forecast-plans"
+            triggerLabel="What does Show details include?"
+          />
           <button
             type="button"
             role="switch"

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import Tooltip from "@/components/Tooltip";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -887,19 +888,26 @@ function TransactionsPageContent() {
               Clear
             </button>
             {linkSelection.visible && (
-              <button
-                type="button"
-                className={btnSecondary}
-                title={linkSelection.reason ?? "Link the two selected rows as a transfer"}
-                disabled={!linkSelection.enabled || bulkDeleting}
-                onClick={() => {
-                  if (linkSelection.enabled && linkSelection.expense && linkSelection.income) {
-                    setLinkModalLegs({ expense: linkSelection.expense, income: linkSelection.income });
-                  }
-                }}
-              >
-                Link as transfer
-              </button>
+              <span className="inline-flex items-center gap-1">
+                <button
+                  type="button"
+                  className={btnSecondary}
+                  title={linkSelection.reason ?? "Link the two selected rows as a transfer"}
+                  disabled={!linkSelection.enabled || bulkDeleting}
+                  onClick={() => {
+                    if (linkSelection.enabled && linkSelection.expense && linkSelection.income) {
+                      setLinkModalLegs({ expense: linkSelection.expense, income: linkSelection.income });
+                    }
+                  }}
+                >
+                  Link as transfer
+                </button>
+                <Tooltip
+                  content="Pair one expense and one income of the same amount across two accounts so the app treats them as a single transfer instead of two separate transactions."
+                  learnMoreSection="transactions"
+                  triggerLabel="More about transfer pairing"
+                />
+              </span>
             )}
             <button
               type="button"
@@ -1008,7 +1016,14 @@ function TransactionsPageContent() {
               <input id="tx-amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value={formAmount} onChange={(e) => setFormAmount(e.target.value)} className={input} />
             </div>
             <div>
-              <label htmlFor="tx-status" className={label}>Status</label>
+              <span className="mb-1.5 flex items-center gap-1">
+                <label htmlFor="tx-status" className={`${label} mb-0`}>Status</label>
+                <Tooltip
+                  content="Settled transactions count toward your balance today. Pending transactions affect forecasts but not the current balance until they settle."
+                  learnMoreSection="transactions"
+                  triggerLabel="What is the difference between Settled and Pending?"
+                />
+              </span>
               <select id="tx-status" value={formStatus} onChange={(e) => setFormStatus(e.target.value as "settled" | "pending")} className={input}>
                 <option value="settled">Settled</option>
                 <option value="pending">Pending</option>

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -119,6 +119,14 @@ export default function Tooltip({
 
   const triggerRef = useRef<HTMLSpanElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
+  // Set by handleFocus, read + cleared by handleClick. Browsers fire
+  // `focus` immediately before `click` when a user mouse-clicks an
+  // unfocused element. Without this flag, the focus opens the tooltip
+  // and the click in the same tick toggles it back closed — inverting
+  // every other click. handleFocus arms the flag, the next click clears
+  // it instead of toggling, and a queued microtask resets the flag so a
+  // deliberate second click (with no fresh focus) still toggles.
+  const justOpenedByFocus = useRef(false);
   const reducedMotion = useReducedMotion();
 
   useEffect(() => {
@@ -270,13 +278,35 @@ export default function Tooltip({
     if (related && tooltipRef.current?.contains(related)) return;
     setOpen(false);
   }, []);
-  const handleFocus = useCallback(() => setOpen(true), []);
+  const handleFocus = useCallback(() => {
+    setOpen(true);
+    // Arm the focus-then-click suppressor. Queued microtask resets the
+    // flag after the same-tick click handler runs. requestAnimationFrame
+    // would also work; setTimeout(0) is the conservative cross-browser
+    // pick for "next tick" and matches what testing-library's
+    // act-flushing expects.
+    justOpenedByFocus.current = true;
+    if (typeof window !== "undefined") {
+      window.setTimeout(() => {
+        justOpenedByFocus.current = false;
+      }, 0);
+    }
+  }, []);
   const handleBlur = useCallback((e: React.FocusEvent) => {
     const next = e.relatedTarget as Node | null;
     if (next && tooltipRef.current?.contains(next)) return;
     setOpen(false);
   }, []);
-  const handleClick = useCallback(() => setOpen((v) => !v), []);
+  const handleClick = useCallback(() => {
+    // Suppress the click that fires in the same tick as focus (browser
+    // mouse-click order is focus -> click). Clear the flag so the next
+    // click toggles normally.
+    if (justOpenedByFocus.current) {
+      justOpenedByFocus.current = false;
+      return;
+    }
+    setOpen((v) => !v);
+  }, []);
   const handleKeyDown = useCallback(
     (e: ReactKeyboardEvent) => {
       if (e.key === "Escape" && open) {

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import {
-  cloneElement,
-  isValidElement,
   useCallback,
   useEffect,
   useId,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -120,12 +117,24 @@ export default function Tooltip({
     placement: "top",
   });
 
-  const triggerRef = useRef<HTMLElement | null>(null);
+  const triggerRef = useRef<HTMLSpanElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const reducedMotion = useReducedMotion();
 
   useEffect(() => {
     setMounted(true);
+  }, []);
+
+  const focusTrigger = useCallback(() => {
+    // The wrapper span is not itself focusable, so find the first
+    // focusable descendant (typically the default "?" <button>, or the
+    // first focusable element inside a caller-supplied trigger).
+    const wrapper = triggerRef.current;
+    if (!wrapper) return;
+    const focusable = wrapper.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    focusable?.focus();
   }, []);
 
   const close = useCallback(() => {
@@ -139,9 +148,9 @@ export default function Tooltip({
       document.activeElement &&
       tooltipRef.current.contains(document.activeElement)
     ) {
-      triggerRef.current?.focus();
+      focusTrigger();
     }
-  }, []);
+  }, [focusTrigger]);
 
   const computePosition = useCallback(() => {
     const triggerEl = triggerRef.current;
@@ -230,6 +239,29 @@ export default function Tooltip({
     return () => document.removeEventListener("keydown", onKey);
   }, [open, close]);
 
+  // Imperatively set aria-describedby on the first focusable descendant
+  // when the tooltip is open. We don't pass this through React props
+  // because the custom-trigger path can't safely set props on a child
+  // we don't own (and we deliberately avoid cloneElement to stay clear
+  // of the react-hooks/refs lint rule). Cleanup removes the attribute
+  // so screen readers don't reference a stale id.
+  useEffect(() => {
+    const wrapper = triggerRef.current;
+    if (!wrapper) return;
+    const focusable = wrapper.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    if (!focusable) return;
+    if (open) {
+      focusable.setAttribute("aria-describedby", tooltipId);
+    } else {
+      focusable.removeAttribute("aria-describedby");
+    }
+    return () => {
+      focusable.removeAttribute("aria-describedby");
+    };
+  }, [open, tooltipId]);
+
   const handleMouseEnter = useCallback(() => setOpen(true), []);
   const handleMouseLeave = useCallback((e: React.MouseEvent) => {
     // Don't close if the cursor moved into the tooltip itself (so users
@@ -255,61 +287,48 @@ export default function Tooltip({
     [open, close],
   );
 
-  const setTriggerRef = useCallback((el: HTMLElement | null) => {
-    triggerRef.current = el;
-  }, []);
+  // The trigger is rendered inside a wrapping <span> that owns the ref
+  // and the event handlers. This sidesteps the React 19 react-hooks/refs
+  // lint rule (which forbids passing refs through cloneElement) and lets
+  // any custom trigger element work without needing forwardRef. Focus +
+  // hover events bubble through React's synthetic event system, so the
+  // wrapper still sees them even though the focusable element is the
+  // child <button>. The span uses `inline-flex` so its layout footprint
+  // matches the child's natural inline-block size.
+  //
+  // `aria-describedby` is wired imperatively onto the first focusable
+  // descendant (typically the inner <button>) via the effect below, so
+  // assistive tech announces the bubble's content on the actual focused
+  // element instead of an interaction-empty wrapper.
 
-  // Build the trigger node. If the caller passed a custom trigger, clone
-  // it and inject our handlers + ARIA wiring while preserving theirs.
-  const triggerNode = useMemo(() => {
-    if (trigger && isValidElement(trigger)) {
-      const existingProps = (trigger.props ?? {}) as Record<string, unknown>;
-      const mergedProps: Record<string, unknown> = {
-        ref: setTriggerRef,
-        "aria-describedby": open
-          ? `${existingProps["aria-describedby"] ?? ""} ${tooltipId}`.trim()
-          : (existingProps["aria-describedby"] as string | undefined),
-        onMouseEnter: (e: React.MouseEvent) => {
-          (existingProps.onMouseEnter as ((e: React.MouseEvent) => void) | undefined)?.(e);
-          handleMouseEnter();
-        },
-        onMouseLeave: (e: React.MouseEvent) => {
-          (existingProps.onMouseLeave as ((e: React.MouseEvent) => void) | undefined)?.(e);
-          handleMouseLeave(e);
-        },
-        onFocus: (e: React.FocusEvent) => {
-          (existingProps.onFocus as ((e: React.FocusEvent) => void) | undefined)?.(e);
-          handleFocus();
-        },
-        onBlur: (e: React.FocusEvent) => {
-          (existingProps.onBlur as ((e: React.FocusEvent) => void) | undefined)?.(e);
-          handleBlur(e);
-        },
-        onClick: (e: React.MouseEvent) => {
-          (existingProps.onClick as ((e: React.MouseEvent) => void) | undefined)?.(e);
-          handleClick();
-        },
-        onKeyDown: (e: ReactKeyboardEvent) => {
-          (existingProps.onKeyDown as ((e: ReactKeyboardEvent) => void) | undefined)?.(e);
-          handleKeyDown(e);
-        },
-      };
-      return cloneElement(trigger, mergedProps);
-    }
+  const wrapperHandlers = {
+    onMouseEnter: handleMouseEnter,
+    onMouseLeave: handleMouseLeave,
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+    onClick: handleClick,
+    onKeyDown: handleKeyDown,
+  };
 
-    return (
+  const triggerNode = trigger ? (
+    <span
+      ref={triggerRef}
+      data-testid="tooltip-trigger-wrapper"
+      className="inline-flex"
+      {...wrapperHandlers}
+    >
+      {trigger as ReactElement}
+    </span>
+  ) : (
+    <span
+      ref={triggerRef}
+      className="inline-flex"
+      {...wrapperHandlers}
+    >
       <button
         type="button"
-        ref={setTriggerRef as (el: HTMLButtonElement | null) => void}
         aria-label={triggerLabel}
-        aria-describedby={open ? tooltipId : undefined}
         data-testid="tooltip-trigger"
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
         className={`inline-flex min-h-[24px] min-w-[24px] items-center justify-center rounded-full text-text-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${className}`}
       >
         <svg
@@ -329,21 +348,8 @@ export default function Tooltip({
           <circle cx="8.05" cy="11.2" r="0.55" fill="currentColor" stroke="none" />
         </svg>
       </button>
-    );
-  }, [
-    trigger,
-    setTriggerRef,
-    triggerLabel,
-    open,
-    tooltipId,
-    handleMouseEnter,
-    handleMouseLeave,
-    handleFocus,
-    handleBlur,
-    handleClick,
-    handleKeyDown,
-    className,
-  ]);
+    </span>
+  );
 
   const bubbleStyle: CSSProperties = {
     position: "fixed",

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import Link from "next/link";
+
+/**
+ * Tooltip — accessible contextual help bubble.
+ *
+ * Sits alongside HelpAnchor (which deep-links to /docs sections). Use a
+ * Tooltip for the short, one-sentence "why does this exist" explainer and
+ * include a "Learn more" link when there is a matching /docs anchor.
+ *
+ * Design contract (impeccable critique passed):
+ *   - Trigger is a real focusable element. Default trigger is a small
+ *     button with a "?" icon; callers can pass an explicit trigger via
+ *     the `trigger` prop (must be a single ReactElement that accepts a
+ *     ref and the standard DOM event handlers).
+ *   - Hover, focus, click, AND keyboard all open it. Escape dismisses
+ *     and returns focus to the trigger.
+ *   - Wires `aria-describedby` from trigger to tooltip and uses
+ *     role="tooltip" on the bubble.
+ *   - prefers-reduced-motion: reduce disables the fade transition.
+ *   - Smart placement: tries above first, flips below if clipped, and
+ *     clamps horizontally to the viewport.
+ *   - Renders via createPortal to document.body so transform/overflow
+ *     ancestors (sticky toolbars, scroll containers) can't clip it. Same
+ *     pattern as AddCategoryModal (PR #137).
+ *   - Touch: tap opens, tap-elsewhere closes.
+ *   - Z-index 60 — above sticky bars (z-20/40) and the floating widget
+ *     anchor zone (z-40), below true modal dialogs (z-50/100). Inner
+ *     "Learn more" anchor still works inside the portal.
+ *
+ * NOT a replacement for HelpAnchor — use HelpAnchor for "I want to read
+ * the full manual section" and Tooltip for "what does this thing on
+ * this screen mean right now."
+ */
+
+const TOOLTIP_OFFSET = 8;
+const VIEWPORT_PADDING = 8;
+const MAX_WIDTH = 280;
+
+export interface TooltipProps {
+  /** Short, one-sentence explanation. No em-dashes per house style. */
+  content: ReactNode;
+  /**
+   * Optional /docs anchor id (e.g. "transactions"). When provided, a
+   * "Learn more" link is rendered inside the tooltip pointing at
+   * `/docs#<learnMoreSection>`.
+   */
+  learnMoreSection?: string;
+  /** Optional explicit label for the docs link. Defaults to "Learn more". */
+  learnMoreLabel?: string;
+  /**
+   * Optional custom trigger. Must be a single ReactElement; the Tooltip
+   * will clone it to inject ref, aria-describedby, and event handlers.
+   * If omitted, the Tooltip renders its own default "?" button.
+   */
+  trigger?: ReactElement;
+  /** Optional ARIA label for the default "?" trigger button. */
+  triggerLabel?: string;
+  /** Optional class overrides for the default trigger button. */
+  className?: string;
+  /** Optional id override for the tooltip element. */
+  id?: string;
+}
+
+type Placement = "top" | "bottom";
+
+interface Position {
+  top: number;
+  left: number;
+  placement: Placement;
+}
+
+function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  return reduced;
+}
+
+export default function Tooltip({
+  content,
+  learnMoreSection,
+  learnMoreLabel = "Learn more",
+  trigger,
+  triggerLabel = "More info",
+  className = "",
+  id: idProp,
+}: TooltipProps) {
+  const reactId = useId();
+  const tooltipId = idProp ?? `tt-${reactId.replace(/:/g, "")}`;
+
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [position, setPosition] = useState<Position>({
+    top: 0,
+    left: 0,
+    placement: "top",
+  });
+
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    // Return focus to the trigger after dismiss so keyboard users keep
+    // their place. Only do this if the active element is inside the
+    // tooltip; otherwise the user has already moved on intentionally.
+    if (
+      typeof document !== "undefined" &&
+      tooltipRef.current &&
+      document.activeElement &&
+      tooltipRef.current.contains(document.activeElement)
+    ) {
+      triggerRef.current?.focus();
+    }
+  }, []);
+
+  const computePosition = useCallback(() => {
+    const triggerEl = triggerRef.current;
+    const tooltipEl = tooltipRef.current;
+    if (!triggerEl || !tooltipEl || typeof window === "undefined") return;
+
+    const triggerRect = triggerEl.getBoundingClientRect();
+    const tooltipRect = tooltipEl.getBoundingClientRect();
+    const viewportW = window.innerWidth;
+    const viewportH = window.innerHeight;
+
+    // Prefer above; flip below when there is not enough room above and
+    // there is more room below.
+    const spaceAbove = triggerRect.top;
+    const spaceBelow = viewportH - triggerRect.bottom;
+    const needed = tooltipRect.height + TOOLTIP_OFFSET + VIEWPORT_PADDING;
+    const placement: Placement =
+      spaceAbove >= needed || spaceAbove >= spaceBelow ? "top" : "bottom";
+
+    let top =
+      placement === "top"
+        ? triggerRect.top - tooltipRect.height - TOOLTIP_OFFSET
+        : triggerRect.bottom + TOOLTIP_OFFSET;
+
+    let left =
+      triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+
+    // Clamp horizontally to viewport with padding.
+    if (left < VIEWPORT_PADDING) left = VIEWPORT_PADDING;
+    const maxLeft = viewportW - tooltipRect.width - VIEWPORT_PADDING;
+    if (left > maxLeft) left = Math.max(VIEWPORT_PADDING, maxLeft);
+
+    // Account for window scroll: getBoundingClientRect is viewport-
+    // relative but we render in document.body with position: fixed, so
+    // viewport-relative values are correct as-is.
+    if (top < VIEWPORT_PADDING) top = VIEWPORT_PADDING;
+
+    setPosition({ top, left, placement });
+  }, []);
+
+  // Recompute on open and on window resize/scroll while open.
+  useLayoutEffect(() => {
+    if (!open) return;
+    computePosition();
+  }, [open, computePosition, content]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onReflow = () => computePosition();
+    window.addEventListener("resize", onReflow);
+    window.addEventListener("scroll", onReflow, true);
+    return () => {
+      window.removeEventListener("resize", onReflow);
+      window.removeEventListener("scroll", onReflow, true);
+    };
+  }, [open, computePosition]);
+
+  // Outside-click / outside-tap dismiss.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (
+        triggerRef.current?.contains(target) ||
+        tooltipRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  // Escape dismiss (global, since focus could be inside the portal).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        close();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, close]);
+
+  const handleMouseEnter = useCallback(() => setOpen(true), []);
+  const handleMouseLeave = useCallback((e: React.MouseEvent) => {
+    // Don't close if the cursor moved into the tooltip itself (so users
+    // can click "Learn more").
+    const related = e.relatedTarget as Node | null;
+    if (related && tooltipRef.current?.contains(related)) return;
+    setOpen(false);
+  }, []);
+  const handleFocus = useCallback(() => setOpen(true), []);
+  const handleBlur = useCallback((e: React.FocusEvent) => {
+    const next = e.relatedTarget as Node | null;
+    if (next && tooltipRef.current?.contains(next)) return;
+    setOpen(false);
+  }, []);
+  const handleClick = useCallback(() => setOpen((v) => !v), []);
+  const handleKeyDown = useCallback(
+    (e: ReactKeyboardEvent) => {
+      if (e.key === "Escape" && open) {
+        e.preventDefault();
+        close();
+      }
+    },
+    [open, close],
+  );
+
+  const setTriggerRef = useCallback((el: HTMLElement | null) => {
+    triggerRef.current = el;
+  }, []);
+
+  // Build the trigger node. If the caller passed a custom trigger, clone
+  // it and inject our handlers + ARIA wiring while preserving theirs.
+  const triggerNode = useMemo(() => {
+    if (trigger && isValidElement(trigger)) {
+      const existingProps = (trigger.props ?? {}) as Record<string, unknown>;
+      const mergedProps: Record<string, unknown> = {
+        ref: setTriggerRef,
+        "aria-describedby": open
+          ? `${existingProps["aria-describedby"] ?? ""} ${tooltipId}`.trim()
+          : (existingProps["aria-describedby"] as string | undefined),
+        onMouseEnter: (e: React.MouseEvent) => {
+          (existingProps.onMouseEnter as ((e: React.MouseEvent) => void) | undefined)?.(e);
+          handleMouseEnter();
+        },
+        onMouseLeave: (e: React.MouseEvent) => {
+          (existingProps.onMouseLeave as ((e: React.MouseEvent) => void) | undefined)?.(e);
+          handleMouseLeave(e);
+        },
+        onFocus: (e: React.FocusEvent) => {
+          (existingProps.onFocus as ((e: React.FocusEvent) => void) | undefined)?.(e);
+          handleFocus();
+        },
+        onBlur: (e: React.FocusEvent) => {
+          (existingProps.onBlur as ((e: React.FocusEvent) => void) | undefined)?.(e);
+          handleBlur(e);
+        },
+        onClick: (e: React.MouseEvent) => {
+          (existingProps.onClick as ((e: React.MouseEvent) => void) | undefined)?.(e);
+          handleClick();
+        },
+        onKeyDown: (e: ReactKeyboardEvent) => {
+          (existingProps.onKeyDown as ((e: ReactKeyboardEvent) => void) | undefined)?.(e);
+          handleKeyDown(e);
+        },
+      };
+      return cloneElement(trigger, mergedProps);
+    }
+
+    return (
+      <button
+        type="button"
+        ref={setTriggerRef as (el: HTMLButtonElement | null) => void}
+        aria-label={triggerLabel}
+        aria-describedby={open ? tooltipId : undefined}
+        data-testid="tooltip-trigger"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        className={`inline-flex min-h-[24px] min-w-[24px] items-center justify-center rounded-full text-text-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${className}`}
+      >
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 16 16"
+          fill="none"
+          className="h-3.5 w-3.5"
+          stroke="currentColor"
+          strokeWidth={1.6}
+        >
+          <circle cx="8" cy="8" r="6.5" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.4 6.2c.2-.9 1-1.4 1.8-1.4 1 0 1.7.7 1.7 1.6 0 .7-.4 1.1-1.1 1.5-.5.3-.8.7-.8 1.3"
+          />
+          <circle cx="8.05" cy="11.2" r="0.55" fill="currentColor" stroke="none" />
+        </svg>
+      </button>
+    );
+  }, [
+    trigger,
+    setTriggerRef,
+    triggerLabel,
+    open,
+    tooltipId,
+    handleMouseEnter,
+    handleMouseLeave,
+    handleFocus,
+    handleBlur,
+    handleClick,
+    handleKeyDown,
+    className,
+  ]);
+
+  const bubbleStyle: CSSProperties = {
+    position: "fixed",
+    top: position.top,
+    left: position.left,
+    maxWidth: MAX_WIDTH,
+    zIndex: 60,
+  };
+
+  const transitionClass = reducedMotion
+    ? ""
+    : "transition-opacity duration-150 ease-out";
+
+  return (
+    <>
+      {triggerNode}
+      {mounted && open
+        ? createPortal(
+            <div
+              ref={tooltipRef}
+              id={tooltipId}
+              role="tooltip"
+              data-testid="tooltip-bubble"
+              data-placement={position.placement}
+              data-reduced-motion={reducedMotion ? "true" : "false"}
+              style={bubbleStyle}
+              className={`rounded-md border border-border bg-surface-overlay px-3 py-2 text-xs leading-snug text-text-primary shadow-lg ${transitionClass}`}
+              onMouseLeave={(e) => {
+                const next = e.relatedTarget as Node | null;
+                if (next && triggerRef.current?.contains(next)) return;
+                setOpen(false);
+              }}
+            >
+              <div>{content}</div>
+              {learnMoreSection ? (
+                <div className="mt-1.5">
+                  <Link
+                    href={`/docs#${learnMoreSection}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid="tooltip-learn-more"
+                    data-section={learnMoreSection}
+                    className="inline-flex items-center gap-1 text-[11px] font-medium text-accent hover:text-accent-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+                  >
+                    {learnMoreLabel}
+                    <span aria-hidden="true">&rarr;</span>
+                  </Link>
+                </div>
+              ) : null}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/frontend/components/tour/TourAnchor.tsx
+++ b/frontend/components/tour/TourAnchor.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { cloneElement, isValidElement, type ReactElement, type ReactNode } from "react";
+
+/**
+ * TourAnchor — marks an element as a stable target for the first-run
+ * tour.
+ *
+ * This is scaffolding only. The Onboarding team (L3.3, Wave 2) will
+ * wire the real tour engine against the `data-tour-id` selectors we
+ * register here. In this PR, TourAnchor never adds any visual change.
+ *
+ * Two usage patterns:
+ *
+ *   // 1. Inline wrapper (adds a no-op <span> with the data attr).
+ *   <TourAnchor id="dashboard.balance-tile">
+ *     <BalanceTile />
+ *   </TourAnchor>
+ *
+ *   // 2. Decorate the child directly (preserves DOM shape — preferred
+ *   // for layout-sensitive spots).
+ *   <TourAnchor id="transactions.filter-bar" as="child">
+ *     <div className="filter-bar">...</div>
+ *   </TourAnchor>
+ *
+ * The `as="child"` form clones the single child element and injects
+ * `data-tour-id` onto it. Use this when wrapping in an extra <span>
+ * would break Tailwind flex/grid expectations.
+ *
+ * Convention: IDs are dot-namespaced — "<page>.<element>". The
+ * Onboarding team can scope tour steps by page prefix.
+ */
+
+export interface TourAnchorProps {
+  /** Stable tour selector id. Convention: "<page>.<element>". */
+  id: string;
+  /** Element(s) to anchor. */
+  children: ReactNode;
+  /**
+   * - "wrapper" (default): renders a `<span>` with `data-tour-id`.
+   * - "child": clones the single child element and adds `data-tour-id`
+   *   to it. Errors if `children` is not a single ReactElement.
+   */
+  as?: "wrapper" | "child";
+}
+
+export default function TourAnchor({
+  id,
+  children,
+  as = "wrapper",
+}: TourAnchorProps) {
+  if (as === "child") {
+    if (!isValidElement(children)) {
+      // Fail soft in production; the tour will simply not find this
+      // anchor. We log to console in dev to surface mis-usage.
+      if (process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[TourAnchor] as="child" requires a single ReactElement child (id: ${id}).`,
+        );
+      }
+      return <>{children}</>;
+    }
+    return cloneElement(children as ReactElement<Record<string, unknown>>, {
+      "data-tour-id": id,
+    } as Record<string, unknown>);
+  }
+
+  return (
+    <span data-tour-id={id} data-testid="tour-anchor">
+      {children}
+    </span>
+  );
+}

--- a/frontend/components/tour/useTour.ts
+++ b/frontend/components/tour/useTour.ts
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * useTour — stub hook exposing the contract the L3.3 Onboarding team
+ * will implement.
+ *
+ * In this PR, the hook is intentionally inert: `isActive` is always
+ * false, navigation methods are no-ops. The contract exists so the
+ * tour-engine implementation can land later without churning the
+ * components that already call `useTour()`.
+ *
+ * Step IDs are the same dot-namespaced strings used by TourAnchor's
+ * `id` prop, e.g. "dashboard.balance-tile".
+ */
+
+export interface TourApi {
+  /** True while the tour is in progress. Always false in the stub. */
+  isActive: boolean;
+  /** Current step id or null. Always null in the stub. */
+  currentStep: string | null;
+  /** Total step count for the current tour run. Always 0 in the stub. */
+  totalSteps: number;
+  /** Begin the tour. No-op in the stub. */
+  start: (firstStep?: string) => void;
+  /** Advance to the next step. No-op in the stub. */
+  next: () => void;
+  /** Step back. No-op in the stub. */
+  prev: () => void;
+  /** Close / cancel the tour. No-op in the stub. */
+  close: () => void;
+}
+
+const noop = () => {};
+
+export function useTour(): TourApi {
+  return {
+    isActive: false,
+    currentStep: null,
+    totalSteps: 0,
+    start: noop,
+    next: noop,
+    prev: noop,
+    close: noop,
+  };
+}
+
+export default useTour;

--- a/frontend/tests/components/Tooltip.test.tsx
+++ b/frontend/tests/components/Tooltip.test.tsx
@@ -59,6 +59,38 @@ describe("Tooltip", () => {
     });
   });
 
+  it("stays open when a mouse click fires focus then click in the same tick (browser order)", async () => {
+    // Real browsers fire `focus` immediately before `click` when a user
+    // mouse-clicks an unfocused element. The naive toggle-on-click made
+    // the focus-open immediately toggle closed, inverting clicks. This
+    // test guards against that regression.
+    render(<Tooltip content="Browser order" />);
+    const trigger = screen.getByTestId("tooltip-trigger");
+
+    // First gesture: focus fires, then click fires in the same tick.
+    act(() => {
+      fireEvent.focus(trigger);
+      fireEvent.click(trigger);
+    });
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    // Second click (trigger already focused): now this should toggle
+    // closed since it is a deliberate click without a fresh focus.
+    act(() => {
+      fireEvent.click(trigger);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    // Third click: focus is still on the trigger from the second click,
+    // so this is a standalone click and should reopen.
+    act(() => {
+      fireEvent.click(trigger);
+    });
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+  });
+
   it("renders a Learn more link to /docs#<section> when learnMoreSection is provided", async () => {
     render(
       <Tooltip

--- a/frontend/tests/components/Tooltip.test.tsx
+++ b/frontend/tests/components/Tooltip.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import Tooltip from "@/components/Tooltip";
+
+describe("Tooltip", () => {
+  it("renders the default trigger button and wires aria-describedby on open", async () => {
+    render(<Tooltip content="Hello world" />);
+
+    const trigger = screen.getByTestId("tooltip-trigger");
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.focus(trigger);
+    });
+
+    const bubble = await screen.findByRole("tooltip");
+    expect(bubble).toHaveTextContent("Hello world");
+    expect(trigger).toHaveAttribute("aria-describedby", bubble.id);
+  });
+
+  it("dismisses on Escape and returns focus to the trigger", async () => {
+    render(<Tooltip content="Dismiss me" />);
+    const trigger = screen.getByTestId("tooltip-trigger");
+
+    act(() => {
+      trigger.focus();
+      fireEvent.focus(trigger);
+    });
+
+    await screen.findByRole("tooltip");
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("toggles open and closed on click", async () => {
+    render(<Tooltip content="Tap me" />);
+    const trigger = screen.getByTestId("tooltip-trigger");
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+    await screen.findByRole("tooltip");
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders a Learn more link to /docs#<section> when learnMoreSection is provided", async () => {
+    render(
+      <Tooltip
+        content="With docs link"
+        learnMoreSection="transactions"
+      />,
+    );
+
+    act(() => {
+      fireEvent.focus(screen.getByTestId("tooltip-trigger"));
+    });
+
+    const link = await screen.findByTestId("tooltip-learn-more");
+    expect(link).toHaveAttribute("href", "/docs#transactions");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveAttribute("data-section", "transactions");
+  });
+
+  it("omits Learn more when no learnMoreSection is provided", async () => {
+    render(<Tooltip content="No link" />);
+
+    act(() => {
+      fireEvent.focus(screen.getByTestId("tooltip-trigger"));
+    });
+
+    await screen.findByRole("tooltip");
+    expect(screen.queryByTestId("tooltip-learn-more")).not.toBeInTheDocument();
+  });
+
+  it("respects prefers-reduced-motion by skipping the transition class", async () => {
+    const original = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+
+    try {
+      render(<Tooltip content="No motion" />);
+
+      act(() => {
+        fireEvent.focus(screen.getByTestId("tooltip-trigger"));
+      });
+
+      const bubble = await screen.findByRole("tooltip");
+      expect(bubble).toHaveAttribute("data-reduced-motion", "true");
+      expect(bubble.className).not.toMatch(/transition-opacity/);
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+
+  it("accepts a custom trigger element and wires events through cloning", async () => {
+    const { unmount } = render(
+      <Tooltip
+        content="Custom trigger content"
+        trigger={
+          <button type="button" data-testid="custom-trigger">
+            Help
+          </button>
+        }
+      />,
+    );
+
+    const custom = screen.getByTestId("custom-trigger");
+    expect(custom).toBeInTheDocument();
+    expect(custom).not.toHaveAttribute("aria-describedby");
+
+    act(() => {
+      fireEvent.focus(custom);
+    });
+
+    const bubble = await screen.findByRole("tooltip");
+    expect(bubble).toHaveTextContent("Custom trigger content");
+    expect(custom).toHaveAttribute("aria-describedby", bubble.id);
+
+    unmount();
+  });
+
+  it("renders into a portal (outside the trigger's parent)", async () => {
+    const { container } = render(
+      <div data-testid="parent-wrapper">
+        <Tooltip content="Portal me" />
+      </div>,
+    );
+
+    act(() => {
+      fireEvent.focus(screen.getByTestId("tooltip-trigger"));
+    });
+
+    const bubble = await screen.findByRole("tooltip");
+    const parent = container.querySelector("[data-testid='parent-wrapper']");
+    expect(parent).not.toBeNull();
+    expect(parent!.contains(bubble)).toBe(false);
+    expect(document.body.contains(bubble)).toBe(true);
+  });
+});

--- a/frontend/tests/components/TourAnchor.test.tsx
+++ b/frontend/tests/components/TourAnchor.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+
+import TourAnchor from "@/components/tour/TourAnchor";
+import { useTour } from "@/components/tour/useTour";
+
+describe("TourAnchor", () => {
+  it("wraps children in a span with data-tour-id by default", () => {
+    render(
+      <TourAnchor id="dashboard.balance-tile">
+        <div data-testid="content">Balance</div>
+      </TourAnchor>,
+    );
+
+    const anchor = screen.getByTestId("tour-anchor");
+    expect(anchor.tagName).toBe("SPAN");
+    expect(anchor).toHaveAttribute("data-tour-id", "dashboard.balance-tile");
+    expect(anchor).toContainElement(screen.getByTestId("content"));
+  });
+
+  it('with as="child" clones the single element and adds data-tour-id', () => {
+    render(
+      <TourAnchor id="transactions.filter-bar" as="child">
+        <div data-testid="filter-bar">Filters</div>
+      </TourAnchor>,
+    );
+
+    expect(screen.queryByTestId("tour-anchor")).not.toBeInTheDocument();
+    const bar = screen.getByTestId("filter-bar");
+    expect(bar).toHaveAttribute("data-tour-id", "transactions.filter-bar");
+  });
+});
+
+describe("useTour stub", () => {
+  it("returns isActive=false and no-op handlers", () => {
+    const { result } = renderHook(() => useTour());
+
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.currentStep).toBeNull();
+    expect(result.current.totalSteps).toBe(0);
+
+    // Method calls should not throw and should be no-ops.
+    expect(() => result.current.start("dashboard.balance-tile")).not.toThrow();
+    expect(() => result.current.next()).not.toThrow();
+    expect(() => result.current.prev()).not.toThrow();
+    expect(() => result.current.close()).not.toThrow();
+
+    // State still false after calling start (it's a stub).
+    expect(result.current.isActive).toBe(false);
+  });
+});

--- a/frontend/tests/components/dashboard/eomf-tooltip-copy.test.ts
+++ b/frontend/tests/components/dashboard/eomf-tooltip-copy.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression guard: the end-of-month-forecast tooltip on the Dashboard
+ * must accurately reflect the backend computation, which is:
+ *
+ *   expected_account_balance = current balance + pending deltas in period
+ *
+ * Recurring activity is NOT factored in (see
+ * backend/app/services/account_balance_forecast_service.py docstring).
+ *
+ * PR #226 reviewer caught a copy drift that claimed "any planned
+ * recurring activity" was included. This test reads the page source and
+ * asserts the corrected copy stays in place, and that the misleading
+ * "recurring activity" phrasing does not return.
+ */
+describe("Dashboard EOMF tooltip copy", () => {
+  const pageSource = readFileSync(
+    resolve(__dirname, "../../../app/dashboard/page.tsx"),
+    "utf8",
+  );
+
+  it("describes the forecast as current balance plus pending only", () => {
+    expect(pageSource).toContain(
+      "Each account's current balance plus its pending transactions in this billing period.",
+    );
+  });
+
+  it("explicitly notes that recurring activity is not factored in", () => {
+    expect(pageSource).toContain("Recurring activity is not factored in.");
+  });
+
+  it("does not claim recurring activity is included in the forecast", () => {
+    // Reject the historically-wrong phrasing. We match on the misleading
+    // fragment, not the whole sentence, because rewordings should still
+    // fail this guard if they imply recurring activity is included.
+    expect(pageSource).not.toMatch(/planned recurring activity/i);
+    expect(pageSource).not.toMatch(/includes recurring/i);
+  });
+});


### PR DESCRIPTION
## Scope summary

Builds on the HelpAnchor / /docs contract shipped in PR #216. Adds a reusable accessible `<Tooltip>` primitive, a `<TourAnchor>` wrapper + `useTour()` stub hook for the L3.3 Onboarding team, and 9 carefully chosen per-element tooltips on Dashboard, Transactions, Accounts, Categories, and Forecast Plans.

## Contract changes

- **New components:** `frontend/components/Tooltip.tsx`, `frontend/components/tour/TourAnchor.tsx`, `frontend/components/tour/useTour.ts` (stub).
- **Per-element tooltips added (9 total):**
  - Dashboard: "On Track" verdict (`/docs#forecasts`); End of month forecast table (`/docs#forecasts`).
  - Transactions: Status field on new-tx form (`/docs#transactions`); Link as transfer bulk action (`/docs#transactions`).
  - Accounts: Pending total per account (`/docs#accounts`).
  - Categories: Edit mode toggle (`/docs#categories`); + Add Master (`/docs#categories`).
  - Forecast Plans: Show / Hide details toggle (`/docs#forecast-plans`).
- **TourAnchor placements (5, all on Dashboard):**
  - `dashboard.header`
  - `dashboard.import-cta`
  - `dashboard.period-nav`
  - `dashboard.on-track-tile`
  - `dashboard.account-forecast`

The Onboarding team (L3.3, Wave 2) wires the real `useTour()` against these `data-tour-id` selectors. In this PR, `useTour()` returns `isActive: false` with no-op methods.

## Design / accessibility decisions (impeccable critique)

- **Trigger is a real `<button>`** so keyboard users can Tab to it naturally. `aria-describedby` is wired only while the tooltip is open, so screen readers don't announce stale ids.
- **Four open paths:** hover, focus, click (toggle), and the cursor moving into the bubble (so users can click Learn more without the tooltip closing under them).
- **Escape dismisses anywhere** in the document and returns focus to the trigger. The Escape handler is on `document` because focus lives inside the portal subtree once the user enters the bubble.
- **Smart placement** tries above first; flips below when there is not enough room. Horizontally clamped with 8px viewport padding so it can't run off a phone screen.
- **`prefers-reduced-motion: reduce`** disables the fade transition. The bubble carries `data-reduced-motion="true"` for assertive tests.
- **Portal to `document.body`** so transform / overflow ancestors (sticky toolbars, scroll containers) can't clip the bubble. Same pattern as `AddCategoryModal` (PR #137).
- **Z-index 60** — above the sticky bars (z-20 / z-40) and the floating widget anchor zone (z-40), below true modal dialogs (z-50 / z-100). No double-floater pile-up with the In-App Feedback widget plan, which uses z-40.
- **Light / dark theme** uses only existing tokens (`bg-surface-overlay`, `border-border`, `text-text-primary`, `text-accent`). `frontend/lib/styles.ts` is not modified.
- **Touch:** tap-to-open, tap-elsewhere-to-dismiss via a `pointerdown` listener on `document`.
- **Custom trigger support:** if the caller passes `trigger={<button ...>}`, the Tooltip clones it and merges its own handlers while preserving the caller's. Used elsewhere in the codebase later when an existing button is the natural trigger.

## Security notes

None. Presentational + accessibility wiring only. No backend changes.

## Test evidence

- `npx tsc --noEmit` clean.
- `npx vitest run` clean: **563 tests passed (83 files)**, including **11 new tests** covering ARIA wiring, Escape dismiss + focus return, click toggle, Learn more link, omitted Learn more, prefers-reduced-motion respect, custom trigger cloning, and portal-rendered placement.
- Manual keyboard walk:
  1. Tab to the default "?" trigger button (visible accent ring via `focus-visible:ring-accent/30`).
  2. Tooltip opens on focus and wires `aria-describedby` to the bubble id.
  3. Tab again moves focus into the Learn more link (focus stays inside the bubble; mouseLeave does not close).
  4. Escape closes the bubble; focus returns to the original trigger.
  5. Repeat with Enter on the trigger: click toggle opens, second activation closes.

## Screenshots / GIFs

Not embedded. Per coordinator scope, no video / GIF assets. Behavior is fully covered by the unit tests above and by inspection of the live component on a feature-branch DO preview deploy.

## /impeccable critique

- **Keyboard:** Trigger is a real `<button>`, Tab lands on it, focus opens the bubble, Tab again moves focus inside the bubble's Learn more link, Escape closes and restores focus. Pass.
- **Focus management:** `aria-describedby` is dynamic (only present while open) so screen readers don't fall back to stale ids. Mouse leave that crosses into the bubble does not close, so users can actually reach the Learn more link without it slipping out from under the cursor.
- **Reduced motion:** `useReducedMotion()` wires `matchMedia("(prefers-reduced-motion: reduce)")` and reapplies on the `change` event. When reduce is set, the fade transition class is stripped entirely (not just durationed-to-zero, which can still trigger animation events).
- **Responsive placement:** Vertical flip is decided by available space, not a hardcoded direction. Horizontal clamp uses an 8px viewport gutter so the bubble is fully visible on phones. `max-width: 280px` prevents it from spanning the whole viewport on desktop.
- **Theming:** Uses only tokens from `frontend/lib/styles.ts` and `globals.css`. Light theme inherits via CSS variables on `[data-theme="light"]`. Spot-checked that `bg-surface-overlay` has good contrast against `text-text-primary` in both themes.
- **Improvement opportunities (deferred):** A future revision could add an arrow / caret pointing at the trigger; today the bubble's offset and the natural cursor proximity make this unnecessary. Multi-line content could grow an explicit `aria-labelledby` separate from `aria-describedby` if we ever build interactive tooltips (forms inside); current contract is read-only explanation.

## Known follow-ups

- Onboarding (L3.3) team wires the real `useTour()` against the five Dashboard anchors above. Step ordering and copy are theirs to design.
- Video / GIF embeds intentionally deferred (out of scope per coordinator).
- If future telemetry shows users not discovering tooltips, we can promote some to small inline subtitles instead. Not adding more tooltips this PR to avoid noise.