### PR TITLE
feat(ui): accounts side-by-side layout + recurring Generate due tooltip

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -341,9 +341,17 @@ export default function AccountsPage() {
       {fetching ? (
         <Spinner />
       ) : (
-        <div className="flex flex-col gap-6">
+        // Layout: stacks vertically on mobile/tablet (default flex-col),
+        // splits into a 1/3 + 2/3 grid at lg+ so the short Account Types
+        // table no longer leaves a wide whitespace band above the
+        // Accounts list. Items align to start so the Types card keeps its
+        // intrinsic height instead of stretching to match Accounts.
+        <div
+          data-testid="accounts-page-grid"
+          className="flex flex-col gap-6 lg:grid lg:grid-cols-3 lg:items-start lg:gap-6"
+        >
           {/* Account Types */}
-          <div className={card}>
+          <div className={`${card} lg:col-span-1`}>
             <div className={cardHeader}>
               <h2 className={cardTitle}>Account Types</h2>
             </div>
@@ -408,7 +416,7 @@ export default function AccountsPage() {
           </div>
 
           {/* Accounts */}
-          <div className={card}>
+          <div className={`${card} lg:col-span-2`}>
             <div className={`flex items-center justify-between ${cardHeader}`}>
               <h2 className={cardTitle}>Accounts</h2>
               {accountTypes.length > 0 && (

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -29,6 +29,7 @@ const sections = [
   { id: "system-health", label: "System health" },
   { id: "dashboard", label: "Dashboard" },
   { id: "transactions", label: "Transactions" },
+  { id: "recurring", label: "Recurring transactions" },
   { id: "accounts", label: "Accounts" },
   { id: "categories", label: "Categories" },
   { id: "budgets", label: "Budgets" },
@@ -428,6 +429,30 @@ export default function DocsPage() {
               filter by status, account, or category, and to sort the
               columns. Imports land here as a preview first, so nothing
               is committed until you confirm.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="recurring">Recurring transactions</h2>
+            <p>
+              The Recurring page lists every template you have set up,
+              split into Active and Paused. Templates are created by
+              promoting an existing transaction (open the row on the
+              Transactions page and use "Promote to recurring"); they
+              are not authored directly here.
+            </p>
+            <h3>Generate Due</h3>
+            <p>
+              "Generate Due" materializes the next occurrence for every
+              active recurring template whose next due date has already
+              passed. Run it when you want pending rows to appear ahead
+              of their settled date, for example to forecast a credit
+              card statement that has not closed yet. The app also
+              generates rows on its own at the appropriate time, so
+              this is a convenience action rather than a required step.
+              Stopping a template removes its remaining pending future
+              rows; settled past rows are kept because they are real
+              money movements.
             </p>
           </section>
 

--- a/frontend/app/recurring/page.tsx
+++ b/frontend/app/recurring/page.tsx
@@ -89,24 +89,36 @@ export default function RecurringPage() {
 
   return (
     <AppShell>
-      <div className="mb-8 flex items-center justify-between">
-        <h1 className={`${pageTitle} mb-0`}>Recurring Transactions</h1>
-        {/* Generate Due cluster: the button materializes pending
-            occurrences whose next_due_date has already passed. The
-            HelpAnchor next to it deep-links to the /docs#recurring
-            section so the user can read the full explanation without
-            losing context (opens in a new tab). */}
-        <div className="flex items-center gap-1">
-          <button onClick={handleGenerate} className={btnSecondary}>
-            Generate Due
-          </button>
+      {/* Responsive header: title + HelpAnchor stay together in the
+          heading (inline-title variant from PR #242 expects the
+          HelpAnchor to be a sibling of the heading text). Generate
+          Due is a separate item in the flex row that drops to its
+          own row at <sm so the cluster doesn't overflow on mobile.
+          Pattern: vertical stack on mobile (flex-col), row +
+          space-between at sm+. */}
+      <header
+        data-testid="recurring-page-header"
+        className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <h1 className={`${pageTitle} mb-0 flex items-start gap-1`}>
+          Recurring Transactions
+          {/* HelpAnchor sits next to the title (not the button) so it
+              follows the inline-title variant contract and gives
+              every page the same "title + ?" reading order. Deep-
+              links to /docs#recurring. */}
           <HelpAnchor
             section="recurring"
-            label="Generate due"
+            label="Recurring transactions"
             variant="inline-title"
           />
-        </div>
-      </div>
+        </h1>
+        <button
+          onClick={handleGenerate}
+          className={`${btnSecondary} self-start sm:self-auto`}
+        >
+          Generate Due
+        </button>
+      </header>
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
       {successMsg && <div className={`mb-6 ${successCls}`}>{successMsg}</div>}

--- a/frontend/app/recurring/page.tsx
+++ b/frontend/app/recurring/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -90,9 +91,21 @@ export default function RecurringPage() {
     <AppShell>
       <div className="mb-8 flex items-center justify-between">
         <h1 className={`${pageTitle} mb-0`}>Recurring Transactions</h1>
-        <button onClick={handleGenerate} className={btnSecondary}>
-          Generate Due
-        </button>
+        {/* Generate Due cluster: the button materializes pending
+            occurrences whose next_due_date has already passed. The
+            HelpAnchor next to it deep-links to the /docs#recurring
+            section so the user can read the full explanation without
+            losing context (opens in a new tab). */}
+        <div className="flex items-center gap-1">
+          <button onClick={handleGenerate} className={btnSecondary}>
+            Generate Due
+          </button>
+          <HelpAnchor
+            section="recurring"
+            label="Generate due"
+            variant="inline-title"
+          />
+        </div>
       </div>
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}

--- a/frontend/tests/app/accounts-side-by-side-layout.test.tsx
+++ b/frontend/tests/app/accounts-side-by-side-layout.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AccountsPage from "@/app/accounts/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/accounts",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+  allow_manual_balance_adjustment: false,
+};
+
+const ACCOUNT_TYPES = [
+  { id: 1, name: "Credit Card", slug: "credit_card", is_system: true, account_count: 1 },
+  { id: 2, name: "Checking", slug: "checking", is_system: true, account_count: 1 },
+];
+
+const ACCOUNTS = [
+  {
+    id: 10,
+    name: "Amex Primary",
+    account_type_id: 1,
+    account_type_name: "Credit Card",
+    account_type_slug: "credit_card",
+    balance: "0.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: false,
+    close_day: 5,
+  },
+];
+
+function mockApi() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/account-types") return Promise.resolve(ACCOUNT_TYPES);
+    if (url === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([]);
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("AccountsPage — side-by-side layout (post-#199 follow-up)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockApi();
+  });
+
+  it("wraps the two cards in a 3-column grid at lg+ that stacks below lg", async () => {
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+
+    const grid = screen.getByTestId("accounts-page-grid");
+    expect(grid).toBeInTheDocument();
+    // Default (below lg) keeps the stacked column layout introduced by
+    // PR #199 so mobile + tablet match the shape users already learned.
+    expect(grid.className).toMatch(/\bflex-col\b/);
+    // lg+ promotes to a 3-column grid. Account Types takes 1/3 and
+    // Accounts takes 2/3 — see the next assertion for span checks.
+    expect(grid.className).toMatch(/\blg:grid\b/);
+    expect(grid.className).toMatch(/\blg:grid-cols-3\b/);
+    // items-start so the Types card keeps its intrinsic height instead
+    // of stretching to match the taller Accounts card.
+    expect(grid.className).toMatch(/\blg:items-start\b/);
+  });
+
+  it("places Account Types in col-span-1 and Accounts in col-span-2 at lg+", async () => {
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+
+    const grid = screen.getByTestId("accounts-page-grid");
+    const [typesCard, accountsCard] = Array.from(grid.children) as HTMLElement[];
+
+    // Two direct children: Types card first (DOM order keeps mobile
+    // stack visually identical to post-#199), Accounts second.
+    expect(grid.children.length).toBe(2);
+    expect(typesCard.className).toMatch(/\blg:col-span-1\b/);
+    expect(accountsCard.className).toMatch(/\blg:col-span-2\b/);
+  });
+
+  it("still renders the Account Types and Accounts cards with all controls", async () => {
+    render(<AccountsPage />);
+    await waitFor(() => expect(screen.getByText(/Amex Primary/)).toBeInTheDocument());
+
+    // Account Types card content survived the reflow.
+    expect(screen.getByRole("heading", { name: /Account Types/ })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/New type name/)).toBeInTheDocument();
+
+    // Accounts card actions survived (Add Account toggle + row actions).
+    expect(screen.getByRole("button", { name: /\+ Add Account/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Edit Amex Primary$/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Delete Amex Primary$/ })).toBeInTheDocument();
+
+    // Page-title HelpAnchor still present (link with `Help: Accounts`).
+    expect(
+      screen.getByRole("link", { name: /Help: Accounts/ }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/app/recurring-generate-due-help-anchor.test.tsx
+++ b/frontend/tests/app/recurring-generate-due-help-anchor.test.tsx
@@ -56,7 +56,7 @@ function mockApi() {
   }) as never);
 }
 
-describe("RecurringPage — Generate Due HelpAnchor", () => {
+describe("RecurringPage — header layout + Generate Due HelpAnchor", () => {
   beforeEach(() => {
     vi.mocked(apiFetch).mockReset();
     vi.mocked(useAuth).mockReturnValue({
@@ -71,7 +71,7 @@ describe("RecurringPage — Generate Due HelpAnchor", () => {
     mockApi();
   });
 
-  it("renders a HelpAnchor next to the Generate Due button pointing at /docs#recurring", async () => {
+  it("renders a HelpAnchor next to the page title pointing at /docs#recurring", async () => {
     render(<RecurringPage />);
     await waitFor(() =>
       expect(
@@ -79,16 +79,16 @@ describe("RecurringPage — Generate Due HelpAnchor", () => {
       ).toBeInTheDocument(),
     );
 
-    // aria-label includes "Help: Generate due" so screen-reader users
-    // pick up the affordance association before the icon.
-    const helpLink = screen.getByRole("link", { name: /Help: Generate due/ });
+    // aria-label includes "Help: Recurring transactions" so screen-
+    // reader users pick up the topic association before the icon.
+    const helpLink = screen.getByRole("link", { name: /Help: Recurring transactions/ });
     expect(helpLink).toHaveAttribute("href", "/docs#recurring");
     expect(helpLink).toHaveAttribute("target", "_blank");
     expect(helpLink).toHaveAttribute("rel", "noopener noreferrer");
     expect(helpLink).toHaveAttribute("data-section", "recurring");
   });
 
-  it("uses the inline-title HelpAnchor variant (next to the page-title button cluster)", async () => {
+  it("uses the inline-title HelpAnchor variant (next to the page H1)", async () => {
     render(<RecurringPage />);
     await waitFor(() =>
       expect(
@@ -97,20 +97,55 @@ describe("RecurringPage — Generate Due HelpAnchor", () => {
     );
 
     const helpLink = screen.getByTestId("help-anchor");
-    // inline-title sits next to a page-title-level affordance and
-    // self-aligns to cap height of adjacent text. card-corner would
-    // absolutely position, which is wrong here — the surrounding flex
-    // row is not a relative card.
+    // inline-title self-aligns to cap height of adjacent heading
+    // text. card-corner would absolutely position, which is wrong
+    // here since the surrounding flex row is not a relative card.
     expect(helpLink).toHaveAttribute("data-variant", "inline-title");
   });
 
-  it("keeps the Generate Due button clickable next to the help icon", async () => {
+  it("nests the HelpAnchor inside the H1 alongside the title text", async () => {
+    // Geometric promise of the inline-title variant: the icon lives
+    // INSIDE the heading element so it tracks the title across
+    // breakpoints. If the HelpAnchor escaped to a sibling div, it
+    // would no longer wrap with the title on mobile and the mobile
+    // overflow regression would creep back in.
+    render(<RecurringPage />);
+    const heading = await screen.findByRole("heading", { name: /Recurring transactions/i, level: 1 });
+    const helpLink = screen.getByTestId("help-anchor");
+    expect(heading.contains(helpLink)).toBe(true);
+  });
+
+  it("stacks the header vertically on mobile and switches to a row at sm+", async () => {
+    render(<RecurringPage />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Generate Due/ }),
+      ).toBeInTheDocument(),
+    );
+
+    const header = screen.getByTestId("recurring-page-header");
+    // Default (mobile) stacks the title cluster + Generate Due
+    // button vertically so the row never overflows on 375px-wide
+    // screens.
+    expect(header.className).toMatch(/\bflex-col\b/);
+    expect(header.className).toMatch(/\bgap-3\b/);
+    // sm+ flips to a row with the button right-aligned.
+    expect(header.className).toMatch(/\bsm:flex-row\b/);
+    expect(header.className).toMatch(/\bsm:items-center\b/);
+    expect(header.className).toMatch(/\bsm:justify-between\b/);
+  });
+
+  it("keeps the Generate Due button clickable as a sibling of the title", async () => {
     render(<RecurringPage />);
     const button = await screen.findByRole("button", { name: /Generate Due/ });
 
-    // The HelpAnchor is a sibling of the button inside the title-row
-    // flex cluster, not a wrapper, so the button stays a button.
+    // Button stays a real <button> (not wrapped by the HelpAnchor
+    // link), so the click handler still fires.
     expect(button.tagName).toBe("BUTTON");
     expect(button).not.toBeDisabled();
+    // self-start at <sm so the button doesn't stretch full-width on
+    // mobile; self-auto at sm+ so the row layout takes over.
+    expect(button.className).toMatch(/\bself-start\b/);
+    expect(button.className).toMatch(/\bsm:self-auto\b/);
   });
 });

--- a/frontend/tests/app/recurring-generate-due-help-anchor.test.tsx
+++ b/frontend/tests/app/recurring-generate-due-help-anchor.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import RecurringPage from "@/app/recurring/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/recurring",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+  allow_manual_balance_adjustment: false,
+};
+
+function mockApi() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/recurring") return Promise.resolve([]);
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("RecurringPage — Generate Due HelpAnchor", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockApi();
+  });
+
+  it("renders a HelpAnchor next to the Generate Due button pointing at /docs#recurring", async () => {
+    render(<RecurringPage />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Generate Due/ }),
+      ).toBeInTheDocument(),
+    );
+
+    // aria-label includes "Help: Generate due" so screen-reader users
+    // pick up the affordance association before the icon.
+    const helpLink = screen.getByRole("link", { name: /Help: Generate due/ });
+    expect(helpLink).toHaveAttribute("href", "/docs#recurring");
+    expect(helpLink).toHaveAttribute("target", "_blank");
+    expect(helpLink).toHaveAttribute("rel", "noopener noreferrer");
+    expect(helpLink).toHaveAttribute("data-section", "recurring");
+  });
+
+  it("uses the inline-title HelpAnchor variant (next to the page-title button cluster)", async () => {
+    render(<RecurringPage />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Generate Due/ }),
+      ).toBeInTheDocument(),
+    );
+
+    const helpLink = screen.getByTestId("help-anchor");
+    // inline-title sits next to a page-title-level affordance and
+    // self-aligns to cap height of adjacent text. card-corner would
+    // absolutely position, which is wrong here — the surrounding flex
+    // row is not a relative card.
+    expect(helpLink).toHaveAttribute("data-variant", "inline-title");
+  });
+
+  it("keeps the Generate Due button clickable next to the help icon", async () => {
+    render(<RecurringPage />);
+    const button = await screen.findByRole("button", { name: /Generate Due/ });
+
+    // The HelpAnchor is a sibling of the button inside the title-row
+    // flex cluster, not a wrapper, so the button stays a button.
+    expect(button.tagName).toBe("BUTTON");
+    expect(button).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

- Reflow `/accounts` at `lg+` into a 3-column grid: Account Types in `col-span-1`, Accounts in `col-span-2`. Below `lg` keeps the post-PR-#199 stacked layout, so mobile / tablet shape is unchanged.
- Add a `HelpAnchor` (variant `inline-title`) next to the H1 on `/recurring`, nested inside the heading per the inline-title variant contract from PR #242. Deep-links to `/docs#recurring`.
- Make the `/recurring` page header responsive: flex-col stack on mobile, flex-row + space-between at sm+, so title + HelpAnchor + Generate Due button no longer overflow on 375px screens (fix for owner P1 finding on first review pass).
- Add a new **Recurring transactions** section to `/docs` (with a Generate Due subsection) so the new HelpAnchor resolves to a real anchor per the L5.3 contract.

## Design notes

- Accounts ratio chosen 1/3 + 2/3 (not 1/4 + 3/4) so the Account Types card has room for system badges + count column without truncating; the Accounts list keeps the action cluster on one row at lg+. Memo `project_accounts_side_by_side_layout.md` Q3 (asymmetric grid).
- Breakpoint `lg:` (1024px) rather than `md:` because the Accounts row's internal grid breaks at `md:` itself; promoting the outer grid at `md:` would double-collapse the action column on narrow tablets. Stack stays through tablet, splits on desktop.
- `lg:items-start` so the short Types card keeps its intrinsic height instead of stretching to the Accounts card's height.
- Recurring header uses `flex-col gap-3 sm:flex-row sm:items-center sm:justify-between` so the cluster stacks vertically below 640px and flips to a row at sm+. HelpAnchor lives INSIDE the H1 so it wraps with the title across breakpoints. Generate Due is `self-start sm:self-auto` so it doesn't stretch full-width on mobile.

## Screenshot handoff (owner-side capture)

Agent stack couldn't seed. Owner-side:
```
gh pr checkout <N> && ./pfv restart
```

Then capture:
1. /accounts side-by-side layout, desktop, light
2. /accounts stacked layout, mobile 375x812
3. /accounts with both panels populated, desktop, dark
4. /recurring desktop header (title + ? + Generate Due in one row), light
5. /recurring desktop header (title + ? + Generate Due in one row), dark
6. /recurring mobile 375x812 header (title cluster on top, Generate Due button on its own row below)
7. /recurring tablet 768px header (still stacked since fold is at sm: 640px, so verify the sm+ flip kicks in cleanly)