### PR TITLE
feat(transactions): manual batch entry endpoint + grid UI (L3.2 Wave 2A)

### DIFF
--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -1,15 +1,20 @@
 import datetime
-from typing import Literal
+from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+)
 
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models.account import Account
 from app.models.transaction import TransactionType
 from app.models.user import User
+from app.rate_limit import get_client_ip
 from app.schemas.import_batch import (
     BatchTransactionsRequest,
     BatchTransactionsResponse,
@@ -31,8 +36,17 @@ from app.schemas.transaction import (
 from app.schemas.transaction_suggestions import (
     DescriptionSuggestionsResponse,
 )
-from app.services import transaction_service as svc
+from app.services import (
+    audit_service,
+    transaction_batch_service,
+    transaction_service as svc,
+)
 from app.services.exceptions import NotFoundError, ValidationError
+
+
+def _request_id() -> Optional[str]:
+    """Return the structlog-bound request_id, if any."""
+    return structlog.contextvars.get_contextvars().get("request_id")
 
 router = APIRouter(prefix="/api/v1/transactions", tags=["transactions"])
 
@@ -271,35 +285,69 @@ async def transfer_candidates(
 @router.post(
     "/batch",
     response_model=BatchTransactionsResponse,
-    status_code=501,
+    status_code=200,
 )
 async def batch_create_transactions(
     body: BatchTransactionsRequest,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(
+        get_session_factory
+    ),
 ):
-    """**STUB** — Manual batch transaction entry, Wave 2 deliverable.
+    """Manual batch transaction entry (L3.2 Wave 2A).
 
-    Contract: accept ``list[TransactionCreate]`` (wrapped in
-    ``BatchTransactionRow`` with a stable ``row_number``), process each
-    row in its own savepoint, return per-row results + aggregate counters.
-    Rows are NOT flagged ``is_imported`` — they're user-typed, not bank
-    sourced.
+    Accepts up to 500 rows, each wrapped in ``BatchTransactionRow`` with
+    a stable ``row_number``. Each row is processed inside its own
+    savepoint; failures roll back that one savepoint and surface as a
+    ``BatchRowError`` while surviving rows commit on the outer
+    transaction at the end of the request.
+
+    Rows are user-typed, NOT imported — ``is_imported=False``. Per-row
+    validation mirrors the single-row ``POST /api/v1/transactions``
+    path (account + category org-scope, category-type compatibility,
+    amount/date bounds enforced by the shared ``TransactionCreate``
+    schema). Duplicate ``row_number`` values are rejected with 422 at
+    schema validation time (validator on
+    ``BatchTransactionsRequest``).
+
+    One audit event is emitted per batch invocation summarizing
+    imported / error counts. The audit row is written in its own
+    transaction (``record_audit_event``) so it persists even if the
+    outer commit fails midway — matching the audit semantics elsewhere
+    in the codebase.
 
     Frozen contract: see spec at
     ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
-    §0.2 (Manual batch entry shape) and ``app/schemas/import_batch.py``.
-
-    Wave 2 Manual Batch Entry team owns implementation.
+    §0.2 and ``app/schemas/import_batch.py``.
     """
-    _ = (current_user.org_id, db, len(body.rows))
-    raise HTTPException(
-        status_code=501,
-        detail=(
-            "Batch transaction entry not implemented — see L3.2 dispatch "
-            "(specs/2026-05-12-l3-2-import-contracts.md §0.2)"
-        ),
+    response = await transaction_batch_service.create_batch(
+        db, current_user.org_id, body
     )
+    await db.commit()
+
+    # One audit event per batch invocation. Carries counters + the
+    # length of the input list so a future regression in the request
+    # parser (e.g. silent row truncation) is visible in the audit log.
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="transactions.batch_create",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=current_user.org_id,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success" if response.error_count == 0 else "failure",
+        detail={
+            "row_count": len(body.rows),
+            "imported_count": response.imported_count,
+            "error_count": response.error_count,
+        },
+    )
+
+    return response
 
 
 @router.get(

--- a/backend/app/services/transaction_batch_service.py
+++ b/backend/app/services/transaction_batch_service.py
@@ -1,0 +1,161 @@
+"""Manual batch transaction entry service (L3.2 Wave 2A).
+
+Implements ``POST /api/v1/transactions/batch``. Rows are user-typed (not
+imported from a bank file) and therefore land with ``is_imported=False``.
+Each row runs inside its own ``db.begin_nested()`` savepoint so a single
+failing row doesn't take down the rest of the batch — failures are
+collected into a per-row error list and returned to the caller.
+
+The endpoint sits outside the import router by design (see spec
+§0.2 in ``2026-05-12-l3-2-import-contracts.md``): manual batch entry
+doesn't go through file preview, transfer detection, or
+duplicate-of-linked-leg checks. Per-row validation mirrors the
+single-row ``create_transaction`` path (account + category org-scope,
+category-type compatibility, amount/date bounds enforced by the
+shared ``TransactionCreate`` schema).
+
+Smart-rules learning runs best-effort AFTER each successful row's
+savepoint commits — mirroring the single-row create path — so a
+learn failure on row N never poisons rows N+1..M.
+"""
+from __future__ import annotations
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.import_batch import (
+    BatchRowError,
+    BatchRowResult,
+    BatchTransactionsRequest,
+    BatchTransactionsResponse,
+)
+from app.services import transaction_service
+from app.services.exceptions import (
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
+from app.services.category_rules_service import learn_from_choice
+
+logger = structlog.stdlib.get_logger()
+
+
+def _error_message(exc: Exception) -> str:
+    """Render a service-layer exception as a flat human-readable string.
+
+    The domain exceptions (``ValidationError``, ``NotFoundError``,
+    ``ConflictError``) carry either a ``detail`` attribute or a plain
+    ``args[0]`` message; normalize them so the response payload stays
+    a flat ``{"row_number": int, "error": str}`` shape. Unexpected
+    exceptions surface as a generic message so we never leak SQL
+    state or stack frames to the client.
+    """
+    if isinstance(exc, (ValidationError, ConflictError)):
+        detail = getattr(exc, "detail", None)
+        if isinstance(detail, str):
+            return detail
+        if detail is not None:
+            return str(detail)
+        return str(exc) or exc.__class__.__name__
+    if isinstance(exc, NotFoundError):
+        return str(exc) or "not found"
+    return "Internal error processing row"
+
+
+async def create_batch(
+    db: AsyncSession,
+    org_id: int,
+    body: BatchTransactionsRequest,
+) -> BatchTransactionsResponse:
+    """Process a manual batch entry request.
+
+    Per-row contract:
+      * Each row gets its own ``db.begin_nested()`` savepoint.
+      * Validation errors / conflicts / not-found errors are caught,
+        the savepoint rolls back, and a ``BatchRowError`` is appended.
+      * Unexpected exceptions are logged and surface as a generic
+        per-row error (never as a 500 — one bad row must not kill
+        the batch).
+      * Successful rows are flushed inside the savepoint, then the
+        savepoint commits and the row's ID is appended to ``results``.
+
+    Smart-rules learning runs OUTSIDE the per-row savepoint after each
+    successful insert, best-effort, to match the single-row create
+    semantics. A learn failure is logged but never bubbles up.
+
+    The caller (the router) owns the outer transaction's final
+    ``db.commit()``. Returning the response object signals success;
+    the router commits once at the end so all surviving rows land
+    atomically from the client's perspective.
+    """
+    results: list[BatchRowResult] = []
+    errors: list[BatchRowError] = []
+
+    for row in body.rows:
+        try:
+            async with db.begin_nested():
+                tx = await transaction_service._create_transaction_no_commit(
+                    db,
+                    org_id,
+                    row.transaction,
+                    is_imported=False,
+                )
+            results.append(
+                BatchRowResult(row_number=row.row_number, transaction_id=tx.id)
+            )
+        except (ValidationError, ConflictError, NotFoundError) as exc:
+            errors.append(
+                BatchRowError(
+                    row_number=row.row_number,
+                    error=_error_message(exc),
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive: log + continue.
+            await logger.aerror(
+                "transactions.batch.row_unexpected_error",
+                org_id=org_id,
+                row_number=row.row_number,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            errors.append(
+                BatchRowError(
+                    row_number=row.row_number,
+                    error=_error_message(exc),
+                )
+            )
+
+    # Best-effort smart-rules learning per committed row. Each learn
+    # runs in its OWN savepoint so a learn failure only rolls back its
+    # own staged rule (not the row it would have learned from, and
+    # never another row). This mirrors the single-row create path's
+    # try/except-around-learn semantics while staying compatible with
+    # the outer transaction the router will commit at the end.
+    for result in results:
+        try:
+            async with db.begin_nested():
+                tx = await transaction_service.get_transaction(
+                    db, org_id, result.transaction_id
+                )
+                await learn_from_choice(
+                    db,
+                    org_id=org_id,
+                    description=tx.description,
+                    category_id=tx.category_id,
+                    source="user_edit",
+                )
+        except Exception as exc:  # noqa: BLE001 — best effort.
+            await logger.awarning(
+                "transactions.batch.learn_failed",
+                org_id=org_id,
+                row_id=result.transaction_id,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+
+    return BatchTransactionsResponse(
+        imported_count=len(results),
+        error_count=len(errors),
+        results=results,
+        errors=errors,
+    )

--- a/backend/tests/routers/test_import_contracts.py
+++ b/backend/tests/routers/test_import_contracts.py
@@ -31,7 +31,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import StaticPool
 
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models import Base
 from app.models.user import Organization, Role, User
 from app.routers.import_router import router as import_router
@@ -108,6 +108,12 @@ def _make_app(session_factory, *, authenticated: bool = True) -> FastAPI:
         app.dependency_overrides[get_current_user] = reject_user
 
     app.dependency_overrides[get_db] = override_get_db
+    # Audit writes go through ``record_audit_event(session_factory, ...)``
+    # which opens its own transaction. Point that factory at the same
+    # in-memory engine the rest of the test uses so audit rows land in
+    # the same DB (and a missing override doesn't silently surface as
+    # a 500 in the new manual-batch path).
+    app.dependency_overrides[get_session_factory] = lambda: session_factory
 
     # Wire the same domain exception handlers main.py installs so the
     # Pydantic 422 / domain-error mapping is identical to production.
@@ -247,8 +253,14 @@ async def test_reconcile_validates_extra_fields_forbidden(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_batch_returns_501_when_authenticated(session_factory):
-    """Batch endpoint returns 501."""
+async def test_batch_returns_200_with_per_row_errors(session_factory):
+    """Batch endpoint is implemented: returns 200 with per-row outcomes.
+
+    Calling with an account_id / category_id that doesn't exist in the
+    seeded org returns a per-row error rather than a 5xx. The endpoint
+    now lives — the previous 501 contract gate is replaced by a
+    per-row outcome assertion.
+    """
     await _seed_user(session_factory)
     app = _make_app(session_factory)
     payload = {
@@ -268,8 +280,11 @@ async def test_batch_returns_501_when_authenticated(session_factory):
     }
     with TestClient(app) as client:
         resp = client.post("/api/v1/transactions/batch", json=payload)
-    assert resp.status_code == 501
-    assert "not implemented" in resp.json()["detail"].lower()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["imported_count"] == 0
+    assert body["error_count"] == 1
+    assert body["errors"][0]["row_number"] == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_transaction_batch_service.py
+++ b/backend/tests/services/test_transaction_batch_service.py
@@ -1,0 +1,312 @@
+"""Tests for the manual batch transaction entry service (L3.2 Wave 2A).
+
+Pins the savepoint isolation invariant: a failing row rolls back its
+own savepoint without taking down the rest of the batch. Also covers
+the happy path and the not-found / org-scope error surfaces.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.transaction import Transaction
+from app.schemas.import_batch import (
+    BatchTransactionRow,
+    BatchTransactionsRequest,
+)
+from app.schemas.transaction import TransactionCreate
+from app.services.transaction_batch_service import create_batch
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession) -> dict:
+    """Seed two orgs (cross-org isolation tests), an account, and
+    expense + income categories."""
+    org = Organization(name="Primary", billing_cycle_day=1)
+    other = Organization(name="Other", billing_cycle_day=1)
+    db.add_all([org, other])
+    await db.flush()
+
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True
+    )
+    db.add(at)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, name="Cash", account_type_id=at.id,
+        balance=Decimal("1000.00"), currency="EUR",
+    )
+    other_at = AccountType(
+        org_id=other.id, name="Checking", slug="checking", is_system=True
+    )
+    db.add(other_at)
+    await db.flush()
+    other_acct = Account(
+        org_id=other.id, name="Other Cash", account_type_id=other_at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add_all([acct, other_acct])
+    await db.flush()
+
+    expense_cat = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        type=CategoryType.EXPENSE,
+    )
+    income_cat = Category(
+        org_id=org.id, name="Salary", slug="salary",
+        type=CategoryType.INCOME,
+    )
+    db.add_all([expense_cat, income_cat])
+    await db.commit()
+
+    return {
+        "org_id": org.id,
+        "other_org_id": other.id,
+        "account_id": acct.id,
+        "other_account_id": other_acct.id,
+        "expense_cat_id": expense_cat.id,
+        "income_cat_id": income_cat.id,
+    }
+
+
+def _row(
+    n: int,
+    *,
+    account_id: int,
+    category_id: int,
+    amount: str = "10.00",
+    description: str | None = None,
+    tx_type: str = "expense",
+) -> BatchTransactionRow:
+    return BatchTransactionRow(
+        row_number=n,
+        transaction=TransactionCreate(
+            account_id=account_id,
+            category_id=category_id,
+            description=description or f"Row {n}",
+            amount=Decimal(amount),
+            type=tx_type,
+            date=date(2026, 5, 10),
+        ),
+    )
+
+
+async def test_create_batch_happy_path_ten_rows(db_session):
+    """All ten rows commit, response counters match, savepoint commits
+    persist on the outer transaction."""
+    seed = await _seed(db_session)
+    rows = [
+        _row(i, account_id=seed["account_id"], category_id=seed["expense_cat_id"])
+        for i in range(1, 11)
+    ]
+    body = BatchTransactionsRequest(rows=rows)
+
+    response = await create_batch(db_session, seed["org_id"], body)
+    await db_session.commit()
+
+    assert response.imported_count == 10
+    assert response.error_count == 0
+    assert len(response.results) == 10
+    assert [r.row_number for r in response.results] == list(range(1, 11))
+
+    # All ten rows are visible on the outer transaction.
+    found = (await db_session.execute(
+        select(Transaction).where(Transaction.org_id == seed["org_id"])
+    )).scalars().all()
+    assert len(found) == 10
+
+
+async def test_create_batch_partial_success_isolates_failing_row(db_session):
+    """A row referencing a non-existent category fails; the surrounding
+    rows commit. Savepoint rollback must not poison subsequent rows."""
+    seed = await _seed(db_session)
+    rows = [
+        _row(1, account_id=seed["account_id"], category_id=seed["expense_cat_id"]),
+        # Row 2: category_id 999_999 doesn't exist → ValidationError.
+        _row(2, account_id=seed["account_id"], category_id=999_999),
+        _row(3, account_id=seed["account_id"], category_id=seed["expense_cat_id"]),
+    ]
+    body = BatchTransactionsRequest(rows=rows)
+
+    response = await create_batch(db_session, seed["org_id"], body)
+    await db_session.commit()
+
+    assert response.imported_count == 2
+    assert response.error_count == 1
+    assert {r.row_number for r in response.results} == {1, 3}
+    assert response.errors[0].row_number == 2
+    assert response.errors[0].error  # human-readable, non-empty
+
+    # Surviving rows committed; bad row left no transaction behind.
+    descs = sorted([
+        t.description
+        for t in (await db_session.execute(
+            select(Transaction).where(Transaction.org_id == seed["org_id"])
+        )).scalars()
+    ])
+    assert descs == ["Row 1", "Row 3"]
+
+
+async def test_create_batch_rejects_cross_org_account(db_session):
+    """A row pointing at another org's account fails with a per-row
+    error. No leakage across the org boundary."""
+    seed = await _seed(db_session)
+    rows = [
+        _row(
+            1,
+            account_id=seed["other_account_id"],
+            category_id=seed["expense_cat_id"],
+        ),
+    ]
+    body = BatchTransactionsRequest(rows=rows)
+
+    response = await create_batch(db_session, seed["org_id"], body)
+    await db_session.commit()
+
+    assert response.imported_count == 0
+    assert response.error_count == 1
+    assert response.errors[0].row_number == 1
+
+
+async def test_create_batch_rejects_cross_org_category(db_session):
+    """A category that exists in a sibling org is invisible — fails
+    org-scope validation."""
+    seed = await _seed(db_session)
+    # Stash a category in the OTHER org.
+    other_cat = Category(
+        org_id=seed["other_org_id"],
+        name="Their Groceries",
+        slug="their-groceries",
+        type=CategoryType.EXPENSE,
+    )
+    db_session.add(other_cat)
+    await db_session.commit()
+
+    rows = [
+        _row(
+            1,
+            account_id=seed["account_id"],
+            category_id=other_cat.id,
+        ),
+    ]
+    body = BatchTransactionsRequest(rows=rows)
+
+    response = await create_batch(db_session, seed["org_id"], body)
+    await db_session.commit()
+
+    assert response.imported_count == 0
+    assert response.error_count == 1
+
+
+async def test_create_batch_rejects_category_type_mismatch(db_session):
+    """An income transaction tagged with an expense-only category fails
+    at the type guard."""
+    seed = await _seed(db_session)
+    rows = [
+        _row(
+            1,
+            account_id=seed["account_id"],
+            category_id=seed["expense_cat_id"],
+            tx_type="income",
+        ),
+        # Valid expense row alongside — partial success.
+        _row(
+            2,
+            account_id=seed["account_id"],
+            category_id=seed["expense_cat_id"],
+            tx_type="expense",
+        ),
+    ]
+    body = BatchTransactionsRequest(rows=rows)
+
+    response = await create_batch(db_session, seed["org_id"], body)
+    await db_session.commit()
+
+    assert response.imported_count == 1
+    assert response.error_count == 1
+    assert response.errors[0].row_number == 1
+    assert response.results[0].row_number == 2
+
+
+async def test_create_batch_rows_are_not_imported(db_session):
+    """Manual batch rows MUST land with ``is_imported=False`` — they
+    are user-typed, not bank-sourced (per spec §0.2)."""
+    seed = await _seed(db_session)
+    rows = [
+        _row(1, account_id=seed["account_id"], category_id=seed["expense_cat_id"]),
+    ]
+    body = BatchTransactionsRequest(rows=rows)
+
+    response = await create_batch(db_session, seed["org_id"], body)
+    await db_session.commit()
+
+    assert response.imported_count == 1
+    tx = (await db_session.execute(
+        select(Transaction).where(
+            Transaction.id == response.results[0].transaction_id
+        )
+    )).scalar_one()
+    assert tx.is_imported is False
+
+
+async def test_create_batch_updates_account_balance(db_session):
+    """Savepoint-committed rows apply balance updates exactly like the
+    single-row create path. Three EUR 10 expenses on a EUR 1000 account
+    must drop the balance to EUR 970."""
+    seed = await _seed(db_session)
+    rows = [
+        _row(
+            i,
+            account_id=seed["account_id"],
+            category_id=seed["expense_cat_id"],
+        )
+        for i in range(1, 4)
+    ]
+    body = BatchTransactionsRequest(rows=rows)
+
+    response = await create_batch(db_session, seed["org_id"], body)
+    await db_session.commit()
+
+    assert response.imported_count == 3
+    acct = (await db_session.execute(
+        select(Account).where(Account.id == seed["account_id"])
+    )).scalar_one()
+    assert acct.balance == Decimal("970.00")
+
+
+pytestmark = pytest.mark.asyncio

