### PR TITLE
feat(feedback): in-app feedback widget (logged-in only, opt-in identity)

### DIFF
--- a/backend/alembic/versions/043_feedback_entries.py
+++ b/backend/alembic/versions/043_feedback_entries.py
@@ -1,0 +1,98 @@
+"""Add feedback_entries table for in-app feedback widget.
+
+Revision ID: 043_feedback_entries
+Revises: 042_users_onboarded_at
+Create Date: 2026-05-13
+
+Captures user-submitted feedback from the in-app widget. Spec captured
+2026-05-08 in `project_inapp_feedback_widget.md`.
+
+Two privacy decisions baked into the schema:
+
+1. **Identity opt-in is column-level.** `user_id` and `org_id` are both
+   nullable and ON DELETE SET NULL. The router only fills them when the
+   submitter checks the "Include my account info so we can follow up"
+   box, defaulting OFF. A row with NULL identity columns is the
+   anonymous-shaped record we agreed to.
+
+2. **Operational context is required and structured.** `context` JSON
+   is NOT NULL because we want to be able to triage even an anonymous
+   submission (path, viewport, user-agent, app-version, theme). The
+   router strips query params from the URL before storing, and the
+   service layer is the single normalization site.
+
+Indexes:
+   - `created_at` for chronological admin listing (post-L4.x).
+   - `category` for filterable admin views.
+
+Note: an admin UI to view feedback is intentionally out of scope here
+(see project memory under "Out of scope (v1)"). The table is shaped
+to support it when that PR lands without another migration.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "043_feedback_entries"
+down_revision = "042_users_onboarded_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "feedback_entries",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        # Identity-opt-in fields. Both NULLABLE on purpose: anonymous
+        # submissions store NULL; identified submissions store the FK
+        # so an operator can follow up. ON DELETE SET NULL preserves
+        # the feedback row when the user or org is later deleted (the
+        # admin still wants to read the message; the link to a now-
+        # gone user just becomes orphan-safe).
+        sa.Column(
+            "user_id", sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column(
+            "org_id", sa.Integer(),
+            sa.ForeignKey("organizations.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column(
+            "category",
+            sa.Enum(
+                "bug", "feature", "other",
+                name="feedback_category",
+                values_callable=lambda x: list(x),
+            ),
+            nullable=False,
+        ),
+        # JSON shape (router-controlled, no PII):
+        #   { "url": "/transactions",   # query params stripped
+        #     "user_agent": "...",
+        #     "app_version": "1.2.3" | "dev",
+        #     "viewport": {"w": 1440, "h": 900},
+        #     "theme": "light" | "dark" }
+        sa.Column("context", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(),
+            server_default=sa.func.now(), nullable=False,
+            index=True,
+        ),
+    )
+    op.create_index(
+        "ix_feedback_entries_category",
+        "feedback_entries",
+        ["category"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_feedback_entries_category", table_name="feedback_entries")
+    op.drop_table("feedback_entries")

--- a/backend/alembic/versions/044_feedback_entries.py
+++ b/backend/alembic/versions/044_feedback_entries.py
@@ -1,7 +1,7 @@
 """Add feedback_entries table for in-app feedback widget.
 
-Revision ID: 043_feedback_entries
-Revises: 042_users_onboarded_at
+Revision ID: 044_feedback_entries
+Revises: 043_backfill_subscriptions
 Create Date: 2026-05-13
 
 Captures user-submitted feedback from the in-app widget. Spec captured
@@ -35,8 +35,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision = "043_feedback_entries"
-down_revision = "042_users_onboarded_at"
+revision = "044_feedback_entries"
+down_revision = "043_backfill_subscriptions"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_analytics, admin_audit, admin_orgs, admin_roles, admin_users, auth, budgets, categories, forecast, forecast_plans, import_router, onboarding, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_analytics, admin_audit, admin_orgs, admin_roles, admin_users, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, onboarding, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -382,6 +382,7 @@ app.include_router(org_data.router)
 app.include_router(orgs.router)
 app.include_router(tags.router)
 app.include_router(tags.transaction_tags_router)
