### PR TITLE
fix(transactions): batch entry grid layout (headers + missing cells)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -239,6 +239,83 @@ a, button { transition: all 0.15s ease; }
   background-color: #f1f3f4;
 }
 
+/* /transactions/batch responsive table.
+   Under the `md` breakpoint (Tailwind default: 768px), collapse the
+   9-column spreadsheet into one stacked labeled card per row. Each
+   `<td>` exposes its column name through `data-label`, the head row
+   hides, and the `<tr>` becomes a block-level grid that pairs label
+   and field together. Tokens (border, surface-raised, text-muted)
+   stay theme-aware so light + dark both inherit cleanly. */
+@media (max-width: 767.98px) {
+  .batch-grid {
+    display: block;
+  }
+  .batch-grid__head {
+    /* Hide the header row but keep it in the a11y tree for screen
+       readers (visually hidden, not display:none). */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .batch-grid tbody {
+    display: block;
+  }
+  .batch-grid__row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    margin-bottom: 0.75rem;
+    background-color: var(--color-surface-raised);
+  }
+  .batch-grid__row:last-child {
+    margin-bottom: 0;
+  }
+  .batch-grid__row > td {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    width: auto !important;
+  }
+  .batch-grid__row > td::before {
+    content: attr(data-label);
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+    margin-bottom: 0.25rem;
+  }
+  /* Span the full row width on cells that hold long inputs. */
+  .batch-grid__row > td[data-label="Description"],
+  .batch-grid__row > td[data-label="Account"],
+  .batch-grid__row > td[data-label="Category"],
+  .batch-grid__row > td[data-label="Result"] {
+    grid-column: span 2 / span 2;
+  }
+  .batch-grid__row > td[data-label="Row"] {
+    grid-column: span 2 / span 2;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .batch-grid__row > td[data-label="Row"]::before {
+    margin-bottom: 0;
+  }
+  .batch-grid__remove {
+    grid-column: span 2 / span 2;
+    text-align: right;
+  }
+}
+
 /* Honor user's reduced-motion preference. WCAG 2.2 AA + PRODUCT.md
    commitment. Disables animations, transitions, and smooth-scroll for
    anyone with the OS-level preference set. Placed last so it wins

--- a/frontend/app/transactions/batch/page.tsx
+++ b/frontend/app/transactions/batch/page.tsx
@@ -46,10 +46,19 @@ import {
   cardTitle,
   error as errorCls,
   input,
-  label,
   pageTitle,
   success as successCls,
 } from "@/lib/styles";
+
+// `label` (in lib/styles) bakes in `display: block` + `mb-1.5` so it can
+// sit on top of form inputs in stacked single-transaction forms. Apply
+// it to a `<th>` and the cell collapses out of the table row, dragging
+// every header into a vertical stack while the `<td>`s flow as normal
+// table cells (root cause of the 2026-05-13 layout regression).
+// `thLabel` keeps the same typography but lets the browser default
+// `display: table-cell` win.
+const thLabel =
+  "text-xs font-semibold uppercase tracking-[0.08em] text-text-muted";
 import type {
   Account,
   BatchTransactionRowInput,
@@ -65,6 +74,7 @@ const MAX_ROWS = 500;
 // need a non-changing key so React doesn't lose focus when the user
 // removes a row above the cursor.
 type DraftStatus = "idle" | "ok" | "error";
+type TxStatus = "settled" | "pending";
 
 interface DraftRow {
   key: string;
@@ -74,6 +84,7 @@ interface DraftRow {
   type: "expense" | "income";
   account_id: number | "";
   category_id: number | "";
+  tx_status: TxStatus;
   status: DraftStatus;
   errorMessage?: string;
 }
@@ -87,6 +98,7 @@ function blankRow(): DraftRow {
     type: "expense",
     account_id: "",
     category_id: "",
+    tx_status: "settled",
     status: "idle",
   };
 }
@@ -213,6 +225,7 @@ export default function BatchEntryPage() {
           amount: row.amount,
           type: row.type,
           date: row.date,
+          status: row.tx_status,
         },
       })),
     };
@@ -265,6 +278,146 @@ export default function BatchEntryPage() {
     setRows(Array.from({ length: DEFAULT_ROW_COUNT }, blankRow));
     setSummary(null);
     setTopError("");
+  }
+
+  // Render the inputs for a single row once and reuse them across the
+  // desktop `<table>` cells and the mobile labeled-card layout. Handlers
+  // close over `updateRow`, `accounts`, `categories`, `newRowFocusRef`
+  // from the enclosing component so the two layouts stay byte-for-byte
+  // in sync with state, ARIA, and focus management.
+  function renderRowFields(row: DraftRow, idx: number, isNewest: boolean) {
+    return {
+      date: (
+        <input
+          type="date"
+          className={input}
+          value={row.date}
+          onChange={(e) => updateRow(idx, { date: e.target.value })}
+          aria-label={`Row ${idx + 1} date`}
+          ref={isNewest ? newRowFocusRef : undefined}
+        />
+      ),
+      description: (
+        <DescriptionAutocomplete
+          id={`row-${row.key}-description`}
+          type={row.type}
+          value={row.description}
+          onChange={(next) => updateRow(idx, { description: next })}
+          onPick={(s) => {
+            // Pre-fill the category only when the row's category is still
+            // empty, mirroring the single-transaction add form. We never
+            // overwrite a user-chosen category.
+            if (row.category_id === "") {
+              updateRow(idx, {
+                description: s.description,
+                category_id: s.category_id,
+              });
+            }
+          }}
+          placeholder="e.g. Coffee shop"
+          ariaLabel={`Row ${idx + 1} description`}
+        />
+      ),
+      amount: (
+        <input
+          type="number"
+          step="0.01"
+          min="0.01"
+          className={input}
+          value={row.amount}
+          placeholder="0.00"
+          onChange={(e) => updateRow(idx, { amount: e.target.value })}
+          aria-label={`Row ${idx + 1} amount`}
+        />
+      ),
+      type: (
+        <select
+          className={input}
+          value={row.type}
+          onChange={(e) =>
+            updateRow(idx, {
+              type: e.target.value as "expense" | "income",
+              // Type change invalidates current category; clear it.
+              category_id: "",
+            })
+          }
+          aria-label={`Row ${idx + 1} type`}
+        >
+          <option value="expense">Expense</option>
+          <option value="income">Income</option>
+        </select>
+      ),
+      account: (
+        <select
+          className={input}
+          value={row.account_id === "" ? "" : String(row.account_id)}
+          onChange={(e) =>
+            updateRow(idx, {
+              account_id:
+                e.target.value === "" ? "" : Number(e.target.value),
+            })
+          }
+          aria-label={`Row ${idx + 1} account`}
+        >
+          <option value="">Pick account…</option>
+          {accounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+        </select>
+      ),
+      category: (
+        <CategorySelect
+          id={`row-${row.key}-category`}
+          categories={categories}
+          value={row.category_id}
+          onChange={(cid) => updateRow(idx, { category_id: cid })}
+          filterType={row.type}
+          aria-label={`Row ${idx + 1} category`}
+        />
+      ),
+      status: (
+        <select
+          className={input}
+          value={row.tx_status}
+          onChange={(e) =>
+            updateRow(idx, { tx_status: e.target.value as TxStatus })
+          }
+          aria-label={`Row ${idx + 1} status`}
+        >
+          <option value="settled">Settled</option>
+          <option value="pending">Pending</option>
+        </select>
+      ),
+      result: (
+        <>
+          {row.status === "ok" && (
+            <span
+              className="inline-flex items-center gap-1 text-success"
+              aria-label={`Row ${idx + 1} imported`}
+            >
+              <span aria-hidden>✓</span> Imported
+            </span>
+          )}
+          {row.status === "error" && (
+            <span
+              className="inline-flex items-start gap-1 text-danger"
+              role="alert"
+            >
+              <span aria-hidden>✕</span>
+              <span className="text-xs">{row.errorMessage}</span>
+            </span>
+          )}
+          {row.status === "idle" && !rowIsBlank(row) &&
+            (rowIsValid(row) ? (
+              <span className="text-xs text-text-muted">Ready</span>
+            ) : (
+              <span className="text-xs text-warning">Fill all cells</span>
+            ))}
+        </>
+      ),
+    };
   }
 
   return (
@@ -335,19 +488,32 @@ export default function BatchEntryPage() {
             .
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm" role="grid" aria-label="Batch entry grid">
-              <thead>
-                <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
-                  <th className="w-6 px-2 py-2"></th>
-                  <th className={`${label} w-32 px-2 py-2`}>Date</th>
-                  <th className={`${label} w-64 px-2 py-2`}>Description</th>
-                  <th className={`${label} w-28 px-2 py-2`}>Amount</th>
-                  <th className={`${label} w-28 px-2 py-2`}>Type</th>
-                  <th className={`${label} w-44 px-2 py-2`}>Account</th>
-                  <th className={`${label} w-44 px-2 py-2`}>Category</th>
-                  <th className={`${label} w-32 px-2 py-2`}>Status</th>
-                  <th className="w-10 px-2 py-2"></th>
+          <div className="overflow-x-auto md:overflow-x-auto">
+            {/* Single `<table>` source of truth. On md+ it renders as a
+                spreadsheet. Under md it falls back to one stacked
+                labeled card per row via the `batch-grid` CSS rules in
+                `app/globals.css` (each `<td>` exposes its column name
+                through `data-label`, the header row hides, and rows
+                turn into vertical mini-forms). Keeping a single DOM
+                tree avoids the dup-aria-label trap that the earlier
+                desktop/mobile split surfaced in tests. */}
+            <table
+              className="batch-grid w-full text-sm"
+              role="grid"
+              aria-label="Batch entry grid"
+            >
+              <thead className="batch-grid__head">
+                <tr className="border-b border-border text-left">
+                  <th scope="col" className="w-10 px-2 py-2 text-xs text-text-muted">#</th>
+                  <th scope="col" className={`${thLabel} w-32 px-2 py-2`}>Date</th>
+                  <th scope="col" className={`${thLabel} w-64 px-2 py-2`}>Description</th>
+                  <th scope="col" className={`${thLabel} w-28 px-2 py-2`}>Amount</th>
+                  <th scope="col" className={`${thLabel} w-28 px-2 py-2`}>Type</th>
+                  <th scope="col" className={`${thLabel} w-44 px-2 py-2`}>Account</th>
+                  <th scope="col" className={`${thLabel} w-44 px-2 py-2`}>Category</th>
+                  <th scope="col" className={`${thLabel} w-32 px-2 py-2`}>Status</th>
+                  <th scope="col" className={`${thLabel} w-32 px-2 py-2`}>Result</th>
+                  <th scope="col" className="w-10 px-2 py-2"><span className="sr-only">Remove</span></th>
                 </tr>
               </thead>
               <tbody>
