### PR TITLE
feat(accounts): opening_balance + opening_balance_date (L3.2 Wave 2A)

### DIFF
--- a/backend/alembic/versions/041_opening_balance.py
+++ b/backend/alembic/versions/041_opening_balance.py
@@ -1,0 +1,119 @@
+"""Add opening_balance + opening_balance_date to accounts (L3.2 Wave 2A).
+
+Revision ID: 041_opening_balance
+Revises: 040_users_email_case_insensitive
+Create Date: 2026-05-12
+
+Implements the column-shape half of the Opening Balance contract
+(``specs/2026-05-12-l3-2-import-contracts.md`` §0.4 row C / §4 / §4.4).
+
+Two additive columns on ``accounts``:
+
+1. ``opening_balance NUMERIC(12, 2) NOT NULL DEFAULT 0`` — user-stated
+   starting amount. NOT a derived quantity; backfilled to 0 for every
+   existing account by the column-level ``server_default``. The Wave 2A
+   UI lets a user enter a non-zero opening balance at account-creation
+   time or edit it later via ``PATCH /api/v1/accounts/{id}``.
+
+2. ``opening_balance_date DATE NOT NULL DEFAULT (current_date)`` —
+   the date the user states their starting balance applies from. UI
+   default is today. Picks up ``current_date`` for backfilled rows.
+
+Backfill (CANONICAL, locked 2026-05-12 in §4.4 of the contract):
+
+    Migration sets ``opening_balance = 0`` for ALL existing accounts.
+    Users adjust to their actual starting balance via the Opening
+    Balance UI (Wave 2A) after migration. No derived formula. The
+    0-backfill is drift-free: editing or deleting a historical
+    transaction post-migration does NOT shift the stated starting
+    amount, because ``opening_balance`` is a user-stated input, not a
+    function of the transaction stream.
+
+The backfill is delivered automatically by the ``NOT NULL DEFAULT 0``
+DDL — MySQL 8 and SQLite both fill existing rows with 0 at column-add
+time. A defensive post-DDL ``UPDATE`` covers the (already paranoid)
+edge case where a dialect leaves the new column NULL on some pre-
+existing row, and the post-migration assertion is:
+
+    SELECT COUNT(*) FROM accounts WHERE opening_balance != 0
+
+which MUST return 0 immediately after upgrade. See
+``backend/tests/migrations/test_041_opening_balance.py`` for the
+regression gate.
+
+Forward-compatibility note: the Reconciliation UI team (Wave 2B) will
+chain its migration (``transactions.reconciliation_state``,
+``transactions.import_batch_id``, new ``import_batches`` table) off
+this revision — so they should set ``down_revision = "041_opening_balance"``
+when their PR opens.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "041_opening_balance"
+down_revision: Union[str, None] = "040_users_email_case_insensitive"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # opening_balance: column-level server_default "0" delivers the
+    # CANONICAL backfill to every pre-existing row on both MySQL 8 and
+    # SQLite. Numeric(12, 2) matches accounts.balance / transactions.amount.
+    op.add_column(
+        "accounts",
+        sa.Column(
+            "opening_balance",
+            sa.Numeric(12, 2),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+    # opening_balance_date: DATE NOT NULL with the contract's
+    # "DEFAULT current_date" semantics. MySQL 8 requires the function
+    # default to be parenthesised — ``DEFAULT (CURRENT_DATE)`` — whereas
+    # SQLite accepts the bare ``DEFAULT CURRENT_DATE`` form. We pick the
+    # dialect-correct literal so the column's server-side default keeps
+    # working for ANY future INSERT that omits the field (the existing-
+    # row backfill below is a separate, explicit step).
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        date_default = sa.text("(CURRENT_DATE)")
+    else:
+        date_default = sa.text("CURRENT_DATE")
+    op.add_column(
+        "accounts",
+        sa.Column(
+            "opening_balance_date",
+            sa.Date(),
+            nullable=False,
+            server_default=date_default,
+        ),
+    )
+
+    # Defensive post-DDL backfill for ``opening_balance``. The column-
+    # level server_default already fills the new column with 0 at DDL
+    # time on both dialects we care about, but this UPDATE is the belt-
+    # and-braces guarantee called out by §4.4 / the Test Boundary row
+    # (Opening Balance team): post-migration, every row's
+    # opening_balance MUST be 0. The WHERE clause is a no-op when the
+    # DDL already filled the column correctly.
+    bind.execute(
+        sa.text(
+            "UPDATE accounts SET opening_balance = 0 "
+            "WHERE opening_balance IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    # Symmetric drop. Order is immaterial — both columns are independent
+    # additions with no FKs, indexes, or constraints introduced here.
+    op.drop_column("accounts", "opening_balance_date")
+    op.drop_column("accounts", "opening_balance")

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -1,9 +1,10 @@
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
 
 from sqlalchemy import (
     Boolean,
+    Date,
     DateTime,
     ForeignKey,
     Integer,
@@ -60,6 +61,16 @@ class Account(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     close_day: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # User-stated opening balance for the account. Migration 041 sets
+    # this to 0 for every existing account (canonical backfill, see
+    # contract §4.4). New accounts may set it at create time; existing
+    # accounts may edit it via PATCH /api/v1/accounts/{id}.
+    opening_balance: Mapped[Decimal] = mapped_column(
+        Numeric(12, 2), nullable=False, default=Decimal("0.00"), server_default="0"
+    )
+    opening_balance_date: Mapped[date] = mapped_column(
+        Date, nullable=False, server_default=func.current_date()
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -2,11 +2,11 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy import select, update
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models.account import Account, AccountType
 from app.models.transaction import Transaction
 from app.models.user import Organization, Role, User
@@ -19,6 +19,7 @@ from app.schemas.account import (
     BalanceAdjustmentResponse,
     ReconcileResponse,
 )
+from app.services import audit_service
 from app.services.exceptions import ConflictError, ValidationError
 from app.services.transaction_service import (
     adjust_account_balance,
@@ -52,6 +53,8 @@ def _to_response(account: Account) -> AccountResponse:
         is_active=account.is_active,
         close_day=account.close_day,
         is_default=account.is_default,
+        opening_balance=account.opening_balance,
+        opening_balance_date=account.opening_balance_date,
     )
 
 
@@ -84,14 +87,22 @@ async def create_account(
     if at_result.scalar_one_or_none() is None:
         raise HTTPException(status_code=400, detail="Invalid account type")
 
-    account = Account(
+    # opening_balance_date: caller may omit (and ride the DB default of
+    # CURRENT_DATE) or supply an explicit date. We pass it through only
+    # when supplied so the column-level server_default applies on omission.
+    kwargs = dict(
         org_id=current_user.org_id,
         account_type_id=body.account_type_id,
         name=body.name,
         balance=body.balance,
         currency=body.currency,
         close_day=body.close_day,
+        opening_balance=body.opening_balance,
     )
+    if body.opening_balance_date is not None:
+        kwargs["opening_balance_date"] = body.opening_balance_date
+
+    account = Account(**kwargs)
     db.add(account)
     await db.commit()
 
@@ -124,8 +135,10 @@ async def get_account(
 async def update_account(
     account_id: int,
     body: AccountUpdate,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     result = await db.execute(
         select(Account)
@@ -135,6 +148,12 @@ async def update_account(
     account = result.scalar_one_or_none()
     if account is None:
         raise HTTPException(status_code=404, detail="Account not found")
+
+    # Snapshot opening fields BEFORE mutation so the audit detail can
+    # compare old vs new even after commit-time refresh / expire.
+    old_opening_balance = account.opening_balance
+    old_opening_balance_date = account.opening_balance_date
+    opening_changed = False
 
     if body.name is not None:
         account.name = body.name
@@ -168,7 +187,56 @@ async def update_account(
     elif body.is_default is False:
         account.is_default = False
 
+    # Opening balance fields. Both fields are optional in the body; we
+    # only mutate when explicitly supplied. The audit-event is emitted
+    # iff at least one of the two fields actually changed.
+    if body.opening_balance is not None and body.opening_balance != account.opening_balance:
+        account.opening_balance = body.opening_balance
+        opening_changed = True
+    if (
+        body.opening_balance_date is not None
+        and body.opening_balance_date != account.opening_balance_date
+    ):
+        account.opening_balance_date = body.opening_balance_date
+        opening_changed = True
+
+    # Capture identity NOW so any post-commit expire doesn't break the
+    # audit-event payload.
+    actor_user_id = current_user.id
+    actor_email = current_user.email
+    actor_org_id = current_user.org_id
+    req_id = _request_id()
+    ip = get_client_ip(request)
+    new_opening_balance = account.opening_balance
+    new_opening_balance_date = account.opening_balance_date
+
     await db.commit()
+
+    if opening_changed:
+        # Fire-and-forget audit row in its own session. Matches the
+        # convention in tags / admin_users / auth.
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="account.opening_balance.update",
+            actor_user_id=actor_user_id,
+            actor_email=actor_email,
+            target_org_id=actor_org_id,
+            target_org_name=None,
+            request_id=req_id,
+            ip_address=ip,
+            outcome="success",
+            detail={
+                "account_id": account_id,
+                "old_opening_balance": str(old_opening_balance),
+                "new_opening_balance": str(new_opening_balance),
+                "old_opening_balance_date": old_opening_balance_date.isoformat()
+                if old_opening_balance_date is not None
+                else None,
+                "new_opening_balance_date": new_opening_balance_date.isoformat()
+                if new_opening_balance_date is not None
+                else None,
+            },
+        )
 
     result = await db.execute(
         select(Account)

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -1,7 +1,14 @@
+from datetime import date
 from decimal import Decimal
 from typing import Optional
 
 from pydantic import BaseModel, Field
+
+
+# Mirrors the Numeric(12, 2) DB constraint on accounts.opening_balance.
+# A schema-level range produces a clean 422 instead of a DB-overflow 500.
+_OPENING_BALANCE_CAP_HI = Decimal("9999999999.99")
+_OPENING_BALANCE_CAP_LO = Decimal("-9999999999.99")
 
 
 class AccountTypeCreate(BaseModel):
@@ -28,6 +35,18 @@ class AccountCreate(BaseModel):
     balance: Decimal = Decimal("0.00")
     currency: str = "EUR"
     close_day: Optional[int] = Field(default=None, ge=1, le=28)
+    # Opening balance (L3.2 Wave 2A). User-stated starting amount.
+    # Defaults to 0 when the caller omits it, matching the migration's
+    # backfill. ``opening_balance_date`` defaults to today on the DB
+    # side; the API surface accepts a caller-provided override.
+    opening_balance: Decimal = Field(
+        default=Decimal("0.00"),
+        ge=_OPENING_BALANCE_CAP_LO,
+        le=_OPENING_BALANCE_CAP_HI,
+        max_digits=12,
+        decimal_places=2,
+    )
+    opening_balance_date: Optional[date] = None
 
 
 class AccountUpdate(BaseModel):
@@ -36,6 +55,16 @@ class AccountUpdate(BaseModel):
     is_active: Optional[bool] = None
     close_day: Optional[int] = Field(default=None, ge=1, le=28)
     is_default: Optional[bool] = None
+    # Both opening fields are editable post-create. Audit-logged on
+    # change (see ``accounts.update_account``).
+    opening_balance: Optional[Decimal] = Field(
+        default=None,
+        ge=_OPENING_BALANCE_CAP_LO,
+        le=_OPENING_BALANCE_CAP_HI,
+        max_digits=12,
+        decimal_places=2,
+    )
+    opening_balance_date: Optional[date] = None
 
 
 class AccountResponse(BaseModel):
@@ -49,6 +78,8 @@ class AccountResponse(BaseModel):
     is_active: bool
     close_day: Optional[int] = None
     is_default: bool = False
+    opening_balance: Decimal = Decimal("0.00")
+    opening_balance_date: Optional[date] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/tests/migrations/test_041_opening_balance.py
+++ b/backend/tests/migrations/test_041_opening_balance.py
@@ -1,0 +1,84 @@
+"""Migration 041 — opening_balance + opening_balance_date.
+
+Asserts the CANONICAL contract-locked invariant from
+``specs/2026-05-12-l3-2-import-contracts.md`` §4.4:
+
+    For existing accounts, the migration backfills
+    ``opening_balance = 0`` for every row.
+
+We run the assertion as a live SQL probe against the post-upgrade
+schema. The Wave 2A Opening Balance team owns this gate; any future
+migration that violates it (by inserting a non-zero opening_balance
+on a pre-existing row before the column was introduced, or by
+changing the DDL default) must update this file too.
+
+Skipped unless ``PFV_RUN_MYSQL_TESTS=1`` because the assertion is
+against the real post-migration MySQL state. The default DATABASE_URL
+is MySQL even in environments where no MySQL is running, so an
+explicit opt-in is the only reliable signal.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import text
+
+from app.database import get_db
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("PFV_RUN_MYSQL_TESTS") != "1",
+    reason="MySQL-only migration test; set PFV_RUN_MYSQL_TESTS=1 to run.",
+)
+
+
+@pytest.mark.asyncio
+async def test_opening_balance_backfill_is_zero_for_every_account():
+    """§4.4: ``SELECT COUNT(*) FROM accounts WHERE opening_balance != 0``
+    MUST equal 0 immediately after upgrade. This proves the canonical
+    backfill landed for every pre-existing account."""
+    async for db in get_db():
+        result = await db.execute(
+            text("SELECT COUNT(*) AS n FROM accounts WHERE opening_balance != 0")
+        )
+        row = result.first()
+        assert row.n == 0, (
+            f"§4.4 backfill regression: {row.n} accounts have a non-zero "
+            "opening_balance immediately after migration. Every existing "
+            "account must be backfilled to 0; users set the real value via "
+            "the Opening Balance UI."
+        )
+        break
+
+
+@pytest.mark.asyncio
+async def test_opening_balance_columns_have_correct_types():
+    """Schema-level sanity: the two columns landed with the contract's
+    exact types (DECIMAL(12,2) and DATE) and are NOT NULL. The contract
+    pins the shape so the OFX + Reconciliation teams can rely on it."""
+    async for db in get_db():
+        result = await db.execute(
+            text(
+                "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, "
+                "       NUMERIC_PRECISION, NUMERIC_SCALE "
+                "FROM information_schema.COLUMNS "
+                "WHERE TABLE_SCHEMA = DATABASE() "
+                "AND TABLE_NAME = 'accounts' "
+                "AND COLUMN_NAME IN ('opening_balance', 'opening_balance_date')"
+            )
+        )
+        rows = {r.COLUMN_NAME: r for r in result.all()}
+        assert "opening_balance" in rows
+        assert "opening_balance_date" in rows
+
+        ob = rows["opening_balance"]
+        assert ob.DATA_TYPE == "decimal"
+        assert ob.IS_NULLABLE == "NO"
+        assert ob.NUMERIC_PRECISION == 12
+        assert ob.NUMERIC_SCALE == 2
+
+        obd = rows["opening_balance_date"]
+        assert obd.DATA_TYPE == "date"
+        assert obd.IS_NULLABLE == "NO"
+        break