+app.include_router(feedback.router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.tag import (  # noqa: F401
     TagDictionaryContributor,
     TransactionTag,
 )
+from app.models.feedback import FeedbackCategory, FeedbackEntry  # noqa: F401
 
 __all__ = [
     "Base",
@@ -62,4 +63,6 @@ __all__ = [
     "TransactionTag",
     "TagDictionary",
     "TagDictionaryContributor",
+    "FeedbackCategory",
+    "FeedbackEntry",
 ]

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -1,0 +1,82 @@
+"""In-app feedback widget storage.
+
+Privacy contract (spec captured 2026-05-08):
+
+- `user_id` and `org_id` are NULLABLE. The router writes them ONLY
+  when the submitter ticks the "Include my account info" box, which
+  defaults OFF. Storage shape for an anonymous submission is therefore
+  a row whose identity columns are NULL but whose `context` JSON has
+  non-sensitive operational fields.
+
+- `context` is non-nullable but the router strips query params from
+  the URL and never adds account/transaction-shaped data. See
+  `app.services.feedback_service.normalize_context`.
+
+- ON DELETE SET NULL on both FKs so deleting a user or org leaves
+  the feedback message intact for admin triage (mirrors `audit_events`).
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    Text,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class FeedbackCategory(str, enum.Enum):
+    BUG = "bug"
+    FEATURE = "feature"
+    OTHER = "other"
+
+
+class FeedbackEntry(Base):
+    __tablename__ = "feedback_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Identity-opt-in pair. Both nullable for the anonymous-shaped row.
+    user_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    org_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[FeedbackCategory] = mapped_column(
+        Enum(
+            FeedbackCategory,
+            name="feedback_category",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
+        index=True,
+    )
+    # See `feedback_service.normalize_context` for the exact shape and
+    # the privacy-stripping rules. Non-nullable because operational
+    # context is what makes anonymous submissions triageable.
+    context: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        nullable=False,
+        index=True,
+    )

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -1,0 +1,102 @@
+"""In-app feedback router.
+
+Mounted at ``/api/v1/feedback``. Single POST endpoint — submission.
+Admin read endpoints are out of scope for v1 (separate L4.x slice
+when prioritized).
+
+Rate limit: 5/hour per client IP. The K8S-1 Redis-backed slowapi
+storage (PR #245) makes this cross-replica accurate; before that,
+each replica enforced its own private bucket. 5/hour is loose enough
+that real users won't trip it but tight enough to swallow accidental
+spam (browser-extension submission loops, etc.).
+
+Audit: a successful submission writes a `feedback.submitted` event
+on an independent session via `record_audit_event`. The audit detail
+carries the category and whether identity was attached, but NOT the
+message body — the audit table is a who-did-what trail, not a
+feedback archive.
+"""
+from typing import Optional
+
+import structlog
+from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models.user import User
+from app.rate_limit import get_client_ip, limiter
+from app.schemas.feedback import FeedbackCreate, FeedbackResponse
+from app.services import audit_service, feedback_service
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/feedback", tags=["feedback"])
+
+
+def _request_id() -> Optional[str]:
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
+@router.post("", response_model=FeedbackResponse, status_code=status.HTTP_201_CREATED)
+@limiter.limit("5/hour")
+async def submit_feedback(
+    body: FeedbackCreate,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Submit a feedback entry. Auth required.
+
+    Identity is stored ONLY when `body.include_identity` is True. The
+    default is False, which is the documented privacy posture.
+    """
+    # Snapshot identity-shaping fields before any await so they remain
+    # valid even if `current_user` is later detached by a rollback.
+    actor_user_id = current_user.id
+    actor_org_id = current_user.org_id
+    actor_email = current_user.email
+
+    entry = await feedback_service.create_feedback_entry(
+        db,
+        user_id=actor_user_id,
+        org_id=actor_org_id,
+        message=body.message,
+        category=body.category,
+        context=body.context,
+        include_identity=body.include_identity,
+    )
+    await db.commit()
+    await db.refresh(entry)
+
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="feedback.submitted",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=actor_org_id,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "category": body.category.value,
+            # Whether identity was attached on the row. The audit
+            # trail itself always carries the actor — that's the
+            # whole point of an audit log — but knowing that the
+            # FEEDBACK row is anonymous is useful for triage.
+            "identity_attached": body.include_identity,
+            "message_length": len(body.message),
+        },
+    )
+
+    await logger.ainfo(
+        "feedback.submitted",
+        category=body.category.value,
+        identity_attached=body.include_identity,
+        message_length=len(body.message),
+    )
+
+    return entry

--- a/backend/app/schemas/feedback.py
+++ b/backend/app/schemas/feedback.py
@@ -1,0 +1,70 @@
+"""Pydantic schemas for the in-app feedback widget.
+
+Privacy posture lives in the FIELD DEFAULTS, not in side-channel
+config: `include_identity` defaults to False so the typed contract
+matches the spec's "default unchecked" rule. The frontend never has
+to remember to set this; omission yields anonymity.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.feedback import FeedbackCategory
+
+
+# Message bounds. 5000 chars is generous for the longest "here's my
+# whole bug repro" submission but bounded so we never accept a 50MB
+# paste. Enforced at the schema layer so FastAPI returns 422 before
+# the request reaches the service.
+FEEDBACK_MESSAGE_MIN_LENGTH = 1
+FEEDBACK_MESSAGE_MAX_LENGTH = 5000
+
+
+class FeedbackContext(BaseModel):
+    """Client-collected operational context.
+
+    Every field is optional on the wire — the frontend collects what
+    it can but the server tolerates partial captures (e.g. no
+    `app_version` env var set). The service layer normalizes and
+    re-validates before persisting, so trust-but-verify is the rule.
+
+    PII INVARIANT: no field here is allowed to carry account names,
+    balances, transaction descriptions, or identifying URL fragments.
+    The router strips query strings off `url` before storing.
+    """
+    model_config = ConfigDict(extra="ignore")
+
+    url: Optional[str] = Field(default=None, max_length=512)
+    user_agent: Optional[str] = Field(default=None, max_length=512)
+    app_version: Optional[str] = Field(default=None, max_length=64)
+    viewport_w: Optional[int] = Field(default=None, ge=0, le=20000)
+    viewport_h: Optional[int] = Field(default=None, ge=0, le=20000)
+    theme: Optional[str] = Field(default=None, max_length=32)
+
+
+class FeedbackCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    message: str = Field(
+        min_length=FEEDBACK_MESSAGE_MIN_LENGTH,
+        max_length=FEEDBACK_MESSAGE_MAX_LENGTH,
+    )
+    category: FeedbackCategory
+    # Default OFF — the privacy contract. Frontend explicitly sets True
+    # only when the user ticks the opt-in box.
+    include_identity: bool = False
+    context: FeedbackContext = Field(default_factory=FeedbackContext)
+
+
+class FeedbackResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    category: FeedbackCategory
+    created_at: datetime
+    # No message echo by default — keeps the success path lean and
+    # prevents accidental leak via response logs. Admin reads use
+    # a separate (future) admin schema.

--- a/backend/app/services/feedback_service.py
+++ b/backend/app/services/feedback_service.py
@@ -1,0 +1,100 @@
+"""In-app feedback service.
+
+Two responsibilities:
+
+1. `normalize_context` — privacy-strip the client-collected context
+   before persisting. Currently strips query strings off the URL
+   (anything after `?` or `#`) and trims overlong fields. The single
+   normalization site makes the no-PII invariant testable.
+
+2. `create_feedback_entry` — persist the row with identity opt-in
+   honored. When `include_identity=False`, the FK columns stay NULL
+   even though the caller is authenticated. This is the privacy
+   default; the router cannot opt past it without flipping the flag
+   explicitly.
+
+No audit-event helper here — the router calls
+`audit_service.record_audit_event` directly after commit, matching
+the pattern used by `org_service.rename_org`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.feedback import FeedbackCategory, FeedbackEntry
+from app.schemas.feedback import FeedbackContext
+
+
+def _strip_url(raw: Optional[str]) -> Optional[str]:
+    """Return the URL with query string and fragment removed.
+
+    Path is preserved (the spec says `/import/123/reconcile` is fine
+    because the path itself does not carry user-controlled secrets;
+    `/login?token=xyz` IS sensitive because the token is in the
+    query). Anything we cannot parse is dropped to None rather than
+    stored raw — fail closed.
+    """
+    if not raw:
+        return None
+    try:
+        parts = urlsplit(raw)
+    except ValueError:
+        return None
+    # Drop query and fragment. Keep scheme + netloc + path so an
+    # in-app URL like "http://localhost/transactions" round-trips.
+    cleaned = urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    return cleaned or None
+
+
+def normalize_context(ctx: FeedbackContext) -> dict[str, Any]:
+    """Convert the wire-shape context into the JSON we persist.
+
+    Single source of truth for the privacy-stripping rules. Tests
+    point at this function directly so any future relaxation has to
+    pass the same assertion battery.
+    """
+    payload: dict[str, Any] = {}
+    cleaned_url = _strip_url(ctx.url)
+    if cleaned_url is not None:
+        payload["url"] = cleaned_url
+    if ctx.user_agent:
+        payload["user_agent"] = ctx.user_agent
+    if ctx.app_version:
+        payload["app_version"] = ctx.app_version
+    if ctx.viewport_w is not None and ctx.viewport_h is not None:
+        payload["viewport"] = {"w": ctx.viewport_w, "h": ctx.viewport_h}
+    if ctx.theme:
+        payload["theme"] = ctx.theme
+    return payload
+
+
+async def create_feedback_entry(
+    db: AsyncSession,
+    *,
+    user_id: Optional[int],
+    org_id: Optional[int],
+    message: str,
+    category: FeedbackCategory,
+    context: FeedbackContext,
+    include_identity: bool,
+) -> FeedbackEntry:
+    """Persist a feedback row honoring the identity opt-in.
+
+    The CALLER passes the authenticated user_id / org_id; this function
+    decides whether to record them based on `include_identity`. Storing
+    the gate decision here (rather than in the router) means tests can
+    drive it directly without going through HTTP.
+    """
+    row = FeedbackEntry(
+        user_id=user_id if include_identity else None,
+        org_id=org_id if include_identity else None,
+        message=message,
+        category=category,
+        context=normalize_context(context),
+    )
+    db.add(row)
+    await db.flush()
+    return row

--- a/backend/tests/routers/test_feedback.py
+++ b/backend/tests/routers/test_feedback.py
@@ -1,0 +1,290 @@
+"""Feedback router tests — HTTP surface + audit wiring.
+
+Covers:
+- Auth-required (no current_user override -> 401-ish from the dep).
+- Message validation (empty rejects, oversize rejects).
+- Category enum validation.
+- Identity opt-in default-OFF behavior end-to-end.
+- Audit event `feedback.submitted` emitted with the right fields.
+
+Pattern mirrors `test_tags.py`: in-memory SQLite + FastAPI app with
+dependency overrides.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.feedback import FeedbackCategory, FeedbackEntry
+from app.models.user import Organization, Role, User
+from app.routers.feedback import router as feedback_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Feedback Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="reporter",
+            email="r@x.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id}
+
+
+def make_app(factory, user_id: int):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        async with factory() as db:
+            return (
+                await db.execute(select(User).where(User.id == user_id))
+            ).scalar_one()
+
+    def override_session_factory():
+        return factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(feedback_router)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Happy path + privacy contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_anonymous_by_default(session_factory):
+    """include_identity defaults False; the row must be anonymous."""
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={
+                "message": "Something is off on the dashboard",
+                "category": "bug",
+                "context": {
+                    "url": "http://localhost/dashboard",
+                    "user_agent": "TestClient",
+                    "theme": "dark",
+                },
+            },
+        )
+    assert res.status_code == 201, res.text
+    async with session_factory() as db:
+        rows = (await db.execute(select(FeedbackEntry))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.user_id is None, "user_id stored despite include_identity not set"
+    assert row.org_id is None
+    assert row.category == FeedbackCategory.BUG
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_identified_when_optin(session_factory):
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={
+                "message": "Please add export to CSV",
+                "category": "feature",
+                "include_identity": True,
+                "context": {},
+            },
+        )
+    assert res.status_code == 201, res.text
+    async with session_factory() as db:
+        row = (await db.execute(select(FeedbackEntry))).scalar_one()
+    assert row.user_id == seeds["user_id"]
+    assert row.org_id == seeds["org_id"]
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_strips_query_string_from_url(session_factory):
+    """Privacy invariant: even if frontend sends ?token=..., we don't store it."""
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={
+                "message": "x",
+                "category": "other",
+                "context": {"url": "http://localhost/login?token=SECRET"},
+            },
+        )
+    assert res.status_code == 201, res.text
+    async with session_factory() as db:
+        row = (await db.execute(select(FeedbackEntry))).scalar_one()
+    assert "SECRET" not in str(row.context)
+    assert row.context["url"] == "http://localhost/login"
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_emits_audit_event(session_factory):
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={
+                "message": "Crash on import preview",
+                "category": "bug",
+                "include_identity": False,
+                "context": {},
+            },
+        )
+    assert res.status_code == 201
+    async with session_factory() as db:
+        events = (
+            await db.execute(
+                select(AuditEvent).where(AuditEvent.event_type == "feedback.submitted")
+            )
+        ).scalars().all()
+    assert len(events) == 1
+    audit = events[0]
+    assert audit.actor_user_id == seeds["user_id"]
+    assert audit.outcome.value == "success"
+    assert audit.detail["category"] == "bug"
+    assert audit.detail["identity_attached"] is False
+    # The audit log must NOT mirror the message body.
+    assert "Crash" not in str(audit.detail)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_empty_message_rejected(session_factory):
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={"message": "", "category": "bug"},
+        )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_oversize_message_rejected(session_factory):
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={"message": "x" * 5001, "category": "bug"},
+        )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_invalid_category_rejected(session_factory):
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={"message": "x", "category": "spam"},
+        )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_unknown_field_rejected(session_factory):
+    """`extra="forbid"` on the schema — typos won't silently succeed."""
+    seeds = await _seed(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={"message": "x", "category": "bug", "wat": "no"},
+        )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_requires_auth(session_factory):
+    """No get_current_user override -> the real HTTPBearer dep runs and
+    rejects the unauth call. We mount the router into an app WITHOUT the
+    auth override so this verifies the dep is wired.
+    """
+    app = FastAPI()
+    app.include_router(feedback_router)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/feedback",
+            json={"message": "x", "category": "bug"},
+        )
+    assert res.status_code in (401, 403)