@@ -355,145 +521,25 @@ export default function BatchEntryPage() {
                   const isLast = idx === rows.length - 1;
                   const isNewest =
                     idx === rows.length - 1 && rows.length > DEFAULT_ROW_COUNT;
+                  const fields = renderRowFields(row, idx, isNewest);
                   return (
                     <tr
                       key={row.key}
-                      className="border-b border-border last:border-b-0"
+                      className="batch-grid__row border-b border-border last:border-b-0"
                       data-row-index={idx}
                     >
-                      <td className="px-2 py-2 text-xs text-text-muted">
+                      <td className="px-2 py-2 text-xs text-text-muted" data-label="Row">
                         {idx + 1}
                       </td>
-                      <td className="px-2 py-2">
-                        <input
-                          type="date"
-                          className={input}
-                          value={row.date}
-                          onChange={(e) =>
-                            updateRow(idx, { date: e.target.value })
-                          }
-                          aria-label={`Row ${idx + 1} date`}
-                          ref={isNewest ? newRowFocusRef : undefined}
-                        />
-                      </td>
-                      <td className="px-2 py-2">
-                        <DescriptionAutocomplete
-                          id={`row-${row.key}-description`}
-                          type={row.type}
-                          value={row.description}
-                          onChange={(next) =>
-                            updateRow(idx, { description: next })
-                          }
-                          onPick={(s) => {
-                            // Pre-fill the category only when the row's
-                            // category is still empty, mirroring the
-                            // single-transaction add form. We never
-                            // overwrite a user-chosen category.
-                            if (row.category_id === "") {
-                              updateRow(idx, {
-                                description: s.description,
-                                category_id: s.category_id,
-                              });
-                            }
-                          }}
-                          placeholder="e.g. Coffee shop"
-                          ariaLabel={`Row ${idx + 1} description`}
-                        />
-                      </td>
-                      <td className="px-2 py-2">
-                        <input
-                          type="number"
-                          step="0.01"
-                          min="0.01"
-                          className={input}
-                          value={row.amount}
-                          placeholder="0.00"
-                          onChange={(e) =>
-                            updateRow(idx, { amount: e.target.value })
-                          }
-                          aria-label={`Row ${idx + 1} amount`}
-                        />
-                      </td>
-                      <td className="px-2 py-2">
-                        <select
-                          className={input}
-                          value={row.type}
-                          onChange={(e) =>
-                            updateRow(idx, {
-                              type: e.target.value as "expense" | "income",
-                              // Type change invalidates current category; clear it.
-                              category_id: "",
-                            })
-                          }
-                          aria-label={`Row ${idx + 1} type`}
-                        >
-                          <option value="expense">Expense</option>
-                          <option value="income">Income</option>
-                        </select>
-                      </td>
-                      <td className="px-2 py-2">
-                        <select
-                          className={input}
-                          value={row.account_id === "" ? "" : String(row.account_id)}
-                          onChange={(e) =>
-                            updateRow(idx, {
-                              account_id:
-                                e.target.value === ""
-                                  ? ""
-                                  : Number(e.target.value),
-                            })
-                          }
-                          aria-label={`Row ${idx + 1} account`}
-                        >
-                          <option value="">Pick account…</option>
-                          {accounts.map((a) => (
-                            <option key={a.id} value={a.id}>
-                              {a.name}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                      <td className="px-2 py-2">
-                        <CategorySelect
-                          id={`row-${row.key}-category`}
-                          categories={categories}
-                          value={row.category_id}
-                          onChange={(cid) =>
-                            updateRow(idx, { category_id: cid })
-                          }
-                          filterType={row.type}
-                          aria-label={`Row ${idx + 1} category`}
-                        />
-                      </td>
-                      <td className="px-2 py-2">
-                        {row.status === "ok" && (
-                          <span
-                            className="inline-flex items-center gap-1 text-success"
-                            aria-label={`Row ${idx + 1} imported`}
-                          >
-                            <span aria-hidden>✓</span> Imported
-                          </span>
-                        )}
-                        {row.status === "error" && (
-                          <span
-                            className="inline-flex items-start gap-1 text-danger"
-                            role="alert"
-                          >
-                            <span aria-hidden>✕</span>
-                            <span className="text-xs">{row.errorMessage}</span>
-                          </span>
-                        )}
-                        {row.status === "idle" && !rowIsBlank(row) && (
-                          rowIsValid(row) ? (
-                            <span className="text-xs text-text-muted">Ready</span>
-                          ) : (
-                            <span className="text-xs text-warning">
-                              Fill all cells
-                            </span>
-                          )
-                        )}
-                      </td>
-                      <td className="px-2 py-2">
+                      <td className="px-2 py-2" data-label="Date">{fields.date}</td>
+                      <td className="px-2 py-2" data-label="Description">{fields.description}</td>
+                      <td className="px-2 py-2" data-label="Amount">{fields.amount}</td>
+                      <td className="px-2 py-2" data-label="Type">{fields.type}</td>
+                      <td className="px-2 py-2" data-label="Account">{fields.account}</td>
+                      <td className="px-2 py-2" data-label="Category">{fields.category}</td>
+                      <td className="px-2 py-2" data-label="Status">{fields.status}</td>
+                      <td className="px-2 py-2" data-label="Result">{fields.result}</td>
+                      <td className="px-2 py-2 batch-grid__remove">
                         <button
                           type="button"
                           onClick={() => removeRow(idx)}

--- a/frontend/tests/app/transactions-batch-page-layout.test.tsx
+++ b/frontend/tests/app/transactions-batch-page-layout.test.tsx
@@ -1,0 +1,379 @@
+/**
+ * Regression coverage for the 2026-05-13 layout bug.
+ *
+ * Symptom: column header labels (`<th>` with `${label}` token) inherited
+ * `display: block` + `mb-1.5` from `lib/styles.ts`. The `block` override
+ * forced every header out of `display: table-cell`, stacking them
+ * vertically while `<tbody>`'s `<td>`s rendered as horizontal table
+ * cells. Users saw a left-aligned vertical list (DATE / DESCRIPTION /
+ * AMOUNT / ...) above a single row of inputs that didn't match the
+ * stacked headers in count or column width.
+ *
+ * Fix in `app/transactions/batch/page.tsx`:
+ *   - `<th>` no longer applies the `${label}` token; uses a local
+ *     `thLabel` class that drops `block` + `mb-1.5`.
+ *   - Row template now matches headers 1:1 (9 columns):
+ *     [#] [Date] [Description] [Amount] [Type] [Account] [Category]
+ *     [Status] [Result], plus a trailing `<th>` for the delete button.
+ *   - Status column = transaction status (settled / pending) select,
+ *     matching the single-transaction form. Submission outcome moved
+ *     to a separate `Result` column.
+ *
+ * This file asserts:
+ *   1. Header order matches the row-cell order (the layout-bug
+ *      regression test).
+ *   2. Every row exposes all expected inputs (incl. Description
+ *      autocomplete + Status select).
+ *   3. The Status select submits as `status: "settled" | "pending"`
+ *      on the batch payload, wiring the new field end-to-end.
+ *   4. A snapshot of the `<thead>` row (column order + classes) so
+ *      future refactors fail loudly if the header structure drifts.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import BatchEntryPage from "@/app/transactions/batch/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+// Stub CategorySelect to a native <select> like the sibling tests do,
+// so we exercise grid layout without dragging in the typeahead.
+vi.mock("@/components/ui/CategorySelect", () => ({
+  default: ({
+    value,
+    onChange,
+    categories,
+    "aria-label": ariaLabel,
+  }: {
+    value: number | "";
+    onChange: (id: number | "") => void;
+    categories: { id: number; name: string }[];
+    "aria-label"?: string;
+  }) => (
+    <select
+      aria-label={ariaLabel}
+      value={value === "" ? "" : String(value)}
+      onChange={(e) =>
+        onChange(e.target.value === "" ? "" : Number(e.target.value))
+      }
+    >
+      <option value="">Pick…</option>
+      {categories.map((c) => (
+        <option key={c.id} value={c.id}>
+          {c.name}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("@/components/transactions/DescriptionAutocomplete", () => ({
+  default: ({
+    id,
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    id: string;
+    value: string;
+    onChange: (next: string) => void;
+    ariaLabel?: string;
+  }) => (
+    <input
+      id={id}
+      type="text"
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/transactions/batch",
+}));
+
+const ACCOUNTS = [
+  {
+    id: 10,
+    name: "Primary",
+    account_type_id: 1,
+    account_type_name: "Checking",
+    account_type_slug: "checking",
+    balance: "150.00",
+    currency: "EUR",
+    is_active: true,
+    is_default: true,
+    close_day: null,
+  },
+];
+
+const CATEGORIES = [
+  {
+    id: 5,
+    name: "Groceries",
+    slug: "groceries",
+    parent_id: null,
+    type: "expense",
+    is_system: false,
+  },
+];
+
+const BASE_USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  password_set: true,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+function defaultMock() {
+  vi.mocked(apiFetch).mockImplementation((path: string) => {
+    if (path === "/api/v1/accounts") return Promise.resolve(ACCOUNTS);
+    if (path === "/api/v1/categories") return Promise.resolve(CATEGORIES);
+    return Promise.resolve([]);
+  });
+}
+
+function setUser() {
+  vi.mocked(useAuth).mockReturnValue({
+    user: { ...BASE_USER, role: "owner" } as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+describe("Batch entry layout (regression 2026-05-13)", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    defaultMock();
+    setUser();
+  });
+
+  it("renders the headers in the same order as the row cells", async () => {
+    const { container } = render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 1 description");
+
+    const headerCells = Array.from(container.querySelectorAll("thead th"));
+    const headerLabels = headerCells
+      .map((th) => th.textContent?.trim())
+      .filter((s): s is string => Boolean(s) && s !== "Remove");
+
+    expect(headerLabels).toEqual([
+      "#",
+      "Date",
+      "Description",
+      "Amount",
+      "Type",
+      "Account",
+      "Category",
+      "Status",
+      "Result",
+    ]);
+
+    // First-row cell order must align with the header order via data-label.
+    const firstRow = container.querySelector("tbody tr");
+    expect(firstRow).not.toBeNull();
+    const cellLabels = Array.from(firstRow!.querySelectorAll("td[data-label]"))
+      .map((td) => td.getAttribute("data-label"));
+    expect(cellLabels).toEqual([
+      "Row",
+      "Date",
+      "Description",
+      "Amount",
+      "Type",
+      "Account",
+      "Category",
+      "Status",
+      "Result",
+    ]);
+  });
+
+  it("does not apply `display: block` to header cells", async () => {
+    const { container } = render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 1 description");
+
+    // The bug was caused by the shared `label` style (which includes
+    // `block`) being applied to `<th>` elements. Guard against that
+    // regression by asserting no header cell carries the token's
+    // signature classes (`mb-1.5` + `block`) together.
+    const headerCells = Array.from(container.querySelectorAll("thead th"));
+    for (const th of headerCells) {
+      const cls = th.className;
+      const hasBlock = cls.split(/\s+/).includes("block");
+      expect(hasBlock).toBe(false);
+    }
+  });
+
+  it("renders every input cell per row (incl. description + status)", async () => {
+    render(<BatchEntryPage />);
+    // Description was missing from the broken visible row layout.
+    expect(await screen.findByLabelText("Row 1 description")).toBeTruthy();
+    expect(screen.getByLabelText("Row 1 date")).toBeTruthy();
+    expect(screen.getByLabelText("Row 1 amount")).toBeTruthy();
+    expect(screen.getByLabelText("Row 1 type")).toBeTruthy();
+    expect(screen.getByLabelText("Row 1 account")).toBeTruthy();
+    expect(screen.getByLabelText("Row 1 category")).toBeTruthy();
+    // Status select was missing entirely before the fix.
+    const statusSel = screen.getByLabelText("Row 1 status") as HTMLSelectElement;
+    expect(statusSel.tagName).toBe("SELECT");
+    const options = Array.from(statusSel.options).map((o) => o.value);
+    expect(options).toEqual(["settled", "pending"]);
+    expect(statusSel.value).toBe("settled");
+  });
+
+  it("sends row.status on the batch payload", async () => {
+    render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 1 description");
+
+    fireEvent.change(screen.getByLabelText("Row 1 description"), {
+      target: { value: "Coffee" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 amount"), {
+      target: { value: "9.50" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 account"), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 category"), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 status"), {
+      target: { value: "pending" },
+    });
+
+    let capturedBody: string | null = null;
+    vi.mocked(apiFetch).mockImplementationOnce((path, init) => {
+      capturedBody = (init?.body as string) ?? null;
+      return Promise.resolve({
+        imported_count: 1,
+        error_count: 0,
+        results: [{ row_number: 1, transaction_id: 99 }],
+        errors: [],
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Submit 1 row$/ }));
+
+    await waitFor(() => {
+      expect(capturedBody).not.toBeNull();
+    });
+    const parsed = JSON.parse(capturedBody as unknown as string);
+    expect(parsed.rows[0].transaction.status).toBe("pending");
+  });
+
+  it("matches the canonical thead snapshot", async () => {
+    const { container } = render(<BatchEntryPage />);
+    await screen.findByLabelText("Row 1 description");
+    const thead = container.querySelector(".batch-grid > thead");
+    expect(thead).toMatchInlineSnapshot(`
+      <thead
+        class="batch-grid__head"
+      >
+        <tr
+          class="border-b border-border text-left"
+        >
+          <th
+            class="w-10 px-2 py-2 text-xs text-text-muted"
+            scope="col"
+          >
+            #
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-32 px-2 py-2"
+            scope="col"
+          >
+            Date
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-64 px-2 py-2"
+            scope="col"
+          >
+            Description
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-28 px-2 py-2"
+            scope="col"
+          >
+            Amount
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-28 px-2 py-2"
+            scope="col"
+          >
+            Type
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-44 px-2 py-2"
+            scope="col"
+          >
+            Account
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-44 px-2 py-2"
+            scope="col"
+          >
+            Category
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-32 px-2 py-2"
+            scope="col"
+          >
+            Status
+          </th>
+          <th
+            class="text-xs font-semibold uppercase tracking-[0.08em] text-text-muted w-32 px-2 py-2"
+            scope="col"
+          >
+            Result
+          </th>
+          <th
+            class="w-10 px-2 py-2"
+            scope="col"
+          >
+            <span
+              class="sr-only"
+            >
+              Remove
+            </span>
+          </th>
+        </tr>
+      </thead>
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

- Root cause: \`<th>\` cells in \`/transactions/batch\` inherited \`display: block\` + \`mb-1.5\` from the shared \`label\` token (\`lib/styles.ts\`), forcing every header out of \`display: table-cell\` and stacking them vertically. Description + Status appeared "missing" because their column widths collapsed once the header row stopped reserving space.
- Fix: drop \`label\` from \`<th>\`; use a local \`thLabel\` class that keeps the typography but lets the browser default \`display: table-cell\` win. Row template now matches headers 1:1 over 9 columns. New Status column = transaction status (\`settled\` / \`pending\`) select; submission outcome moved to a separate Result column.
- Mobile (< md): responsive \`.batch-grid\` CSS in \`globals.css\` collapses the 9-column table into stacked labeled mini-form cards via \`data-label\` + \`::before\`, without duplicating DOM (so aria-label lookups in tests stay deterministic).

## Coverage

- \`frontend/tests/app/transactions-batch-page-layout.test.tsx\` (new) asserts header order, header-to-cell alignment, every per-row input (Description + Status incl.), the status field round-tripping on the payload, and an inline \`<thead>\` snapshot so future refactors fail loudly if the column structure drifts.
- Existing batch tests (\`transactions-batch-page.test.tsx\` + \`...-autocomplete.test.tsx\`) still pass — 12/12.
- Full vitest suite: 776 / 776 passing. \`npx tsc --noEmit\` clean. \`npm run lint\` 0 errors. Design-tokens check passed.

## Screenshot handoff (owner-side capture)

Agent stack couldn't seed/migrate due to worktree .git gitlink. Owner-side:
\`\`\`
gh pr checkout <N> && ./pfv restart && navigate to /transactions/batch
\`\`\`

Capture:
1. Empty grid (5 default rows) — desktop, light
2. Empty grid — mobile 375x812
3. Grid with 2-3 rows filled (date, description, amount, type, account, category, status all visible) — desktop
4. Mobile filled — 375x812