### PR TITLE
feat(transactions): description suggestions endpoint + autocomplete (L3.2 Wave 2A)

### DIFF
--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Literal, Optional
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
@@ -40,6 +40,7 @@ from app.services import (
     audit_service,
     transaction_batch_service,
     transaction_service as svc,
+    transaction_suggestions_service as suggestions_svc,
 )
 from app.services.exceptions import NotFoundError, ValidationError
 
@@ -47,6 +48,16 @@ from app.services.exceptions import NotFoundError, ValidationError
 def _request_id() -> Optional[str]:
     """Return the structlog-bound request_id, if any."""
     return structlog.contextvars.get_contextvars().get("request_id")
+
+
+# Dedicated logger for the suggestions endpoint so its events are easy
+# to filter in structured logs without colliding with general
+# transactions handlers. Privacy rules in §5.4 of the L3.2 import
+# contract: we log only org_id, type, query_length, result_count,
+# never the raw ``q`` or returned descriptions.
+suggestions_logger = structlog.stdlib.get_logger(
+    "app.routers.transactions.suggestions"
+)
 
 router = APIRouter(prefix="/api/v1/transactions", tags=["transactions"])
 
@@ -353,40 +364,53 @@ async def batch_create_transactions(
 @router.get(
     "/suggestions/descriptions",
     response_model=DescriptionSuggestionsResponse,
-    status_code=501,
 )
 async def suggest_descriptions(
+    response: Response,
     type: Literal["income", "expense", "transfer"] = Query(...),
     q: str | None = Query(default=None, min_length=2, max_length=255),
     limit: int = Query(default=10, ge=1, le=25),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """**STUB** — Description autocomplete, Wave 2 deliverable.
+    """Description autocomplete for the manual-entry form (L3.2 Wave 2A).
 
-    Contract: return the user's most-used descriptions for ``type``,
-    ranked by prefix-match → frequency → recency. Org-scoped (never
-    leaks across orgs). Never logs raw descriptions or raw query strings.
+    Returns the user's most-used descriptions for ``type``, ranked by
+    prefix-match → frequency → recency. Org-scoped — never leaks
+    across orgs. When ``q`` is omitted, returns the top-N most-used
+    descriptions for ``type`` (useful for the "recent descriptions"
+    hint on an empty input).
 
-    When ``q`` is omitted, returns top-N most-used descriptions (useful
-    for the manual-entry form's "recent descriptions" hint).
+    Privacy (§5.4): the raw query string ``q`` and the returned
+    descriptions MUST NOT appear in logs. We log only ``org_id``,
+    ``type``, ``query_length``, ``result_count``.
+
+    Cache: ``Cache-Control: private, max-age=60`` — per-user, no shared
+    CDN cache (§5.4).
 
     Frozen contract: see spec at
     ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
-    §5 (Description Suggestions Contract) and
-    ``app/schemas/transaction_suggestions.py``.
-
-    Wave 2 Description Suggestions team owns implementation. Frontend
-    is expected to debounce 300 ms and skip requests when q.length < 2.
+    §5 and ``app/schemas/transaction_suggestions.py``.
     """
-    _ = (current_user.org_id, db, type, q, limit)
-    raise HTTPException(
-        status_code=501,
-        detail=(
-            "Description suggestions not implemented — see L3.2 dispatch "
-            "(specs/2026-05-12-l3-2-import-contracts.md §5)"
-        ),
+    suggestions = await suggestions_svc.get_description_suggestions(
+        db,
+        org_id=current_user.org_id,
+        type=type,
+        q=q,
+        limit=limit,
     )
+    # No-PII log line (§5.4): never log raw descriptions or the raw
+    # query string. ``query_length`` is the only signal we keep about
+    # ``q``; ``result_count`` reflects what we're returning.
+    suggestions_logger.info(
+        "transactions.suggestions.descriptions",
+        org_id=current_user.org_id,
+        type=type,
+        query_length=len(q) if q else 0,
+        result_count=len(suggestions),
+    )
+    response.headers["Cache-Control"] = "private, max-age=60"
+    return DescriptionSuggestionsResponse(suggestions=suggestions)
 
 
 @router.get("/{transaction_id}", response_model=TransactionResponse)

--- a/backend/app/services/transaction_suggestions_service.py
+++ b/backend/app/services/transaction_suggestions_service.py
@@ -1,0 +1,214 @@
+"""Description-suggestion autocomplete service (L3.2 Wave 2A).
+
+Implements the contract frozen at
+``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
+§5.
+
+Ranking (server-authoritative):
+  1. Prefix match first (``description LIKE :q || '%'``) ranked above
+     substring matches.
+  2. Then frequency (``COUNT(*) DESC``) among same-rank rows.
+  3. Then recency (``MAX(date) DESC``) as tiebreaker.
+
+Source: the org's own ``transactions`` table, filtered by ``org_id`` and
+``type``. No cross-org leak. No ``merchant_dictionary`` data.
+
+Privacy: the caller (router) MUST NOT log raw descriptions or the raw
+``q`` query string. This service does not log either; callers should
+emit only ``org_id``, ``type``, ``query_length``, ``result_count`` per
+§5.4.
+
+Each returned suggestion carries the description's most-frequently-paired
+category for that org. When the same description has been used with
+multiple categories, the most-used wins (ties broken by recency).
+"""
+from __future__ import annotations
+
+import datetime
+from typing import Literal
+
+from sqlalchemy import case, desc, func, literal, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.category import Category
+from app.models.transaction import Transaction, TransactionType
+from app.schemas.transaction_suggestions import DescriptionSuggestion
+
+
+def _normalize_prefix(q: str) -> str:
+    """Escape LIKE metacharacters so a raw user query can't widen the match.
+
+    LIKE in SQL treats ``%`` and ``_`` as wildcards. A user typing
+    ``50%`` should not accidentally search for "50 followed by
+    anything". Escape with a backslash and pass it to the query.
+    """
+    return q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+async def get_description_suggestions(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    type: Literal["income", "expense", "transfer"],
+    q: str | None,
+    limit: int,
+) -> list[DescriptionSuggestion]:
+    """Return ranked description suggestions for an org.
+
+    Args:
+        db: Async session.
+        org_id: Caller's org. ALL queries filter on this — no cross-org
+            leak.
+        type: Transaction type to filter (matches the manual-entry
+            form's selected mode).
+        q: Optional search query. Caller is responsible for the 2-char
+            minimum (the router rejects shorter ``q`` with 422); this
+            service is permissive so service-level tests can assert
+            the empty-q (recent items) path.
+        limit: Cap on results (1..25 per the schema).
+
+    Returns:
+        Up to ``limit`` ``DescriptionSuggestion`` rows, ordered by
+        prefix-match → frequency → recency.
+
+    Notes on rank stability:
+        - Prefix matches always rank above substring matches.
+        - When ``q`` is None or empty, every grouped row carries
+          ``prefix_rank = 0`` (no prefix tiering needed) and the
+          frequency/recency ordering produces the "top-N most-used"
+          recent-items list per §5.3.
+    """
+    # Map the literal string ``type`` to the SQLAlchemy enum so MySQL's
+    # ENUM column matches. SQLAlchemy enum binding accepts the Python
+    # enum object directly.
+    type_enum = TransactionType(type)
+
+    # ── Phase 1: rank descriptions with aggregates ───────────────────
+    # Group by description, count uses, max date, and (when q is set)
+    # tier prefix matches above substring matches.
+    if q:
+        like_arg = _normalize_prefix(q)
+        prefix_pat = like_arg + "%"
+        substr_pat = "%" + like_arg + "%"
+        # SQLite's ``LIKE`` is case-insensitive by default for ASCII;
+        # MySQL's default collation (utf8mb4_0900_ai_ci) is likewise
+        # case-insensitive. Using ``LIKE`` (with explicit ESCAPE) keeps
+        # the query portable. Postgres would need ``ILIKE`` but the
+        # codebase targets MySQL.
+        prefix_rank_expr = func.sum(
+            case(
+                (
+                    Transaction.description.like(prefix_pat, escape="\\"),
+                    1,
+                ),
+                else_=0,
+            )
+        )
+        # We must restrict to rows that match either prefix OR
+        # substring, then derive the rank from whether ANY row in the
+        # group is a prefix hit. ``func.sum`` on the CASE delivers
+        # >0 if any row of the group matches the prefix; we cast that
+        # to a 0/1 tier via ORDER BY.
+        # Build the filter as "prefix OR substring" — substring is the
+        # superset, so this collapses to a single LIKE on the broader
+        # pattern.
+        filter_clauses = [
+            Transaction.org_id == org_id,
+            Transaction.type == type_enum,
+            Transaction.description.like(substr_pat, escape="\\"),
+        ]
+    else:
+        prefix_rank_expr = literal(0)
+        filter_clauses = [
+            Transaction.org_id == org_id,
+            Transaction.type == type_enum,
+        ]
+
+    desc_stmt = (
+        select(
+            Transaction.description.label("description"),
+            func.count(Transaction.id).label("use_count"),
+            func.max(Transaction.date).label("last_used"),
+            prefix_rank_expr.label("prefix_rank"),
+        )
+        .where(*filter_clauses)
+        .group_by(Transaction.description)
+        .order_by(
+            desc("prefix_rank"),
+            desc("use_count"),
+            desc("last_used"),
+        )
+        .limit(limit)
+    )
+    rows = (await db.execute(desc_stmt)).all()
+    if not rows:
+        return []
+
+    descriptions = [r.description for r in rows]
+
+    # ── Phase 2: pick the most-frequent category per description ────
+    # One follow-up query keyed by the descriptions we just selected.
+    # We deliberately avoid a window function so the path stays
+    # portable to SQLite (used by router/service tests) and MySQL 8.
+    cat_stmt = (
+        select(
+            Transaction.description.label("description"),
+            Transaction.category_id.label("category_id"),
+            func.count(Transaction.id).label("pair_count"),
+            func.max(Transaction.date).label("pair_last_used"),
+        )
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.type == type_enum,
+            Transaction.description.in_(descriptions),
+        )
+        .group_by(Transaction.description, Transaction.category_id)
+        .order_by(
+            Transaction.description,
+            desc("pair_count"),
+            desc("pair_last_used"),
+        )
+    )
+    cat_rows = (await db.execute(cat_stmt)).all()
+
+    # First row per description (sorted by count desc, recency desc)
+    # is the winning pair.
+    top_category_by_desc: dict[str, int] = {}
+    for r in cat_rows:
+        if r.description not in top_category_by_desc:
+            top_category_by_desc[r.description] = r.category_id
+
+    # ── Phase 3: resolve category display names ─────────────────────
+    category_ids = list({cid for cid in top_category_by_desc.values()})
+    name_stmt = select(Category.id, Category.name).where(
+        Category.org_id == org_id,
+        Category.id.in_(category_ids),
+    )
+    cat_name_rows = (await db.execute(name_stmt)).all()
+    category_name_by_id = {row.id: row.name for row in cat_name_rows}
+
+    # ── Phase 4: shape the response ─────────────────────────────────
+    # If a description's category was somehow soft-deleted or scoped
+    # out of the org, skip it rather than crash — the schema requires
+    # a non-null category_id + name.
+    out: list[DescriptionSuggestion] = []
+    for r in rows:
+        cat_id = top_category_by_desc.get(r.description)
+        if cat_id is None:
+            continue
+        cat_name = category_name_by_id.get(cat_id)
+        if cat_name is None:
+            continue
+        last_used = r.last_used
+        if isinstance(last_used, datetime.datetime):
+            last_used = last_used.date()
+        out.append(
+            DescriptionSuggestion(
+                description=r.description,
+                category_id=cat_id,
+                category_name=cat_name,
+                use_count=int(r.use_count),
+                last_used=last_used,
+            )
+        )
+    return out

--- a/backend/tests/routers/test_import_contracts.py
+++ b/backend/tests/routers/test_import_contracts.py
@@ -406,8 +406,15 @@ async def test_batch_validates_max_rows(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_suggestions_returns_501_when_authenticated(session_factory):
-    """Description-suggestions endpoint returns 501."""
+async def test_suggestions_returns_200_with_empty_payload_for_seeded_user(
+    session_factory,
+):
+    """Description-suggestions endpoint is now implemented (L3.2 Wave 2A).
+
+    With no transactions seeded for the contract user, the endpoint
+    returns 200 with an empty suggestions list — confirming the
+    handler is no longer the 501 stub but is wired to the service.
+    """
     await _seed_user(session_factory)
     app = _make_app(session_factory)
     with TestClient(app) as client:
@@ -415,8 +422,9 @@ async def test_suggestions_returns_501_when_authenticated(session_factory):
             "/api/v1/transactions/suggestions/descriptions",
             params={"type": "expense", "q": "alb", "limit": 10},
         )
-    assert resp.status_code == 501
-    assert "not implemented" in resp.json()["detail"].lower()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"suggestions": []}
 
 
 @pytest.mark.asyncio
@@ -473,7 +481,7 @@ async def test_suggestions_validates_max_limit(session_factory):
 
 @pytest.mark.asyncio
 async def test_suggestions_q_omitted_is_valid_at_contract_layer(session_factory):
-    """When q is omitted, request shape is valid (server returns 501)."""
+    """When q is omitted, request shape is valid (server returns 200)."""
     await _seed_user(session_factory)
     app = _make_app(session_factory)
     with TestClient(app) as client:
@@ -481,8 +489,10 @@ async def test_suggestions_q_omitted_is_valid_at_contract_layer(session_factory)
             "/api/v1/transactions/suggestions/descriptions",
             params={"type": "income"},
         )
-    # 501, not 422 — q is optional per contract.
-    assert resp.status_code == 501
+    # 200, not 422 — q is optional per contract; the live handler
+    # returns an empty list when the org has no transactions seeded.
+    assert resp.status_code == 200
+    assert resp.json() == {"suggestions": []}
 
 
 # ── OpenAPI surface check ───────────────────────────────────────────────────

--- a/backend/tests/routers/test_transactions_suggestions.py
+++ b/backend/tests/routers/test_transactions_suggestions.py
@@ -1,0 +1,326 @@
+"""Router-level tests for description-suggestion autocomplete (L3.2 Wave 2A).
+
+Focus: privacy + caching + end-to-end shape. Ranking is covered by the
+service-layer tests; here we verify the HTTP surface:
+
+- Auth required (401 without a session).
+- ``Cache-Control: private, max-age=60`` (per §5.4).
+- The handler logs only ``org_id``, ``type``, ``query_length``,
+  ``result_count`` — NEVER the raw ``q`` or returned descriptions.
+  This is the most important guard (§5.4 privacy rule).
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+import structlog
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization, Role, User
+from app.routers.transactions import router as transactions_router
+from app.security import hash_password
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+# ── shared fixtures ──────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_world(factory) -> tuple[int, int]:
+    """Seed an org with an account, a category, and a few transactions.
+
+    Returns ``(org_id, user_id)``.
+    """
+    async with factory() as db:
+        org = Organization(name="LogTest", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+        db.add(at)
+        await db.flush()
+        acct = Account(
+            org_id=org.id,
+            account_type_id=at.id,
+            name="Main",
+            balance=Decimal("0.00"),
+            currency="EUR",
+        )
+        cat = Category(org_id=org.id, name="Groceries", type=CategoryType.EXPENSE)
+        db.add_all([acct, cat])
+        await db.flush()
+        # A few transactions so the ranking has data to chew on.
+        for d, desc in [
+            (datetime.date(2026, 5, 11), "Albert Heijn"),
+            (datetime.date(2026, 5, 10), "Albert Heijn"),
+            (datetime.date(2026, 5, 9), "Albert Cuyp"),
+        ]:
+            db.add(
+                Transaction(
+                    org_id=org.id,
+                    account_id=acct.id,
+                    category_id=cat.id,
+                    description=desc,
+                    amount=Decimal("12.34"),
+                    type=TransactionType.EXPENSE,
+                    status=TransactionStatus.SETTLED,
+                    date=d,
+                    settled_date=d,
+                    is_imported=False,
+                )
+            )
+        user = User(
+            org_id=org.id,
+            username="logtest",
+            email="log@test.example",
+            password_hash=hash_password("pw-test-12345"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return org.id, user.id
+
+
+def _make_app(session_factory, *, authenticated: bool = True) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    if authenticated:
+        async def override_current_user() -> User:
+            from sqlalchemy import select
+            async with session_factory() as db:
+                return (
+                    await db.execute(
+                        select(User).where(User.is_superadmin.is_(True))
+                    )
+                ).scalar_one()
+        app.dependency_overrides[get_current_user] = override_current_user
+    else:
+        async def reject_user():
+            raise HTTPException(status_code=401, detail="not authenticated")
+        app.dependency_overrides[get_current_user] = reject_user
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    @app.exception_handler(NotFoundError)
+    async def _nfe(request, exc):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ValidationError)
+    async def _vle(request, exc):
+        return JSONResponse(status_code=400, content={"detail": exc.detail})
+
+    @app.exception_handler(ConflictError)
+    async def _cfe(request, exc):
+        return JSONResponse(status_code=409, content={"detail": exc.detail})
+
+    app.include_router(transactions_router)
+    return app
+
+
+# ── auth ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_requires_auth(session_factory):
+    await _seed_world(session_factory)
+    app = _make_app(session_factory, authenticated=False)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense", "q": "Alb"},
+        )
+    assert resp.status_code == 401
+
+
+# ── shape + ranking sanity at HTTP layer ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_returns_ranked_suggestions(session_factory):
+    await _seed_world(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense", "q": "Alb", "limit": 10},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "suggestions" in body
+    descs = [s["description"] for s in body["suggestions"]]
+    assert descs == ["Albert Heijn", "Albert Cuyp"]
+    # Verify the contract response shape — every suggestion carries the
+    # required keys, including the category hint.
+    for s in body["suggestions"]:
+        assert {
+            "description",
+            "category_id",
+            "category_name",
+            "use_count",
+            "last_used",
+        } == set(s.keys())
+
+
+@pytest.mark.asyncio
+async def test_cache_control_private(session_factory):
+    """Privacy: response is cacheable per-user only (§5.4)."""
+    await _seed_world(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense"},
+        )
+    assert resp.status_code == 200
+    cc = resp.headers.get("cache-control", "")
+    assert "private" in cc
+    assert "max-age=60" in cc
+
+
+# ── no-PII logging guard ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_pii_in_logs(session_factory, caplog):
+    """Strictest privacy guard (§5.4).
+
+    During a request with known query strings ('AlbertSecret123', plus
+    seeded descriptions 'Albert Heijn' / 'Albert Cuyp'), NONE of those
+    strings may appear in any APPLICATION log record at INFO level or
+    above. INFO is what production runs at; DB-driver DEBUG logs do
+    include bound parameter values, but those are off in production
+    and never reach the JSON log stream.
+
+    The metric event MUST still carry query_length + result_count so
+    operators can monitor usage without seeing user input.
+    """
+    await _seed_world(session_factory)
+    app = _make_app(session_factory)
+
+    # Force structlog routing through stdlib so caplog sees our event.
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+
+    with caplog.at_level(logging.INFO):
+        with TestClient(app) as client:
+            resp = client.get(
+                "/api/v1/transactions/suggestions/descriptions",
+                params={"type": "expense", "q": "AlbertSecret123"},
+            )
+    assert resp.status_code == 200
+
+    # Only inspect APPLICATION logs (app.*). Excludes httpx access-log
+    # records (which include the URL, where ``q`` lives in the query
+    # string by design) and DB-driver DEBUG which is off in production.
+    app_records = [
+        r for r in caplog.records
+        if r.name.startswith("app.") and r.levelno >= logging.INFO
+    ]
+    rendered = "\n".join(
+        r.getMessage() + " " + json.dumps(r.__dict__, default=str)
+        for r in app_records
+    )
+    # The raw query string must NEVER appear in any application log.
+    assert "AlbertSecret123" not in rendered, (
+        f"Raw query leaked into application log output:\n{rendered}"
+    )
+    # Seeded descriptions must likewise stay out of any application log.
+    for desc_str in ("Albert Heijn", "Albert Cuyp"):
+        assert desc_str not in rendered, (
+            f"Description '{desc_str}' leaked into application logs:\n{rendered}"
+        )
+
+    # The metric/event must still carry query_length + result_count.
+    metric_lines = [
+        r for r in app_records
+        if r.name.startswith("app.routers.transactions.suggestions")
+    ]
+    assert metric_lines, "Expected at least one suggestions logger event"
+    blob = "\n".join(
+        json.dumps(r.__dict__, default=str) + "\n" + r.getMessage()
+        for r in metric_lines
+    )
+    assert "query_length" in blob
+    assert "result_count" in blob
+
+
+# ── q-omitted path ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_q_omitted_returns_top_n(session_factory):
+    """When q is omitted, the most-used descriptions surface."""
+    await _seed_world(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense"},
+        )
+    assert resp.status_code == 200
+    descs = [s["description"] for s in resp.json()["suggestions"]]
+    # "Albert Heijn" has 2 uses; "Albert Cuyp" has 1. Most-used first.
+    assert descs == ["Albert Heijn", "Albert Cuyp"]
+
+
+# ── q < 2 chars is rejected at the router ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_short_q_is_rejected(session_factory):
+    await _seed_world(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/v1/transactions/suggestions/descriptions",
+            params={"type": "expense", "q": "a"},
+        )
+    assert resp.status_code == 422

--- a/backend/tests/services/test_transaction_suggestions_service.py
+++ b/backend/tests/services/test_transaction_suggestions_service.py
@@ -1,0 +1,423 @@
+"""Service-layer tests for description-suggestion autocomplete (L3.2 Wave 2A).
+
+Pins the ranking contract from
+``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md``
+§5:
+
+1. Prefix match first.
+2. Then frequency (use_count DESC).
+3. Then recency (last_used DESC).
+
+And the privacy/org-scope rules:
+- No cross-org leak.
+- Type filter is respected.
+- ``q`` shorter than 2 chars: handled at the router; the service is
+  permissive so it can serve the "recent items" path when ``q`` is None.
+- ``limit`` cap.
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization
+from app.services.transaction_suggestions_service import (
+    get_description_suggestions,
+)
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_org(factory, name: str) -> tuple[int, int, int]:
+    """Seed an org with one account-type, one account, and one category.
+
+    Returns ``(org_id, account_id, category_id)``.
+    """
+    async with factory() as db:
+        org = Organization(name=name, billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+        db.add(at)
+        await db.flush()
+        acct = Account(
+            org_id=org.id,
+            account_type_id=at.id,
+            name="Main",
+            balance=Decimal("0.00"),
+            currency="EUR",
+        )
+        cat = Category(
+            org_id=org.id,
+            name="Groceries",
+            type=CategoryType.EXPENSE,
+        )
+        db.add_all([acct, cat])
+        await db.commit()
+        return org.id, acct.id, cat.id
+
+
+async def _add_category(factory, org_id: int, name: str, type_: CategoryType) -> int:
+    async with factory() as db:
+        c = Category(org_id=org_id, name=name, type=type_)
+        db.add(c)
+        await db.commit()
+        return c.id
+
+
+async def _add_tx(
+    factory,
+    *,
+    org_id: int,
+    account_id: int,
+    category_id: int,
+    description: str,
+    date: datetime.date,
+    amount: str = "10.00",
+    type_: TransactionType = TransactionType.EXPENSE,
+) -> None:
+    async with factory() as db:
+        tx = Transaction(
+            org_id=org_id,
+            account_id=account_id,
+            category_id=category_id,
+            description=description,
+            amount=Decimal(amount),
+            type=type_,
+            status=TransactionStatus.SETTLED,
+            date=date,
+            settled_date=date,
+            is_imported=False,
+        )
+        db.add(tx)
+        await db.commit()
+
+
+# ── ranking ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_prefix_matches_rank_above_substring(session_factory):
+    """Prefix matches MUST come back before substring matches even if
+    the substring match is more frequent."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "RankOrg")
+    # Substring match used 5 times.
+    for i in range(5):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Super Albert Market",
+            date=datetime.date(2026, 5, 1),
+        )
+    # Prefix match used only 2 times.
+    for i in range(2):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Albert Heijn",
+            date=datetime.date(2026, 4, 15),
+        )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q="Alb", limit=10
+        )
+
+    assert len(out) == 2
+    assert out[0].description == "Albert Heijn"
+    assert out[1].description == "Super Albert Market"
+
+
+@pytest.mark.asyncio
+async def test_within_prefix_tier_frequency_wins(session_factory):
+    """Among prefix matches, higher use_count wins."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "FreqOrg")
+    for i in range(3):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Albert Cuyp",
+            date=datetime.date(2026, 5, 1),
+        )
+    for i in range(7):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Albert Heijn",
+            date=datetime.date(2026, 4, 1),
+        )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q="Alb", limit=10
+        )
+
+    assert [s.description for s in out] == ["Albert Heijn", "Albert Cuyp"]
+    assert out[0].use_count == 7
+    assert out[1].use_count == 3
+
+
+@pytest.mark.asyncio
+async def test_within_same_frequency_recency_wins(session_factory):
+    """Two prefix-matched descriptions with equal use_count: most-recent
+    last_used wins the tiebreaker."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "RecencyOrg")
+    for d in [datetime.date(2026, 5, 11), datetime.date(2026, 5, 12)]:
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Albert Heijn",
+            date=d,
+        )
+    for d in [datetime.date(2026, 1, 1), datetime.date(2026, 1, 2)]:
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Albert Cuyp",
+            date=d,
+        )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q="Alb", limit=10
+        )
+
+    assert [s.description for s in out] == ["Albert Heijn", "Albert Cuyp"]
+    assert out[0].last_used == datetime.date(2026, 5, 12)
+
+
+@pytest.mark.asyncio
+async def test_empty_q_returns_top_n_most_used(session_factory):
+    """When q is None (router-permissive path), service returns the
+    top-N most-used descriptions for the org+type — the "recent items"
+    hint used by an empty input."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "EmptyOrg")
+    for _ in range(4):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Coffee",
+            date=datetime.date(2026, 5, 10),
+        )
+    for _ in range(2):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Lunch",
+            date=datetime.date(2026, 5, 11),
+        )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q=None, limit=10
+        )
+
+    assert [s.description for s in out] == ["Coffee", "Lunch"]
+
+
+@pytest.mark.asyncio
+async def test_limit_caps_results(session_factory):
+    """Service respects the `limit` arg."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "LimitOrg")
+    for i in range(7):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description=f"Merchant-{i:02d}",
+            date=datetime.date(2026, 5, 1),
+        )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q=None, limit=3
+        )
+    assert len(out) == 3
+
+
+# ── isolation ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_other_org_data_does_not_leak(session_factory):
+    """Suggestions filter strictly on org_id."""
+    org_a, acct_a, cat_a = await _seed_org(session_factory, "OrgA")
+    org_b, acct_b, cat_b = await _seed_org(session_factory, "OrgB")
+    await _add_tx(
+        session_factory,
+        org_id=org_b,
+        account_id=acct_b,
+        category_id=cat_b,
+        description="Albert Heijn",
+        date=datetime.date(2026, 5, 1),
+    )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_a, type="expense", q="Alb", limit=10
+        )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_type_filter_excludes_other_types(session_factory):
+    """Only the requested transaction type contributes to the ranking."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "TypeOrg")
+    income_cat = await _add_category(
+        session_factory, org_id, "Salary", CategoryType.INCOME
+    )
+    for _ in range(5):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Albert Heijn",
+            date=datetime.date(2026, 5, 1),
+            type_=TransactionType.EXPENSE,
+        )
+    for _ in range(5):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=income_cat,
+            description="Albert Heijn",
+            date=datetime.date(2026, 5, 1),
+            type_=TransactionType.INCOME,
+        )
+
+    async with session_factory() as db:
+        out_exp = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q="Alb", limit=10
+        )
+        out_inc = await get_description_suggestions(
+            db, org_id=org_id, type="income", q="Alb", limit=10
+        )
+
+    assert len(out_exp) == 1 and out_exp[0].use_count == 5
+    assert out_exp[0].category_id == cat_id
+    assert len(out_inc) == 1 and out_inc[0].use_count == 5
+    assert out_inc[0].category_id == income_cat
+
+
+# ── category pairing ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_top_category_is_most_used_pair(session_factory):
+    """When a description appears with multiple categories, the
+    suggestion reports the most-frequently-paired one."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "CatPairOrg")
+    other_cat = await _add_category(
+        session_factory, org_id, "Coffee Shop", CategoryType.EXPENSE
+    )
+    # Albert Heijn paired with Groceries (cat_id) 4 times.
+    for _ in range(4):
+        await _add_tx(
+            session_factory,
+            org_id=org_id,
+            account_id=account_id,
+            category_id=cat_id,
+            description="Albert Heijn",
+            date=datetime.date(2026, 4, 1),
+        )
+    # And with Coffee Shop just once.
+    await _add_tx(
+        session_factory,
+        org_id=org_id,
+        account_id=account_id,
+        category_id=other_cat,
+        description="Albert Heijn",
+        date=datetime.date(2026, 5, 11),
+    )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q="Alb", limit=10
+        )
+    assert len(out) == 1
+    s = out[0]
+    assert s.description == "Albert Heijn"
+    assert s.use_count == 5
+    assert s.category_id == cat_id
+    assert s.category_name == "Groceries"
+
+
+# ── LIKE-metacharacter safety ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_like_metacharacters_in_q_are_escaped(session_factory):
+    """A query containing '%' MUST be treated as a literal, not a
+    wildcard. Otherwise a one-char q like '%' could match everything,
+    bypassing the 2-char minimum's privacy intent."""
+    org_id, account_id, cat_id = await _seed_org(session_factory, "EscOrg")
+    await _add_tx(
+        session_factory,
+        org_id=org_id,
+        account_id=account_id,
+        category_id=cat_id,
+        description="Albert Heijn",
+        date=datetime.date(2026, 5, 1),
+    )
+    await _add_tx(
+        session_factory,
+        org_id=org_id,
+        account_id=account_id,
+        category_id=cat_id,
+        description="50% Off Sale",
+        date=datetime.date(2026, 5, 2),
+    )
+
+    async with session_factory() as db:
+        out = await get_description_suggestions(
+            db, org_id=org_id, type="expense", q="50%", limit=10
+        )
+
+    assert [s.description for s in out] == ["50% Off Sale"]

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -18,6 +18,7 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import LinkAsTransferModal from "@/components/transactions/LinkAsTransferModal";
 import MarkAsTransferModal from "@/components/transactions/MarkAsTransferModal";
 import UnpairTransferModal from "@/components/transactions/UnpairTransferModal";
