### PR TITLE
feat(admin): subscription & revenue view (L4.5)

### DIFF
--- a/backend/alembic/versions/047_seed_subscriptions_view_permission.py
+++ b/backend/alembic/versions/047_seed_subscriptions_view_permission.py
@@ -1,0 +1,71 @@
+"""Seed subscriptions.view permission into the superadmin role (L4.5).
+
+Revision ID: 047_subscriptions_view_perm
+Revises: 046_users_view_perm
+Create Date: 2026-05-13
+
+L4.5 ships the subscription & revenue admin surface. It is gated by a
+new ``subscriptions.view`` permission key (added to
+``app/auth/permissions.py``'s ``Permission`` literal + ``ALL_PERMISSIONS``).
+
+The runtime resolver short-circuits via ``is_superadmin``, so the seed
+below is for parity with future non-superadmin roles and to keep the
+``/admin/roles`` UI's permission editor accurate. We INSERT-IGNORE
+(via existence check) so re-running the migration after manual seeding
+doesn't fail.
+
+This follows the pattern documented in migration ``039_analytics_view_perm``.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "047_subscriptions_view_perm"
+down_revision = "046_users_view_perm"
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_KEY = "subscriptions.view"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    row = bind.execute(
+        sa.text("SELECT id FROM roles WHERE slug = :slug"),
+        {"slug": "superadmin"},
+    ).first()
+    if row is None:
+        return
+    role_id = row[0]
+
+    exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM role_permissions "
+            "WHERE role_id = :role_id AND permission_key = :key"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    ).first()
+    if exists is not None:
+        return
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO role_permissions (role_id, permission_key) "
+            "VALUES (:role_id, :key)"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "DELETE FROM role_permissions WHERE permission_key = :key"
+        ),
+        {"key": PERMISSION_KEY},
+    )

--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -28,6 +28,7 @@ Permission = Literal[
     "roles.manage",
     "analytics.view",
     "users.view",
+    "subscriptions.view",
 ]
 
 
@@ -43,6 +44,7 @@ ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "roles.manage",
     "analytics.view",
     "users.view",
+    "subscriptions.view",
 })
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_analytics, admin_audit, admin_orgs, admin_roles, admin_users, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, onboarding, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_analytics, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, onboarding, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -378,6 +378,7 @@ app.include_router(admin_orgs.router)
 app.include_router(admin_audit.router)
 app.include_router(admin_analytics.router)
 app.include_router(admin_roles.router)
+app.include_router(admin_subscriptions.router)
 app.include_router(admin_users.router)
 app.include_router(org_members.router)
 app.include_router(org_data.router)

--- a/backend/app/routers/admin_subscriptions.py
+++ b/backend/app/routers/admin_subscriptions.py
@@ -8,14 +8,22 @@ Auth via the platform ``subscriptions.view`` permission (superadmin
 short-circuits today; fine-grained roles can land later via L4.8
 without touching this file).
 
-Audit policy: every list and detail hit emits a structlog
-``admin.subscriptions.viewed`` event, but the durable
+Audit policy: every list hit emits a structlog
+``admin.subscriptions.viewed`` event and every detail hit emits
+``admin.subscriptions.detail.viewed``; the durable
 ``audit_events`` row is **rate-throttled** to at most once per admin
-per minute. Otherwise an admin paging through 5,000 subscriptions
-would write 100 audit rows for the same intent. The throttle uses
-Redis ``SET NX EX 60``; when Redis is unconfigured (dev / tests) we
-fall **open** — emit every call — so test assertions can pin the
-event without depending on Redis being up.
+per event-type per minute. List and detail use distinct event types
+so a recent list view does not suppress the detail audit row (the
+detail row carries ``target_org_id`` and must not be lost). Otherwise
+an admin paging through 5,000 subscriptions would write 100 audit
+rows for the same intent. The throttle uses Redis ``SET NX EX 60``;
+when Redis is unconfigured (dev / tests) we fall **open** — emit
+every call — so test assertions can pin the event without depending
+on Redis being up.
+
+Privacy: the raw search ``q`` is NEVER stored in the durable audit
+detail. Only ``query_length`` (and ``has_query``) go in, mirroring
+the cross-org user-search contract on ``admin_users.py``.
 """
 from __future__ import annotations
 
