### PR TITLE
feat(admin): cross-org user search + drill-down (L4.4 slice)

### DIFF
--- a/backend/alembic/versions/046_seed_users_view_permission.py
+++ b/backend/alembic/versions/046_seed_users_view_permission.py
@@ -1,0 +1,81 @@
+"""Seed users.view permission into the superadmin role (L4.4 slice).
+
+Revision ID: 046_users_view_perm
+Revises: 045_reconciliation_state
+Create Date: 2026-05-13
+
+L4.4 ships the cross-org user search admin surface
+(``/api/v1/admin/users`` list + detail). The endpoints are gated by a
+new ``users.view`` permission key (added to
+``app/auth/permissions.py``'s ``Permission`` literal + ``ALL_PERMISSIONS``).
+
+The runtime resolver short-circuits via ``is_superadmin``, so the seed
+below is for parity with future non-superadmin roles and to keep the
+``/admin/roles`` UI's permission editor accurate. We INSERT-IGNORE
+(via existence check) so re-running the migration after manual seeding
+doesn't fail.
+
+This follows the pattern documented in migration
+``033_add_roles_and_role_permissions`` and the analytics-view follow-up
+``039_seed_analytics_view_permission``.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "046_users_view_perm"
+down_revision = "045_reconciliation_state"
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_KEY = "users.view"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Locate the superadmin role; if the row is missing (e.g. someone
+    # ran the downgrade for 033 manually), bail silently. The runtime
+    # short-circuit still covers superadmins, and this seed is purely
+    # for UI parity.
+    row = bind.execute(
+        sa.text("SELECT id FROM roles WHERE slug = :slug"),
+        {"slug": "superadmin"},
+    ).first()
+    if row is None:
+        return
+    role_id = row[0]
+
+    # Idempotent insert: skip if the (role_id, permission_key) row
+    # already exists. Composite PK means a plain INSERT would explode
+    # on rerun under MySQL.
+    exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM role_permissions "
+            "WHERE role_id = :role_id AND permission_key = :key"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    ).first()
+    if exists is not None:
+        return
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO role_permissions (role_id, permission_key) "
+            "VALUES (:role_id, :key)"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "DELETE FROM role_permissions WHERE permission_key = :key"
+        ),
+        {"key": PERMISSION_KEY},
+    )

--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -27,6 +27,7 @@ Permission = Literal[
     "audit.view",
     "roles.manage",
     "analytics.view",
+    "users.view",
 ]
 
 
@@ -41,6 +42,7 @@ ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "audit.view",
     "roles.manage",
     "analytics.view",
+    "users.view",
 })
 
 

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -1,19 +1,32 @@
 """Admin user-management router.
 
-Mounted at ``/api/v1/admin/users``. Currently exposes a single
-recovery endpoint — ``POST /merge`` — used by a superadmin to fold
-one ``users`` row into another. Built primarily for the pre-launch
-case where an early version of the Google SSO callback inserted a
-duplicate row at an email that already had a local-password user.
+Mounted at ``/api/v1/admin/users``. Exposes:
 
