### PR TITLE
feat(dashboard): match Recent Transactions column order with /transactions + sortable Status

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -177,12 +177,12 @@ export default function DashboardPage() {
   // Item 6 (system-wide sort persistence): the dashboard transactions table
   // and the Spending by Category card both persist their sort state via
   // localStorage so a navigate-away-and-back lands the user where they were.
-  type DashTxSort = "date" | "description" | "amount";
+  type DashTxSort = "date" | "description" | "status" | "amount";
   const dashTxSort = usePersistedSort<DashTxSort>(
     SORT_KEY_DASHBOARD_TRANSACTIONS,
     "date",
     "desc",
-    ["date", "description", "amount"] as const,
+    ["date", "description", "status", "amount"] as const,
   );
   const dashSortField = dashTxSort.field;
   const dashSortDir = dashTxSort.dir;
@@ -581,6 +581,8 @@ export default function DashboardPage() {
     if (dashSortField === field) {
       dashTxSort.setSort(field, dashSortDir === "asc" ? "desc" : "asc");
     } else {
+      // Default direction per field: date desc (newest first), description /
+      // status asc (alphabetical: pending before settled), amount asc.
       dashTxSort.setSort(field, field === "date" ? "desc" : "asc");
     }
   }
@@ -604,6 +606,10 @@ export default function DashboardPage() {
       let cmp = 0;
       if (dashSortField === "date") cmp = a.date.localeCompare(b.date);
       else if (dashSortField === "description") cmp = a.description.localeCompare(b.description);
+      // Status sort is alphabetical on the enum value: "pending" < "settled"
+      // so asc surfaces pending rows first (what the user wants to act on),
+      // desc surfaces settled first.
+      else if (dashSortField === "status") cmp = a.status.localeCompare(b.status);
       else if (dashSortField === "amount") cmp = Number(a.amount) - Number(b.amount);
       return dashSortDir === "asc" ? cmp : -cmp;
     });
