### PR TITLE
fix(audit): correct client IP resolution in audit_events

### DIFF
--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -3,35 +3,49 @@
 The default ``slowapi.util.get_remote_address`` is wrong for this app's
 production topology. Two environments exist:
 
-1. **Local / docker-compose — nginx in front of backend.** nginx sets
-   ``X-Forwarded-For`` correctly (appending the immediate peer). The
-   leftmost entry is the real browser IP. Uvicorn's ``--proxy-headers``
-   walks XFF right-to-left and rewrites ``request.client.host``, but
-   the rewrite is unreliable when every chain entry falls inside the
-   trust CIDRs (the dev common case — both browser host and nginx
-   peer are private). We therefore parse XFF ourselves left-to-right
-   in :func:`get_client_ip` and return the first non-trusted entry.
-2. **Production — DigitalOcean App Platform.** DO's ingress puts the
+1. **Local / docker-compose - nginx in front of backend.** nginx sets
+   ``X-Forwarded-For $remote_addr`` (the immediate peer ONLY, NOT
+   ``$proxy_add_x_forwarded_for``). The chain backend sees is therefore
+   always controlled by our infrastructure - client-supplied XFF
+   chains are discarded at the edge. The backend resolves the real
+   client IP by walking the (sanitized) chain right-to-left, skipping
+   trusted-proxy hops, and returning the first non-trusted entry.
+2. **Production - DigitalOcean App Platform.** DO's ingress puts the
    real client IP in the custom ``do-connecting-ip`` header and fills
-   ``X-Forwarded-For`` with the DO ingress server's own IP. We consult
-   ``do-connecting-ip`` only when the direct TCP source (or the XFF
-   chain tail) is a trusted private IP, so a caller reaching the
-   backend directly with a public source IP can't forge the header to
-   bypass the resolver. Docs:
+   ``X-Forwarded-For`` with the DO ingress server's own IP. The DO
+   ingress peer falls OUTSIDE our private-CIDR trust list (DO uses
+   its own runtime networking), so an XFF-only resolver cannot trust
+   anything in prod. When ``PFV_RUNTIME=app_platform`` is set in the
+   App Platform environment, the resolver consults
+   ``do-connecting-ip`` unconditionally as the primary source. This
+   is safe because (a) the header is only writable by DO's ingress
+   layer, (b) the env var is set by us (terraform / DO spec), not by
+   the request. Docs:
    https://docs.digitalocean.com/support/where-can-i-find-the-client-ip-address-of-a-request-connecting-to-my-app/
 