--- a/backend/tests/test_account_opening_balance.py
+++ b/backend/tests/test_account_opening_balance.py
@@ -1,0 +1,324 @@
+"""Opening balance on accounts (L3.2 Wave 2A).
+
+Covers the API surface that PR #227 locked in
+``specs/2026-05-12-l3-2-import-contracts.md`` §0.4 / §4 / §4.4:
+
+- ``POST /api/v1/accounts`` accepts optional ``opening_balance`` and
+  ``opening_balance_date``; both default to 0 / today when omitted.
+- ``PUT /api/v1/accounts/{id}`` edits both fields; an actual change
+  writes an ``account.opening_balance.update`` audit row with the
+  old + new values. A no-op PUT (same values, or fields omitted)
+  writes no audit row.
+- ``GET /api/v1/accounts/{id}`` exposes both fields on the response.
+
+Backend stack: FastAPI + SQLAlchemy 2.0 async, in-memory aiosqlite
+mirroring the test_account_balance_adjustment.py setup.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Account, AccountType, Organization
+from app.models.audit_event import AuditEvent
+from app.models.base import Base
+from app.models.user import Role, User
+from app.routers.accounts import router as accounts_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded(session_factory) -> dict:
+    """Seed an org with an admin user, an account type, and one account
+    that the tests then PUT against. ``account.opening_balance`` is
+    initialised to 0 to mirror the migration's CANONICAL backfill."""
+    async with session_factory() as db:
+        org = Organization(name="OB Test Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+
+        admin = User(
+            org_id=org.id,
+            username="admin",
+            email="admin@ob.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.ADMIN,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(admin)
+
+        at = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True
+        )
+        db.add(at)
+        await db.flush()
+
+        acct = Account(
+            org_id=org.id,
+            account_type_id=at.id,
+            name="Primary",
+            balance=Decimal("0.00"),
+            currency="EUR",
+            is_active=True,
+            opening_balance=Decimal("0.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        db.add(acct)
+        await db.commit()
+
+        return {
+            "org_id": org.id,
+            "admin_id": admin.id,
+            "account_type_id": at.id,
+            "account_id": acct.id,
+        }
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    async def override_current_user() -> User:
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.role == Role.ADMIN))
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(accounts_router)
+    return app
+
+
+# ── Create ────────────────────────────────────────────────────────────────
+
+
+def test_create_account_defaults_opening_balance_to_zero(session_factory, seeded):
+    """Caller omits opening_balance — server defaults to 0."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "Secondary",
+                "account_type_id": seeded["account_type_id"],
+                "balance": "0.00",
+                "currency": "EUR",
+            },
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert Decimal(body["opening_balance"]) == Decimal("0.00")
+    # opening_balance_date is set by the DB default — on SQLite that
+    # resolves to today. We only assert it's present and parseable.
+    assert body["opening_balance_date"] is not None
+    date.fromisoformat(body["opening_balance_date"])
+
+
+def test_create_account_with_explicit_opening_balance(session_factory, seeded):
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "Savings",
+                "account_type_id": seeded["account_type_id"],
+                "balance": "0.00",
+                "currency": "EUR",
+                "opening_balance": "1500.00",
+                "opening_balance_date": "2025-12-31",
+            },
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert Decimal(body["opening_balance"]) == Decimal("1500.00")
+    assert body["opening_balance_date"] == "2025-12-31"
+
+
+def test_create_account_rejects_oversized_opening_balance(session_factory, seeded):
+    """Schema-level guard keeps a Numeric(12, 2) overflow off the DB layer."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "Big",
+                "account_type_id": seeded["account_type_id"],
+                "balance": "0.00",
+                "currency": "EUR",
+                "opening_balance": "99999999999999.99",
+            },
+        )
+    assert res.status_code == 422
+
+
+# ── Read ──────────────────────────────────────────────────────────────────
+
+
+def test_get_account_exposes_opening_balance_fields(session_factory, seeded):
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.get(f"/api/v1/accounts/{seeded['account_id']}")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert "opening_balance" in body
+    assert "opening_balance_date" in body
+    assert Decimal(body["opening_balance"]) == Decimal("0.00")
+    assert body["opening_balance_date"] == "2026-01-01"
+
+
+# ── Update ────────────────────────────────────────────────────────────────
+
+
+def test_update_account_opening_balance_writes_audit_row(session_factory, seeded):
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={
+                "opening_balance": "250.50",
+                "opening_balance_date": "2025-06-15",
+            },
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert Decimal(body["opening_balance"]) == Decimal("250.50")
+    assert body["opening_balance_date"] == "2025-06-15"
+
+    # Audit event written in its own session (record_audit_event path).
+    import asyncio
+
+    async def _audit_rows():
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.event_type == "account.opening_balance.update"
+                    )
+                )
+            ).scalars().all()
+
+    rows = asyncio.get_event_loop().run_until_complete(_audit_rows())
+    assert len(rows) == 1, "expected exactly one audit event"
+    detail = rows[0].detail
+    assert detail["account_id"] == seeded["account_id"]
+    assert detail["old_opening_balance"] == "0.00"
+    assert detail["new_opening_balance"] == "250.50"
+    assert detail["old_opening_balance_date"] == "2026-01-01"
+    assert detail["new_opening_balance_date"] == "2025-06-15"
+
+
+def test_update_account_opening_balance_no_change_no_audit(session_factory, seeded):
+    """Submitting the same values is a no-op — no audit row."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={
+                "opening_balance": "0.00",
+                "opening_balance_date": "2026-01-01",
+            },
+        )
+    assert res.status_code == 200, res.text
+
+    import asyncio
+
+    async def _audit_rows():
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.event_type == "account.opening_balance.update"
+                    )
+                )
+            ).scalars().all()
+
+    rows = asyncio.get_event_loop().run_until_complete(_audit_rows())
+    assert rows == []
+
+
+def test_update_account_omitting_opening_fields_does_not_touch_them(
+    session_factory, seeded
+):
+    """A PUT with only ``name`` set must leave opening_balance unchanged
+    and emit no opening-balance audit row."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={"name": "Renamed"},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["name"] == "Renamed"
+    assert Decimal(body["opening_balance"]) == Decimal("0.00")
+    assert body["opening_balance_date"] == "2026-01-01"
+
+    import asyncio
+
+    async def _audit_rows():
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.event_type == "account.opening_balance.update"
+                    )
+                )
+            ).scalars().all()
+
+    rows = asyncio.get_event_loop().run_until_complete(_audit_rows())
+    assert rows == []
+
+
+def test_update_account_rejects_oversized_opening_balance(session_factory, seeded):
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['account_id']}",
+            json={"opening_balance": "999999999999.99"},
+        )
+    assert res.status_code == 422