-Auth: ``orgs.manage`` (which superadmins short-circuit). The
-operation rewrites identifying data so we want the highest gate
-we have today.
+- ``POST /merge`` (since PR #222): superadmin recovery to fold one
+  ``users`` row into another. Built primarily for the pre-launch case
+  where an early version of the Google SSO callback inserted a
+  duplicate row at an email that already had a local-password user.
+  Gated by ``orgs.manage`` because it rewrites identifying data.
+
+- ``GET /`` and ``GET /{user_id}`` (L4.4 slice): cross-org user
+  search. Read-only discovery surface so a superadmin can find a user
+  across every org. Gated by ``users.view``.
+
+The two surfaces share a router by design so the in-app URL space
+stays flat (``/api/v1/admin/users`` for everything user-shaped), but
+they sit on independent service modules:
+
+- ``user_merge_service``: mutating recovery flow.
+- ``admin_users_search_service``: read-only list/detail.
 """
 from __future__ import annotations
 
+import time
+from threading import Lock
+from typing import Literal, Optional
+
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.auth.permissions import require_permission
@@ -22,13 +35,68 @@ from app.deps import get_session_factory
 from app.models.user import User
 from app.rate_limit import get_client_ip
 from app.schemas.admin_users import UserMergeRequest, UserMergeResponse
-from app.services import audit_service, user_merge_service
+from app.services import (
+    admin_users_search_service,
+    audit_service,
+    user_merge_service,
+)
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 
 logger = structlog.stdlib.get_logger()
 
 router = APIRouter(prefix="/api/v1/admin/users", tags=["admin-users"])
+
+
+# ── Audit throttle (process-local) ──────────────────────────────────
+#
+# The list / detail GETs are issued by a superadmin clicking through
+# the admin UI. Without a throttle, an actor scrolling a paginated
+# list could spray dozens of ``admin.user.viewed`` audit rows in a
+# second. That is useless noise that drowns the genuine signal.
+#
+# Contract:
+#   - Throttle window is 60s.
+#   - List views are throttled per ``actor_user_id``.
+#   - Detail views are throttled per ``(actor_user_id, target_user_id)``
+#     so opening user A then user B writes two rows, but refreshing
+#     user A within the window stays quiet.
+#   - Throttle state is in-process; restart resets the window. That is
+#     acceptable for audit cardinality (cold start writes are the
+#     valid first row), and it keeps the read path free of a DB
+#     round-trip.
+#
+# The throttle is intentionally NOT applied to ``POST /merge``. Every
+# merge attempt must be auditable.
+_AUDIT_THROTTLE_SECONDS = 60.0
+_audit_throttle_state: dict[tuple, float] = {}
+_audit_throttle_lock = Lock()
+
+
+def _should_emit_view_audit(key: tuple) -> bool:
+    """Return True when this (key) hasn't fired within the window."""
+    now = time.monotonic()
+    with _audit_throttle_lock:
+        last = _audit_throttle_state.get(key)
+        if last is not None and (now - last) < _AUDIT_THROTTLE_SECONDS:
+            return False
+        _audit_throttle_state[key] = now
+        # Opportunistic GC: drop entries older than 4x the window so
+        # the dict doesn't grow unbounded across long-lived processes.
+        cutoff = now - (_AUDIT_THROTTLE_SECONDS * 4)
+        stale = [k for k, ts in _audit_throttle_state.items() if ts < cutoff]
+        for k in stale:
+            _audit_throttle_state.pop(k, None)
+    return True
+
+
+def _reset_audit_throttle_for_tests() -> None:
+    """Test helper: clear the in-process throttle dictionary.
+
+    Pure side-effect helper. Production code MUST NOT call this.
+    """
+    with _audit_throttle_lock:
+        _audit_throttle_state.clear()
 
 
 def _request_id() -> str | None:
@@ -167,3 +235,126 @@ async def merge_users(
         target_user_id=body.target_user_id,
         counts=counts,
     )
+
+
+# ── Cross-org user search (L4.4 slice) ──────────────────────────────
+
+
+_STATUS_FILTER = Literal["active", "inactive", "unverified", "superadmin"]
+_ROLE_FILTER = Literal["owner", "admin", "member"]
+
+
+@router.get("")
+async def list_users(
+    request: Request,
+    q: Optional[str] = Query(default=None, max_length=120),
+    org_id: Optional[int] = Query(default=None, ge=1),
+    role: Optional[_ROLE_FILTER] = Query(default=None),
+    status_filter: Optional[_STATUS_FILTER] = Query(default=None, alias="status"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    actor: User = Depends(require_permission("users.view")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Paginated cross-org user list.
+
+    Privacy note: ``q`` is NEVER logged. Only ``query_length`` and
+    ``result_count`` go to structlog so a raw search string can't
+    leak into the log pipeline.
+
+    Audit: one ``admin.user.list.viewed`` row per actor per minute
+    (process-local throttle). The first hit always records.
+    """
+    payload = await admin_users_search_service.list_users(
+        db,
+        q=q,
+        org_filter=org_id,
+        role_filter=role,
+        status_filter=status_filter,
+        limit=limit,
+        offset=offset,
+    )
+
+    await logger.ainfo(
+        "admin.user.list.viewed",
+        actor_user_id=actor.id,
+        actor_email=actor.email,
+        query_length=len(q) if q else 0,
+        org_filter=org_id,
+        role_filter=role,
+        status_filter=status_filter,
+        result_count=len(payload["items"]),
+        total=payload["total"],
+    )
+
+    if _should_emit_view_audit(("list", actor.id)):
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.user.list.viewed",
+            actor_user_id=actor.id,
+            actor_email=actor.email,
+            target_org_id=None,
+            target_org_name=None,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail={
+                "query_length": len(q) if q else 0,
+                "org_filter": org_id,
+                "role_filter": role,
+                "status_filter": status_filter,
+                "result_count": len(payload["items"]),
+                "total": payload["total"],
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+
+    return payload
+
+
+@router.get("/{user_id}")
+async def get_user_detail(
+    user_id: int,
+    request: Request,
+    actor: User = Depends(require_permission("users.view")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Full user detail with org memberships + recent audit events.
+
+    Audit: one ``admin.user.viewed`` row per (actor, user_id) per
+    minute (process-local throttle).
+    """
+    try:
+        payload = await admin_users_search_service.get_user_detail(
+            db, user_id=user_id
+        )
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+
+    await logger.ainfo(
+        "admin.user.viewed",
+        actor_user_id=actor.id,
+        actor_email=actor.email,
+        target_user_id=user_id,
+    )
+
+    if _should_emit_view_audit(("detail", actor.id, user_id)):
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.user.viewed",
+            actor_user_id=actor.id,
+            actor_email=actor.email,
+            target_org_id=None,
+            target_org_name=None,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail={"target_user_id": user_id},
+        )
+
+    return payload

--- a/backend/app/services/admin_users_search_service.py
+++ b/backend/app/services/admin_users_search_service.py
@@ -1,0 +1,232 @@
+"""Cross-org user search service (L4.4 slice).
+
+Backs the admin ``/api/v1/admin/users`` list and detail surface that
+lets a superadmin discover a user across the whole platform regardless
+of their org. Sits alongside ``user_merge_service`` (the recovery
+endpoint) but stays read-only. No mutating ops live here.
+
+Privacy: this service does NOT log raw search input. Callers (router)
+should log ``query_length`` / ``result_count`` only, never ``q``. This
+mirrors the description-suggestions contract (Wave 2A section 5.4).
+
+Shape decisions:
+
+- Search semantics: ``q`` is matched case-insensitively as a prefix
+  against ``email`` / ``username`` and as a substring against the
+  composed ``first_name + last_name`` display name. Prefix-then-
+  substring keeps the typical "I have an email or handle" case fast
+  without ruling out "I half-remember the name".
+- A user has exactly one org today (``users.org_id`` is single-FK),
+  so the returned ``orgs`` field is a single-element array. The shape
+  is pre-multi-org so the frontend can fan out later without a schema
+  break.
+- Recent audit events: filtered by ``actor_user_id`` (the events this
+  user performed). ``audit_events`` has no ``target_user_id`` column,
+  so we don't attempt the "events about this user" cut here. That is
+  an L4.7 expansion of the audit schema.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.services.exceptions import NotFoundError
+
+
+# Status options the router exposes. Matches the User flags we cut on.
+_STATUS_VALUES = frozenset({"active", "inactive", "unverified", "superadmin"})
+
+
+def _normalize_like(q: str) -> str:
+    """Escape LIKE metacharacters so a raw user query can't widen the match.
+
+    Same shape as ``transaction_suggestions_service._normalize_prefix``.
+    """
+    return q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _compose_display_name(user: User) -> Optional[str]:
+    parts = [p for p in (user.first_name, user.last_name) if p]
+    return " ".join(parts) if parts else None
+
+
+def _serialize_org(org: Organization, role: Role) -> dict:
+    return {
+        "org_id": org.id,
+        "name": org.name,
+        "role": role.value,
+    }
+
+
+def _serialize_user_row(user: User, org: Optional[Organization]) -> dict:
+    """Common list-row payload. Caller embeds ``orgs`` as a list."""
+    return {
+        "id": user.id,
+        "email": user.email,
+        "username": user.username,
+        "display_name": _compose_display_name(user),
+        "is_superadmin": user.is_superadmin,
+        "is_active": user.is_active,
+        "email_verified": user.email_verified,
+        "mfa_enabled": user.mfa_enabled,
+        "password_changed_at": (
+            user.password_changed_at.isoformat()
+            if user.password_changed_at else None
+        ),
+        "onboarded_at": (
+            user.onboarded_at.isoformat() if user.onboarded_at else None
+        ),
+        "created_at": (
+            user.created_at.isoformat() if user.created_at else None
+        ),
+        "orgs": [_serialize_org(org, user.role)] if org is not None else [],
+    }
+
+
+async def list_users(
+    db: AsyncSession,
+    *,
+    q: Optional[str] = None,
+    org_filter: Optional[int] = None,
+    role_filter: Optional[str] = None,
+    status_filter: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict:
+    """Paginated cross-org user list for the admin table.
+
+    ``q`` matches case-insensitively as prefix against ``email`` /
+    ``username`` and substring against ``first_name || ' ' || last_name``.
+
+    ``org_filter`` narrows to a single org id (drives the "user in org X"
+    drill-in from the orgs page once it lands). ``role_filter`` and
+    ``status_filter`` cut against the user's role/active/verified flags.
+
+    Returns ``{items, total, limit, offset}`` for direct JSON dump.
+    """
+    base = select(User, Organization).outerjoin(
+        Organization, Organization.id == User.org_id
+    )
+    count_base = select(func.count()).select_from(User)
+
+    where_clauses = []
+
+    if q:
+        q_lower = q.lower()
+        like_prefix_lower = _normalize_like(q_lower) + "%"
+        like_substr_lower = "%" + _normalize_like(q_lower) + "%"
+        # MySQL utf8mb4_0900_ai_ci is case-insensitive; SQLite LIKE is
+        # case-insensitive for ASCII. Lowering both sides keeps locale
+        # quirks (e.g. the email-as-CS column added by migration 040)
+        # from leaking case sensitivity into the search.
+        where_clauses.append(
+            or_(
+                func.lower(User.email).like(like_prefix_lower, escape="\\"),
+                func.lower(User.username).like(like_prefix_lower, escape="\\"),
+                func.lower(
+                    func.coalesce(User.first_name, "")
+                    + " "
+                    + func.coalesce(User.last_name, "")
+                ).like(like_substr_lower, escape="\\"),
+            )
+        )
+
+    if org_filter is not None:
+        where_clauses.append(User.org_id == org_filter)
+
+    if role_filter:
+        try:
+            role_enum = Role(role_filter)
+        except ValueError:
+            # Unknown role: return zero rows rather than 500.
+            return {"items": [], "total": 0, "limit": limit, "offset": offset}
+        where_clauses.append(User.role == role_enum)
+
+    if status_filter:
+        status_norm = status_filter.lower()
+        if status_norm not in _STATUS_VALUES:
+            return {"items": [], "total": 0, "limit": limit, "offset": offset}
+        if status_norm == "active":
+            where_clauses.append(User.is_active.is_(True))
+        elif status_norm == "inactive":
+            where_clauses.append(User.is_active.is_(False))
+        elif status_norm == "unverified":
+            where_clauses.append(User.email_verified.is_(False))
+        elif status_norm == "superadmin":
+            where_clauses.append(User.is_superadmin.is_(True))
+
+    for clause in where_clauses:
+        base = base.where(clause)
+        count_base = count_base.where(clause)
+
+    total = (await db.scalar(count_base)) or 0
+
+    rows = (
+        await db.execute(
+            base.order_by(User.created_at.desc(), User.id.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+    ).all()
+
+    items = [_serialize_user_row(user, org) for user, org in rows]
+
+    return {"items": items, "total": total, "limit": limit, "offset": offset}
+
+
+async def get_user_detail(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    audit_limit: int = 10,
+) -> dict:
+    """Full user payload + org memberships + recent audit events.
+
+    Raises ``NotFoundError`` if the user id doesn't exist.
+    """
+    row = (
+        await db.execute(
+            select(User, Organization)
+            .outerjoin(Organization, Organization.id == User.org_id)
+            .where(User.id == user_id)
+        )
+    ).first()
+    if row is None:
+        raise NotFoundError(f"User {user_id}")
+    user, org = row
+
+    payload = _serialize_user_row(user, org)
+    # Detail-only fields (kept off the list payload to stay lean).
+    payload["password_set"] = user.password_set
+    payload["sessions_invalidated_at"] = (
+        user.sessions_invalidated_at.isoformat()
+        if user.sessions_invalidated_at else None
+    )
+    payload["phone"] = user.phone
+
+    # Recent audit events authored by this user. Stable ordering by
+    # ``created_at DESC, id DESC`` mirrors ``list_audit_events``.
+    events_result = await db.execute(
+        select(AuditEvent)
+        .where(AuditEvent.actor_user_id == user_id)
+        .order_by(AuditEvent.created_at.desc(), AuditEvent.id.desc())
+        .limit(audit_limit)
+    )
+    audit_rows = list(events_result.scalars().all())
+    payload["recent_audit_events"] = [
+        {
+            "id": row.id,
+            "event_type": row.event_type,
+            "outcome": row.outcome.value,
+            "target_org_id": row.target_org_id,
+            "target_org_name": row.target_org_name,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+        }
+        for row in audit_rows
+    ]
+
+    return payload

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -53,6 +53,7 @@ def test_all_permissions_contains_known_platform_permissions() -> None:
         "audit.view",
         "roles.manage",
         "analytics.view",
+        "users.view",
     })
 
 

--- a/backend/tests/routers/test_admin_users_search.py
+++ b/backend/tests/routers/test_admin_users_search.py
@@ -1,0 +1,286 @@
+"""Router coverage for ``GET /api/v1/admin/users`` and
+``GET /api/v1/admin/users/{user_id}`` (L4.4 slice).
+
+Service-level behavior is pinned in
+``tests/services/test_admin_users_search_service.py``. This file
+covers:
+
+- Auth gate: missing ``users.view`` returns 403.
+- 404 on unknown user id.
+- Audit-throttle behavior: first list-view writes a row, second
+  within the window does not. Same per-(actor, target) for detail.
+- Privacy: raw ``q`` string never appears in structlog event detail.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.routers.admin_users import (
+    _reset_audit_throttle_for_tests,
+    router as admin_users_router,
+)
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture(autouse=True)
+def _reset_throttle():
+    """Clear the in-process audit throttle before EVERY test so the
+    throttle in one test never bleeds into the next."""
+    _reset_audit_throttle_for_tests()
+    yield
+    _reset_audit_throttle_for_tests()
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, actor_user_id: int) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    async def override_current_user() -> User:
+        async with session_factory() as db:
+            user = await db.get(User, actor_user_id)
+            assert user is not None
+            return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_users_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        admin_org = Organization(name="Admin Org", billing_cycle_day=1)
+        target_org = Organization(name="Target", billing_cycle_day=1)
+        db.add_all([admin_org, target_org])
+        await db.commit()
+
+        sa = User(
+            org_id=admin_org.id, username="root", email="root@platform.io",
+            password_hash=hash_password("pw"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        member = User(
+            org_id=admin_org.id, username="member", email="member@platform.io",
+            password_hash=hash_password("pw"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        target = User(
+            org_id=target_org.id, username="target_owner",
+            email="t_owner@target.io",
+            password_hash=hash_password("pw"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, member, target])
+        await db.commit()
+        return {
+            "sa_id": sa.id,
+            "member_id": member.id,
+            "target_id": target.id,
+            "admin_org_id": admin_org.id,
+            "target_org_id": target_org.id,
+        }
+
+
+# ── auth gate ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_users_requires_users_view(session_factory) -> None:
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["member_id"])
+    client = TestClient(app)
+    resp = client.get("/api/v1/admin/users")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_requires_users_view(session_factory) -> None:
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["member_id"])
+    client = TestClient(app)
+    resp = client.get(f"/api/v1/admin/users/{ids['target_id']}")
+    assert resp.status_code == 403
+
+
+# ── happy paths ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_users_superadmin_sees_cross_org(session_factory) -> None:
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["sa_id"])
+    client = TestClient(app)
+    resp = client.get("/api/v1/admin/users")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 3
+    emails = {item["email"] for item in body["items"]}
+    assert "t_owner@target.io" in emails  # cross-org visible.
+
+
+@pytest.mark.asyncio
+async def test_list_users_q_filters(session_factory) -> None:
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["sa_id"])
+    client = TestClient(app)
+    resp = client.get("/api/v1/admin/users", params={"q": "target"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["email"] == "t_owner@target.io"
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_returns_payload(session_factory) -> None:
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["sa_id"])
+    client = TestClient(app)
+    resp = client.get(f"/api/v1/admin/users/{ids['target_id']}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == ids["target_id"]
+    assert body["email"] == "t_owner@target.io"
+    assert body["orgs"][0]["org_id"] == ids["target_org_id"]
+    assert isinstance(body["recent_audit_events"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_404(session_factory) -> None:
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["sa_id"])
+    client = TestClient(app)
+    resp = client.get("/api/v1/admin/users/9999999")
+    assert resp.status_code == 404
+
+
+# ── audit throttle ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_audit_throttle_writes_once_per_window(session_factory) -> None:
+    """Three GETs in the same window: exactly one audit row."""
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["sa_id"])
+    client = TestClient(app)
+    for _ in range(3):
+        resp = client.get("/api/v1/admin/users")
+        assert resp.status_code == 200
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.user.list.viewed"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    # Audit detail carries the bounded fields (no raw q allowed).
+    detail = rows[0].detail
+    assert detail is not None
+    assert "query_length" in detail
+    assert "result_count" in detail
+    assert "q" not in detail  # raw search string must not be persisted
+
+
+@pytest.mark.asyncio
+async def test_detail_audit_throttle_per_target(session_factory) -> None:
+    """Two different targets within the same window: two audit rows."""
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["sa_id"])
+    client = TestClient(app)
+    # Same actor opens two different users; each should record.
+    client.get(f"/api/v1/admin/users/{ids['target_id']}")
+    client.get(f"/api/v1/admin/users/{ids['target_id']}")
+    client.get(f"/api/v1/admin/users/{ids['member_id']}")
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.user.viewed"
+                )
+            )
+        ).scalars().all()
+    target_ids = sorted([r.detail["target_user_id"] for r in rows])
+    assert target_ids == sorted([ids["target_id"], ids["member_id"]])
+
+
+# ── privacy: raw q never in audit detail ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_raw_q_not_in_audit_detail(session_factory) -> None:
+    """A successful list query never persists ``q`` itself.
+
+    The audit row carries ``query_length`` (an int) plus other metadata,
+    but the raw ``q`` string must not appear anywhere in
+    ``detail``. This mirrors the description-suggestions privacy
+    contract (Wave 2A section 5.4).
+    """
+    ids = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=ids["sa_id"])
+    client = TestClient(app)
+
+    secret = "supersecret-query-XYZ"
+    resp = client.get("/api/v1/admin/users", params={"q": secret})
+    assert resp.status_code == 200
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.user.list.viewed"
+                )
+            )
+        ).scalars().all()
+
+    # We expect exactly one row (first-call always records).
+    assert len(rows) == 1
+    detail = rows[0].detail or {}
+    # ``q`` itself must be absent. ``query_length`` is the only echo
+    # of search input the audit row carries.
+    assert "q" not in detail
+    assert "query" not in detail
+    assert detail.get("query_length") == len(secret)
+    # Defensive: serialize the entire row and assert the secret string
+    # is not embedded anywhere (e.g., a future field rename).
+    import json
+    assert secret not in json.dumps(detail)

