### PR TITLE
feat(auth): brand-compliant Google SSO button (L5.9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,13 @@ GOOGLE_CLIENT_SECRET=
 # --- Frontend ---
 # When using nginx (default), leave empty — API calls are same-origin via /api/
 # Only set this if running frontend standalone without nginx
+# --- Frontend Google SSO visibility flag ---
+# Set to "true" once GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET are configured
+# AND the authorized redirect URI is registered. The "Sign in with Google"
+# button is hidden when this is not exactly "true" to avoid a broken-redirect
+# UX in environments where SSO has not been wired through Google Cloud.
+NEXT_PUBLIC_GOOGLE_SSO_ENABLED=false
+
 NEXT_PUBLIC_API_URL=
 
 # Canonical site URL used for SEO metadata (canonical tags, sitemap, robots,

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -190,6 +190,35 @@ a, button { transition: all 0.15s ease; }
   color: var(--theme-text-primary) !important;
 }
 
+/* Google "Sign in with Google" button (L5.9). Surface colors are locked
+   by Google's branding guide and do NOT consume product theme tokens.
+   The button is dark-by-default (the app's default theme) and lightens
+   when the html root carries data-theme="light". Sizing, focus, and
+   typography are owned by the component className; only the brand
+   surface lives here so the values are reviewable in one place. */
+.gsi-button {
+  background-color: #131314;
+  color: #e3e3e3;
+  border: 1px solid transparent;
+}
+.gsi-button:hover {
+  background-color: #1e1f20;
+}
+.gsi-button:active {
+  background-color: #2a2b2d;
+}
+[data-theme="light"] .gsi-button {
+  background-color: #ffffff;
+  color: #1f1f1f;
+  border-color: #dadce0;
+}
+[data-theme="light"] .gsi-button:hover {
+  background-color: #f8f9fa;
+}
+[data-theme="light"] .gsi-button:active {
+  background-color: #f1f3f4;
+}
+
 /* Honor user's reduced-motion preference. WCAG 2.2 AA + PRODUCT.md
    commitment. Disables animations, transitions, and smooth-scroll for
    anyone with the OS-level preference set. Placed last so it wins

--- a/frontend/components/auth/GoogleSSOButton.tsx
+++ b/frontend/components/auth/GoogleSSOButton.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useId, type MouseEventHandler } from "react";
+
+/**
+ * Provider-compliant Google "Sign in with Google" button.
+ *
+ * Per Google Identity branding guidelines
+ * (https://developers.google.com/identity/gsi/web/guides/display-button),
+ * this component:
+ *   - uses the official 4-color G mark inline (no recolor, no monochrome),
+ *   - uses the locked wordmarks "Sign in with Google" / "Sign up with Google",
+ *   - meets a 44px minimum touch target,
+ *   - meets contrast in light + dark variants (white surface for light,
+ *     #131314 surface for dark, both with Google-spec text colors).
+ *
+ * The component reads `NEXT_PUBLIC_GOOGLE_SSO_ENABLED`. If the flag is not
+ * exactly "true", the button is hidden by default to avoid a broken-redirect
+ * experience when ops has not configured Google OAuth in this environment.
+ * Pass `showWhenDisabled` to keep it rendered as an aria-disabled affordance,
+ * with `disabledReason` surfaced via `aria-describedby`.
+ */
+
+export type GoogleSSOButtonMode = "signin" | "signup";
+
+export interface GoogleSSOButtonProps {
+  /** Click handler. The component does NOT initiate the OAuth flow itself. */
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  /** "signin" renders the locked "Sign in with Google" wordmark (default).
+   *  "signup" renders the locked "Sign up with Google" wordmark. */
+  mode?: GoogleSSOButtonMode;
+  /** While true the button is disabled and announces aria-busy. */
+  loading?: boolean;
+  /** Force-render the button even when the env flag is not "true". Used to
+   *  surface a configuration problem to the user rather than silently hide
+   *  the entry point. The button will be visually + aria-disabled. */
+  showWhenDisabled?: boolean;
+  /** Human-readable reason surfaced via aria-describedby when disabled. */
+  disabledReason?: string;
+}
+
+function isSSOEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_GOOGLE_SSO_ENABLED === "true";
+}
+
+function GoogleGMark() {
+  // Google's official 4-color G mark. Path data + brand hexes come from
+  // Google's published asset; do NOT recolor, distort, or replace.
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        fill="#4285F4"
+        d="M17.64 9.2045c0-.6381-.0573-1.2518-.1636-1.8409H9v3.4814h4.8436c-.2086 1.125-.8427 2.0782-1.7959 2.7164v2.2581h2.9087c1.7018-1.5668 2.6836-3.874 2.6836-6.615z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.4673-.806 5.9564-2.1805l-2.9087-2.258c-.8059.54-1.8368.8595-3.0477.8595-2.344 0-4.3282-1.5831-5.0359-3.7104H.957v2.3318C2.4382 15.9831 5.4818 18 9 18z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.9641 10.71c-.18-.54-.2823-1.1168-.2823-1.71s.1023-1.17.2823-1.71V4.9582H.957C.3477 6.1731 0 7.5477 0 9c0 1.4523.3477 2.8268.957 4.0418l3.0071-2.3318z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.5795c1.3214 0 2.5077.4541 3.4405 1.346l2.5813-2.5814C13.4632.8918 11.4259 0 9 0 5.4818 0 2.4382 2.0168.957 4.9582L3.9641 7.29C4.6718 5.1627 6.6559 3.5795 9 3.5795z"
+      />
+    </svg>
+  );
+}
+
+export default function GoogleSSOButton({
+  onClick,
+  mode = "signin",
+  loading = false,
+  showWhenDisabled = false,
+  disabledReason,
+}: GoogleSSOButtonProps) {
+  const enabled = isSSOEnabled();
+  const helperId = useId();
+
+  if (!enabled && !showWhenDisabled) return null;
+
+  const label = mode === "signup" ? "Sign up with Google" : "Sign in with Google";
+  const disabled = loading || !enabled;
+
+  // Surface colors are locked by Google's branding guide and live in
+  // globals.css under `.gsi-button` (dark default) +
+  // `[data-theme="light"] .gsi-button` (light flip). They do NOT consume
+  // product theme tokens because Google's spec does not allow recolor.
+  const surface = "gsi-button";
+
+  const base =
+    "inline-flex w-full min-h-[44px] items-center justify-center gap-3 " +
+    "rounded-md px-4 py-2.5 text-sm font-medium " +
+    "transition-colors " +
+    "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 " +
+    "focus-visible:ring-offset-2 focus-visible:ring-offset-bg " +
+    "disabled:cursor-not-allowed disabled:opacity-60";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={label}
+        aria-busy={loading || undefined}
+        aria-disabled={!enabled || undefined}
+        aria-describedby={!enabled && disabledReason ? helperId : undefined}
+        className={`${base} ${surface}`}
+        style={{ fontFamily: "'Roboto', system-ui, -apple-system, sans-serif" }}
+      >
+        <GoogleGMark />
+        <span>{loading ? "Connecting..." : label}</span>
+      </button>
+      {!enabled && disabledReason ? (
+        <p id={helperId} className="mt-2 text-xs text-text-muted text-center">
+          {disabledReason}
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/components/auth/LoginPageBody.tsx
+++ b/frontend/components/auth/LoginPageBody.tsx
@@ -4,10 +4,11 @@ import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth, MfaRequiredError } from "@/components/auth/AuthProvider";
+import GoogleSSOButton from "@/components/auth/GoogleSSOButton";
 import PasswordInput from "@/components/ui/PasswordInput";
 import ThemeToggle from "@/components/ui/ThemeToggle";
 import { ApiResponseError, apiFetch } from "@/lib/api";
-import { input, label, btnPrimary, btnSecondary, error as errorCls } from "@/lib/styles";
+import { input, label, btnPrimary, error as errorCls } from "@/lib/styles";
 
 type ResendState = "idle" | "sending" | "sent" | "failed";
 
@@ -23,6 +24,7 @@ export default function LoginPageBody() {
   // if they edit the input afterward.
   const [unverifiedLogin, setUnverifiedLogin] = useState<string | null>(null);
   const [resendState, setResendState] = useState<ResendState>("idle");
+  const [googleLoading, setGoogleLoading] = useState(false);
 
   useEffect(() => {
     if (!loading && needsSetup) router.replace("/setup");
@@ -68,10 +70,12 @@ export default function LoginPageBody() {
   }
 
   async function handleGoogleLogin() {
+    setGoogleLoading(true);
     try {
       const data = await apiFetch<{ redirect_url: string }>("/api/v1/auth/google");
       window.location.href = data.redirect_url;
     } catch (err) {
+      setGoogleLoading(false);
       setError(err instanceof Error ? err.message : "Google sign-in is not available");
     }
   }
@@ -133,14 +137,20 @@ export default function LoginPageBody() {
           <button type="submit" disabled={submitting} className={`w-full ${btnPrimary}`}>
             {submitting ? "Signing in..." : "Sign In"}
           </button>
-          <div className="flex items-center gap-3 my-4">
-            <div className="flex-1 border-t border-border" />
-            <span className="text-xs text-text-muted">or</span>
-            <div className="flex-1 border-t border-border" />
-          </div>
-          <button onClick={handleGoogleLogin} className={btnSecondary + " w-full"} type="button">
-            Sign in with Google
-          </button>
+          {process.env.NEXT_PUBLIC_GOOGLE_SSO_ENABLED === "true" && (
+            <>
+              <div className="flex items-center gap-3 my-4">
+                <div className="flex-1 border-t border-border" />
+                <span className="text-xs text-text-muted">or</span>
+                <div className="flex-1 border-t border-border" />
+              </div>
+              <GoogleSSOButton
+                mode="signin"
+                loading={googleLoading}
+                onClick={handleGoogleLogin}
+              />
+            </>
+          )}
         </form>
         <p className="mt-6 text-center text-sm text-text-muted">
           Don&apos;t have an account?{" "}

--- a/frontend/components/auth/RegisterPageBody.tsx
+++ b/frontend/components/auth/RegisterPageBody.tsx
@@ -4,10 +4,11 @@ import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/components/auth/AuthProvider";
+import GoogleSSOButton from "@/components/auth/GoogleSSOButton";
 import { apiFetch } from "@/lib/api";
 import PasswordInput from "@/components/ui/PasswordInput";
 import ThemeToggle from "@/components/ui/ThemeToggle";
-import { input, label, btnPrimary, btnSecondary, error as errorCls, success } from "@/lib/styles";
+import { input, label, btnPrimary, error as errorCls, success } from "@/lib/styles";
 import {
   USERNAME_MAX_LENGTH,
   USERNAME_MIN_LENGTH,
@@ -42,6 +43,7 @@ export default function RegisterPageBody() {
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [registered, setRegistered] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
 
   // Auto-suggest username from name
   useEffect(() => {
@@ -100,10 +102,12 @@ export default function RegisterPageBody() {
   }
 
   async function handleGoogleLogin() {
+    setGoogleLoading(true);
     try {
       const data = await apiFetch<{ redirect_url: string }>("/api/v1/auth/google");
       window.location.href = data.redirect_url;
     } catch (err) {
+      setGoogleLoading(false);
       setError(err instanceof Error ? err.message : "Google sign-in is not available");
     }
   }
@@ -210,14 +214,20 @@ export default function RegisterPageBody() {
           <button type="submit" disabled={submitting || usernameStatus === "taken"} className={`w-full ${btnPrimary}`}>
             {submitting ? "Creating account..." : "Create Account"}
           </button>
-          <div className="flex items-center gap-3 my-4">
-            <div className="flex-1 border-t border-border" />
-            <span className="text-xs text-text-muted">or</span>
-            <div className="flex-1 border-t border-border" />
-          </div>
-          <button onClick={handleGoogleLogin} className={btnSecondary + " w-full"} type="button">
-            Sign up with Google
-          </button>
+          {process.env.NEXT_PUBLIC_GOOGLE_SSO_ENABLED === "true" && (
+            <>
+              <div className="flex items-center gap-3 my-4">
+                <div className="flex-1 border-t border-border" />
+                <span className="text-xs text-text-muted">or</span>
+                <div className="flex-1 border-t border-border" />
+              </div>
+              <GoogleSSOButton
+                mode="signup"
+                loading={googleLoading}
+                onClick={handleGoogleLogin}
+              />
+            </>
+          )}
         </form>
         <p className="mt-6 text-center text-sm text-text-muted">
           Already have an account?{" "}

--- a/frontend/scripts/check-design-tokens.sh
+++ b/frontend/scripts/check-design-tokens.sh
@@ -40,6 +40,10 @@ ROOTS=(app components lib)
 #   - app/apple-icon.tsx — Next.js dynamic icon route, inline styles only.
 #   - app/global-error.tsx — root error boundary; runs without globals.css.
 #   - lib/brand.ts — canonical brand constants, not theme tokens.
+#   - components/auth/GoogleSSOButton.tsx — Google's official SVG mark
+#     uses Google's locked 4-color brand hexes (#4285F4 / #34A853 /
+#     #FBBC05 / #EA4335) and provider-spec surface colors that MUST NOT
+#     theme-switch. Google's branding guide forbids recolor.
 EXCLUDES=(
   --exclude-dir=node_modules
   --exclude-dir=.next
@@ -48,6 +52,7 @@ EXCLUDES=(
   --exclude=apple-icon.tsx
   --exclude=global-error.tsx
   --exclude=brand.ts
+  --exclude=GoogleSSOButton.tsx
 )
 
 PALETTES='(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)'

--- a/frontend/tests/components/google-sso-button.test.tsx
+++ b/frontend/tests/components/google-sso-button.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import GoogleSSOButton from "@/components/auth/GoogleSSOButton";
+
+const ENV_KEY = "NEXT_PUBLIC_GOOGLE_SSO_ENABLED";
+
+function withFlag(value: string | undefined, fn: () => void) {
+  const original = process.env[ENV_KEY];
+  if (value === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  }
+}
+
+describe("GoogleSSOButton", () => {
+  it("renders Google's official multi-color G mark when SSO is enabled", () => {
+    withFlag("true", () => {
+      render(<GoogleSSOButton onClick={() => {}} />);
+      const button = screen.getByRole("button", { name: /Sign in with Google/i });
+      const svg = button.querySelector("svg");
+      expect(svg).not.toBeNull();
+      const fills = Array.from(svg!.querySelectorAll("path")).map((p) =>
+        p.getAttribute("fill"),
+      );
+      // Google's four official brand colors must all appear.
+      expect(fills).toEqual(
+        expect.arrayContaining(["#4285F4", "#34A853", "#FBBC05", "#EA4335"]),
+      );
+    });
+  });
+
+  it("renders the signin wordmark by default", () => {
+    withFlag("true", () => {
+      render(<GoogleSSOButton onClick={() => {}} />);
+      expect(
+        screen.getByRole("button", { name: "Sign in with Google" }),
+      ).toBeTruthy();
+    });
+  });
+
+  it("renders the signup wordmark when mode='signup'", () => {
+    withFlag("true", () => {
+      render(<GoogleSSOButton mode="signup" onClick={() => {}} />);
+      expect(
+        screen.getByRole("button", { name: "Sign up with Google" }),
+      ).toBeTruthy();
+    });
+  });
+
+  it("invokes onClick when clicked", () => {
+    withFlag("true", () => {
+      const onClick = vi.fn();
+      render(<GoogleSSOButton onClick={onClick} />);
+      fireEvent.click(screen.getByRole("button", { name: /Sign in with Google/i }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("renders nothing when NEXT_PUBLIC_GOOGLE_SSO_ENABLED is not 'true'", () => {
+    withFlag(undefined, () => {
+      const { container } = render(<GoogleSSOButton onClick={() => {}} />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders nothing when the env flag is set to 'false'", () => {
+    withFlag("false", () => {
+      const { container } = render(<GoogleSSOButton onClick={() => {}} />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("when showWhenDisabled is true and disabled, marks the button aria-disabled and exposes the reason via aria-describedby", () => {
+    withFlag(undefined, () => {
+      render(
+        <GoogleSSOButton
+          onClick={() => {}}
+          showWhenDisabled
+          disabledReason="Google sign-in is not configured"
+        />,
+      );
+      const button = screen.getByRole("button", { name: /Sign in with Google/i });
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+      const describedBy = button.getAttribute("aria-describedby");
+      expect(describedBy).not.toBeNull();
+      const helper = document.getElementById(describedBy!);
+      expect(helper?.textContent).toBe("Google sign-in is not configured");
+    });
+  });
+
+  it("carries the locked `gsi-button` surface class so theme overrides hit it", () => {
+    withFlag("true", () => {
+      render(<GoogleSSOButton onClick={() => {}} />);
+      const button = screen.getByRole("button", { name: /Sign in with Google/i });
+      // The light/dark surface colors are driven by globals.css selectors
+      // scoped to `.gsi-button` and `[data-theme="light"] .gsi-button` so
+      // we can't recolor the brand surface and it tracks the host theme
+      // toggle without depending on Tailwind dark-mode plumbing.
+      expect(button.className).toMatch(/\bgsi-button\b/);
+    });
+  });
+
+  it("when loading, disables the button and sets aria-busy", () => {
+    withFlag("true", () => {
+      render(<GoogleSSOButton onClick={() => {}} loading />);
+      const button = screen.getByRole("button", { name: /Sign in with Google/i });
+      expect(button.getAttribute("aria-busy")).toBe("true");
+      expect((button as HTMLButtonElement).disabled).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Scope summary

Provider-compliant Google branded button on `/login` and `/register`. No auth-logic changes; the L1.7 SSO initiate + callback flow stays untouched.

## Contract changes

- New `<GoogleSSOButton />` component at `frontend/components/auth/GoogleSSOButton.tsx`.
- Public frontend flag `NEXT_PUBLIC_GOOGLE_SSO_ENABLED` drives visibility. Anything other than the literal string `"true"` hides the button and its "or" divider so unconfigured environments never present a broken-redirect entry point.
- Brand surface colors for the button live in `frontend/app/globals.css` under `.gsi-button` (dark default) and `[data-theme="light"] .gsi-button` (light flip). Google's spec does not allow product theme tokens to recolor the surface.

## Security notes

- No auth logic changed. `backend/app/routers/auth.py` was read-only.
- Button hides when SSO is not configured (avoids a broken-redirect UX).
- ARIA: `aria-label="Sign in with Google"` (or "Sign up with Google" on `/register`), `aria-busy="true"` while the initiate request is in flight, `aria-disabled` + `aria-describedby` when forced visible in an unconfigured state.
- Focus state: `focus-visible:ring-2 ring-accent/40 ring-offset-2 ring-offset-bg` so the ring is visible on both light and dark surfaces.

## Google branding compliance checklist

- [x] Official 4-color G mark used (inline SVG, no recolor, no monochrome substitution).
- [x] Locked wordmark: "Sign in with Google" (signin mode) / "Sign up with Google" (signup mode on `/register`).
- [x] Color + contrast per spec for both light and dark themes (light: `#ffffff` surface, `#dadce0` border, `#1f1f1f` text; dark: `#131314` surface, `#e3e3e3` text).
- [x] Minimum size: `min-h-[44px]` (40px Google minimum + 4px headroom for touch).
- [x] Focus, hover, active states match Google's spec (hover `#f8f9fa` / `#1e1f20`; active `#f1f3f4` / `#2a2b2d`).

## Ops checklist (owner to action; out of scope for this PR)

- [ ] Create Google Cloud OAuth 2.0 Client (Workspace admin → OAuth consent screen + Credentials).
- [ ] `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` set in DO App Platform secrets.
- [ ] Authorized redirect URI: `https://app.thebetterdecision.com/api/v1/auth/google/callback`.
- [ ] `NEXT_PUBLIC_GOOGLE_SSO_ENABLED=true` set in App Platform env (or whichever environments should expose the button).
- [ ] Submit the OAuth app for Google's branding review. The branded button this PR ships is a prerequisite for moving out of "Testing" mode.

## Test evidence

- `npx tsc --noEmit`: clean.
- `npm run lint`: 0 errors (86 pre-existing warnings, no new ones).
- `npm test`: 578/578 passed, including 9 new `GoogleSSOButton` tests covering the multi-color G mark, both wordmarks, click wiring, env-flag hide, `aria-disabled` + `aria-describedby` when forced visible, the locked surface class, and the `aria-busy` loading state.

## Screenshots

Desktop, light theme:

![login-desktop-light](https://github.com/flamarion/pfv/releases/download/pr-229-l5-9-google-sso-screenshots/login-desktop-light.png)

Desktop, dark theme:

![login-desktop-dark](https://github.com/flamarion/pfv/releases/download/pr-229-l5-9-google-sso-screenshots/login-desktop-dark.png)

Mobile 375x812, light theme:

![login-mobile-light](https://github.com/flamarion/pfv/releases/download/pr-229-l5-9-google-sso-screenshots/login-mobile-light.png)

Mobile 375x812, dark theme:

![login-mobile-dark](https://github.com/flamarion/pfv/releases/download/pr-229-l5-9-google-sso-screenshots/login-mobile-dark.png)

Register, light theme:

![register-desktop-light](https://github.com/flamarion/pfv/releases/download/pr-229-l5-9-google-sso-screenshots/register-desktop-light.png)

Register, dark theme:

![register-desktop-dark](https://github.com/flamarion/pfv/releases/download/pr-229-l5-9-google-sso-screenshots/register-desktop-dark.png)

Disabled / hidden state (flag unset, dev server restarted with `NEXT_PUBLIC_GOOGLE_SSO_ENABLED=false`):

![login-disabled-state](https://github.com/flamarion/pfv/releases/download/pr-229-l5-9-google-sso-screenshots/login-disabled-state.png)

## /impeccable critique (inline summary)

1. Wordmark policy: Google's brand guide sanctions both "Sign in with Google" and "Sign up with Google". The component supports both via a `mode` prop, defaulted to `signin`; `/register` passes `mode="signup"`.
2. Placement: below the primary submit, separated by an "or" divider. Both the divider and the button are gated by the same env flag, so an unconfigured environment shows neither.
3. Focus state: `focus-visible:ring-2 ring-accent/40 ring-offset-2 ring-offset-bg`, so the ring stays visible on both the white light surface and the near-black dark surface.
4. Loading state: while the SSO initiate request is in flight, the button is `disabled` + `aria-busy="true"` and the label changes to "Connecting...". The local `googleLoading` state is reset on failure so the user can retry.
5. Disabled state: when the env flag is missing, the button renders `null` by default. Callers that want to surface a configuration problem can pass `showWhenDisabled` + `disabledReason`; the disabled affordance carries `aria-disabled="true"` and an `aria-describedby` helper paragraph.
6. Sizing: `min-h-[44px]`, exceeding the Apple HIG and Google IDX minimums for touch targets.
7. Color compliance: the locked palette lives in `globals.css` under `.gsi-button`, keeping product theme tokens (brass, parchment, etc.) from accidentally recoloring the Google brand surface.
