### PR TITLE
fix(help): uniform HelpAnchor placement (top-right of cards, top-aligned on titles)

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -219,7 +219,7 @@ export default function AccountsPage() {
 
   return (
     <AppShell>
-      <div className="mb-8 flex items-center gap-1">
+      <div className="mb-8 flex items-start gap-1">
         <h1 className={`${pageTitle} mb-0`}>Accounts</h1>
         <HelpAnchor section="accounts" label="Accounts" />
       </div>

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -354,7 +354,7 @@ export default function AdminDashboardPage() {
       <div className="space-y-6">
         <header className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <div className="flex items-center gap-1">
+            <div className="flex items-start gap-1">
               <h1 className="font-display text-2xl text-text-primary">Admin</h1>
               <HelpAnchor section="admin" label="Admin" />
             </div>

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -206,7 +206,7 @@ export default function BudgetsPage() {
   return (
     <AppShell>
       <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-1">
+        <div className="flex items-start gap-1">
           <h1 className={`${pageTitle} mb-0`}>Budgets</h1>
           <HelpAnchor section="budgets" label="Budgets" />
         </div>

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -375,7 +375,7 @@ export default function CategoriesPage() {
   return (
     <AppShell>
       <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-1">
+        <div className="flex items-start gap-1">
           <h1 className={`${pageTitle} mb-0`}>Categories</h1>
           <HelpAnchor section="categories" label="Categories" />
         </div>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -620,7 +620,7 @@ export default function DashboardPage() {
     <AppShell>
       <TourAnchor id="dashboard.header" as="child">
         <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center gap-1">
+          <div className="flex items-start gap-1">
             <h1 className={`${pageTitle} mb-0`}>Dashboard</h1>
             <HelpAnchor section="dashboard" label="Dashboard" />
           </div>
@@ -715,20 +715,24 @@ export default function DashboardPage() {
               therefore collapses (PR #226 regression visible on prod).
               Every other TourAnchor on this page already uses
               `as="child"`; this one was the lone exception. */}
+          {/* On Track row: the `?` lives INSIDE the tile's top-right
+              corner via a positioned overlay, mirroring the
+              AccountMonthEndForecast tile below. The previous layout
+              put HelpTooltip in a sibling flex column so it visibly
+              protruded outside the card border (owner bug report
+              2026-05-13). */}
           <TourAnchor id="dashboard.on-track-tile" as="child">
-            <div className="flex items-start gap-2">
-              <div className="flex-1">
-                <OnTrackTile
-                  forecastPlan={forecast}
-                  projection={forecastProjection}
-                  projectionFailed={projectionFailed}
-                  projectionLoading={projectionLoading}
-                  onRetryProjection={() => void loadForecastProjection()}
-                  isPastPeriod={isPastSelectedPeriod}
-                  isFuturePeriod={isFutureSelectedPeriod}
-                />
-              </div>
-              <div className="pt-3">
+            <div className="relative">
+              <OnTrackTile
+                forecastPlan={forecast}
+                projection={forecastProjection}
+                projectionFailed={projectionFailed}
+                projectionLoading={projectionLoading}
+                onRetryProjection={() => void loadForecastProjection()}
+                isPastPeriod={isPastSelectedPeriod}
+                isFuturePeriod={isFutureSelectedPeriod}
+              />
+              <div className="absolute right-3 top-3">
                 <HelpTooltip
                   content="On Track compares spent so far to your planned spending for this period. Watch warns at 95 percent, Over at 105 percent."
                   learnMoreSection="forecasts"

--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -597,7 +597,7 @@ export default function ForecastPlansClient({
     <AppShell>
       {/* Header */}
       <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-1">
+        <div className="flex items-start gap-1">
           <h1 className={`${pageTitle} mb-0`}>Forecast Plans</h1>
           <HelpAnchor section="forecast-plans" label="Forecast Plans" />
         </div>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -921,7 +921,7 @@ function TransactionsPageContent() {
         </div>
       )}
       <div className="mb-8 flex items-center justify-between">
-        <div className="flex items-center gap-1">
+        <div className="flex items-start gap-1">
           <h1 className={`${pageTitle} mb-0`}>Transactions</h1>
           <HelpAnchor section="transactions" label="Transactions" />
         </div>

--- a/frontend/components/HelpAnchor.tsx
+++ b/frontend/components/HelpAnchor.tsx
@@ -14,19 +14,53 @@ import { HelpCircle } from "lucide-react";
  * Token-clean per `scripts/check-design-tokens.sh`: muted by default,
  * accent on hover/focus. Touch target ≥44px on mobile (WCAG 2.5.8) and
  * compact 28px at desktop where the cursor is precise.
+ *
+ * Placement variants (PR fix/help-anchor-placement-uniform):
+ *
+ * - `inline-title` (default): for HelpAnchors next to a page H1.
+ *   Self-aligns to the top of the flex row via `self-start` + a small
+ *   `mt-1` nudge so the `?` lands at the cap height of the heading
+ *   instead of the baseline. Owner spec: "on top of the headers."
+ *
+ * - `card-corner`: for HelpAnchors that live inside a `relative` card
+ *   container. Absolutely positions at `top-3 right-3` so the `?` is
+ *   docked in the card's top-right corner, INSIDE the card border.
+ *   Owner spec: "inside the cards."
  */
+export type HelpAnchorVariant = "inline-title" | "card-corner";
+
 type HelpAnchorProps = {
   /** /docs section id, e.g. "dashboard". Must exist in the docs page. */
   section: string;
   /** Optional extra context for screen readers. Falls back to the section name. */
   label?: string;
+  /** Placement variant. Default `inline-title` for header rows. */
+  variant?: HelpAnchorVariant;
   /** Optional class overrides for layout fit (margin, alignment). */
   className?: string;
+};
+
+// Shared visual + a11y classes. Held constant across variants so the
+// `?` icon reads the same wherever it appears; only positioning shifts.
+const BASE_CLASSES =
+  "inline-flex min-h-[44px] min-w-[44px] md:min-h-7 md:min-w-7 items-center justify-center rounded-full text-text-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30";
+
+const VARIANT_CLASSES: Record<HelpAnchorVariant, string> = {
+  // `self-start` overrides any items-center on the parent flex row, so
+  // the icon top-aligns with the heading text regardless of how the
+  // parent wraps it. `mt-1` lifts it to the heading's cap height
+  // without inflating the row's total height.
+  "inline-title": "self-start mt-1",
+  // Docks inside the top-right corner of a positioned-relative card.
+  // `top-3 right-3` matches the spacing rhythm of the existing
+  // AccountMonthEndForecast tile, which is the correct reference.
+  "card-corner": "absolute top-3 right-3",
 };
 
 export default function HelpAnchor({
   section,
   label,
+  variant = "inline-title",
   className = "",
 }: HelpAnchorProps) {
   const ariaLabel = `Help: ${label ?? section}`;
@@ -38,7 +72,8 @@ export default function HelpAnchor({
       aria-label={ariaLabel}
       data-testid="help-anchor"
       data-section={section}
-      className={`inline-flex min-h-[44px] min-w-[44px] md:min-h-7 md:min-w-7 items-center justify-center rounded-full text-text-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${className}`}
+      data-variant={variant}
+      className={`${BASE_CLASSES} ${VARIANT_CLASSES[variant]} ${className}`}
     >
       <HelpCircle
         aria-hidden="true"

--- a/frontend/tests/app/dashboard-on-track-tour-anchor-shape.test.tsx
+++ b/frontend/tests/app/dashboard-on-track-tour-anchor-shape.test.tsx
@@ -105,11 +105,11 @@ describe("DashboardPage — dashboard.on-track-tile TourAnchor shape (prod align
     mockEmptyDashboard();
   });
 
-  it("places data-tour-id directly on the flex row (not on a wrapping span)", async () => {
+  it("places data-tour-id directly on the on-track wrapper (not on a wrapping span)", async () => {
     const { container } = render(<DashboardPage />);
 
     // Wait for the dashboard to finish loading and render the on-track
-    // anchor. The flex row is the element we'll find by its tour id.
+    // anchor. The wrapper is the element we'll find by its tour id.
     await waitFor(() => {
       const tagged = container.querySelector('[data-tour-id="dashboard.on-track-tile"]');
       expect(tagged).not.toBeNull();
@@ -119,14 +119,16 @@ describe("DashboardPage — dashboard.on-track-tile TourAnchor shape (prod align
       '[data-tour-id="dashboard.on-track-tile"]',
     ) as HTMLElement;
 
-    // Must be the block flex container itself, not a wrapping span.
+    // Must be the block container itself, not a wrapping span.
+    // (PR #226 regression: TourAnchor without `as="child"` wraps the
+    // child in an inline span, which collapses block-level vertical
+    // margins from the parent `space-y-5` rule.)
     expect(tagged.tagName).toBe("DIV");
 
-    // And must carry the layout-critical flex classes that get
-    // collapsed when wrapped in an inline span.
-    expect(tagged.className).toContain("flex");
-    expect(tagged.className).toContain("items-start");
-    expect(tagged.className).toContain("gap-2");
+    // Wrapper must be positioned-relative so the in-card help marker
+    // can dock in the top-right corner via absolute positioning.
+    // Owner spec 2026-05-13: "tooltip inside the cards."
+    expect(tagged.className).toContain("relative");
 
     // Defensive: ensure no sibling span carries the tour id either.
     const taggedSpans = container.querySelectorAll(

--- a/frontend/tests/components/HelpAnchor.test.tsx
+++ b/frontend/tests/components/HelpAnchor.test.tsx
@@ -44,4 +44,51 @@ describe("HelpAnchor", () => {
     expect(svg).not.toBeNull();
     expect(svg).toHaveAttribute("aria-hidden", "true");
   });
+
+  // Placement uniformity — PR fix/help-anchor-placement-uniform.
+  // The default `variant="inline-title"` is for HelpAnchors that sit
+  // next to a page heading. Tested by checking that the anchor's class
+  // list includes the top-aligned positioning hook so a parent flex row
+  // with `items-start` (or our wrapper below) lifts the `?` to align
+  // with the TOP of the heading text instead of its baseline.
+  it("defaults to the inline-title variant and self-aligns to the top of adjacent text", () => {
+    render(<HelpAnchor section="dashboard" label="Dashboard" />);
+
+    const anchor = screen.getByTestId("help-anchor");
+    expect(anchor).toHaveAttribute("data-variant", "inline-title");
+    // `self-start` lifts this single child to the top of the flex row,
+    // regardless of the parent's items alignment. That is the load-
+    // bearing geometric promise of inline-title.
+    expect(anchor.className).toMatch(/\bself-start\b/);
+    // Margin pulls the icon up to align with the cap height of a large
+    // heading without inflating layout height.
+    expect(anchor.className).toMatch(/\bmt-1\b/);
+  });
+
+  // The card-corner variant is for HelpAnchors that live inside a
+  // card / tile. The geometric contract is `absolute top-3 right-3`
+  // so a `relative` card parent docks the `?` in its top-right.
+  it("supports a card-corner variant that absolutely positions in the top-right of a relative parent", () => {
+    render(<HelpAnchor section="on-track" variant="card-corner" />);
+
+    const anchor = screen.getByTestId("help-anchor");
+    expect(anchor).toHaveAttribute("data-variant", "card-corner");
+    expect(anchor.className).toMatch(/\babsolute\b/);
+    expect(anchor.className).toMatch(/\btop-3\b/);
+    expect(anchor.className).toMatch(/\bright-3\b/);
+  });
+
+  it("still accepts caller-supplied className overrides on top of variant defaults", () => {
+    render(
+      <HelpAnchor
+        section="budgets"
+        variant="card-corner"
+        className="z-10"
+      />,
+    );
+
+    const anchor = screen.getByTestId("help-anchor");
+    expect(anchor.className).toMatch(/\babsolute\b/);
+    expect(anchor.className).toMatch(/\bz-10\b/);
+  });
 });


### PR DESCRIPTION
## Bug

Owner screenshot 2026-05-13 surfaced two HelpAnchor placement bugs:

1. Dashboard page-title `?` sat at the **baseline** of the large "Dashboard" heading, looking floaty and mis-aligned. Owner ask: "on top of the headers."
2. Dashboard On Track tile `?` (a `HelpTooltip`, visually identical to the HelpAnchor icon) was rendered as a **sibling flex column** outside the card border, so it visually **protruded** out the top-right edge of the tile. The Expected Month-End Balance tile next to it already had its `?` correctly **inside** the card via an absolute-positioned overlay. The two tiles were inconsistent.

Owner instruction:

> Place the tooltip inside the cards and on top of the headers if any other are in different placement.

## Audit table

| Site | Before placement | After placement |
|---|---|---|
| `/dashboard` page title | `flex items-center` row, `?` at heading baseline | `flex items-start` row + HelpAnchor `inline-title` variant lifts `?` to heading top |
| `/dashboard` On Track tile | `?` (HelpTooltip) in **sibling flex column outside the card** | `?` absolutely positioned **inside the card** at top-3 right-3, mirroring the EOMF tile |
| `/transactions` page title | `flex items-center` row, `?` at baseline | `inline-title` variant, top-aligned |
| `/accounts` page title | `flex items-center` row, `?` at baseline | `inline-title` variant, top-aligned |
| `/categories` page title | `flex items-center` row, `?` at baseline | `inline-title` variant, top-aligned |
| `/budgets` page title | `flex items-center` row, `?` at baseline | `inline-title` variant, top-aligned |
| `/forecast-plans` page title | `flex items-center` row, `?` at baseline | `inline-title` variant, top-aligned |
| `/admin` page title | `flex items-center` row, `?` at baseline | `inline-title` variant, top-aligned |

## Canonical pattern

`HelpAnchor` now ships two placement variants:

- `variant="inline-title"` (default): for HelpAnchors next to a page H1. Self-aligns to the top of the flex row via `self-start mt-1`, so the `?` lands at the cap height of the heading regardless of the parent's `items-*` value. Owner ask: "on top of the headers."
- `variant="card-corner"`: for HelpAnchors that live inside a `relative` card container. Absolutely positions at `top-3 right-3`. Owner ask: "inside the cards."

The Dashboard On Track tile is **not** a HelpAnchor call site (it uses `HelpTooltip`, which is owned by PR #226). The fix at that call site is purely a layout change at the dashboard page, not a Tooltip component change: the sibling flex column was replaced with the same `<div className="relative"><tile/><div className="absolute right-3 top-3"><HelpTooltip/></div></div>` shape the adjacent EOMF tile already uses.

## Variant API

```tsx
<HelpAnchor section="dashboard" label="Dashboard" />
// → variant="inline-title", self-aligns to top of heading

<HelpAnchor section="forecasts" variant="card-corner" />
// → absolute top-3 right-3 inside a relative-positioned card
```

## Tests

- 3 new `HelpAnchor` tests cover the variant API: default variant, card-corner variant, and caller className override on top of variant defaults.
- Updated `dashboard-on-track-tour-anchor-shape.test.tsx` to assert the new `relative` wrapper around the on-track tile while keeping the existing "must be a DIV, not a wrapper span" and "must be a direct child of `space-y-5`" guards (the PR #226 regression these guard against is preserved).

CI gate status (run inside isolated `team-help-anchor` compose project):

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors (88 pre-existing warnings unchanged, none in changed files)
- [x] `bash frontend/scripts/check-design-tokens.sh` clean
- [x] `npx vitest run` 672 passed (full frontend suite), incl. 8 HelpAnchor tests + 3 on-track-tour-anchor shape tests

## Screenshots

Attached via prerelease tag `pr-help-anchor-placement` (link in the next comment).

## Design notes (informal critique, in lieu of `/impeccable critique`)

- Visual rhythm: large H1s with a 28px secondary affordance look unbalanced when the smaller mark sits at the text baseline. Top-alignment + a 4px top nudge (`mt-1`) gives the `?` the same optical weight as a small uppercase label or chip would have.
- The `self-start` class on the anchor itself (rather than `items-start` on the parent only) makes the alignment promise robust to future call-site refactors that might forget to lift the parent's items-* value.
- The card-corner variant uses the **same** `top-3 right-3` spacing the existing Forecast EOMF tile uses, so the canonical pattern is what was already shipped on one tile, just generalized.

## Known follow-ups

- The Forecast Plans page also has a HelpTooltip near the "Show details" toggle. It is not protruding, so it is intentionally out of scope here. If a future audit wants to fold those toggle-row tooltips under a canonical pattern, that is a separate PR.

## Strictly out of scope

- TourAnchor (owned by PR #234).
- The Tooltip primitive (owned by PR #226). The On Track fix at the call site is a layout move, not a component change.
- Copy edits or `aria-label` rewrites.