--- a/backend/tests/services/test_admin_users_search_service.py
+++ b/backend/tests/services/test_admin_users_search_service.py
@@ -1,0 +1,331 @@
+"""Service-layer coverage for ``admin_users_search_service`` (L4.4 slice).
+
+Pinned behaviors:
+
+- Cross-org search returns users from every org, not the actor's only.
+- ``q`` matches email/username prefix and display-name substring,
+  case-insensitively.
+- LIKE metacharacters in ``q`` are escaped so a raw ``%`` does not
+  widen the match.
+- ``org_filter`` / ``role_filter`` / ``status_filter`` narrow correctly.
+- ``get_user_detail`` returns the user's single org membership plus
+  the recent audit events authored by them.
+- Detail-not-found raises ``NotFoundError``.
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import admin_users_search_service
+from app.services.exceptions import NotFoundError
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory) -> dict:
+    """Two orgs, four users across them, with varied flags."""
+    async with factory() as db:
+        org_a = Organization(name="Acme", billing_cycle_day=1)
+        org_b = Organization(name="Beta", billing_cycle_day=1)
+        db.add_all([org_a, org_b])
+        await db.commit()
+
+        alice = User(
+            org_id=org_a.id, username="alice", email="alice@acme.io",
+            first_name="Alice", last_name="Smith",
+            password_hash=hash_password("pw"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True, mfa_enabled=True,
+        )
+        bob = User(
+            org_id=org_a.id, username="bob", email="bob@acme.io",
+            first_name="Bob",
+            password_hash=hash_password("pw"),
+            role=Role.ADMIN, is_active=True, email_verified=False,
+        )
+        carol = User(
+            org_id=org_b.id, username="carol", email="carol@beta.io",
+            first_name="Carol", last_name="Jones",
+            password_hash=hash_password("pw"),
+            role=Role.MEMBER, is_active=False, email_verified=True,
+        )
+        dave = User(
+            org_id=org_b.id, username="dave_admin", email="dave@beta.io",
+            password_hash=hash_password("pw"),
+            role=Role.OWNER, is_active=True, email_verified=True,
+        )
+        db.add_all([alice, bob, carol, dave])
+        await db.commit()
+
+        # Two audit events authored by Alice. recent_audit_events
+        # should return them in DESC order.
+        e1 = AuditEvent(
+            event_type="admin.org.delete",
+            actor_user_id=alice.id,
+            actor_email=alice.email,
+            target_org_id=org_b.id,
+            target_org_name=org_b.name,
+            outcome=AuditOutcome.SUCCESS,
+            detail={"snapshot": {"name": "Beta"}},
+        )
+        e2 = AuditEvent(
+            event_type="admin.org.subscription.override",
+            actor_user_id=alice.id,
+            actor_email=alice.email,
+            target_org_id=org_a.id,
+            target_org_name=org_a.name,
+            outcome=AuditOutcome.SUCCESS,
+            detail={},
+        )
+        db.add_all([e1, e2])
+        await db.commit()
+
+        return {
+            "org_a_id": org_a.id,
+            "org_b_id": org_b.id,
+            "alice_id": alice.id,
+            "bob_id": bob.id,
+            "carol_id": carol.id,
+            "dave_id": dave.id,
+        }
+
+
+# ── list_users ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_users_returns_cross_org(session_factory) -> None:
+    """No filter: all users across both orgs come back."""
+    ids = await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db)
+    assert result["total"] == 4
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {
+        "alice@acme.io", "bob@acme.io",
+        "carol@beta.io", "dave@beta.io",
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_users_q_matches_email_prefix(session_factory) -> None:
+    """``q='ali'`` matches alice via email prefix."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db, q="ali")
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"alice@acme.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_q_matches_username_prefix(session_factory) -> None:
+    """``q='dave'`` matches dave_admin via username prefix."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db, q="dave")
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"dave@beta.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_q_matches_name_substring(session_factory) -> None:
+    """``q='jones'`` matches Carol Jones via display-name substring."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db, q="jones")
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"carol@beta.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_q_is_case_insensitive(session_factory) -> None:
+    """Upper-case query matches lower-case email."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db, q="ALICE")
+    assert result["total"] == 1
+    assert result["items"][0]["email"] == "alice@acme.io"
+
+
+@pytest.mark.asyncio
+async def test_list_users_q_escapes_like_metacharacters(session_factory) -> None:
+    """``q='%'`` must NOT match every user (LIKE-wildcard escape)."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db, q="%")
+    assert result["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_users_org_filter(session_factory) -> None:
+    """``org_filter`` narrows to a single org."""
+    ids = await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(
+            db, org_filter=ids["org_b_id"]
+        )
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"carol@beta.io", "dave@beta.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_role_filter(session_factory) -> None:
+    """``role_filter='member'`` returns only members."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db, role_filter="member")
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"carol@beta.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_unknown_role_filter_returns_empty(session_factory) -> None:
+    """An unknown role string short-circuits to empty rather than 500."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(
+            db, role_filter="not-a-role"
+        )
+    assert result["items"] == []
+    assert result["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_users_status_filter_inactive(session_factory) -> None:
+    """``status='inactive'`` returns the disabled user."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(
+            db, status_filter="inactive"
+        )
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"carol@beta.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_status_filter_unverified(session_factory) -> None:
+    """``status='unverified'`` returns users without email_verified."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(
+            db, status_filter="unverified"
+        )
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"bob@acme.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_status_filter_superadmin(session_factory) -> None:
+    """``status='superadmin'`` returns the platform superadmin."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(
+            db, status_filter="superadmin"
+        )
+    emails = {item["email"] for item in result["items"]}
+    assert emails == {"alice@acme.io"}
+
+
+@pytest.mark.asyncio
+async def test_list_users_pagination(session_factory) -> None:
+    """``limit`` + ``offset`` slice the result. Total is full count."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        page1 = await admin_users_search_service.list_users(db, limit=2, offset=0)
+        page2 = await admin_users_search_service.list_users(db, limit=2, offset=2)
+    assert page1["total"] == 4
+    assert page2["total"] == 4
+    assert len(page1["items"]) == 2
+    assert len(page2["items"]) == 2
+    # No overlap.
+    page1_ids = {item["id"] for item in page1["items"]}
+    page2_ids = {item["id"] for item in page2["items"]}
+    assert page1_ids.isdisjoint(page2_ids)
+
+
+@pytest.mark.asyncio
+async def test_list_users_row_shape(session_factory) -> None:
+    """List row carries the contracted fields including ``orgs`` array."""
+    ids = await _seed(session_factory)
+    async with session_factory() as db:
+        result = await admin_users_search_service.list_users(db, q="alice")
+    row = result["items"][0]
+    assert row["id"] == ids["alice_id"]
+    assert row["email"] == "alice@acme.io"
+    assert row["username"] == "alice"
+    assert row["display_name"] == "Alice Smith"
+    assert row["is_superadmin"] is True
+    assert row["is_active"] is True
+    assert row["email_verified"] is True
+    assert row["mfa_enabled"] is True
+    assert isinstance(row["orgs"], list) and len(row["orgs"]) == 1
+    assert row["orgs"][0]["org_id"] == ids["org_a_id"]
+    assert row["orgs"][0]["name"] == "Acme"
+    assert row["orgs"][0]["role"] == "owner"
+
+
+# ── get_user_detail ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_returns_user_org_and_audit(session_factory) -> None:
+    """Detail carries org membership and recent audit events."""
+    ids = await _seed(session_factory)
+    async with session_factory() as db:
+        detail = await admin_users_search_service.get_user_detail(
+            db, user_id=ids["alice_id"]
+        )
+    assert detail["id"] == ids["alice_id"]
+    assert detail["email"] == "alice@acme.io"
+    assert detail["orgs"][0]["org_id"] == ids["org_a_id"]
+    # Detail-only fields present.
+    assert "password_set" in detail
+    assert "sessions_invalidated_at" in detail
+    # Alice authored two audit events; recent_audit_events is non-empty.
+    assert len(detail["recent_audit_events"]) == 2
+    types = {e["event_type"] for e in detail["recent_audit_events"]}
+    assert types == {"admin.org.delete", "admin.org.subscription.override"}
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_missing_raises_not_found(session_factory) -> None:
+    """Nonexistent user id raises NotFoundError."""
+    await _seed(session_factory)
+    async with session_factory() as db:
+        with pytest.raises(NotFoundError):
+            await admin_users_search_service.get_user_detail(db, user_id=99999)
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_user_without_audit_events(session_factory) -> None:
+    """A user with no authored events has an empty recent_audit_events list."""
+    ids = await _seed(session_factory)
+    async with session_factory() as db:
+        detail = await admin_users_search_service.get_user_detail(
+            db, user_id=ids["bob_id"]
+        )
+    assert detail["recent_audit_events"] == []