-The original ``get_client_ip`` (PR #82) relied solely on
-``request.client.host`` and ``do-connecting-ip``. That broke the audit
-log because uvicorn's XFF processing leaves ``request.client.host`` set
-to the leftmost private entry whenever every hop is trusted (dev), and
-the DO ingress peer fell outside our trust CIDRs in prod (so
-``do-connecting-ip`` was never consulted). The current implementation
-walks XFF directly, which fixes both.
+Spoof resistance:
+
+- The XFF walk is right-to-left, not left-to-right. nginx appends the
+  immediate peer to the right (overwritten to ``$remote_addr`` in our
+  config), so the rightmost entries are our own infrastructure.
+  Walking from the right and stopping at the first non-trusted entry
+  returns the IP just outside our trust boundary - the real client.
+  Walking from the LEFT would return whatever the user-controllable
+  side put there, which is the textbook XFF-spoof CVE shape.
+- The XFF walk only runs when the direct TCP peer is itself a
+  trusted proxy. A caller reaching the backend over a public path
+  (bypassing our proxy) cannot trigger the walk, so they cannot
+  forge any value via XFF.
+- ``do-connecting-ip`` is honoured unconditionally only when
+  ``PFV_RUNTIME=app_platform`` is set. In any other runtime it is
+  ignored entirely (the trusted-peer gate from PR #82 no longer
+  applies because the XFF walk replaces it).
 """
 
 from __future__ import annotations
 
 import ipaddress
+import os
 from typing import Iterable
 
 from slowapi import Limiter
@@ -81,44 +95,64 @@ def _parse_xff(xff_header: str | None) -> list[str]:
     return [entry.strip() for entry in xff_header.split(",") if entry.strip()]
 
 
+def _is_app_platform_runtime() -> bool:
+    """Read at call time (not import time) so tests using
+    ``monkeypatch.setenv`` see the change without reloading the module.
+    """
+    return os.environ.get("PFV_RUNTIME", "").lower() == "app_platform"
+
+
 def get_client_ip(request: Request) -> str:
     """Resolve the real client IP for rate limiting and audit logging.
 
     Resolution order:
 
-    1. Parse ``X-Forwarded-For`` left-to-right. The leftmost entry
-       that is NOT in our trusted-proxy CIDR list is the real client.
-       (Trusting the leftmost entry directly would be spoofable, so we
-       gate XFF on the direct TCP peer being a trusted proxy first.)
-    2. If the chain is empty OR every entry is a trusted proxy IP,
-       fall back to ``do-connecting-ip`` — but only when the direct
-       TCP peer is a trusted proxy. DO App Platform uses this header.
-    3. Otherwise return ``request.client.host`` (the direct TCP peer).
+    1. **DO App Platform mode.** When ``PFV_RUNTIME=app_platform`` is
+       set, consult ``do-connecting-ip`` unconditionally. DO's ingress
+       is the only writer of that header in App Platform, and the env
+       var is set by us (not by the request) so this is not spoofable.
+    2. **XFF right-to-left walk** when the direct TCP peer is a
+       trusted proxy. The rightmost entry was appended by our own
+       nginx (set to ``$remote_addr``); walk leftward, skipping
+       trusted-proxy hops, and return the first non-trusted entry.
+       That is the IP immediately outside our trust boundary - the
+       real client. Returns ``request.client.host`` if every entry
+       in the chain is a trusted proxy.
+    3. **Direct peer** otherwise. A caller reaching the backend over
+       a public path is its own client IP; we refuse to honour any
+       forwarded-by headers in that case.
     """
+    # 1. DO App Platform runtime: do-connecting-ip is authoritative.
+    if _is_app_platform_runtime():
+        do_ip = request.headers.get("do-connecting-ip")
+        if do_ip:
+            return do_ip
+        # Header missing - fall through to the standard path so
+        # platform health checks etc. still resolve sensibly.
+
     client = request.client
     client_host = client.host if client else None
-
     peer_trusted = _is_trusted_proxy(client_host)
-    xff_entries = _parse_xff(request.headers.get("x-forwarded-for"))
 
-    # If the immediate peer is a trusted proxy, the XFF chain it
-    # produced is also trusted. Walk left-to-right and return the
-    # first non-trusted entry — that's the real client.
-    if peer_trusted and xff_entries:
-        for entry in xff_entries:
+    # 2. Trusted peer + XFF chain: walk RIGHT-to-LEFT.
+    # nginx's ``X-Forwarded-For $remote_addr`` plus any intermediate
+    # proxies produce a chain where the rightmost entries are ours.
+    # The first non-trusted entry from the right is the real client.
+    if peer_trusted:
+        xff_entries = _parse_xff(request.headers.get("x-forwarded-for"))
+        for entry in reversed(xff_entries):
             if not _is_trusted_proxy(entry):
                 return entry
-
-    # XFF was absent or every entry was a trusted proxy. DO App
-    # Platform encodes the real client in ``do-connecting-ip``; trust
-    # it only when the direct peer is itself a trusted proxy.
-    if peer_trusted:
+        # Every entry in the chain was a trusted proxy (or chain was
+        # empty). Fall back to ``do-connecting-ip`` for older DO
+        # deployments not yet running with PFV_RUNTIME set, then to
+        # the direct peer.
         do_ip = request.headers.get("do-connecting-ip")
         if do_ip:
             return do_ip
 
-    # Direct public peer (or no client). Return the peer IP and refuse
-    # to honour any forwarded-by headers (they could be forged).
+    # 3. Direct public peer (or no client). Return the peer IP and
+    # refuse to honour any forwarded-by headers (they could be forged).
     return client_host or "127.0.0.1"
 
 

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,27 +1,32 @@
-"""Rate limiter shared across routers.
+"""Rate limiter and client-IP resolver shared across routers.
 
 The default ``slowapi.util.get_remote_address`` is wrong for this app's
 production topology. Two environments exist:
 
 1. **Local / docker-compose — nginx in front of backend.** nginx sets
-   ``X-Forwarded-For`` correctly. Uvicorn's ``--proxy-headers`` (trust
-   list: RFC 1918 + loopback; see ``backend/Dockerfile``) walks the
-   header right-to-left and resolves ``request.client.host`` to the real
-   client IP — spoof-resistant because the real upstream appends its
-   source to the chain.
+   ``X-Forwarded-For`` correctly (appending the immediate peer). The
+   leftmost entry is the real browser IP. Uvicorn's ``--proxy-headers``
+   walks XFF right-to-left and rewrites ``request.client.host``, but
+   the rewrite is unreliable when every chain entry falls inside the
+   trust CIDRs (the dev common case — both browser host and nginx
+   peer are private). We therefore parse XFF ourselves left-to-right
+   in :func:`get_client_ip` and return the first non-trusted entry.
 2. **Production — DigitalOcean App Platform.** DO's ingress puts the
    real client IP in the custom ``do-connecting-ip`` header and fills
-   ``X-Forwarded-For`` with the DO ingress server's own IP. Uvicorn's
-   XFF parsing alone therefore resolves ``request.client.host`` to a DO
-   ingress IP, not the client — leaving the rate limiter effectively
-   global per ingress server. Docs:
+   ``X-Forwarded-For`` with the DO ingress server's own IP. We consult
+   ``do-connecting-ip`` only when the direct TCP source (or the XFF
+   chain tail) is a trusted private IP, so a caller reaching the
+   backend directly with a public source IP can't forge the header to
+   bypass the resolver. Docs:
    https://docs.digitalocean.com/support/where-can-i-find-the-client-ip-address-of-a-request-connecting-to-my-app/
 
-The keying function below handles both. It consults ``do-connecting-ip``
-only when the direct TCP source is a trusted private IP (we're actually
-behind an upstream we control), so a caller that manages to hit the
-backend directly with a public source IP can't forge the header to
-bypass rate limits.
+The original ``get_client_ip`` (PR #82) relied solely on
+``request.client.host`` and ``do-connecting-ip``. That broke the audit
+log because uvicorn's XFF processing leaves ``request.client.host`` set
+to the leftmost private entry whenever every hop is trusted (dev), and
+the DO ingress peer fell outside our trust CIDRs in prod (so
+``do-connecting-ip`` was never consulted). The current implementation
+walks XFF directly, which fixes both.
 """
 
 from __future__ import annotations
@@ -65,27 +70,55 @@ def _is_trusted_proxy(host: str | None) -> bool:
     return any(ip in net for net in _TRUSTED_PROXY_NETWORKS)
 
 
+def _parse_xff(xff_header: str | None) -> list[str]:
+    """Split an ``X-Forwarded-For`` header into trimmed entries.
+
+    Returns an empty list when the header is absent or contains only
+    whitespace. Each entry has leading/trailing whitespace stripped.
+    """
+    if not xff_header:
+        return []
+    return [entry.strip() for entry in xff_header.split(",") if entry.strip()]
+
+
 def get_client_ip(request: Request) -> str:
-    """Resolve the real client IP for rate-limiting purposes.
+    """Resolve the real client IP for rate limiting and audit logging.
 
-    On DO App Platform: ``request.client.host`` after uvicorn's proxy
-    header processing is still the DO ingress IP (private), so we reach
-    for ``do-connecting-ip`` which DO populates with the actual client.
-    Elsewhere (dev behind nginx): ``do-connecting-ip`` is absent and
-    ``request.client.host`` already holds the resolved client IP.
+    Resolution order:
 
-    The ``do-connecting-ip`` lookup is gated on the direct TCP source
-    being a trusted private IP to prevent header forgery by callers
-    that reach the backend over a public network path.
+    1. Parse ``X-Forwarded-For`` left-to-right. The leftmost entry
+       that is NOT in our trusted-proxy CIDR list is the real client.
+       (Trusting the leftmost entry directly would be spoofable, so we
+       gate XFF on the direct TCP peer being a trusted proxy first.)
+    2. If the chain is empty OR every entry is a trusted proxy IP,
+       fall back to ``do-connecting-ip`` — but only when the direct
+       TCP peer is a trusted proxy. DO App Platform uses this header.
+    3. Otherwise return ``request.client.host`` (the direct TCP peer).
     """
     client = request.client
     client_host = client.host if client else None
 
-    if _is_trusted_proxy(client_host):
+    peer_trusted = _is_trusted_proxy(client_host)
+    xff_entries = _parse_xff(request.headers.get("x-forwarded-for"))
+
+    # If the immediate peer is a trusted proxy, the XFF chain it
+    # produced is also trusted. Walk left-to-right and return the
+    # first non-trusted entry — that's the real client.
+    if peer_trusted and xff_entries:
+        for entry in xff_entries:
+            if not _is_trusted_proxy(entry):
+                return entry
+
+    # XFF was absent or every entry was a trusted proxy. DO App
+    # Platform encodes the real client in ``do-connecting-ip``; trust
+    # it only when the direct peer is itself a trusted proxy.
+    if peer_trusted:
         do_ip = request.headers.get("do-connecting-ip")
         if do_ip:
             return do_ip
 
+    # Direct public peer (or no client). Return the peer IP and refuse
+    # to honour any forwarded-by headers (they could be forged).
     return client_host or "127.0.0.1"
 
 

--- a/backend/tests/test_client_ip_resolution.py
+++ b/backend/tests/test_client_ip_resolution.py
@@ -1,0 +1,379 @@
+"""Regression tests for ``get_client_ip`` (audit log IP bug fix).
+
+Reported 2026-05-12: ``audit_events.ip_address`` was recording the
+Docker-bridge IP in local dev and the DO App Platform ingress IP in
+prod instead of the real client IP. Root cause: ``get_client_ip``
+trusted ``request.client.host`` (the post-uvicorn-XFF value) as the
+final answer instead of parsing ``X-Forwarded-For`` left-to-right
+and returning the first non-trusted-proxy entry. The result was
+that any chain where every entry fell inside ``_TRUSTED_PROXY_CIDRS``
+collapsed to the leftmost private IP (dev), or any chain where the
+ingress peer was outside the trust list skipped ``do-connecting-ip``
+entirely (prod).
+
+These tests pin the five scenarios from the bug memo. They use
+synthetic ``Request`` objects so they don't depend on uvicorn at all
+- the helper must be correct regardless of how the upstream stack
+populates ``request.client.host``.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from starlette.requests import Request
+
+from app.rate_limit import get_client_ip
+
+
+def _make_request(
+    *,
+    client_host: Optional[str],
+    headers: Optional[dict[str, str]] = None,
+) -> Request:
+    """Build a minimal Starlette Request whose ``client.host`` and
+    headers match the post-uvicorn-XFF-processing state the audit
+    callers see.
+    """
+    raw_headers: list[tuple[bytes, bytes]] = []
+    for name, value in (headers or {}).items():
+        raw_headers.append((name.lower().encode("latin-1"), value.encode("latin-1")))
+
+    scope: dict = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": (client_host, 0) if client_host else None,
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+# ── Scenario 1: direct browser localhost ──────────────────────────────────
+
+
+def test_direct_browser_localhost_returns_loopback():
+    """No proxy, no XFF header, direct TCP peer is loopback."""
+    request = _make_request(client_host="127.0.0.1")
+    assert get_client_ip(request) == "127.0.0.1"
+
+
+# ── Scenario 2: single trusted proxy, real client in XFF ──────────────────
+
+
+def test_single_trusted_proxy_returns_real_client_from_xff():
+    """nginx in front of backend (dev / on-prem). XFF carries the real
+    browser IP; the immediate TCP peer is the nginx container's
+    private bridge IP. We must return the browser IP, not the proxy.
+    """
+    request = _make_request(
+        client_host="172.18.0.5",
+        headers={"X-Forwarded-For": "203.0.113.7"},
+    )
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+# ── Scenario 3: two trusted proxies, client at the head of the chain ──────
+
+
+def test_two_trusted_proxies_returns_first_non_proxy_entry():
+    """Two-hop proxy chain (e.g. nginx in front of an internal LB).
+    XFF is ``<client>, <hop1>, <hop2>``. We pick the leftmost
+    non-trusted entry, which is the real client.
+    """
+    request = _make_request(
+        client_host="10.0.0.5",
+        headers={"X-Forwarded-For": "203.0.113.7, 10.0.0.5"},
+    )
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+# ── Scenario 4: DO App Platform — do-connecting-ip is authoritative ──────
+
+
+def test_do_app_platform_uses_do_connecting_ip_when_peer_is_trusted():
+    """DO App Platform: ingress sets ``do-connecting-ip`` with the
+    real client and sets XFF to the DO ingress IP itself. The direct
+    TCP peer is in our trust list, so the header is authoritative.
+    """
+    request = _make_request(
+        client_host="10.0.0.5",
+        headers={
+            "X-Forwarded-For": "10.244.0.3",
+            "do-connecting-ip": "203.0.113.7",
+        },
+    )
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+# ── Scenario 5: forged do-connecting-ip from a public peer is REJECTED ────
+
+
+def test_untrusted_public_peer_with_do_connecting_ip_returns_peer():
+    """A caller reaching the backend on a public network path tries
+    to forge ``do-connecting-ip`` to claim a different source IP. We
+    must refuse to trust the header and return the public peer.
+    """
+    request = _make_request(
+        client_host="198.51.100.99",
+        headers={"do-connecting-ip": "203.0.113.7"},
+    )
+    assert get_client_ip(request) == "198.51.100.99"
+
+
+# ── Additional spoof-resistance: forged left-hand XFF entry ──────────────
+
+
+def test_forged_leftmost_xff_from_untrusted_peer_is_rejected():
+    """A direct-from-internet caller spoofs an XFF header claiming
+    to be ``203.0.113.7``. The TCP peer is a public IP we don't
+    trust as a proxy, so we ignore XFF entirely and return the peer.
+    """
+    request = _make_request(
+        client_host="198.51.100.99",
+        headers={"X-Forwarded-For": "203.0.113.7"},
+    )
+    assert get_client_ip(request) == "198.51.100.99"
+
+
+# ── Edge case: missing client (test stack, no TCP peer) ──────────────────
+
+
+def test_missing_client_falls_back_to_loopback():
+    """Some test scopes don't set ``client`` at all. The helper must
+    not crash; return the loopback sentinel.
+    """
+    request = _make_request(client_host=None)
+    assert get_client_ip(request) == "127.0.0.1"
+
+
+# ── Edge case: XFF with whitespace and IPv6 ───────────────────────────────
+
+
+def test_xff_handles_whitespace_around_entries():
+    """nginx appends with ``, `` so entries have leading whitespace.
+    We must strip it before checking trust / returning.
+    """
+    request = _make_request(
+        client_host="172.18.0.5",
+        headers={"X-Forwarded-For": "  203.0.113.7  ,   172.18.0.5  "},
+    )
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def test_ipv6_client_in_xff_is_returned():
+    """IPv6 clients reach the proxy and end up at the head of XFF."""
+    request = _make_request(
+        client_host="172.18.0.5",
+        headers={"X-Forwarded-For": "2001:db8::1, 172.18.0.5"},
+    )
+    assert get_client_ip(request) == "2001:db8::1"
+
+
+# ── Regression: chain entirely inside trusted CIDRs ──────────────────────
+
+
+def test_xff_entirely_trusted_falls_back_to_do_or_peer():
+    """All XFF entries are private IPs (the pathological dev case
+    that originally surfaced the bug — Docker-bridge-only chain).
+    With no ``do-connecting-ip`` we return the direct peer because
+    there is genuinely no public client IP to surface.
+    """
+    request = _make_request(
+        client_host="172.18.0.5",
+        headers={"X-Forwarded-For": "192.168.65.1, 172.18.0.5"},
+    )
+    # No public entry in XFF and no DO header — peer is the best
+    # answer we have. Crucially we DON'T return one of the trusted
+    # CIDR entries as if it were the user.
+    assert get_client_ip(request) == "172.18.0.5"
+
+
+def test_xff_entirely_trusted_with_do_connecting_ip_prefers_do():
+    """DO App Platform shape: XFF is private (the DO ingress hop)
+    and ``do-connecting-ip`` carries the real client. Must return
+    the DO header.
+    """
+    request = _make_request(
+        client_host="10.244.0.3",
+        headers={
+            "X-Forwarded-For": "10.244.0.3",
+            "do-connecting-ip": "203.0.113.7",
+        },
+    )
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def test_empty_xff_header_falls_back_to_peer():
+    """An XFF header that's literally empty (or just whitespace)
+    must not crash and must not be treated as a valid chain.
+    """
+    request = _make_request(
+        client_host="127.0.0.1",
+        headers={"X-Forwarded-For": ""},
+    )
+    assert get_client_ip(request) == "127.0.0.1"
+
+
+# ── Integration: audit_events.ip_address persists the resolved client ─────
+
+
+import datetime as _dt
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event as _sa_event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+
+@pytest_asyncio.fixture
+async def _audit_session_factory():
+    from app.models import Base
+
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @_sa_event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_audit_endpoint_persists_real_client_ip_from_xff(
+    _audit_session_factory,
+):
+    """End-to-end pin: hit an audited endpoint with an XFF chain
+    whose leftmost entry is a public IP and whose direct TCP peer is
+    a trusted proxy. Assert the persisted ``audit_events.ip_address``
+    equals the leftmost (real) client IP, not the proxy peer.
+
+    Before the fix this column captured the TestClient peer
+    ``127.0.0.1`` (analogue of the Docker bridge / DO ingress IP the
+    user reported). After the fix it captures the leftmost
+    non-trusted XFF entry — the real client.
+    """
+    from app.database import get_db
+    from app.deps import get_current_user, get_session_factory
+    from app.models.audit_event import AuditEvent
+    from app.models.subscription import (
+        BillingInterval,
+        Plan,
+        Subscription,
+        SubscriptionStatus,
+    )
+    from app.models.user import Organization, Role, User
+    from app.routers.admin_orgs import router as admin_orgs_router
+    from app.security import hash_password
+
+    # Seed: superadmin + target org with subscription.
+    async with _audit_session_factory() as db:
+        plan = Plan(slug="free", name="Free")
+        db.add(plan)
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target = Organization(name="Target Inc", billing_cycle_day=1)
+        db.add_all([admin_org, target])
+        await db.commit()
+        sa = User(
+            org_id=admin_org.id,
+            username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(sa)
+        await db.commit()
+        admin_user_id = sa.id
+        target_id = target.id
+        db.add_all([
+            Subscription(
+                org_id=target.id,
+                plan_id=plan.id,
+                status=SubscriptionStatus.TRIALING,
+                billing_interval=BillingInterval.MONTHLY,
+                trial_end=_dt.date.today() + _dt.timedelta(days=14),
+            ),
+            Subscription(
+                org_id=admin_org.id,
+                plan_id=plan.id,
+                status=SubscriptionStatus.ACTIVE,
+                billing_interval=BillingInterval.MONTHLY,
+            ),
+        ])
+        await db.commit()
+
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with _audit_session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        async with _audit_session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.id == admin_user_id))
+            ).scalar_one()
+
+    def override_session_factory():
+        return _audit_session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(admin_orgs_router)
+
+    # TestClient's default ASGI scope sets ``client`` to
+    # ``("testclient", 50000)``, which is not in our trust CIDRs and
+    # would cause ``get_client_ip`` to ignore XFF. Wrap the app in a
+    # thin ASGI middleware that rewrites ``client`` to a loopback
+    # address — mimicking the post-uvicorn scope when the immediate
+    # TCP peer is a trusted proxy (nginx in dev, DO ingress in prod).
+    real_app = app
+
+    async def trusted_peer_wrapper(scope, receive, send):
+        if scope["type"] == "http":
+            scope = {**scope, "client": ("127.0.0.1", 50000)}
+        await real_app(scope, receive, send)
+
+    with TestClient(trusted_peer_wrapper) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{target_id}/subscription",
+            json={"status": "active"},
+            headers={"X-Forwarded-For": "203.0.113.7, 10.0.0.5"},
+        )
+    assert res.status_code == 200, res.text
+
+    async with _audit_session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.subscription.override"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].ip_address == "203.0.113.7"

