### PR TITLE
feat(transactions): description suggestions in manual batch grid

### DIFF
--- a/frontend/app/transactions/batch/page.tsx
+++ b/frontend/app/transactions/batch/page.tsx
@@ -35,6 +35,7 @@ import {
 import Link from "next/link";
 import AppShell from "@/components/AppShell";
 import CategorySelect from "@/components/ui/CategorySelect";
+import DescriptionAutocomplete from "@/components/transactions/DescriptionAutocomplete";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { todayISO } from "@/lib/format";
 import {
@@ -376,16 +377,27 @@ export default function BatchEntryPage() {
                         />
                       </td>
                       <td className="px-2 py-2">
-                        <input
-                          type="text"
-                          className={input}
+                        <DescriptionAutocomplete
+                          id={`row-${row.key}-description`}
+                          type={row.type}
                           value={row.description}
-                          placeholder="e.g. Coffee shop"
-                          onChange={(e) =>
-                            updateRow(idx, { description: e.target.value })
+                          onChange={(next) =>
+                            updateRow(idx, { description: next })
                           }
-                          aria-label={`Row ${idx + 1} description`}
-                          maxLength={255}
+                          onPick={(s) => {
+                            // Pre-fill the category only when the row's
+                            // category is still empty, mirroring the
+                            // single-transaction add form. We never
+                            // overwrite a user-chosen category.
+                            if (row.category_id === "") {
+                              updateRow(idx, {
+                                description: s.description,
+                                category_id: s.category_id,
+                              });
+                            }
+                          }}
+                          placeholder="e.g. Coffee shop"
+                          ariaLabel={`Row ${idx + 1} description`}
                         />
                       </td>
                       <td className="px-2 py-2">

--- a/frontend/tests/app/transactions-batch-page-autocomplete.test.tsx
+++ b/frontend/tests/app/transactions-batch-page-autocomplete.test.tsx
@@ -1,0 +1,397 @@
+/**
+ * Batch entry + description autocomplete integration tests.
+ *
+ * Verifies the wiring between the multi-row batch grid
+ * (`/transactions/batch`) and the reusable `DescriptionAutocomplete`
+ * component:
+ *
+ *  1. Each row's autocomplete has an isolated fetch lifecycle. Typing
+ *     in row 1 fires one fetch tagged with row 1's value; row 2's
+ *     state is untouched.
+ *  2. Picking a suggestion in row 1 populates row 1's description AND
+ *     fills row 1's category (when the row's category is still empty),
+ *     without touching row 2.
+ *  3. Tab from row 1's description moves to the next CELL of row 1,
+ *     not to row 2 (the autocomplete's combobox doesn't trap Tab).
+ *  4. Submitting a batch where rows were populated via the autocomplete
+ *     persists those rows through `/api/v1/transactions/batch` with
+ *     the correct description + category_id payloads.
+ *
+ * We replace `apiFetch` with a single mock that branches on URL so the
+ * autocomplete's real fetch path (300ms debounce + AbortController)
+ * runs unmocked. `vi.useFakeTimers()` lets us step past the debounce
+ * without sleeping.
+ */
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import BatchEntryPage from "@/app/transactions/batch/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>(
+    "@/lib/api",
+  );
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/AuthProvider")
+  >("@/components/auth/AuthProvider");
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+// CategorySelect stubbed to a native select so we can read/set
+// `Row N category` like the sibling test file does.
+vi.mock("@/components/ui/CategorySelect", () => ({
+  default: ({
+    value,
+    onChange,
+    categories,
+    "aria-label": ariaLabel,
+  }: {
+    value: number | "";
+    onChange: (id: number | "") => void;
+    categories: { id: number; name: string }[];
+    "aria-label"?: string;
+  }) => (
+    <select
+      aria-label={ariaLabel}
+      value={value === "" ? "" : String(value)}
+      onChange={(e) =>
+        onChange(e.target.value === "" ? "" : Number(e.target.value))
+      }
+    >
+      <option value="">Pick…</option>
+      {categories.map((c) => (
+        <option key={c.id} value={c.id}>
+          {c.name}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/transactions/batch",
+}));
+
+const ACCOUNTS = [
+  {
+    id: 10,
+    name: "Primary",
+    account_type_id: 1,
+    account_type_name: "Checking",
+    account_type_slug: "checking",
+    balance: "150.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: true,
+    close_day: null,
+  },
+];
+
+const CATEGORIES = [
+  {
+    id: 5,
+    name: "Groceries",
+    slug: "groceries",
+    parent_id: null,
+    type: "expense",
+    is_system: false,
+  },
+  {
+    id: 6,
+    name: "Coffee",
+    slug: "coffee",
+    parent_id: null,
+    type: "expense",
+    is_system: false,
+  },
+];
+
+const BASE_USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const SUGGESTION_ALBERT = {
+  description: "Albert Heijn",
+  category_id: 5,
+  category_name: "Groceries",
+  use_count: 12,
+  last_used: "2026-05-10",
+};
+
+/** Records every /suggestions request the autocomplete dispatches so
+ *  tests can assert per-row isolation. */
+type RecordedCall = {
+  url: string;
+  q: string;
+  type: string;
+};
+
+function makeApiMock(recorded: RecordedCall[]) {
+  vi.mocked(apiFetch).mockImplementation((path: string) => {
+    if (path === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
+    if (path === "/api/v1/categories") return Promise.resolve(CATEGORIES);
+    if (path.startsWith("/api/v1/transactions/suggestions/descriptions")) {
+      const url = new URL(path, "http://localhost");
+      recorded.push({
+        url: path,
+        q: url.searchParams.get("q") ?? "",
+        type: url.searchParams.get("type") ?? "",
+      });
+      // Match suggestions when q starts with "Albert".
+      if ((url.searchParams.get("q") ?? "").startsWith("Albert")) {
+        return Promise.resolve({ suggestions: [SUGGESTION_ALBERT] });
+      }
+      return Promise.resolve({ suggestions: [] });
+    }
+    if (path === "/api/v1/transactions/batch") {
+      return Promise.resolve({
+        imported_count: 1,
+        error_count: 0,
+        results: [{ row_number: 1, transaction_id: 99 }],
+        errors: [],
+      });
+    }
+    return Promise.resolve([]);
+  });
+}
+
+function setUser() {
+  vi.mocked(useAuth).mockReturnValue({
+    user: { ...BASE_USER, role: "owner" } as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+/** Step past the 300ms autocomplete debounce + resolve the pending
+ *  microtask queue so the fetcher's `.then()` lands. */
+async function flushDebounce() {
+  await act(async () => {
+    vi.advanceTimersByTime(350);
+  });
+  // Two microtask drains — one for the fetch promise, one for the
+  // setState batch the component schedules from inside the .then().
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("Batch entry — description autocomplete integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(apiFetch).mockReset();
+    setUser();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("isolates per-row autocomplete fetches", async () => {
+    const recorded: RecordedCall[] = [];
+    makeApiMock(recorded);
+    render(<BatchEntryPage />);
+
+    // The initial /accounts + /categories awaits land on real timers'
+    // microtasks, so advance until the description inputs exist.
+    await waitFor(() => screen.getByLabelText("Row 1 description"));
+
+    // Type in row 1 only.
+    const row1Desc = screen.getByLabelText("Row 1 description");
+    fireEvent.change(row1Desc, { target: { value: "Albert" } });
+
+    await flushDebounce();
+
+    // Exactly one suggestions call, tagged with row 1's value.
+    const suggestionCalls = recorded.filter((c) => c.q === "Albert");
+    expect(suggestionCalls).toHaveLength(1);
+    expect(suggestionCalls[0].type).toBe("expense");
+
+    // Row 2 input is still empty — no fetch was issued for it.
+    const row2Desc = screen.getByLabelText("Row 2 description") as HTMLInputElement;
+    expect(row2Desc.value).toBe("");
+  });
+
+  it("picking a suggestion fills the row's description and category, leaving siblings untouched", async () => {
+    const recorded: RecordedCall[] = [];
+    makeApiMock(recorded);
+    render(<BatchEntryPage />);
+
+    await waitFor(() => screen.getByLabelText("Row 1 description"));
+
+    const row1Desc = screen.getByLabelText("Row 1 description") as HTMLInputElement;
+    fireEvent.change(row1Desc, { target: { value: "Albert" } });
+    await flushDebounce();
+
+    // The dropdown's first option has role="option" with the
+    // suggestion's description as text.
+    const option = await screen.findByRole("option", { name: /Albert Heijn/ });
+    // The component commits on mousedown.
+    fireEvent.mouseDown(option);
+
+    // Row 1's description took the suggestion's value.
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Row 1 description") as HTMLInputElement).value,
+      ).toBe("Albert Heijn");
+    });
+
+    // Row 1's category got pre-filled from the suggestion.
+    const row1Cat = screen.getByLabelText("Row 1 category") as HTMLSelectElement;
+    expect(row1Cat.value).toBe("5");
+
+    // Row 2 is completely untouched.
+    expect(
+      (screen.getByLabelText("Row 2 description") as HTMLInputElement).value,
+    ).toBe("");
+    expect(
+      (screen.getByLabelText("Row 2 category") as HTMLSelectElement).value,
+    ).toBe("");
+  });
+
+  it("does not overwrite a category the user already picked", async () => {
+    const recorded: RecordedCall[] = [];
+    makeApiMock(recorded);
+    render(<BatchEntryPage />);
+
+    await waitFor(() => screen.getByLabelText("Row 1 description"));
+
+    // User picks a non-default category FIRST.
+    const row1Cat = screen.getByLabelText("Row 1 category") as HTMLSelectElement;
+    fireEvent.change(row1Cat, { target: { value: "6" } });
+    expect(row1Cat.value).toBe("6");
+
+    // Then types into the description and picks a suggestion whose
+    // top category is 5.
+    const row1Desc = screen.getByLabelText("Row 1 description");
+    fireEvent.change(row1Desc, { target: { value: "Albert" } });
+    await flushDebounce();
+
+    const option = await screen.findByRole("option", { name: /Albert Heijn/ });
+    fireEvent.mouseDown(option);
+
+    // Description still got picked, but category stays as user choice.
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Row 1 description") as HTMLInputElement).value,
+      ).toBe("Albert Heijn");
+    });
+    expect(
+      (screen.getByLabelText("Row 1 category") as HTMLSelectElement).value,
+    ).toBe("6");
+  });
+
+  it("Tab from a row's description does not jump to the next row", async () => {
+    const recorded: RecordedCall[] = [];
+    makeApiMock(recorded);
+    render(<BatchEntryPage />);
+
+    await waitFor(() => screen.getByLabelText("Row 1 description"));
+
+    const row1Desc = screen.getByLabelText("Row 1 description");
+    const row2Desc = screen.getByLabelText("Row 2 description");
+    row1Desc.focus();
+    expect(document.activeElement).toBe(row1Desc);
+
+    // Component's keydown handler should NOT preventDefault on Tab —
+    // it simply closes the dropdown so the browser's native focus
+    // traversal lands on the next focusable cell (row 1 amount), not
+    // on row 2's description.
+    const ev = fireEvent.keyDown(row1Desc, { key: "Tab" });
+    // fireEvent returns true when the event was not preventDefault'd.
+    expect(ev).toBe(true);
+    // The autocomplete didn't yank focus to row 2.
+    expect(document.activeElement).not.toBe(row2Desc);
+  });
+
+  it("submits a batch of rows populated via the autocomplete", async () => {
+    const recorded: RecordedCall[] = [];
+    makeApiMock(recorded);
+    render(<BatchEntryPage />);
+
+    await waitFor(() => screen.getByLabelText("Row 1 description"));
+
+    // Pick a suggestion for row 1's description + category.
+    const row1Desc = screen.getByLabelText("Row 1 description");
+    fireEvent.change(row1Desc, { target: { value: "Albert" } });
+    await flushDebounce();
+    const option = await screen.findByRole("option", {
+      name: /Albert Heijn/,
+    });
+    fireEvent.mouseDown(option);
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Row 1 description") as HTMLInputElement).value,
+      ).toBe("Albert Heijn");
+    });
+
+    // Fill the remaining row 1 cells so the row is submittable.
+    fireEvent.change(screen.getByLabelText("Row 1 amount"), {
+      target: { value: "12.50" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 account"), {
+      target: { value: "10" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Submit 1 row$/ }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Row 1 imported")).toBeTruthy();
+    });
+
+    // Verify the batch payload carried the suggestion's category.
+    const batchCall = vi
+      .mocked(apiFetch)
+      .mock.calls.find(([p]) => p === "/api/v1/transactions/batch");
+    expect(batchCall).toBeDefined();
+    const body = JSON.parse((batchCall![1] as RequestInit).body as string);
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].transaction.description).toBe("Albert Heijn");
+    expect(body.rows[0].transaction.category_id).toBe(5);
+  });
+});

--- a/frontend/tests/app/transactions-batch-page.test.tsx
+++ b/frontend/tests/app/transactions-batch-page.test.tsx
@@ -53,6 +53,37 @@ vi.mock("@/components/ui/CategorySelect", () => ({
   ),
 }));
 