--- a/frontend/app/admin/users/[user_id]/page.tsx
+++ b/frontend/app/admin/users/[user_id]/page.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { hasPlatformPermission } from "@/lib/auth";
+import {
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  pageTitle,
+} from "@/lib/styles";
+
+// Detail view for a single user. Three cards:
+// - Identity: id, email, username, name, flags.
+// - Org memberships: list with link to each /admin/orgs/[id].
+// - Recent audit events: last 10 events authored by this user.
+//
+// No mutating buttons. L4.4 slice is read-only discovery; the
+// admin-invite / password-reset / impersonate slices ship separately.
+
+type OrgRef = {
+  org_id: number;
+  name: string;
+  role: string;
+};
+
+type AuditEventRow = {
+  id: number;
+  event_type: string;
+  outcome: string;
+  target_org_id: number | null;
+  target_org_name: string | null;
+  created_at: string | null;
+};
+
+type UserDetail = {
+  id: number;
+  email: string;
+  username: string;
+  display_name: string | null;
+  is_superadmin: boolean;
+  is_active: boolean;
+  email_verified: boolean;
+  mfa_enabled: boolean;
+  password_set: boolean;
+  password_changed_at: string | null;
+  sessions_invalidated_at: string | null;
+  onboarded_at: string | null;
+  created_at: string | null;
+  phone: string | null;
+  orgs: OrgRef[];
+  recent_audit_events: AuditEventRow[];
+};
+
+function YesNo({ value }: { value: boolean }) {
+  return (
+    <span className={value ? "text-success" : "text-text-muted"}>
+      {value ? "Yes" : "No"}
+    </span>
+  );
+}
+
+export default function AdminUserDetailPage() {
+  const params = useParams();
+  const userId = Number(params?.user_id);
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [detail, setDetail] = useState<UserDetail | null>(null);
+  const [error, setError] = useState("");
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!hasPlatformPermission(user, "users.view")) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "users.view")) return;
+    if (!Number.isFinite(userId)) {
+      setError("Invalid user id");
+      setFetching(false);
+      return;
+    }
+    setFetching(true);
+    apiFetch<UserDetail>(`/api/v1/admin/users/${userId}`)
+      .then((d) => setDetail(d))
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
+      .finally(() => setFetching(false));
+  }, [loading, user, userId]);
+
+  if (loading || !user || !hasPlatformPermission(user, "users.view")) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-2">
+          <h1 className={`${pageTitle} mb-0`}>
+            {detail?.display_name || detail?.email || "User"}
+          </h1>
+          <HelpAnchor section="admin-users" label="User detail" variant="inline-title" />
+        </div>
+        <Link
+          href="/admin/users"
+          className="text-sm text-text-muted hover:text-accent"
+        >
+          Back to users
+        </Link>
+      </div>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      {fetching && (
+        <div className="flex justify-center py-12">
+          <Spinner />
+        </div>
+      )}
+
+      {!fetching && detail && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <div className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Identity</h2>
+            </div>
+            <dl className="divide-y divide-border-subtle px-6 py-2 text-sm">
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">User ID</dt>
+                <dd className="tabular-nums">{detail.id}</dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Email</dt>
+                <dd>{detail.email}</dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Username</dt>
+                <dd>{detail.username}</dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Display name</dt>
+                <dd>{detail.display_name ?? "—"}</dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Active</dt>
+                <dd>
+                  <YesNo value={detail.is_active} />
+                </dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Email verified</dt>
+                <dd>
+                  <YesNo value={detail.email_verified} />
+                </dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Superadmin</dt>
+                <dd>
+                  <YesNo value={detail.is_superadmin} />
+                </dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">MFA enabled</dt>
+                <dd>
+                  <YesNo value={detail.mfa_enabled} />
+                </dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Password set</dt>
+                <dd>
+                  <YesNo value={detail.password_set} />
+                </dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Created</dt>
+                <dd className="tabular-nums">
+                  {detail.created_at?.slice(0, 10) ?? "—"}
+                </dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Onboarded</dt>
+                <dd className="tabular-nums">
+                  {detail.onboarded_at?.slice(0, 10) ?? "—"}
+                </dd>
+              </div>
+              <div className="flex justify-between py-2">
+                <dt className="text-text-muted">Password last changed</dt>
+                <dd className="tabular-nums">
+                  {detail.password_changed_at?.slice(0, 10) ?? "—"}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className={card}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Organization memberships</h2>
+            </div>
+            <div className="px-6 py-4 text-sm">
+              {detail.orgs.length === 0 && (
+                <p className="text-text-muted">No org memberships.</p>
+              )}
+              {detail.orgs.length > 0 && (
+                <ul className="space-y-2">
+                  {detail.orgs.map((org) => (
+                    <li
+                      key={org.org_id}
+                      className="flex items-center justify-between rounded-md border border-border-subtle px-3 py-2"
+                    >
+                      <Link
+                        href={`/admin/orgs/${org.org_id}`}
+                        className="text-accent hover:text-accent-hover"
+                      >
+                        {org.name}
+                      </Link>
+                      <span className="text-xs uppercase tracking-wider text-text-muted">
+                        {org.role}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          <div className={`${card} lg:col-span-2`}>
+            <div className={cardHeader}>
+              <h2 className={cardTitle}>Recent audit events</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                    <th className="px-6 py-3">When</th>
+                    <th className="px-6 py-3">Event</th>
+                    <th className="px-6 py-3">Outcome</th>
+                    <th className="px-6 py-3">Target org</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detail.recent_audit_events.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="px-6 py-6 text-center text-text-muted">
+                        No recent audit events authored by this user.
+                      </td>
+                    </tr>
+                  )}
+                  {detail.recent_audit_events.map((ev) => (
+                    <tr key={ev.id} className="border-b border-border-subtle">
+                      <td className="px-6 py-3 text-text-secondary tabular-nums">
+                        {ev.created_at?.replace("T", " ").slice(0, 19) ?? "—"}
+                      </td>
+                      <td className="px-6 py-3 font-mono text-xs text-text-secondary">
+                        {ev.event_type}
+                      </td>
+                      <td className="px-6 py-3 text-text-secondary">{ev.outcome}</td>
+                      <td className="px-6 py-3 text-text-secondary">
+                        {ev.target_org_id ? (
+                          <Link
+                            href={`/admin/orgs/${ev.target_org_id}`}
+                            className="hover:text-accent"
+                          >
+                            {ev.target_org_name ?? `Org ${ev.target_org_id}`}
+                          </Link>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
@@ -25,11 +25,17 @@ import {
 //   The query string is the source of truth for filter state. On
 //   mount we read q / org_id / role / status / offset from
 //   ``useSearchParams`` and seed React state from them. Filter
-//   changes are mirrored back to the URL via ``router.replace`` (no
-//   history entry per keystroke). That means:
+//   changes are mirrored back to the URL via ``router.replace`` so:
 //     - refreshing keeps the filters
-//     - the back button restores the previous filter state
 //     - a filtered URL is shareable / linkable
+//   Filter changes do NOT create separate history entries. The
+//   choice is deliberate ``router.replace`` rather than
+//   ``router.push``: every keystroke or chip tap would otherwise
+//   become a back-button stop, and admin filter UX rarely benefits
+//   from that. Back-button restoration of filter state is therefore
+//   out of contract; it requires a future ``router.push``-on-commit
+//   path (debounce settled, URL actually changed).
+//
 //   The URL write is debounced through the same 300 ms ``q``
 //   debounce so a keypress sequence does not stomp ``router.replace``
 //   on every character. Other (single-tap) filters update the URL
@@ -167,8 +173,22 @@ function AdminUsersPageContent() {
       });
   }, [loading, user]);
 
-  // Debounce the search input. Resets offset to 0 whenever q changes.
+  // Debounce the search input. Resets offset to 0 whenever the user
+  // types a new query.
+  //
+  // First-mount guard: the effect fires once on mount because qInput
+  // was seeded from the URL. Without the guard, that first run would
+  // call ``setOffset(0)`` after the debounce window and clobber an
+  // ``offset=50`` (or any non-zero) value we just seeded from the
+  // URL. The ref flips on the first run so subsequent (user-driven)
+  // qInput changes still reset the offset, which is the contract for
+  // a new search.
+  const isInitialDebounceRunRef = useRef(true);
   useEffect(() => {
+    if (isInitialDebounceRunRef.current) {
+      isInitialDebounceRunRef.current = false;
+      return;
+    }
     const handle = setTimeout(() => {
       setQ(qInput.trim());
       setOffset(0);
@@ -196,10 +216,11 @@ function AdminUsersPageContent() {
   }, [loading, user, q, orgId, role, status, offset]);
 
   // Mirror filter state back to the URL. Uses ``router.replace`` so
-  // the back button steps through user-visible state changes, not
-  // every intermediate keystroke. ``q`` is already debounced upstream
-  // (the qInput effect commits to ``q`` after 300 ms); other filters
-  // tap and apply, so they write to the URL eagerly.
+  // filter changes do not pile up as back-button stops (see the
+  // top-of-file URL state contract for the trade-off). ``q`` is
+  // already debounced upstream (the qInput effect commits to ``q``
+  // after 300 ms); other filters tap and apply, so they write to
+  // the URL eagerly.
   //
   // ``scroll: false`` keeps the table position stable across writes;
   // without it Next 15 scrolls to the top of the page on every

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
@@ -20,12 +20,23 @@ import {
 
 // L4.4 cross-org user search list. Mirrors /admin/orgs/page.tsx in
 // shape: header + search input + filter chips + paginated table.
-// Filter behavior:
-// - search bar debounces 300ms.
-// - role / status chips are radio-like (one active at a time).
-// - "Org" filter is a dropdown sourced from /admin/orgs (cap 200).
-// The query string is the source of truth for the filter state when
-// the user navigates away and back; offset resets when filters change.
+//
+// URL state contract:
+//   The query string is the source of truth for filter state. On
+//   mount we read q / org_id / role / status / offset from
+//   ``useSearchParams`` and seed React state from them. Filter
+//   changes are mirrored back to the URL via ``router.replace`` (no
+//   history entry per keystroke). That means:
+//     - refreshing keeps the filters
+//     - the back button restores the previous filter state
+//     - a filtered URL is shareable / linkable
+//   The URL write is debounced through the same 300 ms ``q``
+//   debounce so a keypress sequence does not stomp ``router.replace``
+//   on every character. Other (single-tap) filters update the URL
+//   eagerly.
+//
+// Mounted under a top-level <Suspense> because ``useSearchParams`` is
+// a client boundary in Next 15.
 
 type OrgRef = {
   org_id: number;
@@ -75,21 +86,57 @@ function chipClass(active: boolean): string {
     "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors",
     active
       ? "border-accent bg-accent/10 text-accent"
-      : "border-border bg-bg-elevated text-text-secondary hover:border-border-strong hover:text-text",
+      : "border-border bg-surface text-text-secondary hover:bg-surface-raised hover:border-border hover:text-text-primary",
   ].join(" ");
 }
 
 export default function AdminUsersPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <Spinner />
+        </div>
+      }
+    >
+      <AdminUsersPageContent />
+    </Suspense>
+  );
+}
+
+function AdminUsersPageContent() {
   const { user, loading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Seed filter state from the URL on the FIRST render so a refresh
+  // (or a shared / bookmarked filtered URL) lands the page in the
+  // same state. We rely on these reads being stable across the first
+  // render only; subsequent param changes flow through React state.
+  const initialQ = searchParams.get("q") ?? "";
+  const initialOrgId = (() => {
+    const raw = searchParams.get("org_id");
+    if (raw === null || raw === "") return "" as const;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : ("" as const);
+  })();
+  const initialRole = searchParams.get("role") ?? "";
+  const initialStatus = searchParams.get("status") ?? "";
+  const initialOffset = (() => {
+    const raw = searchParams.get("offset");
+    if (raw === null || raw === "") return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  })();
 
   // Filter state.
-  const [qInput, setQInput] = useState("");
-  const [q, setQ] = useState("");
-  const [orgId, setOrgId] = useState<number | "">("");
-  const [role, setRole] = useState<string>("");
-  const [status, setStatus] = useState<string>("");
-  const [offset, setOffset] = useState(0);
+  const [qInput, setQInput] = useState(initialQ);
+  const [q, setQ] = useState(initialQ);
+  const [orgId, setOrgId] = useState<number | "">(initialOrgId);
+  const [role, setRole] = useState<string>(initialRole);
+  const [status, setStatus] = useState<string>(initialStatus);
+  const [offset, setOffset] = useState(initialOffset);
 
   const [data, setData] = useState<UsersListResponse | null>(null);
   const [orgOptions, setOrgOptions] = useState<OrgPickerOption[]>([]);
@@ -147,6 +194,34 @@ export default function AdminUsersPage() {
       .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
       .finally(() => setFetching(false));
   }, [loading, user, q, orgId, role, status, offset]);
+
+  // Mirror filter state back to the URL. Uses ``router.replace`` so
+  // the back button steps through user-visible state changes, not
+  // every intermediate keystroke. ``q`` is already debounced upstream
+  // (the qInput effect commits to ``q`` after 300 ms); other filters
+  // tap and apply, so they write to the URL eagerly.
+  //
+  // ``scroll: false`` keeps the table position stable across writes;
+  // without it Next 15 scrolls to the top of the page on every
+  // ``router.replace``.
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "users.view")) return;
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    if (orgId !== "") params.set("org_id", String(orgId));
+    if (role) params.set("role", role);
+    if (status) params.set("status", status);
+    if (offset > 0) params.set("offset", String(offset));
+    const query = params.toString();
+    // Skip the write when the URL already matches. Cheap string
+    // compare; avoids a needless ``router.replace`` (and the React
+    // re-render it triggers) on first mount when state was seeded
+    // from the URL.
+    const current = searchParams.toString();
+    if (query === current) return;
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, user, q, orgId, role, status, offset, pathname, router]);
 
   const filtersActive = useMemo(
     () => Boolean(q || orgId !== "" || role || status),
@@ -277,7 +352,7 @@ export default function AdminUsersPage() {
             <button
               type="button"
               onClick={resetFilters}
-              className="ml-auto text-xs text-text-muted underline hover:text-text"
+              className="ml-auto text-xs text-text-muted underline hover:text-text-primary"
             >
               Clear filters
             </button>

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import HelpAnchor from "@/components/HelpAnchor";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { hasPlatformPermission } from "@/lib/auth";
+import {
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  pageTitle,
+} from "@/lib/styles";
+
+// L4.4 cross-org user search list. Mirrors /admin/orgs/page.tsx in
+// shape: header + search input + filter chips + paginated table.
+// Filter behavior:
+// - search bar debounces 300ms.
+// - role / status chips are radio-like (one active at a time).
+// - "Org" filter is a dropdown sourced from /admin/orgs (cap 200).
+// The query string is the source of truth for the filter state when
+// the user navigates away and back; offset resets when filters change.
+
+type OrgRef = {
+  org_id: number;
+  name: string;
+  role: string;
+};
+
+type UserRow = {
+  id: number;
+  email: string;
+  username: string;
+  display_name: string | null;
+  is_superadmin: boolean;
+  is_active: boolean;
+  email_verified: boolean;
+  mfa_enabled: boolean;
+  password_changed_at: string | null;
+  onboarded_at: string | null;
+  created_at: string | null;
+  orgs: OrgRef[];
+};
+
+type UsersListResponse = {
+  items: UserRow[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+type OrgPickerOption = {
+  id: number;
+  name: string;
+};
+
+type OrgsListResponse = {
+  items: { id: number; name: string }[];
+  total: number;
+};
+
+const PAGE_SIZE = 50;
+const SEARCH_DEBOUNCE_MS = 300;
+const ROLE_OPTIONS = ["owner", "admin", "member"] as const;
+const STATUS_OPTIONS = ["active", "inactive", "unverified", "superadmin"] as const;
+
+function chipClass(active: boolean): string {
+  return [
+    "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+    active
+      ? "border-accent bg-accent/10 text-accent"
+      : "border-border bg-bg-elevated text-text-secondary hover:border-border-strong hover:text-text",
+  ].join(" ");
+}
+
+export default function AdminUsersPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  // Filter state.
+  const [qInput, setQInput] = useState("");
+  const [q, setQ] = useState("");
+  const [orgId, setOrgId] = useState<number | "">("");
+  const [role, setRole] = useState<string>("");
+  const [status, setStatus] = useState<string>("");
+  const [offset, setOffset] = useState(0);
+
+  const [data, setData] = useState<UsersListResponse | null>(null);
+  const [orgOptions, setOrgOptions] = useState<OrgPickerOption[]>([]);
+  const [fetching, setFetching] = useState(true);
+  const [error, setError] = useState("");
+
+  // Permission gate.
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!hasPlatformPermission(user, "users.view")) {
+      router.replace("/dashboard");
+    }
+  }, [loading, user, router]);
+
+  // Load the org picker once. Capped at 200 rows because that is the
+  // backend's cap; the picker is a dropdown not an infinite list.
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "users.view")) return;
+    apiFetch<OrgsListResponse>("/api/v1/admin/orgs?limit=200")
+      .then((d) => setOrgOptions(d.items.map((o) => ({ id: o.id, name: o.name }))))
+      .catch(() => {
+        // Silent: a missing picker degrades the filter UX but doesn't
+        // block the list itself. The list page still works.
+      });
+  }, [loading, user]);
+
+  // Debounce the search input. Resets offset to 0 whenever q changes.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setQ(qInput.trim());
+      setOffset(0);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [qInput]);
+
+  // Fetch the list. Re-runs whenever any filter changes.
+  useEffect(() => {
+    if (loading || !user || !hasPlatformPermission(user, "users.view")) return;
+    setFetching(true);
+    setError("");
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+    });
+    if (q) params.set("q", q);
+    if (orgId !== "") params.set("org_id", String(orgId));
+    if (role) params.set("role", role);
+    if (status) params.set("status", status);
+    apiFetch<UsersListResponse>(`/api/v1/admin/users?${params.toString()}`)
+      .then((d) => setData(d))
+      .catch((err) => setError(extractErrorMessage(err, "Failed to load")))
+      .finally(() => setFetching(false));
+  }, [loading, user, q, orgId, role, status, offset]);
+
+  const filtersActive = useMemo(
+    () => Boolean(q || orgId !== "" || role || status),
+    [q, orgId, role, status],
+  );
+
+  function resetFilters() {
+    setQInput("");
+    setQ("");
+    setOrgId("");
+    setRole("");
+    setStatus("");
+    setOffset(0);
+  }
+
+  if (loading || !user || !hasPlatformPermission(user, "users.view")) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-2">
+          <h1 className={`${pageTitle} mb-0`}>Users</h1>
+          <HelpAnchor section="admin-users" label="Users admin" variant="inline-title" />
+        </div>
+      </div>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>All users</h2>
+        </div>
+
+        {/* Search row */}
+        <div className="px-6 py-4">
+          <input
+            type="search"
+            value={qInput}
+            onChange={(e) => setQInput(e.target.value)}
+            placeholder="Search by email, username, or name"
+            className={`${input} w-full max-w-sm`}
+            aria-label="Search users"
+          />
+        </div>
+
+        {/* Filter chips */}
+        <div className="flex flex-wrap items-center gap-2 px-6 pb-4">
+          <span className="text-xs uppercase tracking-wider text-text-muted">Org</span>
+          <select
+            value={orgId === "" ? "" : String(orgId)}
+            onChange={(e) => {
+              const val = e.target.value;
+              setOrgId(val === "" ? "" : Number(val));
+              setOffset(0);
+            }}
+            aria-label="Filter by organization"
+            className={`${input} max-w-[14rem]`}
+          >
+            <option value="">All</option>
+            {orgOptions.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name}
+              </option>
+            ))}
+          </select>
+
+          <span className="ml-2 text-xs uppercase tracking-wider text-text-muted">Role</span>
+          <button
+            type="button"
+            className={chipClass(role === "")}
+            onClick={() => {
+              setRole("");
+              setOffset(0);
+            }}
+          >
+            All
+          </button>
+          {ROLE_OPTIONS.map((r) => (
+            <button
+              key={r}
+              type="button"
+              className={chipClass(role === r)}
+              onClick={() => {
+                setRole(role === r ? "" : r);
+                setOffset(0);
+              }}
+            >
+              {r}
+            </button>
+          ))}
+
+          <span className="ml-2 text-xs uppercase tracking-wider text-text-muted">Status</span>
+          <button
+            type="button"
+            className={chipClass(status === "")}
+            onClick={() => {
+              setStatus("");
+              setOffset(0);
+            }}
+          >
+            All
+          </button>
+          {STATUS_OPTIONS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              className={chipClass(status === s)}
+              onClick={() => {
+                setStatus(status === s ? "" : s);
+                setOffset(0);
+              }}
+            >
+              {s}
+            </button>
+          ))}
+
+          {filtersActive && (
+            <button
+              type="button"
+              onClick={resetFilters}
+              className="ml-auto text-xs text-text-muted underline hover:text-text"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        {/* Table */}
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3">Name / email</th>
+                <th className="px-6 py-3">Username</th>
+                <th className="px-6 py-3">Org</th>
+                <th className="px-6 py-3">Role</th>
+                <th className="px-6 py-3">Status</th>
+                <th className="px-6 py-3">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && (
+                <tr>
+                  <td colSpan={6} className="px-6 py-6 text-center text-text-muted">
+                    Loading
+                  </td>
+                </tr>
+              )}
+              {!fetching && data?.items.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-6 py-6 text-center text-text-muted">
+                    No users match the current filters.
+                  </td>
+                </tr>
+              )}
+              {!fetching &&
+                data?.items.map((row) => {
+                  const primaryOrg = row.orgs[0];
+                  const statusLabel = row.is_superadmin
+                    ? "superadmin"
+                    : !row.is_active
+                      ? "inactive"
+                      : !row.email_verified
+                        ? "unverified"
+                        : "active";
+                  return (
+                    <tr key={row.id} className="border-b border-border-subtle">
+                      <td className="px-6 py-3">
+                        <Link
+                          href={`/admin/users/${row.id}`}
+                          className="text-accent hover:text-accent-hover"
+                        >
+                          {row.display_name || row.email}
+                        </Link>
+                        {row.display_name && (
+                          <div className="text-xs text-text-muted">{row.email}</div>
+                        )}
+                      </td>
+                      <td className="px-6 py-3 text-text-secondary">{row.username}</td>
+                      <td className="px-6 py-3 text-text-secondary">
+                        {primaryOrg ? (
+                          <Link
+                            href={`/admin/orgs/${primaryOrg.org_id}`}
+                            className="hover:text-accent"
+                          >
+                            {primaryOrg.name}
+                          </Link>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="px-6 py-3 text-text-secondary">
+                        {primaryOrg?.role ?? "—"}
+                      </td>
+                      <td className="px-6 py-3 text-text-secondary">{statusLabel}</td>
+                      <td className="px-6 py-3 text-text-secondary tabular-nums">
+                        {row.created_at?.slice(0, 10) ?? "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        </div>
+
+        {data && data.total > PAGE_SIZE && (
+          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
+            <span>
+              {offset + 1}–{Math.min(offset + PAGE_SIZE, data.total)} of {data.total}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                disabled={offset + PAGE_SIZE >= data.total}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -19,6 +19,7 @@ import {
   Settings,
   Shield,
   Tag,
+  Users,
   Wallet,
   X,
 } from "lucide-react";
@@ -104,6 +105,12 @@ const systemItems: readonly SystemNavItem[] = [
     label: "Organizations",
     permission: "orgs.view",
     icon: <Building2 {...NAV_ICON_PROPS} />,
+  },
+  {
+    href: "/admin/users",
+    label: "Users",
+    permission: "users.view",
+    icon: <Users {...NAV_ICON_PROPS} />,
   },
   {
     href: "/admin/audit",

--- a/frontend/scripts/check-design-tokens.sh
+++ b/frontend/scripts/check-design-tokens.sh
@@ -93,6 +93,75 @@ run_check "text-white / text-black (use tokens)" "${WHITE_BLACK_RE}" \
 run_check "Hard-coded hex literals" "${HEX_RE}" \
   --include='*.ts' --include='*.tsx'
 
+# ── Phantom theme-token utilities ────────────────────────────────────
+#
+# Catches Tailwind classes that READ like a project token (e.g.
+# ``bg-bg-elevated`` or ``hover:text-text``) but reference a name that
+# does not exist as ``--color-<name>`` in ``app/globals.css``. These
+# are silent: Tailwind emits no rule for an unknown utility, so the
+# element renders without styling and the bug ships invisibly.
+#
+# The check is scoped to OUR project prefixes (bg, surface, border,
+# text, accent, success, danger, warning, sidebar) so Tailwind's own
+# compound utilities (``text-balance``, ``border-collapse``,
+# ``bg-clip``, etc.) are never flagged. ``text-primary`` would slip
+# through (no hyphen after ``primary``), so the regex requires the
+# project namespace to be the SECOND segment of a 2+-segment class.
+#
+# Added 2026-05-13 after L4.4 cross-org user search shipped phantom
+# ``bg-bg-elevated`` and ``border-border-strong`` utilities (PR #257
+# review comment).
+PROJECT_NAMESPACES='(bg|surface|border|text|accent|success|danger|warning|sidebar)'
+PHANTOM_RE="\\b(hover:)?(bg|text|border|ring|fill|stroke|placeholder|caret|outline|divide|shadow|from|to|via|decoration)-${PROJECT_NAMESPACES}(-[a-z0-9]+)+\\b"
+
+# Harvest the catalog from globals.css. Each --color-<name> line gives
+# us a valid token suffix. ``--color-bg`` and ``--color-text-primary``
+# become catalog entries ``bg`` and ``text-primary``.
+CATALOG_FILE="$(mktemp)"
+trap 'rm -f "${CATALOG_FILE}"' EXIT
+grep -E '^\s+--color-[a-z0-9-]+:' app/globals.css \
+  | sed -E 's/^\s+--color-([a-z0-9-]+):.*/\1/' \
+  | sort -u > "${CATALOG_FILE}"
+
+# Collect candidate phantom utilities from the codebase, normalize to
+# the suffix we can compare against the catalog, then filter.
+candidates="$(grep -rEnH "${PHANTOM_RE}" \
+  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' \
+  "${EXCLUDES[@]}" "${ROOTS[@]}" 2>/dev/null || true)"
+
+if [ -n "${candidates}" ]; then
+  phantom_hits=""
+  while IFS= read -r line; do
+    # Extract every matching utility on the line; one line may carry
+    # several classes inside a single string.
+    while IFS= read -r token; do
+      # Strip the optional ``hover:`` prefix + the Tailwind property
+      # (``bg-``, ``text-``, etc.) so what remains is the token suffix
+      # the catalog stores.
+      suffix="$(echo "${token}" | sed -E 's/^(hover:)?(bg|text|border|ring|fill|stroke|placeholder|caret|outline|divide|shadow|from|to|via|decoration)-//')"
+      if ! grep -qx "${suffix}" "${CATALOG_FILE}"; then
+        phantom_hits+="${line}    (unknown token: ${token} -> --color-${suffix} missing)
+"
+        break  # one hit per line is enough; avoid noisy dupes.
+      fi
+    done < <(echo "${line}" | grep -oE "${PHANTOM_RE}")
+  done <<< "${candidates}"
+
+  if [ -n "${phantom_hits}" ]; then
+    # Phantom-token findings are reported as WARNINGS in this commit
+    # (do not flip ``fail`` to 1). There is one pre-existing offender
+    # in ``app/import/page.tsx`` that predates this check; gating CI
+    # on it would expand scope. Each follow-up PR that touches a
+    # phantom site should drop it from the list. Once the list is
+    # empty, promote this block to ``fail=1`` so the check gates CI
+    # on its own.
+    echo "── Phantom theme-token utilities (no --color-* match) ─────"
+    echo "WARNING (not currently fatal). Fix at first opportunity."
+    printf '%s' "${phantom_hits}"
+    echo
+  fi
+fi
+
 if [ "${fail}" -ne 0 ]; then
   echo "Design-token check failed. Replace the offenders with theme tokens"
   echo "from app/globals.css (e.g. bg-warning, text-danger, etc.) or with"

--- a/frontend/tests/app/admin-user-detail-page.test.tsx
+++ b/frontend/tests/app/admin-user-detail-page.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AdminUserDetailPage from "@/app/admin/users/[user_id]/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/users/42",
+  useParams: () => ({ user_id: "42" }),
+}));
+
+const SUPERADMIN = {
+  id: 1,
+  username: "root",
+  email: "root@platform.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Platform",
+  billing_cycle_day: 1,
+  is_superadmin: true,
+  is_active: true,
+  mfa_enabled: false,
+};
+
+const SAMPLE_DETAIL = {
+  id: 42,
+  email: "ada@acme.io",
+  username: "ada",
+  display_name: "Ada Lovelace",
+  is_superadmin: false,
+  is_active: true,
+  email_verified: true,
+  mfa_enabled: true,
+  password_set: true,
+  password_changed_at: "2026-04-30T10:00:00",
+  sessions_invalidated_at: null,
+  onboarded_at: "2026-04-15T10:00:00",
+  created_at: "2026-04-15T10:00:00",
+  phone: null,
+  orgs: [{ org_id: 10, name: "Acme Co", role: "owner" }],
+  recent_audit_events: [
+    {
+      id: 1,
+      event_type: "admin.org.subscription.override",
+      outcome: "success",
+      target_org_id: 11,
+      target_org_name: "Beta",
+      created_at: "2026-05-12T15:00:00",
+    },
+  ],
+};
+
+describe("AdminUserDetailPage", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders the user identity card and org membership", async () => {
+    apiFetchMock.mockResolvedValueOnce(SAMPLE_DETAIL as never);
+
+    render(<AdminUserDetailPage />);
+
+    // Page title is the display name.
+    await screen.findByRole("heading", { name: "Ada Lovelace" });
+    // Identity fields present.
+    expect(screen.getByText("ada@acme.io")).toBeInTheDocument();
+    expect(screen.getByText("ada")).toBeInTheDocument();
+    // Org membership link.
+    expect(screen.getByRole("link", { name: "Acme Co" })).toHaveAttribute(
+      "href",
+      "/admin/orgs/10",
+    );
+    // Recent audit event row.
+    expect(screen.getByText("admin.org.subscription.override")).toBeInTheDocument();
+  });
+
+  it("redirects non-superadmin users without users.view away from the page", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminUserDetailPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("shows an error banner on failed fetch", async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error("boom"));
+
+    render(<AdminUserDetailPage />);
+
+    await screen.findByRole("alert");
+  });
+});

--- a/frontend/tests/app/admin-users-page.test.tsx
+++ b/frontend/tests/app/admin-users-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import AdminUsersPage from "@/app/admin/users/page";
 import { apiFetch } from "@/lib/api";
@@ -286,4 +286,73 @@ describe("AdminUsersPage", () => {
       }
     });
   });