--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -34,6 +34,9 @@ export default function AccountsPage() {
   const [editAcctId, setEditAcctId] = useState<number | null>(null);
   const [editAcctName, setEditAcctName] = useState("");
   const [editAcctCloseDay, setEditAcctCloseDay] = useState("");
+  // L3.2 Wave 2A — opening balance fields are editable from the row.
+  const [editAcctOpeningBalance, setEditAcctOpeningBalance] = useState("0.00");
+  const [editAcctOpeningBalanceDate, setEditAcctOpeningBalanceDate] = useState("");
 
   const [showAccountForm, setShowAccountForm] = useState(false);
   const [acctName, setAcctName] = useState("");
@@ -41,6 +44,13 @@ export default function AccountsPage() {
   const [acctBalance, setAcctBalance] = useState("0.00");
   const [acctCurrency, setAcctCurrency] = useState("EUR");
   const [acctCloseDay, setAcctCloseDay] = useState("");
+  // L3.2 Wave 2A — opening balance + date on the create form. The date
+  // input defaults to today so most users skip the picker; the contract
+  // (§4.4) backfills 0 for existing accounts, so the create form is the
+  // first chance to state a real starting amount.
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const [acctOpeningBalance, setAcctOpeningBalance] = useState("0.00");
+  const [acctOpeningBalanceDate, setAcctOpeningBalanceDate] = useState(todayIso);
   const selectedType = accountTypes.find((t) => t.id === acctTypeId) ?? null;
 
   const [error, setError] = useState("");
@@ -144,9 +154,13 @@ export default function AccountsPage() {
           name: acctName, account_type_id: acctTypeId, balance: acctBalance,
           currency: acctCurrency,
           close_day: selectedType?.slug === "credit_card" && acctCloseDay ? Number(acctCloseDay) : null,
+          opening_balance: acctOpeningBalance || "0.00",
+          opening_balance_date: acctOpeningBalanceDate || null,
         }),
       });
