### PR TITLE
chore(rate-limit): Redis-backed slowapi storage (K8S-1)

### DIFF
--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -48,8 +48,13 @@ import ipaddress
 import os
 from typing import Iterable
 
+import structlog
 from slowapi import Limiter
 from starlette.requests import Request
+
+from app.config import settings
+
+logger = structlog.stdlib.get_logger()
 
 
 # Kept in lockstep with ``--forwarded-allow-ips`` in backend/Dockerfile,
@@ -156,4 +161,44 @@ def get_client_ip(request: Request) -> str:
     return client_host or "127.0.0.1"
 
 
-limiter = Limiter(key_func=get_client_ip)
+def _build_limiter() -> Limiter:
+    """Construct the slowapi ``Limiter`` with Redis-backed storage when
+    ``settings.redis_url`` is configured, else fall back to in-memory.
+
+    Cross-replica accuracy (K8S-1, L0.6 audit). slowapi's default
+    in-memory storage keeps counters per-process, so once we scale
+    horizontally each replica enforces its own private budget. Pointing
+    the limiter at the same Redis the rest of the app already uses
+    (see ``redis_client.py``) makes the budget shared across replicas.
+
+    Storage shape: ``storage_uri="redis://..."`` is passed to the
+    ``Limiter`` constructor. slowapi delegates to ``limits`` which
+    instantiates its own Redis client from the URI. The app's
+    ``redis_client.get_client()`` is not directly reused because the
+    ``slowapi.Limiter`` constructor (v0.1.9) accepts only a URI string
+    plus ``storage_options: Dict[str, str]``, not an already-built
+    client/pool.
+
+    Fallback: if ``settings.redis_url`` is empty (local dev without the
+    compose Redis service), we keep the in-memory storage and warn so
+    the gap is visible in logs. Production / compose always set the URL.
+    """
+    redis_url = settings.redis_url
+    if redis_url:
+        logger.info(
+            "rate_limit.storage",
+            backend="redis",
+            multi_replica_safe=True,
+        )
+        return Limiter(key_func=get_client_ip, storage_uri=redis_url)
+
+    logger.warning(
+        "rate_limit.storage",
+        backend="memory",
+        multi_replica_safe=False,
+        reason="settings.redis_url empty; per-replica counters only",
+    )
+    return Limiter(key_func=get_client_ip)
+
+
+limiter = _build_limiter()

--- a/backend/tests/test_rate_limit_storage.py
+++ b/backend/tests/test_rate_limit_storage.py
@@ -1,0 +1,83 @@
+"""Regression tests for slowapi Limiter storage selection (K8S-1).
+
+L0.6 multi-replica readiness audit (2026-05-08) flagged in-memory
+rate-limit storage as a bug for horizontal scale: counters are per-
+process, so each replica enforces its own private budget. K8S-1
+points the limiter at Redis when configured (shared budget across
+replicas) and falls back to in-memory only when ``settings.redis_url``
+is empty.
+
+These tests pin the construction-time wiring of ``_build_limiter`` so
+the choice is observable without standing up Redis in CI:
+
+- With ``redis_url`` set: the Limiter is built with a Redis storage
+  URI and its underlying ``limits`` storage class is the Redis one.
+- With ``redis_url`` empty: the Limiter falls back to the default
+  in-memory ``MemoryStorage`` and a warning is logged.
+
+The Redis case here only inspects construction (no live Redis call);
+the manual smoke test in the PR body covers the end-to-end persist-
+across-restart behaviour.
+"""
+from __future__ import annotations
+
+from limits.storage import MemoryStorage
+
+from app import rate_limit
+from app.config import settings
+
+
+def test_limiter_uses_redis_storage_when_redis_url_set(monkeypatch):
+    """K8S-1: with ``settings.redis_url`` set, the Limiter is built
+    against the Redis storage backend so counters are shared across
+    replicas.
+    """
+    monkeypatch.setattr(settings, "redis_url", "redis://example:6379/0")
+
+    limiter = rate_limit._build_limiter()
+
+    # slowapi defers storage creation until first access via the
+    # ``_storage`` property. Touching it forces the limits library to
+    # resolve the URI; we then assert it picked the Redis backend.
+    storage = limiter._storage
+    assert type(storage).__name__ == "RedisStorage", (
+        f"expected Redis-backed storage, got {type(storage).__name__}"
+    )
+
+
+def test_limiter_falls_back_to_memory_when_redis_url_empty(monkeypatch, capsys):
+    """When ``settings.redis_url`` is empty (e.g. local dev without
+    the compose Redis service), the Limiter keeps the in-memory
+    backend and surfaces a warning so the gap is visible in logs.
+
+    structlog writes to stdout via its stdlib bridge, so we sample
+    ``capsys`` (not ``caplog``) to confirm the warning event surfaced.
+    """
+    monkeypatch.setattr(settings, "redis_url", "")
+
+    limiter = rate_limit._build_limiter()
+    captured = capsys.readouterr()
+
+    storage = limiter._storage
+    assert isinstance(storage, MemoryStorage), (
+        f"expected in-memory fallback, got {type(storage).__name__}"
+    )
+    # Warning must mention the rate-limit storage event so ops can grep.
+    combined = captured.out + captured.err
+    assert "rate_limit.storage" in combined, (
+        "expected a rate_limit.storage warning when redis_url is empty"
+    )
+    assert "backend=memory" in combined, (
+        "expected the fallback warning to identify backend=memory"
+    )
+
+
+def test_module_level_limiter_built_at_import_time():
+    """Smoke: the module-level ``limiter`` exposed to routers is the
+    object built by ``_build_limiter`` at import time, not a stale
+    placeholder. This is what ``app.state.limiter`` and every router's
+    ``@limiter.limit(...)`` decorator binds to.
+    """
+    assert rate_limit.limiter is not None
+    # ``key_func`` must still be the topology-aware resolver from PR #233.
+    assert rate_limit.limiter._key_func is rate_limit.get_client_ip


