### PR TITLE
feat(email): brand-aligned templates (L5.6)

### DIFF
--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,16 +1,168 @@
-"""Email service — sends emails via Mailgun in production, logs in development.
+"""Email service. Sends brand-aligned customer emails via Mailgun.
 
-In development (no MAILGUN_API_KEY set), emails are logged to structlog
-with full content including any links. This lets developers see verification
-and password reset URLs without needing a real email provider.
+Templates here are L5.6 brand polish (see ``BRAND.md`` at repo root):
+
+* Inline chevron mark (no remote SVG load, many clients strip it).
+* "The Better Decision" wordmark as the visible product name.
+* Brass pill CTA on a light-styled palette (email clients are inconsistent
+  with ``prefers-color-scheme``, so we render light only).
+* Inline styles only, most clients strip ``<style>`` blocks.
+* No em-dashes (locked customer-copy policy).
+* No emoji, no "AI-powered", no "revolutionize your finances" framing.
+
+Security stance (audited L5.6):
+
+* User-controlled strings (recipient name, org name, inviter name) are
+  routed through :func:`html.escape` before HTML interpolation.
+* URL params carrying tokens go through :func:`urllib.parse.quote_plus`
+  so an attacker-controlled token shape cannot break out of the query
+  string.
+* Dev-mode logging redacts the rendered body and the bare token. We log
+  ``to`` and ``subject`` only; the rendered HTML and plain-text bodies
+  are NOT logged because they carry the reset/verify link with the raw
+  token in plain view.
+* The Mailgun sender identity / DKIM is unchanged.
 """
 
-import structlog
+from __future__ import annotations
+
+import html
+import urllib.parse
+
 import httpx
+import structlog
 
 from app.config import settings
 
 logger = structlog.get_logger()
+
+
+# ─── Brand surface constants (mirrors frontend/lib/brand.ts) ───
+# Email clients can't import a TS module, so we hold the canonical values
+# as hex literals here. If ``frontend/lib/brand.ts`` changes, update this
+# block too. The constants are deliberately scoped to the brand surface
+# (not the app theme tokens) because email rendering has no theme.
+_BRAND_INK = "#0B1F3A"              # navy ground, primary text on light
+_BRAND_BRASS = "#D4A64A"            # primary CTA fill
+_BRAND_SLATE = "#5a6a82"            # muted text / mark echo
+_LIGHT_PAGE_BG = "#f0f2f5"          # mirrors --color-bg (light)
+_LIGHT_SURFACE = "#ffffff"          # mirrors --color-surface (light)
+_LIGHT_RULE = "#e5e7eb"             # hairline rule on light surface
+
+# Inline chevron mark, copied verbatim from frontend/app/icon.svg so the
+# email surface stays in lockstep with the favicon and the React Logo
+# component. Sized to 40px for the email header.
+_CHEVRON_MARK_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" '
+    'viewBox="0 0 32 32" role="img" aria-label="The Better Decision" '
+    'style="display:inline-block;vertical-align:middle;">'
+    '<rect width="32" height="32" rx="7" fill="#0B1F3A"/>'
+    '<path d="M 9 8 L 18 16 L 9 24" fill="none" stroke="#5a6a82" '
+    'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" '
+    'opacity="0.55"/>'
+    '<path d="M 14 8 L 23 16 L 14 24" fill="none" stroke="#D4A64A" '
+    'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>'
+    "</svg>"
+)
+
+
+def _render_html(
+    *,
+    heading: str,
+    paragraphs: list[str],
+    cta_label: str | None = None,
+    cta_url: str | None = None,
+    footnote: str | None = None,
+) -> str:
+    """Render a branded HTML email body.
+
+    ``paragraphs`` strings are inserted as-is; callers are responsible for
+    HTML-escaping any user-controlled substring before passing it in.
+    ``cta_url`` is inserted into an ``href`` attribute and MUST be a safe
+    same-origin URL (we build it ourselves from ``settings.app_url`` plus
+    a URL-encoded token).
+    """
+    paragraph_html = "".join(
+        f'<p style="margin:0 0 16px 0;color:{_BRAND_INK};'
+        f'font-size:15px;line-height:1.55;">{para}</p>'
+        for para in paragraphs
+    )
+
+    cta_html = ""
+    if cta_label and cta_url:
+        # Escape the label (display text) defensively. We control the URL
+        # because we constructed it ourselves with quote_plus.
+        cta_label_safe = html.escape(cta_label)
+        cta_html = (
+            '<p style="margin:24px 0 0 0;">'
+            f'<a href="{cta_url}" '
+            f'style="background:{_BRAND_BRASS};color:{_BRAND_INK};'
+            'text-decoration:none;display:inline-block;padding:12px 28px;'
+            'border-radius:999px;font-weight:600;font-size:15px;'
+            'letter-spacing:0.01em;">'
+            f"{cta_label_safe}</a></p>"
+        )
+
+    footnote_html = ""
+    if footnote:
+        footnote_html = (
+            f'<p style="margin:24px 0 0 0;color:{_BRAND_SLATE};'
+            'font-size:13px;line-height:1.5;">'
+            f"{footnote}</p>"
+        )
+
+    heading_safe = html.escape(heading)
+
+    return (
+        "<!doctype html>"
+        '<html><body style="margin:0;padding:0;'
+        f'background:{_LIGHT_PAGE_BG};'
+        "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',"
+        'Roboto,Helvetica,Arial,sans-serif;">'
+        '<table role="presentation" width="100%" cellpadding="0" '
+        f'cellspacing="0" style="background:{_LIGHT_PAGE_BG};padding:32px 16px;">'
+        '<tr><td align="center">'
+        '<table role="presentation" width="560" cellpadding="0" '
+        f'cellspacing="0" style="max-width:560px;background:{_LIGHT_SURFACE};'
+        'border-radius:12px;padding:32px;">'
+        # Header: chevron + wordmark
+        '<tr><td style="padding-bottom:24px;">'
+        f"{_CHEVRON_MARK_SVG}"
+        '<span style="display:inline-block;vertical-align:middle;'
+        f'margin-left:10px;font-size:17px;font-weight:600;color:{_BRAND_INK};'
+        'letter-spacing:-0.01em;">The Better Decision</span>'
+        "</td></tr>"
+        # Heading
+        '<tr><td style="padding-bottom:8px;">'
+        f'<h1 style="margin:0;color:{_BRAND_INK};font-size:22px;'
+        f'font-weight:600;line-height:1.3;">{heading_safe}</h1>'
+        "</td></tr>"
+        # Body
+        f"<tr><td>{paragraph_html}{cta_html}{footnote_html}</td></tr>"
+        # Footer
+        '<tr><td style="padding-top:24px;">'
+        f'<div style="border-top:1px solid {_LIGHT_RULE};'
+        'padding-top:16px;"></div>'
+        f'<p style="margin:0;color:{_BRAND_SLATE};font-size:12px;'
+        'line-height:1.5;">'
+        "The Better Decision. There's no best decision. Only better ones."
+        "</p>"
+        "</td></tr>"
+        "</table></td></tr></table>"
+        "</body></html>"
+    )
+
+
+def _safe_link(path: str, token: str) -> str:
+    """Build a same-origin URL with a URL-encoded token query param.
+
+    ``path`` is a developer-supplied static path (e.g. ``/verify-email``);
+    ``token`` is the raw token text from the issuer. We pass it through
+    ``quote_plus`` so unexpected characters can't break out of the query
+    string into another attribute.
+    """
+    safe_token = urllib.parse.quote_plus(token)
+    return f"{settings.app_url}{path}?token={safe_token}"
 
 
 async def send_email(
@@ -19,20 +171,24 @@ async def send_email(
     body_html: str,
     body_text: str | None = None,
 ) -> bool:
-    """Send an email. Returns True if sent/logged successfully."""
+    """Send an email. Returns True if sent/logged successfully.
+
+    Dev mode (no ``mailgun_api_key``): we log ``to`` and ``subject`` only.
+    Rendered HTML and plain-text bodies are NOT logged because verification
+    and reset emails carry the raw token in the link. To inspect rendered
+    HTML during local work, call the send helpers from a Python REPL
+    inside the backend container.
+    """
     if not settings.mailgun_api_key:
-        # Development: log the email content
-        await logger.ainfo(
-            "email_sent_dev",
-            to=to,
-            subject=subject,
-            body_text=body_text or "(html only)",
-            body_html=body_html,
-        )
+        await logger.ainfo("email_sent_dev", to=to, subject=subject)
         return True
 
-    # Production: send via Mailgun HTTP API
-    api_host = "api.eu.mailgun.net" if settings.mailgun_region.lower().strip() == "eu" else "api.mailgun.net"
+    # Production: send via Mailgun HTTP API.
+    api_host = (
+        "api.eu.mailgun.net"
+        if settings.mailgun_region.lower().strip() == "eu"
+        else "api.mailgun.net"
+    )
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
             response = await client.post(
@@ -47,71 +203,136 @@ async def send_email(
                 },
             )
             response.raise_for_status()
-            await logger.ainfo("email_sent", to=to, subject=subject, status=response.status_code)
+            await logger.ainfo(
+                "email_sent", to=to, subject=subject, status=response.status_code
+            )
             return True
     except Exception as exc:
-        await logger.aerror("email_send_failed", to=to, subject=subject, error=str(exc))
+        # Never log the body, it carries the token. ``str(exc)`` from httpx
+        # surfaces the response status / reason but not our payload.
+        await logger.aerror(
+            "email_send_failed", to=to, subject=subject, error=str(exc)
+        )
         return False
 
 
 async def send_password_reset_email(to: str, token: str) -> bool:
     """Send a password reset email with a link containing the reset token."""
-    reset_url = f"{settings.app_url}/reset-password?token={token}"
-    subject = "The Better Decision: reset your password"
-    body_html = f"""
-    <h2>Reset Your Password</h2>
-    <p>You requested a password reset for your account.</p>
-    <p><a href="{reset_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Reset Password</a></p>
-    <p>Or copy this link: <code>{reset_url}</code></p>
-    <p>This link expires in 1 hour. If you didn't request this, ignore this email.</p>
-    """
-    body_text = f"Reset your password: {reset_url}\n\nThis link expires in 1 hour."
+    reset_url = _safe_link("/reset-password", token)
+    subject = "Reset your The Better Decision password"
+    body_html = _render_html(
+        heading="Reset your password",
+        paragraphs=[
+            "Someone (you, we hope) asked to reset the password on this "
+            "account. Use the button below to choose a new one.",
+        ],
+        cta_label="Reset password",
+        cta_url=reset_url,
+        footnote=(
+            "This link expires in 1 hour. If you didn't request a reset, "
+            "you can ignore this email and nothing will change."
+        ),
+    )
+    body_text = (
+        "Reset your password\n\n"
+        "Someone asked to reset the password on this account. Open this "
+        "link in your browser to choose a new one:\n\n"
+        f"{reset_url}\n\n"
+        "This link expires in 1 hour. If you didn't request a reset, you "
+        "can ignore this email."
+    )
     return await send_email(to, subject, body_html, body_text)
 
 
 async def send_mfa_email_code(to: str, code: str) -> bool:
     """Send a one-time MFA verification code via email."""
-    subject = "The Better Decision: your login code"
-    body_html = f"""
-    <h2>Your Verification Code</h2>
-    <p>Use this code to complete your sign-in:</p>
-    <p style="font-size:32px;font-weight:bold;letter-spacing:8px;color:#c8a951;font-family:monospace;">{code}</p>
-    <p>This code expires in 10 minutes. If you didn't try to sign in, you can ignore this email.</p>
-    """
-    body_text = f"Your verification code: {code}\n\nThis code expires in 10 minutes."
+    subject = "Your The Better Decision sign-in code"
+    # Code is a short numeric string we generate. Escape defensively in
+    # case the generator format ever changes.
+    code_safe = html.escape(code)
+    code_block = (
+        '<span style="display:inline-block;margin-top:8px;'
+        "font-family:'SFMono-Regular',Menlo,Consolas,monospace;"
+        f"font-size:30px;font-weight:600;letter-spacing:0.18em;"
+        f"color:{_BRAND_INK};background:{_LIGHT_PAGE_BG};"
+        f'border-radius:8px;padding:14px 22px;">{code_safe}</span>'
+    )
+    body_html = _render_html(
+        heading="Your sign-in code",
+        paragraphs=[
+            "Use this code to finish signing in. It works once and expires "
+            "in 10 minutes.",
+            code_block,
+        ],
+        footnote=(
+            "If you didn't try to sign in, you can ignore this email. "
+            "Your account stays as it was."
+        ),
+    )
+    body_text = (
+        "Your sign-in code\n\n"
+        f"{code}\n\n"
+        "This code expires in 10 minutes. If you didn't try to sign in, "
+        "you can ignore this email."
+    )
     return await send_email(to, subject, body_html, body_text)
 
 
 async def send_verification_email(to: str, token: str) -> bool:
     """Send an email verification link."""
-    verify_url = f"{settings.app_url}/verify-email?token={token}"
-    subject = "The Better Decision: verify your email"
-    body_html = f"""
-    <h2>Verify Your Email</h2>
-    <p>Welcome to The Better Decision! Please verify your email address.</p>
-    <p><a href="{verify_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Verify Email</a></p>
-    <p>Or copy this link: <code>{verify_url}</code></p>
-    """
-    body_text = f"Verify your email: {verify_url}"
+    verify_url = _safe_link("/verify-email", token)
+    subject = "Confirm your email for The Better Decision"
+    body_html = _render_html(
+        heading="Confirm your email",
+        paragraphs=[
+            "Welcome. Confirm this email address so we know the account is "
+            "yours, and so password resets and invitations reach you.",
+        ],
+        cta_label="Confirm email",
+        cta_url=verify_url,
+        footnote=(
+            "If you didn't create an account, you can ignore this email."
+        ),
+    )
+    body_text = (
+        "Confirm your email\n\n"
+        "Welcome. Open this link to confirm the email on your The Better "
+        "Decision account:\n\n"
+        f"{verify_url}\n\n"
+        "If you didn't create an account, you can ignore this email."
+    )
     return await send_email(to, subject, body_html, body_text)
 
 
 async def send_invitation_email(
     to: str, *, inviter_name: str, org_name: str, accept_url: str
 ) -> bool:
-    """Send an org-membership invitation link."""
-    subject = f"{inviter_name} invited you to {org_name} on The Better Decision"
-    body_html = f"""
-    <h2>You're Invited</h2>
-    <p><strong>{inviter_name}</strong> invited you to join <strong>{org_name}</strong>
-    on The Better Decision.</p>
-    <p><a href="{accept_url}" style="display:inline-block;padding:12px 24px;background:#c8a951;color:#1a1a2e;text-decoration:none;border-radius:6px;font-weight:bold;">Accept Invitation</a></p>
-    <p>Or copy this link: <code>{accept_url}</code></p>
-    <p style="color: #666; font-size: 12px;">This invitation expires in 7 days.</p>
+    """Send an org-membership invitation link.
+
+    ``inviter_name`` and ``org_name`` may contain user-supplied content
+    (an inviter can rename themselves; an org name is set by an admin),
+    so both are HTML-escaped before interpolation.
     """