-      setAcctName(""); setAcctTypeId(""); setAcctBalance("0.00"); setAcctCloseDay(""); setShowAccountForm(false);
+      setAcctName(""); setAcctTypeId(""); setAcctBalance("0.00"); setAcctCloseDay("");
+      setAcctOpeningBalance("0.00"); setAcctOpeningBalanceDate(todayIso);
+      setShowAccountForm(false);
       await reload();
     } catch (err) { setError(extractErrorMessage(err)); }
   }
@@ -164,6 +178,8 @@ export default function AccountsPage() {
     setEditAcctId(a.id);
     setEditAcctName(a.name);
     setEditAcctCloseDay(a.close_day ? String(a.close_day) : "");
+    setEditAcctOpeningBalance(String(a.opening_balance ?? "0.00"));
+    setEditAcctOpeningBalanceDate(a.opening_balance_date ?? "");
   }
 
   async function handleSaveAcct() {
@@ -175,6 +191,8 @@ export default function AccountsPage() {
         body: JSON.stringify({
           name: editAcctName,
           close_day: editAcctCloseDay ? Number(editAcctCloseDay) : null,
+          opening_balance: editAcctOpeningBalance || "0.00",
+          opening_balance_date: editAcctOpeningBalanceDate || null,
         }),
       });
       setEditAcctId(null);