### PR DESCRIPTION
## Summary

L0.6 multi-replica readiness audit (2026-05-08) flagged slowapi's default in-memory storage as a horizontal-scaling bug. With more than one replica each process keeps its own counters, so the per-IP budget is effectively multiplied by the replica count. K8S-1 wires the Limiter to the same Redis the rest of the app already uses, so the budget is shared across replicas. Single-replica today, drop-in correct once HPA goes live.

## Storage shape

Option **(A)** chosen: pass `storage_uri=settings.redis_url` to the `slowapi.Limiter` constructor. slowapi delegates to `limits`, which instantiates a Redis client from the URI.

Option (B) (inject the app's existing `redis_client.get_client()` instance) was not viable on the slowapi version pinned in `requirements.txt` (0.1.9): the `Limiter` constructor only accepts a URI plus `storage_options: Dict[str, str]`, not a pre-built client. A second connection pool to the same Valkey is a non-issue (small, identical config, the existing pool handles MFA-nonce traffic only).

## Fallback behavior

When `settings.redis_url` is empty (e.g. local dev without the compose Redis service), `_build_limiter()` keeps the default in-memory storage and emits a `structlog.warning("rate_limit.storage", backend="memory", multi_replica_safe=False, ...)` so the gap is grep-able. Compose dev (`docker-compose.yml`) and production (DO App Platform secret + droplet) both set `REDIS_URL`, so the warning path is local-only.

## `get_client_ip` frozen

The `get_client_ip` resolver and all its XFF / `do-connecting-ip` / nginx-overwrite helpers from PR #233 are untouched. The only change to `rate_limit.py` is the new `_build_limiter()` helper and the import of `settings` / `structlog`.

## Manual smoke test

In the isolated `team-k8s-1-redis-slowapi` compose stack:

1. Hammered `/api/v1/auth/check-username` (limit `20/minute`) 22 times from inside the backend container. Got 20x 200, then 2x 429. Budget consumed.
2. `docker compose restart backend`, waited for `/health` to come back.
3. Hammered the same endpoint 5 more times. All 5 returned 429.

With the old in-memory storage, step 3 would have returned 200 (counters reset on process restart). With Redis-backed storage the counters survived, which is the same property that makes them survive across replicas.

`backend=redis multi_replica_safe=True` info log fired at startup, confirming the construction path.

## Tests

- New `backend/tests/test_rate_limit_storage.py` (3 tests) pins:
  - Redis URL set → `RedisStorage` backend
  - Redis URL empty → `MemoryStorage` + `rate_limit.storage backend=memory` warning
  - Module-level `limiter` exposes the topology-aware `get_client_ip` from PR #233.
- Existing `test_client_ip_resolution.py` (19 tests) and `test_rate_limit_sensitive_endpoints.py` (4 tests) still pass.
- Full backend suite: 1013 passed, 4 skipped.

## Refs

- L0.6 HPA readiness audit (see `~/.claude/projects/-Users-fjorge-src-pfv/memory/project_roadmap.md`)
- PR #233 (audit-log IP fix) — `get_client_ip` frozen as a result.
- PR #69 — original Redis client infrastructure that this PR shares.