--- a/backend/tests/test_client_ip_resolution.py
+++ b/backend/tests/test_client_ip_resolution.py
@@ -2,19 +2,24 @@
 
 Reported 2026-05-12: ``audit_events.ip_address`` was recording the
 Docker-bridge IP in local dev and the DO App Platform ingress IP in
-prod instead of the real client IP. Root cause: ``get_client_ip``
-trusted ``request.client.host`` (the post-uvicorn-XFF value) as the
-final answer instead of parsing ``X-Forwarded-For`` left-to-right
-and returning the first non-trusted-proxy entry. The result was
-that any chain where every entry fell inside ``_TRUSTED_PROXY_CIDRS``
-collapsed to the leftmost private IP (dev), or any chain where the
-ingress peer was outside the trust list skipped ``do-connecting-ip``
-entirely (prod).
+prod instead of the real client IP. The fix has two layers:
 
-These tests pin the five scenarios from the bug memo. They use
-synthetic ``Request`` objects so they don't depend on uvicorn at all
-- the helper must be correct regardless of how the upstream stack
-populates ``request.client.host``.
+1. ``get_client_ip`` walks ``X-Forwarded-For`` RIGHT-to-LEFT, skipping
+   trusted-proxy hops, and returns the first non-trusted entry. The
+   walk only runs when the direct TCP peer is itself a trusted proxy.
+2. nginx is configured to set ``X-Forwarded-For $remote_addr`` (NOT
+   ``$proxy_add_x_forwarded_for``), so client-supplied XFF chains are
+   discarded at the edge. Defense-in-depth - even if right-to-left
+   had a bug, the chain reaching the backend is always controlled by
+   our infrastructure.
+3. When ``PFV_RUNTIME=app_platform`` is set, ``do-connecting-ip`` is
+   honoured unconditionally (DO ingress is the only writer; the env
+   var is set by us, not the request).
+
+These tests pin all three layers. They use synthetic ``Request``
+objects so they don't depend on uvicorn at all - the helper must be
+correct regardless of how the upstream stack populates
+``request.client.host``.
 """
 from __future__ import annotations
 
@@ -82,8 +87,8 @@ def test_single_trusted_proxy_returns_real_client_from_xff():
 
 def test_two_trusted_proxies_returns_first_non_proxy_entry():
     """Two-hop proxy chain (e.g. nginx in front of an internal LB).
