### PR TITLE
feat(infra): apex S3 + CloudFront + ACM + IAM OIDC (L5.2a PR-A)

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -4,6 +4,14 @@ Terraform Cloud workspace `FlamaCorp/pfv` managing the DigitalOcean
 infrastructure for the self-hosted MySQL + Redis pair behind `pfv`. State
 and runs live in TFC; this directory holds the configuration.
 
+> The apex landing (AWS S3 + CloudFront + ACM + IAM OIDC) lives in a
+> separate workspace `FlamaCorp/pfv-apex` with working directory
+> `infra/terraform/apex/` and trigger pattern `infra/terraform/apex/**`.
+> Keeping the AWS provisioning isolated from this DigitalOcean workspace
+> contains the blast radius and lets each workspace use its own auth
+> path (DO API token here, AWS OIDC there). See
+> [`apex/README.md`](apex/README.md) for the apex setup.
+
 ## Resources managed
 
 | Resource | Purpose |

--- a/infra/terraform/apex/.gitignore
+++ b/infra/terraform/apex/.gitignore
@@ -1,0 +1,13 @@
+.terraform/
+# .terraform.lock.hcl is committed (TFC needs it for reproducible runs).
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+crash.log
+crash.*.log
+terraform.tfvars
+*.auto.tfvars
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/terraform/apex/.terraform.lock.hcl
+++ b/infra/terraform/apex/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.50"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -1,0 +1,210 @@
+# pfv terraform: apex landing (AWS S3 + CloudFront + ACM + IAM OIDC)
+
+Terraform Cloud workspace `FlamaCorp/pfv-apex` managing the AWS-side
+infrastructure for the `thebetterdecision.com` apex marketing site.
+`app.thebetterdecision.com` stays on DigitalOcean App Platform. State and
+runs live in TFC; this directory holds the configuration.
+
+This is PR-A of the L5.2a apex split. **No Route 53 A-record changes are
+made here.** PR-D performs the apex `A` ALIAS swap to CloudFront after
+PR-B (GitHub Actions deploy workflow) and PR-C (Next.js static export)
+have landed and been validated against the CloudFront-assigned
+`dXXX.cloudfront.net` hostname.
+
+## Resources managed
+
+| Resource | Purpose |
+|---|---|
+| `aws_s3_bucket` (+ public-access-block, versioning, SSE, lifecycle, ownership) | Private origin bucket for the static export |
+| `aws_cloudfront_distribution` | Edge distribution with HTTPS, HSTS, www -> apex redirect |
+| `aws_cloudfront_origin_access_control` | OAC (NOT legacy OAI) so only this distribution can read the bucket |
+| `aws_cloudfront_function` | Viewer-request function redirecting `www` to apex with 301 |
+| `aws_cloudfront_response_headers_policy` | Security headers: HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy |
+| `aws_acm_certificate` + `_validation` | DNS-validated cert in `us-east-1` (CloudFront requirement) for apex + www |
+| `aws_route53_record.apex_acm_validation` | ACM `_<token>.<domain>` validation CNAMEs in the existing zone. **Does NOT touch the apex A record.** |
+| `aws_iam_openid_connect_provider.github` | Trust for GitHub Actions OIDC tokens |
+| `aws_iam_openid_connect_provider.tfc` | Trust for Terraform Cloud workload identity tokens |
+| `aws_iam_role.github_actions_apex_deploy` | Deploy role (s3 put/delete + cloudfront invalidation, scoped to this bucket + distribution) |
+| `aws_iam_role.tfc_apex_provisioner` | TFC-assumed role for managing this module's resources |
+
+## Workspace variables
+
+Set in TFC (`FlamaCorp/pfv-apex` -> Variables); never committed.
+
+| Name | Kind | Sensitive | Description |
+|---|---|---|---|
+| `aws_account_id` | Terraform | no | 12-digit AWS account ID owning the apex resources |
+| `AWS_ACCESS_KEY_ID` | Env | yes | **Bootstrap only**. Delete after first apply (see Bootstrap). |
+| `AWS_SECRET_ACCESS_KEY` | Env | yes | **Bootstrap only**. Delete after first apply (see Bootstrap). |
+| `TFC_AWS_PROVIDER_AUTH` | Env | no | Set to `true` after bootstrap to switch TFC to OIDC. |
+| `TFC_AWS_RUN_ROLE_ARN` | Env | no | After bootstrap, the `tfc_role_arn` output. Tells TFC to assume that role via workload identity. |
+
+Defaults for `aws_region`, `domain`, `github_repo`, `tfc_organization`,
+`tfc_workspace_pattern`, and `noncurrent_version_expiration_days` live in
+`variables.tf` and rarely need overriding.
+
+## Outputs (consumed by other PRs)
+
+Read from TFC -> Workspace -> Outputs after apply.
+
+- `github_actions_role_arn` -> **PR-B** sets this as `role-to-assume` in
+  the `aws-actions/configure-aws-credentials` step of the deploy workflow.
+- `s3_bucket_name` -> **PR-B** uses for `aws s3 sync .out s3://<bucket>`.
+- `cloudfront_distribution_id` -> **PR-B** uses for
+  `aws cloudfront create-invalidation`. **PR-D** uses for the apex A
+  ALIAS target.
+- `cloudfront_distribution_domain` -> Pre-cutover verification URL.
+  Browse this `dXXX.cloudfront.net` hostname end-to-end before PR-D fires.
+- `cloudfront_distribution_hosted_zone_id` -> **PR-D** uses when
+  constructing the `aws_route53_record` apex A ALIAS.
+- `route53_zone_id` -> **PR-D** uses to target the apex zone.
+- `tfc_role_arn` -> Set as `TFC_AWS_RUN_ROLE_ARN` env variable in this
+  workspace after the bootstrap apply. Lets TFC drop static keys.
+
+## Workflow
+
+- **Speculative plan**: every PR touching `infra/terraform/apex/**` gets
+  a TFC plan posted as a status check on the PR.
+- **Apply**: triggered on merge to `main`, gated on **manual confirm** in
+  the TFC UI. Auto-apply is intentionally off, matching the
+  `FlamaCorp/pfv` (data droplet) workspace policy. No infra change ever
+  lands without an operator clicking Confirm & Apply.
+- **Local CLI**: `terraform login` once, then
+  `terraform -chdir=infra/terraform/apex plan` reaches the same remote
+  state. CLI plan/apply is debug-only per the workspace policy
+  (`feedback_terraform_vcs_only`).
+
+## Bootstrap
+
+First TFC apply needs **something** to authenticate to AWS, because the
+OIDC providers and the `tfc-apex-provisioner` role only exist after this
+module applies. We use a **single static-credential bootstrap run**, then
+flip to OIDC immediately.
+
+### One-time bootstrap (owner runs)
+
+1. In AWS, create an IAM user named `pfv-apex-bootstrap` with
+   `AdministratorAccess`. Generate an access key pair.
+2. In TFC -> `FlamaCorp/pfv-apex` -> Variables, add:
+   - `AWS_ACCESS_KEY_ID` (Environment, sensitive) = the key id
+   - `AWS_SECRET_ACCESS_KEY` (Environment, sensitive) = the secret
+   - `aws_account_id` (Terraform) = your 12-digit account id
+3. Configure the workspace's VCS settings:
+   - Repo: `flamarion/pfv`
+   - Working directory: `infra/terraform/apex`
+   - Trigger pattern: `infra/terraform/apex/**`
+   - Auto-apply: **off**
+4. Open this PR. TFC runs a speculative plan against the worktree;
+   inspect the plan carefully, then merge.
+5. On merge, TFC creates an apply run. Click **Confirm & Apply** in the
+   TFC UI. The run provisions S3, CloudFront, ACM (validates via DNS,
+   takes 2-5 minutes), the OIDC providers, and the two IAM roles.
+6. **Switch TFC off static keys**:
+   - In TFC -> `FlamaCorp/pfv-apex` -> Variables, set:
+     - `TFC_AWS_PROVIDER_AUTH` (Environment) = `true`
+     - `TFC_AWS_RUN_ROLE_ARN` (Environment) = the `tfc_role_arn` output
+       from the bootstrap apply (e.g.
+       `arn:aws:iam::123456789012:role/tfc-apex-provisioner`)
+   - Delete `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the
+     workspace variables.
+7. In AWS, delete the `pfv-apex-bootstrap` IAM user (or at minimum
+   deactivate its access key). Do this within an hour of the bootstrap
+   apply.
+8. Trigger a no-op plan in TFC to confirm OIDC works end-to-end. Empty
+   plan = success.
+
+### Why this path (B) over manual OIDC bootstrap (A)
+
+We considered a path where the owner manually creates the OIDC providers
+in the AWS console before the first TFC run. That avoids ever using
+static keys, but it splits the resource graph: the OIDC providers exist
+outside Terraform state, so subsequent applies that touch their
+thumbprints or trust policies have to be done manually too. Path B keeps
+everything in Terraform from day one, at the cost of one hour of an
+admin-scoped IAM user. The static-keys window is tightly bounded.
+
+## Module layout
+
+```
+.
+├── main.tf                   # S3, CloudFront, ACM, IAM OIDC + roles
+├── variables.tf              # All inputs + defaults
+├── outputs.tf                # Consumed by PR-B and PR-D
+├── versions.tf               # cloud{} (TFC), provider pins
+├── providers.tf              # Default + us-east-1 alias for ACM
+├── terraform.tfvars.example  # Reference only; TFC sets vars in the workspace
+├── .gitignore
+└── README.md                 # This file
+```
+
+This module is intentionally **flat** (single directory, no submodules)
+because each AWS resource here is referenced by exactly one consumer.
+The `infra/terraform/` (DO data droplet) module nests `vpc/`,
+`droplet/`, and `firewall/` because each is reused across attachment
+targets; apex has no such reuse story.
+
+## Security notes
+
+### Least privilege
+
+- The **GitHub Actions deploy role** can `PutObject`, `DeleteObject`,
+  `ListBucket` on the apex bucket only, and `CreateInvalidation` on the
+  apex distribution only. No other bucket, no other distribution.
+- The **TFC apex provisioner role** can manage the apex bucket and
+  distribution, ACM certs in `us-east-1`, the two IAM OIDC providers,
+  and its own + the GH Actions role. Route 53 is **read-only** with the
+  single exception of ACM validation CNAME writes scoped to the apex
+  zone. Apex `A` record writes are **NOT** granted by this module; PR-D
+  widens the policy at cutover.
+- The **S3 bucket** has all four public-access-block flags ON. Read
+  access is granted exclusively to the apex CloudFront distribution
+  service-principal, scoped by `SourceArn` condition.
+
+### OAC vs OAI
+
+We use Origin Access Control (OAC, the AWS-recommended successor to OAI)
+because OAC supports SigV4 to the bucket, dynamic-content origins, and
+KMS-encrypted buckets. Legacy OAI is in maintenance mode and AWS has
+documented OAC as the long-term path.
+
+### Headers
+
+- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()`
+
+CSP is intentionally **not** set in this module. PR-C will author the
+CSP alongside the static-export's actual asset graph and add it via a
+follow-up to the response-headers policy.
+
+## Rollback
+
+Every resource in this module is `terraform destroy`-able. Removing the
+module leaves no Route 53 record changes behind (the apex A record is
+untouched). The ACM validation CNAMEs are deleted with the cert. If
+emergency teardown is needed during the bootstrap window, the owner can
+also destroy from CLI against the `pfv-apex` workspace (state lives in
+TFC, so `terraform login && terraform -chdir=infra/terraform/apex
+destroy` is sufficient).
+
+## Cost
+
+| Line | Monthly |
+|---|---|
+| S3 storage (static export, ~5 MB) | <$0.01 |
+| S3 requests (deploys + invalidations) | <$0.10 |
+| CloudFront (PriceClass_100, modest traffic) | ~$1.00 |
+| ACM certificate | $0.00 (free for CloudFront) |
+| Route 53 zone (existing) | $0.50 (not new) |
+| IAM OIDC providers | $0.00 |
+| **Total new spend** | **~$1.10** |
+
+## See also
+
+- `../README.md`: DO data droplet workspace (`FlamaCorp/pfv`)
+- `~/.claude/projects/-Users-fjorge-src-pfv/memory/project_apex_s3_cloudfront.md`:
+  canonical plan and locked decisions (D1-D5)
+- `~/.claude/projects/-Users-fjorge-src-pfv/memory/feedback_terraform_vcs_only.md`:
+  Terraform is VCS-driven; CLI is debug-only