+
+  it("seeds offset from URL and preserves it after the debounce window", async () => {
+    // Regression for the bug where the qInput-debounce effect would
+    // fire once on mount (because qInput was seeded from the URL)
+    // and clobber the seeded offset back to 0. Owner reviewed the
+    // first L4.4 URL-state pass and caught this; the fix is a
+    // first-mount ref guard in the debounce effect.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      currentSearchParams = new URLSearchParams("q=ada&offset=50");
+      apiFetchMock.mockImplementation((url: string) => {
+        if (url.startsWith("/api/v1/admin/orgs")) {
+          return Promise.resolve({ items: [], total: 0 } as never);
+        }
+        return Promise.resolve(SAMPLE_USERS as never);
+      });
+
+      render(<AdminUsersPage />);
+
+      // First fetch carries the seeded offset.
+      await waitFor(() => {
+        const userCalls = apiFetchMock.mock.calls
+          .map((c) => c[0] as string)
+          .filter((u) => u.startsWith("/api/v1/admin/users"));
+        expect(userCalls[0]).toContain("offset=50");
+        expect(userCalls[0]).toContain("q=ada");
+      });
+
+      // Advance past the debounce window. If the first-mount guard
+      // is missing, the debounce effect fires here and calls
+      // setOffset(0), which would trigger a fresh fetch with
+      // offset=0 and a router.replace that drops the offset param.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(SEARCH_DEBOUNCE_MS + 100);
+      });
+
+      // No subsequent /api/v1/admin/users fetch may carry offset=0.
+      // Every user fetch must still carry offset=50.
+      const allUserCalls = apiFetchMock.mock.calls
+        .map((c) => c[0] as string)
+        .filter((u) => u.startsWith("/api/v1/admin/users"));
+      for (const u of allUserCalls) {
+        expect(u).toContain("offset=50");
+      }
+
+      // The URL writer must NEVER have rewritten the URL to drop
+      // offset. If it ran, the only acceptable form contains offset=50.
+      for (const call of replaceMock.mock.calls) {
+        const url = call[0] as string;
+        // If the URL has a query string, it must keep offset=50.
+        // If there is no query string at all the writer dropped
+        // offset, which is the failure mode this test catches.
+        if (url.includes("?")) {
+          expect(url).toContain("offset=50");
+        } else {
+          throw new Error(
+            `router.replace called with no query string (offset dropped): ${url}`,
+          );
+        }
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
+
+// Constant duplicated from the page module so the test can advance
+// fake timers past the page's debounce window without importing
+// implementation detail across a module boundary.
+const SEARCH_DEBOUNCE_MS = 300;

--- a/frontend/tests/app/admin-users-page.test.tsx
+++ b/frontend/tests/app/admin-users-page.test.tsx
@@ -21,9 +21,13 @@ vi.mock("@/components/auth/AuthProvider", async () => {
 });
 
 const replaceMock = vi.fn();
+// Per-test search params. Tests can mutate this BEFORE calling
+// ``render`` to seed the page from a specific URL.
+let currentSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/admin/users",
+  useSearchParams: () => currentSearchParams,
 }));
 
 const SUPERADMIN = {
@@ -90,6 +94,7 @@ describe("AdminUsersPage", () => {
   beforeEach(() => {
     apiFetchMock.mockReset();
     replaceMock.mockReset();
+    currentSearchParams = new URLSearchParams();
     useAuthMock.mockReturnValue({
       user: SUPERADMIN as never,
       loading: false,
@@ -221,6 +226,64 @@ describe("AdminUsersPage", () => {
           (u) => u.includes("/api/v1/admin/users") && u.includes("role=owner"),
         ),
       ).toBe(true);
+    });
+  });
+
+  // ── URL state contract ────────────────────────────────────────────
+
+  it("seeds filter state from the URL on mount", async () => {
+    // Land the page with a filter URL. The page should render the
+    // chips in that state AND issue the corresponding API call.
+    currentSearchParams = new URLSearchParams("q=ada&status=active&role=owner");
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/v1/admin/orgs")) {
+        return Promise.resolve({ items: [], total: 0 } as never);
+      }
+      return Promise.resolve(SAMPLE_USERS as never);
+    });
+
+    render(<AdminUsersPage />);
+
+    // Search input reflects the seeded ``q``.
+    const searchInput = (await screen.findByLabelText(
+      /search users/i,
+    )) as HTMLInputElement;
+    expect(searchInput.value).toBe("ada");
+
+    // First /admin/users call carries the seeded filters.
+    await waitFor(() => {
+      const calls = apiFetchMock.mock.calls.map((c) => c[0] as string);
+      const userCall = calls.find((u) => u.startsWith("/api/v1/admin/users"));
+      expect(userCall).toBeDefined();
+      expect(userCall).toContain("q=ada");
+      expect(userCall).toContain("status=active");
+      expect(userCall).toContain("role=owner");
+    });
+  });
+
+  it("writes filter changes back to the URL via router.replace", async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/v1/admin/orgs")) {
+        return Promise.resolve({ items: [], total: 0 } as never);
+      }
+      return Promise.resolve(SAMPLE_USERS as never);
+    });
+
+    render(<AdminUsersPage />);
+    await screen.findByText("Ada Lovelace");
+
+    fireEvent.click(screen.getByRole("button", { name: "admin" }));
+
+    await waitFor(() => {
+      // Some replace call has to carry role=admin in the path.
+      const urls = replaceMock.mock.calls.map((c) => c[0] as string);
+      expect(urls.some((u) => u.includes("role=admin"))).toBe(true);
+      // And every replace call passes scroll: false so the table
+      // doesn't jump on every URL write.
+      for (const call of replaceMock.mock.calls) {
+        const opts = call[1] as { scroll?: boolean } | undefined;
+        if (opts) expect(opts.scroll).toBe(false);
+      }
     });
   });
 });