+// DescriptionAutocomplete pulls a debounced /suggestions fetch on every
+// keystroke. The grid-level tests below assert row composition,
+// keyboard nav, and submit wiring, so stub it to a plain <input> that
+// matches the prod component's external contract (value/onChange/
+// ariaLabel). End-to-end autocomplete + pick + category-prefill is
+// covered separately in `transactions-batch-page-autocomplete.test.tsx`.
+vi.mock("@/components/transactions/DescriptionAutocomplete", () => ({
+  default: ({
+    id,
+    value,
+    onChange,
+    ariaLabel,
+    placeholder,
+  }: {
+    id: string;
+    value: string;
+    onChange: (next: string) => void;
+    ariaLabel?: string;
+    placeholder?: string;
+  }) => (
+    <input
+      id={id}
+      type="text"
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
 const stableRouter = { push: vi.fn(), replace: vi.fn() };
 vi.mock("next/navigation", () => ({
   useRouter: () => stableRouter,


### PR DESCRIPTION
## Summary

Wires `DescriptionAutocomplete` (#239) into each row of the Manual Batch Entry grid (#237). The PR #237 dispatch brief explicitly deferred this integration as a follow-up.

## Integration shape

- Each row's plain `<input type=\"text\">` for description is replaced with `<DescriptionAutocomplete>`, scoped by `row.type` so income rows see income-only suggestions and expense rows see expense-only suggestions.
- Picking a suggestion in a row populates the row's description AND pre-fills the row's category from `suggestion.category_id`, but only when the row's category is still empty. A category the user already chose is never overwritten (mirrors the single-transaction add form's contract).
- Per-row `AbortController` state is isolated by virtue of how `DescriptionAutocomplete` was written in #239 — each instance owns its own debounce timer, its own controller, and its own dropdown state. Typing in row 1 cannot cancel row 2's in-flight fetch.

## Keyboard contract

- Tab: closes the row's autocomplete popup and lets native focus traversal land on the next CELL of the same row (not row 2). Verified by test.
- ArrowDown / ArrowUp: navigates within the popup listbox.
- Enter on a highlighted suggestion: commits the pick, keeps focus in the description input, does NOT submit the batch.
- Enter with no suggestion highlighted: bubbles like before. The grid's existing \"Enter on the last cell of the last row appends a row\" handler is still wired through the trash button, unchanged.

## Tests

5 new integration tests in `frontend/tests/app/transactions-batch-page-autocomplete.test.tsx`:

1. Per-row fetch isolation: typing in row 1 fires exactly one suggestions call with the row 1 query and leaves row 2 untouched.
2. Pick → fills description AND category in the row; siblings untouched.
3. No-overwrite: when the user picked a category first, picking a suggestion only fills the description.
4. Tab from row 1's description does not jump focus to row 2 (the autocomplete doesn't trap Tab).
5. End-to-end submit: a row populated entirely via autocomplete pick + amount + account submits with `description=\"Albert Heijn\"` and `category_id=5` in the batch payload.

The existing `transactions-batch-page.test.tsx` keeps its grid-mechanics coverage; `DescriptionAutocomplete` is mocked there to a plain input so the row composition tests stay focused (same pattern as the existing `CategorySelect` stub).

## Validation

- `npx vitest run tests/app/transactions-batch-page.test.tsx tests/app/transactions-batch-page-autocomplete.test.tsx`: 12/12 pass.
- `npx vitest run tests/components/transactions/description-autocomplete.test.tsx`: 10/10 pass (no regression on the upstream component's own suite).
- `npm test` (full frontend suite): 746/746 pass.
- `npx tsc --noEmit`: clean.
- `npm run lint`: 0 errors, 0 warnings on changed files. (Pre-existing repo warnings unchanged.)

Run via `docker compose -p team-batch-desc-autocomplete` on an isolated stack; the user's main stack was not touched.

## Screenshot handoff

Owner: please capture for the merge thread.

1. Batch entry page with row 1's description open showing the autocomplete listbox.
2. Suggestion picked: row 1's description filled + row 1's category auto-set.
3. Multi-row submission outcome strip (\"3 rows imported\").

## Scope guardrails honored

- `DescriptionAutocomplete` component unchanged (frozen by #239).
- Batch endpoint / service unchanged (frozen by #237).
- Single-transaction form (`/transactions`) untouched.
- Reconciliation edit modal (#247) out of scope.