@@ -338,6 +356,37 @@ export default function AccountsPage() {
                       <input id="acct-close" type="number" min={1} max={28} value={acctCloseDay} onChange={(e) => setAcctCloseDay(e.target.value)} className={`w-24 ${input}`} placeholder="15" />
                     </div>
                   )}
+                  {/* L3.2 Wave 2A — opening balance + date. Optional;
+                      defaults are 0 / today. Helper text aimed at the
+                      pre-launch friends-only audience: most users won't
+                      know their starting balance and that's fine, we
+                      simply count from 0. */}
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                    <div className="w-full sm:flex-1">
+                      <label htmlFor="acct-opening-balance" className={label}>Opening balance</label>
+                      <input
+                        id="acct-opening-balance"
+                        type="number"
+                        step="0.01"
+                        value={acctOpeningBalance}
+                        onChange={(e) => setAcctOpeningBalance(e.target.value)}
+                        className={input}
+                      />
+                    </div>
+                    <div className="w-full sm:w-44">
+                      <label htmlFor="acct-opening-balance-date" className={label}>Starting from</label>
+                      <input
+                        id="acct-opening-balance-date"
+                        type="date"
+                        value={acctOpeningBalanceDate}
+                        onChange={(e) => setAcctOpeningBalanceDate(e.target.value)}
+                        className={input}
+                      />
+                    </div>
+                  </div>
+                  <p className="text-xs text-text-muted">
+                    Your account&apos;s starting amount. Leave at 0 if you don&apos;t know.
+                  </p>
                   <button type="submit" className={`w-full min-h-[44px] sm:w-auto sm:min-h-0 ${btnPrimary}`}>Create Account</button>
                 </form>
               )}