--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -33,7 +33,7 @@ Set in TFC (`FlamaCorp/pfv-apex` -> Variables); never committed.
 
 | Name | Kind | Sensitive | Description |
 |---|---|---|---|
-| `aws_account_id` | Terraform | no | 12-digit AWS account ID owning the apex resources |
+| `aws_account_id` | Terraform | optional | 12-digit AWS account ID owning the apex resources. Strictly not a secret, but commonly marked Sensitive in TFC so it does not appear in plan/apply output. |
 | `AWS_ACCESS_KEY_ID` | Env | yes | **Bootstrap only**. Delete after first apply (see Bootstrap). |
 | `AWS_SECRET_ACCESS_KEY` | Env | yes | **Bootstrap only**. Delete after first apply (see Bootstrap). |
 | `TFC_AWS_PROVIDER_AUTH` | Env | no | Set to `true` after bootstrap to switch TFC to OIDC. |

--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -18,7 +18,7 @@ have landed and been validated against the CloudFront-assigned
 | `aws_s3_bucket` (+ public-access-block, versioning, SSE, lifecycle, ownership) | Private origin bucket for the static export |
 | `aws_cloudfront_distribution` | Edge distribution with HTTPS, HSTS, www -> apex redirect |
 | `aws_cloudfront_origin_access_control` | OAC (NOT legacy OAI) so only this distribution can read the bucket |
-| `aws_cloudfront_function` | Viewer-request function redirecting `www` to apex with 301 |
+| `aws_cloudfront_function` | Viewer-request function: (1) `www` -> apex 301 redirect, then (2) S3 directory-index rewrite (`/privacy/` -> `/privacy/index.html`) |
 | `aws_cloudfront_response_headers_policy` | Security headers: HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy |
 | `aws_acm_certificate` + `_validation` | DNS-validated cert in `us-east-1` (CloudFront requirement) for apex + www |
 | `aws_route53_record.apex_acm_validation` | ACM `_<token>.<domain>` validation CNAMEs in the existing zone. **Does NOT touch the apex A record.** |
@@ -149,16 +149,68 @@ targets; apex has no such reuse story.
 
 - The **GitHub Actions deploy role** can `PutObject`, `DeleteObject`,
   `ListBucket` on the apex bucket only, and `CreateInvalidation` on the
-  apex distribution only. No other bucket, no other distribution.
+  apex distribution only. No other bucket, no other distribution. The
+  trust policy uses `StringEquals` on the OIDC `sub` claim, pinned to
+  exactly `repo:flamarion/pfv:ref:refs/heads/main`. PR-context tokens
+  have a different `sub` and are rejected at the trust level. Workflow
+  `if:` guards alone would be insufficient because PR authors can edit
+  the workflow file; this restriction is IAM-enforced.
+  - **PR previews are not possible with this role.** If a future
+    requirement asks for preview deploys per PR, the correct path is a
+    separate read-only IAM role with its own trust policy (e.g.
+    conditioned on `pull_request` sub patterns and granted only
+    `s3:ListBucket`/`s3:GetObject`). That role is deliberately out of
+    scope for PR-A.
 - The **TFC apex provisioner role** can manage the apex bucket and
   distribution, ACM certs in `us-east-1`, the two IAM OIDC providers,
   and its own + the GH Actions role. Route 53 is **read-only** with the
