### PR TITLE
fix(transactions): category filter actually filters

### DIFF
--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -14,7 +14,7 @@ import datetime
 from decimal import Decimal
 
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -1708,7 +1708,26 @@ async def list_transactions(
     if account_id is not None:
         q = q.where(Transaction.account_id == account_id)
     if category_id is not None:
-        q = q.where(Transaction.category_id == category_id)
+        # Master-includes-subs semantics: the /transactions filter
+        # dropdown lists masters and subs flat, so a user picking a
+        # master expects every row in that bucket (direct hits AND
+        # rows tagged with any of the master's subcategories). Subs
+        # remain exact-match (one-directional inclusion). Regression
+        # guard for the 2026-05-13 user report that the category
+        # filter "did not filter anything".
+        sub_ids_q = (
+            select(Category.id)
+            .where(
+                Category.org_id == org_id,
+                Category.parent_id == category_id,
+            )
+        )
+        q = q.where(
+            or_(
+                Transaction.category_id == category_id,
+                Transaction.category_id.in_(sub_ids_q),
+            )
+        )
     if tx_type is not None:
         q = q.where(Transaction.type == TransactionType(tx_type))
     if status is not None:

--- a/backend/tests/services/test_transaction_service_category_filter.py
+++ b/backend/tests/services/test_transaction_service_category_filter.py
@@ -1,0 +1,208 @@
+"""Category filter regression coverage for ``transaction_service.list_transactions``.
+
+The /transactions page sends ``category_id=<id>`` on the query string when the
+user picks a category from the dropdown. The backend service must restrict the
+result to rows whose ``category_id`` matches. A 2026-05-13 user report flagged
+this filter as a no-op, so this test pins the contract.
+"""
+import pytest
+import pytest_asyncio
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import Base
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.services import transaction_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def world(db_session: AsyncSession):
+    """Org + account + two top-level categories so we can prove the
+    filter discriminates. A subcategory of ``food`` is also created
+    so we can pin the "selecting a master includes its subs" contract.
+    """
+    org = Organization(name="Test", billing_cycle_day=1)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True,
+    )
+    db_session.add(at)
+    await db_session.flush()
+    acct = Account(
+        org_id=org.id, name="Main", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db_session.add(acct)
+    groceries = Category(
+        org_id=org.id, name="Groceries", slug="groceries",
+        type=CategoryType.EXPENSE, is_system=False,
+    )
+    dining = Category(
+        org_id=org.id, name="Dining", slug="dining",
+        type=CategoryType.EXPENSE, is_system=False,
+    )
+    db_session.add_all([groceries, dining])
+    await db_session.flush()
+    # Subcategory of ``groceries`` (master), used in
+    # ``test_master_category_filter_includes_subcategories``.
+    groceries_sub = Category(
+        org_id=org.id, name="Bulk", slug="bulk",
+        type=CategoryType.EXPENSE, is_system=False,
+        parent_id=groceries.id,
+    )
+    db_session.add(groceries_sub)
+    await db_session.flush()
+    return {
+        "org": org, "account": acct,
+        "groceries": groceries, "dining": dining,
+        "groceries_sub": groceries_sub,
+    }
+
+
+def _make_tx(
+    world,
+    *,
+    category: Category,
+    description: str,
+    dt: date = date(2026, 5, 15),
+    amount: str = "10.00",
+) -> Transaction:
+    return Transaction(
+        org_id=world["org"].id,
+        account_id=world["account"].id,
+        category_id=category.id,
+        description=description,
+        amount=Decimal(amount),
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.SETTLED,
+        date=dt,
+        settled_date=dt,
+    )
+
+
+async def test_category_filter_returns_only_matching_rows(db_session, world):
+    """Passing ``category_id`` must restrict the result to that category."""
+    db_session.add_all([
+        _make_tx(world, category=world["groceries"], description="g1"),
+        _make_tx(world, category=world["groceries"], description="g2"),
+        _make_tx(world, category=world["dining"], description="d1"),
+        _make_tx(world, category=world["dining"], description="d2"),
+    ])
+    await db_session.flush()
+
+    rows = await transaction_service.list_transactions(
+        db_session, world["org"].id, category_id=world["groceries"].id,
+    )
+    assert sorted(r.description for r in rows) == ["g1", "g2"]
+
+
+async def test_category_filter_none_returns_all(db_session, world):
+    """``category_id=None`` (the default) must not filter."""
+    db_session.add_all([
+        _make_tx(world, category=world["groceries"], description="g1"),
+        _make_tx(world, category=world["dining"], description="d1"),
+    ])
+    await db_session.flush()
+
+    rows = await transaction_service.list_transactions(
+        db_session, world["org"].id,
+    )
+    assert sorted(r.description for r in rows) == ["d1", "g1"]
+
+
+async def test_master_category_filter_includes_subcategories(db_session, world):
+    """Selecting a master category must also return rows tagged with any
+    of its subcategories.
+
+    Reproduces the 2026-05-13 user report: the dropdown lists masters and
+    subs flat, so a user picking the "Food & Dining" master expects every
+    row in that food bucket, including ones tagged with "Groceries" /
+    "Restaurants" / etc. Exact-match against ``category_id`` excluded them.
+    """
+    db_session.add_all([
+        _make_tx(world, category=world["groceries"], description="g-master"),
+        _make_tx(world, category=world["groceries_sub"], description="g-sub"),
+        _make_tx(world, category=world["dining"], description="d-master"),
+    ])
+    await db_session.flush()
+
+    rows = await transaction_service.list_transactions(
+        db_session, world["org"].id, category_id=world["groceries"].id,
+    )
+    assert sorted(r.description for r in rows) == ["g-master", "g-sub"]
+
+
+async def test_subcategory_filter_exact_match_only(db_session, world):
+    """Selecting a subcategory must NOT pull in its master's other subs
+    or rows tagged directly with the master.
+
+    The master-inclusion behavior is one-directional: master -> subs, not
+    the reverse. A user picking "Groceries" sub wants only Groceries rows.
+    """
+    db_session.add_all([
+        _make_tx(world, category=world["groceries"], description="g-master"),
+        _make_tx(world, category=world["groceries_sub"], description="g-sub"),
+    ])
+    await db_session.flush()
+
+    rows = await transaction_service.list_transactions(
+        db_session, world["org"].id, category_id=world["groceries_sub"].id,
+    )
+    assert [r.description for r in rows] == ["g-sub"]
+
+
+async def test_category_filter_compounds_with_date_range(db_session, world):
+    """``category_id`` AND ``date_from``/``date_to`` must both apply."""
+    db_session.add_all([
+        _make_tx(
+            world, category=world["groceries"], description="g-may",
+            dt=date(2026, 5, 15),
+        ),
+        _make_tx(
+            world, category=world["groceries"], description="g-apr",
+            dt=date(2026, 4, 15),
+        ),
+        _make_tx(
+            world, category=world["dining"], description="d-may",
+            dt=date(2026, 5, 15),
+        ),
+    ])
+    await db_session.flush()
+
+    rows = await transaction_service.list_transactions(
+        db_session, world["org"].id,
+        category_id=world["groceries"].id,
+        date_from=date(2026, 5, 1),
+        date_to=date(2026, 5, 31),
+    )
+    assert [r.description for r in rows] == ["g-may"]


### PR DESCRIPTION
## Root cause

`backend/app/services/transaction_service.py:1711` filtered with
`Transaction.category_id == category_id` (exact match). The
`/transactions` filter dropdown lists masters and subcategories
flat (`frontend/app/transactions/page.tsx:1167-1170`), so when a user
picks a master that has subs and the org has any rows tagged under
those subs, the filtered list drops them silently. With the user's
seeded chart (seven masters, three to seven subs each), this looks
like "the filter does nothing" because the matching count is often
empty after picking a master while the dashboard's "Spending by
Category" cards still link to the master deep-link.

## Why the existing test suite missed it

`tests/services/test_transaction_service_list_filters.py` covers the
period-bucketing path on `list_transactions`, and
`tests/services/test_transaction_service_tag_filters.py` covers the
tag-AND/OR/exclude paths, but no test exercised `category_id` at all.
Bug class: missing-filter-coverage on a per-parameter axis.

## Fix

`if category_id is not None` now ORs the exact match with an
IN-subquery over the named category's subcategory ids
(`Category.parent_id == category_id`, scoped to `org_id`).

Master picks pull in all rows tagged with any of that master's subs.
Sub picks remain exact-match (the inclusion is one-directional). The
service signature is unchanged, the router signature is unchanged,
and the wire-level contract (`?category_id=<int>`) is unchanged, so
the dashboard deep links and persisted filter state continue to work.

## Repro

1. Seed an org with the system category set (masters + subs).
2. Add a transaction tagged with a subcategory (e.g., Food & Dining → Groceries).
3. `GET /api/v1/transactions?category_id=<food_and_dining_id>`.
4. Before fix: only direct hits returned, sub row missing.
5. After fix: master direct hits AND all sub-tagged rows returned.

## Before / after

| State | Screenshot |
|-|-|
| Master "Food & Dining" selected, BEFORE fix (sub row missing) | [before-fix-master-only.png](https://github.com/flamarion/pfv/releases/download/cf-screenshots-1778651222/before-fix-master-only.png) |
| Master "Food & Dining" selected, AFTER fix (sub row included) | [after-fix-master-filter.png](https://github.com/flamarion/pfv/releases/download/cf-screenshots-1778651222/after-fix-master-filter.png) |
| All categories baseline (5 rows) | [before-master-filter.png](https://github.com/flamarion/pfv/releases/download/cf-screenshots-1778651222/before-master-filter.png) |

## Regression coverage

`backend/tests/services/test_transaction_service_category_filter.py`
adds five test cases:

- `test_category_filter_returns_only_matching_rows` (flat exact match)
- `test_category_filter_none_returns_all` (filter is opt-in)
- `test_master_category_filter_includes_subcategories` (the bug)
- `test_subcategory_filter_exact_match_only` (inclusion is one-directional)
- `test_category_filter_compounds_with_date_range` (master + date_from/date_to)

## Sibling-filter risk audit

- `account_id` filter is single-axis (no parent/child relation), exact-match is correct.
- `tx_type`, `status` are enums, exact-match is correct.
- `date_from` / `date_to` already use `effective_period_date_expr()` (`coalesce(settled_date, date)`), unaffected.
- `search` is a `LIKE %term%`, unaffected.
- `tags` / `tags_exclude` are already set-based, unaffected.
- The same master/sub flatten-then-filter pattern appears on the
  Budgets and Categories pages but those routes filter by their own
  schema fields (budgets have a `category_id` column, categories
  page lists categories directly), out of scope here.

## Test status

- Full backend suite: 956 passed, 4 skipped (isolated stack).
- Frontend test suite: 669 passed (vitest).
- Frontend lint: 0 errors.
- Frontend typecheck: clean.