+import DescriptionAutocomplete from "@/components/transactions/DescriptionAutocomplete";
 import ResetSortFiltersButton from "@/components/ui/ResetSortFiltersButton";
 import {
   FILTERS_KEY_TRANSACTIONS,
@@ -1012,7 +1013,34 @@ function TransactionsPageContent() {
             )}
             <div>
               <label htmlFor="tx-desc" className={label}>Description</label>
-              <input id="tx-desc" type="text" required={formMode === "transaction"} placeholder={formMode === "transfer" ? "Auto: Transfer from X to Y" : "What was it for?"} value={formDescription} onChange={(e) => setFormDescription(e.target.value)} className={input} />
+              {formMode === "transaction" ? (
+                <DescriptionAutocomplete
+                  id="tx-desc"
+                  type={formType}
+                  value={formDescription}
+                  onChange={setFormDescription}
+                  onPick={(s) => {
+                    // Pre-fill category from the most-common pair for
+                    // this description, but only if the user has not
+                    // already chosen one. Matches the spec's "optional
+                    // pre-populate" rule for the category hint.
+                    if (formCategoryId === "") {
+                      setFormCategoryId(s.category_id);
+                    }
+                  }}
+                  placeholder="What was it for?"
+                  required
+                />
+              ) : (
+                <input
+                  id="tx-desc"
+                  type="text"
+                  placeholder="Auto: Transfer from X to Y"
+                  value={formDescription}
+                  onChange={(e) => setFormDescription(e.target.value)}
+                  className={input}
+                />
+              )}
             </div>
             <div>
               <label htmlFor="tx-amount" className={label}>Amount</label>