@@ -1111,69 +1117,101 @@ export default function DashboardPage() {
             <div className={`flex items-center justify-between ${cardHeader}`}>
               <h2 className={cardTitle}>Recent Transactions</h2>
             </div>
-            {/* Sortable mini-header */}
-            <div className="flex items-center justify-between px-5 py-1.5 border-b border-border-subtle text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-              <div className="flex items-center gap-3">
-                <button onClick={() => toggleDashSort("date")} className="w-16 text-left min-h-[32px] hover:text-text-primary">Date{dashSortField === "date" ? (dashSortDir === "asc" ? " ↑" : " ↓") : ""}</button>
-                <button onClick={() => toggleDashSort("description")} className="text-left min-h-[32px] hover:text-text-primary">Description{dashSortField === "description" ? (dashSortDir === "asc" ? " ↑" : " ↓") : ""}</button>
+            {/* Sortable mini-header. Column order mirrors /transactions:
+                Date / Description / Status / Amount. Hidden under sm; mobile
+                rows collapse to a two-line layout (see below) where header
+                labels are redundant. */}
+            <div className="hidden sm:block border-b border-border-subtle px-5 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+              <div className="grid grid-cols-12 items-center gap-3">
+                {([
+                  { field: "date" as const, label: "Date", span: "col-span-2", align: "text-left" },
+                  { field: "description" as const, label: "Description", span: "col-span-6", align: "text-left" },
+                  { field: "status" as const, label: "Status", span: "col-span-2", align: "text-center" },
+                  { field: "amount" as const, label: "Amount", span: "col-span-2", align: "text-right" },
+                ]).map((col) => (
+                  <button
+                    key={col.field}
+                    onClick={() => toggleDashSort(col.field)}
+                    className={`${col.span} ${col.align} min-h-[32px] hover:text-text-primary transition-colors`}
+                  >
+                    {col.label}{dashSortField === col.field ? (dashSortDir === "asc" ? " ↑" : " ↓") : ""}
+                  </button>
+                ))}
               </div>
-              <button onClick={() => toggleDashSort("amount")} className="min-h-[32px] hover:text-text-primary">Amount{dashSortField === "amount" ? (dashSortDir === "asc" ? " ↑" : " ↓") : ""}</button>
             </div>
             <div className="divide-y divide-border-subtle">
               {sortedVisibleTxs.map((tx) => {
                 const isTransfer = tx.linked_transaction_id !== null;
                 const linkedTx = isTransfer ? txMap.get(tx.linked_transaction_id!) : null;
+                const amountClass = `text-sm font-medium tabular-nums ${isTransfer ? "text-info" : tx.type === "income" ? "text-success" : "text-danger"}`;
+                const amountText = `${isTransfer ? "" : tx.type === "income" ? "+" : "-"}${formatAmount(tx.amount)}`;
+                const subline = isTransfer && linkedTx ? (
+                  <>{tx.account_name} &rarr; {linkedTx.account_name}</>
+                ) : (
+                  <>{tx.account_name} &middot; {tx.category_name}</>
+                );
+                const statusPill = !isTransfer ? (
+                  <button
+                    onClick={async () => {
+                      try {
+                        await apiFetch(`/api/v1/transactions/${tx.id}`, {
+                          method: "PUT",
+                          body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }),
+                        });
+                        await loadTransactions(page);
+                        await loadRefs();
+                        void loadForecastProjection();
+                        void loadAccountMonthEndForecast();
+                        // Independent of `page`: a toggle on page 2
+                        // still has to refresh the strip's totals.
+                        void loadPendingTransactions();
+                      } catch (err) {
+                        setError(extractErrorMessage(err));
+                      }
+                    }}
+                    aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
+                    aria-pressed={tx.status === "settled"}
+                    className="inline-flex min-h-[44px] items-center"
+                  >
+                    {/* Outer button carries the WCAG 2.5.8 touch target;
+                        inner span matches /transactions' pill visual. */}
+                    <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-warning-dim text-warning"}`}>
+                      {tx.status}
+                    </span>
+                  </button>
+                ) : null;
                 return (
-                  <div key={tx.id} className="flex items-center justify-between px-5 py-2.5">
-                    <Link
-                      href={transactionHighlightHref(tx)}
-                      className="-mx-2 -my-1.5 flex min-w-0 items-center gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
-                    >
-                      <span className="text-xs tabular-nums text-text-muted w-16 shrink-0">{tx.date.slice(5)}</span>
-                      <div className="min-w-0">
-                        <p className="text-sm text-text-primary truncate">{tx.description}</p>
-                        <p className="text-[11px] text-text-muted truncate">
-                          {isTransfer && linkedTx ? <>{tx.account_name} &rarr; {linkedTx.account_name}</> : <>{tx.account_name} · {tx.category_name}</>}
-                        </p>
+                  <div key={tx.id} className="px-5 py-2.5">
+                    {/* Responsive single-tree row. On sm+, this is a 12-col
+                        grid mirroring the header (Date / Description / Status
+                        / Amount). Below sm, the wrapper drops to a flex
+                        column so we get a two-line layout: line 1 the link
+                        (date + description + subline), line 2 the status
+                        pill + amount on the right. Single Link/pill node so
+                        deep-link tests that match `findByRole("link", ...)`
+                        keep working. */}
+                    <div className="flex flex-col gap-1.5 sm:grid sm:grid-cols-12 sm:items-center sm:gap-3">
+                      <Link
+                        href={transactionHighlightHref(tx)}
+                        className="-mx-2 -my-1.5 flex min-w-0 items-center gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-surface-raised focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent sm:col-span-8 sm:my-0"
+                      >
+                        <span className="w-16 shrink-0 text-xs tabular-nums text-text-muted sm:w-auto">{tx.date.slice(5)}</span>
+                        <div className="min-w-0">
+                          <p className="text-sm text-text-primary truncate">{tx.description}</p>
+                          <p className="text-[11px] text-text-muted truncate">{subline}</p>
+                        </div>
+                      </Link>
+                      {/* Status + Amount: on desktop these split into their
+                          own columns (col-span-2 each). On mobile they share
+                          one flex row indented under the description. */}
+                      <div className="flex items-center justify-between gap-2 pl-[4.75rem] sm:contents sm:pl-0">
+                        <div className="sm:col-span-2 sm:flex sm:justify-center">
+                          {statusPill}
+                        </div>
+                        <div className="sm:col-span-2 sm:text-right">
+                          <span className={amountClass}>{amountText}</span>
+                        </div>
                       </div>
-                    </Link>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <span className={`text-sm font-medium tabular-nums ${isTransfer ? "text-info" : tx.type === "income" ? "text-success" : "text-danger"}`}>
-                        {isTransfer ? "" : tx.type === "income" ? "+" : "-"}{formatAmount(tx.amount)}
-                      </span>
-                      {!isTransfer && (
-                        <button
-                          onClick={async () => {
-                            try {
-                              await apiFetch(`/api/v1/transactions/${tx.id}`, {
-                                method: "PUT",
-                                body: JSON.stringify({ status: tx.status === "settled" ? "pending" : "settled" }),
-                              });
-                              await loadTransactions(page);
-                              await loadRefs();
-                              void loadForecastProjection();
-                              void loadAccountMonthEndForecast();
-                              // Independent of `page` — a toggle on page 2
-                              // still has to refresh the strip's totals.
-                              void loadPendingTransactions();
-                            } catch (err) {
-                              setError(extractErrorMessage(err));
-                            }
-                          }}
-                          aria-label={`Mark as ${tx.status === "settled" ? "pending" : "settled"}`}
-                          aria-pressed={tx.status === "settled"}
-                          className="inline-flex min-h-[44px] items-center"
-                        >
-                          {/* Outer button carries the WCAG 2.5.8
-                              touch-target hit area; inner span keeps
-                              the lean visual that matches /transactions.
-                              Pending uses the warning token so it reads
-                              as actionable, not muted gray. */}
-                          <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tx.status === "settled" ? "bg-success-dim text-success" : "bg-warning-dim text-warning"}`}>
-                            {tx.status}
-                          </span>
-                        </button>
-                      )}
                     </div>
                   </div>
                 );

--- a/frontend/tests/app/dashboard-recent-tx-columns.test.tsx
+++ b/frontend/tests/app/dashboard-recent-tx-columns.test.tsx
@@ -1,0 +1,251 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import DashboardPage from "@/app/dashboard/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/dashboard",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const TXS = [
+  {
+    id: 1,
+    account_id: 10,
+    amount: "12.00",
+    type: "expense",
+    status: "settled",
+    date: "2026-05-03",
+    description: "Apples",
+    category_id: 1,
+    category_name: "Groceries",
+    account_name: "Checking",
+    currency: "EUR",
+    linked_transaction_id: null,
+    is_imported: false,
+    settled_date: "2026-05-03",
+  },
+  {
+    id: 2,
+    account_id: 10,
+    amount: "50.00",
+    type: "expense",
+    status: "pending",
+    date: "2026-05-02",
+    description: "Bananas",
+    category_id: 1,
+    category_name: "Groceries",
+    account_name: "Credit",
+    currency: "EUR",
+    linked_transaction_id: null,
+    is_imported: false,
+    settled_date: null,
+  },
+];
+
+function mockDashboard() {
+  vi.mocked(apiFetch).mockImplementation(((url: string) => {
+    if (url === "/api/v1/accounts") return Promise.resolve([]);
+    if (url === "/api/v1/categories") return Promise.resolve([]);
+    if (url === "/api/v1/budgets" || url.startsWith("/api/v1/budgets?")) return Promise.resolve([]);
+    if (url === "/api/v1/settings/billing-cycle") return Promise.resolve({ billing_cycle_day: 1 });
+    if (url === "/api/v1/settings/billing-period")
+      return Promise.resolve({ id: 1, start_date: "2026-05-01", end_date: null });
+    if (url === "/api/v1/settings/billing-periods")
+      return Promise.resolve([{ id: 1, start_date: "2026-05-01", end_date: null }]);
+    if (url.startsWith("/api/v1/forecast-plans/current")) return Promise.resolve(null);
+    if (url.startsWith("/api/v1/forecast?period_start=")) return Promise.resolve(null);
+    if (url.startsWith("/api/v1/transactions?status=pending")) return Promise.resolve([TXS[1]]);
+    if (url.startsWith("/api/v1/transactions")) return Promise.resolve(TXS);
+    return Promise.resolve({});
+  }) as never);
+}
+
+describe("DashboardPage Recent Transactions columns", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    window.history.pushState({}, "", "/dashboard");
+    window.localStorage.clear();
+    vi.mocked(useAuth).mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    mockDashboard();
+  });
+
+  function getRecentTxHeader(container: HTMLElement, name: string): HTMLElement {
+    // Recent Transactions mini-header is the only Dashboard element where
+    // Date/Description/Status/Amount appear as a 12-col grid of <button>s
+    // directly under a `hidden sm:block` wrapper. Locate that wrapper, then
+    // pick the column header whose textContent starts with the given label.
+    // This isolates us from the Spending card's "Amount" header (which uses
+    // aria-label="Sort by amount") and from any unrelated dashboard buttons.
+    const grids = container.querySelectorAll(".hidden.sm\\:block .grid.grid-cols-12");
+    for (const grid of Array.from(grids)) {
+      const btns = grid.querySelectorAll(":scope > button");
+      for (const b of Array.from(btns)) {
+        const txt = b.textContent ?? "";
+        if (txt.startsWith(name)) return b as HTMLElement;
+      }
+    }
+    throw new Error(`No Recent Tx sort header for "${name}"`);
+  }
+
+  async function findHeaderButton(name: string, container?: HTMLElement) {
+    return await waitFor(() => {
+      const root = container ?? document.body;
+      return getRecentTxHeader(root, name);
+    });
+  }
+
+  it("renders sort headers in /transactions order: Date, Description, Status, Amount", async () => {
+    const { container } = render(<DashboardPage />);
+
+    // The mini-header lives in a hidden sm:block; jsdom layouts ignore
+    // breakpoints so the header still renders in the DOM and is queryable.
+    const dateBtn = await findHeaderButton("Date", container);
+    const descBtn = await findHeaderButton("Description", container);
+    const statusBtn = await findHeaderButton("Status", container);
+    const amountBtn = await findHeaderButton("Amount", container);
+
+    // Confirm document order matches column order left -> right.
+    const ordered = [dateBtn, descBtn, statusBtn, amountBtn];
+    for (let i = 0; i < ordered.length - 1; i++) {
+      const rel = ordered[i].compareDocumentPosition(ordered[i + 1]);
+      expect(rel & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    }
+  });
+
+  it("clicking Status header toggles sort and shows arrow indicator", async () => {
+    const { container } = render(<DashboardPage />);
+
+    const statusBtn = await findHeaderButton("Status", container);
+
+    // First click: ascending (alphabetical -> pending before settled).
+    fireEvent.click(statusBtn);
+    await waitFor(() => {
+      expect(getRecentTxHeader(container, "Status").textContent ?? "").toMatch(
+        /Status\s+↑/,
+      );
+    });
+
+    // Second click on the same header flips to descending.
+    fireEvent.click(getRecentTxHeader(container, "Status"));
+    await waitFor(() => {
+      expect(getRecentTxHeader(container, "Status").textContent ?? "").toMatch(
+        /Status\s+↓/,
+      );
+    });
+  });
+
+  it("default sort is Date desc; status-asc places pending row above settled", async () => {
+    const { container } = render(<DashboardPage />);
+
+    // Wait for both rows to render. Each tx row is a single responsive
+    // wrapper (flex on mobile, grid-cols-12 on sm+); we read row textContent
+    // off the wrapper directly.
+    const desktopRows = () =>
+      Array.from(
+        container.querySelectorAll(".flex.flex-col.sm\\:grid.sm\\:grid-cols-12"),
+      );
+    const rowText = (idx: number) =>
+      desktopRows()[idx]?.textContent ?? "";
+
+    await waitFor(() => {
+      expect(desktopRows().length).toBeGreaterThanOrEqual(2);
+      expect(rowText(0)).toContain("Apples");
+      expect(rowText(1)).toContain("Bananas");
+    });
+
+    // Default: date desc -> 2026-05-03 ("Apples") above 2026-05-02 ("Bananas").
+    expect(rowText(0)).toContain("Apples");
+    expect(rowText(1)).toContain("Bananas");
+
+    // Switch to status asc -> "pending" ("Bananas") above "settled" ("Apples").
+    const statusBtn = await findHeaderButton("Status", container);
+    fireEvent.click(statusBtn);
+    await waitFor(() => {
+      expect(getRecentTxHeader(container, "Status").textContent ?? "").toMatch(
+        /Status\s+↑/,
+      );
+    });
+
+    await waitFor(() => {
+      expect(rowText(0)).toContain("Bananas");
+      expect(rowText(1)).toContain("Apples");
+    });
+  });
+
+  it("uses responsive grid: 12-col on sm+, flex two-line on mobile", async () => {
+    const { container } = render(<DashboardPage />);
+
+    await waitFor(() => {
+      // Each transaction row wraps in a `flex flex-col sm:grid sm:grid-cols-12`
+      // container — one node per tx, no duplicated subtrees.
+      expect(
+        container.querySelectorAll(".flex.flex-col.sm\\:grid.sm\\:grid-cols-12")
+          .length,
+      ).toBeGreaterThanOrEqual(2);
+    });
+
+    // Header row is `hidden sm:block` to disappear under sm; the row wrapper
+    // is always present (the breakpoint flips layout, not visibility).
+    const header = container.querySelector(".hidden.sm\\:block .grid.grid-cols-12");
+    expect(header).toBeTruthy();
+
+    // Confirm Status pill + Amount share a single flex container on mobile
+    // and split to columns on sm+ via Tailwind's `sm:contents`.
+    const mobileSplit = container.querySelectorAll(".flex.items-center.justify-between.sm\\:contents");
+    expect(mobileSplit.length).toBeGreaterThan(0);
+
+    // Right-aligned tabular amount must exist (rightmost cell on sm+).
+    const amountSpans = container.querySelectorAll(".sm\\:text-right .tabular-nums");
+    expect(amountSpans.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Recent Transactions widget on `/dashboard` now uses the same column order as `/transactions`: Date / Description / Status / Amount.
- Amount lives in its own rightmost cell (was crammed next to the status pill).
- Status becomes a sortable column. Default click sorts ascending (alphabetical), which puts pending rows above settled, the typical action target.
- Mobile (under sm): single Link/pill node, two-line layout (date + description on line 1, status pill + amount on line 2 indented under the description). Deep-link tests stay green because there is only one Link per row.

## Sort behavior

- Date: default desc (newest first), toggles.
- Description: default asc (alphabetical), toggles.
- Status: default asc (pending before settled, because `pending` < `settled` alphabetically), toggles to desc on second click.
- Amount: default asc, toggles.

Sort indicator arrow (↑ / ↓) renders next to the active column header.

## Tests

- New `frontend/tests/app/dashboard-recent-tx-columns.test.tsx`:
  - Column order Date / Description / Status / Amount (document position assertion).
  - Status header click toggles asc then desc, arrow updates.
  - Default Date desc; Status asc places pending row above settled.
  - Responsive single-tree layout (one row wrapper per tx, no DOM duplication).
- Existing dashboard suites (`dashboard-pending-toggle-refresh`, `dashboard-sort-header-touch-targets`, all 113 frontend test files, 775 tests) pass.

## Screenshot handoff (owner-side capture)

Agent stack could not seed. Owner-side:

```
gh pr checkout <N> && ./pfv restart
```

Then navigate to `/dashboard` and capture:

1. Recent Transactions widget default state (sorted by date desc), desktop, light theme.
2. After clicking Status column header (sorted by status asc), desktop.
3. Mobile 375x812, two-line-per-row layout.
4. Pagination next-page click, confirm column order preserved.