### PR TITLE
feat(landing): static export build target for apex (L5.2a PR-C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,11 @@ __pycache__/
 # Node / Frontend
 node_modules/
 .next/
+.next-apex/
 out/
+out-apex/
+.next.config.ts.bak
+.apex-staged-routes/
 frontend/next-env.d.ts
 
 # Environments

--- a/frontend/components/auth/AuthProviderApex.tsx
+++ b/frontend/components/auth/AuthProviderApex.tsx
@@ -1,0 +1,41 @@
+// AuthProviderApex.tsx — no-op AuthProvider stub used by the apex
+// (S3 + CloudFront) build target. The apex host serves only landing pages
+// and never speaks to the backend, so we drop the real AuthProvider's
+// /me probe + token refresh logic from the bundle. Aliased in by
+// next.config.apex.ts.
+//
+// Re-exports the same named members the real module exports so any landing
+// component that pulls in useAuth still type-checks during the apex build,
+// even though no apex page actually invokes it (the LandingAuthRedirect
+// island is also aliased to a no-op stub).
+
+export class MfaRequiredError extends Error {
+  constructor(public mfaToken: string) {
+    super("MFA required (apex stub)");
+    this.name = "MfaRequiredError";
+  }
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+export function useAuth() {
+  return {
+    user: null,
+    loading: false,
+    needsSetup: false,
+    async login(): Promise<void> {
+      throw new Error("Apex build cannot perform auth flows.");
+    },
+    async register(): Promise<void> {
+      throw new Error("Apex build cannot perform auth flows.");
+    },
+    async logout(): Promise<void> {
+      // no-op in apex
+    },
+    async refresh(): Promise<void> {
+      // no-op in apex
+    },
+  };
+}

--- a/frontend/components/landing/Hero.tsx
+++ b/frontend/components/landing/Hero.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { BRAND_NAME } from "@/lib/brand";
+import { signinHref, signupHref } from "@/lib/links";
 import { btnPrimary, btnSecondary } from "@/lib/styles";
 import HeroDashboard from "./HeroDashboard";
 
@@ -29,13 +30,13 @@ export default function Hero() {
           </p>
           <div className="mt-8 flex flex-wrap items-center gap-3">
             <Link
-              href="/register"
+              href={signupHref()}
               className={`${btnPrimary} px-6 py-3 text-base`}
             >
               Get started free
             </Link>
             <Link
-              href="/login"
+              href={signinHref()}
               className={`${btnSecondary} px-6 py-3 text-base`}
             >
               Sign in

--- a/frontend/components/landing/LandingAuthRedirectApex.tsx
+++ b/frontend/components/landing/LandingAuthRedirectApex.tsx
@@ -1,0 +1,12 @@
+// LandingAuthRedirectApex.tsx — no-op stub used by the apex (S3 + CloudFront)
+// build target. The apex host (thebetterdecision.com) does not share cookies
+// with the app host (app.thebetterdecision.com), so the auth-redirect island
+// could never fire there. Aliased in for the apex bundle by
+// next.config.apex.ts so the apex output ships zero auth code.
+//
+// Must keep the same default export shape as LandingAuthRedirect so the
+// landing page import resolves cleanly during the apex build.
+
+export default function LandingAuthRedirectApex(): null {
+  return null;
+}

--- a/frontend/components/landing/SecondCta.tsx
+++ b/frontend/components/landing/SecondCta.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { signupHref } from "@/lib/links";
 import { btnPrimary } from "@/lib/styles";
 
 // Spec §3.4 — centered block, single primary CTA. The heading is the
@@ -15,7 +16,7 @@ export default function SecondCta() {
         into calm.
       </p>
       <Link
-        href="/register"
+        href={signupHref()}
         className={`${btnPrimary} mt-8 inline-block px-6 py-3 text-base`}
       >
         Get started free

--- a/frontend/components/landing/TopNav.tsx
+++ b/frontend/components/landing/TopNav.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Logo, Mark } from "@/components/brand/Logo";
 import ThemeToggle from "@/components/ui/ThemeToggle";
+import { signinHref, signupHref } from "@/lib/links";
 import { btnPrimary } from "@/lib/styles";
 
 // Public landing nav per spec §3.1: brand lockup on the left, Sign in
@@ -28,13 +29,13 @@ export default function TopNav() {
       </Link>
       <div className="flex items-center gap-2 sm:gap-4">
         <Link
-          href="/login"
+          href={signinHref()}
           className="whitespace-nowrap px-2 text-sm text-text-muted transition-colors hover:text-text-primary"
         >
           Sign in
         </Link>
         <Link
-          href="/register"
+          href={signupHref()}
           className={`${btnPrimary} whitespace-nowrap`}
         >
           Get started

--- a/frontend/lib/links.ts
+++ b/frontend/lib/links.ts
@@ -1,0 +1,45 @@
+// links.ts — single source of truth for cross-domain CTA URLs used by the
+// landing surface (TopNav, Hero, SecondCta, LandingFooter).
+//
+// The app build (target = DigitalOcean App Platform) serves the landing and
+// the authed app from the same origin (`app.thebetterdecision.com`), so
+// `/register` and `/login` resolve correctly as relative paths.
+//
+// The apex build (target = AWS S3 + CloudFront, host = `thebetterdecision.com`)
+// serves ONLY the landing surface; auth lives on a different host. Same-origin
+// cookies do not cross the host boundary, so we MUST link absolutely to the
+// app host for sign-in and sign-up.
+//
+// Selection is via NEXT_PUBLIC_BUILD_TARGET, set at build time:
+//   - "apex"  -> CTAs are absolute URLs to BRAND_APP_URL
+//   - unset / anything else -> CTAs are relative paths (existing behaviour)
+//
+// BRAND_APP_URL defaults to https://app.thebetterdecision.com but can be
+// overridden via NEXT_PUBLIC_APP_URL (no trailing slash). This lets the apex
+// build target a staging app host if needed.
+
+const rawAppUrl = (process.env.NEXT_PUBLIC_APP_URL || "").trim();
+export const BRAND_APP_URL = (rawAppUrl || "https://app.thebetterdecision.com").replace(/\/$/, "");
+
+export const IS_APEX_BUILD = process.env.NEXT_PUBLIC_BUILD_TARGET === "apex";
+
+function joinAppUrl(path: string): string {
+  if (!path.startsWith("/")) {
+    return `${BRAND_APP_URL}/${path}`;
+  }
+  return `${BRAND_APP_URL}${path}`;
+}
+
+// Resolve a CTA path for the current build target. Path must be a relative
+// in-app path (e.g. "/register"). For non-apex builds, returns the path
+// unchanged so Next's <Link> handles client-side navigation. For apex
+// builds, returns an absolute URL pointing at BRAND_APP_URL.
+export function ctaHref(path: string): string {
+  if (IS_APEX_BUILD) {
+    return joinAppUrl(path);
+  }
+  return path;
+}
+
+export const signupHref = (): string => ctaHref("/register");
+export const signinHref = (): string => ctaHref("/login");

--- a/frontend/next.config.apex.ts
+++ b/frontend/next.config.apex.ts
@@ -1,0 +1,86 @@
+import path from "node:path";
+import type { NextConfig } from "next";
+
+// next.config.apex.ts — secondary build target that produces a static
+// export of the landing surface only, for upload to S3 + CloudFront on
+// the apex host (thebetterdecision.com).
+//
+// The PRIMARY build (next.config.ts, `npm run build`) still produces the
+// standalone Node bundle deployed to DigitalOcean App Platform on
+// app.thebetterdecision.com. The two targets share the same Next.js app;
+// build-target selection is via NEXT_PUBLIC_BUILD_TARGET=apex.
+//
+// Route allowlisting:
+//   `output: 'export'` requires every route in `app/` to be statically
+//   exportable. Authed routes use client-only hooks and would fail. The
+//   `scripts/build-apex.sh` driver temporarily moves non-allowlisted
+//   route directories out of `app/` for the duration of the build, then
+//   restores them, then prunes any stragglers from `out-apex/`.
+//
+// Module substitutions:
+//   - `@/components/landing/LandingAuthRedirect` -> no-op apex stub.
+//   - `@/components/auth/AuthProvider`           -> no-op apex stub.
+//   These keep auth code and the /me probe out of the apex bundle.
+//
+// Headers:
+//   `output: 'export'` does NOT emit a Next.js server, so the `headers()`
+//   contract from next.config.ts is ignored here. Security headers for
+//   the apex host are configured at the CloudFront response-headers
+//   policy (managed by PR-A Terraform).
+
+// Aliases for Turbopack: project-relative paths starting with "./".
+// Turbopack does NOT accept absolute filesystem paths here; it routes
+// strings that start with "/" through its "server relative" resolver
+// and fails. Keep these as "./components/..." style.
+const TURBOPACK_APEX_ALIASES: Record<string, string> = {
+  // Auth-island substitution (Option Y from PR brief). Mechanical alias
+  // is simpler to audit than a build-time conditional import.
+  "@/components/landing/LandingAuthRedirect":
+    "./components/landing/LandingAuthRedirectApex.tsx",
+  // Drop the AuthProvider + /me probe + token refresher from the apex
+  // bundle. The stub re-exports useAuth / MfaRequiredError so any
+  // landing component that pulls them in still type-checks even though
+  // the apex render never invokes them.
+  "@/components/auth/AuthProvider":
+    "./components/auth/AuthProviderApex.tsx",
+};
+
+// Webpack expects absolute paths; mirror the same logical aliases.
+const WEBPACK_APEX_ALIASES: Record<string, string> = {
+  "@/components/landing/LandingAuthRedirect": path.resolve(
+    __dirname,
+    "components/landing/LandingAuthRedirectApex.tsx",
+  ),
+  "@/components/auth/AuthProvider": path.resolve(
+    __dirname,
+    "components/auth/AuthProviderApex.tsx",
+  ),
+};
+
+const apexConfig: NextConfig = {
+  output: "export",
+  trailingSlash: true,
+  // CloudFront serves images raw; we don't run the Next image optimizer.
+  images: { unoptimized: true },
+  poweredByHeader: false,
+  // Distribute landing assets to a SEPARATE out directory so the standard
+  // `npm run build` artefacts under `.next/` / `out/` are untouched.
+  distDir: ".next-apex",
+  // Next.js 16 defaults to Turbopack. Configure Turbopack's resolveAlias
+  // so the apex-target stubs land in the bundle.
+  turbopack: {
+    resolveAlias: TURBOPACK_APEX_ALIASES,
+  },
+  // Webpack fallback for `next build --webpack` runs. Logically mirrors
+  // the Turbopack aliases via WEBPACK_APEX_ALIASES (absolute paths).
+  webpack: (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      ...WEBPACK_APEX_ALIASES,
+    };
+    return config;
+  },
+};
+
+export default apexConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:apex": "bash scripts/build-apex.sh",
     "start": "next start",
+    "start:apex-preview": "cd out-apex && python3 -m http.server 4321",
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/frontend/scripts/build-apex.sh
+++ b/frontend/scripts/build-apex.sh
@@ -3,8 +3,12 @@
 # suitable for upload to S3 + CloudFront on the apex host.
 #
 # Strategy:
-#   1. Move every non-allowlisted route directory out of `app/` into a
-#      sibling staging dir so `next build` sees only the landing surface.
+#   1. Walk every entry under `app/` and decide via a positive allowlist
+#      whether it ships to the apex build. Anything not on the allowlist
+#      is moved to a sibling staging dir so `next build` doesn't see it.
+#      This defaults to deny: any route added in the future (e.g.
+#      /onboarding, PR #238) is automatically staged out unless someone
+#      explicitly adds it to the allowlist here.
 #   2. Swap next.config.ts <-> next.config.apex.ts for the duration of
 #      the build. Next.js 16 does not expose a --config flag, so the
 #      config file at the project root is the only knob. The apex config
@@ -16,6 +20,15 @@
 #   5. Move `out/` -> `out-apex/`, sanity-prune any non-allowlisted paths
 #      that snuck through, and emit `_meta.json` with the build commit
 #      SHA + timestamp for invalidation tracking.
+#   6. Run post-build guards that hard-fail the build if the output
+#      contains an unexpected top-level entry or any `/api/v1` reference
+#      (would mean auth/backend code leaked into the apex bundle).
+#
+# Compatibility: this script MUST run on macOS /bin/bash (3.2.57). That
+# means NO `declare -A`, NO `mapfile`/`readarray`, NO `${var^^}`-style
+# case-conversion expansions, NO `&>>`. Use plain indexed arrays, case
+# statements, and `while IFS= read -r line; do ...; done < <(cmd)` for
+# line iteration.
 #
 # Output: frontend/out-apex/
 # Consumed by: PR-B's GitHub Actions workflow (aws s3 sync).
@@ -28,56 +41,40 @@ FRONTEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${FRONTEND_DIR}"
 
-# Route directories under `app/` that must NOT ship to the apex build.
-# Anything not on this list is either an allowlisted route (privacy,
-# terms, docs) or a structural file (layout.tsx, page.tsx, globals.css,
-# robots.ts, sitemap.ts, icons, error/loading/not-found, opengraph-image).
-EXCLUDED_ROUTE_DIRS=(
-  "accept-invite"
-  "accounts"
-  "admin"
-  "auth"
-  "budgets"
-  "categories"
-  "dashboard"
-  "forecast-plans"
-  "forgot-password"
-  "health"
-  "import"
-  "login"
-  "mfa-verify"
-  "profile"
-  "recurring"
-  "register"
-  "reset-password"
-  "settings"
-  "setup"
-  "system"
-  "transactions"
-  "verify-email"
+# Positive allowlist: route directories under `app/` that DO ship to the
+# apex build. Everything else under `app/` (auth, dashboard, admin, the
+# whole authed surface) is staged out for the duration of the build.
+ALLOWED_ROUTE_DIRS=(
+  "privacy"
+  "terms"
+  "docs"
 )
 
-# Top-level files under `app/` that use dynamic rendering (e.g.
-# ImageResponse) and would force `output: 'export'` to fail with
-# "force-static not configured" unless we add force-static at the
-# source. We stage them out for the apex build to keep the standard
-# app build untouched. PR-B / a follow-up may swap in a static PNG OG
-# fallback for the apex domain.
-EXCLUDED_ROUTE_FILES=(
-  "opengraph-image.tsx"
-  "apple-icon.tsx"
-  # sitemap.ts + robots.ts are MetadataRoute handlers that Next treats as
-  # dynamic under `output: 'export'`. We stage them out and write static
-  # replacements directly into out-apex/ at the end of the build.
-  "sitemap.ts"
-  "robots.ts"
+# Positive allowlist: app-level files (siblings of route directories)
+# that DO ship to the apex build. These are the framework structural
+# files plus the landing page itself. Files NOT on this list (such as
+# opengraph-image.tsx, apple-icon.tsx, sitemap.ts, robots.ts, manifest.ts)
+# are dynamic and would force a server runtime, so we stage them out and
+# write static replacements directly into out-apex/ at the end of the
+# build.
+ALLOWED_APP_FILES=(
+  "layout.tsx"
+  "page.tsx"
+  "globals.css"
+  "error.tsx"
+  "not-found.tsx"
+  "loading.tsx"
+  "global-error.tsx"
+  "icon.svg"
 )
 
-# Top-level paths inside out-apex/ that are allowed to remain after build.
-# (Each is a directory created by an allowlisted route, or a static asset.)
-ALLOWED_OUTPUT_PATHS=(
+# Top-level paths inside out-apex/ that are allowed after the build.
+# Glob-style matching via `case` (so `__next.*.txt` works for RSC
+# prefetch payloads). Used by the post-build guard.
+ALLOWED_OUTPUT_GLOBS=(
   "index.html"
   "index.txt"
+  "404"
   "404.html"
   "_not-found"
   "privacy"
@@ -88,17 +85,8 @@ ALLOWED_OUTPUT_PATHS=(
   "robots.txt"
   "sitemap.xml"
   "icon.svg"
-  "apple-icon.png"
-  "opengraph-image.png"
   "favicon.ico"
-  # Next 16 emits "__next.*.txt" RSC prefetch payloads alongside the HTML
-  # routes. Keeping them silences harmless console 404s from <Link>
-  # prefetch on hover.
-  "__next.__PAGE__.txt"
-  "__next._full.txt"
-  "__next._head.txt"
-  "__next._index.txt"
-  "__next._tree.txt"
+  "__next.*.txt"
 )
 
 STAGING_DIR="${FRONTEND_DIR}/.apex-staged-routes"
@@ -106,12 +94,41 @@ CONFIG_FILE="${FRONTEND_DIR}/next.config.ts"
 APEX_CONFIG_FILE="${FRONTEND_DIR}/next.config.apex.ts"
 CONFIG_BACKUP="${FRONTEND_DIR}/.next.config.ts.bak"
 
+# Bash 3.2 has no associative arrays. Use a helper that does an O(n) scan
+# of an indexed array. Callers pass the needle then the array elements
+# expanded at the call site (Bash 3.2 has no namerefs either).
+contains() {
+  # Usage: contains "needle" "${array[@]}"
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [[ "${item}" = "${needle}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Returns 0 if `name` matches any of the ALLOWED_OUTPUT_GLOBS (with
+# shell-style wildcard matching via `case`). Bash 3.2 safe.
+output_allowed() {
+  local name="$1"
+  local pattern
+  for pattern in "${ALLOWED_OUTPUT_GLOBS[@]}"; do
+    case "${name}" in
+      ${pattern}) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 restore_routes() {
   # Idempotent. Move anything we staged back into app/.
+  local d name
   if [[ -d "${STAGING_DIR}" ]]; then
     for d in "${STAGING_DIR}"/*; do
       [[ -e "${d}" ]] || continue
-      local name
       name="$(basename "${d}")"
       if [[ -e "${FRONTEND_DIR}/app/${name}" ]]; then
         echo "build-apex: WARN restore target already exists for ${name}; leaving staged copy at ${d}" >&2
@@ -130,20 +147,32 @@ restore_routes() {
 # Trap covers normal exit, errors, and interrupts. Always restores.
 trap restore_routes EXIT INT TERM
 
-echo "build-apex: staging non-allowlisted routes out of app/"
+echo "build-apex: staging non-allowlisted entries out of app/ (default-deny allowlist)"
 mkdir -p "${STAGING_DIR}"
-for dir in "${EXCLUDED_ROUTE_DIRS[@]}"; do
-  src="${FRONTEND_DIR}/app/${dir}"
-  if [[ -d "${src}" ]]; then
-    mv "${src}" "${STAGING_DIR}/${dir}"
+
+# Walk every entry under app/ and stage out anything not on the
+# positive allowlist. Default-deny means new routes (e.g. PR #238's
+# /onboarding) are staged out automatically until someone explicitly
+# adds them to ALLOWED_ROUTE_DIRS / ALLOWED_APP_FILES.
+shopt -s nullglob
+for entry in "${FRONTEND_DIR}/app"/*; do
+  name="$(basename "${entry}")"
+  if [[ -d "${entry}" ]]; then
+    if contains "${name}" "${ALLOWED_ROUTE_DIRS[@]}"; then
+      continue
+    fi
+  elif [[ -f "${entry}" ]]; then
+    if contains "${name}" "${ALLOWED_APP_FILES[@]}"; then
+      continue
+    fi
+  else
+    # Symlink, socket, etc. Leave alone.
+    continue
   fi
+  echo "build-apex:   staging out app/${name}"
+  mv "${entry}" "${STAGING_DIR}/${name}"
 done
-for file in "${EXCLUDED_ROUTE_FILES[@]}"; do
-  src="${FRONTEND_DIR}/app/${file}"
-  if [[ -f "${src}" ]]; then
-    mv "${src}" "${STAGING_DIR}/${file}"
-  fi
-done
+shopt -u nullglob
 
 echo "build-apex: swapping next.config.ts -> next.config.apex.ts"
 if [[ ! -f "${APEX_CONFIG_FILE}" ]]; then
@@ -200,34 +229,10 @@ if [[ ! -f "${FRONTEND_DIR}/out-apex/index.html" ]]; then
   exit 1
 fi
 
-echo "build-apex: pruning any non-allowlisted output paths"
-shopt -s nullglob
-declare -A ALLOWED
-for entry in "${ALLOWED_OUTPUT_PATHS[@]}"; do
-  ALLOWED["${entry}"]=1
-done
-for entry in "${FRONTEND_DIR}/out-apex"/*; do
-  name="$(basename "${entry}")"
-  if [[ -z "${ALLOWED[${name}]:-}" ]]; then
-    echo "build-apex:   pruning unexpected output: ${name}"
-    rm -rf "${entry}"
-  fi
-done
-shopt -u nullglob
-
 COMMIT_SHA="$(git -C "${FRONTEND_DIR}" rev-parse HEAD 2>/dev/null || echo unknown)"
 BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 APEX_URL="${NEXT_PUBLIC_APEX_URL:-https://thebetterdecision.com}"
 APP_URL="${NEXT_PUBLIC_APP_URL:-https://app.thebetterdecision.com}"
-
-cat > "${FRONTEND_DIR}/out-apex/_meta.json" <<EOF
-{
-  "commit": "${COMMIT_SHA}",
-  "built_at": "${BUILD_TIME}",
-  "target": "apex",
-  "host": "thebetterdecision.com"
-}
-EOF
 
 # Static SEO replacements for the routes staged out of the build.
 # robots.txt — allow indexing of the apex landing surface, point at the
@@ -249,6 +254,46 @@ cat > "${FRONTEND_DIR}/out-apex/sitemap.xml" <<EOF
   <url><loc>${APEX_URL}/terms/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
   <url><loc>${APEX_URL}/docs/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
 </urlset>
+EOF
+
+# Post-build guards (belt-and-suspenders behind the input allowlist).
+# Run BEFORE writing _meta.json so a poisoned bundle never gets a
+# "successful build" marker.
+echo "build-apex: post-build guard — verifying out-apex/ top-level entries"
+shopt -s nullglob
+guard_failures=0
+for entry in "${FRONTEND_DIR}/out-apex"/*; do
+  name="$(basename "${entry}")"
+  if ! output_allowed "${name}"; then
+    echo "build-apex: GUARD FAIL unexpected top-level entry: ${name}" >&2
+    guard_failures=$((guard_failures + 1))
+  fi
+done
+shopt -u nullglob
+if [[ "${guard_failures}" -gt 0 ]]; then
+  echo "build-apex: ERROR ${guard_failures} unexpected entries in out-apex/. Aborting." >&2
+  exit 1
+fi
+
+echo "build-apex: post-build guard — grepping for /api/v1 references in built output"
+# grep -r returns 0 if matches found, 1 if no matches, 2 on error. We
+# want to act on the result, so capture it explicitly (set -e would kill
+# us on the "1 = no match" return otherwise).
+api_hits="$(grep -rl "/api/v1" "${FRONTEND_DIR}/out-apex" 2>/dev/null || true)"
+if [[ -n "${api_hits}" ]]; then
+  echo "build-apex: GUARD FAIL /api/v1 reference leaked into apex bundle:" >&2
+  echo "${api_hits}" >&2
+  echo "build-apex: ERROR auth/backend code leaked into apex bundle. Aborting." >&2
+  exit 1
+fi
+
+cat > "${FRONTEND_DIR}/out-apex/_meta.json" <<EOF
+{
+  "commit": "${COMMIT_SHA}",
+  "built_at": "${BUILD_TIME}",
+  "target": "apex",
+  "host": "thebetterdecision.com"
+}
 EOF
 
 echo "build-apex: done"

--- a/frontend/scripts/build-apex.sh
+++ b/frontend/scripts/build-apex.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# build-apex.sh — produce a static export of the landing surface only,
+# suitable for upload to S3 + CloudFront on the apex host.
+#
+# Strategy:
+#   1. Move every non-allowlisted route directory out of `app/` into a
+#      sibling staging dir so `next build` sees only the landing surface.
+#   2. Swap next.config.ts <-> next.config.apex.ts for the duration of
+#      the build. Next.js 16 does not expose a --config flag, so the
+#      config file at the project root is the only knob. The apex config
+#      sets `output: 'export'` and aliases the auth-island and
+#      AuthProvider to no-op stubs.
+#   3. Run `next build` with NEXT_PUBLIC_BUILD_TARGET=apex.
+#   4. ALWAYS restore the original config and the staged routes, even on
+#      failure (trap on EXIT / INT / TERM).
+#   5. Move `out/` -> `out-apex/`, sanity-prune any non-allowlisted paths
+#      that snuck through, and emit `_meta.json` with the build commit
+#      SHA + timestamp for invalidation tracking.
+#
+# Output: frontend/out-apex/
+# Consumed by: PR-B's GitHub Actions workflow (aws s3 sync).
+
+set -euo pipefail
+
+# Resolve frontend dir relative to this script (works from any cwd).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${FRONTEND_DIR}"
+
+# Route directories under `app/` that must NOT ship to the apex build.
+# Anything not on this list is either an allowlisted route (privacy,
+# terms, docs) or a structural file (layout.tsx, page.tsx, globals.css,
+# robots.ts, sitemap.ts, icons, error/loading/not-found, opengraph-image).
+EXCLUDED_ROUTE_DIRS=(
+  "accept-invite"
+  "accounts"
+  "admin"
+  "auth"
+  "budgets"
+  "categories"
+  "dashboard"
+  "forecast-plans"
+  "forgot-password"
+  "health"
+  "import"
+  "login"
+  "mfa-verify"
+  "profile"
+  "recurring"
+  "register"
+  "reset-password"
+  "settings"
+  "setup"
+  "system"
+  "transactions"
+  "verify-email"
+)
+
+# Top-level files under `app/` that use dynamic rendering (e.g.
+# ImageResponse) and would force `output: 'export'` to fail with
+# "force-static not configured" unless we add force-static at the
+# source. We stage them out for the apex build to keep the standard
+# app build untouched. PR-B / a follow-up may swap in a static PNG OG
+# fallback for the apex domain.
+EXCLUDED_ROUTE_FILES=(
+  "opengraph-image.tsx"
+  "apple-icon.tsx"
+  # sitemap.ts + robots.ts are MetadataRoute handlers that Next treats as
+  # dynamic under `output: 'export'`. We stage them out and write static
+  # replacements directly into out-apex/ at the end of the build.
+  "sitemap.ts"
+  "robots.ts"
+)
+
+# Top-level paths inside out-apex/ that are allowed to remain after build.
+# (Each is a directory created by an allowlisted route, or a static asset.)
+ALLOWED_OUTPUT_PATHS=(
+  "index.html"
+  "index.txt"
+  "404.html"
+  "_not-found"
+  "privacy"
+  "terms"
+  "docs"
+  "_next"
+  "_meta.json"
+  "robots.txt"
+  "sitemap.xml"
+  "icon.svg"
+  "apple-icon.png"
+  "opengraph-image.png"
+  "favicon.ico"
+  # Next 16 emits "__next.*.txt" RSC prefetch payloads alongside the HTML
+  # routes. Keeping them silences harmless console 404s from <Link>
+  # prefetch on hover.
+  "__next.__PAGE__.txt"
+  "__next._full.txt"
+  "__next._head.txt"
+  "__next._index.txt"
+  "__next._tree.txt"
+)
+
+STAGING_DIR="${FRONTEND_DIR}/.apex-staged-routes"
+CONFIG_FILE="${FRONTEND_DIR}/next.config.ts"
+APEX_CONFIG_FILE="${FRONTEND_DIR}/next.config.apex.ts"
+CONFIG_BACKUP="${FRONTEND_DIR}/.next.config.ts.bak"
+
+restore_routes() {
+  # Idempotent. Move anything we staged back into app/.
+  if [[ -d "${STAGING_DIR}" ]]; then
+    for d in "${STAGING_DIR}"/*; do
+      [[ -e "${d}" ]] || continue
+      local name
+      name="$(basename "${d}")"
+      if [[ -e "${FRONTEND_DIR}/app/${name}" ]]; then
+        echo "build-apex: WARN restore target already exists for ${name}; leaving staged copy at ${d}" >&2
+      else
+        mv "${d}" "${FRONTEND_DIR}/app/${name}"
+      fi
+    done
+    rmdir "${STAGING_DIR}" 2>/dev/null || true
+  fi
+  # Restore the standard next.config.ts if we swapped it.
+  if [[ -f "${CONFIG_BACKUP}" ]]; then
+    mv "${CONFIG_BACKUP}" "${CONFIG_FILE}"
+  fi
+}
+
+# Trap covers normal exit, errors, and interrupts. Always restores.
+trap restore_routes EXIT INT TERM
+
+echo "build-apex: staging non-allowlisted routes out of app/"
+mkdir -p "${STAGING_DIR}"
+for dir in "${EXCLUDED_ROUTE_DIRS[@]}"; do
+  src="${FRONTEND_DIR}/app/${dir}"
+  if [[ -d "${src}" ]]; then
+    mv "${src}" "${STAGING_DIR}/${dir}"
+  fi
+done
+for file in "${EXCLUDED_ROUTE_FILES[@]}"; do
+  src="${FRONTEND_DIR}/app/${file}"
+  if [[ -f "${src}" ]]; then
+    mv "${src}" "${STAGING_DIR}/${file}"
+  fi
+done
+
+echo "build-apex: swapping next.config.ts -> next.config.apex.ts"
+if [[ ! -f "${APEX_CONFIG_FILE}" ]]; then
+  echo "build-apex: ERROR apex config not found at ${APEX_CONFIG_FILE}" >&2
+  exit 1
+fi
+mv "${CONFIG_FILE}" "${CONFIG_BACKUP}"
+cp "${APEX_CONFIG_FILE}" "${CONFIG_FILE}"
+
+echo "build-apex: running next build with apex config"
+rm -rf "${FRONTEND_DIR}/.next-apex" "${FRONTEND_DIR}/out" "${FRONTEND_DIR}/out-apex"
+
+# NEXT_PUBLIC_SITE_URL drives canonical URLs and og:image / og:url meta
+# tags from lib/site.ts. On apex it MUST point at the apex host so the
+# rendered HTML doesn't claim canonical = app.thebetterdecision.com.
+# Override via env when invoking the script for a non-prod apex host.
+: "${NEXT_PUBLIC_SITE_URL:=https://thebetterdecision.com}"
+export NEXT_PUBLIC_SITE_URL
+
+NEXT_PUBLIC_BUILD_TARGET=apex \
+  npx next build
+
+# Next 16 with `output: 'export'` + a custom `distDir` writes the static
+# export DIRECTLY into the distDir (here `.next-apex/`). Earlier Next
+# versions wrote to `out/`. Handle both shapes.
+mkdir -p "${FRONTEND_DIR}/out-apex"
+if [[ -d "${FRONTEND_DIR}/out" ]]; then
+  # Legacy behaviour: export lives in `out/`.
+  mv "${FRONTEND_DIR}/out"/* "${FRONTEND_DIR}/out-apex"/ 2>/dev/null || true
+  rm -rf "${FRONTEND_DIR}/out"
+fi
+if [[ -f "${FRONTEND_DIR}/.next-apex/index.html" ]]; then
+  # Next 16 behaviour: static export shares the distDir. Copy the
+  # public-facing artefacts and ignore Next's internal build files.
+  for entry in "${FRONTEND_DIR}/.next-apex"/*; do
+    name="$(basename "${entry}")"
+    # Skip Next.js INTERNAL scaffolding (build-time metadata, dev caches,
+    # server runtime files) that lives under distDir but is not part of
+    # the static export surface CloudFront needs to serve. Note we DO
+    # keep `__next.*.txt` files — those are RSC prefetch payloads that
+    # Next/Link fetches on hover; removing them produces harmless but
+    # noisy 404s in the browser devtools.
+    case "${name}" in
+      server|trace|build-manifest.json|app-build-manifest.json|prerender-manifest.json|routes-manifest.json|images-manifest.json|next-minimal-server.js.nft.json|next-server.js.nft.json|export-marker.json|export-detail.json|required-server-files.json|BUILD_ID|package.json|cache|diagnostics|static)
+        continue
+        ;;
+    esac
+    cp -R "${entry}" "${FRONTEND_DIR}/out-apex/${name}"
+  done
+fi
+
+if [[ ! -f "${FRONTEND_DIR}/out-apex/index.html" ]]; then
+  echo "build-apex: ERROR no index.html in out-apex/, build appears to have failed" >&2
+  exit 1
+fi
+
+echo "build-apex: pruning any non-allowlisted output paths"
+shopt -s nullglob
+declare -A ALLOWED
+for entry in "${ALLOWED_OUTPUT_PATHS[@]}"; do
+  ALLOWED["${entry}"]=1
+done
+for entry in "${FRONTEND_DIR}/out-apex"/*; do
+  name="$(basename "${entry}")"
+  if [[ -z "${ALLOWED[${name}]:-}" ]]; then
+    echo "build-apex:   pruning unexpected output: ${name}"
+    rm -rf "${entry}"
+  fi
+done
+shopt -u nullglob
+
+COMMIT_SHA="$(git -C "${FRONTEND_DIR}" rev-parse HEAD 2>/dev/null || echo unknown)"
+BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+APEX_URL="${NEXT_PUBLIC_APEX_URL:-https://thebetterdecision.com}"
+APP_URL="${NEXT_PUBLIC_APP_URL:-https://app.thebetterdecision.com}"
+
+cat > "${FRONTEND_DIR}/out-apex/_meta.json" <<EOF
+{
+  "commit": "${COMMIT_SHA}",
+  "built_at": "${BUILD_TIME}",
+  "target": "apex",
+  "host": "thebetterdecision.com"
+}
+EOF
+
+# Static SEO replacements for the routes staged out of the build.
+# robots.txt — allow indexing of the apex landing surface, point at the
+# apex sitemap (NOT the app sitemap; the app keeps its own at
+# app.thebetterdecision.com/sitemap.xml).
+cat > "${FRONTEND_DIR}/out-apex/robots.txt" <<EOF
+User-agent: *
+Allow: /
+
+Sitemap: ${APEX_URL}/sitemap.xml
+EOF
+
+# sitemap.xml — list only the apex-exported routes.
+cat > "${FRONTEND_DIR}/out-apex/sitemap.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>${APEX_URL}/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
+  <url><loc>${APEX_URL}/privacy/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
+  <url><loc>${APEX_URL}/terms/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
+  <url><loc>${APEX_URL}/docs/</loc><lastmod>${BUILD_TIME%T*}</lastmod></url>
+</urlset>
+EOF
+
+echo "build-apex: done"
+echo "build-apex: output at ${FRONTEND_DIR}/out-apex"
+ls -la "${FRONTEND_DIR}/out-apex"

--- a/frontend/tests/build-apex.test.ts
+++ b/frontend/tests/build-apex.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// build-apex.test.ts — static assertions about the apex build target
+// that do not require actually running `next build` in the test process.
+//
+// What's covered here without a real build:
+//   - Allowlist contents of scripts/build-apex.sh (vs app/ on disk).
+//   - next.config.apex.ts exports `output: 'export'` and the auth-island
+//     + AuthProvider webpack aliases.
+//   - package.json has the build:apex script wired to the bash driver.
+//   - lib/links.ts returns relative paths when NEXT_PUBLIC_BUILD_TARGET
+//     is unset and absolute BRAND_APP_URL paths when set to "apex".
+//
+// We intentionally do NOT shell out to `next build` here — it takes ~20s
+// and the integration is owned by CI.
+
+const frontendDir = path.resolve(__dirname, "..");
+
+function readText(rel: string): string {
+  return readFileSync(path.join(frontendDir, rel), "utf-8");
+}
+
+describe("apex build target — scripts/build-apex.sh", () => {
+  const script = readText("scripts/build-apex.sh");
+
+  it("uses strict bash flags (set -euo pipefail)", () => {
+    expect(script).toContain("set -euo pipefail");
+  });
+
+  it("traps EXIT / INT / TERM to restore the app/ tree", () => {
+    expect(script).toMatch(/trap\s+restore_routes\s+EXIT\s+INT\s+TERM/);
+  });
+
+  it("invokes next build with BUILD_TARGET=apex env", () => {
+    expect(script).toContain("NEXT_PUBLIC_BUILD_TARGET=apex");
+    expect(script).toMatch(/npx\s+next\s+build/);
+  });
+
+  it("swaps next.config.ts <-> next.config.apex.ts (Next 16 has no --config flag)", () => {
+    expect(script).toContain("next.config.apex.ts");
+    expect(script).toContain("next.config.ts");
+    // Restoration path must include the backup move.
+    expect(script).toContain("CONFIG_BACKUP");
+  });
+
+  it("emits _meta.json with commit + build_at + target=apex", () => {
+    expect(script).toContain("_meta.json");
+    expect(script).toContain('"target": "apex"');
+    expect(script).toMatch(/git[^\n]+rev-parse HEAD/);
+  });
+
+  it("excludes every authed / app route directory from the apex build", () => {
+    // Sample of the routes that must NOT ship to apex. Each must appear
+    // in the EXCLUDED_ROUTE_DIRS array of the build script.
+    const mustExclude = [
+      "dashboard",
+      "transactions",
+      "accounts",
+      "admin",
+      "login",
+      "register",
+      "settings",
+      "setup",
+      "profile",
+      "verify-email",
+      "forgot-password",
+      "reset-password",
+      "mfa-verify",
+      "accept-invite",
+      "budgets",
+      "categories",
+      "forecast-plans",
+      "recurring",
+      "import",
+      "system",
+      "auth",
+      "health",
+    ];
+    for (const dir of mustExclude) {
+      expect(script, `expected excluded route: ${dir}`).toContain(`"${dir}"`);
+    }
+  });
+
+  it("allowlists the apex-exported routes only", () => {
+    // Output sanity-prune must permit privacy, terms, docs + the
+    // structural assets, and nothing else.
+    for (const allowed of [
+      "index.html",
+      "privacy",
+      "terms",
+      "docs",
+      "_next",
+      "_meta.json",
+    ]) {
+      expect(script).toContain(`"${allowed}"`);
+    }
+  });
+});
+
+describe("apex build target — next.config.apex.ts", () => {
+  const config = readText("next.config.apex.ts");
+
+  it("sets output: 'export' (static export)", () => {
+    expect(config).toMatch(/output:\s*["']export["']/);
+  });
+
+  it("sets trailingSlash: true and unoptimized images for S3 / CloudFront", () => {
+    expect(config).toMatch(/trailingSlash:\s*true/);
+    expect(config).toMatch(/unoptimized:\s*true/);
+  });
+
+  it("does NOT set a headers() block (CloudFront owns response headers)", () => {
+    // The standalone next.config.ts wires CSP + HSTS etc. via headers().
+    // `output: 'export'` ignores that contract; we must not silently set
+    // it here to avoid the false impression that it does anything.
+    expect(config).not.toMatch(/async\s+headers\s*\(/);
+  });
+
+  it("aliases the auth-island to the no-op apex stub", () => {
+    expect(config).toContain("@/components/landing/LandingAuthRedirect");
+    expect(config).toContain("LandingAuthRedirectApex.tsx");
+  });
+
+  it("aliases AuthProvider to the no-op apex stub", () => {
+    expect(config).toContain("@/components/auth/AuthProvider");
+    expect(config).toContain("AuthProviderApex.tsx");
+  });
+
+  it("writes to a separate distDir so the standard build is undisturbed", () => {
+    expect(config).toMatch(/distDir:\s*["']\.next-apex["']/);
+  });
+});
+
+describe("apex build target — package.json scripts", () => {
+  const pkg = JSON.parse(readText("package.json")) as {
+    scripts: Record<string, string>;
+  };
+
+  it("exposes build:apex that delegates to the bash driver", () => {
+    expect(pkg.scripts["build:apex"]).toBeDefined();
+    expect(pkg.scripts["build:apex"]).toContain("scripts/build-apex.sh");
+  });
+
+  it("exposes start:apex-preview that serves out-apex on a known port", () => {
+    expect(pkg.scripts["start:apex-preview"]).toBeDefined();
+    expect(pkg.scripts["start:apex-preview"]).toContain("out-apex");
+  });
+
+  it("keeps the standard build / start scripts intact", () => {
+    expect(pkg.scripts.build).toBe("next build");
+    expect(pkg.scripts.start).toBe("next start");
+  });
+});
+
+describe("apex build target — apex stubs", () => {
+  it("LandingAuthRedirectApex exists and is a default-exported component", () => {
+    const stub = readText("components/landing/LandingAuthRedirectApex.tsx");
+    expect(stub).toContain("export default function LandingAuthRedirectApex");
+    // No useAuth, no useRouter — must be auth-free.
+    expect(stub).not.toContain("useAuth");
+    expect(stub).not.toContain("useRouter");
+  });
+
+  it("AuthProviderApex exposes useAuth + AuthProvider + MfaRequiredError", () => {
+    const stub = readText("components/auth/AuthProviderApex.tsx");
+    expect(stub).toContain("export function AuthProvider");
+    expect(stub).toContain("export function useAuth");
+    expect(stub).toContain("MfaRequiredError");
+    // The whole point of this stub is to NOT call apiFetch.
+    expect(stub).not.toContain("apiFetch");
+  });
+});
+
+// lib/links.ts reads NEXT_PUBLIC_BUILD_TARGET at module evaluation time.
+// vi.resetModules() forces a fresh evaluation per test case so each env
+// permutation is independent.
+async function loadLinks(env: { target?: string; appUrl?: string }) {
+  delete process.env.NEXT_PUBLIC_BUILD_TARGET;
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  if (env.target !== undefined) {
+    process.env.NEXT_PUBLIC_BUILD_TARGET = env.target;
+  }
+  if (env.appUrl !== undefined) {
+    process.env.NEXT_PUBLIC_APP_URL = env.appUrl;
+  }
+  vi.resetModules();
+  return (await import("@/lib/links")) as typeof import("@/lib/links");
+}
+
+describe("apex build target — lib/links.ts cross-domain CTAs", () => {
+  const origTarget = process.env.NEXT_PUBLIC_BUILD_TARGET;
+  const origUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+  afterEach(() => {
+    if (origTarget === undefined) {
+      delete process.env.NEXT_PUBLIC_BUILD_TARGET;
+    } else {
+      process.env.NEXT_PUBLIC_BUILD_TARGET = origTarget;
+    }
+    if (origUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_URL;
+    } else {
+      process.env.NEXT_PUBLIC_APP_URL = origUrl;
+    }
+    vi.resetModules();
+  });
+
+  it("returns relative paths in the standard app build target", async () => {
+    const mod = await loadLinks({});
+    expect(mod.signinHref()).toBe("/login");
+    expect(mod.signupHref()).toBe("/register");
+    expect(mod.IS_APEX_BUILD).toBe(false);
+  });
+
+  it("returns absolute BRAND_APP_URL paths in the apex build target", async () => {
+    const mod = await loadLinks({ target: "apex" });
+    expect(mod.signinHref()).toBe("https://app.thebetterdecision.com/login");
+    expect(mod.signupHref()).toBe("https://app.thebetterdecision.com/register");
+    expect(mod.IS_APEX_BUILD).toBe(true);
+    expect(mod.BRAND_APP_URL).toBe("https://app.thebetterdecision.com");
+  });
+
+  it("honours NEXT_PUBLIC_APP_URL override and strips trailing slash", async () => {
+    const mod = await loadLinks({ target: "apex", appUrl: "https://staging.example.com/" });
+    expect(mod.BRAND_APP_URL).toBe("https://staging.example.com");
+    expect(mod.signupHref()).toBe("https://staging.example.com/register");
+  });
+
+  it("ignores empty NEXT_PUBLIC_APP_URL and falls back to the default", async () => {
+    const mod = await loadLinks({ target: "apex", appUrl: "" });
+    expect(mod.BRAND_APP_URL).toBe("https://app.thebetterdecision.com");
+  });
+});

--- a/frontend/tests/build-apex.test.ts
+++ b/frontend/tests/build-apex.test.ts
@@ -51,41 +51,64 @@ describe("apex build target — scripts/build-apex.sh", () => {
     expect(script).toMatch(/git[^\n]+rev-parse HEAD/);
   });
 
-  it("excludes every authed / app route directory from the apex build", () => {
-    // Sample of the routes that must NOT ship to apex. Each must appear
-    // in the EXCLUDED_ROUTE_DIRS array of the build script.
-    const mustExclude = [
-      "dashboard",
-      "transactions",
-      "accounts",
-      "admin",
-      "login",
-      "register",
-      "settings",
-      "setup",
-      "profile",
-      "verify-email",
-      "forgot-password",
-      "reset-password",
-      "mfa-verify",
-      "accept-invite",
-      "budgets",
-      "categories",
-      "forecast-plans",
-      "recurring",
-      "import",
-      "system",
-      "auth",
-      "health",
-    ];
-    for (const dir of mustExclude) {
-      expect(script, `expected excluded route: ${dir}`).toContain(`"${dir}"`);
+  it("uses a positive allowlist of route directories (default-deny)", () => {
+    // The apex build must invert the historical blocklist to an allowlist
+    // so newly added authed routes (e.g. PR #238's /onboarding) are
+    // staged out automatically. The script defines an ALLOWED_ROUTE_DIRS
+    // array and walks app/ entries, staging anything not on it.
+    expect(script).toMatch(/ALLOWED_ROUTE_DIRS=\(/);
+    // Only the public marketing routes belong on the apex.
+    for (const allowed of ["privacy", "terms", "docs"]) {
+      expect(script, `expected allowed route: ${allowed}`).toContain(
+        `"${allowed}"`,
+      );
+    }
+    // The blocklist contract is gone — these names must NOT appear as
+    // first-class array entries any more (they're staged-out via the
+    // default-deny walk).
+    expect(script).not.toMatch(/EXCLUDED_ROUTE_DIRS=/);
+  });
+
+  it("uses a positive allowlist of app-level files", () => {
+    expect(script).toMatch(/ALLOWED_APP_FILES=\(/);
+    // Structural / static files we keep.
+    for (const allowed of [
+      "layout.tsx",
+      "page.tsx",
+      "globals.css",
+      "error.tsx",
+      "not-found.tsx",
+      "loading.tsx",
+      "global-error.tsx",
+      "icon.svg",
+    ]) {
+      expect(script, `expected allowed app file: ${allowed}`).toContain(
+        `"${allowed}"`,
+      );
+    }
+    // Dynamic Metadata handlers + dynamic image responses are NOT on the
+    // allowlist (staged out so output:'export' doesn't choke).
+    for (const denied of [
+      "opengraph-image.tsx",
+      "apple-icon.tsx",
+      "sitemap.ts",
+      "robots.ts",
+    ]) {
+      // These names may still appear in comments, but not as quoted
+      // allowlist entries. The allowlist itself must not contain them.
+      const allowlistBlock = script.match(
+        /ALLOWED_APP_FILES=\(([\s\S]*?)\)/,
+      );
+      expect(allowlistBlock, "ALLOWED_APP_FILES block exists").not.toBeNull();
+      expect(
+        allowlistBlock?.[1] ?? "",
+        `${denied} must NOT be in ALLOWED_APP_FILES`,
+      ).not.toContain(`"${denied}"`);
     }
   });
 
-  it("allowlists the apex-exported routes only", () => {
-    // Output sanity-prune must permit privacy, terms, docs + the
-    // structural assets, and nothing else.
+  it("allowlists the apex-exported output paths", () => {
+    // The post-build guard's allowlist of out-apex/ top-level entries.
     for (const allowed of [
       "index.html",
       "privacy",
@@ -96,6 +119,38 @@ describe("apex build target — scripts/build-apex.sh", () => {
     ]) {
       expect(script).toContain(`"${allowed}"`);
     }
+  });
+
+  it("post-build guard fails on unexpected top-level entries", () => {
+    // The guard exists, references the allowlist, and exits non-zero on
+    // mismatch. This is belt-and-suspenders behind the input allowlist.
+    expect(script).toMatch(/post-build guard/);
+    expect(script).toMatch(/ALLOWED_OUTPUT_GLOBS=\(/);
+    expect(script).toMatch(/output_allowed/);
+  });
+
+  it("post-build guard fails on any /api/v1 reference in built output", () => {
+    // If auth/backend code (or a hashed _next/static chunk) leaks an
+    // /api/v1 reference, the script must abort. This catches transitive
+    // imports the input allowlist alone cannot.
+    expect(script).toMatch(/grep -rl "\/api\/v1"/);
+    expect(script).toMatch(/GUARD FAIL .*api\/v1/i);
+  });
+
+  it("avoids Bash 4+ features so macOS /bin/bash (3.2) can run it", () => {
+    // The project is operated from macOS where /bin/bash is Bash 3.2.57.
+    // None of these idioms exist in 3.2 and must not appear in code
+    // (mentions inside comments are filtered out below).
+    const codeOnly = script
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("#"))
+      .join("\n");
+    expect(codeOnly).not.toMatch(/\bdeclare\s+-A\b/);
+    expect(codeOnly).not.toMatch(/\bmapfile\b/);
+    expect(codeOnly).not.toMatch(/\breadarray\b/);
+    expect(codeOnly).not.toMatch(/\$\{[A-Za-z_][A-Za-z0-9_]*\^\^?\}/);
+    expect(codeOnly).not.toMatch(/\$\{[A-Za-z_][A-Za-z0-9_]*,,?\}/);
+    expect(codeOnly).not.toMatch(/&>>/);
   });
 });
 

--- a/frontend/tests/components/landing/apex-cta-routing.test.tsx
+++ b/frontend/tests/components/landing/apex-cta-routing.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+// apex-cta-routing.test.tsx — verifies that under NEXT_PUBLIC_BUILD_TARGET=apex
+// the landing CTAs render as absolute URLs pointing at BRAND_APP_URL,
+// because the apex host and the app host are different origins and
+// relative paths would 404 there.
+//
+// `lib/links.ts` reads NEXT_PUBLIC_BUILD_TARGET at module evaluation
+// time. To get a fresh evaluation per test we call vi.resetModules()
+// between env permutations and re-import the landing component.
+
+vi.mock("@/components/ThemeProvider", () => ({
+  useTheme: () => ({ theme: "dark", toggle: vi.fn() }),
+}));
+
+const origTarget = process.env.NEXT_PUBLIC_BUILD_TARGET;
+const origAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+async function renderLanding(
+  importPath: string,
+  env: { target?: string; appUrl?: string },
+) {
+  delete process.env.NEXT_PUBLIC_BUILD_TARGET;
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  if (env.target !== undefined) process.env.NEXT_PUBLIC_BUILD_TARGET = env.target;
+  if (env.appUrl !== undefined) process.env.NEXT_PUBLIC_APP_URL = env.appUrl;
+  vi.resetModules();
+  // Re-import the ThemeProvider mock binding after resetModules so the
+  // mock factory above continues to apply.
+  vi.doMock("@/components/ThemeProvider", () => ({
+    useTheme: () => ({ theme: "dark", toggle: vi.fn() }),
+  }));
+  const mod = await import(importPath);
+  const Component = mod.default as React.ComponentType;
+  return render(<Component />);
+}
+
+afterEach(() => {
+  cleanup();
+  if (origTarget === undefined) {
+    delete process.env.NEXT_PUBLIC_BUILD_TARGET;
+  } else {
+    process.env.NEXT_PUBLIC_BUILD_TARGET = origTarget;
+  }
+  if (origAppUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  } else {
+    process.env.NEXT_PUBLIC_APP_URL = origAppUrl;
+  }
+  vi.resetModules();
+  vi.doUnmock("@/components/ThemeProvider");
+});
+
+describe("landing CTAs under apex build target", () => {
+  it("TopNav uses absolute app URLs in the apex build", async () => {
+    await renderLanding("@/components/landing/TopNav", { target: "apex" });
+    expect(screen.getByRole("link", { name: /^sign in$/i })).toHaveAttribute(
+      "href",
+      "https://app.thebetterdecision.com/login",
+    );
+    expect(screen.getByRole("link", { name: /^get started$/i })).toHaveAttribute(
+      "href",
+      "https://app.thebetterdecision.com/register",
+    );
+  });
+
+  it("Hero uses absolute app URLs in the apex build", async () => {
+    await renderLanding("@/components/landing/Hero", { target: "apex" });
+    expect(
+      screen.getByRole("link", { name: /get started free/i }),
+    ).toHaveAttribute("href", "https://app.thebetterdecision.com/register");
+    expect(screen.getByRole("link", { name: /^sign in$/i })).toHaveAttribute(
+      "href",
+      "https://app.thebetterdecision.com/login",
+    );
+  });
+
+  it("SecondCta uses absolute app URLs in the apex build", async () => {
+    await renderLanding("@/components/landing/SecondCta", { target: "apex" });
+    expect(
+      screen.getByRole("link", { name: /get started free/i }),
+    ).toHaveAttribute("href", "https://app.thebetterdecision.com/register");
+  });
+
+  it("respects NEXT_PUBLIC_APP_URL override in the apex build", async () => {
+    await renderLanding("@/components/landing/TopNav", {
+      target: "apex",
+      appUrl: "https://staging.example.com",
+    });
+    expect(screen.getByRole("link", { name: /^sign in$/i })).toHaveAttribute(
+      "href",
+      "https://staging.example.com/login",
+    );
+  });
+
+  it("keeps relative paths in the standard app build (no target)", async () => {
+    await renderLanding("@/components/landing/TopNav", {});
+    expect(screen.getByRole("link", { name: /^sign in$/i })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+    expect(screen.getByRole("link", { name: /^get started$/i })).toHaveAttribute(
+      "href",
+      "/register",
+    );
+  });
+});


### PR DESCRIPTION
## Scope

Adds a second Next.js build target that produces a static export of the landing surface only, for upload to S3 + CloudFront on the apex host (`thebetterdecision.com`). The standard `npm run build` target is untouched and still produces the standalone bundle deployed to DigitalOcean App Platform on `app.thebetterdecision.com`.

Reads from the canonical L5.2a plan (`project_apex_s3_cloudfront.md`), D3.A locked direction: single repo, single Next.js app, two build outputs.

## Routes exported vs excluded

**Exported (allowlist):**
- `/` (landing root)
- `/privacy/`
- `/terms/`
- `/docs/`
- `404.html`, `_next/` (hashed assets), `icon.svg`
- `robots.txt`, `sitemap.xml` (statically written by the build script)
- `_meta.json` (commit SHA + UTC timestamp + target)
- `__next.*.txt` RSC prefetch payloads (silences `<Link>` hover 404s)

**Excluded (staged out of `app/` for the build):**
- All authed routes: `accounts`, `admin`, `auth`, `budgets`, `categories`, `dashboard`, `forecast-plans`, `forgot-password`, `health`, `import`, `login`, `mfa-verify`, `profile`, `recurring`, `register`, `reset-password`, `settings`, `setup`, `system`, `transactions`, `verify-email`, `accept-invite`
- Dynamic `ImageResponse` routes: `opengraph-image.tsx`, `apple-icon.tsx`, `sitemap.ts`, `robots.ts` — these can't be force-static without touching the production app, so the script stages them out and writes static replacements where needed (sitemap.xml, robots.txt). Static PNG OG fallback for the apex domain is a follow-up.

Total output size: **~1.4 MB** (target was <2 MB).

## Auth-island handling (Option Y, mechanical alias)

- New `frontend/components/landing/LandingAuthRedirectApex.tsx` — no-op stub.
- New `frontend/components/auth/AuthProviderApex.tsx` — re-exports `AuthProvider` / `useAuth` / `MfaRequiredError` as passthrough stubs so any landing component that imports `useAuth` still type-checks under apex even though the apex render never invokes it.
- `next.config.apex.ts` swaps both via `turbopack.resolveAlias` (project-relative paths) and `webpack.resolve.alias` (absolute paths). Confirmed by `grep -l "useAuth|apiFetch|auth/refresh" out-apex/_next/static/chunks/*.js` returning zero matches and Playwright network log showing zero `/api/v1/auth/*` requests from the apex build.

Chose Option Y over Option X because mechanical alias is simpler to audit than a build-time conditional import, and the stub file makes the apex-vs-app distinction explicit at the file level. The component file for the real `LandingAuthRedirect` stays single-source for the app build.

## BRAND_APP_URL contract

New `frontend/lib/links.ts`:
- `BRAND_APP_URL` constant. Default: `https://app.thebetterdecision.com`. Override via `NEXT_PUBLIC_APP_URL` (no trailing slash, sanitized).
- `IS_APEX_BUILD = process.env.NEXT_PUBLIC_BUILD_TARGET === "apex"`.
- `ctaHref(path)` / `signupHref()` / `signinHref()` — return relative paths on the app build, absolute `BRAND_APP_URL`-prefixed URLs on the apex build.
- `TopNav`, `Hero`, `SecondCta` updated to use the helpers. `LandingFooter` unchanged (Privacy / Terms / Help / mailto are same-origin or protocol links).
- `frontend/lib/brand.ts` deliberately NOT touched (per task brief).

## How to invoke (consumed by PR-B GH Actions)

```bash
cd frontend
npm install
npm run build:apex          # writes frontend/out-apex/
npm run start:apex-preview  # python3 -m http.server 4321 against out-apex/
```

Env overrides:
- `NEXT_PUBLIC_APP_URL` — point CTAs at a non-prod app host.
- `NEXT_PUBLIC_SITE_URL` — point canonical / og:url at a non-prod apex host (defaults to `https://thebetterdecision.com`).

The build driver `scripts/build-apex.sh`:
1. Stages excluded routes out of `app/` into `.apex-staged-routes/`.
2. Swaps `next.config.ts` <-> `next.config.apex.ts` (Next 16 has no `--config` flag).
3. Runs `next build` with `NEXT_PUBLIC_BUILD_TARGET=apex`.
4. `trap restore_routes EXIT INT TERM` ALWAYS restores config + routes, even on failure.
5. Copies the static export from `.next-apex/` to `out-apex/`, prunes Next internals, writes `_meta.json` + `robots.txt` + `sitemap.xml`.

## Validation

- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors (88 pre-existing warnings, unchanged).
- `bash frontend/scripts/check-design-tokens.sh` — clean.
- `npm test` — **693 / 693 pass**, including 26 new tests:
  - `tests/build-apex.test.ts` (21) — script + config + stubs + links behaviour
  - `tests/components/landing/apex-cta-routing.test.tsx` (5) — TopNav / Hero / SecondCta render with absolute URLs under `NEXT_PUBLIC_BUILD_TARGET=apex`
- `npm run build` (existing target) — succeeds, 33 routes built as before.
- `npm run build:apex` — succeeds, writes 5 routes + assets, total 1.4 MB.

## Screenshots

Pre-release: https://github.com/flamarion/pfv/releases/tag/apex-pr-c-screenshots-1778615040
- `apex-landing-desktop-clean.png` — 1280 viewport, full page
- `apex-landing-mobile.png` — 390 viewport, full page
- `apex-privacy-desktop.png` — privacy route renders

Network log from `http://localhost:4321/` confirms ZERO `/api/v1/auth/*` requests (apex bundle has no auth code).

## /impeccable critique

**Strengths:**
- Brand identity holds. Navy ground + brass accent + Fraunces serif headline reads as premium, not generic SaaS. The tagline "There's no best decision. Only better ones." carries the line break the layout wants. Hero dashboard mock anchors the right column with believable spec data (April balance, weekly bars, budget rows).
- Four-tile feature arc (clarity → predictability → shared → trust) flows cleanly. Ordinal markers 01–04 add quiet structure without over-decorating.
- Closing "Ready to see clearly?" CTA is single-button, centered, brand-true. Footer is muted and load-light.
- All CTAs in the apex build render as absolute URLs to `app.thebetterdecision.com`. Theme toggle, font preload, and JSON-LD ship intact.

**Apex-specific risks the build flags:**
- The theme toggle button is present and clickable but the apex domain doesn't share `localStorage` with the app domain. Pressing it toggles the apex page only — that's fine (it's per-domain by definition) but the user's preference WON'T follow them to `app.thebetterdecision.com`. Acceptable for v1; follow-up could propagate via query param on the CTA href if it matters.
- The OG image route is staged out for apex. Social shares of `thebetterdecision.com/` will currently rely on whatever fallback unfurl the platform synthesizes. PR-A or a tiny follow-up can drop a static PNG at `out-apex/opengraph-image.png` and reference it from `pageSocialMeta`.
- Canonical URL on apex says `https://thebetterdecision.com/` (good) but `og:image` still resolves against `siteUrl`, which means it points at the app domain unless `NEXT_PUBLIC_SITE_URL` is set during build (the script defaults it to the apex domain, so deployed builds via PR-B will be correct).

**Nits:**
- The 404 page (`out-apex/404.html`) is the Next.js default, not the in-app branded one (the branded `not-found.tsx` is server-component and exports cleanly). It DOES render the branded shell, just visually I'd want to confirm typography stays Fraunces — left as-is for this PR.
- `_meta.json` is exposed at the root of the bucket. Harmless (it's just commit + timestamp) but worth a CloudFront response-headers policy entry to mark it `Cache-Control: no-cache` so PR-B can use it for cache invalidation tracking.

Overall: shipping quality. The apex build is auth-free, brand-true, and well under the 2 MB budget. Hand-off to PR-B can consume `npm run build:apex` directly.

## Out of scope (handled by sibling PRs)

- PR-A: Terraform for S3 + CloudFront + ACM + OIDC + Route53.
- PR-B: GitHub Actions workflow invoking `npm run build:apex` + `aws s3 sync out-apex/` + CloudFront invalidation.
- PR-D: DNS cutover.