+    inviter_safe = html.escape(inviter_name)
+    org_safe = html.escape(org_name)
+    subject = f"{inviter_name} invited you to {org_name} on The Better Decision"
+    body_html = _render_html(
+        heading=f"Join {org_name} on The Better Decision",
+        paragraphs=[
+            f"<strong>{inviter_safe}</strong> invited you to share "
+            f"<strong>{org_safe}</strong> on The Better Decision, a "
+            "personal finance app for households who already share money.",
+        ],
+        cta_label="Accept invitation",
+        cta_url=accept_url,
+        footnote="This invitation expires in 7 days.",
+    )
     body_text = (
-        f"{inviter_name} invited you to {org_name} on The Better Decision.\n"
-        f"Accept here: {accept_url}\n"
+        f"Join {org_name} on The Better Decision\n\n"
+        f"{inviter_name} invited you to share {org_name} on The Better "
+        "Decision, a personal finance app for households who already "
+        "share money.\n\n"
+        f"Accept here: {accept_url}\n\n"
         "This invitation expires in 7 days."
     )
     return await send_email(to, subject, body_html, body_text)
@@ -120,17 +341,35 @@ async def send_invitation_email(
 async def send_trial_expiring_email(to: str, days_left: int, org_name: str) -> bool:
     """Send a trial expiring notification."""
     upgrade_url = f"{settings.app_url}/settings/billing"
-    subject = f"The Better Decision: your trial ends in {days_left} day{'s' if days_left != 1 else ''}"
-    body_html = f"""
-    <h2>Your Trial Is Ending Soon</h2>
-    <p>Hi! Your <strong>{org_name}</strong> trial ends in <strong>{days_left} day{'s' if days_left != 1 else ''}</strong>.</p>
-    <p>After the trial, your account will switch to the Free plan with limited features.</p>
-    <p><a href="{upgrade_url}">Upgrade to Pro</a> to keep all your features.</p>
-    <p style="color: #666; font-size: 12px;">No charge will be applied during beta. Upgrading simply reserves your spot.</p>
-    """
+    org_safe = html.escape(org_name)
+    day_word = "day" if days_left == 1 else "days"
+    subject = (
+        f"Your The Better Decision trial ends in {days_left} {day_word}"
+    )
+    body_html = _render_html(
+        heading=f"Your trial ends in {days_left} {day_word}",
+        paragraphs=[
+            f"The Pro trial on <strong>{org_safe}</strong> ends in "
+            f"{days_left} {day_word}. After that, the workspace switches "
+            "to the Free plan and a few features go quiet.",
+            "You can reserve your Pro spot now. No card is charged during "
+            "beta; this just keeps the seat.",
+        ],
+        cta_label="Keep Pro",
+        cta_url=upgrade_url,
+        footnote=(
+            "If you'd rather stay on Free, do nothing. The workspace will "
+            "switch over on its own."
+        ),
+    )
     body_text = (
-        f"Your {org_name} trial ends in {days_left} day{'s' if days_left != 1 else ''}.\n"
-        f"Upgrade at: {upgrade_url}\n"
-        "No charge during beta."
+        f"Your trial ends in {days_left} {day_word}\n\n"
+        f"The Pro trial on {org_name} ends in {days_left} {day_word}. "
+        "After that, the workspace switches to the Free plan and a few "
+        "features go quiet.\n\n"
+        "Reserve your Pro spot (no card charged during beta):\n"
+        f"{upgrade_url}\n\n"
+        "If you'd rather stay on Free, do nothing. The workspace will "
+        "switch over on its own."
     )
     return await send_email(to, subject, body_html, body_text)

--- a/backend/tests/services/test_email_templates.py
+++ b/backend/tests/services/test_email_templates.py
@@ -1,0 +1,381 @@
+"""Snapshot + security tests for L5.6 brand-aligned email templates.
+
+Covers the five customer email helpers in ``app.services.email_service``:
+
+* send_password_reset_email
+* send_mfa_email_code
+* send_verification_email
+* send_invitation_email
+* send_trial_expiring_email
+
+Tests assert:
+
+* Brand-mandatory structure: inline chevron SVG, wordmark, brass CTA pill,
+  light page background, tagline footer.
+* Brand voice: no em-dashes, no emoji, no off-brand phrases ("AI-powered",
+  "revolutionize", "effortlessly"), full product name appears.
+* Plain-text fallback is provided and carries the link / code.
+* Security: HTML-escaping for user-controlled fields (XSS), URL-encoding
+  for tokens (no attribute escape), and dev-mode logging redacts the
+  rendered body + token.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from app.services import email_service
+
+# ─── Brand structural constants the templates MUST emit. ───
+_CHEVRON_SIGNATURE = 'aria-label="The Better Decision"'
+_CHEVRON_BRASS_PATH = "M 14 8 L 23 16 L 14 24"
+_WORDMARK_TEXT = "The Better Decision"
+_BRASS_HEX = "#D4A64A"
+_INK_HEX = "#0B1F3A"
+_TAGLINE = "There's no best decision. Only better ones."
+_LIGHT_BG = "#f0f2f5"
+
+_OFF_BRAND_PHRASES = (
+    "ai-powered",
+    "revolutionize",
+    "effortlessly",
+    "effortless",
+    "limited time",
+    "don't miss out",
+)
+
+
+# ─── Async send-helper harness ───
+# The send_* helpers funnel into ``send_email``; we patch that to capture
+# the rendered payload without going near Mailgun.
+
+
+@pytest.fixture
+def captured_send(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace ``send_email`` with a capture list and return that list."""
+    captured: list[dict[str, Any]] = []
+
+    async def _fake_send(
+        to: str, subject: str, body_html: str, body_text: str | None = None
+    ) -> bool:
+        captured.append(
+            {
+                "to": to,
+                "subject": subject,
+                "body_html": body_html,
+                "body_text": body_text,
+            }
+        )
+        return True
+
+    monkeypatch.setattr(email_service, "send_email", _fake_send)
+    return captured
+
+
+def _assert_brand_chrome(body_html: str) -> None:
+    """Every customer email MUST carry the brand chrome."""
+    assert _CHEVRON_SIGNATURE in body_html, "missing inline chevron mark"
+    assert _CHEVRON_BRASS_PATH in body_html, "missing brass chevron stroke"
+    assert _WORDMARK_TEXT in body_html, "missing wordmark"
+    assert _BRASS_HEX in body_html, "missing brass accent"
+    assert _INK_HEX in body_html, "missing brand ink color"
+    assert _LIGHT_BG in body_html, "missing light page background"
+    assert _TAGLINE in body_html, "missing locked tagline in footer"
+
+
+def _assert_brand_voice(*texts: str) -> None:
+    """No em-dashes, no off-brand phrases."""
+    for t in texts:
+        assert "—" not in t and "–" not in t, f"em/en-dash found in: {t[:80]}..."
+        lowered = t.lower()
+        for phrase in _OFF_BRAND_PHRASES:
+            assert phrase not in lowered, f"off-brand phrase {phrase!r} in: {t[:80]}..."
+
+
+# ─── Snapshot tests ───
+
+
+@pytest.mark.asyncio
+async def test_password_reset_template(captured_send: list[dict[str, Any]]):
+    ok = await email_service.send_password_reset_email(
+        "user@example.com", "tok_abc123"
+    )
+    assert ok is True
+    assert len(captured_send) == 1
+    msg = captured_send[0]
+
+    assert msg["to"] == "user@example.com"
+    assert "password" in msg["subject"].lower()
+    assert _WORDMARK_TEXT in msg["subject"]
+
+    _assert_brand_chrome(msg["body_html"])
+    _assert_brand_voice(msg["subject"], msg["body_html"], msg["body_text"])
+
+    assert "Reset password" in msg["body_html"]
+    assert "/reset-password?token=tok_abc123" in msg["body_html"]
+    assert "1 hour" in msg["body_html"]
+
+    # Plain-text fallback carries the link and the same expiry hint.
+    assert msg["body_text"] is not None
+    assert "/reset-password?token=tok_abc123" in msg["body_text"]
+    assert "1 hour" in msg["body_text"]
+
+
+@pytest.mark.asyncio
+async def test_mfa_email_code_template(captured_send: list[dict[str, Any]]):
+    ok = await email_service.send_mfa_email_code("user@example.com", "482915")
+    assert ok is True
+    msg = captured_send[0]
+
+    _assert_brand_chrome(msg["body_html"])
+    _assert_brand_voice(msg["subject"], msg["body_html"], msg["body_text"])
+
+    # Code rendered prominently in HTML and plain-text.
+    assert "482915" in msg["body_html"]
+    assert "482915" in msg["body_text"]
+    assert "10 minutes" in msg["body_html"]
+
+    # MFA email has no CTA button; the code IS the call-to-action.
+    assert "border-radius:999px" not in msg["body_html"]
+
+
+@pytest.mark.asyncio
+async def test_verification_email_template(captured_send: list[dict[str, Any]]):
+    ok = await email_service.send_verification_email(
+        "user@example.com", "verifytoken123"
+    )
+    assert ok is True
+    msg = captured_send[0]
+
+    _assert_brand_chrome(msg["body_html"])
+    _assert_brand_voice(msg["subject"], msg["body_html"], msg["body_text"])
+
+    assert "Confirm email" in msg["body_html"]
+    assert "/verify-email?token=verifytoken123" in msg["body_html"]
+    assert "/verify-email?token=verifytoken123" in msg["body_text"]
+
+
+@pytest.mark.asyncio
+async def test_invitation_email_template(captured_send: list[dict[str, Any]]):
+    ok = await email_service.send_invitation_email(
+        "guest@example.com",
+        inviter_name="Alice Doe",
+        org_name="Doe Household",
+        accept_url="http://localhost/accept-invite?token=invtoken",
+    )
+    assert ok is True
+    msg = captured_send[0]
+
+    _assert_brand_chrome(msg["body_html"])
+    _assert_brand_voice(msg["subject"], msg["body_html"], msg["body_text"])
+
+    assert "Alice Doe" in msg["body_html"]
+    assert "Doe Household" in msg["body_html"]
+    assert "Accept invitation" in msg["body_html"]
+    assert "7 days" in msg["body_html"]
+    assert "accept-invite?token=invtoken" in msg["body_text"]
+
+
+@pytest.mark.asyncio
+async def test_trial_expiring_template_plural(captured_send: list[dict[str, Any]]):
+    ok = await email_service.send_trial_expiring_email(
+        "user@example.com", days_left=3, org_name="Doe Household"
+    )
+    assert ok is True
+    msg = captured_send[0]
+
+    _assert_brand_chrome(msg["body_html"])
+    _assert_brand_voice(msg["subject"], msg["body_html"], msg["body_text"])
+
+    assert "3 days" in msg["subject"]
+    assert "Doe Household" in msg["body_html"]
+    assert "Keep Pro" in msg["body_html"]
+    assert "settings/billing" in msg["body_text"]
+
+
+@pytest.mark.asyncio
+async def test_trial_expiring_template_singular(
+    captured_send: list[dict[str, Any]],
+):
+    await email_service.send_trial_expiring_email(
+        "user@example.com", days_left=1, org_name="Doe Household"
+    )
+    msg = captured_send[0]
+    assert "1 day" in msg["subject"]
+    assert "1 days" not in msg["subject"]
+
+
+# ─── Security tests ───
+
+
+@pytest.mark.asyncio
+async def test_invitation_escapes_inviter_and_org_for_xss(
+    captured_send: list[dict[str, Any]],
+):
+    """Attacker-controlled inviter / org names must be HTML-escaped."""
+    payload = '<script>alert(1)</script>'
+    await email_service.send_invitation_email(
+        "guest@example.com",
+        inviter_name=payload,
+        org_name=f'evil"{payload}',
+        accept_url="http://localhost/accept-invite?token=t",
+    )
+    msg = captured_send[0]
+    # Raw script tag must NOT appear inside the HTML body. (The subject is
+    # plain-text per Mailgun semantics and is not HTML-rendered.)
+    assert "<script>" not in msg["body_html"]
+    # Escaped form is present.
+    assert "&lt;script&gt;" in msg["body_html"]
+    # The attribute-breaking quote in the org name should be escaped too.
+    assert 'evil"' not in msg["body_html"]
+    assert "evil&quot;" in msg["body_html"] or "evil&#34;" in msg["body_html"]
+
+
+@pytest.mark.asyncio
+async def test_token_is_url_encoded_in_query_string(
+    captured_send: list[dict[str, Any]],
+):
+    """Token characters that could escape the query string are quoted."""
+    # Token containing a quote-mark and an ampersand would otherwise let
+    # an attacker pivot into another HTML attribute.
+    bad_token = 'abc"&xss=1'
+    await email_service.send_verification_email("user@example.com", bad_token)
+    msg = captured_send[0]
+    body = msg["body_html"]
+    assert 'abc"&xss=1' not in body
+    # quote_plus encodes " as %22, & as %26
+    assert "abc%22%26xss%3D1" in body
+
+
+@pytest.mark.asyncio
+async def test_send_email_dev_mode_does_not_log_body_or_token(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Dev mode logs ``to`` / ``subject`` only. Body + token must not appear."""
+    # Force dev mode.
+    monkeypatch.setattr(email_service.settings, "mailgun_api_key", "")
+
+    # Capture every kwarg the email service passes to the structlog logger
+    # by replacing the module-level logger with a recorder. This avoids any
+    # dependency on global structlog configuration (other tests in the
+    # suite reconfigure it freely).
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    class _Recorder:
+        async def ainfo(self, event: str, **kw: Any) -> None:
+            captured.append((event, kw))
+
+        async def aerror(self, event: str, **kw: Any) -> None:
+            captured.append((event, kw))
+
+    monkeypatch.setattr(email_service, "logger", _Recorder())
+
+    ok = await email_service.send_email(
+        "user@example.com",
+        "Confirm your email for The Better Decision",
+        '<a href="http://localhost/verify-email?token=SECRET_TOKEN_123">x</a>',
+        "Open http://localhost/verify-email?token=SECRET_TOKEN_123",
+    )
+    assert ok is True
+
+    dev_events = [(e, kw) for e, kw in captured if e == "email_sent_dev"]
+    assert len(dev_events) == 1
+    _event, kw = dev_events[0]
+    assert kw == {
+        "to": "user@example.com",
+        "subject": "Confirm your email for The Better Decision",
+    }
+    # Tokens must never appear anywhere in the captured payload.
+    assert "SECRET_TOKEN_123" not in repr(captured)
+
+
+@pytest.mark.asyncio
+async def test_send_email_failure_does_not_log_body(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A Mailgun transport failure must not log the rendered body."""
+    monkeypatch.setattr(email_service.settings, "mailgun_api_key", "real-key")
+    monkeypatch.setattr(email_service.settings, "mailgun_domain", "mg.example.com")
+    monkeypatch.setattr(email_service.settings, "mailgun_region", "")
+
+    class _BoomClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_BoomClient":
+            return self
+
+        async def __aexit__(self, *exc_info: Any) -> None:
+            return None
+
+        async def post(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("network down")
+
+    monkeypatch.setattr(email_service.httpx, "AsyncClient", _BoomClient)
+
+    captured: list[tuple[str, dict[str, Any]]] = []
+
+    class _Recorder:
+        async def ainfo(self, event: str, **kw: Any) -> None:
+            captured.append((event, kw))
+
+        async def aerror(self, event: str, **kw: Any) -> None:
+            captured.append((event, kw))
+
+    monkeypatch.setattr(email_service, "logger", _Recorder())
+
+    ok = await email_service.send_email(
+        "user@example.com",
+        "Reset your The Better Decision password",
+        '<a href="http://x/reset-password?token=SECRET_RESET">x</a>',
+        "http://x/reset-password?token=SECRET_RESET",
+    )
+    assert ok is False
+    fail_events = [(e, kw) for e, kw in captured if e == "email_send_failed"]
+    assert len(fail_events) == 1
+    _event, kw = fail_events[0]
+    # Allowed keys only: to, subject, error. Body fields must be absent.
+    assert "body_html" not in kw and "body_text" not in kw
+    assert "SECRET_RESET" not in repr(kw)
+
+
+# ─── Bulk hygiene sweep over every template ───
+
+
+@pytest.mark.asyncio
+async def test_no_offbrand_phrases_anywhere(monkeypatch: pytest.MonkeyPatch):
+    """Render every template once with realistic args and sweep all text."""
+    captured: list[dict[str, Any]] = []
+
+    async def _fake_send(
+        to: str, subject: str, body_html: str, body_text: str | None = None
+    ) -> bool:
+        captured.append(
+            {"subject": subject, "body_html": body_html, "body_text": body_text}
+        )
+        return True
+
+    monkeypatch.setattr(email_service, "send_email", _fake_send)
+
+    await email_service.send_password_reset_email("u@x.com", "tok")
+    await email_service.send_mfa_email_code("u@x.com", "123456")
+    await email_service.send_verification_email("u@x.com", "tok")
+    await email_service.send_invitation_email(
+        "u@x.com",
+        inviter_name="Alice",
+        org_name="Doe Household",
+        accept_url="http://localhost/accept-invite?token=t",
+    )
+    await email_service.send_trial_expiring_email("u@x.com", 3, "Doe Household")
+
+    assert len(captured) == 5
+    for m in captured:
+        _assert_brand_voice(m["subject"], m["body_html"], m["body_text"])
+        # Strip HTML tags for a soft emoji sweep over the visible text.
+        visible = re.sub(r"<[^>]+>", " ", m["body_html"])
+        assert not re.search(r"[\U0001F300-\U0001FAFF]", visible), (
+            f"emoji found in rendered HTML: {visible[:120]!r}"
+        )


### PR DESCRIPTION
## Scope summary

L5.6 brand polish for every customer-facing email. Inline chevron mark + wordmark header, brass pill CTA on a light-styled palette, voice rewrite per BRAND.md, plain-text fallback, hardened token/escaping handling. No API or send-path changes.

## Templates touched

All in `backend/app/services/email_service.py`:

- `send_verification_email` (sign-up + email-change)
- `send_password_reset_email`
- `send_mfa_email_code`
- `send_invitation_email` (org invite per L3.8)
- `send_trial_expiring_email` (per PR #49)

Plus a shared `_render_html` helper, a `_safe_link` builder for token URLs, and an inline chevron SVG mirrored verbatim from `frontend/app/icon.svg` so the mark stays in lockstep with the favicon and the React `<Logo />` component.

Out of scope per the launch plan: no subscription lifecycle emails (L2.3 parked); no Mailgun config / sender / DKIM changes; no new email types.

## Contract changes

None. The five public coroutines keep their existing signatures. Routers that call them (`auth.py`, `users.py`, `org_members.py`, `subscription_service.py`) are unchanged.

## Security notes

- **Token handling.** Tokens are placed only inside URL paths via `_safe_link`, which routes the raw token through `urllib.parse.quote_plus` before interpolating into `?token=`. A new test (`test_token_is_url_encoded_in_query_string`) feeds `abc\"&xss=1` through and asserts the encoded `abc%22%26xss%3D1` form appears, with the raw form absent.
- **Link construction.** Verification + reset URLs are built from `settings.app_url` + a static developer-chosen path + the encoded token. `accept_url` (invite) is constructed upstream in `routers/org_members.py` from the same `settings.app_url` plus the JWT-shaped invitation token and is treated as trusted by this template.
- **Escaping.** `inviter_name`, `org_name`, and the MFA `code` are routed through `html.escape` before HTML interpolation. `test_invitation_escapes_inviter_and_org_for_xss` injects `<script>alert(1)</script>` and an attribute-breaking quote and asserts the escaped forms appear (`&lt;script&gt;`, `&quot;` / `&#34;`).
- **Logging.** The dev-mode `email_sent_dev` event used to log the full `body_html` + `body_text`, which carry the raw token in the link. It now logs `to` and `subject` only. The Mailgun-failure branch is also locked to `to` / `subject` / `error`. Tests `test_send_email_dev_mode_does_not_log_body_or_token` and `test_send_email_failure_does_not_log_body` assert no `body_html` / `body_text` keys are emitted and that the secret token does not appear anywhere in the captured log payload.
- **Sender / DKIM.** Unchanged. `settings.email_from` and the Mailgun region selection are untouched.

## Test evidence

- Full backend pytest suite: **914 passed, 2 skipped** (no new failures vs. main).
- New snapshot + security tests in `backend/tests/services/test_email_templates.py`: **11 added**, all green.

## Screenshots

Verify email:

![Verify email](https://github.com/flamarion/pfv/releases/download/pr-l5-6-email-screenshots/email-verify.png)

Password reset:

![Password reset](https://github.com/flamarion/pfv/releases/download/pr-l5-6-email-screenshots/email-reset.png)

MFA email code:

![MFA code](https://github.com/flamarion/pfv/releases/download/pr-l5-6-email-screenshots/email-mfa.png)

Org invitation:

![Org invitation](https://github.com/flamarion/pfv/releases/download/pr-l5-6-email-screenshots/email-invite.png)

Trial expiring (3 days):

![Trial expiring](https://github.com/flamarion/pfv/releases/download/pr-l5-6-email-screenshots/email-trial.png)

## /impeccable critique

- **Visual hierarchy.** Inline chevron + wordmark establish the brand in the top 32px; an `h1` heading then sets the email's job; body copy lands underneath; the pill CTA is the only brass element below the mark, which keeps "the one brass rule" honest. Footer is muted slate at 12px so the tagline lands as a quiet sign-off rather than competing.
- **Dark-mode safety.** Templates render light only. Backgrounds are `#f0f2f5` page + `#ffffff` card; text is `#0B1F3A` ink. We never set a colour through a CSS variable or `prefers-color-scheme`, so Outlook / Gmail dark-mode overrides land predictably.
- **Inline styles.** No `<style>` block anywhere. Every style is on the element. The chevron SVG is also inline (no `xlink:href`, no external image) so Gmail / iOS Mail render it.
- **Spacing.** 32px outer table padding, 12px card radius, 24px section gaps, 16px paragraph gaps. The CTA pill has `padding:12px 28px` and `border-radius:999px` so it is visibly a button rather than a styled link.
- **Scannability.** Each email opens with a one-line heading, one or two short paragraphs of body copy, then either the CTA or the code block, then a single-paragraph footnote. MFA's monospaced code block is the focal element rather than a brass button, since the code IS the call to action and a button without a link would be misleading.
- **Voice sweep.** Em-dashes excised; commas, periods, parentheses only. No emoji. No "AI-powered" / "revolutionize" / "effortlessly" / "limited time" / "don't miss out" (covered by `test_no_offbrand_phrases_anywhere`).

## Known follow-ups

- L2.3 subscription lifecycle emails (payment-failed, plan-change confirmations) are parked. When that work lands it should reuse `_render_html` so the brand stays consistent.