--- a/frontend/app/transactions/batch/page.tsx
+++ b/frontend/app/transactions/batch/page.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+/**
+ * Manual batch transaction entry (L3.2 Wave 2A).
+ *
+ * Spreadsheet-style grid (5 default empty rows) where the user types a
+ * handful of receipts at once and submits as a single request. The
+ * backend processes each row in its own savepoint so partial-success
+ * is the contract: surviving rows commit, failing rows surface a
+ * per-row error icon next to the row.
+ *
+ * UX:
+ *  - Default state: 5 empty rows (matches the spec's "5-10 visible"
+ *    target). "+ Add row" appends; per-row trash icon removes (down to
+ *    a floor of 1 row, since min_length=1 on the request shape).
+ *  - Keyboard nav: Tab moves to the next cell. Pressing Enter inside
+ *    the last field of the last row appends a new row and focuses
+ *    its first field. Shift+Tab walks backward.
+ *  - Validation is client-side first (each cell must be filled before
+ *    submit), then server-side per-row on submit. Per-row errors
+ *    render inline beside the row's status column.
+ *  - Submit is disabled while any row is missing a required cell,
+ *    while the request is in flight, and after submit until the user
+ *    resets the form or navigates away. We do NOT auto-retry — partial
+ *    success means the user can clear the bad rows and submit again.
+ */
+
+import {
+  KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Link from "next/link";
+import AppShell from "@/components/AppShell";
+import CategorySelect from "@/components/ui/CategorySelect";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { todayISO } from "@/lib/format";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  label,
+  pageTitle,
+  success as successCls,
+} from "@/lib/styles";
+import type {
+  Account,
+  BatchTransactionRowInput,
+  BatchTransactionsResponse,
+  Category,
+} from "@/lib/types";
+
+const DEFAULT_ROW_COUNT = 5;
+const MAX_ROWS = 500;
+
+// Stable client-side row identity. ``row_number`` shipped to the API is
+// derived from array index on submit (1-based), but inside the form we
+// need a non-changing key so React doesn't lose focus when the user
+// removes a row above the cursor.
+type DraftStatus = "idle" | "ok" | "error";
+
+interface DraftRow {
+  key: string;
+  date: string;
+  description: string;
+  amount: string;
+  type: "expense" | "income";
+  account_id: number | "";
+  category_id: number | "";
+  status: DraftStatus;
+  errorMessage?: string;
+}
+
+function blankRow(): DraftRow {
+  return {
+    key: crypto.randomUUID(),
+    date: todayISO(),
+    description: "",
+    amount: "",
+    type: "expense",
+    account_id: "",
+    category_id: "",
+    status: "idle",
+  };
+}
+
+function rowIsBlank(row: DraftRow): boolean {
+  return (
+    !row.description.trim() &&
+    !row.amount.trim() &&
+    row.account_id === "" &&
+    row.category_id === ""
+  );
+}
+
+function rowIsValid(row: DraftRow): boolean {
+  if (!row.date) return false;
+  if (!row.description.trim()) return false;
+  if (!row.amount.trim()) return false;
+  const amt = Number(row.amount);
+  if (!Number.isFinite(amt) || amt <= 0) return false;
+  if (row.account_id === "") return false;
+  if (row.category_id === "") return false;
+  return true;
+}
+
+export default function BatchEntryPage() {
+  const [rows, setRows] = useState<DraftRow[]>(() =>
+    Array.from({ length: DEFAULT_ROW_COUNT }, blankRow),
+  );
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [topError, setTopError] = useState("");
+  const [summary, setSummary] = useState<{
+    imported: number;
+    errored: number;
+  } | null>(null);
+
+  // Ref for the first cell of the most-recently-added row so we can
+  // focus it after "+ Add row" / Enter-to-extend.
+  const newRowFocusRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [acctList, catList] = await Promise.all([
+          apiFetch<Account[]>("/api/v1/accounts"),
+          apiFetch<Category[]>("/api/v1/categories"),
+        ]);
+        setAccounts(acctList.filter((a) => a.is_active));
+        setCategories(catList);
+      } catch (err) {
+        setTopError(extractErrorMessage(err, "Failed to load accounts"));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const populatedRows = useMemo(
+    () => rows.filter((r) => !rowIsBlank(r)),
+    [rows],
+  );
+
+  const submitEnabled = useMemo(() => {
+    if (submitting) return false;
+    if (populatedRows.length === 0) return false;
+    return populatedRows.every(rowIsValid);
+  }, [populatedRows, submitting]);
+
+  function updateRow(idx: number, patch: Partial<DraftRow>) {
+    setRows((prev) => {
+      const next = [...prev];
+      next[idx] = { ...next[idx], ...patch, status: "idle", errorMessage: undefined };
+      return next;
+    });
+  }
+
+  function addRow() {
+    if (rows.length >= MAX_ROWS) return;
+    const fresh = blankRow();
+    setRows((prev) => [...prev, fresh]);
+    // Focus the new row's first cell on the next tick.
+    setTimeout(() => {
+      newRowFocusRef.current?.focus();
+    }, 0);
+  }
+
+  function removeRow(idx: number) {
+    setRows((prev) => {
+      if (prev.length <= 1) return prev;
+      return prev.filter((_, i) => i !== idx);
+    });
+  }
+
+  function handleRowKeyDown(
+    e: KeyboardEvent<HTMLInputElement | HTMLSelectElement>,
+    idx: number,
+    isLastCell: boolean,
+  ) {
+    // Enter on the last cell of the last row adds a new row and moves
+    // focus to its first field. This mirrors spreadsheet ergonomics.
+    if (e.key === "Enter" && isLastCell && idx === rows.length - 1) {
+      e.preventDefault();
+      addRow();
+    }
+  }
+
+  async function handleSubmit() {
+    setTopError("");
+    setSummary(null);
+    if (populatedRows.length === 0) return;
+
+    // Map populated rows to API payload. row_number is 1-based and
+    // unique per-row across the request (the validator on
+    // BatchTransactionsRequest rejects duplicates with 422).
+    const payload: { rows: BatchTransactionRowInput[] } = {
+      rows: populatedRows.map((row, i) => ({
+        row_number: i + 1,
+        transaction: {
+          account_id: row.account_id as number,
+          category_id: row.category_id as number,
+          description: row.description.trim(),
+          amount: row.amount,
+          type: row.type,
+          date: row.date,
+        },
+      })),
+    };
+
+    setSubmitting(true);
+    try {
+      const resp = await apiFetch<BatchTransactionsResponse>(
+        "/api/v1/transactions/batch",
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+      );
+      // Splat results back onto the populated rows by row_number so
+      // success/error icons land on the right grid row.
+      setRows((prev) => {
+        const next = [...prev];
+        // Build (populated index → row_number) map.
+        const populatedKeys = populatedRows.map((r) => r.key);
+        const okSet = new Set(resp.results.map((r) => r.row_number));
+        const errMap = new Map(
+          resp.errors.map((e) => [e.row_number, e.error]),
+        );
+        for (const [key, rowNumber] of populatedKeys.map(
+          (k, i) => [k, i + 1] as const,
+        )) {
+          const realIdx = next.findIndex((r) => r.key === key);
+          if (realIdx < 0) continue;
+          if (okSet.has(rowNumber)) {
+            next[realIdx] = { ...next[realIdx], status: "ok", errorMessage: undefined };
+          } else if (errMap.has(rowNumber)) {
+            next[realIdx] = {
+              ...next[realIdx],
+              status: "error",
+              errorMessage: errMap.get(rowNumber)!,
+            };
+          }
+        }
+        return next;
+      });
+      setSummary({ imported: resp.imported_count, errored: resp.error_count });
+    } catch (err) {
+      setTopError(extractErrorMessage(err, "Batch submit failed"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function resetForm() {
+    setRows(Array.from({ length: DEFAULT_ROW_COUNT }, blankRow));
+    setSummary(null);
+    setTopError("");
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-8 flex items-center justify-between">
+        <h1 className={`${pageTitle} mb-0`}>Batch entry</h1>
+        <div className="flex items-center gap-2">
+          <Link href="/transactions" className={btnSecondary}>
+            Back to transactions
+          </Link>
+        </div>
+      </div>
+
+      <p className="mb-6 max-w-2xl text-sm text-text-muted">
+        Type a handful of receipts at once. Each row commits independently,
+        so a typo in one row never blocks the rest of the batch. Press Tab
+        to move between cells. Press Enter on the last cell of the last
+        row to add another row.
+      </p>
+
+      {topError && <div className={`mb-6 ${errorCls}`}>{topError}</div>}
+
+      {summary && (
+        <div
+          className={`mb-6 ${summary.errored === 0 ? successCls : errorCls}`}
+          role="status"
+          aria-live="polite"
+        >
+          {summary.imported} row{summary.imported === 1 ? "" : "s"} imported
+          {summary.errored > 0 && (
+            <>
+              , {summary.errored} row{summary.errored === 1 ? "" : "s"}{" "}
+              failed. See the per-row messages below.
+            </>
+          )}
+          .
+        </div>
+      )}
+
+      <div className={`${card} overflow-hidden`}>
+        <div className={`${cardHeader} flex items-center justify-between`}>
+          <h2 className={cardTitle}>
+            <span aria-live="polite">
+              {populatedRows.length} of {rows.length} row
+              {rows.length === 1 ? "" : "s"} filled
+            </span>
+          </h2>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={addRow}
+              className={btnSecondary}
+              disabled={rows.length >= MAX_ROWS}
+            >
+              + Add row
+            </button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="p-6 text-sm text-text-muted">Loading…</div>
+        ) : accounts.length === 0 ? (
+          <div className="p-6 text-sm text-text-muted">
+            No active accounts. Add an account first from{" "}
+            <Link href="/accounts" className="underline">
+              Accounts
+            </Link>
+            .
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" role="grid" aria-label="Batch entry grid">
+              <thead>
+                <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+                  <th className="w-6 px-2 py-2"></th>
+                  <th className={`${label} w-32 px-2 py-2`}>Date</th>
+                  <th className={`${label} w-64 px-2 py-2`}>Description</th>
+                  <th className={`${label} w-28 px-2 py-2`}>Amount</th>
+                  <th className={`${label} w-28 px-2 py-2`}>Type</th>
+                  <th className={`${label} w-44 px-2 py-2`}>Account</th>
+                  <th className={`${label} w-44 px-2 py-2`}>Category</th>
+                  <th className={`${label} w-32 px-2 py-2`}>Status</th>
+                  <th className="w-10 px-2 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, idx) => {
+                  const isLast = idx === rows.length - 1;
+                  const isNewest =
+                    idx === rows.length - 1 && rows.length > DEFAULT_ROW_COUNT;
+                  return (
+                    <tr
+                      key={row.key}
+                      className="border-b border-border last:border-b-0"
+                      data-row-index={idx}
+                    >
+                      <td className="px-2 py-2 text-xs text-text-muted">
+                        {idx + 1}
+                      </td>
+                      <td className="px-2 py-2">
+                        <input
+                          type="date"
+                          className={input}
+                          value={row.date}
+                          onChange={(e) =>
+                            updateRow(idx, { date: e.target.value })
+                          }
+                          aria-label={`Row ${idx + 1} date`}
+                          ref={isNewest ? newRowFocusRef : undefined}
+                        />
+                      </td>
+                      <td className="px-2 py-2">
+                        <input
+                          type="text"
+                          className={input}
+                          value={row.description}
+                          placeholder="e.g. Coffee shop"
+                          onChange={(e) =>
+                            updateRow(idx, { description: e.target.value })
+                          }
+                          aria-label={`Row ${idx + 1} description`}
+                          maxLength={255}
+                        />
+                      </td>
+                      <td className="px-2 py-2">
+                        <input
+                          type="number"
+                          step="0.01"
+                          min="0.01"
+                          className={input}
+                          value={row.amount}
+                          placeholder="0.00"
+                          onChange={(e) =>
+                            updateRow(idx, { amount: e.target.value })
+                          }
+                          aria-label={`Row ${idx + 1} amount`}
+                        />
+                      </td>
+                      <td className="px-2 py-2">
+                        <select
+                          className={input}
+                          value={row.type}
+                          onChange={(e) =>
+                            updateRow(idx, {
+                              type: e.target.value as "expense" | "income",
+                              // Type change invalidates current category; clear it.
+                              category_id: "",
+                            })
+                          }
+                          aria-label={`Row ${idx + 1} type`}
+                        >
+                          <option value="expense">Expense</option>
+                          <option value="income">Income</option>
+                        </select>
+                      </td>
+                      <td className="px-2 py-2">
+                        <select
+                          className={input}
+                          value={row.account_id === "" ? "" : String(row.account_id)}
+                          onChange={(e) =>
+                            updateRow(idx, {
+                              account_id:
+                                e.target.value === ""
+                                  ? ""
+                                  : Number(e.target.value),
+                            })
+                          }
+                          aria-label={`Row ${idx + 1} account`}
+                        >
+                          <option value="">Pick account…</option>
+                          {accounts.map((a) => (
+                            <option key={a.id} value={a.id}>
+                              {a.name}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-2 py-2">
+                        <CategorySelect
+                          id={`row-${row.key}-category`}
+                          categories={categories}
+                          value={row.category_id}
+                          onChange={(cid) =>
+                            updateRow(idx, { category_id: cid })
+                          }
+                          filterType={row.type}
+                          aria-label={`Row ${idx + 1} category`}
+                        />
+                      </td>
+                      <td className="px-2 py-2">
+                        {row.status === "ok" && (
+                          <span
+                            className="inline-flex items-center gap-1 text-success"
+                            aria-label={`Row ${idx + 1} imported`}
+                          >
+                            <span aria-hidden>✓</span> Imported
+                          </span>
+                        )}
+                        {row.status === "error" && (
+                          <span
+                            className="inline-flex items-start gap-1 text-danger"
+                            role="alert"
+                          >
+                            <span aria-hidden>✕</span>
+                            <span className="text-xs">{row.errorMessage}</span>
+                          </span>
+                        )}
+                        {row.status === "idle" && !rowIsBlank(row) && (
+                          rowIsValid(row) ? (
+                            <span className="text-xs text-text-muted">Ready</span>
+                          ) : (
+                            <span className="text-xs text-warning">
+                              Fill all cells
+                            </span>
+                          )
+                        )}
+                      </td>
+                      <td className="px-2 py-2">
+                        <button
+                          type="button"
+                          onClick={() => removeRow(idx)}
+                          className="text-text-muted hover:text-danger"
+                          aria-label={`Remove row ${idx + 1}`}
+                          disabled={rows.length <= 1}
+                          onKeyDown={(e) =>
+                            handleRowKeyDown(
+                              e as unknown as KeyboardEvent<HTMLInputElement>,
+                              idx,
+                              isLast,
+                            )
+                          }
+                        >
+                          ✕
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6 flex items-center justify-end gap-2">
+        {summary && (
+          <button type="button" onClick={resetForm} className={btnSecondary}>
+            Clear and start over
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className={btnPrimary}
+          disabled={!submitEnabled}
+        >
+          {submitting
+            ? "Submitting…"
+            : `Submit ${populatedRows.length || ""} row${
+                populatedRows.length === 1 ? "" : "s"
+              }`.trim()}
+        </button>
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -931,6 +931,9 @@ function TransactionsPageContent() {
               {showForm ? "Cancel" : "+ New Transaction"}
             </button>
           )}
+          <Link href="/transactions/batch" className={btnSecondary}>
+            Batch entry
+          </Link>
           <Link href="/import" className={btnSecondary}>
             Import
           </Link>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -264,6 +264,43 @@ export interface ImportConfirmResponse {
   errors: ImportRowError[];
 }
 
+// L3.2 Wave 2A manual batch transaction entry. Wraps a TransactionCreate
+// payload with a stable row_number for per-row outcome mapping.
+export interface BatchTransactionRowInput {
+  row_number: number;
+  transaction: {
+    account_id: number;
+    category_id: number;
+    description: string;
+    amount: string;
+    type: "income" | "expense";
+    date: string;
+    status?: "settled" | "pending";
+    settled_date?: string | null;
+  };
+}
+
+export interface BatchTransactionsRequestBody {
+  rows: BatchTransactionRowInput[];
+}
+
+export interface BatchRowResult {
+  row_number: number;
+  transaction_id: number;
+}
+
+export interface BatchRowError {
+  row_number: number;
+  error: string;
+}
+
+export interface BatchTransactionsResponse {
+  imported_count: number;
+  error_count: number;
+  results: BatchRowResult[];
+  errors: BatchRowError[];
+}
+
 export interface Plan {
   id: number;
   name: string;

--- a/frontend/tests/app/transactions-batch-page.test.tsx
+++ b/frontend/tests/app/transactions-batch-page.test.tsx
@@ -1,0 +1,244 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import BatchEntryPage from "@/app/transactions/batch/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+// CategorySelect is a heavyweight typeahead — stub it to a plain native
+// <select> in tests so we can exercise the batch grid's row composition
+// without dragging in the typeahead's dropdown lifecycle. The real
+// component is covered by its own tests.
+vi.mock("@/components/ui/CategorySelect", () => ({
+  default: ({
+    value,
+    onChange,
+    categories,
+    "aria-label": ariaLabel,
+  }: {
+    value: number | "";
+    onChange: (id: number | "") => void;
+    categories: { id: number; name: string }[];
+    "aria-label"?: string;
+  }) => (
+    <select
+      aria-label={ariaLabel}
+      value={value === "" ? "" : String(value)}
+      onChange={(e) =>
+        onChange(e.target.value === "" ? "" : Number(e.target.value))
+      }
+    >
+      <option value="">Pick…</option>
+      {categories.map((c) => (
+        <option key={c.id} value={c.id}>
+          {c.name}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/transactions/batch",
+}));
+
+const ACCOUNTS = [
+  {
+    id: 10,
+    name: "Primary",
+    account_type_id: 1,
+    account_type_name: "Checking",
+    account_type_slug: "checking",
+    balance: "150.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: true,
+    close_day: null,
+  },
+];
+
+const CATEGORIES = [
+  {
+    id: 5,
+    name: "Groceries",
+    slug: "groceries",
+    parent_id: null,
+    type: "expense",
+    is_system: false,
+  },
+];
+
+const BASE_USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+function defaultMock() {
+  vi.mocked(apiFetch).mockImplementation((path: string) => {
+    if (path === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
+    if (path === "/api/v1/categories") return Promise.resolve(CATEGORIES);
+    return Promise.resolve([]);
+  });
+}
+
+function setUser() {
+  vi.mocked(useAuth).mockReturnValue({
+    user: { ...BASE_USER, role: "owner" } as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+async function fillRow(rowIndex: number) {
+  const desc = await screen.findByLabelText(`Row ${rowIndex} description`);
+  fireEvent.change(desc, { target: { value: `Coffee ${rowIndex}` } });
+
+  const amount = screen.getByLabelText(`Row ${rowIndex} amount`);
+  fireEvent.change(amount, { target: { value: "9.50" } });
+
+  const account = screen.getByLabelText(`Row ${rowIndex} account`);
+  fireEvent.change(account, { target: { value: "10" } });
+
+  // Category select is stubbed to a native <select> in this test file.
+  const cat = screen.getByLabelText(`Row ${rowIndex} category`);
+  fireEvent.change(cat, { target: { value: "5" } });
+}
+
+describe("Batch entry page", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    defaultMock();
+    setUser();
+  });
+
+  it("renders 5 default empty rows", async () => {
+    render(<BatchEntryPage />);
+    await waitFor(() => {
+      expect(screen.getByLabelText("Row 1 description")).toBeTruthy();
+      expect(screen.getByLabelText("Row 5 description")).toBeTruthy();
+      expect(screen.queryByLabelText("Row 6 description")).toBeNull();
+    });
+  });
+
+  it('appends a new row when "+ Add row" is clicked', async () => {
+    render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 5 description");
+    fireEvent.click(screen.getByRole("button", { name: /Add row/ }));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Row 6 description")).toBeTruthy();
+    });
+  });
+
+  it("removes a row when the trash button is clicked", async () => {
+    render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 5 description");
+    fireEvent.click(screen.getByLabelText("Remove row 3"));
+    await waitFor(() => {
+      // After removal, only 4 rows remain. The 5th label disappears.
+      expect(screen.queryByLabelText("Row 5 description")).toBeNull();
+    });
+  });
+
+  it("disables submit while no row is filled", async () => {
+    render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 1 description");
+    const submit = screen.getByRole("button", { name: /^Submit/ });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("submits filled rows and renders per-row outcomes (happy path)", async () => {
+    render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 1 description");
+
+    await fillRow(1);
+
+    vi.mocked(apiFetch).mockImplementationOnce(() =>
+      Promise.resolve({
+        imported_count: 1,
+        error_count: 0,
+        results: [{ row_number: 1, transaction_id: 42 }],
+        errors: [],
+      }),
+    );
+
+    const submit = screen.getByRole("button", { name: /Submit 1 row$/ });
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Row 1 imported")).toBeTruthy();
+    });
+    expect(screen.getByRole("status").textContent).toMatch(/1 row imported/);
+  });
+
+  it("renders per-row error message on partial-success response", async () => {
+    render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 1 description");
+
+    await fillRow(1);
+
+    vi.mocked(apiFetch).mockImplementationOnce(() =>
+      Promise.resolve({
+        imported_count: 0,
+        error_count: 1,
+        results: [],
+        errors: [{ row_number: 1, error: "Invalid amount" }],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Submit 1 row$/ }));
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole("alert");
+      expect(alerts.some((n) => n.textContent?.includes("Invalid amount"))).toBe(true);
+    });
+  });
+
+  it("adds a new row on Enter at the last cell of the last row", async () => {
+    render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 5 description");
+    // The trash button on the last row is the final focusable cell.
+    const removeLast = screen.getByLabelText("Remove row 5");
+    fireEvent.keyDown(removeLast, { key: "Enter" });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Row 6 description")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements `POST /api/v1/transactions/batch` and a spreadsheet-style grid at `/transactions/batch`. Per-row savepoint isolation so a bad row never takes down the batch; per-row outcomes render inline.

- Backend: new `transaction_batch_service.create_batch` (per-row `db.begin_nested()`), router handler replaces the 501 stub, single audit event per invocation (`transactions.batch_create`), rows land with `is_imported=False` per spec section 0.2.
- Frontend: new `/transactions/batch` route with 5 default rows, +/- row controls, Enter-to-extend on the last cell, per-row success/error icons. New "Batch entry" link on the transactions header.
- Tests: service-level savepoint + cross-org + type-guard + balance-application; router-level partial-success contract; frontend grid render + add-row + submit + per-row error display + keyboard nav.

Contract frozen by #227. Touches only the `batch_create_transactions` function in `transactions.py` — disjoint scope from the Description Suggestions team's `suggest_descriptions` work on the same file.

LoC: ~1380 inserted / 28 deleted across 8 files.