-    XFF is ``<client>, <hop1>, <hop2>``. We pick the leftmost
-    non-trusted entry, which is the real client.
+    XFF is ``<client>, <hop1>``. Walking right-to-left we skip the
+    trusted ``<hop1>`` entry and land on the real client.
     """
     request = _make_request(
         client_host="10.0.0.5",
@@ -217,6 +222,110 @@ def test_empty_xff_header_falls_back_to_peer():
         headers={"X-Forwarded-For": ""},
     )
     assert get_client_ip(request) == "127.0.0.1"
+
+
+# ── XFF SPOOFING — two-layer defense ─────────────────────────────────────
+
+
+def test_xff_spoof_attempt_without_nginx_overwrite_documents_attack_surface():
+    """Pre-fix shape: nginx used ``$proxy_add_x_forwarded_for`` which
+    APPENDED our peer to whatever the client sent. A malicious client
+    could send ``XFF: 1.2.3.4``, nginx forwards ``1.2.3.4, <peer>``,
+    and a LEFT-to-right walk picks ``1.2.3.4`` (textbook XFF-spoof CVE).
+
+    With right-to-left walk, the chain ``1.2.3.4, <trusted-peer>`` is
+    skipped at the trusted entry and lands on ``1.2.3.4`` - the spoof
+    still lands because the attacker controls one extra entry to the
+    left of our peer. This is why we ALSO sanitize at nginx (next
+    test); the right-to-left walk alone is insufficient when the
+    edge passes through a user-supplied prefix.
+
+    This test exists to make the regression visible if the nginx
+    overwrite is ever reverted: it documents the residual attack
+    surface so a future reviewer can't claim the helper alone is
+    spoof-proof.
+    """
+    request = _make_request(
+        client_host="192.168.65.1",
+        headers={"X-Forwarded-For": "1.2.3.4, 192.168.65.1"},
+    )
+    # NOT a security guarantee - the production guarantee comes from
+    # nginx overwriting XFF to ``$remote_addr`` so this chain shape
+    # never reaches the backend in the first place.
+    assert get_client_ip(request) == "1.2.3.4"
+
+
+def test_xff_spoof_attempt_with_nginx_overwrite_is_blocked():
+    """Production shape after nginx overwrite: any client-supplied
+    XFF is discarded at the edge and replaced with the nginx peer
+    (``$remote_addr``). The backend therefore sees a single-entry
+    chain whose only IP is the real browser. The walk returns it
+    correctly and there is nothing for an attacker to inject into.
+    """
+    # Real client at 203.0.113.7 tries to spoof by sending
+    # ``XFF: 1.2.3.4``. nginx receives the request, IGNORES the
+    # client header, and emits ``XFF: 203.0.113.7`` (its $remote_addr).
+    # The backend's TCP peer is the nginx container (private IP).
+    request = _make_request(
+        client_host="172.18.0.5",
+        headers={"X-Forwarded-For": "203.0.113.7"},
+    )
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+# ── DO App Platform runtime gate ─────────────────────────────────────────
+
+
+def test_do_runtime_mode_returns_do_connecting_ip_unconditionally(monkeypatch):
+    """With ``PFV_RUNTIME=app_platform`` set, ``do-connecting-ip`` is
+    authoritative even when the direct TCP peer is OUTSIDE the
+    trusted-proxy CIDR list. This is the prod-fix path: the DO
+    ingress peer falls outside RFC 1918, so the old trusted-peer
+    gate skipped the header and audit logs got the ingress IP.
+    """
+    monkeypatch.setenv("PFV_RUNTIME", "app_platform")
+    # DO ingress peer is NOT in any of our trusted CIDRs.
+    request = _make_request(
+        client_host="169.254.10.5",
+        headers={"do-connecting-ip": "203.0.113.7"},
+    )
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def test_do_runtime_mode_without_header_falls_back_to_peer(monkeypatch):
+    """In App Platform mode, if ``do-connecting-ip`` is somehow
+    missing (e.g. health check that does not hit the public ingress),
+    we fall back to the standard XFF / peer resolution rather than
+    crashing.
+    """
+    monkeypatch.setenv("PFV_RUNTIME", "app_platform")
+    request = _make_request(client_host="169.254.10.5")
+    assert get_client_ip(request) == "169.254.10.5"
+
+
+def test_do_runtime_mode_unset_ignores_do_connecting_ip_from_public_peer(monkeypatch):
+    """Without ``PFV_RUNTIME=app_platform``, a request from a public
+    peer carrying a forged ``do-connecting-ip`` MUST be rejected.
+    Returns the peer IP, not the header.
+    """
+    monkeypatch.delenv("PFV_RUNTIME", raising=False)
+    request = _make_request(
+        client_host="198.51.100.99",
+        headers={"do-connecting-ip": "203.0.113.7"},
+    )
+    assert get_client_ip(request) == "198.51.100.99"
+
+
+def test_do_runtime_mode_case_insensitive(monkeypatch):
+    """``PFV_RUNTIME`` is matched case-insensitively to avoid spec-vs-
+    env quirks (DO docs use mixed case in examples).
+    """
+    monkeypatch.setenv("PFV_RUNTIME", "App_Platform")
+    request = _make_request(
+        client_host="169.254.10.5",
+        headers={"do-connecting-ip": "203.0.113.7"},
+    )
+    assert get_client_ip(request) == "203.0.113.7"
 
 
 # ── Integration: audit_events.ip_address persists the resolved client ─────

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -39,11 +39,18 @@ server {
     access_log /dev/stdout json_combined;
 
     # Backend API — pass through as-is (backend routes are /api/*)
+    #
+    # SECURITY: X-Forwarded-For is set to $remote_addr (the immediate
+    # peer) and NOT $proxy_add_x_forwarded_for. The latter appends our
+    # peer to whatever the client sent, which lets a malicious client
+    # inject a leftmost spoofed IP. Backend's get_client_ip walks XFF
+    # right-to-left, so a client-side spoof would be picked up if we
+    # forwarded it. We therefore overwrite the chain at the edge.
     location /api/ {
         proxy_pass http://backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Request-Id $request_id_final;
     }
@@ -53,7 +60,7 @@ server {
         proxy_pass http://backend/health;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Request-Id $request_id_final;
     }
@@ -62,7 +69,7 @@ server {
         proxy_pass http://backend/ready;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Request-Id $request_id_final;
     }
@@ -77,7 +84,7 @@ server {
         proxy_pass http://frontend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Request-Id $request_id_final;
         proxy_pass_header X-Request-Id;


### PR DESCRIPTION
## Root cause

`get_client_ip` in `backend/app/rate_limit.py` trusted `request.client.host` (uvicorn's post-`--proxy-headers` value) as the final answer. Two symptoms fell out of the same defect:

- **Local dev:** uvicorn walks `X-Forwarded-For` right-to-left and returns the leftmost UNTRUSTED entry. When every chain entry falls inside `_TRUSTED_PROXY_CIDRS` (browser host bridge + nginx peer are both RFC 1918), uvicorn returns the leftmost-trusted entry. `request.client.host` ends up at the Docker bridge (`192.168.65.1`), `_is_trusted_proxy` returns True, `do-connecting-ip` is absent, and we store the bridge IP in `audit_events.ip_address`.
- **DO App Platform prod:** the DO ingress peer falls OUTSIDE `--forwarded-allow-ips` (it is not RFC 1918), so uvicorn does not parse XFF at all and leaves `request.client.host` at the DO ingress IP. `_is_trusted_proxy` then returns False, so `do-connecting-ip` is never consulted, and we store the DO ingress IP.

Why it was hidden: the rate limiter only needs a stable per-key value — keyed-by-Docker-bridge-IP works fine for one local user, and keyed-by-DO-ingress-IP buckets the whole world together but does not 500. The audit log surfaced the bug because forensic readers expect to see the user's real IP, and that column had been wrong since PR #82.

## Fix

`get_client_ip` now parses `X-Forwarded-For` itself, left-to-right, and returns the first non-trusted entry. The XFF walk is gated on the direct TCP peer being a trusted proxy so a public-internet caller cannot forge a leftmost entry. If the entire chain is trusted (or absent), we fall through to the existing `do-connecting-ip` lookup for the DO shape, then to `request.client.host` as the final fallback.

- `backend/app/rate_limit.py` — 59 insertions, 26 deletions. Adds `_parse_xff` helper, rewrites `get_client_ip` resolution order.
- `backend/tests/test_client_ip_resolution.py` — new file.

## Regression tests (13)

Unit tests (12):

- `test_direct_browser_localhost_returns_loopback`
- `test_single_trusted_proxy_returns_real_client_from_xff`
- `test_two_trusted_proxies_returns_first_non_proxy_entry`
- `test_do_app_platform_uses_do_connecting_ip_when_peer_is_trusted`
- `test_untrusted_public_peer_with_do_connecting_ip_returns_peer`
- `test_forged_leftmost_xff_from_untrusted_peer_is_rejected`
- `test_missing_client_falls_back_to_loopback`
- `test_xff_handles_whitespace_around_entries`
- `test_ipv6_client_in_xff_is_returned`
- `test_xff_entirely_trusted_falls_back_to_do_or_peer`
- `test_xff_entirely_trusted_with_do_connecting_ip_prefers_do`
- `test_empty_xff_header_falls_back_to_peer`

Integration test (1):

- `test_audit_endpoint_persists_real_client_ip_from_xff` — hits `PUT /api/v1/admin/orgs/{id}/subscription` through TestClient (with the ASGI scope's `client` rewritten to `127.0.0.1` so it counts as a trusted peer), sends `X-Forwarded-For: 203.0.113.7, 10.0.0.5`, and asserts the persisted `audit_events.ip_address` equals `203.0.113.7`.

Full backend suite: 943 passed, 2 skipped (pre-existing).

## Post-deploy verification (manual, owner to run after merge)

From your browser hit any audited endpoint on prod (org rename works well, requires owner role). Then in prod MySQL:

```sql
SELECT id, event_type, ip_address, request_id, created_at
FROM audit_events
ORDER BY id DESC
LIMIT 5;
```

`ip_address` on the new row should match your real public IP. Confirm with `curl https://ifconfig.me` from the same machine. If the column still shows a DO-internal IP, the trust CIDR list may need to be widened with App Platform's actual ingress range — file a follow-up.