--- a/frontend/tests/app/admin-users-page.test.tsx
+++ b/frontend/tests/app/admin-users-page.test.tsx
@@ -1,0 +1,226 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AdminUsersPage from "@/app/admin/users/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/users",
+}));
+
+const SUPERADMIN = {
+  id: 1,
+  username: "root",
+  email: "root@platform.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Platform",
+  billing_cycle_day: 1,
+  is_superadmin: true,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const SAMPLE_USERS = {
+  items: [
+    {
+      id: 42,
+      email: "ada@acme.io",
+      username: "ada",
+      display_name: "Ada Lovelace",
+      is_superadmin: false,
+      is_active: true,
+      email_verified: true,
+      mfa_enabled: false,
+      password_changed_at: null,
+      onboarded_at: "2026-04-30T10:00:00",
+      created_at: "2026-04-15T10:00:00",
+      orgs: [{ org_id: 10, name: "Acme Co", role: "owner" }],
+    },
+    {
+      id: 43,
+      email: "bob@beta.io",
+      username: "bob",
+      display_name: null,
+      is_superadmin: false,
+      is_active: false,
+      email_verified: true,
+      mfa_enabled: false,
+      password_changed_at: null,
+      onboarded_at: null,
+      created_at: "2026-04-10T10:00:00",
+      orgs: [{ org_id: 11, name: "Beta", role: "member" }],
+    },
+  ],
+  total: 2,
+  limit: 50,
+  offset: 0,
+};
+
+describe("AdminUsersPage", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders the users table from the API", async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/v1/admin/orgs")) {
+        return Promise.resolve({
+          items: [
+            { id: 10, name: "Acme Co" },
+            { id: 11, name: "Beta" },
+          ],
+          total: 2,
+        } as never);
+      }
+      return Promise.resolve(SAMPLE_USERS as never);
+    });
+
+    render(<AdminUsersPage />);
+
+    // Both display names should land in the rendered rows.
+    await screen.findByText("Ada Lovelace");
+    expect(screen.getByText("bob@beta.io")).toBeInTheDocument();
+    // Status column derives from flags: bob is_active=false -> inactive.
+    // ("inactive" appears as a filter chip too; assert the count
+    // is > 1 to confirm both occurrences are rendered without colliding
+    // on a single matcher.)
+    expect(screen.getAllByText("inactive").length).toBeGreaterThan(0);
+    // Org link shows the org name.
+    expect(screen.getAllByText("Acme Co").length).toBeGreaterThan(0);
+  });
+
+  it("redirects non-superadmin users without users.view away from the page", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminUsersPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("renders for a non-superadmin who carries users.view in permissions", async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/v1/admin/orgs")) {
+        return Promise.resolve({ items: [], total: 0 } as never);
+      }
+      return Promise.resolve(SAMPLE_USERS as never);
+    });
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["users.view"],
+      } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminUsersPage />);
+
+    await screen.findByText("Ada Lovelace");
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("debounces the search input and re-fires the list call with q", async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/v1/admin/orgs")) {
+        return Promise.resolve({ items: [], total: 0 } as never);
+      }
+      return Promise.resolve(SAMPLE_USERS as never);
+    });
+
+    render(<AdminUsersPage />);
+
+    await screen.findByText("Ada Lovelace");
+
+    const searchInput = screen.getByLabelText(/search users/i) as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: "ada" } });
+
+    // Wait for the debounced fetch to fire with q=ada.
+    await waitFor(
+      () => {
+        const calls = apiFetchMock.mock.calls.map((c) => c[0] as string);
+        expect(
+          calls.some((u) => u.includes("/api/v1/admin/users") && u.includes("q=ada")),
+        ).toBe(true);
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  it("applies the role filter chip and includes role= in the API call", async () => {
+    apiFetchMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/v1/admin/orgs")) {
+        return Promise.resolve({ items: [], total: 0 } as never);
+      }
+      return Promise.resolve(SAMPLE_USERS as never);
+    });
+
+    render(<AdminUsersPage />);
+    await screen.findByText("Ada Lovelace");
+
+    fireEvent.click(screen.getByRole("button", { name: "owner" }));
+
+    await waitFor(() => {
+      const calls = apiFetchMock.mock.calls.map((c) => c[0] as string);
+      expect(
+        calls.some(
+          (u) => u.includes("/api/v1/admin/users") && u.includes("role=owner"),
+        ),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Surface shape

**Option A — top-level `/admin/users` list with drill-down.**
Mirrors `/admin/orgs` and matches the owner ask (cross-org discovery
affordance). A drill-down route handles per-user inspection.

Considered (B) embedding search inside `/admin/orgs/[id]`, but that
ties cross-org search to the org page and ignores the "I have an
email, who is this person?" entry point. (A) wins.

## Backend

- **New permission:** `users.view`. Added to `Permission` Literal and
  `ALL_PERMISSIONS` in `backend/app/auth/permissions.py`.
- **Migration:** `046_seed_users_view_permission` chains off
  `045_reconciliation_state`. Idempotent seed of the new key into the
  superadmin role row (mirrors `039_seed_analytics_view_permission`).
  Single head confirmed (`alembic heads` -> `046_users_view_perm`).
- **Service:** `admin_users_search_service` with `list_users` +
  `get_user_detail`. Case-insensitive prefix match on email/username,
  substring match on composed display name. LIKE metacharacters
  escaped (`%`, `_`, `\`).
- **Router:** `admin_users` router extended with `GET /` and
  `GET /{user_id}`. Gated by `users.view`.

## Audit throttle

- Window: **60 seconds**, process-local.
- List view: one `admin.user.list.viewed` row per `actor_user_id` per
  window. First hit always records.
- Detail view: one `admin.user.viewed` row per
  `(actor_user_id, target_user_id)` per window. Opening user A then
  user B writes two rows; refreshing user A within the window stays
  quiet.
- Privacy: raw `q` is **never** logged to structlog or persisted to
  the audit row's `detail` JSON. Only `query_length` (int) appears.

## Frontend

- `/admin/users` paginated table with debounced (300 ms) search, org
  dropdown sourced from `/admin/orgs`, role/status filter chips,
  HelpAnchor with `inline-title` variant.
- `/admin/users/[user_id]` detail page: identity card, org memberships
  (linked to `/admin/orgs/[id]`), recent audit events table.
- AppShell adds a Users entry in the System section, gated on
  `users.view`.
- No mutating buttons. Admin invite / password reset / MFA reset /
  impersonate are explicitly **out of scope** for this slice.

## CI

- Backend pytest: 1122 passed, 9 skipped.
- Frontend vitest: 779 passed.
- TypeScript: clean.
- Lint: 0 errors. The two `set-state-in-effect` warnings on the new
  pages match the existing `/admin/orgs` pattern.
- Design-tokens check: passed.
- Migration up/down/up: clean. Single head confirmed.

## Screenshot handoff

Please capture (and attach inline on this PR before merge):
- [ ] `/admin/users` empty state (no users match the current filters)
- [ ] `/admin/users` populated list with search active
- [ ] `/admin/users` filter chips: role + status both selected
- [ ] `/admin/users/[user_id]` detail page with audit events visible
- [ ] AppShell sidebar showing the new Users entry under System