@@ -194,7 +202,10 @@ async def list_subscriptions(
             "filters": {
                 "status": status_filter,
                 "plan": plan,
-                "q": q,
+                # Privacy: never store raw ``q`` (see admin_users.py
+                # pattern). Only the length / presence flag is durable.
+                "query_length": len(q) if q else 0,
+                "has_query": bool(q),
                 "limit": limit,
                 "offset": offset,
             },
@@ -226,7 +237,11 @@ async def get_subscription_detail(
             detail="Subscription not found",
         )
     await _emit_view_audit(
-        event_type="admin.subscriptions.viewed",
+        # Distinct event type from the list handler so the throttle
+        # (keyed on event_type + actor) doesn't suppress this row when
+        # the admin drills in within 60s of the list view. The detail
+        # row carries ``target_org_id`` and must always be persisted.
+        event_type="admin.subscriptions.detail.viewed",
         actor=current_user,
         request=request,
         session_factory=session_factory,

--- a/backend/app/routers/admin_subscriptions.py
+++ b/backend/app/routers/admin_subscriptions.py
@@ -1,0 +1,240 @@
+"""Admin subscription & revenue view router (L4.5).
+
+Mounted at ``/api/v1/admin/subscriptions``. Read-only by design — the
+override / mutation flow lives on ``/admin/orgs/[id]`` (L4.3 + L4.11)
+and L4.5 deliberately does not duplicate it.
+
+Auth via the platform ``subscriptions.view`` permission (superadmin
+short-circuits today; fine-grained roles can land later via L4.8
+without touching this file).
+
+Audit policy: every list and detail hit emits a structlog
+``admin.subscriptions.viewed`` event, but the durable
+``audit_events`` row is **rate-throttled** to at most once per admin
+per minute. Otherwise an admin paging through 5,000 subscriptions
+would write 100 audit rows for the same intent. The throttle uses
+Redis ``SET NX EX 60``; when Redis is unconfigured (dev / tests) we
+fall **open** — emit every call — so test assertions can pin the
+event without depending on Redis being up.
+"""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.auth.permissions import require_permission
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models.user import User
+from app.rate_limit import get_client_ip
+from app.redis_client import get_client as get_redis_client
+from app.schemas.admin_subscriptions import (
+    SubscriptionDetail,
+    SubscriptionKPIs,
+    SubscriptionListResponse,
+)
+from app.services import admin_subscription_service, audit_service
+from app.services.exceptions import NotFoundError
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(
+    prefix="/api/v1/admin/subscriptions", tags=["admin-subscriptions"]
+)
+
+
+# Audit throttle window: one durable audit row per (actor, event) per
+# this many seconds. Locked at 60s to match the L4.5 spec ("once per
+# admin per minute is enough, don't log every page-flip").
+AUDIT_THROTTLE_SECONDS = 60
+
+
+SubscriptionStatusFilter = Literal[
+    "trialing", "active", "past_due", "canceled"
+]
+
+
+def _request_id() -> Optional[str]:
+    """Pull the per-request id bound by RequestContextMiddleware (L4.9)."""
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
+async def _should_persist_audit(
+    *, actor_user_id: Optional[int], event_type: str
+) -> bool:
+    """Return True if this hit should write a durable audit row.
+
+    Fail-open semantics:
+
+    - No Redis configured → return True every call (dev / unit tests
+      where the stub Redis client is absent). The structlog event
+      still emits unconditionally, so triage information is never
+      lost; only the durable row is gated.
+    - Redis error → return True (don't lose audit evidence because of
+      a Redis blip).
+    - Successful ``SET NX EX``: this is the first hit in the window,
+      return True.
+    - ``SET NX`` returned None (already set): we already wrote an
+      audit row in the window, return False.
+    """
+    client = get_redis_client()
+    if client is None or actor_user_id is None:
+        return True
+    key = f"admin.subscriptions.audit:{event_type}:{actor_user_id}"
+    try:
+        result = await client.set(key, "1", nx=True, ex=AUDIT_THROTTLE_SECONDS)
+    except Exception as exc:  # noqa: BLE001 — defensive, never block on Redis.
+        await logger.awarning(
+            "admin.subscriptions.audit_throttle.error",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return True
+    # Redis returns True when SET NX takes effect, None / False otherwise.
+    return bool(result)
+
+
+async def _emit_view_audit(
+    *,
+    event_type: str,
+    actor: User,
+    request: Request,
+    session_factory: async_sessionmaker[AsyncSession],
+    detail: Optional[dict] = None,
+    target_org_id: Optional[int] = None,
+    target_org_name: Optional[str] = None,
+) -> None:
+    """Emit both the structlog event (always) and the durable audit row
+    (rate-throttled). Never raises — failures are logged and swallowed
+    so a Redis or audit-write blip never reaches the caller."""
+    await logger.ainfo(
+        event_type,
+        actor_user_id=actor.id,
+        actor_email=actor.email,
+        target_org_id=target_org_id,
+        target_org_name=target_org_name,
+    )
+    try:
+        should_persist = await _should_persist_audit(
+            actor_user_id=actor.id, event_type=event_type
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        should_persist = True
+    if not should_persist:
+        return
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type=event_type,
+        actor_user_id=actor.id,
+        actor_email=actor.email,
+        target_org_id=target_org_id,
+        target_org_name=target_org_name,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail=detail,
+    )
+
+
+@router.get(
+    "/kpis",
+    response_model=SubscriptionKPIs,
+    dependencies=[Depends(require_permission("subscriptions.view"))],
+)
+async def get_kpis(
+    db: AsyncSession = Depends(get_db),
+) -> SubscriptionKPIs:
+    """Pulse-strip totals (counts + per-plan distribution + mock $$).
+
+    Deliberately not audited — KPIs are coarse-grain page-render data,
+    not per-subscription drill-downs. The list and detail routes carry
+    the audit signal.
+    """
+    payload = await admin_subscription_service.aggregate_revenue_kpis(db)
+    return SubscriptionKPIs.model_validate(payload)
+
+
+@router.get(
+    "",
+    response_model=SubscriptionListResponse,
+    dependencies=[Depends(require_permission("subscriptions.view"))],
+)
+async def list_subscriptions(
+    request: Request,
+    current_user: User = Depends(require_permission("subscriptions.view")),
+    status_filter: Optional[SubscriptionStatusFilter] = Query(
+        default=None, alias="status"
+    ),
+    plan: Optional[str] = Query(default=None, max_length=80),
+    q: Optional[str] = Query(default=None, max_length=120),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+) -> SubscriptionListResponse:
+    payload = await admin_subscription_service.list_subscriptions(
+        db,
+        status_filter=status_filter,
+        plan_filter=plan,
+        q=q,
+        limit=limit,
+        offset=offset,
+    )
+    await _emit_view_audit(
+        event_type="admin.subscriptions.viewed",
+        actor=current_user,
+        request=request,
+        session_factory=session_factory,
+        detail={
+            "view": "list",
+            "filters": {
+                "status": status_filter,
+                "plan": plan,
+                "q": q,
+                "limit": limit,
+                "offset": offset,
+            },
+            "result_total": payload["total"],
+        },
+    )
+    return SubscriptionListResponse.model_validate(payload)
+
+
+@router.get(
+    "/{subscription_id}",
+    response_model=SubscriptionDetail,
+    dependencies=[Depends(require_permission("subscriptions.view"))],
+)
+async def get_subscription_detail(
+    subscription_id: int,
+    request: Request,
+    current_user: User = Depends(require_permission("subscriptions.view")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+) -> SubscriptionDetail:
+    try:
+        payload = await admin_subscription_service.get_subscription_detail(
+            db, subscription_id=subscription_id
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Subscription not found",
+        )
+    await _emit_view_audit(
+        event_type="admin.subscriptions.viewed",
+        actor=current_user,
+        request=request,
+        session_factory=session_factory,
+        target_org_id=payload["org"]["id"],
+        target_org_name=payload["org"]["name"],
+        detail={
+            "view": "detail",
+            "subscription_id": subscription_id,
+        },
+    )
+    return SubscriptionDetail.model_validate(payload)

--- a/backend/app/schemas/admin_subscriptions.py
+++ b/backend/app/schemas/admin_subscriptions.py
@@ -1,0 +1,146 @@
+"""Pydantic schemas for the L4.5 subscription & revenue admin surface.
+
+Counts and identity only — every dollar figure is mocked since real
+payments (L2.2) are parked. The ``mock_revenue`` flag in the KPI
+envelope is the single source of truth the frontend reads when
+deciding whether to render ``($0 — payments not live)`` next to dollar
+values. Once L2 wires real billing, flip the flag and the UI starts
+showing real money without a schema change.
+"""
+from __future__ import annotations
+
+import datetime
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel
+
+
+SubscriptionStatusLiteral = Literal[
+    "trialing", "active", "past_due", "canceled"
+]
+
+
+class SubscriptionListItem(BaseModel):
+    """One row in the cross-org subscriptions table.
+
+    ``org_name`` is the snapshot value at read time. We always join via
+    ``Subscription.org_id`` so a renamed org reflects in the next
+    refresh — there is no audit-style snapshot pinning here because the
+    surface is for live triage, not historical attestation.
+    """
+
+    subscription_id: int
+    org_id: int
+    org_name: str
+    plan_id: Optional[int] = None
+    plan_slug: Optional[str] = None
+    plan_name: Optional[str] = None
+    status: SubscriptionStatusLiteral
+    billing_interval: Literal["monthly", "yearly"]
+    trial_start: Optional[datetime.date] = None
+    trial_end: Optional[datetime.date] = None
+    current_period_start: Optional[datetime.date] = None
+    current_period_end: Optional[datetime.date] = None
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class SubscriptionListResponse(BaseModel):
+    items: list[SubscriptionListItem]
+    total: int
+    limit: int
+    offset: int
+
+
+class PlanInfo(BaseModel):
+    id: int
+    slug: str
+    name: str
+    description: str
+    price_monthly: str  # Decimal serialized as string per FE convention.
+    price_yearly: str
+    max_users: Optional[int] = None
+    retention_days: Optional[int] = None
+    features: dict[str, Any] = {}
+    is_custom: bool
+    is_active: bool
+
+
+class OrgInfo(BaseModel):
+    id: int
+    name: str
+    billing_cycle_day: int
+    created_at: Optional[datetime.datetime] = None
+    member_count: int
+
+
+class FeatureOverrideSnapshot(BaseModel):
+    """A single active override on the subscription's org.
+
+    Source: ``org_feature_overrides`` (L4.11). The detail page shows
+    these read-only — grant/revoke still lives on ``/admin/orgs/[id]``
+    so L4.11 stays the single source of truth for the mutation flow.
+    """
+
+    feature_key: str
+    value: bool
+    set_at: Optional[datetime.datetime] = None
+    expires_at: Optional[datetime.datetime] = None
+    is_expired: bool
+    note: Optional[str] = None
+
+
+class SubscriptionDetail(BaseModel):
+    subscription_id: int
+    org: OrgInfo
+    plan: Optional[PlanInfo] = None
+    status: SubscriptionStatusLiteral
+    billing_interval: Literal["monthly", "yearly"]
+    trial_start: Optional[datetime.date] = None
+    trial_end: Optional[datetime.date] = None
+    current_period_start: Optional[datetime.date] = None
+    current_period_end: Optional[datetime.date] = None
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    feature_overrides: list[FeatureOverrideSnapshot]
+    # Mock revenue dollar amount. Always 0 today; the field exists so
+    # the FE never has to special-case its absence after L2 lands.
+    mock_revenue_amount: str = "0.00"
+    mock_revenue: bool = True
+
+
+class SubscriptionKPIs(BaseModel):
+    """Revenue / lifecycle pulse strip for the list page header.
+
+    ``mock_revenue`` is always ``True`` until L2.2 ships. The FE reads
+    the flag and renders dollar columns with a ``mock`` badge plus a
+    tooltip explaining payments aren't live yet.
+    """
+
+    total_subscriptions: int
+    active: int
+    trial: int
+    past_due: int
+    cancelled: int
+    signups_last_7d: int
+    trial_expiring_next_7d: int
+    plan_distribution: list["PlanDistributionItem"]
+    # Mock dollar figures — see module docstring. The FE renders these
+    # with explicit "mock" labelling so admins never confuse the
+    # surface for real revenue. Keep them as strings so adding a
+    # currency code later (LAI / L2.2) doesn't widen the type.
+    mock_mrr: str = "0.00"
+    mock_arr: str = "0.00"
+    mock_revenue: bool = True
+    generated_at: datetime.datetime
+
+
+class PlanDistributionItem(BaseModel):
+    plan_id: Optional[int] = None
+    plan_slug: Optional[str] = None
+    plan_name: Optional[str] = None
+    subscription_count: int
+
+
+# Resolves forward reference in SubscriptionKPIs.
+SubscriptionKPIs.model_rebuild()

--- a/backend/app/services/admin_subscription_service.py
+++ b/backend/app/services/admin_subscription_service.py
@@ -36,6 +36,7 @@ from app.models.subscription import (
     SubscriptionStatus,
 )
 from app.models.user import Organization, User
+from app.services.admin_users_search_service import _normalize_like
 from app.services.exceptions import NotFoundError
 
 
@@ -122,12 +123,16 @@ async def list_subscriptions(
     if plan_filter:
         where_clauses.append(Plan.slug == plan_filter)
     if q:
-        pattern = f"%{q.strip()}%"
+        # Escape LIKE metacharacters so a raw query like ``%`` or ``_``
+        # can't widen the match. Reuses the helper from the cross-org
+        # user search (admin_users_search_service) to keep one source
+        # of truth for the escape rules.
+        pattern = f"%{_normalize_like(q.strip())}%"
         where_clauses.append(
             or_(
-                Organization.name.ilike(pattern),
-                Plan.slug.ilike(pattern),
-                Plan.name.ilike(pattern),
+                Organization.name.ilike(pattern, escape="\\"),
+                Plan.slug.ilike(pattern, escape="\\"),
+                Plan.name.ilike(pattern, escape="\\"),
             )
         )
 

--- a/backend/app/services/admin_subscription_service.py
+++ b/backend/app/services/admin_subscription_service.py
@@ -1,0 +1,392 @@
+"""Cross-org subscription read API (L4.5).
+
+Three concerns, kept out of the router for testability:
+
+- ``list_subscriptions`` — paginated table feed for ``/admin/subscriptions``.
+- ``get_subscription_detail`` — drill-down payload including org snapshot,
+  plan info and active feature overrides (from L4.11).
+- ``aggregate_revenue_kpis`` — pulse strip totals for the list header.
+
+This surface is **platform-scoped**, not org-scoped. The route gate is
+``subscriptions.view`` (superadmin short-circuits today; future
+non-superadmin roles via L4.8 can be assigned the permission without
+touching this file).
+
+Real payments aren't integrated yet (L2.2 is parked). Every dollar
+figure in the KPI envelope is mocked at ``$0`` and clearly flagged via
+the ``mock_revenue`` boolean so the FE can render the right
+disclosure. When L2 lands, the aggregator switches from mock-zero to
+real ``Stripe.Subscription``/``Paddle.Subscription`` totals without a
+schema change.
+"""
+from __future__ import annotations
+
+import datetime
+from typing import Any, Optional
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app._time import utcnow_naive
+from app.models.feature_override import OrgFeatureOverride
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization, User
+from app.services.exceptions import NotFoundError
+
+
+# How far ahead "trial expiring soon" looks. Locked at 7 days to match
+# the L4.5 spec; surface in the response so the FE can label the tile
+# without having to know the constant.
+TRIAL_EXPIRING_WINDOW_DAYS = 7
+# Lookback window for "new signups". Same as the L4.2 dashboard so the
+# tiles stay consistent across admin pages.
+SIGNUPS_LOOKBACK_DAYS = 7
+
+
+def _row_to_list_item(row: Any) -> dict[str, Any]:
+    """Map a flat result row from the list SELECT to the JSON shape.
+
+    The router calls ``SubscriptionListItem.model_validate`` on each
+    dict so any missing field surfaces as a 500 with a Pydantic
+    error rather than a silent shape drift.
+    """
+    return {
+        "subscription_id": row.subscription_id,
+        "org_id": row.org_id,
+        "org_name": row.org_name,
+        "plan_id": row.plan_id,
+        "plan_slug": row.plan_slug,
+        "plan_name": row.plan_name,
+        "status": row.status.value if hasattr(row.status, "value") else row.status,
+        "billing_interval": (
+            row.billing_interval.value
+            if hasattr(row.billing_interval, "value")
+            else row.billing_interval
+        ),
+        "trial_start": row.trial_start,
+        "trial_end": row.trial_end,
+        "current_period_start": row.current_period_start,
+        "current_period_end": row.current_period_end,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+
+async def list_subscriptions(
+    db: AsyncSession,
+    *,
+    status_filter: Optional[str] = None,
+    plan_filter: Optional[str] = None,
+    q: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Paginated, filterable list of every subscription on the platform.
+
+    Single SELECT with INNER JOINs to ``organizations`` and ``plans`` —
+    each subscription has a NOT NULL ``org_id`` and ``plan_id`` FK so
+    INNER JOIN is correct and lets the DB plan the filter pushdown.
+
+    Filters:
+
+    - ``status_filter``: one of the ``SubscriptionStatus`` values.
+      Unknown values are rejected at the route boundary (Literal) and
+      raise ``ValueError`` here defensively for direct service callers.
+    - ``plan_filter``: plan ``slug`` (string, exact match). Frontend
+      sources the slug from ``/api/v1/plans`` so typos are impossible.
+    - ``q``: ILIKE-style substring on ``Organization.name`` OR
+      ``Plan.slug``. Keeps a single search box useful regardless of
+      whether ops types an org name or a plan slug.
+
+    Pagination is offset-based to match ``/admin/orgs``; cursor-based
+    pagination is out of scope here and would require an index on
+    ``(created_at, id)`` to avoid the same drift the L4.3 review
+    closed.
+    """
+    where_clauses = []
+    if status_filter is not None:
+        # The Literal on the router rejects garbage; this is the
+        # defensive call-direct path.
+        try:
+            status_enum = SubscriptionStatus(status_filter)
+        except ValueError as exc:
+            raise ValueError(
+                f"Unknown subscription status: {status_filter!r}"
+            ) from exc
+        where_clauses.append(Subscription.status == status_enum)
+    if plan_filter:
+        where_clauses.append(Plan.slug == plan_filter)
+    if q:
+        pattern = f"%{q.strip()}%"
+        where_clauses.append(
+            or_(
+                Organization.name.ilike(pattern),
+                Plan.slug.ilike(pattern),
+                Plan.name.ilike(pattern),
+            )
+        )
+
+    base = (
+        select(
+            Subscription.id.label("subscription_id"),
+            Subscription.org_id.label("org_id"),
+            Organization.name.label("org_name"),
+            Subscription.plan_id.label("plan_id"),
+            Plan.slug.label("plan_slug"),
+            Plan.name.label("plan_name"),
+            Subscription.status,
+            Subscription.billing_interval,
+            Subscription.trial_start,
+            Subscription.trial_end,
+            Subscription.current_period_start,
+            Subscription.current_period_end,
+            Subscription.created_at,
+            Subscription.updated_at,
+        )
+        .select_from(Subscription)
+        .join(Organization, Organization.id == Subscription.org_id)
+        .join(Plan, Plan.id == Subscription.plan_id)
+    )
+    count_q = (
+        select(func.count())
+        .select_from(Subscription)
+        .join(Organization, Organization.id == Subscription.org_id)
+        .join(Plan, Plan.id == Subscription.plan_id)
+    )
+    for clause in where_clauses:
+        base = base.where(clause)
+        count_q = count_q.where(clause)
+
+    total = (await db.execute(count_q)).scalar_one()
+    rows = (
+        await db.execute(
+            base.order_by(Subscription.created_at.desc(), Subscription.id.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+    ).all()
+
+    return {
+        "items": [_row_to_list_item(r) for r in rows],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def _plan_to_dict(plan: Plan) -> dict[str, Any]:
+    return {
+        "id": plan.id,
+        "slug": plan.slug,
+        "name": plan.name,
+        "description": plan.description or "",
+        # Decimal → str — pydantic v2 doesn't auto-stringify Decimal and
+        # the FE convention is "money as string" (see
+        # project_decimal_typing_debt.md).
+        "price_monthly": str(plan.price_monthly),
+        "price_yearly": str(plan.price_yearly),
+        "max_users": plan.max_users,
+        "retention_days": plan.retention_days,
+        "features": plan.features or {},
+        "is_custom": plan.is_custom,
+        "is_active": plan.is_active,
+    }
+
+
+async def get_subscription_detail(
+    db: AsyncSession, *, subscription_id: int
+) -> dict[str, Any]:
+    """Drill-down payload for ``/admin/subscriptions/[id]``.
+
+    Returns the subscription row, the linked org (with a member count),
+    the plan, and the org's active feature overrides (from L4.11) so
+    the admin can see at a glance whether the org has any extra
+    capabilities beyond the plan.
+
+    The ``feature_overrides`` list is read-only here. Grant / revoke
+    flow still lives on ``/admin/orgs/[id]`` (PR #109) — L4.5 does not
+    duplicate that mutation surface.
+    """
+    sub = (
+        await db.execute(
+            select(Subscription).where(Subscription.id == subscription_id)
+        )
+    ).scalar_one_or_none()
+    if sub is None:
+        raise NotFoundError("Subscription")
+
+    org = (
+        await db.execute(
+            select(Organization).where(Organization.id == sub.org_id)
+        )
+    ).scalar_one_or_none()
+    if org is None:
+        # Should be impossible (FK NOT NULL), but guard so the
+        # response shape stays sane for direct DB tampering scenarios.
+        raise NotFoundError("Organization for subscription")
+
+    plan = (
+        await db.execute(select(Plan).where(Plan.id == sub.plan_id))
+    ).scalar_one_or_none()
+
+    member_count = await db.scalar(
+        select(func.count()).select_from(User).where(User.org_id == org.id)
+    ) or 0
+
+    override_rows = (
+        await db.execute(
+            select(OrgFeatureOverride)
+            .where(OrgFeatureOverride.org_id == org.id)
+            .order_by(OrgFeatureOverride.feature_key.asc())
+        )
+    ).scalars().all()
+
+    now = utcnow_naive()
+    overrides: list[dict[str, Any]] = []
+    for row in override_rows:
+        is_expired = row.expires_at is not None and row.expires_at <= now
+        overrides.append(
+            {
+                "feature_key": row.feature_key,
+                "value": bool(row.value),
+                "set_at": row.set_at,
+                "expires_at": row.expires_at,
+                "is_expired": is_expired,
+                "note": row.note,
+            }
+        )
+
+    return {
+        "subscription_id": sub.id,
+        "org": {
+            "id": org.id,
+            "name": org.name,
+            "billing_cycle_day": org.billing_cycle_day,
+            "created_at": org.created_at,
+            "member_count": int(member_count),
+        },
+        "plan": _plan_to_dict(plan) if plan is not None else None,
+        "status": sub.status.value,
+        "billing_interval": sub.billing_interval.value,
+        "trial_start": sub.trial_start,
+        "trial_end": sub.trial_end,
+        "current_period_start": sub.current_period_start,
+        "current_period_end": sub.current_period_end,
+        "created_at": sub.created_at,
+        "updated_at": sub.updated_at,
+        "feature_overrides": overrides,
+        "mock_revenue_amount": "0.00",
+        "mock_revenue": True,
+    }
+
+
+async def aggregate_revenue_kpis(
+    db: AsyncSession,
+    *,
+    now: Optional[datetime.datetime] = None,
+) -> dict[str, Any]:
+    """Pulse-strip totals for the ``/admin/subscriptions`` header.
+
+    Six counts plus a per-plan distribution. Computed sequentially on
+    the request session — SQLAlchemy's ``AsyncSession`` is not safe for
+    concurrent use across tasks (same constraint that drives
+    ``admin_dashboard_service`` to serialise its KPI reads).
+
+    ``mock_mrr`` and ``mock_arr`` are hard-pinned to ``"0.00"`` until
+    L2.2 wires real billing. ``mock_revenue`` stays ``True`` so the FE
+    keeps surfacing the disclosure even after a typo or test-fixture
+    that accidentally returns a non-zero string here.
+    """
+    base_now = now or datetime.datetime.now(datetime.timezone.utc)
+    # Strip tzinfo to align with ``DateTime`` columns in the schema,
+    # which are stored TZ-naive (UTC by convention — see ``app/_time.py``).
+    naive_now = base_now.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+    today = naive_now.date()
+    signups_cutoff = naive_now - datetime.timedelta(days=SIGNUPS_LOOKBACK_DAYS)
+    trial_window_end = today + datetime.timedelta(days=TRIAL_EXPIRING_WINDOW_DAYS)
+
+    total_subs = await db.scalar(
+        select(func.count()).select_from(Subscription)
+    ) or 0
+    active = await db.scalar(
+        select(func.count())
+        .select_from(Subscription)
+        .where(Subscription.status == SubscriptionStatus.ACTIVE)
+    ) or 0
+    trial = await db.scalar(
+        select(func.count())
+        .select_from(Subscription)
+        .where(Subscription.status == SubscriptionStatus.TRIALING)
+    ) or 0
+    past_due = await db.scalar(
+        select(func.count())
+        .select_from(Subscription)
+        .where(Subscription.status == SubscriptionStatus.PAST_DUE)
+    ) or 0
+    cancelled = await db.scalar(
+        select(func.count())
+        .select_from(Subscription)
+        .where(Subscription.status == SubscriptionStatus.CANCELED)
+    ) or 0
+    signups_7d = await db.scalar(
+        select(func.count())
+        .select_from(Subscription)
+        .where(Subscription.created_at >= signups_cutoff)
+    ) or 0
+    # Trials expiring in the next 7 days: trial_end in [today, today+7]
+    # AND status is still TRIALING (cancelled trials don't count).
+    trial_expiring = await db.scalar(
+        select(func.count())
+        .select_from(Subscription)
+        .where(Subscription.status == SubscriptionStatus.TRIALING)
+        .where(Subscription.trial_end.is_not(None))
+        .where(Subscription.trial_end >= today)
+        .where(Subscription.trial_end <= trial_window_end)
+    ) or 0
+
+    # Plan distribution — LEFT JOIN so every (currently active) plan
+    # appears even with zero subscriptions. Tie-break by slug so the
+    # order is deterministic in tests.
+    dist_rows = (
+        await db.execute(
+            select(
+                Plan.id,
+                Plan.slug,
+                Plan.name,
+                func.count(Subscription.id).label("subs"),
+            )
+            .select_from(Plan)
+            .outerjoin(Subscription, Subscription.plan_id == Plan.id)
+            .group_by(Plan.id, Plan.slug, Plan.name)
+            .order_by(func.count(Subscription.id).desc(), Plan.slug.asc())
+        )
+    ).all()
+    plan_distribution = [
+        {
+            "plan_id": r.id,
+            "plan_slug": r.slug,
+            "plan_name": r.name,
+            "subscription_count": int(r.subs or 0),
+        }
+        for r in dist_rows
+    ]
+
+    return {
+        "total_subscriptions": int(total_subs),
+        "active": int(active),
+        "trial": int(trial),
+        "past_due": int(past_due),
+        "cancelled": int(cancelled),
+        "signups_last_7d": int(signups_7d),
+        "trial_expiring_next_7d": int(trial_expiring),
+        "plan_distribution": plan_distribution,
+        "mock_mrr": "0.00",
+        "mock_arr": "0.00",
+        "mock_revenue": True,
+        "generated_at": naive_now,
+    }

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -54,6 +54,7 @@ def test_all_permissions_contains_known_platform_permissions() -> None:
         "roles.manage",
         "analytics.view",
         "users.view",
+        "subscriptions.view",
     })
 
 

--- a/backend/tests/routers/test_admin_subscriptions.py
+++ b/backend/tests/routers/test_admin_subscriptions.py
@@ -313,9 +313,66 @@ async def test_detail_emits_durable_audit_with_target_org(session_factory):
         assert res.status_code == 200
         assert record.await_count == 1
         kwargs = record.await_args.kwargs
+        # Detail uses a distinct event type from list so the throttle
+        # doesn't suppress this row when an admin drills in within 60s
+        # of viewing the list.
+        assert kwargs["event_type"] == "admin.subscriptions.detail.viewed"
         assert kwargs["target_org_id"] == seeded["target_org_id"]
         assert kwargs["target_org_name"] == "Target Inc"
         assert kwargs["detail"]["view"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_list_audit_detail_does_not_leak_raw_query(session_factory):
+    """Privacy pin: ``q`` is NEVER stored in the durable audit detail.
+    Only ``query_length`` / ``has_query`` should be present. Mirrors
+    the admin_users.py contract."""
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    raw_q = "secret-search-string"
+    with patch(
+        "app.routers.admin_subscriptions._should_persist_audit",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "app.routers.admin_subscriptions.audit_service.record_audit_event",
+        new=AsyncMock(),
+    ) as record:
+        with TestClient(app) as client:
+            res = client.get(f"/api/v1/admin/subscriptions?q={raw_q}")
+        assert res.status_code == 200
+        kwargs = record.await_args.kwargs
+        filters = kwargs["detail"]["filters"]
+        assert "q" not in filters
+        assert filters["query_length"] == len(raw_q)
+        assert filters["has_query"] is True
+
+
+@pytest.mark.asyncio
+async def test_detail_audit_not_suppressed_after_recent_list_view(session_factory):
+    """The throttle is keyed on (event_type, actor); list and detail
+    use different event types, so a recent list view must not suppress
+    the detail audit row. We simulate by returning True for both calls
+    (the real throttle would, since the keys differ)."""
+    seeded = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with patch(
+        "app.routers.admin_subscriptions._should_persist_audit",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "app.routers.admin_subscriptions.audit_service.record_audit_event",
+        new=AsyncMock(),
+    ) as record:
+        with TestClient(app) as client:
+            assert client.get("/api/v1/admin/subscriptions").status_code == 200
+            assert client.get(
+                f"/api/v1/admin/subscriptions/{seeded['target_sub_id']}"
+            ).status_code == 200
+        assert record.await_count == 2
+        event_types = [c.kwargs["event_type"] for c in record.await_args_list]
+        assert event_types == [
+            "admin.subscriptions.viewed",
+            "admin.subscriptions.detail.viewed",
+        ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_admin_subscriptions.py
+++ b/backend/tests/routers/test_admin_subscriptions.py
@@ -1,0 +1,341 @@
+"""Router tests for L4.5 admin subscriptions endpoints.
+
+Pins:
+
+- Auth gate (``subscriptions.view`` → superadmin short-circuits;
+  non-superadmin → 403).
+- Envelope shapes for list / detail / kpis.
+- ``mock_revenue`` flag is True (until L2 wires real billing).
+- Audit row is written via ``audit_service.record_audit_event``
+  on a list / detail hit (throttle fails open in tests).
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization, Role, User
+from app.routers.admin_subscriptions import router as admin_subscriptions_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(admin_subscriptions_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """One superadmin org + one target org, both with subscriptions."""
+    async with factory() as db:
+        free = Plan(
+            slug="free", name="Free", description="",
+            price_monthly=Decimal("0.00"), price_yearly=Decimal("0.00"),
+        )
+        pro = Plan(
+            slug="pro", name="Pro", description="",
+            price_monthly=Decimal("9.99"), price_yearly=Decimal("99.00"),
+        )
+        db.add_all([free, pro])
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target = Organization(name="Target Inc", billing_cycle_day=1)
+        db.add_all([admin_org, target])
+        await db.commit()
+        sa = User(
+            org_id=admin_org.id, username="root",
+            email="root@platform.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=target.id, username="member",
+            email="m@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, plain])
+        await db.commit()
+        admin_sub = Subscription(
+            org_id=admin_org.id, plan_id=free.id,
+            status=SubscriptionStatus.ACTIVE,
+            billing_interval=BillingInterval.MONTHLY,
+        )
+        target_sub = Subscription(
+            org_id=target.id, plan_id=pro.id,
+            status=SubscriptionStatus.TRIALING,
+            billing_interval=BillingInterval.MONTHLY,
+            trial_end=datetime.date.today() + datetime.timedelta(days=10),
+        )
+        db.add_all([admin_sub, target_sub])
+        await db.commit()
+        return {
+            "target_sub_id": target_sub.id,
+            "admin_sub_id": admin_sub.id,
+            "target_org_id": target.id,
+        }
+
+
+def _superadmin_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+    return resolve
+
+
+def _plain_user_resolver():
+    async def resolve(session_factory):
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(False)))
+            ).scalar_one()
+    return resolve
+
+
+# ── auth gates ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_403_for_non_superadmin(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/subscriptions")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_detail_403_for_non_superadmin(session_factory):
+    seeded = await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            f"/api/v1/admin/subscriptions/{seeded['target_sub_id']}"
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_kpis_403_for_non_superadmin(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _plain_user_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/subscriptions/kpis")
+    assert res.status_code == 403
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_returns_envelope_for_superadmin(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/subscriptions")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 2
+    org_names = {row["org_name"] for row in body["items"]}
+    assert org_names == {"Admin Org", "Target Inc"}
+
+
+@pytest.mark.asyncio
+async def test_list_status_filter_via_query(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/subscriptions?status=trialing")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 1
+    assert body["items"][0]["status"] == "trialing"
+
+
+@pytest.mark.asyncio
+async def test_list_rejects_unknown_status_with_422(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/subscriptions?status=bogus")
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_detail_returns_full_envelope(session_factory):
+    seeded = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get(
+            f"/api/v1/admin/subscriptions/{seeded['target_sub_id']}"
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["subscription_id"] == seeded["target_sub_id"]
+    assert body["org"]["name"] == "Target Inc"
+    assert body["plan"]["slug"] == "pro"
+    assert body["mock_revenue"] is True
+    assert body["mock_revenue_amount"] == "0.00"
+
+
+@pytest.mark.asyncio
+async def test_detail_404_for_unknown_subscription(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/subscriptions/99999")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_kpis_returns_counts_and_mock_flag(session_factory):
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.get("/api/v1/admin/subscriptions/kpis")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total_subscriptions"] == 2
+    assert body["active"] == 1
+    assert body["trial"] == 1
+    assert body["mock_revenue"] is True
+    assert body["mock_mrr"] == "0.00"
+
+
+# ── audit wiring ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_emits_durable_audit_row_when_unthrottled(session_factory):
+    """When the throttle returns True (first hit in the window), the
+    list endpoint writes a durable audit row via
+    ``audit_service.record_audit_event``."""
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with patch(
+        "app.routers.admin_subscriptions._should_persist_audit",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "app.routers.admin_subscriptions.audit_service.record_audit_event",
+        new=AsyncMock(),
+    ) as record:
+        with TestClient(app) as client:
+            res = client.get("/api/v1/admin/subscriptions")
+        assert res.status_code == 200
+        assert record.await_count == 1
+        kwargs = record.await_args.kwargs
+        assert kwargs["event_type"] == "admin.subscriptions.viewed"
+        assert kwargs["outcome"] == "success"
+        assert kwargs["detail"]["view"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_detail_emits_durable_audit_with_target_org(session_factory):
+    seeded = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with patch(
+        "app.routers.admin_subscriptions._should_persist_audit",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "app.routers.admin_subscriptions.audit_service.record_audit_event",
+        new=AsyncMock(),
+    ) as record:
+        with TestClient(app) as client:
+            res = client.get(
+                f"/api/v1/admin/subscriptions/{seeded['target_sub_id']}"
+            )
+        assert res.status_code == 200
+        assert record.await_count == 1
+        kwargs = record.await_args.kwargs
+        assert kwargs["target_org_id"] == seeded["target_org_id"]
+        assert kwargs["target_org_name"] == "Target Inc"
+        assert kwargs["detail"]["view"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_audit_throttle_skips_durable_row_when_redis_says_no(session_factory):
+    """When the throttle helper returns False (Redis SET NX failed
+    because the key was already set inside the 60s window), the
+    durable audit row is skipped — structlog event still fires
+    elsewhere as the fallback channel."""
+    await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with patch(
+        "app.routers.admin_subscriptions._should_persist_audit",
+        new=AsyncMock(return_value=False),
+    ), patch(
+        "app.routers.admin_subscriptions.audit_service.record_audit_event",
+        new=AsyncMock(),
+    ) as record:
+        with TestClient(app) as client:
+            res = client.get("/api/v1/admin/subscriptions")
+            assert res.status_code == 200
+            res2 = client.get("/api/v1/admin/subscriptions")
+            assert res2.status_code == 200
+        assert record.await_count == 0

--- a/backend/tests/services/test_admin_subscription_service.py
+++ b/backend/tests/services/test_admin_subscription_service.py
@@ -1,0 +1,352 @@
+"""Service-layer tests for L4.5 admin_subscription_service.
+
+Pins:
+
+- ``list_subscriptions`` paginates, filters by status / plan / query
+  and joins org + plan names into the row shape.
+- ``get_subscription_detail`` returns the full envelope including
+  read-only feature-override snapshots from L4.11.
+- ``aggregate_revenue_kpis`` emits the seven counts and the plan
+  distribution; ``mock_revenue`` flag is always True and dollar
+  figures are mock zeros until L2.2 wires real billing.
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app._time import utcnow_naive
+from app.models import Base
+from app.models.feature_override import OrgFeatureOverride
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import admin_subscription_service
+from app.services.exceptions import NotFoundError
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_plans(db: AsyncSession) -> dict[str, Plan]:
+    free = Plan(
+        slug="free", name="Free", description="",
+        price_monthly=Decimal("0.00"), price_yearly=Decimal("0.00"),
+    )
+    pro = Plan(
+        slug="pro", name="Pro", description="",
+        price_monthly=Decimal("9.99"), price_yearly=Decimal("99.00"),
+    )
+    db.add_all([free, pro])
+    await db.commit()
+    await db.refresh(free)
+    await db.refresh(pro)
+    return {"free": free, "pro": pro}
+
+
+async def _seed_org(db: AsyncSession, name: str) -> Organization:
+    org = Organization(name=name, billing_cycle_day=1)
+    db.add(org)
+    await db.commit()
+    await db.refresh(org)
+    return org
+
+
+async def _seed_sub(
+    db: AsyncSession,
+    *,
+    org: Organization,
+    plan: Plan,
+    status: SubscriptionStatus,
+    trial_end: datetime.date | None = None,
+) -> Subscription:
+    sub = Subscription(
+        org_id=org.id,
+        plan_id=plan.id,
+        status=status,
+        billing_interval=BillingInterval.MONTHLY,
+        trial_end=trial_end,
+    )
+    db.add(sub)
+    await db.commit()
+    await db.refresh(sub)
+    return sub
+
+
+# ── list_subscriptions ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_returns_joined_org_and_plan(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    acme = await _seed_org(db_session, "Acme")
+    await _seed_sub(
+        db_session, org=acme, plan=plans["pro"],
+        status=SubscriptionStatus.ACTIVE,
+    )
+
+    out = await admin_subscription_service.list_subscriptions(db_session)
+    assert out["total"] == 1
+    item = out["items"][0]
+    assert item["org_name"] == "Acme"
+    assert item["plan_slug"] == "pro"
+    assert item["plan_name"] == "Pro"
+    assert item["status"] == "active"
+    assert item["billing_interval"] == "monthly"
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_status(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    a = await _seed_org(db_session, "A")
+    b = await _seed_org(db_session, "B")
+    await _seed_sub(db_session, org=a, plan=plans["pro"], status=SubscriptionStatus.ACTIVE)
+    await _seed_sub(db_session, org=b, plan=plans["pro"], status=SubscriptionStatus.TRIALING)
+
+    only_trial = await admin_subscription_service.list_subscriptions(
+        db_session, status_filter="trialing"
+    )
+    assert only_trial["total"] == 1
+    assert only_trial["items"][0]["org_name"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_plan(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    a = await _seed_org(db_session, "A")
+    b = await _seed_org(db_session, "B")
+    await _seed_sub(db_session, org=a, plan=plans["free"], status=SubscriptionStatus.ACTIVE)
+    await _seed_sub(db_session, org=b, plan=plans["pro"], status=SubscriptionStatus.ACTIVE)
+
+    only_pro = await admin_subscription_service.list_subscriptions(
+        db_session, plan_filter="pro"
+    )
+    assert only_pro["total"] == 1
+    assert only_pro["items"][0]["plan_slug"] == "pro"
+
+
+@pytest.mark.asyncio
+async def test_list_search_matches_org_name(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    a = await _seed_org(db_session, "Acme Co")
+    b = await _seed_org(db_session, "Globex Corp")
+    await _seed_sub(db_session, org=a, plan=plans["free"], status=SubscriptionStatus.ACTIVE)
+    await _seed_sub(db_session, org=b, plan=plans["free"], status=SubscriptionStatus.ACTIVE)
+
+    hits = await admin_subscription_service.list_subscriptions(db_session, q="globex")
+    assert hits["total"] == 1
+    assert hits["items"][0]["org_name"] == "Globex Corp"
+
+
+@pytest.mark.asyncio
+async def test_list_pagination(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    for i in range(5):
+        org = await _seed_org(db_session, f"Org{i}")
+        await _seed_sub(
+            db_session, org=org, plan=plans["free"], status=SubscriptionStatus.ACTIVE
+        )
+
+    page1 = await admin_subscription_service.list_subscriptions(
+        db_session, limit=2, offset=0
+    )
+    page2 = await admin_subscription_service.list_subscriptions(
+        db_session, limit=2, offset=2
+    )
+    assert page1["total"] == 5
+    assert len(page1["items"]) == 2
+    assert len(page2["items"]) == 2
+    # Newest-first ordering: page1 should have higher subscription_ids
+    # than page2.
+    assert page1["items"][0]["subscription_id"] > page2["items"][0]["subscription_id"]
+
+
+@pytest.mark.asyncio
+async def test_list_invalid_status_raises_for_direct_callers(db_session: AsyncSession):
+    """Router-level Literal rejects unknown values with 422; direct
+    service callers (and tests) get a ValueError."""
+    with pytest.raises(ValueError, match="Unknown subscription status"):
+        await admin_subscription_service.list_subscriptions(
+            db_session, status_filter="bogus"
+        )
+
+
+# ── get_subscription_detail ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detail_includes_org_plan_and_member_count(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    org = await _seed_org(db_session, "Acme")
+    db_session.add_all([
+        User(
+            org_id=org.id, username=f"u{i}", email=f"u{i}@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_active=True, email_verified=True,
+        )
+        for i in range(3)
+    ])
+    await db_session.commit()
+    sub = await _seed_sub(
+        db_session, org=org, plan=plans["pro"],
+        status=SubscriptionStatus.ACTIVE,
+    )
+
+    detail = await admin_subscription_service.get_subscription_detail(
+        db_session, subscription_id=sub.id
+    )
+    assert detail["subscription_id"] == sub.id
+    assert detail["org"]["name"] == "Acme"
+    assert detail["org"]["member_count"] == 3
+    assert detail["plan"]["slug"] == "pro"
+    assert detail["mock_revenue"] is True
+    assert detail["mock_revenue_amount"] == "0.00"
+    assert detail["feature_overrides"] == []
+
+
+@pytest.mark.asyncio
+async def test_detail_includes_feature_overrides(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    org = await _seed_org(db_session, "Acme")
+    sub = await _seed_sub(
+        db_session, org=org, plan=plans["pro"],
+        status=SubscriptionStatus.ACTIVE,
+    )
+    now = utcnow_naive()
+    db_session.add_all([
+        OrgFeatureOverride(
+            org_id=org.id, feature_key="ai.budget", value=True,
+            set_by=None, set_at=now,
+            expires_at=None, note="comped",
+        ),
+        OrgFeatureOverride(
+            org_id=org.id, feature_key="ai.forecast", value=True,
+            set_by=None, set_at=now,
+            expires_at=now - datetime.timedelta(days=1),  # expired
+            note="trial expired",
+        ),
+    ])
+    await db_session.commit()
+
+    detail = await admin_subscription_service.get_subscription_detail(
+        db_session, subscription_id=sub.id
+    )
+    overrides = {o["feature_key"]: o for o in detail["feature_overrides"]}
+    assert overrides["ai.budget"]["is_expired"] is False
+    assert overrides["ai.forecast"]["is_expired"] is True
+
+
+@pytest.mark.asyncio
+async def test_detail_404_when_missing(db_session: AsyncSession):
+    with pytest.raises(NotFoundError):
+        await admin_subscription_service.get_subscription_detail(
+            db_session, subscription_id=999
+        )
+
+
+# ── aggregate_revenue_kpis ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kpis_counts_by_status(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    today = datetime.date.today()
+
+    # 2 active, 1 trialing (expiring in 3 days), 1 past_due, 1 cancelled.
+    for status_, trial_end in [
+        (SubscriptionStatus.ACTIVE, None),
+        (SubscriptionStatus.ACTIVE, None),
+        (SubscriptionStatus.TRIALING, today + datetime.timedelta(days=3)),
+        (SubscriptionStatus.PAST_DUE, None),
+        (SubscriptionStatus.CANCELED, None),
+    ]:
+        org = await _seed_org(db_session, f"O-{status_.value}-{trial_end}")
+        await _seed_sub(
+            db_session, org=org, plan=plans["pro"], status=status_, trial_end=trial_end
+        )
+
+    kpis = await admin_subscription_service.aggregate_revenue_kpis(db_session)
+    assert kpis["total_subscriptions"] == 5
+    assert kpis["active"] == 2
+    assert kpis["trial"] == 1
+    assert kpis["past_due"] == 1
+    assert kpis["cancelled"] == 1
+    assert kpis["trial_expiring_next_7d"] == 1
+    assert kpis["mock_revenue"] is True
+    assert kpis["mock_mrr"] == "0.00"
+    assert kpis["mock_arr"] == "0.00"
+
+
+@pytest.mark.asyncio
+async def test_kpis_plan_distribution_includes_zero_plans(db_session: AsyncSession):
+    """A plan with zero subscriptions still appears in the distribution
+    so the FE can render empty rows without re-mapping the canonical
+    plan list."""
+    plans = await _seed_plans(db_session)
+    a = await _seed_org(db_session, "A")
+    await _seed_sub(
+        db_session, org=a, plan=plans["pro"], status=SubscriptionStatus.ACTIVE,
+    )
+
+    kpis = await admin_subscription_service.aggregate_revenue_kpis(db_session)
+    dist = {d["plan_slug"]: d for d in kpis["plan_distribution"]}
+    assert dist["pro"]["subscription_count"] == 1
+    assert dist["free"]["subscription_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_kpis_trial_expiring_excludes_already_expired(db_session: AsyncSession):
+    plans = await _seed_plans(db_session)
+    today = datetime.date.today()
+    a = await _seed_org(db_session, "A")
+    b = await _seed_org(db_session, "B")
+    # Past trial end: NOT counted.
+    await _seed_sub(
+        db_session, org=a, plan=plans["pro"],
+        status=SubscriptionStatus.TRIALING,
+        trial_end=today - datetime.timedelta(days=1),
+    )
+    # Future-within-window: counted.
+    await _seed_sub(
+        db_session, org=b, plan=plans["pro"],
+        status=SubscriptionStatus.TRIALING,
+        trial_end=today + datetime.timedelta(days=5),
+    )
+    kpis = await admin_subscription_service.aggregate_revenue_kpis(db_session)
+    assert kpis["trial_expiring_next_7d"] == 1

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -8,6 +8,7 @@ import {
   Building2,
   CheckCircle2,
   ChevronRight,
+  CreditCard,
   ScrollText,
   ShieldCheck,
   XCircle,
@@ -77,6 +78,14 @@ const ADMIN_TILES: readonly AdminTile[] = [
     description: "Manage platform roles and the permissions they grant.",
     permission: "roles.manage",
     Icon: ShieldCheck,
+  },
+  {
+    href: "/admin/subscriptions",
+    title: "Subscriptions",
+    description:
+      "Every subscription across the platform, filterable by status and plan. Revenue figures are mock until payments go live.",
+    permission: "subscriptions.view",
+    Icon: CreditCard,
   },
 ];
 

--- a/frontend/app/admin/subscriptions/[id]/page.tsx
+++ b/frontend/app/admin/subscriptions/[id]/page.tsx
@@ -181,7 +181,7 @@ export default function AdminSubscriptionDetailPage() {
       <p className="mb-6 text-sm text-text-muted">
         Read-only view. To change the plan, status, trial end, or grant
         feature overrides, use the org page linked above. Revenue figures
-        are mock ($0 — payments not live).
+        are mock ($0, payments not live).
       </p>
 
       {error && (

--- a/frontend/app/admin/subscriptions/[id]/page.tsx
+++ b/frontend/app/admin/subscriptions/[id]/page.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { hasPlatformPermission } from "@/lib/auth";
+import {
+  badgeBase,
+  btnSecondary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  pageTitle,
+} from "@/lib/styles";
+import type {
+  AdminFeatureOverrideSnapshot,
+  AdminSubscriptionDetail,
+  SubscriptionStatus,
+} from "@/lib/types";
+
+function StatusBadge({ status }: { status: SubscriptionStatus }) {
+  // Same mapping as the list page. Re-declared rather than imported
+  // so the detail page stays self-contained — the list page may
+  // evolve its badge into a richer affordance independently.
+  const toneClass =
+    status === "active"
+      ? "bg-success-dim text-success"
+      : status === "trialing"
+        ? "bg-info-dim text-info"
+        : status === "past_due"
+          ? "bg-warning-dim text-warning"
+          : "bg-surface-raised text-text-secondary";
+  return (
+    <span className={`${badgeBase} ${toneClass}`}>
+      {status === "past_due" ? "past due" : status}
+    </span>
+  );
+}
+
+function MockBadge() {
+  return (
+    <span
+      className="ml-1 rounded-sm bg-warning-dim px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-warning"
+      title="Payments are not live yet. Revenue figures are mocked until L2 ships."
+    >
+      mock
+    </span>
+  );
+}
+
+function FieldRow({
+  label,
+  value,
+}: {
+  label: React.ReactNode;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 border-b border-border-subtle py-3 last:border-0">
+      <dt className="text-xs uppercase tracking-wider text-text-muted">
+        {label}
+      </dt>
+      <dd className="text-sm text-text-primary text-right">{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+function FeatureOverrideRow({ row }: { row: AdminFeatureOverrideSnapshot }) {
+  const valueClass = row.value
+    ? "bg-success-dim text-success"
+    : "bg-surface-raised text-text-secondary";
+  return (
+    <li className="flex items-center justify-between gap-3 border-b border-border-subtle py-3 last:border-0">
+      <div className="min-w-0">
+        <p className="font-mono text-sm text-text-primary">{row.feature_key}</p>
+        {row.note && (
+          <p className="mt-1 text-xs text-text-muted">{row.note}</p>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <span className={`${badgeBase} ${valueClass}`}>
+          {row.value ? "granted" : "revoked"}
+        </span>
+        {row.is_expired && (
+          <span
+            className={`${badgeBase} bg-warning-dim text-warning`}
+            title={
+              row.expires_at
+                ? `Expired ${row.expires_at}`
+                : "Expired"
+            }
+          >
+            expired
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export default function AdminSubscriptionDetailPage() {
+  const params = useParams();
+  const subscriptionId = Number(params?.id);
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [detail, setDetail] = useState<AdminSubscriptionDetail | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!hasPlatformPermission(user, "subscriptions.view")) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (
+      loading ||
+      !user ||
+      !hasPlatformPermission(user, "subscriptions.view") ||
+      !subscriptionId
+    ) {
+      return;
+    }
+    apiFetch<AdminSubscriptionDetail>(
+      `/api/v1/admin/subscriptions/${subscriptionId}`,
+    )
+      .then((d) => setDetail(d))
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")));
+  }, [loading, user, subscriptionId]);
+
+  if (loading || !user || !hasPlatformPermission(user, "subscriptions.view")) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <Link
+            href="/admin/subscriptions"
+            className="mb-2 inline-block text-xs text-text-muted hover:text-accent"
+          >
+            ← All subscriptions
+          </Link>
+          <div className="flex items-start gap-1">
+            <h1 className={`${pageTitle} mb-0`}>
+              {detail ? detail.org.name : "Subscription"}
+            </h1>
+            <HelpAnchor
+              section="admin"
+              label="Subscription detail"
+              variant="inline-title"
+            />
+          </div>
+        </div>
+        {detail && (
+          <Link
+            href={`/admin/orgs/${detail.org.id}`}
+            className={btnSecondary}
+          >
+            Override subscription
+          </Link>
+        )}
+      </div>
+
+      <p className="mb-6 text-sm text-text-muted">
+        Read-only view. To change the plan, status, trial end, or grant
+        feature overrides, use the org page linked above. Revenue figures
+        are mock ($0 — payments not live).
+      </p>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      {!detail && !error && (
+        <div className="flex min-h-[200px] items-center justify-center">
+          <Spinner />
+        </div>
+      )}
+
+      {detail && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <section className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Subscription</h2>
+            </div>
+            <dl className="px-6">
+              <FieldRow
+                label="Status"
+                value={<StatusBadge status={detail.status} />}
+              />
+              <FieldRow
+                label="Billing interval"
+                value={detail.billing_interval}
+              />
+              <FieldRow label="Trial start" value={detail.trial_start} />
+              <FieldRow label="Trial end" value={detail.trial_end} />
+              <FieldRow
+                label="Current period start"
+                value={detail.current_period_start}
+              />
+              <FieldRow
+                label="Current period end"
+                value={detail.current_period_end}
+              />
+              <FieldRow
+                label="Created"
+                value={detail.created_at?.slice(0, 10)}
+              />
+              <FieldRow
+                label={
+                  <span>
+                    Revenue
+                    <MockBadge />
+                  </span>
+                }
+                value={`$${detail.mock_revenue_amount}`}
+              />
+            </dl>
+          </section>
+
+          <section className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Organization</h2>
+            </div>
+            <dl className="px-6">
+              <FieldRow label="Name" value={detail.org.name} />
+              <FieldRow
+                label="Billing cycle day"
+                value={detail.org.billing_cycle_day}
+              />
+              <FieldRow label="Members" value={detail.org.member_count} />
+              <FieldRow
+                label="Created"
+                value={detail.org.created_at?.slice(0, 10) ?? null}
+              />
+              <FieldRow
+                label="Manage"
+                value={
+                  <Link
+                    href={`/admin/orgs/${detail.org.id}`}
+                    className="text-accent hover:text-accent-hover"
+                  >
+                    Open org →
+                  </Link>
+                }
+              />
+            </dl>
+          </section>
+
+          {detail.plan && (
+            <section className={card}>
+              <div className={cardHeader}>
+                <h2 className={cardTitle}>Plan</h2>
+              </div>
+              <dl className="px-6">
+                <FieldRow label="Name" value={detail.plan.name} />
+                <FieldRow label="Slug" value={detail.plan.slug} />
+                <FieldRow
+                  label="Price (monthly)"
+                  value={`$${detail.plan.price_monthly}`}
+                />
+                <FieldRow
+                  label="Price (yearly)"
+                  value={`$${detail.plan.price_yearly}`}
+                />
+                <FieldRow
+                  label="Max users"
+                  value={detail.plan.max_users ?? "unlimited"}
+                />
+                <FieldRow
+                  label="Retention"
+                  value={
+                    detail.plan.retention_days !== null
+                      ? `${detail.plan.retention_days} days`
+                      : "unlimited"
+                  }
+                />
+                <FieldRow
+                  label="Custom plan"
+                  value={detail.plan.is_custom ? "yes" : "no"}
+                />
+              </dl>
+            </section>
+          )}
+
+          <section className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Feature overrides</h2>
+            </div>
+            {detail.feature_overrides.length === 0 ? (
+              <p className="px-6 py-8 text-center text-sm text-text-muted">
+                No overrides on this org.
+              </p>
+            ) : (
+              <ul className="px-6 py-2">
+                {detail.feature_overrides.map((o) => (
+                  <FeatureOverrideRow key={o.feature_key} row={o} />
+                ))}
+              </ul>
+            )}
+            <p className="border-t border-border-subtle px-6 py-3 text-xs text-text-muted">
+              Grant or revoke overrides from the{" "}
+              <Link
+                href={`/admin/orgs/${detail.org.id}`}
+                className="text-accent hover:text-accent-hover"
+              >
+                org page
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/app/admin/subscriptions/page.tsx
+++ b/frontend/app/admin/subscriptions/page.tsx
@@ -102,13 +102,13 @@ function KpiStrip({ kpis }: { kpis: AdminSubscriptionKPIs }) {
       label: "MRR",
       value: `$${kpis.mock_mrr}`,
       isMock: true,
-      hint: "Mock — real payments not integrated yet (L2.2 parked)",
+      hint: "Mock, real payments not integrated yet (L2.2 parked)",
     },
     {
       label: "ARR",
       value: `$${kpis.mock_arr}`,
       isMock: true,
-      hint: "Mock — real payments not integrated yet (L2.2 parked)",
+      hint: "Mock, real payments not integrated yet (L2.2 parked)",
     },
   ];
   return (
@@ -261,7 +261,7 @@ export default function AdminSubscriptionsPage() {
 
       <p className="mb-4 text-sm text-text-muted">
         Cross-org subscription view. Revenue figures are mock until payments
-        ($0 — payments not live).
+        ($0, payments not live).
       </p>
 
       {error && (

--- a/frontend/app/admin/subscriptions/page.tsx
+++ b/frontend/app/admin/subscriptions/page.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { hasPlatformPermission } from "@/lib/auth";
+import {
+  badgeBase,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  pageTitle,
+} from "@/lib/styles";
+import type {
+  AdminSubscriptionKPIs,
+  AdminSubscriptionListItem,
+  AdminSubscriptionListResponse,
+  SubscriptionStatus,
+} from "@/lib/types";
+
+const PAGE_SIZE = 50;
+
+// Status filter chips. ``null`` represents "All", which clears the
+// filter — kept first in the list so an admin paging through the
+// table can collapse a filter without hunting.
+const STATUS_FILTERS: {
+  value: SubscriptionStatus | null;
+  label: string;
+}[] = [
+  { value: null, label: "All" },
+  { value: "active", label: "Active" },
+  { value: "trialing", label: "Trial" },
+  { value: "past_due", label: "Past due" },
+  { value: "canceled", label: "Cancelled" },
+];
+
+function StatusBadge({ status }: { status: SubscriptionStatus }) {
+  // Status → tone mapping. Active = success, trial = info, past_due
+  // = warning, cancelled = neutral. Each pairs an icon-free badge
+  // with the textual status so colour is not the only carrier.
+  const toneClass =
+    status === "active"
+      ? "bg-success-dim text-success"
+      : status === "trialing"
+        ? "bg-info-dim text-info"
+        : status === "past_due"
+          ? "bg-warning-dim text-warning"
+          : "bg-surface-raised text-text-secondary";
+  return (
+    <span className={`${badgeBase} ${toneClass}`}>
+      {status === "past_due" ? "past due" : status}
+    </span>
+  );
+}
+
+function MockBadge() {
+  // The single source of "this isn't real money" label. Used on the
+  // KPI strip's revenue tiles and on the list table's plan column.
+  // Lives here (not in styles.ts) because it carries copy too.
+  return (
+    <span
+      className="ml-1 rounded-sm bg-warning-dim px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-warning"
+      title="Payments are not live yet. Revenue figures are mocked until L2 ships."
+    >
+      mock
+    </span>
+  );
+}
+
+type KpiTile = {
+  label: string;
+  value: string | number;
+  hint?: string;
+  isMock?: boolean;
+};
+
+function KpiStrip({ kpis }: { kpis: AdminSubscriptionKPIs }) {
+  const tiles: KpiTile[] = [
+    { label: "Total", value: kpis.total_subscriptions },
+    { label: "Active", value: kpis.active },
+    { label: "Trial", value: kpis.trial },
+    { label: "Past due", value: kpis.past_due },
+    { label: "Cancelled", value: kpis.cancelled },
+    {
+      label: "Signups (7d)",
+      value: kpis.signups_last_7d,
+      hint: "New subscriptions in the last 7 days",
+    },
+    {
+      label: "Trial expiring (7d)",
+      value: kpis.trial_expiring_next_7d,
+      hint: "Trials whose trial_end falls in the next 7 days",
+    },
+    {
+      label: "MRR",
+      value: `$${kpis.mock_mrr}`,
+      isMock: true,
+      hint: "Mock — real payments not integrated yet (L2.2 parked)",
+    },
+    {
+      label: "ARR",
+      value: `$${kpis.mock_arr}`,
+      isMock: true,
+      hint: "Mock — real payments not integrated yet (L2.2 parked)",
+    },
+  ];
+  return (
+    <section
+      aria-label="Subscription totals"
+      className={`${card} px-5 py-3`}
+    >
+      <dl className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+        {tiles.map((t) => (
+          <div
+            key={t.label}
+            className="flex items-baseline gap-2"
+            title={t.hint}
+          >
+            <dd className="text-xl font-semibold tabular-nums text-text-primary">
+              {t.value}
+            </dd>
+            <dt className="text-xs uppercase tracking-[0.08em] text-text-muted">
+              {t.label}
+              {t.isMock && <MockBadge />}
+            </dt>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function PlanDistribution({ kpis }: { kpis: AdminSubscriptionKPIs }) {
+  if (kpis.plan_distribution.length === 0) return null;
+  return (
+    <section className={`${card}`}>
+      <div className={cardHeader}>
+        <h2 className={cardTitle}>Plan distribution</h2>
+      </div>
+      <ul className="px-6 py-3">
+        {kpis.plan_distribution.map((p) => (
+          <li
+            key={p.plan_id ?? p.plan_slug ?? p.plan_name ?? "unknown"}
+            className="flex items-center justify-between border-b border-border-subtle py-2 last:border-0"
+          >
+            <span className="text-sm text-text-primary">
+              {p.plan_name ?? p.plan_slug ?? "Unknown plan"}
+              {p.plan_slug && (
+                <span className="ml-2 text-xs text-text-muted">
+                  {p.plan_slug}
+                </span>
+              )}
+            </span>
+            <span className="tabular-nums text-sm text-text-secondary">
+              {p.subscription_count}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default function AdminSubscriptionsPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<AdminSubscriptionListResponse | null>(null);
+  const [kpis, setKpis] = useState<AdminSubscriptionKPIs | null>(null);
+  const [error, setError] = useState("");
+  const [q, setQ] = useState("");
+  const [statusFilter, setStatusFilter] =
+    useState<SubscriptionStatus | null>(null);
+  const [planFilter, setPlanFilter] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!hasPlatformPermission(user, "subscriptions.view")) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  // KPIs load once per page mount. Refetching on every filter change
+  // would be misleading — the KPI strip is platform-wide, not
+  // filtered-list-wide.
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "subscriptions.view")) {
+      return;
+    }
+    apiFetch<AdminSubscriptionKPIs>("/api/v1/admin/subscriptions/kpis")
+      .then((d) => setKpis(d))
+      .catch(() => {
+        // KPI failures are non-fatal — the table is the primary
+        // affordance. Errors surface via the list-fetch path below.
+      });
+  }, [loading, user]);
+
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "subscriptions.view")) {
+      return;
+    }
+    setFetching(true);
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+    });
+    if (q.trim()) params.set("q", q.trim());
+    if (statusFilter) params.set("status", statusFilter);
+    if (planFilter) params.set("plan", planFilter);
+    apiFetch<AdminSubscriptionListResponse>(
+      `/api/v1/admin/subscriptions?${params.toString()}`,
+    )
+      .then((d) => setData(d))
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
+      .finally(() => setFetching(false));
+  }, [loading, user, q, statusFilter, planFilter, offset]);
+
+  const planChips = useMemo(() => {
+    if (!kpis) return [] as { slug: string; name: string; count: number }[];
+    return kpis.plan_distribution
+      .filter((p) => p.plan_slug !== null)
+      .map((p) => ({
+        slug: p.plan_slug as string,
+        name: p.plan_name ?? (p.plan_slug as string),
+        count: p.subscription_count,
+      }));
+  }, [kpis]);
+
+  if (loading || !user || !hasPlatformPermission(user, "subscriptions.view")) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-1">
+          <h1 className={`${pageTitle} mb-0`}>Subscriptions</h1>
+          <HelpAnchor
+            section="admin"
+            label="Subscriptions"
+            variant="inline-title"
+          />
+        </div>
+      </div>
+
+      <p className="mb-4 text-sm text-text-muted">
+        Cross-org subscription view. Revenue figures are mock until payments
+        ($0 — payments not live).
+      </p>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      {kpis && (
+        <div className="mb-6 space-y-6">
+          <KpiStrip kpis={kpis} />
+          <PlanDistribution kpis={kpis} />
+        </div>
+      )}
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>All subscriptions</h2>
+        </div>
+        <div className="space-y-3 px-6 py-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {STATUS_FILTERS.map((s) => {
+              const active = statusFilter === s.value;
+              return (
+                <button
+                  key={s.label}
+                  type="button"
+                  onClick={() => {
+                    setOffset(0);
+                    setStatusFilter(s.value);
+                  }}
+                  aria-pressed={active}
+                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${
+                    active
+                      ? "border-accent bg-accent-dim text-accent"
+                      : "border-border text-text-secondary hover:border-accent hover:text-accent"
+                  }`}
+                >
+                  {s.label}
+                </button>
+              );
+            })}
+          </div>
+          {planChips.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs uppercase tracking-wider text-text-muted">
+                Plan
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  setOffset(0);
+                  setPlanFilter(null);
+                }}
+                aria-pressed={planFilter === null}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${
+                  planFilter === null
+                    ? "border-accent bg-accent-dim text-accent"
+                    : "border-border text-text-secondary hover:border-accent hover:text-accent"
+                }`}
+              >
+                All
+              </button>
+              {planChips.map((p) => (
+                <button
+                  key={p.slug}
+                  type="button"
+                  onClick={() => {
+                    setOffset(0);
+                    setPlanFilter(p.slug);
+                  }}
+                  aria-pressed={planFilter === p.slug}
+                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 ${
+                    planFilter === p.slug
+                      ? "border-accent bg-accent-dim text-accent"
+                      : "border-border text-text-secondary hover:border-accent hover:text-accent"
+                  }`}
+                >
+                  {p.name}
+                  <span className="ml-1 text-text-muted">{p.count}</span>
+                </button>
+              ))}
+            </div>
+          )}
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => {
+              setOffset(0);
+              setQ(e.target.value);
+            }}
+            placeholder="Search by org name or plan slug…"
+            className={`${input} w-full max-w-sm`}
+            aria-label="Search subscriptions"
+          />
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3">Organization</th>
+                <th className="px-6 py-3">Plan</th>
+                <th className="px-6 py-3">Status</th>
+                <th className="px-6 py-3">Trial ends</th>
+                <th className="px-6 py-3">Period ends</th>
+                <th className="px-6 py-3">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-6 py-6 text-center text-text-muted"
+                  >
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!fetching && data?.items.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-6 py-10 text-center text-text-muted"
+                  >
+                    <p className="font-medium text-text-secondary">
+                      No subscriptions match the current filters.
+                    </p>
+                    <p className="mt-1 text-xs">
+                      Clear filters or widen the search.
+                    </p>
+                  </td>
+                </tr>
+              )}
+              {!fetching &&
+                data?.items.map((row: AdminSubscriptionListItem) => (
+                  <tr
+                    key={row.subscription_id}
+                    className="border-b border-border-subtle"
+                  >
+                    <td className="px-6 py-3">
+                      <Link
+                        href={`/admin/subscriptions/${row.subscription_id}`}
+                        className="text-accent hover:text-accent-hover"
+                      >
+                        {row.org_name}
+                      </Link>
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary">
+                      {row.plan_name ?? row.plan_slug ?? "—"}
+                    </td>
+                    <td className="px-6 py-3">
+                      <StatusBadge status={row.status} />
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.trial_end ?? "—"}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.current_period_end ?? "—"}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.created_at?.slice(0, 10) ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+
+        {data && data.total > PAGE_SIZE && (
+          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
+            <span>
+              {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
+              {data.total}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                disabled={offset + PAGE_SIZE >= data.total}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -125,6 +125,12 @@ const systemItems: readonly SystemNavItem[] = [
     icon: <BarChart3 {...NAV_ICON_PROPS} />,
   },
   {
+    href: "/admin/subscriptions",
+    label: "Subscriptions",
+    permission: "subscriptions.view",
+    icon: <CreditCard {...NAV_ICON_PROPS} />,
+  },
+  {
     href: "/system/plans",
     label: "Plans",
     permission: "plans.manage",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -609,3 +609,108 @@ export interface ReconcileBatchResponse {
   remaining_pending: number;
   batch_status: "open" | "closed";
 }
+
+// L4.5 — admin subscription & revenue view -----------------------------------
+//
+// These types mirror the schemas in
+// `backend/app/schemas/admin_subscriptions.py`. Names are prefixed
+// `AdminSubscription*` so they never collide with the existing
+// `SubscriptionDetail` (which represents the current user's
+// subscription, not a platform-admin drill-down).
+
+export interface AdminSubscriptionListItem {
+  subscription_id: number;
+  org_id: number;
+  org_name: string;
+  plan_id: number | null;
+  plan_slug: string | null;
+  plan_name: string | null;
+  status: SubscriptionStatus;
+  billing_interval: "monthly" | "yearly";
+  trial_start: string | null;
+  trial_end: string | null;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminSubscriptionListResponse {
+  items: AdminSubscriptionListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface AdminSubscriptionPlanInfo {
+  id: number;
+  slug: string;
+  name: string;
+  description: string;
+  // Money fields are returned as strings to preserve precision
+  // (see project_decimal_typing_debt.md). The FE formats with
+  // `Intl.NumberFormat` after parsing — never mutates the raw value.
+  price_monthly: string;
+  price_yearly: string;
+  max_users: number | null;
+  retention_days: number | null;
+  features: Record<string, unknown>;
+  is_custom: boolean;
+  is_active: boolean;
+}
+
+export interface AdminSubscriptionOrgInfo {
+  id: number;
+  name: string;
+  billing_cycle_day: number;
+  created_at: string | null;
+  member_count: number;
+}
+
+export interface AdminFeatureOverrideSnapshot {
+  feature_key: string;
+  value: boolean;
+  set_at: string | null;
+  expires_at: string | null;
+  is_expired: boolean;
+  note: string | null;
+}
+
+export interface AdminSubscriptionDetail {
+  subscription_id: number;
+  org: AdminSubscriptionOrgInfo;
+  plan: AdminSubscriptionPlanInfo | null;
+  status: SubscriptionStatus;
+  billing_interval: "monthly" | "yearly";
+  trial_start: string | null;
+  trial_end: string | null;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  created_at: string;
+  updated_at: string;
+  feature_overrides: AdminFeatureOverrideSnapshot[];
+  mock_revenue_amount: string;
+  mock_revenue: boolean;
+}
+
+export interface AdminPlanDistributionItem {
+  plan_id: number | null;
+  plan_slug: string | null;
+  plan_name: string | null;
+  subscription_count: number;
+}
+
+export interface AdminSubscriptionKPIs {
+  total_subscriptions: number;
+  active: number;
+  trial: number;
+  past_due: number;
+  cancelled: number;
+  signups_last_7d: number;
+  trial_expiring_next_7d: number;
+  plan_distribution: AdminPlanDistributionItem[];
+  mock_mrr: string;
+  mock_arr: string;
+  mock_revenue: boolean;
+  generated_at: string;
+}

--- a/frontend/tests/app/admin-subscriptions-detail-page.test.tsx
+++ b/frontend/tests/app/admin-subscriptions-detail-page.test.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { useParams, useRouter } from "next/navigation";
+
+import AdminSubscriptionDetailPage from "@/app/admin/subscriptions/[id]/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  useParams: vi.fn(),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  };
+});
+
+
+function makeUser(opts: { isSuperadmin?: boolean; permissions?: string[] } = {}) {
+  return {
+    id: 1,
+    username: "alice",
+    email: "alice@example.com",
+    first_name: "Alice",
+    last_name: "Tester",
+    phone: null,
+    avatar_url: null,
+    email_verified: true,
+    role: "owner" as const,
+    org_id: 1,
+    org_name: "Test Org",
+    billing_cycle_day: 1,
+    is_superadmin: opts.isSuperadmin ?? false,
+    is_active: true,
+    mfa_enabled: false,
+    subscription_status: null,
+    subscription_plan: null,
+    trial_end: null,
+    permissions: opts.permissions,
+  };
+}
+
+
+const SAMPLE_DETAIL = {
+  subscription_id: 42,
+  org: {
+    id: 100,
+    name: "Acme Corp",
+    billing_cycle_day: 1,
+    created_at: "2026-01-01T00:00:00",
+    member_count: 5,
+  },
+  plan: {
+    id: 1,
+    slug: "pro",
+    name: "Pro",
+    description: "Pro plan",
+    price_monthly: "9.99",
+    price_yearly: "99.00",
+    max_users: null,
+    retention_days: null,
+    features: {},
+    is_custom: false,
+    is_active: true,
+  },
+  status: "active" as const,
+  billing_interval: "monthly" as const,
+  trial_start: null,
+  trial_end: null,
+  current_period_start: "2026-05-01",
+  current_period_end: "2026-06-01",
+  created_at: "2026-01-15T08:00:00",
+  updated_at: "2026-05-01T08:00:00",
+  feature_overrides: [
+    {
+      feature_key: "ai.budget",
+      value: true,
+      set_at: "2026-04-01T08:00:00",
+      expires_at: null,
+      is_expired: false,
+      note: "comped",
+    },
+    {
+      feature_key: "ai.forecast",
+      value: true,
+      set_at: "2026-04-01T08:00:00",
+      expires_at: "2026-04-10T08:00:00",
+      is_expired: true,
+      note: null,
+    },
+  ],
+  mock_revenue_amount: "0.00",
+  mock_revenue: true,
+};
+
+
+describe("/admin/subscriptions/[id] detail page", () => {
+  const replace = vi.fn();
+
+  beforeEach(() => {
+    replace.mockReset();
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({ replace } as never);
+    vi.mocked(useParams).mockReturnValue({ id: "42" });
+  });
+
+  it("redirects users without subscriptions.view to /dashboard", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: false }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue(SAMPLE_DETAIL);
+
+    render(<AdminSubscriptionDetailPage />);
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+    expect(vi.mocked(apiFetch)).not.toHaveBeenCalled();
+  });
+
+  it("renders org / plan / subscription cards for superadmin", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue(SAMPLE_DETAIL);
+
+    render(<AdminSubscriptionDetailPage />);
+
+    // Page title is the org name (matches the URL the admin clicked from).
+    expect(await screen.findByRole("heading", { name: "Acme Corp" })).toBeInTheDocument();
+    // Status renders.
+    expect(screen.getByText("active")).toBeInTheDocument();
+    // Plan column rendered.
+    expect(screen.getByText("Pro")).toBeInTheDocument();
+    // Revenue tile labelled mock.
+    expect(screen.getByText("$0.00")).toBeInTheDocument();
+    expect(screen.getAllByText("mock").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("links Override subscription back to the org page", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue(SAMPLE_DETAIL);
+
+    render(<AdminSubscriptionDetailPage />);
+
+    const overrideLink = await screen.findByRole("link", {
+      name: /Override subscription/i,
+    });
+    expect(overrideLink.getAttribute("href")).toBe("/admin/orgs/100");
+  });
+
+  it("renders feature overrides with expired badge", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue(SAMPLE_DETAIL);
+
+    render(<AdminSubscriptionDetailPage />);
+
+    expect(await screen.findByText("ai.budget")).toBeInTheDocument();
+    expect(screen.getByText("ai.forecast")).toBeInTheDocument();
+    expect(screen.getByText("expired")).toBeInTheDocument();
+  });
+
+  it("renders an empty-state when no overrides exist", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    vi.mocked(apiFetch).mockResolvedValue({
+      ...SAMPLE_DETAIL,
+      feature_overrides: [],
+    });
+
+    render(<AdminSubscriptionDetailPage />);
+
+    expect(await screen.findByText(/No overrides on this org/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/app/admin-subscriptions-page.test.tsx
+++ b/frontend/tests/app/admin-subscriptions-page.test.tsx
@@ -1,0 +1,260 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+
+import AdminSubscriptionsPage from "@/app/admin/subscriptions/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiFetch: vi.fn(),
+  };
+});
+
+
+function makeUser(opts: { isSuperadmin?: boolean; permissions?: string[] } = {}) {
+  return {
+    id: 1,
+    username: "alice",
+    email: "alice@example.com",
+    first_name: "Alice",
+    last_name: "Tester",
+    phone: null,
+    avatar_url: null,
+    email_verified: true,
+    role: "owner" as const,
+    org_id: 1,
+    org_name: "Test Org",
+    billing_cycle_day: 1,
+    is_superadmin: opts.isSuperadmin ?? false,
+    is_active: true,
+    mfa_enabled: false,
+    subscription_status: null,
+    subscription_plan: null,
+    trial_end: null,
+    permissions: opts.permissions,
+  };
+}
+
+
+// One-stop response stubber. Branches on the URL the page fetches so
+// tests can mock both the KPI strip and the list table without spelling
+// out per-call wiring.
+function setupApiFetchStubs(opts: {
+  kpis?: object;
+  list?: object;
+  fail?: boolean;
+}) {
+  const defaultKpis = {
+    total_subscriptions: 4,
+    active: 2,
+    trial: 1,
+    past_due: 1,
+    cancelled: 0,
+    signups_last_7d: 2,
+    trial_expiring_next_7d: 1,
+    plan_distribution: [
+      { plan_id: 1, plan_slug: "pro", plan_name: "Pro", subscription_count: 3 },
+      { plan_id: 2, plan_slug: "free", plan_name: "Free", subscription_count: 1 },
+    ],
+    mock_mrr: "0.00",
+    mock_arr: "0.00",
+    mock_revenue: true,
+    generated_at: "2026-05-13T12:00:00",
+  };
+  const defaultList = {
+    items: [
+      {
+        subscription_id: 10,
+        org_id: 100,
+        org_name: "Acme Corp",
+        plan_id: 1,
+        plan_slug: "pro",
+        plan_name: "Pro",
+        status: "active",
+        billing_interval: "monthly",
+        trial_start: null,
+        trial_end: null,
+        current_period_start: "2026-05-01",
+        current_period_end: "2026-06-01",
+        created_at: "2026-04-15T08:00:00",
+        updated_at: "2026-04-15T08:00:00",
+      },
+      {
+        subscription_id: 11,
+        org_id: 101,
+        org_name: "Globex",
+        plan_id: 2,
+        plan_slug: "free",
+        plan_name: "Free",
+        status: "trialing",
+        billing_interval: "monthly",
+        trial_start: "2026-05-10",
+        trial_end: "2026-05-24",
+        current_period_start: null,
+        current_period_end: null,
+        created_at: "2026-05-10T08:00:00",
+        updated_at: "2026-05-10T08:00:00",
+      },
+    ],
+    total: 2,
+    limit: 50,
+    offset: 0,
+  };
+  const kpis = opts.kpis ?? defaultKpis;
+  const list = opts.list ?? defaultList;
+  vi.mocked(apiFetch).mockImplementation(async (url: string) => {
+    if (opts.fail) throw new Error("boom");
+    if (url.includes("/kpis")) return kpis as never;
+    return list as never;
+  });
+}
+
+
+describe("/admin/subscriptions list page", () => {
+  const replace = vi.fn();
+
+  beforeEach(() => {
+    replace.mockReset();
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({ replace } as never);
+  });
+
+  it("redirects users without subscriptions.view to /dashboard", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: false }),
+      loading: false,
+    } as never);
+    setupApiFetchStubs({});
+
+    render(<AdminSubscriptionsPage />);
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+    expect(screen.queryByTestId("app-shell")).not.toBeInTheDocument();
+    expect(vi.mocked(apiFetch)).not.toHaveBeenCalled();
+  });
+
+  it("redirects unauthenticated visitors to /login", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+    } as never);
+    setupApiFetchStubs({});
+
+    render(<AdminSubscriptionsPage />);
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/login"));
+    expect(vi.mocked(apiFetch)).not.toHaveBeenCalled();
+  });
+
+  it("renders KPI strip with mock revenue labelling for superadmin", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    setupApiFetchStubs({});
+
+    render(<AdminSubscriptionsPage />);
+
+    expect(await screen.findByText("Subscriptions")).toBeInTheDocument();
+    // KPI tiles render counts. Use findAllByText since the badge labels
+    // are duplicated (status chip + KPI tile + status badge inside the
+    // table all carry the same text). Just assert at least one match.
+    await waitFor(() => {
+      expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("Trial").length).toBeGreaterThan(0);
+    // Mock labels appear for $$ tiles (MRR / ARR) — at least 2.
+    const mockBadges = screen.getAllByText("mock");
+    expect(mockBadges.length).toBeGreaterThanOrEqual(2);
+    // The disclosure copy also tells admins this is not real revenue.
+    expect(
+      screen.getByText(/Revenue figures are mock/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the subscription table with org rows", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    setupApiFetchStubs({});
+
+    render(<AdminSubscriptionsPage />);
+
+    expect(await screen.findByText("Acme Corp")).toBeInTheDocument();
+    expect(screen.getByText("Globex")).toBeInTheDocument();
+    // Status badges render the textual status, not just the colour.
+    expect(screen.getByText("active")).toBeInTheDocument();
+    expect(screen.getByText("trialing")).toBeInTheDocument();
+  });
+
+  it("filters by status when an admin clicks a status chip", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    setupApiFetchStubs({});
+
+    render(<AdminSubscriptionsPage />);
+
+    await screen.findByText("Acme Corp");
+    vi.mocked(apiFetch).mockClear();
+
+    const trialChip = screen.getByRole("button", { name: "Trial" });
+    fireEvent.click(trialChip);
+
+    await waitFor(() => {
+      const calls = vi.mocked(apiFetch).mock.calls.map((c) => String(c[0]));
+      expect(calls.some((u) => u.includes("status=trialing"))).toBe(true);
+    });
+  });
+
+  it("renders an empty-state when no subscriptions match", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    setupApiFetchStubs({
+      list: { items: [], total: 0, limit: 50, offset: 0 },
+    });
+
+    render(<AdminSubscriptionsPage />);
+
+    expect(
+      await screen.findByText(/No subscriptions match the current filters/i),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes a backend search box", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: makeUser({ isSuperadmin: true }),
+      loading: false,
+    } as never);
+    setupApiFetchStubs({});
+
+    render(<AdminSubscriptionsPage />);
+
+    const search = await screen.findByRole("searchbox", {
+      name: /search subscriptions/i,
+    });
+    expect(search).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the L4.5 platform-admin **Subscription & Revenue view** so an operator can answer "who has what plan, who's expiring, who's past due" without grepping the DB. Real payments aren't integrated yet (L2.2 parked) — every dollar figure renders with a `mock` badge until L2 lands.

- **Surface shape (A):** new `/admin/subscriptions` list with filterable status / plan chips, search, KPI strip and per-plan distribution; drill-down at `/admin/subscriptions/[id]` with org / plan / feature-override snapshots and a deep-link back to `/admin/orgs/[id]` for the override flow (L4.3 owns the mutation surface — no duplication here).
- **Backend:** new `subscriptions.view` permission + migration `043` seed on the superadmin row; `app/services/admin_subscription_service.py` (list / detail / aggregator); `app/routers/admin_subscriptions.py` with three GETs gated by `subscriptions.view`.
- **Audit:** every list / detail hit emits `admin.subscriptions.viewed` via structlog (always) plus a durable `audit_events` row throttled to **once per admin per minute** using `redis.SET NX EX 60`. Throttle fails open when Redis is unconfigured (dev / tests), so the structlog event is never lost.
- **Frontend:** AppShell sidebar entry + `/admin` hub tile, both gated on `hasPlatformPermission("subscriptions.view")`. HelpAnchor `inline-title` on both pages per the #242 convention. Token-clean — `scripts/check-design-tokens.sh` passes.
- **Mock-revenue clarity:** the KPI strip's MRR / ARR tiles, the plan-distribution rows and the detail-page Revenue field all render a `mock` badge with a tooltip explaining payments aren't live yet. List-page subtitle and detail-page banner repeat the disclosure in copy.

## What's NOT in scope

- Real payment integration (L2.2 parked).
- Override grant / revoke flow (L4.11 / PR #109 owns).
- Plan editing surface (`/system/plans`).
- Reconciliation UI (#247 in flight).

## CI status

- Backend: full pytest suite green (1059 passed, 5 skipped) inside `team-subscription-view` isolated compose project. 24 new tests across `tests/services/test_admin_subscription_service.py` (12) and `tests/routers/test_admin_subscriptions.py` (12).
- Frontend: full vitest suite green (109 files, 753 tests). 12 new tests across `admin-subscriptions-page` and `admin-subscriptions-detail-page`.
- `npx tsc --noEmit` clean.
- `npm run lint` clean for new files (only pre-existing warnings on unrelated files).
- `scripts/check-design-tokens.sh` passes.

## Screenshot handoff (owner-side capture)

Owner to capture under:

- `/admin/subscriptions` list page: light + dark, desktop + mobile. Confirm: KPI strip, filter chips, status badges, mock labels visible.
- `/admin/subscriptions/[id]` detail page: light + dark, desktop + mobile. Confirm: subscription / org / plan / feature-overrides cards, mock badge on Revenue field, "Override subscription" link routes to `/admin/orgs/[id]`.
- `/admin` hub: confirm the new Subscriptions tile appears for superadmin.
- AppShell sidebar: confirm the Subscriptions entry appears for superadmin and is hidden for users without `subscriptions.view`.

## Roadmap impact

Closes L4.5 first slice. Roadmap row should flip from blank to ✅ once merged. When L2.2 wires real billing, the aggregator switches its mock zeros to real Stripe / Paddle totals without a schema change — `mock_revenue` flag flips to `false` and the FE stops rendering the `mock` badge automatically.