@@ -359,12 +408,39 @@ export default function AccountsPage() {
               )}
               <div className="space-y-1">
                 {accounts.map((a) => editAcctId === a.id ? (
-                  <div key={a.id} className="flex flex-col gap-2 rounded-md bg-surface-raised px-3 py-2.5 sm:flex-row sm:items-center sm:gap-3">
-                    <input aria-label="Account name" type="text" value={editAcctName} onChange={(e) => setEditAcctName(e.target.value)} className={`w-full text-sm sm:flex-1 ${input}`}
-                      onKeyDown={(e) => { if (e.key === "Enter") handleSaveAcct(); if (e.key === "Escape") setEditAcctId(null); }} autoFocus />
-                    {a.account_type_slug === "credit_card" && (
-                      <input aria-label="Close day" type="number" min={1} max={28} value={editAcctCloseDay} onChange={(e) => setEditAcctCloseDay(e.target.value)} placeholder="Close day" className={`w-full text-sm sm:w-24 ${input}`} />
-                    )}
+                  <div key={a.id} className="flex flex-col gap-3 rounded-md bg-surface-raised px-3 py-3">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                      <input aria-label="Account name" type="text" value={editAcctName} onChange={(e) => setEditAcctName(e.target.value)} className={`w-full text-sm sm:flex-1 ${input}`}
+                        onKeyDown={(e) => { if (e.key === "Enter") handleSaveAcct(); if (e.key === "Escape") setEditAcctId(null); }} autoFocus />
+                      {a.account_type_slug === "credit_card" && (
+                        <input aria-label="Close day" type="number" min={1} max={28} value={editAcctCloseDay} onChange={(e) => setEditAcctCloseDay(e.target.value)} placeholder="Close day" className={`w-full text-sm sm:w-24 ${input}`} />
+                      )}
+                    </div>
+                    {/* L3.2 Wave 2A — opening balance edit row. Two
+                        compact fields, audit-logged on the backend. */}
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:gap-3">
+                      <div className="w-full sm:flex-1">
+                        <label htmlFor={`edit-acct-opening-balance-${a.id}`} className={label}>Opening balance</label>
+                        <input
+                          id={`edit-acct-opening-balance-${a.id}`}
+                          type="number"
+                          step="0.01"
+                          value={editAcctOpeningBalance}
+                          onChange={(e) => setEditAcctOpeningBalance(e.target.value)}
+                          className={input}
+                        />
+                      </div>
+                      <div className="w-full sm:w-44">
+                        <label htmlFor={`edit-acct-opening-balance-date-${a.id}`} className={label}>Starting from</label>
+                        <input
+                          id={`edit-acct-opening-balance-date-${a.id}`}
+                          type="date"
+                          value={editAcctOpeningBalanceDate}
+                          onChange={(e) => setEditAcctOpeningBalanceDate(e.target.value)}
+                          className={input}
+                        />
+                      </div>
+                    </div>
                     <div className="flex flex-wrap gap-2">
                       <button onClick={handleSaveAcct} className="min-h-[44px] text-xs text-accent hover:text-accent-hover sm:min-h-0">Save</button>
                       <button onClick={() => setEditAcctId(null)} className="min-h-[44px] text-xs text-text-muted sm:min-h-0">Cancel</button>
@@ -410,6 +486,17 @@ export default function AccountsPage() {
                             learnMoreSection="accounts"
                             triggerLabel="What does Pending mean for this account?"
                           />
+                        </span>
+                      ) : null}
+                      {/* L3.2 Wave 2A — opening balance hint. Only
+                          surface when the user set a non-zero value;
+                          accounts left at the 0 backfill stay quiet so
+                          the column doesn't fill with "Opening: 0.00"
+                          noise. */}
+                      {Number(a.opening_balance) !== 0 ? (
+                        <span className="text-xs tabular-nums text-text-muted">
+                          Opening: {formatAmount(Number(a.opening_balance))}
+                          {a.opening_balance_date ? ` since ${a.opening_balance_date}` : ""}
                         </span>
                       ) : null}
                     </div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -78,6 +78,15 @@ export interface Account {
   is_active: boolean;
   close_day: number | null;
   is_default: boolean;
+  // L3.2 Wave 2A — user-stated starting amount. 0 for accounts that
+  // pre-date migration 041; new accounts may set a non-zero value at
+  // create time and edit it later. Marked optional on the TS type so
+  // existing test fixtures and legacy-shape payloads keep compiling;
+  // the runtime API always serializes both fields on AccountResponse.
+  opening_balance?: number | string;
+  // ISO-8601 yyyy-mm-dd. Set to today on existing rows by the
+  // migration; user-editable in the account-edit form.
+  opening_balance_date?: string | null;
 }
 
 export interface Category {


### PR DESCRIPTION
## Scope
L3.2 Wave 2A — Opening Balance team. Implements the column-shape, API, and UI half of the Opening Balance contract locked in `specs/2026-05-12-l3-2-import-contracts.md` §0.4 row C / §4 / §4.4.

Adds two columns to `accounts`:
- `opening_balance NUMERIC(12,2) NOT NULL DEFAULT 0`
- `opening_balance_date DATE NOT NULL DEFAULT (CURRENT_DATE)`

API surface (per §4.3):
- `POST /api/v1/accounts` accepts optional `opening_balance` (default 0) + `opening_balance_date` (default today).
- `PUT /api/v1/accounts/{id}` edits both, audit-logged when either field changes.
- `GET /api/v1/accounts/{id}` exposes both on the response shape.

UI:
- Create form: two new fields with helper text "Your account's starting amount. Leave at 0 if you don't know."
- Edit form: two new fields, inline.
- Account list row: shows "Opening: NN.NN since YYYY-MM-DD" only when opening_balance is non-zero (the 0-backfill stays quiet).

## Migration number + chain
- **Number: 041_opening_balance**
- **down_revision: `040_users_email_case_insensitive`**
- **Reconciliation UI (Wave 2B) chains off 041.** That team should set `down_revision = "041_opening_balance"` in their migration.

DDL note: `opening_balance_date` default uses `(CURRENT_DATE)` on MySQL 8 (parens required for function defaults) and `CURRENT_DATE` on SQLite. Dialect branching is inside the migration.

## Contract — canonical backfill (locked 2026-05-12 in §4.4)
> Migration sets `opening_balance = 0` for ALL existing accounts. Users adjust to their actual starting balance via the Opening Balance UI (Wave 2A) after migration. No derived formula.

This is what shipped. Defensive post-DDL `UPDATE accounts SET opening_balance = 0 WHERE opening_balance IS NULL` is the belt-and-braces guarantee on top of the column-level `DEFAULT 0`.

## Security
- `PUT /api/v1/accounts/{id}` writes an `account.opening_balance.update` audit row (via `audit_service.record_audit_event` against an independent session) whenever `opening_balance` or `opening_balance_date` actually changes. No-op PUTs (same value, or fields omitted) write nothing.
- Schema-level range guards on both `AccountCreate.opening_balance` and `AccountUpdate.opening_balance` keep `Numeric(12,2)` overflow off the DB layer (422 instead of 500).
- All existing org-scoping on `/api/v1/accounts/*` is preserved — opening fields ride on top of the same `current_user.org_id` filter.

## Test evidence
- Backend full suite: **944 passed, 4 skipped, 0 failures** (`docker compose -p team-opening-balance exec backend pytest`).
- Frontend full suite: **659 passed** (`npm test -- --run`).
- `tsc --noEmit`: clean.
- `eslint app/accounts/page.tsx lib/types.ts`: clean (1 pre-existing warning unrelated to this PR).
- Migration up + down + up cycle verified in isolated MySQL stack (alembic at `041_opening_balance`).
- **§4.4 backfill assertion:** `SELECT COUNT(*) FROM accounts WHERE opening_balance != 0` → `0` post-upgrade (regression-gated by `backend/tests/migrations/test_041_opening_balance.py`).

New test files:
- `backend/tests/test_account_opening_balance.py` — 8 tests covering create defaults, create explicit, create overflow guard, get exposes fields, update audit row, update no-op no audit, update omitting fields untouched, update overflow guard.
- `backend/tests/migrations/test_041_opening_balance.py` — 2 MySQL-only tests covering canonical backfill and column types.

## Out of scope
- Suggested-balance helper (§4.3 footnote) — not implemented; would need its own UX cycle.
- `account.balance` computation changes (§4.2 leaves this to `AccountBalanceForecastService` as a separate Wave 2A integration call; not this migration's job).
- Transfer-leg exclusion math (spec §4.4 explicitly removed this concern under the 0-backfill lock).
- Wave 2B (`reconciliation_state`, `import_batches`).

## File layout
- Migration: `backend/alembic/versions/041_opening_balance.py`
- Model: `backend/app/models/account.py`
- Schema: `backend/app/schemas/account.py`
- Router: `backend/app/routers/accounts.py`
- Frontend type: `frontend/lib/types.ts`
- Frontend UI: `frontend/app/accounts/page.tsx`