--- a/frontend/components/transactions/DescriptionAutocomplete.tsx
+++ b/frontend/components/transactions/DescriptionAutocomplete.tsx
@@ -59,10 +59,12 @@ export interface DescriptionAutocompleteProps {
   disabled?: boolean;
   className?: string;
   ariaLabel?: string;
-  /** Override fetch in tests. */
+  /** Override fetch in tests. Receives an AbortSignal so tests can
+   *  observe the cancel path the production fetch uses. */
   fetcher?: (
     type: DescriptionAutocompleteProps["type"],
     q: string,
+    signal: AbortSignal,
   ) => Promise<DescriptionSuggestion[]>;
   /** Override the debounce in tests (default 300ms). */
   debounceMs?: number;
@@ -77,12 +79,30 @@ const DEFAULT_MAX_ITEMS = 8;
 async function defaultFetcher(
   type: DescriptionAutocompleteProps["type"],
   q: string,
+  signal: AbortSignal,
 ): Promise<DescriptionSuggestion[]> {
   const params = new URLSearchParams({ type, q, limit: "25" });
   const data = await apiFetch<ApiResponse>(
     `/api/v1/transactions/suggestions/descriptions?${params}`,
+    { signal },
   );
   return data.suggestions ?? [];
+}
+
+/** True when an error came from a cancelled fetch (DOMException of name
+ *  ``AbortError``). Used to silently swallow expected cancellations
+ *  without conflating them with real network failures. */
+function isAbortError(e: unknown): boolean {
+  if (e instanceof DOMException && e.name === "AbortError") return true;
+  if (
+    typeof e === "object" &&
+    e !== null &&
+    "name" in e &&
+    (e as { name?: string }).name === "AbortError"
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export default function DescriptionAutocomplete({
@@ -106,24 +126,37 @@ export default function DescriptionAutocomplete({
   const [highlightIdx, setHighlightIdx] = useState(-1);
   const [loading, setLoading] = useState(false);
   const [announce, setAnnounce] = useState("");
-  const lastRequestId = useRef(0);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   // Debounced fetch on value change.
+  //
+  // Each effect invocation owns one AbortController. The cleanup
+  // function (running on every dependency change, including when the
+  // user's input drops back below the 2-char minimum) aborts both the
+  // debounce timer AND any in-flight fetch. This is what prevents a
+  // stale response from re-opening the dropdown after the user has
+  // already cleared their query: the cancelled fetch rejects with an
+  // AbortError, which our catch swallows without touching state.
   useEffect(() => {
     if (disabled) return;
     if (!value || value.trim().length < MIN_QUERY_LENGTH) {
+      // Below the minimum: clear visible suggestions immediately.
+      // Any prior in-flight fetch was already aborted by the previous
+      // cleanup before this effect re-ran.
       setSuggestions([]);
       setHighlightIdx(-1);
       return;
     }
-    const requestId = ++lastRequestId.current;
+    const controller = new AbortController();
     const timer = setTimeout(async () => {
       setLoading(true);
       try {
-        const list = await fetcher(type, value.trim());
-        // Drop stale responses if a newer request fired.
-        if (requestId !== lastRequestId.current) return;
+        const list = await fetcher(type, value.trim(), controller.signal);
+        // Double-guard: even when a request is in flight at the moment
+        // the user mutates the input, ``controller.signal.aborted``
+        // becomes true before any later setState lands. We never
+        // commit results from an aborted request.
+        if (controller.signal.aborted) return;
         setSuggestions(list.slice(0, maxItems));
         setHighlightIdx(list.length > 0 ? 0 : -1);
         setOpen(true);
@@ -132,17 +165,25 @@ export default function DescriptionAutocomplete({
             ? "No suggestions"
             : `${list.length} ${list.length === 1 ? "suggestion" : "suggestions"} available`,
         );
-      } catch {
-        // Silent failure: autocomplete is non-critical UX. The user
-        // can keep typing; the field still accepts free-form input.
-        if (requestId !== lastRequestId.current) return;
+      } catch (err) {
+        if (isAbortError(err) || controller.signal.aborted) {
+          // Expected cancellation. No state update; the next effect
+          // run (or the input-below-minimum branch above) owns the
+          // dropdown's new state.
+          return;
+        }
+        // Real failure: silently clear. Autocomplete is non-critical
+        // UX; the field still accepts free-form input.
         setSuggestions([]);
         setHighlightIdx(-1);
       } finally {
-        if (requestId === lastRequestId.current) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     }, debounceMs);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
   }, [value, type, debounceMs, fetcher, maxItems, disabled]);
 
   // Close on click outside.

--- a/frontend/components/transactions/DescriptionAutocomplete.tsx
+++ b/frontend/components/transactions/DescriptionAutocomplete.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { apiFetch } from "@/lib/api";
+import { input } from "@/lib/styles";
+
+/**
+ * Description autocomplete (L3.2 Wave 2A).
+ *
+ * Wraps the single-transaction add/edit form's description input with
+ * a typeahead. Server contract:
+ *   GET /api/v1/transactions/suggestions/descriptions
+ *     ?type=...&q=...&limit=...
+ *
+ * Frontend rules (frozen at
+ * ~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md §5.3):
+ *   - 300 ms debounce.
+ *   - Skip fetch when query length < 2 (the server would 422 it).
+ *   - Render up to 8 entries (server caps at 25 but the UX dropdown
+ *     stays compact).
+ *   - When a suggestion is picked, callers may take its category_id to
+ *     pre-populate their own category selector.
+ *
+ * Accessibility (W3C combobox pattern):
+ *   - input has role="combobox", aria-expanded, aria-controls,
+ *     aria-activedescendant.
+ *   - listbox uses role="listbox"; options use role="option".
+ *   - Arrow keys + Enter + Escape are wired.
+ *   - aria-live="polite" region announces result counts to screen
+ *     readers without stealing focus.
+ */
+
+export type DescriptionSuggestion = {
+  description: string;
+  category_id: number;
+  category_name: string;
+  use_count: number;
+  last_used: string;
+};
+
+type ApiResponse = { suggestions: DescriptionSuggestion[] };
+
+export interface DescriptionAutocompleteProps {
+  id: string;
+  type: "income" | "expense" | "transfer";
+  value: string;
+  onChange: (next: string) => void;
+  onPick?: (s: DescriptionSuggestion) => void;
+  placeholder?: string;
+  required?: boolean;
+  disabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+  /** Override fetch in tests. */
+  fetcher?: (
+    type: DescriptionAutocompleteProps["type"],
+    q: string,
+  ) => Promise<DescriptionSuggestion[]>;
+  /** Override the debounce in tests (default 300ms). */
+  debounceMs?: number;
+  /** Max items rendered in the dropdown (default 8). */
+  maxItems?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 2;
+const DEFAULT_MAX_ITEMS = 8;
+
+async function defaultFetcher(
+  type: DescriptionAutocompleteProps["type"],
+  q: string,
+): Promise<DescriptionSuggestion[]> {
+  const params = new URLSearchParams({ type, q, limit: "25" });
+  const data = await apiFetch<ApiResponse>(
+    `/api/v1/transactions/suggestions/descriptions?${params}`,
+  );
+  return data.suggestions ?? [];
+}
+
+export default function DescriptionAutocomplete({
+  id,
+  type,
+  value,
+  onChange,
+  onPick,
+  placeholder,
+  required,
+  disabled,
+  className = input,
+  ariaLabel,
+  fetcher = defaultFetcher,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  maxItems = DEFAULT_MAX_ITEMS,
+}: DescriptionAutocompleteProps) {
+  const listboxId = useId();
+  const [suggestions, setSuggestions] = useState<DescriptionSuggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  const [highlightIdx, setHighlightIdx] = useState(-1);
+  const [loading, setLoading] = useState(false);
+  const [announce, setAnnounce] = useState("");
+  const lastRequestId = useRef(0);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  // Debounced fetch on value change.
+  useEffect(() => {
+    if (disabled) return;
+    if (!value || value.trim().length < MIN_QUERY_LENGTH) {
+      setSuggestions([]);
+      setHighlightIdx(-1);
+      return;
+    }
+    const requestId = ++lastRequestId.current;
+    const timer = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const list = await fetcher(type, value.trim());
+        // Drop stale responses if a newer request fired.
+        if (requestId !== lastRequestId.current) return;
+        setSuggestions(list.slice(0, maxItems));
+        setHighlightIdx(list.length > 0 ? 0 : -1);
+        setOpen(true);
+        setAnnounce(
+          list.length === 0
+            ? "No suggestions"
+            : `${list.length} ${list.length === 1 ? "suggestion" : "suggestions"} available`,
+        );
+      } catch {
+        // Silent failure: autocomplete is non-critical UX. The user
+        // can keep typing; the field still accepts free-form input.
+        if (requestId !== lastRequestId.current) return;
+        setSuggestions([]);
+        setHighlightIdx(-1);
+      } finally {
+        if (requestId === lastRequestId.current) setLoading(false);
+      }
+    }, debounceMs);
+    return () => clearTimeout(timer);
+  }, [value, type, debounceMs, fetcher, maxItems, disabled]);
+
+  // Close on click outside.
+  useEffect(() => {
+    function handle(e: MouseEvent) {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, []);
+
+  const commitPick = useCallback(
+    (s: DescriptionSuggestion) => {
+      onChange(s.description);
+      onPick?.(s);
+      setOpen(false);
+      setSuggestions([]);
+      setHighlightIdx(-1);
+    },
+    [onChange, onPick],
+  );
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (!open || suggestions.length === 0) {
+      if (e.key === "ArrowDown" && suggestions.length > 0) {
+        setOpen(true);
+        setHighlightIdx(0);
+        e.preventDefault();
+      }
+      return;
+    }
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setHighlightIdx((i) => (i + 1) % suggestions.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setHighlightIdx((i) =>
+          i <= 0 ? suggestions.length - 1 : i - 1,
+        );
+        break;
+      case "Enter":
+        if (highlightIdx >= 0 && highlightIdx < suggestions.length) {
+          e.preventDefault();
+          commitPick(suggestions[highlightIdx]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setOpen(false);
+        setHighlightIdx(-1);
+        break;
+      case "Tab":
+        // Close the popup but let focus move naturally.
+        setOpen(false);
+        break;
+    }
+  };
+
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value);
+    if (e.target.value.trim().length < MIN_QUERY_LENGTH) {
+      setOpen(false);
+    }
+  };
+
+  const handleFocus = () => {
+    if (suggestions.length > 0) setOpen(true);
+  };
+
+  const activeId =
+    open && highlightIdx >= 0 ? `${listboxId}-opt-${highlightIdx}` : undefined;
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <input
+        id={id}
+        type="text"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={open && suggestions.length > 0}
+        aria-controls={listboxId}
+        aria-activedescendant={activeId}
+        aria-label={ariaLabel}
+        autoComplete="off"
+        required={required}
+        disabled={disabled}
+        value={value}
+        placeholder={placeholder}
+        onChange={handleInput}
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        className={className}
+      />
+      {open && suggestions.length > 0 && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          aria-label="Description suggestions"
+          className="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-md border border-border bg-surface-raised shadow-lg"
+        >
+          {suggestions.map((s, i) => (
+            <li
+              key={`${s.description}-${i}`}
+              id={`${listboxId}-opt-${i}`}
+              role="option"
+              aria-selected={i === highlightIdx}
+              onMouseDown={(e) => {
+                // mousedown (not click) so we run before the input
+                // loses focus and closes the dropdown.
+                e.preventDefault();
+                commitPick(s);
+              }}
+              onMouseEnter={() => setHighlightIdx(i)}
+              className={`cursor-pointer px-3 py-2 text-sm ${
+                i === highlightIdx
+                  ? "bg-accent/10 text-text-primary"
+                  : "text-text-primary"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="truncate">{s.description}</span>
+                <span className="shrink-0 text-[10px] text-text-muted">
+                  {s.category_name}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {/* Polite live region: announces result counts to AT users
+          without stealing keyboard focus. */}
+      <div role="status" aria-live="polite" className="sr-only">
+        {loading ? "Loading suggestions" : announce}
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/app/dashboard-projection-race.test.tsx
+++ b/frontend/tests/app/dashboard-projection-race.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import DashboardPage from "@/app/dashboard/page";
 import { apiFetch } from "@/lib/api";
@@ -159,10 +159,14 @@ describe("DashboardPage — projection race protection", () => {
 
     // Now resolve May's stale promise. If the race fix is in place, the
     // late commit must be discarded; the tile must continue to show April.
-    resolveMay(mayStaleData);
-
-    // Flush microtasks + any setState propagation.
-    await new Promise((r) => setTimeout(r, 50));
+    // Wrap in act so any state updates that resolution triggers (even if
+    // they're discarded by the race guard) are flushed inside an act
+    // boundary, eliminating the "not wrapped in act(...)" warnings.
+    await act(async () => {
+      resolveMay(mayStaleData);
+      // Flush microtasks + any setState propagation.
+      await new Promise((r) => setTimeout(r, 50));
+    });
 
     // The hero MUST still show April's verdict, not May's.
     expect(screen.getByText(/ENDED OVER BUDGET/)).toBeInTheDocument();

--- a/frontend/tests/components/transactions/description-autocomplete.test.tsx
+++ b/frontend/tests/components/transactions/description-autocomplete.test.tsx
@@ -9,14 +9,47 @@
  *   aria-expanded.
  * - onPick callback fires with the picked suggestion.
  * - Live region announces result counts politely.
+ * - AbortController invalidates in-flight requests when the user drops
+ *   below the 2-char minimum, so stale responses cannot re-open the
+ *   dropdown (P1 regression from the owner review of PR #239).
  */
 import { useState } from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import DescriptionAutocomplete, {
   type DescriptionSuggestion,
 } from "@/components/transactions/DescriptionAutocomplete";
+
+type Fetcher = (
+  type: "income" | "expense" | "transfer",
+  q: string,
+  signal: AbortSignal,
+) => Promise<DescriptionSuggestion[]>;
+
+/** Hand-controlled fetcher: each call returns a Deferred you can
+ *  resolve when you want, and the AbortSignal each call received so
+ *  tests can assert cancellation. */
+function makeDeferredFetcher() {
+  const calls: {
+    type: "income" | "expense" | "transfer";
+    q: string;
+    signal: AbortSignal;
+    resolve: (list: DescriptionSuggestion[]) => void;
+    reject: (err: unknown) => void;
+  }[] = [];
+  const fetcher: Fetcher = (type, q, signal) => {
+    return new Promise<DescriptionSuggestion[]>((resolve, reject) => {
+      calls.push({ type, q, signal, resolve, reject });
+      // When the host aborts, reject with a DOMException("AbortError")
+      // to match the real fetch() behavior the component handles.
+      signal.addEventListener("abort", () => {
+        reject(new DOMException("The user aborted a request.", "AbortError"));
+      });
+    });
+  };
+  return { fetcher, calls };
+}
 
 const SAMPLE: DescriptionSuggestion[] = [
   {
@@ -41,10 +74,7 @@ function Harness({
   onPick,
 }: {
   initial?: string;
-  fetcher: (
-    type: "income" | "expense" | "transfer",
-    q: string,
-  ) => Promise<DescriptionSuggestion[]>;
+  fetcher: Fetcher;
   onPick?: (s: DescriptionSuggestion) => void;
 }) {
   const [v, setV] = useState(initial);
@@ -80,23 +110,31 @@ describe("DescriptionAutocomplete", () => {
   });
 
   it("does not fetch when query length is below 2 chars", async () => {
-    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(SAMPLE);
     render(<Harness fetcher={fetcher} />);
     const cb = screen.getByRole("combobox");
     fireEvent.change(cb, { target: { value: "a" } });
-    await vi.advanceTimersByTimeAsync(100);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
     expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("debounces fetches and pops the listbox open with results", async () => {
-    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(SAMPLE);
     render(<Harness fetcher={fetcher} />);
     const cb = screen.getByRole("combobox");
     fireEvent.change(cb, { target: { value: "Al" } });
     expect(fetcher).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(50);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
     await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
-    expect(fetcher).toHaveBeenCalledWith("expense", "Al");
+    expect(fetcher).toHaveBeenCalledWith(
+      "expense",
+      "Al",
+      expect.any(AbortSignal),
+    );
     await waitFor(() =>
       expect(screen.getByRole("listbox")).toBeInTheDocument(),
     );
@@ -107,12 +145,14 @@ describe("DescriptionAutocomplete", () => {
   });
 
   it("supports ArrowDown / ArrowUp / Enter keyboard navigation", async () => {
-    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(SAMPLE);
     const onPick = vi.fn();
     render(<Harness fetcher={fetcher} onPick={onPick} />);
     const cb = screen.getByRole("combobox");
     fireEvent.change(cb, { target: { value: "Al" } });
-    await vi.advanceTimersByTimeAsync(50);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
     await waitFor(() =>
       expect(screen.getByRole("listbox")).toBeInTheDocument(),
     );
@@ -131,11 +171,13 @@ describe("DescriptionAutocomplete", () => {
   });
 
   it("closes the listbox on Escape", async () => {
-    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(SAMPLE);
     render(<Harness fetcher={fetcher} />);
     const cb = screen.getByRole("combobox");
     fireEvent.change(cb, { target: { value: "Al" } });
-    await vi.advanceTimersByTimeAsync(50);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
     await waitFor(() =>
       expect(screen.getByRole("listbox")).toBeInTheDocument(),
     );
@@ -144,11 +186,13 @@ describe("DescriptionAutocomplete", () => {
   });
 
   it("announces result count via polite live region", async () => {
-    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(SAMPLE);
     render(<Harness fetcher={fetcher} />);
     const cb = screen.getByRole("combobox");
     fireEvent.change(cb, { target: { value: "Al" } });
-    await vi.advanceTimersByTimeAsync(50);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
     await waitFor(() =>
       expect(screen.getByRole("status")).toHaveTextContent(
         /2 suggestions available/,
@@ -157,45 +201,131 @@ describe("DescriptionAutocomplete", () => {
   });
 
   it("clicking a suggestion selects it", async () => {
-    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const fetcher = vi.fn<Fetcher>().mockResolvedValue(SAMPLE);
     const onPick = vi.fn();
     render(<Harness fetcher={fetcher} onPick={onPick} />);
     const cb = screen.getByRole("combobox");
     fireEvent.change(cb, { target: { value: "Al" } });
-    await vi.advanceTimersByTimeAsync(50);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
     const options = await screen.findAllByRole("option");
     fireEvent.mouseDown(options[0]);
     expect(onPick).toHaveBeenCalledWith(SAMPLE[0]);
     expect((cb as HTMLInputElement).value).toBe("Albert Heijn");
   });
 
-  it("ignores stale responses when the user keeps typing", async () => {
-    const slow = new Promise<DescriptionSuggestion[]>((resolve) =>
-      setTimeout(() => resolve([SAMPLE[0]]), 100),
-    );
-    const fresh = new Promise<DescriptionSuggestion[]>((resolve) =>
-      setTimeout(() => resolve([SAMPLE[1]]), 50),
-    );
-    const fetcher = vi
-      .fn<
-        (
-          type: "income" | "expense" | "transfer",
-          q: string,
-        ) => Promise<DescriptionSuggestion[]>
-      >()
-      .mockImplementationOnce(() => slow)
-      .mockImplementationOnce(() => fresh);
-
+  it("aborts the in-flight request when the user keeps typing", async () => {
+    const { fetcher, calls } = makeDeferredFetcher();
     render(<Harness fetcher={fetcher} />);
     const cb = screen.getByRole("combobox");
+    // Fire request #1.
     fireEvent.change(cb, { target: { value: "Al" } });
-    await vi.advanceTimersByTimeAsync(30);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await waitFor(() => expect(calls).toHaveLength(1));
+    // Mutate input before #1 resolves so a fresh #2 is queued.
     fireEvent.change(cb, { target: { value: "Albe" } });
-    await vi.advanceTimersByTimeAsync(200);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await waitFor(() => expect(calls).toHaveLength(2));
+    // Request #1 should be aborted now; #2 still pending.
+    expect(calls[0].signal.aborted).toBe(true);
+    expect(calls[1].signal.aborted).toBe(false);
+    // Even if the cancelled request "resolves" with stale data, it
+    // must not commit. Resolve #1 with stale data and #2 with the
+    // fresh result.
+    await act(async () => {
+      calls[0].resolve([SAMPLE[0]]); // stale; should be ignored
+      calls[1].resolve([SAMPLE[1]]); // fresh; this is what renders
+    });
     await waitFor(() =>
       expect(screen.getByRole("listbox")).toBeInTheDocument(),
     );
-    // The fresh response (single SAMPLE[1] item) is what wins.
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Albert Cuyp");
+  });
+
+  // ── P1 regression: cleared query must not show stale suggestions ──
+  //
+  // Owner review of PR #239: when the user types ≥2 chars, fetches, then
+  // clears the input back below the 2-char minimum, the in-flight fetch
+  // must be cancelled. If it resolves anyway, the dropdown must NOT
+  // reopen with the stale results.
+
+  it("does not show stale suggestions after the query is cleared below the 2-char minimum", async () => {
+    const { fetcher, calls } = makeDeferredFetcher();
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    // 1. Type 3 chars → debounce → fetch in flight.
+    fireEvent.change(cb, { target: { value: "Alb" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].signal.aborted).toBe(false);
+    // 2. Backspace all 3 chars → query is now "" (below 2-char min).
+    fireEvent.change(cb, { target: { value: "" } });
+    // The effect cleanup runs synchronously on the next render, so by
+    // the time advanceTimers fires, the in-flight fetch is aborted.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    // 3. Stale fetch is cancelled; signal must be aborted.
+    expect(calls[0].signal.aborted).toBe(true);
+    // 4. Try to apply the stale response anyway. The component must
+    //    drop it on the floor because the signal is aborted.
+    await act(async () => {
+      calls[0].resolve([SAMPLE[0], SAMPLE[1]]);
+    });
+    // 5. Listbox must NOT reopen, no stale items in the DOM.
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.queryByText("Albert Heijn")).not.toBeInTheDocument();
+    expect(screen.queryByText("Albert Cuyp")).not.toBeInTheDocument();
+  });
+
+  it("renders only the latest fetch's results across rapid type/backspace cycles", async () => {
+    // Variation: Alb → Alb (no-op typing pause) → backspace → Alb,
+    // resolve the older fetch, assert only the latest fetch wins.
+    const { fetcher, calls } = makeDeferredFetcher();
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "Alb" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await waitFor(() => expect(calls).toHaveLength(1));
+    // User backspaces one char (still 2 chars, "Al") then re-adds
+    // "b" so the value is "Alb" again. Each re-render of the effect
+    // cleans up the previous controller and starts a new fetch.
+    fireEvent.change(cb, { target: { value: "Al" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    fireEvent.change(cb, { target: { value: "Alb" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    await waitFor(() => expect(calls.length).toBeGreaterThanOrEqual(2));
+    // The first (and any intermediate) call must be aborted; the last
+    // call's signal must still be alive.
+    for (let i = 0; i < calls.length - 1; i++) {
+      expect(calls[i].signal.aborted).toBe(true);
+    }
+    expect(calls[calls.length - 1].signal.aborted).toBe(false);
+    // Resolving the stale calls with bogus data must not render.
+    await act(async () => {
+      for (let i = 0; i < calls.length - 1; i++) {
+        calls[i].resolve([SAMPLE[0]]);
+      }
+      calls[calls.length - 1].resolve([SAMPLE[1]]);
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("listbox")).toBeInTheDocument(),
+    );
     const options = screen.getAllByRole("option");
     expect(options).toHaveLength(1);
     expect(options[0]).toHaveTextContent("Albert Cuyp");

--- a/frontend/tests/components/transactions/description-autocomplete.test.tsx
+++ b/frontend/tests/components/transactions/description-autocomplete.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Description-autocomplete component tests (L3.2 Wave 2A).
+ *
+ * Covers:
+ * - Debounce: typing fewer than the debounce window does not fire.
+ * - Min-query-length: q < 2 chars never triggers a fetch.
+ * - Keyboard nav: ArrowDown / ArrowUp / Enter / Escape.
+ * - ARIA wiring: combobox/listbox/option roles, aria-activedescendant,
+ *   aria-expanded.
+ * - onPick callback fires with the picked suggestion.
+ * - Live region announces result counts politely.
+ */
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DescriptionAutocomplete, {
+  type DescriptionSuggestion,
+} from "@/components/transactions/DescriptionAutocomplete";
+
+const SAMPLE: DescriptionSuggestion[] = [
+  {
+    description: "Albert Heijn",
+    category_id: 5,
+    category_name: "Groceries",
+    use_count: 12,
+    last_used: "2026-05-10",
+  },
+  {
+    description: "Albert Cuyp",
+    category_id: 5,
+    category_name: "Groceries",
+    use_count: 4,
+    last_used: "2026-05-05",
+  },
+];
+
+function Harness({
+  initial = "",
+  fetcher,
+  onPick,
+}: {
+  initial?: string;
+  fetcher: (
+    type: "income" | "expense" | "transfer",
+    q: string,
+  ) => Promise<DescriptionSuggestion[]>;
+  onPick?: (s: DescriptionSuggestion) => void;
+}) {
+  const [v, setV] = useState(initial);
+  return (
+    <DescriptionAutocomplete
+      id="tx-desc-test"
+      type="expense"
+      value={v}
+      onChange={setV}
+      onPick={onPick}
+      fetcher={fetcher}
+      debounceMs={20}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("DescriptionAutocomplete", () => {
+  it("renders the combobox with the correct ARIA attributes", () => {
+    const fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    expect(cb).toHaveAttribute("aria-autocomplete", "list");
+    expect(cb).toHaveAttribute("aria-expanded", "false");
+    expect(cb).toHaveAttribute("aria-controls");
+  });
+
+  it("does not fetch when query length is below 2 chars", async () => {
+    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "a" } });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("debounces fetches and pops the listbox open with results", async () => {
+    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "Al" } });
+    expect(fetcher).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(50);
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    expect(fetcher).toHaveBeenCalledWith("expense", "Al");
+    await waitFor(() =>
+      expect(screen.getByRole("listbox")).toBeInTheDocument(),
+    );
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent("Albert Heijn");
+    expect(options[1]).toHaveTextContent("Albert Cuyp");
+  });
+
+  it("supports ArrowDown / ArrowUp / Enter keyboard navigation", async () => {
+    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const onPick = vi.fn();
+    render(<Harness fetcher={fetcher} onPick={onPick} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "Al" } });
+    await vi.advanceTimersByTimeAsync(50);
+    await waitFor(() =>
+      expect(screen.getByRole("listbox")).toBeInTheDocument(),
+    );
+
+    // Default highlight is index 0 after fetch resolves.
+    expect(cb).toHaveAttribute("aria-activedescendant");
+
+    fireEvent.keyDown(cb, { key: "ArrowDown" });
+    fireEvent.keyDown(cb, { key: "Enter" });
+
+    expect(onPick).toHaveBeenCalledWith(SAMPLE[1]);
+    // After picking, the input's value should be the picked description.
+    expect((cb as HTMLInputElement).value).toBe("Albert Cuyp");
+    // And the listbox should be closed.
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("closes the listbox on Escape", async () => {
+    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "Al" } });
+    await vi.advanceTimersByTimeAsync(50);
+    await waitFor(() =>
+      expect(screen.getByRole("listbox")).toBeInTheDocument(),
+    );
+    fireEvent.keyDown(cb, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("announces result count via polite live region", async () => {
+    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "Al" } });
+    await vi.advanceTimersByTimeAsync(50);
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        /2 suggestions available/,
+      ),
+    );
+  });
+
+  it("clicking a suggestion selects it", async () => {
+    const fetcher = vi.fn().mockResolvedValue(SAMPLE);
+    const onPick = vi.fn();
+    render(<Harness fetcher={fetcher} onPick={onPick} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "Al" } });
+    await vi.advanceTimersByTimeAsync(50);
+    const options = await screen.findAllByRole("option");
+    fireEvent.mouseDown(options[0]);
+    expect(onPick).toHaveBeenCalledWith(SAMPLE[0]);
+    expect((cb as HTMLInputElement).value).toBe("Albert Heijn");
+  });
+
+  it("ignores stale responses when the user keeps typing", async () => {
+    const slow = new Promise<DescriptionSuggestion[]>((resolve) =>
+      setTimeout(() => resolve([SAMPLE[0]]), 100),
+    );
+    const fresh = new Promise<DescriptionSuggestion[]>((resolve) =>
+      setTimeout(() => resolve([SAMPLE[1]]), 50),
+    );
+    const fetcher = vi
+      .fn<
+        (
+          type: "income" | "expense" | "transfer",
+          q: string,
+        ) => Promise<DescriptionSuggestion[]>
+      >()
+      .mockImplementationOnce(() => slow)
+      .mockImplementationOnce(() => fresh);
+
+    render(<Harness fetcher={fetcher} />);
+    const cb = screen.getByRole("combobox");
+    fireEvent.change(cb, { target: { value: "Al" } });
+    await vi.advanceTimersByTimeAsync(30);
+    fireEvent.change(cb, { target: { value: "Albe" } });
+    await vi.advanceTimersByTimeAsync(200);
+    await waitFor(() =>
+      expect(screen.getByRole("listbox")).toBeInTheDocument(),
+    );
+    // The fresh response (single SAMPLE[1] item) is what wins.
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Albert Cuyp");
+  });
+});


### PR DESCRIPTION
## Scope

Implements the L3.2 Wave 1 frozen contract for `GET /api/v1/transactions/suggestions/descriptions` (PR #227 stub) and wires the single-transaction add/edit form with a description autocomplete.

Spec: `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-contracts.md` section 5.

## Contract

| Rule | Implementation |
|---|---|
| Ranking | Prefix match, then `COUNT(*) DESC` (frequency), then `MAX(date) DESC` (recency). |
| Min query length | Router rejects `q` shorter than 2 chars with 422. |
| Empty `q` | Returns the org's top-N most-used descriptions for the requested type (the "recent items" hint). |
| Limit cap | 1..25 server-side, default 10; UI shows max 8 in the dropdown. |
| Debounce | 300 ms on the frontend. |
| Org scope | Service filters every query by `org_id`; cross-org leak test is green. |
| Type filter | `expense` / `income` / `transfer` only contribute to their own bucket. |
| Category hint | Each suggestion carries `category_id` + `category_name` from the most-frequently-paired category for that description. UI pre-fills the form's category selector when it is still empty. |
| Cache | `Cache-Control: private, max-age=60`, per-user, no shared CDN. |

## Security

- Strict `org_id` filter at the top of every query; no cross-org SELECT.
- LIKE metacharacters in `q` are escaped, so a one-char trick like `%` cannot widen the match. A test pins this behaviour.
- **No-PII logging guard (spec section 5.4):** the handler logs only `org_id`, `type`, `query_length`, `result_count`. The router test `test_no_pii_in_logs` asserts neither the raw `q` nor any seeded description appears in any application INFO log record. Path:

  `backend/tests/routers/test_transactions_suggestions.py::test_no_pii_in_logs`

## Scope discipline (parallel-team safety)

`backend/app/routers/transactions.py` was touched only for the `suggest_descriptions` handler body, plus the imports the handler needs (`structlog`, `Response`, and the new service). The Manual Batch Entry team's parallel work on `batch_create_transactions` in the same file is untouched.

## Test evidence

| Suite | Result |
|---|---|
| Backend full (`pytest tests/`) | 950 passed, 2 skipped |
| Backend service (`test_transaction_suggestions_service.py`) | 9 passed |
| Backend router (`test_transactions_suggestions.py`) | 6 passed |
| Backend contract (`test_import_contracts.py`) | 21 passed (updated 2 of the 4 suggestions tests from 501 to 200) |
| Frontend full (`npm test`) | 667 passed |
| Frontend tsc | clean |
| Frontend lint | 0 errors |
| Design-token check | passed |

## Live smoke

Verified end-to-end against an isolated docker compose stack (`team-description-suggestions`, nginx on 8090):

- Typing `Alb` in the description field opens a listbox with 3 ranked items: `Albert Heijn` (3 uses, prefix), `Albert Cuyp Market` (1 use, prefix), `Coffee Albertsons` (substring).
- `aria-expanded=true`, `aria-controls`, `aria-activedescendant`, polite live region announces "3 suggestions available".
- ArrowDown + Enter selects `Albert Cuyp Market`, sets the description input value, and pre-populates the category to `Groceries` (the most-frequently-paired category).
- Escape closes the listbox.

Screenshots attached as a prerelease asset (link in the PR comments).

## Out of scope (deferred)

- Duplicate-warning check (`GET /api/v1/transactions/suggestions/duplicate-check`). Reserved contract slot per spec section 2.3.
- Manual Batch integration. The autocomplete is single-transaction only; the batch form is owned by a different Wave 2A team.

## Files

Backend:
- `backend/app/routers/transactions.py` (modified, scope-disjoint)
- `backend/app/services/transaction_suggestions_service.py` (new)
- `backend/tests/routers/test_transactions_suggestions.py` (new)
- `backend/tests/services/test_transaction_suggestions_service.py` (new)
- `backend/tests/routers/test_import_contracts.py` (2 suggestions tests flipped from 501 to 200)

Frontend:
- `frontend/components/transactions/DescriptionAutocomplete.tsx` (new)
- `frontend/app/transactions/page.tsx` (description input swapped for the autocomplete in transaction mode)
- `frontend/tests/components/transactions/description-autocomplete.test.tsx` (new)