--- a/backend/tests/services/test_feedback_service.py
+++ b/backend/tests/services/test_feedback_service.py
@@ -1,0 +1,186 @@
+"""Feedback service tests — privacy contract is the focus.
+
+Three invariants under test:
+
+1. `normalize_context` strips query strings off URLs.
+2. `create_feedback_entry` respects `include_identity=False` even when
+   the caller provides user_id / org_id.
+3. `create_feedback_entry` records user_id / org_id when
+   `include_identity=True`.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.feedback import FeedbackCategory, FeedbackEntry
+from app.models.user import Organization, Role, User
+from app.schemas.feedback import FeedbackContext
+from app.security import hash_password
+from app.services import feedback_service
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_user(factory):
+    async with factory() as db:
+        org = Organization(name="Feedback Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="reporter",
+            email="r@x.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id}
+
+
+# ---------------------------------------------------------------------------
+# normalize_context — privacy stripping
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_context_strips_query_string():
+    ctx = FeedbackContext(url="http://localhost/login?token=xyz&foo=bar")
+    out = feedback_service.normalize_context(ctx)
+    assert out["url"] == "http://localhost/login"
+    assert "token" not in out["url"]
+    assert "xyz" not in out["url"]
+
+
+def test_normalize_context_strips_fragment():
+    ctx = FeedbackContext(url="http://localhost/transactions#tx-12345")
+    out = feedback_service.normalize_context(ctx)
+    assert out["url"] == "http://localhost/transactions"
+    assert "12345" not in out["url"]
+
+
+def test_normalize_context_preserves_clean_path():
+    ctx = FeedbackContext(url="http://localhost/import/123/reconcile")
+    out = feedback_service.normalize_context(ctx)
+    assert out["url"] == "http://localhost/import/123/reconcile"
+
+
+def test_normalize_context_packs_viewport():
+    ctx = FeedbackContext(viewport_w=1440, viewport_h=900)
+    out = feedback_service.normalize_context(ctx)
+    assert out["viewport"] == {"w": 1440, "h": 900}
+
+
+def test_normalize_context_empty_url_returns_no_url_key():
+    ctx = FeedbackContext()
+    out = feedback_service.normalize_context(ctx)
+    assert "url" not in out
+
+
+# ---------------------------------------------------------------------------
+# create_feedback_entry — identity opt-in gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_feedback_anonymous_when_include_identity_false(session_factory):
+    """The PRIVACY DEFAULT. user_id / org_id MUST be NULL on the row."""
+    seeds = await _seed_user(session_factory)
+    async with session_factory() as db:
+        await feedback_service.create_feedback_entry(
+            db,
+            user_id=seeds["user_id"],
+            org_id=seeds["org_id"],
+            message="Something broke",
+            category=FeedbackCategory.BUG,
+            context=FeedbackContext(theme="light"),
+            include_identity=False,
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        row = (await db.execute(select(FeedbackEntry))).scalar_one()
+        assert row.user_id is None, "user_id leaked despite include_identity=False"
+        assert row.org_id is None, "org_id leaked despite include_identity=False"
+        assert row.message == "Something broke"
+        assert row.category == FeedbackCategory.BUG
+        assert row.context == {"theme": "light"}
+
+
+@pytest.mark.asyncio
+async def test_create_feedback_identified_when_include_identity_true(session_factory):
+    seeds = await _seed_user(session_factory)
+    async with session_factory() as db:
+        await feedback_service.create_feedback_entry(
+            db,
+            user_id=seeds["user_id"],
+            org_id=seeds["org_id"],
+            message="Please follow up",
+            category=FeedbackCategory.FEATURE,
+            context=FeedbackContext(),
+            include_identity=True,
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        row = (await db.execute(select(FeedbackEntry))).scalar_one()
+        assert row.user_id == seeds["user_id"]
+        assert row.org_id == seeds["org_id"]
+
+
+@pytest.mark.asyncio
+async def test_create_feedback_url_stripped_in_db(session_factory):
+    """Defense-in-depth: even via the service path, the persisted
+    `context` JSON must NOT contain the query string. This is the
+    integration check that the normalize_context contract reaches DB.
+    """
+    seeds = await _seed_user(session_factory)
+    async with session_factory() as db:
+        await feedback_service.create_feedback_entry(
+            db,
+            user_id=seeds["user_id"],
+            org_id=seeds["org_id"],
+            message="x",
+            category=FeedbackCategory.OTHER,
+            context=FeedbackContext(
+                url="http://localhost/login?token=secret123",
+                user_agent="Mozilla/5.0",
+            ),
+            include_identity=False,
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        row = (await db.execute(select(FeedbackEntry))).scalar_one()
+        assert "secret123" not in str(row.context)
+        assert "token" not in str(row.context)
+        assert row.context.get("url") == "http://localhost/login"
+        assert row.context.get("user_agent") == "Mozilla/5.0"

--- a/frontend/components/AppShellFooter.tsx
+++ b/frontend/components/AppShellFooter.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Logo } from "@/components/brand/Logo";
+import FeedbackTrigger from "@/components/feedback/FeedbackTrigger";
 import CurrentYear from "@/components/ui/CurrentYear";
 import { BRAND_CONTACT_EMAIL } from "@/lib/brand";
 
@@ -47,6 +48,12 @@ export default function AppShellFooter() {
           <Link href="/docs" className="hover:text-text-primary">
             Help
           </Link>
+          <span aria-hidden className="text-text-muted/60">
+            &middot;
+          </span>
+          {/* In-app feedback widget trigger. Logged-in only — the
+              component returns null when there is no authed user. */}
+          <FeedbackTrigger />
           <span aria-hidden className="text-text-muted/60">
             &middot;
           </span>

--- a/frontend/components/feedback/FeedbackTrigger.tsx
+++ b/frontend/components/feedback/FeedbackTrigger.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+import FeedbackWidget from "@/components/feedback/FeedbackWidget";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+/**
+ * Footer-level "Give feedback" link. Logged-in only — renders nothing
+ * when there is no authenticated user (spec section "Auth: Logged-in
+ * users only").
+ *
+ * Mounted by `AppShellFooter`, which itself sits inside the AppShell
+ * and is therefore only rendered for authenticated routes. The
+ * `useAuth().user` gate is defense-in-depth: a future refactor that
+ * promotes the footer to a shared layout still keeps the trigger off
+ * for unauthed visitors.
+ */
+export default function FeedbackTrigger() {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  if (!user) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="hover:text-text-primary"
+        data-testid="feedback-trigger"
+      >
+        Give feedback
+      </button>
+      <FeedbackWidget open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/frontend/components/feedback/FeedbackWidget.tsx
+++ b/frontend/components/feedback/FeedbackWidget.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+
+import SlideInPanel from "@/components/floating/SlideInPanel";
+import HelpAnchor from "@/components/HelpAnchor";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  btnPrimary,
+  btnSecondary,
+  error as errorCls,
+  input,
+  label as labelCls,
+  success as successCls,
+} from "@/lib/styles";
+
+/**
+ * In-app feedback widget — slide-in panel triggered from the
+ * AppShellFooter (logged-in only; the trigger renders nothing for
+ * unauthed visitors). Pattern reference: TransferForm in the same
+ * SlideInPanel chrome for parity with the quick-add experience.
+ *
+ * Privacy contract (spec captured 2026-05-08):
+ *   - Identity opt-in defaults OFF. The checkbox is unchecked on every
+ *     open, including after a successful submit.
+ *   - Auto-collected context (URL, user-agent, app version, viewport,
+ *     theme) is always sent and disclosed to the user via a collapsed
+ *     details panel.
+ *   - The backend further strips query strings off the URL before
+ *     persisting; this is defense-in-depth, not a substitute.
+ */
+
+const MESSAGE_MAX = 5000;
+
+type Category = "bug" | "feature" | "other";
+
+interface AutoContext {
+  url: string;
+  user_agent: string;
+  app_version: string;
+  viewport_w: number;
+  viewport_h: number;
+  theme: string;
+}
+
+function collectAutoContext(): AutoContext {
+  // Strip query + fragment client-side as belt-and-suspenders for the
+  // backend's normalization. A URL like `/login?token=xyz` should
+  // never even cross the wire.
+  const rawUrl =
+    typeof window !== "undefined" ? window.location.href : "";
+  let cleanUrl = rawUrl;
+  try {
+    const u = new URL(rawUrl);
+    u.search = "";
+    u.hash = "";
+    cleanUrl = u.toString();
+  } catch {
+    // Non-parseable URL — fall back to pathname only if available.
+    if (typeof window !== "undefined") {
+      cleanUrl = `${window.location.origin}${window.location.pathname}`;
+    }
+  }
+
+  const theme =
+    typeof document !== "undefined"
+      ? document.documentElement.getAttribute("data-theme") ?? "default"
+      : "default";
+
+  return {
+    url: cleanUrl,
+    user_agent:
+      typeof navigator !== "undefined" ? navigator.userAgent : "",
+    app_version: process.env.NEXT_PUBLIC_APP_VERSION ?? "dev",
+    viewport_w:
+      typeof window !== "undefined" ? window.innerWidth : 0,
+    viewport_h:
+      typeof window !== "undefined" ? window.innerHeight : 0,
+    theme,
+  };
+}
+
+export interface FeedbackWidgetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function FeedbackWidget({
+  open,
+  onClose,
+}: FeedbackWidgetProps) {
+  const [category, setCategory] = useState<Category>("bug");
+  const [message, setMessage] = useState("");
+  const [includeIdentity, setIncludeIdentity] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Recompute on open so a navigation between mounts is reflected.
+  const autoContext = useMemo<AutoContext | null>(
+    () => (open ? collectAutoContext() : null),
+    [open],
+  );
+
+  // Reset transient state every time the panel opens. The privacy
+  // default (identity opt-OUT) is re-asserted here so a previous
+  // tick-and-submit does not survive the close/reopen boundary.
+  //
+  // Implemented via the "compare state to a prop and call setState
+  // during render" pattern from the React docs (see "Adjusting state
+  // when a prop changes" — https://react.dev/reference/react/useState#storing-information-from-previous-renders).
+  // Doing this during render (not in an effect) avoids the cascading
+  // re-render cycle the React 19 lint rule flags on
+  // `react-hooks/set-state-in-effect`.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setMessage("");
+      setIncludeIdentity(false);
+      setError(null);
+      setSuccess(false);
+      setCategory("bug");
+    }
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    setError(null);
+    setSuccess(false);
+
+    if (message.trim().length === 0) {
+      setError("Please write a short message before sending.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const ctx = autoContext ?? collectAutoContext();
+      await apiFetch("/api/v1/feedback", {
+        method: "POST",
+        body: JSON.stringify({
+          message: message.trim(),
+          category,
+          include_identity: includeIdentity,
+          context: {
+            url: ctx.url,
+            user_agent: ctx.user_agent,
+            app_version: ctx.app_version,
+            viewport_w: ctx.viewport_w,
+            viewport_h: ctx.viewport_h,
+            theme: ctx.theme,
+          },
+        }),
+      });
+      setSuccess(true);
+      setMessage("");
+    } catch (err) {
+      setError(extractErrorMessage(err) ?? "We could not send your feedback. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <SlideInPanel
+      open={open}
+      onClose={onClose}
+      title="Send feedback"
+      testId="feedback-widget"
+    >
+      <form
+        onSubmit={handleSubmit}
+        aria-label="Feedback form"
+        className="flex flex-col gap-5"
+      >
+        {success && (
+          <div
+            className={successCls}
+            role="status"
+            aria-live="polite"
+            data-testid="feedback-success"
+          >
+            Thanks, we got it. We read every message.
+          </div>
+        )}
+        {error && (
+          <div
+            className={errorCls}
+            role="alert"
+            data-testid="feedback-error"
+          >
+            {error}
+          </div>
+        )}
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className={labelCls}>
+            What kind of feedback?{" "}
+            <HelpAnchor
+              section="feedback-categories"
+              label="Feedback categories"
+              className="ml-1 inline-flex"
+            />
+          </legend>
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+            {[
+              { value: "bug", label: "Bug", hint: "Something is broken" },
+              { value: "feature", label: "Feature", hint: "Something is missing" },
+              { value: "other", label: "Other", hint: "Anything else" },
+            ].map((opt) => (
+              <label
+                key={opt.value}
+                className={`flex flex-1 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm ${
+                  category === opt.value
+                    ? "border-accent bg-accent-dim text-text-primary"
+                    : "border-border text-text-secondary hover:border-accent/40"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="feedback-category"
+                  value={opt.value}
+                  checked={category === opt.value}
+                  onChange={() => setCategory(opt.value as Category)}
+                  className="h-4 w-4 accent-accent"
+                />
+                <span className="flex flex-col">
+                  <span className="font-medium">{opt.label}</span>
+                  <span className="text-xs text-text-muted">{opt.hint}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="feedback-message" className={labelCls}>
+            Your message
+          </label>
+          <textarea
+            id="feedback-message"
+            data-testid="feedback-message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value.slice(0, MESSAGE_MAX))}
+            rows={6}
+            maxLength={MESSAGE_MAX}
+            placeholder="Tell us what happened, what you expected, or what you wish existed."
+            className={`${input} resize-y`}
+            required
+            aria-describedby="feedback-message-counter"
+          />
+          <div
+            id="feedback-message-counter"
+            className="text-right text-xs text-text-muted"
+          >
+            {message.length} / {MESSAGE_MAX}
+          </div>
+        </div>
+
+        <label className="flex items-start gap-2 rounded-md border border-border bg-surface-raised px-3 py-3 text-sm">
+          <input
+            type="checkbox"
+            data-testid="feedback-include-identity"
+            checked={includeIdentity}
+            onChange={(e) => setIncludeIdentity(e.target.checked)}
+            className="mt-0.5 h-4 w-4 accent-accent"
+          />
+          <span className="flex flex-col">
+            <span className="font-medium text-text-primary">
+              Include my account info so we can follow up
+            </span>
+            <span className="text-xs text-text-muted">
+              Optional. Off by default. We only see who you are if you
+              tick this box.
+            </span>
+          </span>
+        </label>
+
+        {autoContext && (
+          <details
+            className="rounded-md border border-border bg-surface-raised px-3 py-2 text-xs text-text-muted"
+            data-testid="feedback-context-details"
+          >
+            <summary className="cursor-pointer text-text-secondary">
+              What we collect to triage this
+            </summary>
+            <dl className="mt-2 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+              <dt>Page</dt>
+              <dd className="truncate">{autoContext.url}</dd>
+              <dt>App version</dt>
+              <dd>{autoContext.app_version}</dd>
+              <dt>Viewport</dt>
+              <dd>
+                {autoContext.viewport_w} x {autoContext.viewport_h}
+              </dd>
+              <dt>Theme</dt>
+              <dd>{autoContext.theme}</dd>
+              <dt>Browser</dt>
+              <dd className="truncate">{autoContext.user_agent}</dd>
+            </dl>
+            <p className="mt-2">
+              We never include balances, transaction details, account
+              names, or any other account data.
+            </p>
+          </details>
+        )}
+
+        <div className="flex flex-row-reverse items-center justify-start gap-2 pt-2">
+          <button
+            type="submit"
+            className={btnPrimary}
+            disabled={submitting || message.trim().length === 0}
+            data-testid="feedback-submit"
+          >
+            {submitting ? "Sending..." : "Send feedback"}
+          </button>
+          <button
+            type="button"
+            className={btnSecondary}
+            onClick={onClose}
+            data-testid="feedback-cancel"
+          >
+            Close
+          </button>
+        </div>
+      </form>
+    </SlideInPanel>
+  );
+}

--- a/frontend/tests/components/__snapshots__/app-shell-footer.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/app-shell-footer.test.tsx.snap
@@ -100,6 +100,19 @@ exports[`<AppShellFooter /> > snapshot stays stable in dark + light > app-footer
       >
         ·
       </span>
+      <button
+        class="hover:text-text-primary"
+        data-testid="feedback-trigger"
+        type="button"
+      >
+        Give feedback
+      </button>
+      <span
+        aria-hidden="true"
+        class="text-text-muted/60"
+      >
+        ·
+      </span>
       <a
         class="hover:text-text-primary"
         href="mailto:hello@thebetterdecision.com"
@@ -205,6 +218,19 @@ exports[`<AppShellFooter /> > snapshot stays stable in dark + light > app-footer
       >
         Help
       </a>
+      <span
+        aria-hidden="true"
+        class="text-text-muted/60"
+      >
+        ·
+      </span>
+      <button
+        class="hover:text-text-primary"
+        data-testid="feedback-trigger"
+        type="button"
+      >
+        Give feedback
+      </button>
       <span
         aria-hidden="true"
         class="text-text-muted/60"

--- a/frontend/tests/components/app-shell-footer.test.tsx
+++ b/frontend/tests/components/app-shell-footer.test.tsx
@@ -3,6 +3,18 @@ import { render, screen } from "@testing-library/react";
 
 import AppShellFooter from "@/components/AppShellFooter";
 
+// FeedbackTrigger (mounted in the footer for the in-app feedback
+// widget) reads `useAuth()` to gate on logged-in users. The footer
+// itself does not depend on auth, but the trigger does — so these
+// tests mock the auth hook to return a logged-in user. Tests that
+// need the unauth path live in feedback-trigger.test.tsx.
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: 1, username: "tester", email: "t@x.io" },
+    loading: false,
+  }),
+}));
+
 describe("<AppShellFooter />", () => {
   it("renders the muted brand lockup with a copyright line", () => {
     const { container } = render(<AppShellFooter />);

--- a/frontend/tests/components/feedback/feedback-trigger.test.tsx
+++ b/frontend/tests/components/feedback/feedback-trigger.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import FeedbackTrigger from "@/components/feedback/FeedbackTrigger";
+
+const useAuthMock = vi.fn();
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+describe("FeedbackTrigger", () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+  });
+
+  it("renders nothing when there is no authenticated user", () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    const { container } = render(<FeedbackTrigger />);
+    expect(container.textContent).toBe("");
+    expect(
+      screen.queryByTestId("feedback-trigger"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the trigger when the user is authenticated", () => {
+    useAuthMock.mockReturnValue({
+      user: { id: 1, username: "tester", email: "t@x.io" },
+      loading: false,
+    });
+    render(<FeedbackTrigger />);
+    expect(
+      screen.getByRole("button", { name: /give feedback/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/feedback/feedback-widget.test.tsx
+++ b/frontend/tests/components/feedback/feedback-widget.test.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import FeedbackWidget from "@/components/feedback/FeedbackWidget";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>(
+    "@/lib/api",
+  );
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function setLocation(href: string) {
+  // jsdom does not allow direct assignment to window.location, but it
+  // does honor a Property-defined replacement via Object.defineProperty.
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: new URL(href),
+  });
+}
+
+describe("FeedbackWidget", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    setLocation("http://localhost/dashboard");
+  });
+
+  // -------------------------------------------------------------------
+  // Closed-state contract
+  // -------------------------------------------------------------------
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <FeedbackWidget open={false} onClose={() => {}} />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  // -------------------------------------------------------------------
+  // Open-state shape
+  // -------------------------------------------------------------------
+
+  it("shows the form with category radios, message field, and identity opt-in OFF by default", () => {
+    render(<FeedbackWidget open onClose={() => {}} />);
+
+    expect(
+      screen.getByRole("dialog", { name: /send feedback/i }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByLabelText(/bug/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/feature/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/other/i)).toBeInTheDocument();
+
+    const includeIdentity = screen.getByTestId(
+      "feedback-include-identity",
+    ) as HTMLInputElement;
+    expect(includeIdentity.checked).toBe(false);
+  });
+
+  it("captures and discloses auto-context (URL, viewport, theme) without query strings", () => {
+    setLocation("http://localhost/login?token=SECRET");
+    render(<FeedbackWidget open onClose={() => {}} />);
+
+    const details = screen.getByTestId("feedback-context-details");
+    expect(details.textContent).toMatch(/Page/i);
+    expect(details.textContent).toMatch(/Viewport/i);
+    expect(details.textContent).toMatch(/Theme/i);
+    // Query string MUST be stripped before disclosure.
+    expect(details.textContent).not.toMatch(/SECRET/);
+    expect(details.textContent).not.toMatch(/token=/);
+  });
+
+  // -------------------------------------------------------------------
+  // Submission flow
+  // -------------------------------------------------------------------
+
+  it("submits anonymously when identity opt-in is unchecked", async () => {
+    mockedApiFetch.mockResolvedValue({ id: 1 });
+    render(<FeedbackWidget open onClose={() => {}} />);
+
+    fireEvent.change(screen.getByTestId("feedback-message"), {
+      target: { value: "Dashboard chart looks off" },
+    });
+    fireEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(1));
+
+    const [path, options] = mockedApiFetch.mock.calls[0];
+    expect(path).toBe("/api/v1/feedback");
+    expect(options?.method).toBe("POST");
+    const body = JSON.parse(options?.body as string);
+    expect(body.message).toBe("Dashboard chart looks off");
+    expect(body.category).toBe("bug");
+    expect(body.include_identity).toBe(false);
+    expect(body.context.url).toBe("http://localhost/dashboard");
+  });
+
+  it("submits with identity when the opt-in is checked", async () => {
+    mockedApiFetch.mockResolvedValue({ id: 1 });
+    render(<FeedbackWidget open onClose={() => {}} />);
+
+    fireEvent.change(screen.getByTestId("feedback-message"), {
+      target: { value: "Please add export" },
+    });
+    fireEvent.click(screen.getByTestId("feedback-include-identity"));
+    fireEvent.click(screen.getByLabelText(/feature/i));
+    fireEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(
+      mockedApiFetch.mock.calls[0][1]?.body as string,
+    );
+    expect(body.include_identity).toBe(true);
+    expect(body.category).toBe("feature");
+  });
+
+  it("strips query strings off the URL before it reaches the API", async () => {
+    setLocation("http://localhost/import/123/reconcile?session=ABC");
+    mockedApiFetch.mockResolvedValue({ id: 1 });
+    render(<FeedbackWidget open onClose={() => {}} />);
+
+    fireEvent.change(screen.getByTestId("feedback-message"), {
+      target: { value: "Importer crashed" },
+    });
+    fireEvent.click(screen.getByTestId("feedback-submit"));
+
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(
+      mockedApiFetch.mock.calls[0][1]?.body as string,
+    );
+    expect(body.context.url).toBe(
+      "http://localhost/import/123/reconcile",
+    );
+    expect(body.context.url).not.toMatch(/ABC/);
+    expect(body.context.url).not.toMatch(/session/);
+  });
+
+  it("shows a success message after a successful submit", async () => {
+    mockedApiFetch.mockResolvedValue({ id: 1 });
+    render(<FeedbackWidget open onClose={() => {}} />);
+
+    fireEvent.change(screen.getByTestId("feedback-message"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getByTestId("feedback-submit"));
+
+    expect(
+      await screen.findByTestId("feedback-success"),
+    ).toBeInTheDocument();
+  });
+
+  it("disables submit when the message is empty", () => {
+    render(<FeedbackWidget open onClose={() => {}} />);
+    const submit = screen.getByTestId("feedback-submit") as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("shows an inline error when the API call fails", async () => {
+    mockedApiFetch.mockRejectedValue(new Error("Network down"));
+    render(<FeedbackWidget open onClose={() => {}} />);
+
+    fireEvent.change(screen.getByTestId("feedback-message"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getByTestId("feedback-submit"));
+
+    expect(await screen.findByTestId("feedback-error")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------
+  // Privacy default: re-opening the panel resets opt-in
+  // -------------------------------------------------------------------
+
+  it("resets identity opt-in to OFF every time the panel reopens", async () => {
+    const { rerender } = render(
+      <FeedbackWidget open onClose={() => {}} />,
+    );
+    fireEvent.click(screen.getByTestId("feedback-include-identity"));
+    expect(
+      (screen.getByTestId(
+        "feedback-include-identity",
+      ) as HTMLInputElement).checked,
+    ).toBe(true);
+
+    rerender(<FeedbackWidget open={false} onClose={() => {}} />);
+    rerender(<FeedbackWidget open onClose={() => {}} />);
+
+    expect(
+      (screen.getByTestId(
+        "feedback-include-identity",
+      ) as HTMLInputElement).checked,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Backend: migration **043** adds `feedback_entries` (user_id/org_id nullable for identity opt-in), `FeedbackEntry` model, schemas, `feedback_service` with URL-stripping `normalize_context`, and `POST /api/v1/feedback` (rate-limited 5/hour, audit-logged `feedback.submitted`).
- Frontend: `FeedbackWidget` slide-in panel reusing `SlideInPanel` for quick-add parity. `FeedbackTrigger` renders as a \"Give feedback\" link inside `AppShellFooter` only when authenticated.
- Auto-context (URL, viewport, theme, user-agent, app version) is collected and disclosed in a collapsed details panel; URL is stripped of query params and fragment on the client **and** server.
- Identity opt-in defaults OFF on every panel open per the privacy spec.

## Privacy contract

- `user_id` / `org_id` are written to the row only when the submitter ticks \"Include my account info so we can follow up\". Default unchecked, re-asserted on every open.
- `context.url` has query string + fragment stripped both client-side (defense-in-depth) and server-side (`feedback_service._strip_url`). Test `test_submit_feedback_strips_query_string_from_url` is the load-bearing assertion.
- The audit log carries the category and `identity_attached` boolean, but never the message body.
- Privacy policy text update is out-of-scope for this PR (separate ops task).

## Endpoints + paths

- `POST /api/v1/feedback` — `backend/app/routers/feedback.py`
- Service: `backend/app/services/feedback_service.py`
- Migration: `backend/alembic/versions/043_feedback_entries.py` (down/up/down/up verified)
- Widget: `frontend/components/feedback/FeedbackWidget.tsx`
- Trigger: `frontend/components/feedback/FeedbackTrigger.tsx` (mounted in `AppShellFooter`)

## Out of scope

- Admin UI for viewing feedback (separate L4.x slice).
- Slack/email notifications (separate ops integration).
- Anonymous (unauthed) feedback (spec is logged-in only).

## Test status

- Backend: 1053 passed, 5 skipped (full suite). New tests: 17 in `tests/services/test_feedback_service.py` + `tests/routers/test_feedback.py`.
- Frontend: 753 passed across 109 files (full suite). New tests: 12 in `tests/components/feedback/`.
- TypeScript: clean. ESLint: clean. Design-tokens: clean.

## Manual screenshot — handoff

The isolated `team-feedback-widget` compose stack does not expose the frontend port to the host (parity with the main stack's nginx-only ingress). Screenshots will need to be captured against the user's local stack after merge:

1. `./pfv start`
2. Log in.
3. Click \"Give feedback\" at the bottom of the footer.
4. Expected: slide-in panel from the right with category radios, message field, identity opt-in (off by default), and the \"What we collect to triage this\" disclosure expandable.

End-to-end DB smoke (via service path inside the isolated stack):

```
Row 1 (anonymous):   user_id=NULL, org_id=NULL, url='http://localhost/login'  (query stripped)
Row 2 (identified):  user_id=1,    org_id=1,    url='http://localhost/dashboard'
```