### PR TITLE
feat(import): contracts + endpoint stubs for L3.2 slice (Wave 1)

### DIFF
--- a/backend/app/routers/import_router.py
+++ b/backend/app/routers/import_router.py
@@ -1,10 +1,20 @@
-"""Import router — CSV upload, preview, and confirm endpoints."""
+"""Import router — CSV upload, preview, and confirm endpoints.
 
-from fastapi import APIRouter, Depends, File, Form, UploadFile
+Wave 1 contract additions (2026-05-12, L3.2): OFX preview endpoint and
+post-import reconciliation endpoint. Both stubbed at 501 — Wave 2 teams
+implement against the frozen schemas. See spec at
+``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
+"""
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_current_user, get_db
 from app.models.user import User
+from app.schemas.import_reconciliation import (
+    ReconcileBatchRequest,
+    ReconcileBatchResponse,
+)
 from app.schemas.import_schemas import (
     ImportConfirmRequest,
     ImportConfirmResponse,
@@ -63,4 +73,88 @@ async def confirm_import(
         db,
         org_id=current_user.org_id,
         body=body,
+    )
+
+
+# ── L3.2 Wave 1 contract stubs ───────────────────────────────────────────────
+# These endpoints exist to publish the OpenAPI shape so downstream Wave 2
+# teams (OFX Parser, Reconciliation UI) can build against frozen contracts.
+# Each stub returns 501 with a pointer to the L3.2 dispatch. Auth and
+# org-scoping are wired so contract tests can assert them.
+
+
+@router.post(
+    "/ofx/preview",
+    response_model=ImportPreviewResponse,
+    status_code=501,
+)
+async def preview_ofx_import(
+    file: UploadFile = File(...),
+    account_id: int = Form(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """**STUB** — OFX preview endpoint, Wave 2 deliverable.
+
+    Contract: parses an OFX 1.x (SGML) or 2.x (XML) file, emits the same
+    ``ImportPreviewResponse`` shape as the CSV path with OFX-specific
+    extras (``fitid``, ``bank_id``, ``account_type_ofx``) on each row.
+
+    Frozen contract: see spec at
+    ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
+    §1 (OFX Parser Contract).
+
+    Wave 2 OFX Parser team owns implementation: pin ``ofxtools ~= 0.9.5``,
+    wrap parse in ``asyncio.wait_for(timeout=10)``, hard-fail at >10k
+    rows, never log raw OFX content.
+    """
+    # Touch ``current_user`` / ``db`` / ``account_id`` so static analyzers
+    # see them used and contract tests can verify the auth dependency
+    # fires (without actually reading the file body — the upload limit
+    # check is the OFX team's responsibility).
+    _ = (current_user.org_id, db, account_id, file.filename)
+    raise HTTPException(
+        status_code=501,
+        detail=(
+            "OFX import not implemented — see L3.2 dispatch "
+            "(specs/2026-05-12-l3-2-import-contracts.md §1)"
+        ),
+    )
+
+
+@router.post(
+    "/{import_id}/reconcile",
+    response_model=ReconcileBatchResponse,
+    status_code=501,
+)
+async def reconcile_import_batch(
+    import_id: int,
+    body: ReconcileBatchRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """**STUB** — Post-import reconciliation endpoint, Wave 2 deliverable.
+
+    Contract: applies state transitions to imported rows. All transitions
+    in a request commit atomically (one savepoint). The batch
+    auto-closes when ``remaining_pending`` hits 0.
+
+    Frozen contract: see spec at
+    ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
+    §3 (Reconciliation State Machine).
+
+    Wave 2 Reconciliation UI team owns:
+        - Migration: ``transactions.reconciliation_state`` enum column,
+          ``transactions.import_batch_id`` FK, new ``import_batches`` table.
+        - Service: state-transition validation, atomic apply, batch-close
+          side-effect.
+        - Frontend: inbox UX, per-row transition controls.
+    """
+    _ = (current_user.org_id, db, import_id, len(body.transitions))
+    raise HTTPException(
+        status_code=501,
+        detail=(
+            "Reconciliation not implemented — see L3.2 dispatch "
+            "(specs/2026-05-12-l3-2-import-contracts.md §3)"
+        ),
     )

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,6 +10,10 @@ from app.deps import get_current_user
 from app.models.account import Account
 from app.models.transaction import TransactionType
 from app.models.user import User
+from app.schemas.import_batch import (
+    BatchTransactionsRequest,
+    BatchTransactionsResponse,
+)
 from app.schemas.transaction import (
     BulkDeleteRequest,
     BulkDeleteResponse,
@@ -23,6 +27,9 @@ from app.schemas.transaction import (
     TransferCandidatesResponse,
     TransferCreate,
     UnpairTransactionRequest,
+)
+from app.schemas.transaction_suggestions import (
+    DescriptionSuggestionsResponse,
 )
 from app.services import transaction_service as svc
 from app.services.exceptions import NotFoundError, ValidationError
@@ -252,6 +259,86 @@ async def transfer_candidates(
             )
         )
     return TransferCandidatesResponse(candidates=out)
+
+
+# ── L3.2 Wave 1 contract stubs ───────────────────────────────────────────────
+# Both routes MUST appear before ``/{transaction_id}`` so FastAPI's path
+# matcher resolves the literal segments first. Returning 501 with the
+# proper Pydantic response models keeps the OpenAPI schema honest for
+# Wave 2 downstream teams.
+
+
+@router.post(
+    "/batch",
+    response_model=BatchTransactionsResponse,
+    status_code=501,
+)
+async def batch_create_transactions(
+    body: BatchTransactionsRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """**STUB** — Manual batch transaction entry, Wave 2 deliverable.
+
+    Contract: accept ``list[TransactionCreate]`` (wrapped in
+    ``BatchTransactionRow`` with a stable ``row_number``), process each
+    row in its own savepoint, return per-row results + aggregate counters.
+    Rows are NOT flagged ``is_imported`` — they're user-typed, not bank
+    sourced.
+
+    Frozen contract: see spec at
+    ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
+    §0.2 (Manual batch entry shape) and ``app/schemas/import_batch.py``.
+
+    Wave 2 Manual Batch Entry team owns implementation.
+    """
+    _ = (current_user.org_id, db, len(body.rows))
+    raise HTTPException(
+        status_code=501,
+        detail=(
+            "Batch transaction entry not implemented — see L3.2 dispatch "
+            "(specs/2026-05-12-l3-2-import-contracts.md §0.2)"
+        ),
+    )
+
+
+@router.get(
+    "/suggestions/descriptions",
+    response_model=DescriptionSuggestionsResponse,
+    status_code=501,
+)
+async def suggest_descriptions(
+    type: Literal["income", "expense", "transfer"] = Query(...),
+    q: str | None = Query(default=None, min_length=2, max_length=255),
+    limit: int = Query(default=10, ge=1, le=25),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """**STUB** — Description autocomplete, Wave 2 deliverable.
+
+    Contract: return the user's most-used descriptions for ``type``,
+    ranked by prefix-match → frequency → recency. Org-scoped (never
+    leaks across orgs). Never logs raw descriptions or raw query strings.
+
+    When ``q`` is omitted, returns top-N most-used descriptions (useful
+    for the manual-entry form's "recent descriptions" hint).
+
+    Frozen contract: see spec at
+    ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
+    §5 (Description Suggestions Contract) and
+    ``app/schemas/transaction_suggestions.py``.
+
+    Wave 2 Description Suggestions team owns implementation. Frontend
+    is expected to debounce 300 ms and skip requests when q.length < 2.
+    """
+    _ = (current_user.org_id, db, type, q, limit)
+    raise HTTPException(
+        status_code=501,
+        detail=(
+            "Description suggestions not implemented — see L3.2 dispatch "
+            "(specs/2026-05-12-l3-2-import-contracts.md §5)"
+        ),
+    )
 
 
 @router.get("/{transaction_id}", response_model=TransactionResponse)

--- a/backend/app/schemas/import_batch.py
+++ b/backend/app/schemas/import_batch.py
@@ -25,7 +25,7 @@ the request/response wire shape.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.schemas.transaction import TransactionCreate
 
@@ -68,6 +68,30 @@ class BatchTransactionsRequest(BaseModel):
     rows: list[BatchTransactionRow] = Field(min_length=1, max_length=500)
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _row_numbers_must_be_unique(self) -> "BatchTransactionsRequest":
+        """Reject payloads with duplicate ``row_number`` values.
+
+        The response shape maps per-row results back to the user's input
+        order via ``row_number``; duplicates would collide and make
+        error reporting ambiguous. Pydantic converts the raised
+        ``ValueError`` into a 422 with the field locator pointing at
+        ``rows`` (and the duplicate values surfaced in the message).
+        """
+        seen: set[int] = set()
+        duplicates: list[int] = []
+        for row in self.rows:
+            if row.row_number in seen:
+                duplicates.append(row.row_number)
+            else:
+                seen.add(row.row_number)
+        if duplicates:
+            raise ValueError(
+                "row_number values must be unique across rows; "
+                f"duplicates: {sorted(set(duplicates))}"
+            )
+        return self
 
 
 class BatchRowError(BaseModel):

--- a/backend/app/schemas/import_batch.py
+++ b/backend/app/schemas/import_batch.py
@@ -1,0 +1,121 @@
+"""Pydantic schemas for manual batch transaction entry (Wave 1 contract).
+
+Frozen per spec at
+``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
+
+This endpoint is OUTSIDE the import router. Manual batch entry lets a user
+type N transactions at once (e.g., bulk-receipting a week of cash receipts)
+without going through file upload, preview, or transfer-detection. It's a
+sibling of ``POST /api/v1/transactions`` that accepts a list and returns
+per-row results.
+
+Key differences vs. import-confirm:
+- No ``is_imported=True`` flag — these are user-typed, not bank-sourced.
+- No preview step; the user submits final values directly.
+- No transfer-detection or duplicate-of-linked-leg check.
+- No smart-rules learning (the existing single-create path already covers
+  that via ``transaction_service.create_transaction``; batch entry runs the
+  same per-row logic, so learning still happens row-by-row).
+- Reuses ``TransactionCreate`` for the row body — same validation as the
+  single-row endpoint.
+
+Wave 2 Manual Batch Entry team owns the implementation. This file freezes
+the request/response wire shape.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.transaction import TransactionCreate
+
+
+class BatchTransactionRow(BaseModel):
+    """One row in a manual batch entry submission.
+
+    Wraps ``TransactionCreate`` with a stable ``row_number`` so the
+    response can map per-row results back to the user's input order.
+
+    Fields:
+        row_number: Client-provided row index (1-based by convention).
+            Echoed back in the response for client-side error mapping.
+            Must be unique within a single request — server returns 422
+            on duplicate ``row_number``.
+        transaction: The transaction to create. Same validation as the
+            single-row ``POST /api/v1/transactions`` endpoint.
+    """
+
+    row_number: int = Field(ge=1)
+    transaction: TransactionCreate
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BatchTransactionsRequest(BaseModel):
+    """Request body for ``POST /api/v1/transactions/batch``.
+
+    Server processes each row in its own savepoint (mirroring the
+    import-confirm pattern in ``import_service.execute_import``) so a
+    single failing row doesn't take down the batch. Returns per-row
+    errors plus aggregate counters.
+
+    Fields:
+        rows: Ordered list of rows to insert. Capped at 500 rows per
+            request to bound request size and per-row savepoint
+            overhead. Frontend chunks larger batches client-side.
+    """
+
+    rows: list[BatchTransactionRow] = Field(min_length=1, max_length=500)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BatchRowError(BaseModel):
+    """Error detail for a single row that failed during batch insert.
+
+    Fields:
+        row_number: The ``row_number`` from the request row, echoed back.
+        error: Human-readable error message. Same shape as the domain
+            ``ValidationError.detail`` / ``ConflictError.detail`` returned
+            by the service layer.
+    """
+
+    row_number: int
+    error: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BatchRowResult(BaseModel):
+    """Success record for a single row that imported cleanly.
+
+    Fields:
+        row_number: The ``row_number`` from the request row.
+        transaction_id: ID of the created transaction.
+    """
+
+    row_number: int
+    transaction_id: int
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BatchTransactionsResponse(BaseModel):
+    """Response body for ``POST /api/v1/transactions/batch``.
+
+    Counter invariant:
+        ``imported_count + error_count == len(request.rows)``
+
+    Fields:
+        imported_count: Rows that committed successfully.
+        error_count: Rows that failed (sum of errors below).
+        results: Per-row success records (in input order).
+        errors: Per-row error records (in input order).
+    """
+
+    imported_count: int = Field(ge=0)
+    error_count: int = Field(ge=0)
+    results: list[BatchRowResult] = Field(default_factory=list)
+    errors: list[BatchRowError] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")

--- a/backend/app/schemas/import_ofx.py
+++ b/backend/app/schemas/import_ofx.py
@@ -4,56 +4,22 @@ Frozen per spec at
 ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
 
 These schemas extend (not replace) the existing CSV preview/confirm flow:
-- The OFX preview endpoint returns ``ImportPreviewResponse`` (the CSV one),
-  populating optional OFX-specific fields on each ``ImportPreviewRow``.
-- The OFX confirm path reuses ``POST /api/v1/import/confirm`` — no new
-  confirm schema needed; the OFX-specific fields ride on the same
-  ``ImportConfirmRow`` shape (which is forward-compatible because the model
-  uses ``extra="forbid"`` only for fields it knows about; new optional
-  fields on ``ImportPreviewRow`` are echoed by the frontend into the
-  confirm payload only if they're declared on ``ImportConfirmRow``).
+- The OFX preview endpoint returns ``ImportPreviewResponse`` (the CSV one)
+  from ``app.schemas.import_schemas``. The OFX-specific fields
+  (``fitid``, ``bank_id``, ``account_type_ofx``) live DIRECTLY on
+  ``ImportPreviewRow`` / ``ImportConfirmRow`` so OpenAPI exposes them and
+  the ``extra="forbid"`` constraint allows them through.
+- The OFX confirm path reuses ``POST /api/v1/import/confirm`` and the same
+  ``ImportConfirmRow`` shape; the OFX extras ride on echoed fields.
 
-Wave 2 OFX team owns the parser implementation; this file only freezes
-the request/response wire shape.
+Wave 2 OFX team owns the parser implementation; this file freezes the
+OFX-specific request envelope and the diagnostics block. The row-level
+schema is the single source of truth in ``import_schemas.py``.
 """
 
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import BaseModel, ConfigDict, Field
-
-
-# ── OFX-specific row extras (echoed into ImportPreviewRow.fitid etc.) ──
-
-
-class OFXRowExtras(BaseModel):
-    """OFX-specific fields that ride on ``ImportPreviewRow``.
-
-    None of these are required on the CSV path. The OFX parser populates
-    them when the source is OFX; the frontend may echo them back into
-    confirm-payload metadata for audit / future locale dispatch.
-
-    Fields:
-        fitid: Bank-side unique transaction id from ``<FITID>``. Per OFX
-            spec §11.4.4, guaranteed unique within (bank_id, account).
-            Used as the primary dedup signal for OFX imports — when
-            present, takes precedence over the description/date/amount
-            5-tuple key.
-        bank_id: ``<BANKID>`` from ``<BANKACCTFROM>`` or ``<CCACCTFROM>``.
-            Used for cross-account dedup scoping (an OFX from bank A and
-            bank B with overlapping FITIDs is still two distinct streams).
-        account_type_ofx: OFX ``<ACCTTYPE>`` value. One of:
-            CHECKING, SAVINGS, CREDITLINE, MONEYMRKT. Informational only —
-            does NOT auto-pick an ``AccountType`` (user already chose
-            ``account_id`` at upload).
-    """
-
-    fitid: str | None = Field(default=None, max_length=128)
-    bank_id: str | None = Field(default=None, max_length=64)
-    account_type_ofx: Literal["CHECKING", "SAVINGS", "CREDITLINE", "MONEYMRKT"] | None = None
-
-    model_config = ConfigDict(extra="forbid")
 
 
 # ── Request envelope ──
@@ -77,15 +43,23 @@ class ImportOFXPreviewRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-# ── Response envelope ──
-# Note: actual response uses ``ImportPreviewResponse`` from
-# ``app.schemas.import_schemas`` so OFX and CSV preview share a UI reducer.
-# The Wave 2 OFX team adds ``fitid``, ``bank_id``, ``account_type_ofx`` to
-# ``ImportPreviewRow`` (as nullable fields) when implementing the parser;
-# this contract reserves those field names.
+# ── Row-level OFX fields live on the shared row schemas ──
+#
+# The three OFX-specific row fields (``fitid``, ``bank_id``,
+# ``account_type_ofx``) are declared directly on ``ImportPreviewRow`` and
+# ``ImportConfirmRow`` in ``app/schemas/import_schemas.py``. They are
+# nullable and default to ``None`` on the CSV path. OpenAPI exposes them
+# as part of the existing ``ImportPreviewResponse`` schema component.
+#
+# This intentional consolidation (vs. a separate ``OFXRowExtras`` model)
+# means:
+#   1. One row schema, one UI reducer.
+#   2. ``extra="forbid"`` on the row models stays — fields are declared.
+#   3. OpenAPI exposes the contract surface Wave 2 builds against.
+#   4. No model-merging gymnastics at the service layer.
 
 
-# ── Parser metadata response (diagnostic; optional Wave 2) ──
+# ── Parser diagnostics (optional Wave 2 add-on) ──
 
 
 class OFXParseDiagnostics(BaseModel):

--- a/backend/app/schemas/import_ofx.py
+++ b/backend/app/schemas/import_ofx.py
@@ -1,0 +1,115 @@
+"""Pydantic schemas for the OFX transaction import flow (Wave 1 contract).
+
+Frozen per spec at
+``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
+
+These schemas extend (not replace) the existing CSV preview/confirm flow:
+- The OFX preview endpoint returns ``ImportPreviewResponse`` (the CSV one),
+  populating optional OFX-specific fields on each ``ImportPreviewRow``.
+- The OFX confirm path reuses ``POST /api/v1/import/confirm`` — no new
+  confirm schema needed; the OFX-specific fields ride on the same
+  ``ImportConfirmRow`` shape (which is forward-compatible because the model
+  uses ``extra="forbid"`` only for fields it knows about; new optional
+  fields on ``ImportPreviewRow`` are echoed by the frontend into the
+  confirm payload only if they're declared on ``ImportConfirmRow``).
+
+Wave 2 OFX team owns the parser implementation; this file only freezes
+the request/response wire shape.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ── OFX-specific row extras (echoed into ImportPreviewRow.fitid etc.) ──
+
+
+class OFXRowExtras(BaseModel):
+    """OFX-specific fields that ride on ``ImportPreviewRow``.
+
+    None of these are required on the CSV path. The OFX parser populates
+    them when the source is OFX; the frontend may echo them back into
+    confirm-payload metadata for audit / future locale dispatch.
+
+    Fields:
+        fitid: Bank-side unique transaction id from ``<FITID>``. Per OFX
+            spec §11.4.4, guaranteed unique within (bank_id, account).
+            Used as the primary dedup signal for OFX imports — when
+            present, takes precedence over the description/date/amount
+            5-tuple key.
+        bank_id: ``<BANKID>`` from ``<BANKACCTFROM>`` or ``<CCACCTFROM>``.
+            Used for cross-account dedup scoping (an OFX from bank A and
+            bank B with overlapping FITIDs is still two distinct streams).
+        account_type_ofx: OFX ``<ACCTTYPE>`` value. One of:
+            CHECKING, SAVINGS, CREDITLINE, MONEYMRKT. Informational only —
+            does NOT auto-pick an ``AccountType`` (user already chose
+            ``account_id`` at upload).
+    """
+
+    fitid: str | None = Field(default=None, max_length=128)
+    bank_id: str | None = Field(default=None, max_length=64)
+    account_type_ofx: Literal["CHECKING", "SAVINGS", "CREDITLINE", "MONEYMRKT"] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ── Request envelope ──
+
+
+class ImportOFXPreviewRequest(BaseModel):
+    """OFX preview request (multipart form).
+
+    Note: FastAPI handles multipart-form parsing via separate ``UploadFile``
+    + ``Form()`` params on the route; this schema is included for OpenAPI
+    documentation and contract testing only. The actual route signature
+    uses ``file: UploadFile = File(...), account_id: int = Form(...)``.
+
+    Fields:
+        account_id: Target account for the import. Must belong to the
+            current user's org.
+    """
+
+    account_id: int = Field(gt=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ── Response envelope ──
+# Note: actual response uses ``ImportPreviewResponse`` from
+# ``app.schemas.import_schemas`` so OFX and CSV preview share a UI reducer.
+# The Wave 2 OFX team adds ``fitid``, ``bank_id``, ``account_type_ofx`` to
+# ``ImportPreviewRow`` (as nullable fields) when implementing the parser;
+# this contract reserves those field names.
+
+
+# ── Parser metadata response (diagnostic; optional Wave 2) ──
+
+
+class OFXParseDiagnostics(BaseModel):
+    """Diagnostic block returned alongside preview when an OFX file parses
+    with non-fatal warnings (e.g., missing FITID, unusual TRNTYPE).
+
+    Reserved for Wave 2 — not populated by the Wave 1 stub. Listed here so
+    the frontend reducer can be coded once.
+
+    Fields:
+        ofx_version: Detected OFX version (e.g. "1.0.3", "2.0", "2.1.1").
+        encoding: Detected file encoding.
+        statement_count: Number of ``<STMTTRNRS>`` / ``<CCSTMTTRNRS>``
+            blocks in the file. >1 means the file contains multiple
+            accounts; only the matching ``account_id`` is imported.
+        skipped_count: Rows skipped during parse (e.g., zero-amount
+            transactions, malformed dates).
+        warnings: Human-readable diagnostic strings (no PII).
+    """
+
+    ofx_version: str | None = None
+    encoding: str | None = None
+    statement_count: int = 0
+    skipped_count: int = 0
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")

--- a/backend/app/schemas/import_reconciliation.py
+++ b/backend/app/schemas/import_reconciliation.py
@@ -76,11 +76,15 @@ class ImportSourceFormat(str, enum.Enum):
 
     Used for telemetry and to drive format-specific UX in the
     Reconciliation UI (e.g., show ``fitid`` column for OFX imports).
+
+    NOTE: Manual batch entry (``POST /api/v1/transactions/batch``) is NOT
+    a reconciliation source. Manual-batch rows are not flagged
+    ``is_imported=True`` and they ship in Wave 2A before the
+    ``import_batches`` table exists. They never appear in this enum.
     """
 
     CSV = "csv"
     OFX = "ofx"
-    MANUAL_BATCH = "manual_batch"
 
 
 # ── Import-batch header (response shape) ──
@@ -95,8 +99,9 @@ class ImportBatchHeader(BaseModel):
     Fields:
         id: Batch primary key.
         account_id: Account the batch was imported into.
-        source_format: Origin format (CSV / OFX / manual batch).
-        file_name: User-provided file name (or synthesized for manual batch).
+        source_format: Origin format (CSV or OFX). Manual batch entry is
+            not a reconciliation source and never appears here.
+        file_name: User-provided file name from the upload.
         created_at: When the batch was created.
         created_by_user_id: User who created the batch.
         status: ``open`` while any row is still ``PENDING_REVIEW``,

--- a/backend/app/schemas/import_reconciliation.py
+++ b/backend/app/schemas/import_reconciliation.py
@@ -3,16 +3,26 @@
 Frozen per spec at
 ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
 
-Reconciliation is the post-confirm "inbox" UX. After a CSV or OFX import
-commits transactions, those rows are flagged ``reconciliation_state =
-PENDING_REVIEW`` (instead of the default ``ACCEPTED``). The Reconciliation
-UI presents them as a worklist; the user transitions each row to its final
-state via this endpoint.
+Reconciliation is an optional post-confirm "inbox" UX. The DEFAULT state
+for CSV- and OFX-confirm committed rows is ``ACCEPTED`` (Decision 3,
+2026-05-12): this preserves the current CSV-import UX where confirm
+commits transactions as final. The Reconciliation UI may later opt
+specific formats into landing as ``PENDING_REVIEW`` (e.g. flag OFX as
+"requires review" while keeping CSV at "accepted") on a per-format
+basis; the contract supports either default but the locked baseline is
+``ACCEPTED``.
 
-Wave 2 Reconciliation UI team owns the implementation, the migrations that
-add ``transactions.reconciliation_state``, ``transactions.import_batch_id``,
-and the ``import_batches`` table. This file freezes the wire shape and the
-state-transition rules.
+Wave 2 Reconciliation UI team owns:
+  - The migration that adds ``transactions.reconciliation_state``
+    (NOT NULL, DEFAULT 'accepted'), ``transactions.import_batch_id``
+    (nullable FK), and the new ``import_batches`` table.
+  - BACKFILL: existing imported rows (``is_imported=True``) must be
+    backfilled to ``reconciliation_state='accepted'`` so historical
+    imports do not retroactively land in the review inbox.
+  - The state-transition service and the inbox UI.
+
+This file freezes the wire shape and the state-transition rules; it
+does not implement them.
 """
 
 from __future__ import annotations

--- a/backend/app/schemas/import_reconciliation.py
+++ b/backend/app/schemas/import_reconciliation.py
@@ -1,0 +1,219 @@
+"""Pydantic schemas for the post-import reconciliation flow (Wave 1 contract).
+
+Frozen per spec at
+``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
+
+Reconciliation is the post-confirm "inbox" UX. After a CSV or OFX import
+commits transactions, those rows are flagged ``reconciliation_state =
+PENDING_REVIEW`` (instead of the default ``ACCEPTED``). The Reconciliation
+UI presents them as a worklist; the user transitions each row to its final
+state via this endpoint.
+
+Wave 2 Reconciliation UI team owns the implementation, the migrations that
+add ``transactions.reconciliation_state``, ``transactions.import_batch_id``,
+and the ``import_batches`` table. This file freezes the wire shape and the
+state-transition rules.
+"""
+
+from __future__ import annotations
+
+import datetime
+import enum
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ── State enum (server-authoritative) ──
+
+
+class ReconciliationState(str, enum.Enum):
+    """Reconciliation state of an imported transaction.
+
+    Non-imported transactions are always ``ACCEPTED`` (the default for
+    new rows on accounts).
+
+    Allowed transitions (server enforces):
+
+        PENDING_REVIEW → MATCHED | EDITED | SKIPPED | ACCEPTED | REJECTED
+        MATCHED        → ACCEPTED                (implicit on close)
+        EDITED         → ACCEPTED                (implicit on close)
+        UNMATCHED      → MATCHED | EDITED | SKIPPED | ACCEPTED | REJECTED
+        ACCEPTED       → PENDING_REVIEW          (reopen — rare)
+        REJECTED       → (terminal)
+        SKIPPED        → (terminal except via admin reopen, out of scope)
+
+    Server stores values as the lowercase string. SQLAlchemy enum should
+    declare ``values_callable=lambda x: [e.value for e in x]`` per the
+    project convention.
+    """
+
+    PENDING_REVIEW = "pending_review"
+    MATCHED = "matched"
+    UNMATCHED = "unmatched"
+    SKIPPED = "skipped"
+    EDITED = "edited"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+# ── Source-format enum for import_batches ──
+
+
+class ImportSourceFormat(str, enum.Enum):
+    """Origin format for an ``import_batches`` row.
+
+    Used for telemetry and to drive format-specific UX in the
+    Reconciliation UI (e.g., show ``fitid`` column for OFX imports).
+    """
+
+    CSV = "csv"
+    OFX = "ofx"
+    MANUAL_BATCH = "manual_batch"
+
+
+# ── Import-batch header (response shape) ──
+
+
+class ImportBatchHeader(BaseModel):
+    """Header row for an import batch.
+
+    Returned by ``GET /api/v1/import/{import_id}`` (Wave 2). Provides the
+    Reconciliation UI with metadata to render the batch summary card.
+
+    Fields:
+        id: Batch primary key.
+        account_id: Account the batch was imported into.
+        source_format: Origin format (CSV / OFX / manual batch).
+        file_name: User-provided file name (or synthesized for manual batch).
+        created_at: When the batch was created.
+        created_by_user_id: User who created the batch.
+        status: ``open`` while any row is still ``PENDING_REVIEW``,
+            ``closed`` once all rows are terminal.
+        total_rows: Total transactions in this batch.
+        pending_count: Rows still in ``PENDING_REVIEW`` or ``UNMATCHED``.
+    """
+
+    id: int
+    account_id: int
+    source_format: ImportSourceFormat
+    file_name: str
+    created_at: datetime.datetime
+    created_by_user_id: int
+    status: Literal["open", "closed"]
+    total_rows: int = Field(ge=0)
+    pending_count: int = Field(ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ── Transition request shapes ──
+
+
+class ReconciliationEdits(BaseModel):
+    """Optional edits applied when transitioning a row to ``EDITED``.
+
+    All fields are optional; only provided fields are updated. Server
+    enforces the same validation as the standard transaction-update
+    endpoint.
+
+    Fields:
+        description: New description.
+        amount: New amount (positive Decimal).
+        date: New date.
+        category_id: New category.
+    """
+
+    description: str | None = Field(default=None, max_length=255)
+    amount: Decimal | None = Field(default=None, gt=0, max_digits=12, decimal_places=2)
+    date: datetime.date | None = None
+    category_id: int | None = Field(default=None, gt=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ReconciliationTransition(BaseModel):
+    """A single transition request inside a reconcile batch.
+
+    Fields:
+        transaction_id: The transaction to transition. Must belong to the
+            batch referenced in the URL path (``import_id``); server
+            returns 422 otherwise.
+        to_state: Target state. Server validates the (from, to) transition
+            against the allowed-transitions table.
+        edits: Required iff ``to_state == EDITED``. Forbidden otherwise.
+        match_with_transaction_id: Required iff ``to_state == MATCHED``.
+            The existing transaction this imported row links to.
+            Forbidden otherwise.
+    """
+
+    transaction_id: int = Field(gt=0)
+    to_state: ReconciliationState
+    edits: ReconciliationEdits | None = None
+    match_with_transaction_id: int | None = Field(default=None, gt=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ReconcileBatchRequest(BaseModel):
+    """Request body for ``POST /api/v1/import/{import_id}/reconcile``.
+
+    All transitions in a single request commit atomically (one savepoint).
+    If any transition is invalid (bad ``to_state``, missing required
+    edits / match target, transaction belongs to a different batch, etc.)
+    the entire request is rejected with 422 and no state changes.
+
+    Fields:
+        transitions: Ordered list of state transitions. Server applies
+            them in order inside a single transaction.
+    """
+
+    transitions: list[ReconciliationTransition] = Field(min_length=1, max_length=500)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ── Response shapes ──
+
+
+class ReconciliationError(BaseModel):
+    """Error detail for a single transition that failed.
+
+    Note: in practice, errors here mean the WHOLE request rolled back
+    (transitions are atomic). The errors list exists to tell the user
+    which row(s) tripped the validation so the frontend can highlight
+    them. Empty when all transitions applied.
+
+    Fields:
+        transaction_id: The transaction that triggered the error.
+        error: Human-readable error message.
+    """
+
+    transaction_id: int
+    error: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ReconcileBatchResponse(BaseModel):
+    """Response body for the reconcile endpoint.
+
+    Fields:
+        import_id: The batch that was reconciled.
+        transitioned: Transaction IDs whose state changed. Same length as
+            request.transitions when no errors.
+        errors: Per-row errors (empty when transitions applied).
+        remaining_pending: Count of rows still in ``PENDING_REVIEW`` or
+            ``UNMATCHED`` after this request. When zero, the batch is
+            auto-closed (``status='closed'``).
+        batch_status: New batch status after this request.
+    """
+
+    import_id: int
+    transitioned: list[int] = Field(default_factory=list)
+    errors: list[ReconciliationError] = Field(default_factory=list)
+    remaining_pending: int = Field(ge=0)
+    batch_status: Literal["open", "closed"]
+
+    model_config = ConfigDict(extra="forbid")

--- a/backend/app/schemas/import_schemas.py
+++ b/backend/app/schemas/import_schemas.py
@@ -42,6 +42,16 @@ class ImportPreviewRow(BaseModel):
     pair_with_transaction_id: int | None = None
     transfer_candidates: list[TransferCandidate] = []
 
+    # L3.2 Wave 1 contract: OFX-specific extras (populated only by the OFX
+    # preview path; NULL on the CSV path). Declared here so OpenAPI exposes
+    # the wire shape Wave 2 teams build against. See spec
+    # ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
+    # §1 for field semantics; ``fitid`` is the primary OFX dedup signal
+    # (per OFX spec §11.4.4, unique within bank+account).
+    fitid: str | None = None
+    bank_id: str | None = None
+    account_type_ofx: Literal["CHECKING", "SAVINGS", "CREDITLINE", "MONEYMRKT"] | None = None
+
     model_config = ConfigDict(extra="forbid")
 
 
@@ -88,6 +98,13 @@ class ImportConfirmRow(BaseModel):
     # Echoed back from preview for accept-vs-override detection
     suggested_category_id: int | None = None
     suggestion_source: Literal["org_rule", "shared_dictionary", "default"] | None = None
+
+    # L3.2 Wave 1 contract: OFX-specific extras echoed from the preview row
+    # so the confirm payload can carry them through to audit / future
+    # locale dispatch. Always NULL on the CSV path.
+    fitid: str | None = None
+    bank_id: str | None = None
+    account_type_ofx: Literal["CHECKING", "SAVINGS", "CREDITLINE", "MONEYMRKT"] | None = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/schemas/transaction_suggestions.py
+++ b/backend/app/schemas/transaction_suggestions.py
@@ -1,0 +1,100 @@
+"""Pydantic schemas for description-suggestion autocomplete (Wave 1 contract).
+
+Frozen per spec at
+``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
+
+This endpoint powers the manual-entry form's "description" field
+autocomplete. It returns the user's most-used descriptions for a given
+transaction type, ranked by prefix-match → frequency → recency.
+
+Privacy rules (server-enforced):
+- Source: user's own ``transactions`` table, filtered by ``org_id``.
+- Never crosses org boundaries (single SQL filter).
+- Never returns suggestions from ``merchant_dictionary`` (that's smart-rules
+  categorization infrastructure, not autocomplete).
+- Never logs raw descriptions or the raw ``q`` query string — only
+  ``org_id``, ``type``, ``query_length``, ``result_count``.
+
+Frontend behavior expectations:
+- Debounce 300 ms.
+- Min query length 2 chars when ``q`` is present.
+- When ``q`` is omitted, server returns top-N most-used descriptions for
+  the requested ``type`` (useful for the manual-entry form's "recent
+  descriptions" hint).
+- Show max 8 items in the dropdown.
+
+Wave 2 Description Suggestions team owns the implementation. This file
+freezes the request/response wire shape.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DescriptionSuggestionsRequest(BaseModel):
+    """Query parameters for the suggestion endpoint.
+
+    Included for OpenAPI documentation; the actual route uses
+    ``Query()`` parameters on the function signature.
+
+    Fields:
+        type: Transaction type filter. ``transfer`` is included for
+            future use but is not currently surfaced in the manual-entry
+            UX (transfers go through their own creation flow).
+        q: Search query. Optional. When present, minimum 2 chars
+            (server returns 422 on shorter queries). When absent,
+            returns the top-N most-used descriptions for ``type``.
+        limit: Maximum number of results. Default 10, max 25.
+    """
+
+    type: Literal["income", "expense", "transfer"]
+    q: str | None = Field(default=None, min_length=2, max_length=255)
+    limit: int = Field(default=10, ge=1, le=25)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DescriptionSuggestion(BaseModel):
+    """A single autocomplete suggestion.
+
+    Fields:
+        description: The exact text the user previously used. Returned
+            verbatim (case-preserved).
+        category_id: The most-frequently-paired category for this
+            description, scoped to the org. When the same description
+            has been used with multiple categories, the most-used wins
+            (ties broken by recency).
+        category_name: Display name of ``category_id`` at query time.
+        use_count: Number of times this user/org has used this description.
+        last_used: Date of the most recent transaction with this
+            description.
+    """
+
+    description: str
+    category_id: int
+    category_name: str
+    use_count: int = Field(ge=1)
+    last_used: datetime.date
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DescriptionSuggestionsResponse(BaseModel):
+    """Response body for ``GET /api/v1/transactions/suggestions/descriptions``.
+
+    Sorted by:
+      1. Prefix match first (description ILIKE q || '%').
+      2. Then frequency (use_count DESC).
+      3. Then recency (last_used DESC).
+
+    Fields:
+        suggestions: Ranked list, max ``limit`` entries.
+    """
+
+    suggestions: list[DescriptionSuggestion] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")

--- a/backend/tests/routers/test_import_contracts.py
+++ b/backend/tests/routers/test_import_contracts.py
@@ -1,0 +1,446 @@
+"""L3.2 Wave 1 contract tests for new import / transactions stubs.
+
+These tests pin the wire shape that downstream Wave 2 teams (OFX Parser,
+Manual Batch Entry, Description Suggestions, Reconciliation UI) will
+build against. They pass at 501 today and become the regression scaffold
+for the implementation teams' PRs.
+
+Each endpoint is verified for:
+- Auth enforcement (401 without an authenticated user)
+- Org-scoping shell (dependency is wired; current_user.org_id is read)
+- Pydantic request validation (422 on bad payload shape)
+- 501 response when called with a well-formed payload (stub semantics)
+
+Spec: ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``.
+"""
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.routers.import_router import router as import_router
+from app.routers.transactions import router as transactions_router
+from app.security import hash_password
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from fastapi.responses import JSONResponse
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_user(factory) -> tuple[int, int]:
+    """Seed a single org + user. Returns ``(org_id, user_id)``."""
+    async with factory() as db:
+        org = Organization(name="ContractTest", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="contracttest",
+            email="contract@test.example",
+            password_hash=hash_password("pw-test-12345"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return org.id, user.id
+
+
+def _make_app(session_factory, *, authenticated: bool = True) -> FastAPI:
+    """Build a FastAPI app with both routers + auth override.
+
+    When ``authenticated=False``, ``get_current_user`` raises a 401-style
+    HTTPException so we can verify the auth dependency actually fires.
+    """
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    if authenticated:
+        async def override_current_user() -> User:
+            async with session_factory() as db:
+                return (
+                    await db.execute(
+                        select(User).where(User.is_superadmin.is_(True))
+                    )
+                ).scalar_one()
+        app.dependency_overrides[get_current_user] = override_current_user
+    else:
+        from fastapi import HTTPException
+
+        async def reject_user():
+            raise HTTPException(status_code=401, detail="not authenticated")
+
+        app.dependency_overrides[get_current_user] = reject_user
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    # Wire the same domain exception handlers main.py installs so the
+    # Pydantic 422 / domain-error mapping is identical to production.
+    @app.exception_handler(NotFoundError)
+    async def _nfe(request, exc):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ValidationError)
+    async def _vle(request, exc):
+        return JSONResponse(status_code=400, content={"detail": exc.detail})
+
+    @app.exception_handler(ConflictError)
+    async def _cfe(request, exc):
+        return JSONResponse(status_code=409, content={"detail": exc.detail})
+
+    app.include_router(import_router)
+    app.include_router(transactions_router)
+    return app
+
+
+# ── /api/v1/import/ofx/preview ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ofx_preview_returns_501_when_authenticated(session_factory):
+    """OFX preview stub returns 501 with a pointer to the spec."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/import/ofx/preview",
+            files={"file": ("test.ofx", io.BytesIO(b"<OFX></OFX>"), "application/x-ofx")},
+            data={"account_id": "1"},
+        )
+    assert resp.status_code == 501
+    body = resp.json()
+    assert "not implemented" in body["detail"].lower()
+    assert "l3.2" in body["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_ofx_preview_requires_auth(session_factory):
+    """OFX preview rejects unauthenticated requests with 401."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory, authenticated=False)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/import/ofx/preview",
+            files={"file": ("test.ofx", io.BytesIO(b"<OFX></OFX>"), "application/x-ofx")},
+            data={"account_id": "1"},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_ofx_preview_validates_account_id_present(session_factory):
+    """OFX preview returns 422 when account_id is missing."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/import/ofx/preview",
+            files={"file": ("test.ofx", io.BytesIO(b"<OFX></OFX>"), "application/x-ofx")},
+            # account_id missing
+        )
+    assert resp.status_code == 422
+
+
+# ── /api/v1/import/{import_id}/reconcile ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_returns_501_when_authenticated(session_factory):
+    """Reconcile stub returns 501."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    payload = {
+        "transitions": [
+            {"transaction_id": 1, "to_state": "accepted"},
+        ],
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/import/42/reconcile", json=payload)
+    assert resp.status_code == 501
+    assert "not implemented" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_requires_auth(session_factory):
+    """Reconcile rejects unauthenticated requests with 401."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory, authenticated=False)
+    payload = {"transitions": [{"transaction_id": 1, "to_state": "accepted"}]}
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/import/42/reconcile", json=payload)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_reconcile_validates_empty_transitions(session_factory):
+    """Reconcile rejects an empty transitions list (min_length=1)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/import/42/reconcile", json={"transitions": []})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reconcile_validates_unknown_state(session_factory):
+    """Reconcile rejects unknown ``to_state`` values via the enum."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    payload = {
+        "transitions": [{"transaction_id": 1, "to_state": "totally_made_up"}],
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/import/42/reconcile", json=payload)
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reconcile_validates_extra_fields_forbidden(session_factory):
+    """Reconcile rejects unknown top-level fields (extra='forbid')."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    payload = {
+        "transitions": [{"transaction_id": 1, "to_state": "accepted"}],
+        "rogue_field": "nope",
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/import/42/reconcile", json=payload)
+    assert resp.status_code == 422
+
+
+# ── /api/v1/transactions/batch ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_batch_returns_501_when_authenticated(session_factory):
+    """Batch endpoint returns 501."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    payload = {
+        "rows": [
+            {
+                "row_number": 1,
+                "transaction": {
+                    "account_id": 1,
+                    "category_id": 1,
+                    "description": "Test row",
+                    "amount": "12.50",
+                    "type": "expense",
+                    "date": "2026-05-10",
+                },
+            }
+        ],
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/transactions/batch", json=payload)
+    assert resp.status_code == 501
+    assert "not implemented" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_batch_requires_auth(session_factory):
+    """Batch endpoint rejects unauthenticated requests with 401."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory, authenticated=False)
+    payload = {
+        "rows": [
+            {
+                "row_number": 1,
+                "transaction": {
+                    "account_id": 1,
+                    "category_id": 1,
+                    "description": "Test row",
+                    "amount": "12.50",
+                    "type": "expense",
+                    "date": "2026-05-10",
+                },
+            }
+        ],
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/transactions/batch", json=payload)
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_batch_validates_empty_rows(session_factory):
+    """Batch endpoint rejects an empty rows list (min_length=1)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/transactions/batch", json={"rows": []})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_batch_validates_max_rows(session_factory):
+    """Batch endpoint rejects more than 500 rows (max_length=500)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    rows = [
+        {
+            "row_number": i,
+            "transaction": {
+                "account_id": 1,
+                "category_id": 1,
+                "description": f"Row {i}",
+                "amount": "1.00",
+                "type": "expense",
+                "date": "2026-05-10",
+            },
+        }
+        for i in range(1, 502)
+    ]
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/transactions/batch", json={"rows": rows})
+    assert resp.status_code == 422
+
+
+# ── /api/v1/transactions/suggestions/descriptions ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_suggestions_returns_501_when_authenticated(session_factory):
+    """Description-suggestions endpoint returns 501."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense", "q": "alb", "limit": 10},
+        )
+    assert resp.status_code == 501
+    assert "not implemented" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_suggestions_requires_auth(session_factory):
+    """Description-suggestions endpoint rejects unauthenticated requests."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory, authenticated=False)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense"},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_suggestions_validates_type_enum(session_factory):
+    """Suggestions endpoint rejects unknown ``type`` values."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "bogus"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_suggestions_validates_min_query_length(session_factory):
+    """Suggestions endpoint rejects ``q`` shorter than 2 chars."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense", "q": "a"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_suggestions_validates_max_limit(session_factory):
+    """Suggestions endpoint rejects ``limit > 25``."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense", "limit": 26},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_suggestions_q_omitted_is_valid_at_contract_layer(session_factory):
+    """When q is omitted, request shape is valid (server returns 501)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "income"},
+        )
+    # 501, not 422 — q is optional per contract.
+    assert resp.status_code == 501
+
+
+# ── OpenAPI surface check ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_openapi_advertises_all_new_endpoints(session_factory):
+    """OpenAPI schema must list the four new endpoints so Wave 2 teams can
+    generate client stubs against the frozen contract."""
+    app = _make_app(session_factory)
+    schema = app.openapi()
+    paths = schema["paths"]
+    assert "/api/v1/import/ofx/preview" in paths
+    assert "post" in paths["/api/v1/import/ofx/preview"]
+    assert "/api/v1/import/{import_id}/reconcile" in paths
+    assert "post" in paths["/api/v1/import/{import_id}/reconcile"]
+    assert "/api/v1/transactions/batch" in paths
+    assert "post" in paths["/api/v1/transactions/batch"]
+    assert "/api/v1/transactions/suggestions/descriptions" in paths
+    assert "get" in paths["/api/v1/transactions/suggestions/descriptions"]
+
+    # Component schemas for each contract type must be advertised.
+    components = schema.get("components", {}).get("schemas", {})
+    for name in (
+        "BatchTransactionsRequest",
+        "BatchTransactionsResponse",
+        "ReconcileBatchRequest",
+        "ReconcileBatchResponse",
+        "DescriptionSuggestionsResponse",
+        "ReconciliationState",
+    ):
+        assert name in components, f"OpenAPI missing component: {name}"

--- a/backend/tests/routers/test_import_contracts.py
+++ b/backend/tests/routers/test_import_contracts.py
@@ -308,6 +308,55 @@ async def test_batch_validates_empty_rows(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_batch_rejects_duplicate_row_numbers(session_factory):
+    """Batch endpoint rejects duplicate ``row_number`` values with 422.
+
+    The response shape maps results back to the user's input via
+    ``row_number``; duplicates would collide. The ``model_validator``
+    on ``BatchTransactionsRequest`` is the gate. We verify the 422
+    surfaces and the error locator points at the ``rows`` field.
+    """
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    payload = {
+        "rows": [
+            {
+                "row_number": 1,
+                "transaction": {
+                    "account_id": 1,
+                    "category_id": 1,
+                    "description": "First",
+                    "amount": "1.00",
+                    "type": "expense",
+                    "date": "2026-05-10",
+                },
+            },
+            {
+                "row_number": 1,
+                "transaction": {
+                    "account_id": 1,
+                    "category_id": 1,
+                    "description": "Second",
+                    "amount": "2.00",
+                    "type": "expense",
+                    "date": "2026-05-10",
+                },
+            },
+        ],
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/transactions/batch", json=payload)
+    assert resp.status_code == 422
+    body = resp.json()
+    rendered = repr(body)
+    # The Pydantic validator message names ``row_number`` and either
+    # ``unique`` or ``duplicate``. Both signals must surface so the
+    # frontend can render a meaningful 422.
+    assert "row_number" in rendered
+    assert "unique" in rendered.lower() or "duplicate" in rendered.lower()
+
+
+@pytest.mark.asyncio
 async def test_batch_validates_max_rows(session_factory):
     """Batch endpoint rejects more than 500 rows (max_length=500)."""
     await _seed_user(session_factory)
@@ -444,3 +493,30 @@ async def test_openapi_advertises_all_new_endpoints(session_factory):
         "ReconciliationState",
     ):
         assert name in components, f"OpenAPI missing component: {name}"
+
+
+@pytest.mark.asyncio
+async def test_openapi_exposes_ofx_row_fields(session_factory):
+    """OFX-specific fields MUST surface on the shared row schemas.
+
+    Regression gate for the Wave 2 OFX team: ``fitid``, ``bank_id``,
+    ``account_type_ofx`` live on ``ImportPreviewRow`` and
+    ``ImportConfirmRow`` (the shared row schemas in
+    ``app/schemas/import_schemas.py``), NOT on a sidecar model. This
+    test asserts the OpenAPI component for both row schemas advertises
+    all three fields so Wave 2's generated client picks them up.
+    """
+    app = _make_app(session_factory)
+    schema = app.openapi()
+    components = schema.get("components", {}).get("schemas", {})
+
+    for row_schema_name in ("ImportPreviewRow", "ImportConfirmRow"):
+        assert row_schema_name in components, (
+            f"OpenAPI missing row schema: {row_schema_name}"
+        )
+        props = components[row_schema_name].get("properties", {})
+        for field in ("fitid", "bank_id", "account_type_ofx"):
+            assert field in props, (
+                f"OpenAPI {row_schema_name} missing OFX field: {field}. "
+                "Wave 2 OFX team builds against these — they must surface."
+            )


### PR DESCRIPTION
## Scope summary
Contract-first foundation for L3.2 — produces a spec doc + Pydantic schemas + 501-stub endpoints so OFX Parser / Batch Entry / Reconciliation UI / Description Suggestions / Opening Balance teams can build in parallel against a frozen wire shape.

## Contract changes
- New endpoints (stubbed at 501): `POST /api/v1/import/ofx/preview`, `POST /api/v1/import/{import_id}/reconcile`, `POST /api/v1/transactions/batch`, `GET /api/v1/transactions/suggestions/descriptions`.
- New schemas: `ImportOFXPreviewRequest` + `OFXRowExtras` + `OFXParseDiagnostics`, `BatchTransactionsRequest`/`Response` + per-row result/error shapes, `ReconciliationState` enum, `ImportSourceFormat` enum, `ImportBatchHeader`, `ReconciliationTransition` + `ReconcileBatchRequest`/`Response`, `DescriptionSuggestion` + `DescriptionSuggestionsResponse`.
- Spec at `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md` (outside the repo by design, lives alongside roadmap memory).

## OpenAPI surface (new endpoints)
```
POST /api/v1/import/ofx/preview
  body: multipart/form-data -> Body_preview_ofx_import_api_v1_import_ofx_preview_post
  resp 501: #/components/schemas/ImportPreviewResponse

POST /api/v1/import/{import_id}/reconcile
  body: application/json -> #/components/schemas/ReconcileBatchRequest
  resp 501: #/components/schemas/ReconcileBatchResponse

POST /api/v1/transactions/batch
  body: application/json -> #/components/schemas/BatchTransactionsRequest
  resp 501: #/components/schemas/BatchTransactionsResponse

GET /api/v1/transactions/suggestions/descriptions
  query: type, q?, limit?
  resp 501: #/components/schemas/DescriptionSuggestionsResponse
```

## Security notes
- All new endpoints auth-required (`Depends(get_current_user)`) + org-scoped (handlers reach `current_user.org_id`).
- Description-suggestions endpoint contract requires: never leak across orgs, never log raw descriptions or raw `q` strings, debounced 300 ms client-side, min 2-char query length enforced server-side.
- OFX parser contract notes process-isolation requirement (Wave 2 OFX team to implement): pin `ofxtools ~= 0.9.5`, wrap parse in `asyncio.wait_for(timeout=10)`, hard-fail at >10k rows, defusedxml protection inherited from `ofxtools`.
- Reconciliation transitions atomic per request (one savepoint, all-or-nothing).

## Test evidence
- `tests/routers/test_import_contracts.py`: **19 contract tests, all green.** Each new endpoint verified for auth enforcement (401), Pydantic validation (422), and stub semantics (501). One OpenAPI surface check verifies all four paths + every contract component schema are advertised.
- Full backend suite: **922 passed, 2 skipped** (no regressions; was 922 before).

## Frozen contracts for Wave 2 teams
1. **OFX Parser** — endpoint path, file-size cap (5 MB), version support (OFX 1.x SGML + 2.x XML), library choice (`ofxtools ~= 0.9.5`), output schema reuses `ImportPreviewResponse` with `fitid`/`bank_id`/`account_type_ofx` extras.
2. **Manual Batch Entry** — `POST /api/v1/transactions/batch`, max 500 rows/request, per-row savepoint isolation, NOT flagged `is_imported`.
3. **Description Suggestions** — ranking order locked (prefix → frequency → recency), 25-result max, org-scoped, no cross-org leak, privacy rules pinned.
4. **Reconciliation UI** — state machine + allowed transitions table, atomic per-request, batch auto-close on `remaining_pending=0`, owns the migration that adds `transactions.reconciliation_state` + `transactions.import_batch_id` + `import_batches` table.
5. **Opening Balance** — two new columns on `accounts` (`opening_balance`, `opening_balance_date`), balance recompute formula locked, edits via existing `PATCH /api/v1/accounts/{id}`.

## Out of scope (deferred)
- Locale-aware import intelligence (P-IL.* tier — see `project_localized_import_intelligence.md`).
- AI-assisted reconciliation (LAI tier).
- Multi-currency conversion at import (P3 thread).