### PR TITLE
chore(comments): align main.py backfill note with the actual migration mechanism

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -204,8 +204,10 @@ async def lifespan(app: FastAPI):
     if app_settings.app_env != "production":
         await _run_migrations()
     # NOTE: subscription backfill used to run here on every boot. It now
-    # lives in alembic migration 043_backfill_subscriptions (idempotent
-    # via sentinel row in org_settings). Multi-replica safe.
+    # lives in alembic migration 043_backfill_subscriptions, idempotent
+    # via a per-row HAS_SUBSCRIPTION existence check (plus the UNIQUE
+    # constraint on subscriptions.org_id). Multi-replica safe. For manual
+    # re-runs, see `backend/scripts/backfill_subscriptions.py`.
     await logger.ainfo("starting", app=app_settings.app_name, env=app_settings.app_env)
     yield
     await redis_client.close_client()


### PR DESCRIPTION
## Summary

The lifespan comment in `backend/app/main.py` (added in PR #251) claimed migration 043_backfill_subscriptions enforced idempotency via a "sentinel row in org_settings". That is not what the migration does. It iterates orgs and per-row gates inserts with a `HAS_SUBSCRIPTION` existence check on `subscriptions`, backed by the `UNIQUE(org_id)` constraint.

This PR corrects the wording and points at `backend/scripts/backfill_subscriptions.py` for manual re-runs, matching the explanatory block already at the top of `main.py` (lines 31-38).

Comment-only, no functional change.