### PR TITLE
chore: btnPrimary 44px shared-style + ./pfv dev-dep-drift guard (tech debt mini)

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -353,7 +353,7 @@ export default function AccountsPage() {
                   <label htmlFor="type-name" className="sr-only">New type name</label>
                   <input id="type-name" type="text" required placeholder="New type name" value={typeName} onChange={(e) => setTypeName(e.target.value)} className={input} />
                 </div>
-                <button type="submit" className={`w-full min-h-[44px] sm:w-auto sm:min-h-0 ${btnPrimary}`}>Add</button>
+                <button type="submit" className={`w-full sm:w-auto sm:min-h-0 ${btnPrimary}`}>Add</button>
               </form>
               {/* Column header — visible only on sm+ where the row uses
                   the same grid template. Keeps the type name column
@@ -482,7 +482,7 @@ export default function AccountsPage() {
                   <p className="text-xs text-text-muted">
                     Your account&apos;s starting amount. Leave at 0 if you don&apos;t know.
                   </p>
-                  <button type="submit" className={`w-full min-h-[44px] sm:w-auto sm:min-h-0 ${btnPrimary}`}>Create Account</button>
+                  <button type="submit" className={`w-full sm:w-auto sm:min-h-0 ${btnPrimary}`}>Create Account</button>
                 </form>
               )}
               {/* Column header — visible only on md+ where the row uses

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -220,7 +220,7 @@ export default function BudgetsPage() {
             </button>
           )}
           {isCurrentPeriod && availableCategories.length > 0 && (
-            <button onClick={() => setShowForm(!showForm)} className={`${btnPrimary} min-h-[44px] sm:min-h-0`}>
+            <button onClick={() => setShowForm(!showForm)} className={`${btnPrimary} sm:min-h-0`}>
               {showForm ? "Cancel" : "+ Add Budget"}
             </button>
           )}
@@ -301,7 +301,7 @@ export default function BudgetsPage() {
               <label htmlFor="b-amount" className={label}>Monthly limit</label>
               <input id="b-amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value={formAmount} onChange={(e) => setFormAmount(e.target.value)} className={input} />
             </div>
-            <button type="submit" className={`${btnPrimary} min-h-[44px] sm:min-h-0`}>Add</button>
+            <button type="submit" className={`${btnPrimary} sm:min-h-0`}>Add</button>
           </form>
         </div>
       )}

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -535,7 +535,7 @@ export default function CategoriesPage() {
                         <label htmlFor={`sub-desc-${master.id}`} className="sr-only">Description</label>
                         <input id={`sub-desc-${master.id}`} type="text" placeholder="Hint / description" value={newSubDesc} onChange={(e) => setNewSubDesc(e.target.value)} className={input} />
                       </div>
-                      <button type="submit" className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>Add</button>
+                      <button type="submit" className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}>Add</button>
                     </form>
                   )}
 

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -40,7 +40,7 @@ export default function GlobalError({
           <button
             type="button"
             onClick={() => reset()}
-            className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+            className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}
           >
             Try again
           </button>

--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -898,7 +898,7 @@ export default function ForecastPlansClient({
             </div>
             <button
               type="submit"
-              className={`${btnPrimary} w-full min-h-[44px] sm:w-auto sm:min-h-0`}
+              className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}
             >
               Add
             </button>

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -333,7 +333,7 @@ function ImportPageContent() {
           </p>
           <Link
             href="/categories"
-            className={btnPrimary + " mt-4 inline-flex min-h-[44px] items-center sm:min-h-0"}
+            className={btnPrimary + " mt-4 inline-flex items-center sm:min-h-0"}
           >
             Go to Categories
           </Link>
@@ -378,7 +378,7 @@ function ImportPageContent() {
             <button
               onClick={handleUpload}
               disabled={!file || accountId === "" || loading}
-              className={btnPrimary + " min-h-[44px] w-full sm:min-h-0 sm:w-auto"}
+              className={btnPrimary + " w-full sm:min-h-0 sm:w-auto"}
             >
               {loading ? "Parsing..." : "Upload & Preview"}
             </button>
@@ -856,7 +856,7 @@ function ImportPageContent() {
             <button
               onClick={handleConfirm}
               disabled={defaultCategoryId === "" || activeRows.length === 0 || loading}
-              className={btnPrimary + " min-h-[44px] w-full sm:order-1 sm:min-h-0 sm:w-auto"}
+              className={btnPrimary + " w-full sm:order-1 sm:min-h-0 sm:w-auto"}
             >
               {loading
                 ? "Importing..."
@@ -935,7 +935,7 @@ function ImportPageContent() {
             </button>
             <button
               onClick={() => router.push("/transactions")}
-              className={btnPrimary + " min-h-[44px] w-full sm:order-1 sm:min-h-0 sm:w-auto"}
+              className={btnPrimary + " w-full sm:order-1 sm:min-h-0 sm:w-auto"}
             >
               View Transactions
             </button>

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -22,7 +22,7 @@ export default function NotFound() {
         <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-center">
           <Link
             href="/dashboard"
-            className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center`}
+            className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center`}
           >
             Go to dashboard
           </Link>

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -494,7 +494,7 @@ export default function OrganizationSettingsPage() {
                     onClick={handleClosePeriod}
                     disabled={closingPeriod}
                     aria-busy={closingPeriod}
-                    className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                    className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
                   >
                     {closingPeriod && (
                       <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
@@ -558,7 +558,7 @@ export default function OrganizationSettingsPage() {
                   billingCycleDay === savedCycleDay
                 }
                 aria-busy={savingCycle}
-                className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2 sm:mt-[26px]`}
+                className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2 sm:mt-[26px]`}
               >
                 {savingCycle && (
                   <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
@@ -625,7 +625,7 @@ export default function OrganizationSettingsPage() {
                 <label className={label}>Value</label>
                 <input value={value} onChange={(e) => setValue(e.target.value)} className={`${input} w-full`} placeholder="value" />
               </div>
-              <button type="submit" className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>Add</button>
+              <button type="submit" className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}>Add</button>
             </form>
 
             {settings.length > 0 && (

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -250,7 +250,7 @@ export default function SettingsProfilePage() {
               <label htmlFor="profile-phone" className={label}>Phone</label>
               <input id="profile-phone" type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} className={input} placeholder="+1 234 567 8900" />
             </div>
-            <button type="submit" disabled={savingProfile} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+            <button type="submit" disabled={savingProfile} className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}>
               {savingProfile ? "Saving..." : "Save Changes"}
             </button>
           </form>

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -374,7 +374,7 @@ export default function SecurityPage() {
             <button
               type="submit"
               disabled={savingPwd || (!passwordSet && !stepupToken)}
-              className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+              className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}
             >
               {savingPwd
                 ? (passwordSet ? "Changing..." : "Setting...")
@@ -408,7 +408,7 @@ export default function SecurityPage() {
                 onClick={handleSetup}
                 disabled={mfaLoading}
                 aria-busy={mfaLoading}
-                className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
               >
                 {mfaLoading && (
                   <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
@@ -443,7 +443,7 @@ export default function SecurityPage() {
                 <button onClick={() => { setMfaStep("idle"); setSetupData(null); }} className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
                   Cancel
                 </button>
-                <button onClick={() => setMfaStep("verify")} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
+                <button onClick={() => setMfaStep("verify")} className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}>
                   Continue
                 </button>
               </div>
@@ -493,7 +493,7 @@ export default function SecurityPage() {
                   aria-describedby={
                     totpCode.length !== 6 && !mfaLoading ? "mfa-setup-code-hint" : undefined
                   }
-                  className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                  className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
                 >
                   {mfaLoading && (
                     <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
@@ -615,7 +615,7 @@ export default function SecurityPage() {
                       type="submit"
                       disabled={regenerating || !regenPassword}
                       aria-busy={regenerating}
-                      className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                      className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
                     >
                       {regenerating && (
                         <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
@@ -703,7 +703,7 @@ export default function SecurityPage() {
                         type="submit"
                         disabled={disabling || !disablePassword}
                         aria-busy={disabling}
-                        className={`${btnPrimary} !bg-danger hover:!bg-danger/80 w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                        className={`${btnPrimary} !bg-danger hover:!bg-danger/80 w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
                       >
                         {disabling && (
                           <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
@@ -768,7 +768,7 @@ export default function SecurityPage() {
                 type="submit"
                 disabled={savingSession}
                 aria-busy={savingSession}
-                className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
               >
                 {savingSession && (
                   <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />

--- a/frontend/app/system/plans/page.tsx
+++ b/frontend/app/system/plans/page.tsx
@@ -197,7 +197,7 @@ export default function SystemPlansPage() {
     <AppShell>
       <div className="flex flex-col gap-2 mb-8 sm:flex-row sm:items-center sm:justify-between">
         <h1 className={pageTitle + " mb-0"}>Plan Management</h1>
-        <button onClick={openCreate} className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>+ New Plan</button>
+        <button onClick={openCreate} className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}>+ New Plan</button>
       </div>
 
       {error && <p className={`${errorCls} mb-4`}>{error}</p>}
@@ -286,7 +286,7 @@ export default function SystemPlansPage() {
               >
                 Cancel
               </button>
-              <button type="submit" className={`${btnPrimary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>{editing ? "Save" : "Create"}</button>
+              <button type="submit" className={`${btnPrimary} w-full sm:w-auto sm:min-h-0`}>{editing ? "Save" : "Create"}</button>
             </div>
           </form>
         </div>

--- a/frontend/components/AppShellAddTransactionCta.tsx
+++ b/frontend/components/AppShellAddTransactionCta.tsx
@@ -192,7 +192,7 @@ export default function AppShellAddTransactionCta() {
           onClick={openTransaction}
           aria-label="New transaction"
           data-testid="appshell-add-transaction-cta"
-          className={`${btnPrimary} inline-flex min-h-[44px] items-center gap-1.5 rounded-r-none border-r border-accent-text/20`}
+          className={`${btnPrimary} inline-flex items-center gap-1.5 rounded-r-none border-r border-accent-text/20`}
         >
           <Plus className="h-4 w-4" aria-hidden="true" />
           <span className="hidden sm:inline">New transaction</span>
@@ -206,7 +206,7 @@ export default function AppShellAddTransactionCta() {
           aria-expanded={menuOpen}
           aria-controls={menuId}
           data-testid="appshell-quick-add-menu-toggle"
-          className={`${btnPrimary} inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-l-none px-2`}
+          className={`${btnPrimary} inline-flex min-w-[44px] items-center justify-center rounded-l-none px-2`}
         >
           <ChevronDown
             className={`h-4 w-4 transition-transform ${menuOpen ? "rotate-180" : ""}`}

--- a/frontend/components/accounts/AdjustBalanceModal.tsx
+++ b/frontend/components/accounts/AdjustBalanceModal.tsx
@@ -208,7 +208,7 @@ export default function AdjustBalanceModal({ account, onClose, onAdjusted }: Pro
             <button
               type="submit"
               disabled={submitting || parsedTarget === null}
-              className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
+              className={`${btnPrimary} w-full sm:w-auto`}
             >
               {submitting ? (
                 <span className="inline-flex items-center gap-2">

--- a/frontend/components/categories/BatchMoveModal.tsx
+++ b/frontend/components/categories/BatchMoveModal.tsx
@@ -436,7 +436,7 @@ export default function BatchMoveModal({
             disabled={
               targetId === null || submitting || previewing || mixedSelection
             }
-            className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
+            className={`${btnPrimary} w-full sm:w-auto`}
           >
             {submitting ? "Moving..." : "Move"}
           </button>

--- a/frontend/components/categories/DragMoveConfirmModal.tsx
+++ b/frontend/components/categories/DragMoveConfirmModal.tsx
@@ -170,7 +170,7 @@ export default function DragMoveConfirmModal({
             data-testid="drag-move-confirm-button"
             onClick={onConfirm}
             disabled={submitting || previewLoading || preview === null}
-            className={`${btnPrimary} w-full sm:w-auto min-h-[44px]`}
+            className={`${btnPrimary} w-full sm:w-auto`}
           >
             {submitting ? "Moving..." : "Move"}
           </button>

--- a/frontend/components/floating/TransactionForm.tsx
+++ b/frontend/components/floating/TransactionForm.tsx
@@ -377,7 +377,7 @@ export default function TransactionForm({
         <button
           type="submit"
           disabled={submitting}
-          className={`${btnPrimary} min-h-[44px]`}
+          className={btnPrimary}
         >
           {submitting ? "Saving..." : "Save"}
         </button>

--- a/frontend/components/floating/TransferForm.tsx
+++ b/frontend/components/floating/TransferForm.tsx
@@ -358,7 +358,7 @@ export default function TransferForm({
         <button
           type="submit"
           disabled={submitting}
-          className={`${btnPrimary} min-h-[44px]`}
+          className={btnPrimary}
         >
           {submitting ? "Saving..." : "Save"}
         </button>

--- a/frontend/lib/styles.ts
+++ b/frontend/lib/styles.ts
@@ -4,8 +4,12 @@ export const input =
 export const label =
   "mb-1.5 block text-xs font-semibold uppercase tracking-[0.08em] text-text-muted";
 
+// `min-h-[44px]` is baked in to enforce the WCAG / DESIGN.md touch-target
+// floor across every primary button without per-call overrides. Callers
+// that intentionally collapse the floor on larger viewports may still
+// add `sm:min-h-0` (or `md:min-h-0`) after the token.
 export const btnPrimary =
-  "rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-text hover:bg-accent-hover disabled:opacity-50";
+  "min-h-[44px] rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-text hover:bg-accent-hover disabled:opacity-50";
 
 export const btnSecondary =
   "rounded-md border border-border px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-raised transition-colors";

--- a/frontend/tests/components/landing/__snapshots__/TopNav.test.tsx.snap
+++ b/frontend/tests/components/landing/__snapshots__/TopNav.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`<TopNav /> > snapshot stays stable across theme runs > topnav-dark 1`] 
       Sign in
     </a>
     <a
-      class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-text hover:bg-accent-hover disabled:opacity-50 whitespace-nowrap"
+      class="min-h-[44px] rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-text hover:bg-accent-hover disabled:opacity-50 whitespace-nowrap"
       href="/register"
     >
       Get started
@@ -225,7 +225,7 @@ exports[`<TopNav /> > snapshot stays stable across theme runs > topnav-light 1`]
       Sign in
     </a>
     <a
-      class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-text hover:bg-accent-hover disabled:opacity-50 whitespace-nowrap"
+      class="min-h-[44px] rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-text hover:bg-accent-hover disabled:opacity-50 whitespace-nowrap"
       href="/register"
     >
       Get started

--- a/frontend/tests/lib/styles.test.ts
+++ b/frontend/tests/lib/styles.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { btnPrimary, btnSecondary } from "@/lib/styles";
+
+describe("btnPrimary token", () => {
+  it("bakes in the 44px touch-target floor so callers don't have to", () => {
+    // DESIGN.md requires a 44px minimum touch target on every primary
+    // button. Baking this into the shared token removes the per-call
+    // `min-h-[44px]` overrides that PR #64 had to scatter through the
+    // app. If anyone removes the floor here, dozens of buttons quietly
+    // fall below WCAG. This is the systemic-level check that protects
+    // that contract.
+    expect(btnPrimary).toMatch(/(^|\s)min-h-\[44px\](\s|$)/);
+  });
+
+  it("still carries the brand accent surface + label tokens", () => {
+    // Sanity guard so the touch-target fix can't accidentally clobber
+    // the rest of the primary button styling.
+    expect(btnPrimary).toContain("bg-accent");
+    expect(btnPrimary).toContain("text-accent-text");
+    expect(btnPrimary).toContain("hover:bg-accent-hover");
+  });
+
+  it("keeps btnSecondary independent of the floor change", () => {
+    // btnSecondary intentionally does not bake in min-h-[44px]; per-call
+    // sites still apply it where mobile touch targets are required.
+    expect(btnSecondary).not.toMatch(/(^|\s)min-h-\[44px\](\s|$)/);
+  });
+});

--- a/pfv
+++ b/pfv
@@ -29,6 +29,68 @@ Commands:
 EOF
 }
 
+# Warn (do not block) when the host's frontend/package-lock.json hash
+# differs from the lockfile baked into the running frontend container.
+# Drift here is the symptom of:
+#   - `npm install` editing the lockfile on the host without a rebuild,
+#   - a teammate's branch landing new deps that haven't been installed
+#     into the running container,
+#   - the frontend image predating a `package-lock.json` change.
+#
+# Skips cleanly when docker / the frontend container / sha256sum is not
+# available so this stays a fast, non-blocking, dev-loop nicety.
+#
+# Override hooks (test seam): set PFV_DEPDRIFT_HOST_HASH and/or
+# PFV_DEPDRIFT_CONTAINER_HASH to bypass the live `sha256sum` and
+# `docker compose exec` calls. Set PFV_DEPDRIFT_SKIP=1 to disable the
+# guard entirely.
+check_frontend_dep_drift() {
+  [[ "${PFV_DEPDRIFT_SKIP:-}" == "1" ]] && return 0
+
+  local host_lock="frontend/package-lock.json"
+  [[ -f "$host_lock" ]] || return 0
+
+  local host_hash
+  if [[ -n "${PFV_DEPDRIFT_HOST_HASH:-}" ]]; then
+    host_hash="$PFV_DEPDRIFT_HOST_HASH"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    host_hash="$(sha256sum "$host_lock" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    host_hash="$(shasum -a 256 "$host_lock" | awk '{print $1}')"
+  else
+    return 0
+  fi
+
+  local container_hash
+  if [[ -n "${PFV_DEPDRIFT_CONTAINER_HASH:-}" ]]; then
+    container_hash="$PFV_DEPDRIFT_CONTAINER_HASH"
+  else
+    command -v docker >/dev/null 2>&1 || return 0
+    # Only probe when the frontend container is actually up; if it
+    # isn't running we have nothing to compare against and we don't
+    # want to pay the docker round-trip on every ./pfv invocation.
+    local fe_id
+    fe_id="$(docker compose ps -q frontend 2>/dev/null || true)"
+    [[ -n "$fe_id" ]] || return 0
+    container_hash="$(docker compose exec -T frontend sha256sum /app/package-lock.json 2>/dev/null | awk '{print $1}')"
+    [[ -n "$container_hash" ]] || return 0
+  fi
+
+  if [[ "$host_hash" != "$container_hash" ]]; then
+    cat >&2 <<EOF
+WARNING: host frontend/package-lock.json differs from the frontend
+container's installed lockfile. Frontend tests, type-check, and build
+may behave inconsistently until the container is rebuilt.
+
+Fix with either:
+  ./pfv rebuild
+  docker compose exec frontend npm ci
+
+(Set PFV_DEPDRIFT_SKIP=1 to silence this check.)
+EOF
+  fi
+}
+
 cmd_start() {
   echo "Starting PFV2 stack..."
   docker compose up --build -d
@@ -37,6 +99,7 @@ cmd_start() {
   echo "  App:      http://localhost"
   echo "  API:      http://localhost/api/"
   echo "  API docs: http://localhost/api/docs"
+  check_frontend_dep_drift
 }
 
 cmd_stop() {
@@ -47,6 +110,7 @@ cmd_stop() {
 cmd_restart() {
   echo "Restarting..."
   docker compose restart
+  check_frontend_dep_drift
 }
 
 cmd_rebuild() {
@@ -114,6 +178,9 @@ EOF
 
 cmd_logs() {
   local svc="${1:-}"
+  if [[ "$svc" == "frontend" ]]; then
+    check_frontend_dep_drift
+  fi
   if [[ -n "$svc" ]]; then
     shift
     docker compose logs "$svc" "$@"
@@ -124,10 +191,14 @@ cmd_logs() {
 
 cmd_status() {
   docker compose ps
+  check_frontend_dep_drift
 }
 
 cmd_shell() {
   local svc="${1:-backend}"
+  if [[ "$svc" == "frontend" ]]; then
+    check_frontend_dep_drift
+  fi
   docker compose exec "$svc" /bin/sh
 }
 

--- a/scripts/test_pfv_depdrift.sh
+++ b/scripts/test_pfv_depdrift.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Test harness for `check_frontend_dep_drift` in `./pfv`.
+#
+# We can't `source` the full pfv script (the bottom `case` dispatches
+# on $1). Instead, we extract the function block and source that.
+#
+# Run from the repo root:
+#   bash scripts/test_pfv_depdrift.sh
+#
+# Exit code 0 on success, non-zero on assertion failure.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PFV_SCRIPT="$REPO_ROOT/pfv"
+
+if [[ ! -f "$PFV_SCRIPT" ]]; then
+  echo "FAIL: $PFV_SCRIPT not found"
+  exit 1
+fi
+
+# Extract `check_frontend_dep_drift` (and only that function) by reading
+# from its opening line through its closing `}` at column 1. The function
+# is self-contained, no helpers needed.
+tmp_fn="$(mktemp -t pfv_depdrift.XXXXXX.sh)"
+trap 'rm -f "$tmp_fn"' EXIT
+
+awk '
+  /^check_frontend_dep_drift\(\) \{/ { capture = 1 }
+  capture { print }
+  capture && /^\}$/ { capture = 0 }
+' "$PFV_SCRIPT" > "$tmp_fn"
+
+if ! grep -q "check_frontend_dep_drift" "$tmp_fn"; then
+  echo "FAIL: could not extract check_frontend_dep_drift from $PFV_SCRIPT"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$tmp_fn"
+
+pass=0
+fail=0
+
+assert_no_warning() {
+  local name="$1"; shift
+  local out
+  out="$("$@" 2>&1 >/dev/null || true)"
+  if [[ -z "$out" ]]; then
+    echo "PASS: $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $name — expected no output, got: $out"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_warning_matches() {
+  local name="$1"; shift
+  local needle="$1"; shift
+  local out
+  out="$("$@" 2>&1 >/dev/null || true)"
+  if [[ "$out" == *"$needle"* ]]; then
+    echo "PASS: $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $name — expected warning containing '$needle', got: $out"
+    fail=$((fail + 1))
+  fi
+}
+
+# The function reads `frontend/package-lock.json` from $PWD. Run the
+# tests from a tempdir that has an empty placeholder lockfile so the
+# host-hash path is exercised when overrides are NOT set.
+work_dir="$(mktemp -d -t pfv_depdrift_work.XXXXXX)"
+trap 'rm -rf "$work_dir"; rm -f "$tmp_fn"' EXIT
+mkdir -p "$work_dir/frontend"
+echo "{}" > "$work_dir/frontend/package-lock.json"
+cd "$work_dir"
+
+# 1. Matching hashes — no warning.
+assert_no_warning "matching hashes emit no warning" \
+  env PFV_DEPDRIFT_HOST_HASH=abc123 PFV_DEPDRIFT_CONTAINER_HASH=abc123 \
+  bash -c "source '$tmp_fn'; check_frontend_dep_drift"
+
+# 2. Differing hashes — warning fires.
+assert_warning_matches "differing hashes emit drift warning" \
+  "host frontend/package-lock.json differs" \
+  env PFV_DEPDRIFT_HOST_HASH=abc123 PFV_DEPDRIFT_CONTAINER_HASH=def456 \
+  bash -c "source '$tmp_fn'; check_frontend_dep_drift"
+
+# 3. PFV_DEPDRIFT_SKIP=1 silences even when hashes differ.
+assert_no_warning "PFV_DEPDRIFT_SKIP=1 silences mismatched hashes" \
+  env PFV_DEPDRIFT_SKIP=1 PFV_DEPDRIFT_HOST_HASH=abc123 PFV_DEPDRIFT_CONTAINER_HASH=def456 \
+  bash -c "source '$tmp_fn'; check_frontend_dep_drift"
+
+# 4. Missing frontend/package-lock.json — silent skip.
+rm -f "$work_dir/frontend/package-lock.json"
+assert_no_warning "missing package-lock.json skips silently" \
+  bash -c "source '$tmp_fn'; check_frontend_dep_drift"
+echo "{}" > "$work_dir/frontend/package-lock.json"  # restore for any future checks
+
+echo ""
+echo "==================="
+echo "Passed: $pass"
+echo "Failed: $fail"
+echo "==================="
+
+if (( fail > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Two independent XS tech-debt items bundled into one PR. Each is fully self-contained, so an owner can land or revert them separately if needed. Comment per item, please.

---

## Item 1 - `btnPrimary` systemic 44px `min-h`

**Context.** PR #64 originally fixed the 44px touch-target floor on a per-use basis, scattering `min-h-[44px]` across every primary-button call. The roadmap parked the systemic fix for "next time `frontend/lib/styles.ts` is touched."

**Change.**
- `frontend/lib/styles.ts`: bake `min-h-[44px]` into the `btnPrimary` token so the floor is guaranteed everywhere it's used. Comment documents the contract (and that callers may still add `sm:min-h-0` to collapse the floor on desktop).
- 16 page/component files: removed 32 now-redundant per-call `min-h-[44px]` overrides on sites that already pull `btnPrimary`. Surgical edits only; `sm:min-h-0`, layout utilities, flex/sizing classes all preserved.
- `frontend/app/settings/billing/page.tsx` deliberately untouched at line 264: the `min-h-[44px]` there is shared by a `btnPrimary | btnSecondary` ternary, and `btnSecondary` does not yet bake in the floor.
- `ConfirmModal.tsx` untouched: it uses a variant map across `btnPrimary` / `btnSecondary` / `btnWarning` / `btnDangerSolid`, same reason.

**Test.**
- New `frontend/tests/lib/styles.test.ts` asserts `btnPrimary` contains the floor, retains the accent / hover tokens, and that `btnSecondary` does *not* bake in the floor.
- `frontend/tests/components/landing/__snapshots__/TopNav.test.tsx.snap` regenerated to absorb the (intentional) extra class on the rendered HTML.
- Existing `appshell-add-transaction-cta.test.tsx` (which asserts `min-h-[44px]` on the CTA) continues to pass since the class string still contains the floor, just now via the token.

---

## Item 2 - `./pfv dev-dep-drift` guard

**Context.** When a developer's host `package-lock.json` no longer matches the lockfile baked into the running frontend container, frontend tests / typecheck / build can behave inconsistently. Roadmap proposed an XS warning.

**Change.**
- New `check_frontend_dep_drift` function in `./pfv`:
  - Computes `sha256` of `frontend/package-lock.json` on the host.
  - Computes `sha256` of `/app/package-lock.json` inside the running frontend container via `docker compose exec`.
  - On mismatch: prints a non-blocking warning to stderr with two recovery commands (`./pfv rebuild` or `docker compose exec frontend npm ci`) and a `PFV_DEPDRIFT_SKIP=1` escape hatch.
  - Skips silently when: `frontend/package-lock.json` is absent, the frontend container is not running, `sha256sum` / `shasum` is unavailable, or `docker` is unavailable.
- Wired into `cmd_start`, `cmd_restart`, `cmd_status`, `cmd_logs frontend`, and `cmd_shell frontend`. Not wired into `cmd_rebuild` / `cmd_prod` / `cmd_reset` since those rebuild the image and would race the check.

**Drift-check trigger conditions** (for future maintainers):
1. The frontend container is up under the default `docker compose` project.
2. The host has `frontend/package-lock.json`.
3. The container's `/app/package-lock.json` is readable.
4. The two SHA256 hashes differ.
5. `PFV_DEPDRIFT_SKIP=1` is **not** set.

Any other state -> silent skip.

**Test.**
- New `scripts/test_pfv_depdrift.sh` extracts the function from `./pfv` (no full-script source to avoid the dispatch `case`) and asserts: matching hashes are silent, mismatched hashes emit the warning text, `PFV_DEPDRIFT_SKIP=1` silences a mismatch, and a missing host lockfile skips silently. 4/4 PASS.
- Manual smoke verified end-to-end via the team-tech-debt-mini compose project:
  - Hashes match -> no warning.
  - Host lockfile perturbed -> warning fires.
  - Lockfile restored -> no warning.
  - Frontend container stopped -> silent skip.

---

## Validation

- Frontend vitest: 744 / 744 pass (108 files), including the new `tests/lib/styles.test.ts`.
- Frontend `tsc --noEmit`: clean.
- Frontend `npm run lint -- --quiet`: clean.
- `scripts/test_pfv_depdrift.sh`: 4 / 4 pass.
- Manual `./pfv status` smoke: match -> silent, mismatch -> warning, restore -> silent, container down -> silent.

Total diff: ~250 LoC.