-  single exception of ACM validation CNAME writes scoped to the apex
-  zone. Apex `A` record writes are **NOT** granted by this module; PR-D
-  widens the policy at cutover.
+  single exception of ACM validation **CNAME** writes, which are scoped
+  to the apex hosted zone AND restricted by an IAM condition on
+  `route53:ChangeResourceRecordSetsRecordTypes` to the `CNAME` type only.
+  Apex `A` record writes are **IAM-blocked**, not just code-discipline
+  blocked. PR-D widens the IAM condition to add `A` at cutover.
 - The **S3 bucket** has all four public-access-block flags ON. Read
   access is granted exclusively to the apex CloudFront distribution
   service-principal, scoped by `SourceArn` condition.
+
+### OIDC thumbprint rotation
+
+Both `aws_iam_openid_connect_provider` resources compute their SHA-1
+thumbprints at plan time via `data "tls_certificate"` lookups against
+the live OIDC issuer endpoints
+(`token.actions.githubusercontent.com` and `app.terraform.io`). AWS does
+NOT auto-rotate OIDC thumbprints, so hand-pinning is fragile across
+issuer cert rotations; computing on apply keeps trust intact. Requires
+the `hashicorp/tls ~> 4.0` provider, declared in `versions.tf`.
+
+### S3 directory-index handling (CloudFront Function)
+
+S3 REST origin (the OAC path) does NOT translate `/privacy/` to
+`/privacy/index.html`. That's only the S3 static-website-hosting
+endpoint, which is public + non-HTTPS and we deliberately avoid. A
+viewer-request CloudFront Function rewrites directory-style URIs:
+
+- `/privacy/` -> `/privacy/index.html`
+- `/about` (no trailing slash, no extension) -> `/about/index.html`
+- `/_next/static/foo.css` (has extension) -> pass through
+
+The function ALSO performs the `www` -> apex 301 redirect. Order
+matters: redirect runs FIRST (so we never spend rewrite cycles on
+requests we're about to bounce to a different host), rewrite runs
+SECOND (so requests that survive the redirect have S3-resolvable URIs).
+
+Expected behaviour, verifiable against the CloudFront-assigned
+`dXXX.cloudfront.net` URL once PR-B has synced PR-C's `out-apex/`:
+
+| URL | Expected response |
+|---|---|
+| `https://<cf-domain>/` | `index.html` (200) |
+| `https://<cf-domain>/privacy/` | `privacy/index.html` (200) |
+| `https://<cf-domain>/privacy` | `privacy/index.html` (200 after rewrite) |
+| `https://<cf-domain>/terms/` | `terms/index.html` (200) |
+| `https://<cf-domain>/docs/` | `docs/index.html` (200) |
+| `https://<cf-domain>/_next/static/foo.css` | 200 (no rewrite) |
+| `https://www.<apex>/privacy` | 301 -> `https://<apex>/privacy` |
 
 ### OAC vs OAI
 

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -25,11 +25,12 @@ locals {
   # config; the format matches the AWS console convention.
   s3_origin_id = "S3-${local.bucket_name}"
 
-  # GitHub Actions OIDC subject claims. Push to main = full deploy; PRs get
-  # plan-only access (no s3 put/delete, no invalidation), controlled in the
-  # role's inline policy below by NOT granting mutating actions to PRs.
+  # GitHub Actions OIDC subject claim: ONLY push-to-main can assume the
+  # deploy role. PR-context tokens have a different sub (`pull_request`)
+  # and are rejected by the trust policy's StringEquals match. PR previews,
+  # if ever needed, require a separate read-only role (documented as a
+  # follow-up in apex/README.md).
   github_main_sub = "repo:${var.github_repo}:ref:refs/heads/${var.github_main_branch}"
-  github_pr_sub   = var.github_pr_subject_pattern == "" ? null : "repo:${var.github_repo}:${var.github_pr_subject_pattern}"
 
   # TFC workload identity subject claim. The TFC docs document the run-phase
   # suffix; we accept plan + apply so PR speculative plans and merge applies
@@ -44,6 +45,20 @@ locals {
 data "aws_route53_zone" "apex" {
   name         = var.domain
   private_zone = false
+}
+
+# OIDC thumbprint lookups. AWS does NOT silently rotate OIDC provider
+# thumbprints; whatever Terraform commits is what apply uses. Computing
+# the SHA-1 fingerprint from the live TLS handshake at plan time is the
+# documented HashiCorp pattern for keeping the trust intact across cert
+# rotations (the alternative is a hand-pinned list that bit-rots and
+# silently breaks the trust the next time the issuer rotates).
+data "tls_certificate" "github_oidc" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "tls_certificate" "tfc_oidc" {
+  url = "https://app.terraform.io"
 }
 
 ###############################################################################
@@ -225,17 +240,32 @@ resource "aws_cloudfront_response_headers_policy" "apex" {
   }
 }
 
-# CloudFront Function: redirects www.<apex> -> https://<apex> with a 301.
-# Lightweight (no Lambda@Edge cold start cost); runs at viewer-request.
-resource "aws_cloudfront_function" "www_to_apex_redirect" {
-  name    = "${replace(var.domain, ".", "-")}-www-to-apex"
+# CloudFront Function: single viewer-request handler combining
+# (1) www -> apex 301 redirect and (2) directory-style URL rewrites
+# (e.g. /privacy/ -> /privacy/index.html). CloudFront only allows one
+# viewer-request function per behavior, so both behaviors live in this
+# function with a strict order: REDIRECT runs first (so we don't waste
+# work rewriting URIs for requests we're about to bounce), REWRITE runs
+# second (so requests that survive the redirect have S3-resolvable URIs).
+#
+# Why rewrite is needed: with S3 + OAC (REST origin), requests for
+# "/privacy/" hit S3 looking for an object literally named "privacy/" and
+# get a 404/403. The S3 static-website-hosting endpoint translates this
+# automatically, but it's public + non-HTTPS so we deliberately don't use
+# it. PR-C's static export produces out-apex/privacy/index.html etc.;
+# this function bridges the gap.
+resource "aws_cloudfront_function" "viewer_request" {
+  name    = "${replace(var.domain, ".", "-")}-viewer-request"
   runtime = "cloudfront-js-2.0"
-  comment = "301 redirect www.${var.domain} -> https://${var.domain}"
+  comment = "www->apex redirect + S3 directory index rewrite for ${var.domain}"
   publish = true
 
   code = <<-EOT
 function handler(event) {
   var request = event.request;
+
+  // 1) www -> apex 301 redirect. Runs FIRST so we never spend rewrite
+  //    cycles on requests we're about to bounce to a different host.
   var host = request.headers.host && request.headers.host.value;
   if (host && host.toLowerCase() === "${local.www_fqdn}") {
     return {
@@ -245,6 +275,18 @@ function handler(event) {
         "location": { "value": "https://${local.apex_fqdn}" + request.uri }
       }
     };
+  }
+
+  // 2) S3 directory index rewrite. Runs SECOND so it only applies to
+  //    requests that survived the redirect check. "/privacy/" becomes
+  //    "/privacy/index.html"; "/about" (no trailing slash, no extension)
+  //    becomes "/about/index.html". Requests with an extension (".css",
+  //    ".png", ".js") pass through untouched.
+  var uri = request.uri;
+  if (uri.endsWith("/")) {
+    request.uri += "index.html";
+  } else if (!uri.includes(".")) {
+    request.uri += "/index.html";
   }
   return request;
 }
@@ -287,7 +329,7 @@ resource "aws_cloudfront_distribution" "apex" {
 
     function_association {
       event_type   = "viewer-request"
-      function_arn = aws_cloudfront_function.www_to_apex_redirect.arn
+      function_arn = aws_cloudfront_function.viewer_request.arn
     }
   }
 
@@ -365,16 +407,15 @@ resource "aws_s3_bucket_policy" "apex" {
 # instead of double-creating. The bootstrap notes in README.md cover this.
 ###############################################################################
 
-# GitHub Actions OIDC. Thumbprint list is the published GitHub root cert
-# chain; AWS verifies signed JWTs against these. Source:
-# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+# GitHub Actions OIDC. Thumbprints are computed at plan time from the live
+# TLS handshake against token.actions.githubusercontent.com via the
+# tls_certificate data source above. AWS does NOT auto-rotate OIDC
+# provider thumbprints, so hand-pinning a list is fragile across issuer
+# cert rotations; computing on apply keeps the trust intact.
 resource "aws_iam_openid_connect_provider" "github" {
-  url            = "https://token.actions.githubusercontent.com"
-  client_id_list = ["sts.amazonaws.com"]
-  thumbprint_list = [
-    "6938fd4d98bab03faadb97b34396831e3780aea1",
-    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
-  ]
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github_oidc.certificates[0].sha1_fingerprint]
 
   tags = {
     Name = "github-actions-oidc"
@@ -382,15 +423,11 @@ resource "aws_iam_openid_connect_provider" "github" {
 }
 
 # Terraform Cloud workload identity. Single-audience: aws.workload.identity.
+# Thumbprint computed at plan time from app.terraform.io's live cert chain.
 resource "aws_iam_openid_connect_provider" "tfc" {
-  url            = "https://app.terraform.io"
-  client_id_list = ["aws.workload.identity"]
-
-  # TFC's certificate chain rotates; we let AWS resolve the thumbprint from
-  # the JWKS rather than pinning a manual list, by setting a placeholder
-  # that's overwritten on first validation. This matches HashiCorp's
-  # documented pattern for the TFC -> AWS OIDC bridge.
-  thumbprint_list = ["0c8e8c0b6b8e8e8c0b6b8e8e8c0b6b8e8e8c0b6b"]
+  url             = "https://app.terraform.io"
+  client_id_list  = ["aws.workload.identity"]
+  thumbprint_list = [data.tls_certificate.tfc_oidc.certificates[0].sha1_fingerprint]
 
   tags = {
     Name = "tfc-workload-identity"
@@ -399,16 +436,24 @@ resource "aws_iam_openid_connect_provider" "tfc" {
 
 ###############################################################################
 # IAM ROLE: github_actions_apex_deploy
-# Assumable from the pfv repo's GitHub Actions workflows. Main-branch pushes
-# get s3 put/delete + cloudfront invalidation. PRs (if enabled) can ONLY
-# assume the role for plan-style operations because the inline policy below
-# is the only policy attached and it grants mutating actions unconditionally;
-# PR-B's workflow restricts itself further with a job-level `if:` guard.
+# Assumable ONLY from GitHub Actions workflow runs whose OIDC token subject
+# exactly equals `repo:${var.github_repo}:ref:refs/heads/${var.github_main_branch}`.
+# This is the "push to main" subject; PR-context tokens have a different sub
+# (`pull_request`) and cannot match.
+#
+# Why exact-match: workflow-level guards like `if: github.ref == 'refs/heads/main'`
+# are not sufficient because anyone who can open a PR can also rewrite the
+# workflow file in that PR and remove the guard. The trust policy itself
+# must reject non-main subjects.
+#
+# Use `StringEquals` (not StringLike) on the sub claim. NO pull_request
+# patterns. If PR previews are needed later, that requires a SEPARATE
+# read-only role (see follow-up note in apex/README.md).
 ###############################################################################
 
 data "aws_iam_policy_document" "github_actions_trust" {
   statement {
-    sid     = "GitHubActionsFromMain"
+    sid     = "GitHubActionsFromMainOnly"
     effect  = "Allow"
     actions = ["sts:AssumeRoleWithWebIdentity"]
 
@@ -426,7 +471,7 @@ data "aws_iam_policy_document" "github_actions_trust" {
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = compact([local.github_main_sub, local.github_pr_sub])
+      values   = [local.github_main_sub]
     }
   }
 }
@@ -588,18 +633,26 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
   }
 
   # ACM validation creates _<token>.<domain> CNAMEs in the zone. Without
-  # write access to the zone, PR-A's apply cannot complete. Scoped to the
-  # specific zone; this is the ONLY record-mutating permission granted.
+  # write access to the zone, PR-A's apply cannot complete. The
+  # ForAllValues:StringEquals condition on route53:ChangeResourceRecordSetsRecordTypes
+  # restricts the role to CNAME writes ONLY. The apex A record (and any
+  # other record type) is unreachable through this role. PR-D will widen
+  # the condition to add "A" when it ships the apex ALIAS swap. This
+  # makes "no A records in PR-A" an IAM-enforced invariant, not just a
+  # Terraform code-discipline one.
   statement {
-    sid    = "WriteAcmValidationRecords"
+    sid    = "WriteAcmValidationRecordsCnameOnly"
     effect = "Allow"
     actions = [
       "route53:ChangeResourceRecordSets",
     ]
     resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.apex.zone_id}"]
-    # NOTE: ACM validation records are _<token>.<domain> CNAMEs; the apex
-    # A record is left untouched by this PR. PR-D adds the apex A ALIAS;
-    # that's the cutover step.
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "route53:ChangeResourceRecordSetsRecordTypes"
+      values   = ["CNAME"]
+    }
   }
 
   # IAM management for this role chain (self-management) + the OIDC

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -1,0 +1,640 @@
+###############################################################################
+# pfv apex landing: S3 (private) + CloudFront (OAC) + ACM (us-east-1) +
+# IAM OIDC roles (GitHub Actions deploy, TFC apex provisioner).
+#
+# PR-A of the L5.2a apex split. NO Route 53 A-record changes here. The apex
+# stays parked through this PR. ACM DNS-validation records ARE written into
+# the existing Route 53 zone (they don't touch the apex itself, only the
+# _acme-challenge style validation CNAMEs ACM emits).
+#
+# Cutover (apex A ALIAS swap, TTL drop) is PR-D. PR-B consumes
+# github_actions_role_arn from outputs.tf; PR-C produces the static export
+# that gets s3-synced into the bucket.
+###############################################################################
+
+locals {
+  apex_fqdn = var.domain
+  www_fqdn  = "www.${var.domain}"
+
+  # Deterministic, unambiguous bucket name. AWS S3 bucket names are global,
+  # lowercase, and DNS-safe; the apex suffix prevents collisions with any
+  # future "thebetterdecision.com" bucket spun up for a different purpose.
+  bucket_name = "${replace(var.domain, ".", "-")}-apex"
+
+  # CloudFront origin id is purely a local handle within the distribution
+  # config; the format matches the AWS console convention.
+  s3_origin_id = "S3-${local.bucket_name}"
+
+  # GitHub Actions OIDC subject claims. Push to main = full deploy; PRs get
+  # plan-only access (no s3 put/delete, no invalidation), controlled in the
+  # role's inline policy below by NOT granting mutating actions to PRs.
+  github_main_sub = "repo:${var.github_repo}:ref:refs/heads/${var.github_main_branch}"
+  github_pr_sub   = var.github_pr_subject_pattern == "" ? null : "repo:${var.github_repo}:${var.github_pr_subject_pattern}"
+
+  # TFC workload identity subject claim. The TFC docs document the run-phase
+  # suffix; we accept plan + apply so PR speculative plans and merge applies
+  # both work. Workspace pattern uses TFC's glob support.
+  tfc_sub_pattern = "organization:${var.tfc_organization}:project:*:workspace:${var.tfc_workspace_pattern}:run_phase:*"
+}
+
+# Existing hosted zone for the apex domain. We do not create the zone here;
+# it was registered earlier in the project lifecycle and lives in this same
+# AWS account. Failure to find it surfaces as an explicit "no matching zone"
+# error at plan time, which is the desired behaviour.
+data "aws_route53_zone" "apex" {
+  name         = var.domain
+  private_zone = false
+}
+
+###############################################################################
+# S3 BUCKET
+# Private (block public access on all four flags), versioned, SSE-S3.
+# CloudFront reaches it via OAC; no public read path exists.
+###############################################################################
+
+resource "aws_s3_bucket" "apex" {
+  bucket = local.bucket_name
+
+  tags = {
+    Name = local.bucket_name
+    role = "apex-static-origin"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "apex" {
+  bucket = aws_s3_bucket.apex.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "apex" {
+  bucket = aws_s3_bucket.apex.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "apex" {
+  bucket = aws_s3_bucket.apex.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "apex" {
+  bucket = aws_s3_bucket.apex.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "apex" {
+  bucket = aws_s3_bucket.apex.id
+
+  # versioning_configuration above must apply before lifecycle rules that
+  # reference noncurrent_version_expiration; depends_on makes the order
+  # explicit so terraform plan doesn't race.
+  depends_on = [aws_s3_bucket_versioning.apex]
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.noncurrent_version_expiration_days
+    }
+
+    # Abort multipart uploads left behind by a failed deploy after 7 days.
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+###############################################################################
+# ACM CERTIFICATE (us-east-1, CloudFront requirement)
+# DNS-validated via the existing Route 53 zone. Validation records are
+# automatically managed; they're scoped to ACM's _<random>.<domain> CNAMEs
+# and DO NOT touch the apex A record.
+###############################################################################
+
+resource "aws_acm_certificate" "apex" {
+  provider = aws.us_east_1
+
+  domain_name               = local.apex_fqdn
+  subject_alternative_names = [local.www_fqdn]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${local.apex_fqdn}-cf"
+  }
+}
+
+# Route 53 validation records. ACM emits one CNAME per (domain, SAN) pair;
+# the for_each loop materialises them. These records are _<token>.<domain>
+# style and do NOT collide with the apex A record (PR-D's territory).
+resource "aws_route53_record" "apex_acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.apex.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.apex.zone_id
+}
+
+resource "aws_acm_certificate_validation" "apex" {
+  provider = aws.us_east_1
+
+  certificate_arn         = aws_acm_certificate.apex.arn
+  validation_record_fqdns = [for r in aws_route53_record.apex_acm_validation : r.fqdn]
+}
+
+###############################################################################
+# CLOUDFRONT. Origin Access Control (OAC, NOT legacy OAI), response-headers
+# policy with HSTS et al., CloudFront Function for www -> apex 301 redirect.
+###############################################################################
+
+resource "aws_cloudfront_origin_access_control" "apex" {
+  name                              = "${local.bucket_name}-oac"
+  description                       = "OAC for apex landing static site."
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# Response headers policy: HSTS, X-Content-Type-Options, X-Frame-Options,
+# Referrer-Policy, Permissions-Policy. These are baseline web security
+# headers; CSP is intentionally omitted from this PR because the static
+# export's CSP needs to be authored alongside PR-C's build output.
+resource "aws_cloudfront_response_headers_policy" "apex" {
+  name    = "${local.bucket_name}-security-headers"
+  comment = "Baseline security headers for the apex landing distribution."
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = 63072000 # 2 years
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+
+    content_type_options {
+      override = true
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+
+    referrer_policy {
+      referrer_policy = "strict-origin-when-cross-origin"
+      override        = true
+    }
+  }
+
+  custom_headers_config {
+    items {
+      header   = "Permissions-Policy"
+      value    = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+      override = true
+    }
+  }
+}
+
+# CloudFront Function: redirects www.<apex> -> https://<apex> with a 301.
+# Lightweight (no Lambda@Edge cold start cost); runs at viewer-request.
+resource "aws_cloudfront_function" "www_to_apex_redirect" {
+  name    = "${replace(var.domain, ".", "-")}-www-to-apex"
+  runtime = "cloudfront-js-2.0"
+  comment = "301 redirect www.${var.domain} -> https://${var.domain}"
+  publish = true
+
+  code = <<-EOT
+function handler(event) {
+  var request = event.request;
+  var host = request.headers.host && request.headers.host.value;
+  if (host && host.toLowerCase() === "${local.www_fqdn}") {
+    return {
+      statusCode: 301,
+      statusDescription: "Moved Permanently",
+      headers: {
+        "location": { "value": "https://${local.apex_fqdn}" + request.uri }
+      }
+    };
+  }
+  return request;
+}
+EOT
+}
+
+resource "aws_cloudfront_distribution" "apex" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.domain} apex landing (L5.2a)"
+  default_root_object = "index.html"
+  price_class         = "PriceClass_100" # NA + EU PoPs; cheapest tier that covers target users.
+  http_version        = "http2and3"
+
+  aliases = [local.apex_fqdn, local.www_fqdn]
+
+  origin {
+    domain_name              = aws_s3_bucket.apex.bucket_regional_domain_name
+    origin_id                = local.s3_origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.apex.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = local.s3_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    # AWS managed CachingOptimized policy (long TTL, gzip/br on,
+    # query strings ignored). Matches the static-export pattern where
+    # hashed asset filenames are the cache-busting key.
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+
+    # AWS managed CORS-S3Origin: forwards Origin + the bare minimum for
+    # cross-origin font loading without exploding the cache key.
+    origin_request_policy_id = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.apex.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.www_to_apex_redirect.arn
+    }
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_code         = 404
+    response_page_path    = "/404.html"
+    error_caching_min_ttl = 60
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 404
+    response_page_path    = "/404.html"
+    error_caching_min_ttl = 60
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.apex.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = {
+    Name = "${var.domain}-apex"
+  }
+}
+
+###############################################################################
+# S3 BUCKET POLICY. Grant CloudFront (via OAC) read on the bucket. Scoped to
+# this distribution's ARN; no other principal gets access.
+###############################################################################
+
+data "aws_iam_policy_document" "apex_bucket" {
+  statement {
+    sid    = "AllowCloudFrontServicePrincipalReadOnly"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.apex.arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.apex.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "apex" {
+  bucket = aws_s3_bucket.apex.id
+  policy = data.aws_iam_policy_document.apex_bucket.json
+
+  # Public access block must apply BEFORE a bucket policy lands, else the
+  # account-level BPA settings can race the policy evaluation.
+  depends_on = [aws_s3_bucket_public_access_block.apex]
+}
+
+###############################################################################
+# IAM OIDC PROVIDERS. GitHub Actions + Terraform Cloud workload identity.
+# These are AWS-account-global resources; if either provider already exists
+# in the account (e.g. from a different project), this module will conflict
+# at plan time and the owner should `terraform import` the existing one
+# instead of double-creating. The bootstrap notes in README.md cover this.
+###############################################################################
+
+# GitHub Actions OIDC. Thumbprint list is the published GitHub root cert
+# chain; AWS verifies signed JWTs against these. Source:
+# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+
+  tags = {
+    Name = "github-actions-oidc"
+  }
+}
+
+# Terraform Cloud workload identity. Single-audience: aws.workload.identity.
+resource "aws_iam_openid_connect_provider" "tfc" {
+  url            = "https://app.terraform.io"
+  client_id_list = ["aws.workload.identity"]
+
+  # TFC's certificate chain rotates; we let AWS resolve the thumbprint from
+  # the JWKS rather than pinning a manual list, by setting a placeholder
+  # that's overwritten on first validation. This matches HashiCorp's
+  # documented pattern for the TFC -> AWS OIDC bridge.
+  thumbprint_list = ["0c8e8c0b6b8e8e8c0b6b8e8e8c0b6b8e8e8c0b6b"]
+
+  tags = {
+    Name = "tfc-workload-identity"
+  }
+}
+
+###############################################################################
+# IAM ROLE: github_actions_apex_deploy
+# Assumable from the pfv repo's GitHub Actions workflows. Main-branch pushes
+# get s3 put/delete + cloudfront invalidation. PRs (if enabled) can ONLY
+# assume the role for plan-style operations because the inline policy below
+# is the only policy attached and it grants mutating actions unconditionally;
+# PR-B's workflow restricts itself further with a job-level `if:` guard.
+###############################################################################
+
+data "aws_iam_policy_document" "github_actions_trust" {
+  statement {
+    sid     = "GitHubActionsFromMain"
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = compact([local.github_main_sub, local.github_pr_sub])
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_apex_deploy" {
+  name                 = "github-actions-apex-deploy"
+  description          = "Assumed by GitHub Actions (${var.github_repo}) to deploy the apex landing static export."
+  assume_role_policy   = data.aws_iam_policy_document.github_actions_trust.json
+  max_session_duration = 3600
+
+  tags = {
+    role = "github-actions-apex-deploy"
+  }
+}
+
+# Inline policy: scoped to THIS bucket + THIS distribution. No * resources.
+data "aws_iam_policy_document" "github_actions_deploy" {
+  statement {
+    sid       = "ListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = [aws_s3_bucket.apex.arn]
+  }
+
+  statement {
+    sid    = "ReadWriteObjects"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${aws_s3_bucket.apex.arn}/*"]
+  }
+
+  statement {
+    sid    = "InvalidateDistribution"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+      "cloudfront:ListInvalidations",
+    ]
+    resources = [aws_cloudfront_distribution.apex.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_apex_deploy" {
+  name   = "github-actions-apex-deploy-inline"
+  role   = aws_iam_role.github_actions_apex_deploy.id
+  policy = data.aws_iam_policy_document.github_actions_deploy.json
+}
+
+###############################################################################
+# IAM ROLE: tfc_apex_provisioner
+# Assumable from TFC workload identity tokens originating in the pfv-apex
+# workspace (or any workspace matching var.tfc_workspace_pattern). Has full
+# management of THIS module's resources: S3 bucket, CloudFront distribution,
+# ACM cert, IAM role chain. Route 53 access is READ-ONLY (Get* on the apex
+# zone) so PR-A cannot accidentally write A records; PR-D adds the write
+# permissions when the cutover Terraform lands.
+###############################################################################
+
+data "aws_iam_policy_document" "tfc_trust" {
+  statement {
+    sid     = "TFCWorkloadIdentity"
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.tfc.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "app.terraform.io:aud"
+      values   = ["aws.workload.identity"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "app.terraform.io:sub"
+      values   = [local.tfc_sub_pattern]
+    }
+  }
+}
+
+resource "aws_iam_role" "tfc_apex_provisioner" {
+  name                 = "tfc-apex-provisioner"
+  description          = "Assumed by TFC (${var.tfc_organization}/${var.tfc_workspace_pattern}) to provision apex infra."
+  assume_role_policy   = data.aws_iam_policy_document.tfc_trust.json
+  max_session_duration = 3600
+
+  tags = {
+    role = "tfc-apex-provisioner"
+  }
+}
+
+data "aws_iam_policy_document" "tfc_apex_provisioner" {
+  # S3 management on THIS bucket only.
+  statement {
+    sid    = "ManageApexBucket"
+    effect = "Allow"
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      aws_s3_bucket.apex.arn,
+      "${aws_s3_bucket.apex.arn}/*",
+    ]
+  }
+
+  # ListAllMyBuckets is account-wide and needed for some plan operations.
+  statement {
+    sid       = "ListAllBucketsForPlan"
+    effect    = "Allow"
+    actions   = ["s3:ListAllMyBuckets", "s3:GetBucketLocation"]
+    resources = ["*"]
+  }
+
+  # CloudFront management on this distribution. CloudFront IAM is not
+  # ARN-scoped on all actions (some, like CreateDistribution, only accept
+  # "*"); we accept that limitation rather than splitting the policy.
+  statement {
+    sid    = "ManageApexDistribution"
+    effect = "Allow"
+    actions = [
+      "cloudfront:*",
+    ]
+    resources = ["*"]
+  }
+
+  # ACM in us-east-1 for the cert. ACM IAM is region-keyed via resource ARN
+  # so this scopes to certificates in us-east-1 within this account.
+  statement {
+    sid    = "ManageApexCertificate"
+    effect = "Allow"
+    actions = [
+      "acm:*",
+    ]
+    resources = ["arn:aws:acm:us-east-1:${var.aws_account_id}:certificate/*"]
+  }
+
+  # Route 53 READ-ONLY on the apex zone. ACM validation CNAMEs and the
+  # data lookup need Get/List; PR-A intentionally CANNOT write A records.
+  # PR-D will widen this to ChangeResourceRecordSets when cutover lands.
+  statement {
+    sid    = "ReadApexZone"
+    effect = "Allow"
+    actions = [
+      "route53:GetHostedZone",
+      "route53:ListHostedZones",
+      "route53:ListHostedZonesByName",
+      "route53:GetChange",
+      "route53:ListResourceRecordSets",
+    ]
+    resources = ["*"]
+  }
+
+  # ACM validation creates _<token>.<domain> CNAMEs in the zone. Without
+  # write access to the zone, PR-A's apply cannot complete. Scoped to the
+  # specific zone; this is the ONLY record-mutating permission granted.
+  statement {
+    sid    = "WriteAcmValidationRecords"
+    effect = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.apex.zone_id}"]
+    # NOTE: ACM validation records are _<token>.<domain> CNAMEs; the apex
+    # A record is left untouched by this PR. PR-D adds the apex A ALIAS;
+    # that's the cutover step.
+  }
+
+  # IAM management for this role chain (self-management) + the OIDC
+  # providers. Scoped to the apex-related resource names.
+  statement {
+    sid    = "ManageApexIamRoles"
+    effect = "Allow"
+    actions = [
+      "iam:*Role*",
+      "iam:*RolePolic*",
+      "iam:PassRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+    ]
+    resources = [
+      "arn:aws:iam::${var.aws_account_id}:role/github-actions-apex-deploy",
+      "arn:aws:iam::${var.aws_account_id}:role/tfc-apex-provisioner",
+    ]
+  }
+
+  statement {
+    sid    = "ManageOidcProviders"
+    effect = "Allow"
+    actions = [
+      "iam:*OpenIDConnectProvider*",
+    ]
+    resources = [
+      "arn:aws:iam::${var.aws_account_id}:oidc-provider/token.actions.githubusercontent.com",
+      "arn:aws:iam::${var.aws_account_id}:oidc-provider/app.terraform.io",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "tfc_apex_provisioner" {
+  name   = "tfc-apex-provisioner-inline"
+  role   = aws_iam_role.tfc_apex_provisioner.id
+  policy = data.aws_iam_policy_document.tfc_apex_provisioner.json
+}

--- a/infra/terraform/apex/outputs.tf
+++ b/infra/terraform/apex/outputs.tf
@@ -1,0 +1,69 @@
+output "s3_bucket_name" {
+  description = "Name of the apex landing S3 bucket. Consumed by PR-B's GitHub Actions workflow for `aws s3 sync`."
+  value       = aws_s3_bucket.apex.id
+}
+
+output "s3_bucket_arn" {
+  description = "ARN of the apex landing S3 bucket. Useful for cross-account integrations and future log-shipping policies."
+  value       = aws_s3_bucket.apex.arn
+}
+
+output "s3_bucket_regional_domain_name" {
+  description = "Regional domain name of the apex bucket (S3 -> CloudFront origin DNS target). Echoed for debugging."
+  value       = aws_s3_bucket.apex.bucket_regional_domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID. Consumed by PR-B's workflow for `aws cloudfront create-invalidation`. Also the target for PR-D's apex A ALIAS record."
+  value       = aws_cloudfront_distribution.apex.id
+}
+
+output "cloudfront_distribution_arn" {
+  description = "Full ARN of the CloudFront distribution. Used by the bucket policy's SourceArn condition and the GitHub Actions inline policy's invalidation scope."
+  value       = aws_cloudfront_distribution.apex.arn
+}
+
+output "cloudfront_distribution_domain" {
+  description = "CloudFront-assigned dXXX.cloudfront.net hostname. This is the pre-cutover verification URL: PR-C's static export is browsable here once PR-B has synced it. PR-D's Route 53 ALIAS will point to this distribution by its ID, not this hostname."
+  value       = aws_cloudfront_distribution.apex.domain_name
+}
+
+output "cloudfront_distribution_hosted_zone_id" {
+  description = "CloudFront's fixed hosted zone ID (Z2FDTNDATAQYW2). PR-D will need this when constructing the apex A ALIAS record."
+  value       = aws_cloudfront_distribution.apex.hosted_zone_id
+}
+
+output "acm_certificate_arn" {
+  description = "ARN of the validated us-east-1 ACM certificate for apex + www."
+  value       = aws_acm_certificate_validation.apex.certificate_arn
+}
+
+output "route53_zone_id" {
+  description = "Hosted zone ID for the apex domain. Consumed by PR-D for the apex A ALIAS swap."
+  value       = data.aws_route53_zone.apex.zone_id
+}
+
+output "github_actions_role_arn" {
+  description = "ARN of the IAM role GitHub Actions assumes via OIDC. PR-B sets this as `role-to-assume` in aws-actions/configure-aws-credentials."
+  value       = aws_iam_role.github_actions_apex_deploy.arn
+}
+
+output "tfc_role_arn" {
+  description = "ARN of the IAM role TFC assumes via workload identity. Set this in the FlamaCorp/pfv-apex workspace's TFC_AWS_RUN_ROLE_ARN variable so TFC stops needing static credentials after the bootstrap apply."
+  value       = aws_iam_role.tfc_apex_provisioner.arn
+}
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider. Surface this so a future module (or a second repo) can attach roles to the same provider without re-creating it."
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+output "tfc_oidc_provider_arn" {
+  description = "ARN of the Terraform Cloud OIDC provider. Same rationale as github_oidc_provider_arn."
+  value       = aws_iam_openid_connect_provider.tfc.arn
+}
+
+output "apex_domain" {
+  description = "Echo of the apex domain configured by var.domain. Useful for sanity-checking the workspace at a glance."
+  value       = var.domain
+}

--- a/infra/terraform/apex/providers.tf
+++ b/infra/terraform/apex/providers.tf
@@ -1,0 +1,34 @@
+# Default AWS provider: hosts the S3 bucket, IAM, and Route 53 lookups.
+# Region is configurable via var.aws_region; default eu-west-1 matches the
+# rest of the EU-centric pfv stack.
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      project     = "pfv"
+      component   = "apex-landing"
+      managed_by  = "terraform"
+      workspace   = "FlamaCorp/pfv-apex"
+      environment = "prod"
+    }
+  }
+}
+
+# us-east-1 alias provider. CloudFront requires that the ACM certificate
+# attached to a distribution live in us-east-1 regardless of where the
+# origin bucket sits. Only used for aws_acm_certificate + its validation.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      project     = "pfv"
+      component   = "apex-landing"
+      managed_by  = "terraform"
+      workspace   = "FlamaCorp/pfv-apex"
+      environment = "prod"
+    }
+  }
+}

--- a/infra/terraform/apex/terraform.tfvars.example
+++ b/infra/terraform/apex/terraform.tfvars.example
@@ -11,7 +11,6 @@
 # domain                             = "thebetterdecision.com"
 # github_repo                        = "flamarion/pfv"
 # github_main_branch                 = "main"
-# github_pr_subject_pattern          = "pull_request"
 # tfc_organization                   = "FlamaCorp"
 # tfc_workspace_pattern              = "pfv-apex*"
 # noncurrent_version_expiration_days = 90

--- a/infra/terraform/apex/terraform.tfvars.example
+++ b/infra/terraform/apex/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# Reference only. Production runs happen in Terraform Cloud
+# (FlamaCorp/pfv-apex); variables are set as workspace variables there.
+# Use this file ONLY for local-CLI debug runs (`terraform login` then
+# `terraform plan` from a laptop); terraform.tfvars stays gitignored.
+#
+# Required:
+# aws_account_id = "123456789012"
+#
+# Optional overrides (defaults live in variables.tf):
+# aws_region                         = "eu-west-1"
+# domain                             = "thebetterdecision.com"
+# github_repo                        = "flamarion/pfv"
+# github_main_branch                 = "main"
+# github_pr_subject_pattern          = "pull_request"
+# tfc_organization                   = "FlamaCorp"
+# tfc_workspace_pattern              = "pfv-apex*"
+# noncurrent_version_expiration_days = 90

--- a/infra/terraform/apex/variables.tf
+++ b/infra/terraform/apex/variables.tf
@@ -27,15 +27,9 @@ variable "github_repo" {
 }
 
 variable "github_main_branch" {
-  description = "Branch on github_repo whose workflow runs can assume the deploy role for actual deploys (s3 sync + invalidation). PRs targeting this branch can also assume the role for plan-only operations via the github_pr_subject_pattern."
+  description = "Branch on github_repo whose workflow runs are allowed to assume the deploy role. The OIDC trust policy uses StringEquals on the sub claim, so only this exact branch ref can deploy. PR contexts are rejected at the trust level (not just by workflow-level guards), since PR authors could otherwise edit the workflow to bypass guards."
   type        = string
   default     = "main"
-}
-
-variable "github_pr_subject_pattern" {
-  description = "OIDC subject pattern that pull request workflows on github_repo match. Used to allow plan-only access from PRs while keeping deploy-mutating actions scoped to main pushes. Empty string disables PR access entirely."
-  type        = string
-  default     = "pull_request"
 }
 
 variable "tfc_organization" {

--- a/infra/terraform/apex/variables.tf
+++ b/infra/terraform/apex/variables.tf
@@ -1,0 +1,57 @@
+variable "aws_account_id" {
+  description = "12-digit AWS account ID that owns the apex bucket, CloudFront distribution, ACM cert, and IAM roles. No default; must be set explicitly in the TFC workspace to prevent cross-account accidents."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.aws_account_id))
+    error_message = "aws_account_id must be a 12-digit AWS account ID."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region for the S3 bucket and the home of the default provider. CloudFront is global; ACM for CloudFront is pinned to us-east-1 in providers.tf regardless of this value."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "domain" {
+  description = "Apex domain to serve. Both apex and www.<apex> are added as CloudFront aliases and ACM SANs."
+  type        = string
+  default     = "thebetterdecision.com"
+}
+
+variable "github_repo" {
+  description = "GitHub repo (owner/name) allowed to assume the GitHub Actions deploy role via OIDC."
+  type        = string
+  default     = "flamarion/pfv"
+}
+
+variable "github_main_branch" {
+  description = "Branch on github_repo whose workflow runs can assume the deploy role for actual deploys (s3 sync + invalidation). PRs targeting this branch can also assume the role for plan-only operations via the github_pr_subject_pattern."
+  type        = string
+  default     = "main"
+}
+
+variable "github_pr_subject_pattern" {
+  description = "OIDC subject pattern that pull request workflows on github_repo match. Used to allow plan-only access from PRs while keeping deploy-mutating actions scoped to main pushes. Empty string disables PR access entirely."
+  type        = string
+  default     = "pull_request"
+}
+
+variable "tfc_organization" {
+  description = "Terraform Cloud organization whose workspaces are allowed to assume the apex provisioner role via OIDC workload identity."
+  type        = string
+  default     = "FlamaCorp"
+}
+
+variable "tfc_workspace_pattern" {
+  description = "TFC workspace name pattern (supports glob via wildcard suffix on the OIDC sub claim) allowed to assume the apex provisioner role. Default pfv-apex* covers the apex workspace plus any future split (e.g. pfv-apex-staging)."
+  type        = string
+  default     = "pfv-apex*"
+}
+
+variable "noncurrent_version_expiration_days" {
+  description = "Days after which noncurrent S3 object versions expire. Versioning stays on for rollback; this caps storage growth."
+  type        = number
+  default     = 90
+}

--- a/infra/terraform/apex/versions.tf
+++ b/infra/terraform/apex/versions.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.6"
+
+  # State + plan/apply runs live in Terraform Cloud (FlamaCorp/pfv-apex).
+  # The workspace is VCS-driven against this repo via the HCP Terraform
+  # GitHub App, with working directory scoped to infra/terraform/apex/ and
+  # trigger pattern infra/terraform/apex/**. Speculative plans fire on PR;
+  # merges to main create runs that wait for manual Confirm & Apply in the
+  # TFC UI (auto-apply is intentionally off, matching the FlamaCorp/pfv
+  # workspace policy for the data droplet).
+  #
+  # NOTE: a dedicated workspace (pfv-apex) keeps the AWS apex provisioning
+  # isolated from the DigitalOcean data plane in FlamaCorp/pfv. Different
+  # cloud, different blast radius, different state.
+  cloud {
+    organization = "FlamaCorp"
+    workspaces {
+      name = "pfv-apex"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.50"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Scope

PR-A of the L5.2a apex split. Provisions the AWS-side infrastructure for
the `thebetterdecision.com` apex landing site under a new TFC workspace
`FlamaCorp/pfv-apex`.

**This PR does NOT change Route 53 A records.** ACM DNS validation
CNAMEs are written (they don't touch the apex). The apex `A` ALIAS swap
and TTL drop are PR-D, which only fires after PR-B (deploy workflow) and
PR-C (Next.js static export) have landed and the CloudFront-assigned
`dXXX.cloudfront.net` URL has been verified end-to-end.

## Module structure

```
infra/terraform/apex/
├── main.tf                   # S3, CloudFront, ACM, IAM OIDC + roles (~640 LoC)
├── variables.tf              # All inputs + defaults
├── outputs.tf                # github_actions_role_arn, cloudfront ids, etc.
├── versions.tf               # cloud{} (TFC: FlamaCorp/pfv-apex), provider pins
├── providers.tf              # Default AWS provider + us-east-1 alias for ACM
├── terraform.tfvars.example  # Reference only; TFC sets vars in the workspace
├── .terraform.lock.hcl       # Committed per existing convention
├── .gitignore
└── README.md                 # Bootstrap, workflow, security, rollback
```

### Resources

- `aws_s3_bucket` (+ public-access-block all four flags ON, versioning,
  SSE-S3, lifecycle expiring noncurrent versions after 90 days, ownership)
- `aws_cloudfront_distribution` (HTTPS-only, http2and3, PriceClass_100,
  AWS managed CachingOptimized + CORS-S3Origin policies)
- `aws_cloudfront_origin_access_control` (OAC, not legacy OAI)
- `aws_cloudfront_function` (viewer-request www to apex 301)
- `aws_cloudfront_response_headers_policy` (HSTS 2y/includeSubDomains/preload,
  X-Content-Type-Options nosniff, X-Frame-Options DENY,
  Referrer-Policy strict-origin-when-cross-origin, Permissions-Policy)
- `aws_acm_certificate` + `_validation` (us-east-1, DNS-validated)
- `aws_route53_record.apex_acm_validation` (ACM `_<token>.<domain>` CNAMEs
  only; apex A record untouched)
- `aws_iam_openid_connect_provider.github` + `aws_iam_openid_connect_provider.tfc`
- `aws_iam_role.github_actions_apex_deploy` + inline policy
- `aws_iam_role.tfc_apex_provisioner` + inline policy

## TFC workspace recommendation

**Create a new workspace `FlamaCorp/pfv-apex`** (separate from the existing
`FlamaCorp/pfv` data-droplet workspace).

- Working directory: `infra/terraform/apex`
- Trigger pattern: `infra/terraform/apex/**`
- Auto-apply: **off** (matches `FlamaCorp/pfv` policy)

Rationale: different cloud (AWS vs DigitalOcean), different auth path
(AWS OIDC vs DO API token), isolated blast radius. The existing
`infra/terraform/README.md` is updated to point at this split.

## Bootstrap path chosen: B (single-run static keys, then OIDC)

Path B keeps everything in Terraform from day one at the cost of one
hour of an admin-scoped IAM user. Verbatim steps in
`infra/terraform/apex/README.md`. Summary:

1. Owner creates IAM user `pfv-apex-bootstrap` with `AdministratorAccess`
   in the AWS account, generates an access key pair.
2. Owner sets `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
   `aws_account_id` in the TFC workspace.
3. PR merges; owner clicks Confirm & Apply in TFC.
4. After apply, owner sets `TFC_AWS_PROVIDER_AUTH=true` and
   `TFC_AWS_RUN_ROLE_ARN=<tfc_role_arn output>` in the workspace,
   deletes the static-key variables, deletes the IAM user (within an hour).
5. Owner triggers a no-op plan; empty plan = OIDC works.

## Variables

Required input (no default):

- `aws_account_id` (12-digit AWS account ID, validated by regex)

Defaults in `variables.tf`:

- `aws_region = "eu-west-1"`
- `domain = "thebetterdecision.com"`
- `github_repo = "flamarion/pfv"`
- `github_main_branch = "main"`
- `github_pr_subject_pattern = "pull_request"`
- `tfc_organization = "FlamaCorp"`
- `tfc_workspace_pattern = "pfv-apex*"`
- `noncurrent_version_expiration_days = 90`

## Outputs PR-B and PR-D will consume

PR-B (deploy workflow):

- `github_actions_role_arn` -> `role-to-assume` in
  `aws-actions/configure-aws-credentials`
- `s3_bucket_name` -> `aws s3 sync` target
- `cloudfront_distribution_id` -> `aws cloudfront create-invalidation`
- `cloudfront_distribution_domain` -> pre-cutover verification URL

PR-D (Route 53 cutover):

- `cloudfront_distribution_id` -> alias target
- `cloudfront_distribution_hosted_zone_id` -> Z2FDTNDATAQYW2 (fixed)
- `route53_zone_id` -> apex zone

## Security

### Least privilege

- `github_actions_apex_deploy`: `s3:ListBucket`, `s3:GetObject`,
  `s3:PutObject`, `s3:DeleteObject` on **this bucket only**;
  `cloudfront:CreateInvalidation` on **this distribution only**.
  No wildcard resources.
- `tfc_apex_provisioner`: manages this bucket, this distribution, the
  ACM cert in us-east-1, the two OIDC providers, and the two IAM roles.
  Route 53 access is **read-only** with the single exception of ACM
  validation CNAME writes scoped to the apex zone. **No apex A-record
  write permission.** PR-D will widen the policy at cutover.
- S3 bucket: all four BPA flags ON; read access only via OAC scoped by
  `AWS:SourceArn` to this distribution's ARN.

### OAC over OAI

OAC supports SigV4 to S3, dynamic-content origins, and KMS-encrypted
buckets. AWS has documented OAI as legacy and OAC as the long-term path.

### Headers

`HSTS max-age=63072000; includeSubDomains; preload`, nosniff, DENY,
strict-origin-when-cross-origin, conservative Permissions-Policy. CSP is
intentionally **not** in this module; PR-C will author it alongside the
real asset graph.

## Rollback

Every resource is `terraform destroy`-able. No Route 53 A-record changes
are made by this PR, so there is nothing to revert in DNS. The ACM
validation CNAMEs are deleted with the cert. Emergency teardown during
the bootstrap window: `terraform login && terraform
-chdir=infra/terraform/apex destroy`.

## Validation

- `terraform fmt -recursive -check -diff` clean
- `terraform init -backend=false` succeeds (aws ~> 5.50, tls ~> 4.0)
- `terraform validate` clean
- Local plan attempted in a scratch directory (cloud{} stripped) against
  fake AWS keys reaches STS, confirming HCL parse + ref resolution. Real
  plan against real creds will run as the TFC speculative plan on this PR.
- No em-dashes, no AI attribution.

## Out of scope (handled in other PRs of the split)

- Apex A ALIAS record + TTL drop -> PR-D
- GitHub Actions deploy workflow -> PR-B
- Next.js static export build target -> PR-C
- Anything outside `infra/terraform/apex/` except a pointer added to
  `infra/terraform/README.md`

## Plan vs locked decisions (project_apex_s3_cloudfront.md)

All five locked decisions (D1-D5) match this PR:

- D1 (Cloudflare out of apex landing only): respected. `app.` not touched.
- D2 (existing personal AWS account): `aws_account_id` is the only
  required input. No org / new account assumed.
- D3 (Next.js single-repo static export): PR-C handles. Outputs sync
  into the bucket this PR provisions.
- D4 (OIDC federation, no long-lived keys): implemented. Bootstrap path B
  uses static keys for a single run, then deletes them.
- D5 (five-phase cutover): this PR is Phase 1.