### PR TITLE
chore: pfv_app MySQL localhost grant + /settings/security tabs migration

### DIFF
--- a/infra/ansible/roles/mysql/tasks/main.yml
+++ b/infra/ansible/roles/mysql/tasks/main.yml
@@ -72,6 +72,26 @@
     plugin: mysql_native_password
     state: present
 
+# MySQL treats host='%' and host='localhost' as distinct user rows. The
+# host='%' grant covers private-VPC App Platform clients connecting over
+# TCP, but it does NOT match `mysql -u pfv_app -h localhost` (UNIX socket)
+# or `mysql -u pfv_app -h 127.0.0.1` (TCP loopback) on the data droplet
+# itself, both fail with "Access denied". Adding the localhost grant lets
+# the operator drop into a `pfv_app` shell directly on pfv-data-01 without
+# tunnelling through the App Platform pod, which makes routine ops
+# (schema spot-checks, ad-hoc queries) much cheaper. Privileges mirror
+# the host='%' row exactly.
+- name: Create application MySQL user (host=localhost)
+  community.mysql.mysql_user:
+    login_user: root
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+    name: "{{ mysql_app_user }}"
+    password: "{{ mysql_app_password }}"
+    host: localhost
+    priv: "{{ mysql_app_db }}.*:ALL"
+    plugin: mysql_native_password
+    state: present
+
 # Drop /root/.my.cnf AFTER all privileged mysql_user / mysql_db tasks complete.
 # The mysql client library reads /root/.my.cnf when present and authenticates
 # as the user listed there (mysql_backup), which does not have CREATE DATABASE


### PR DESCRIPTION
Tech debt mini-cluster #2. Two roadmap items dispatched together. Owner can comment on each independently.

## Item 1 — pfv_app MySQL localhost grant (SHIPPED IN THIS PR)

**Problem.** On the production data droplet (`pfv-data-01`), the ansible role grants `pfv_app` on `host='%'` only. MySQL treats `host='%'` and `host='localhost'` as distinct user rows, so:

- `mysql -u pfv_app -h localhost` (UNIX socket) returns `Access denied`
- `mysql -u pfv_app -h 127.0.0.1` (TCP loopback) returns `Access denied`

The `host='%'` grant covers App Platform clients reaching the droplet over the private VPC, but it blocks the operator from shelling into `pfv_app` directly on the droplet for schema spot-checks and ad-hoc queries.

**Fix.** Add a second `community.mysql.mysql_user` task with `host: localhost`, mirroring the existing `host='%'` privileges (`{{ mysql_app_db }}.*:ALL`) exactly. Idempotent (`state: present`), so reruns are no-ops on hosts that already have the grant. The existing `host='%'` grant is unchanged.

**Touch point.** `infra/ansible/roles/mysql/tasks/main.yml` — new task inserted between the existing `host='%'` task and the `/root/.my.cnf` drop, with a comment explaining the MySQL distinct-host-row gotcha for future maintainers.

**Validation.**

- `ansible-playbook --syntax-check playbooks/site.yml` — clean (run in dockerized ansible-core 2.17 with `community.mysql` collection installed via `requirements.yml`).
- `yamllint roles/mysql/tasks/main.yml` — unchanged from baseline (1 pre-existing line-length nit on line 36, not introduced by this change).
- `ansible-lint roles/mysql/tasks/main.yml` — only pre-existing `fqcn[canonical]` style nits on all 6 mysql tasks; my new task matches the existing convention exactly.

**Apply on droplet.** After merge, the next ansible-playbook run against `pfv-data-01` will pick up the new grant. Manual verification: `ssh pfv-data-01 'sudo mysql -u pfv_app -h localhost -p pfv_app_db -e "SELECT 1"'` should succeed.

## Item 2 — /settings/security tabs migration (NO-OP, ALREADY SHIPPED)

The roadmap entry describes Security wrapping `AppShell` directly without the tab bar. Investigation:

- `frontend/app/settings/security/page.tsx:321-322` — `return ( <SettingsLayout activeTab=\"/settings/security\"> ...`
- `frontend/app/settings/page.tsx`, `organization/page.tsx`, `billing/page.tsx` — all also wrap `<SettingsLayout activeTab=...>`
- `frontend/components/SettingsLayout.tsx` — renders the `AppShell` shell + the `Profile | Security | Organization | Billing` tab bar, role-filtered

Migration commit is **c855ec8** ("fix: Settings Hub is the real entry point — profile inline, security uses tabs", Apr 16, 2026). The roadmap entry is stale and should be marked closed.

Per the dispatch's "make the reasonable call and continue" instruction I did not invent rework. No frontend files touched. Owner: please tick the L-band tech-debt entry as closed when reviewing.

## Out of scope (preserved, untouched)

- MFA / form polish from PR #225
- Billing period config
- Strict CSP / nonce middleware
- `fqcn[canonical]` ansible-lint pattern cleanup (all 6 mysql tasks already use `community.mysql.*` form, consistent within the role)

## Files changed

- `infra/ansible/roles/mysql/tasks/main.yml` (+20 / -0)