### PR TITLE
chore(infra): disable UFW; rely solely on DO cloud firewall (pfv-data-fw)

### DIFF
--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,38 @@
+# pfv-data-01 Ansible
+
+Configuration management for the pfv data droplet (MySQL + Redis).
+
+Provisioning lives in Terraform (`infra/terraform/`); this playbook handles
+post-boot config: packages, MySQL/Redis tuning, backups, fail2ban, swap.
+
+## Run
+
+```bash
+ansible-playbook -i infra/ansible/inventory.yml \
+  infra/ansible/playbooks/site.yml --limit pfv-data-01
+```
+
+## Firewall: single layer, DO cloud firewall only
+
+The DigitalOcean cloud firewall `pfv-data-fw` is the single source of truth
+for inbound rules on managed droplets. UFW is intentionally **disabled** by
+the `common` role.
+
+### Why
+
+Layering UFW on top of the DO cloud firewall risks silent drops during VPC
+NAT translation: a TCP SYN can reach the droplet's VPC interface from a
+rewritten source address that UFW's CIDR rule no longer matches. Symptoms
+look like generic connectivity timeouts (App Platform to Redis on
+`10.42.0.0/24` was the case that triggered this consolidation on 2026-05-13).
+
+### Rules enforced by `pfv-data-fw`
+
+- TCP 3306 (MySQL): from `10.42.0.0/24`
+- TCP 6379 (Redis): from `10.42.0.0/24`
+- TCP 22 (SSH): from `0.0.0.0/0`
+- ICMP: from the VPC subnet
+
+If you need to add a rule, edit the DO cloud firewall in Terraform (or via
+`doctl compute firewall update`). Do not re-add UFW tasks to the `common`
+role.

--- a/infra/ansible/inventory.yml.example
+++ b/infra/ansible/inventory.yml.example
@@ -10,7 +10,6 @@ all:
       # Made available to roles for binding MySQL/Redis to the VPC interface.
       private_ipv4: REPLACE_PRIVATE_IPV4
   vars:
-    vpc_ip_range: 10.42.0.0/24
     mysql_app_db: pfv2
     mysql_app_user: pfv_app
     # Generate a strong password and (recommended) store via ansible-vault.

--- a/infra/ansible/roles/common/defaults/main.yml
+++ b/infra/ansible/roles/common/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-# CIDR allowed to reach MySQL/Redis through ufw. Override per-host in inventory.
-vpc_ip_range: 10.42.0.0/24
-
 # Swap file size. Tiny droplets benefit a lot from a small swap so MySQL+Redis
 # don't OOM-kill each other under transient pressure.
 swap_file_path: /swapfile

--- a/infra/ansible/roles/common/handlers/main.yml
+++ b/infra/ansible/roles/common/handlers/main.yml
@@ -3,7 +3,3 @@
   ansible.builtin.service:
     name: fail2ban
     state: restarted
-
-- name: Reload ufw
-  community.general.ufw:
-    state: reloaded

--- a/infra/ansible/roles/common/tasks/main.yml
+++ b/infra/ansible/roles/common/tasks/main.yml
@@ -9,7 +9,6 @@
   ansible.builtin.apt:
     name:
       - python3-pymysql       # required by community.mysql modules
-      - ufw
       - fail2ban
       - unattended-upgrades
       - apt-listchanges
@@ -36,40 +35,22 @@
     group: root
     mode: "0644"
 
-# --- ufw -------------------------------------------------------------------
-# DO Cloud Firewall already restricts inbound traffic at the network edge.
-# ufw is defence in depth on the host itself.
-- name: Allow OpenSSH through ufw
-  community.general.ufw:
-    rule: allow
-    name: OpenSSH
+# --- Firewall --------------------------------------------------------------
+# The DigitalOcean cloud firewall (pfv-data-fw) is the single source of truth
+# for inbound rules. Layering ufw on top risks silent drops during VPC NAT
+# translation (a TCP SYN can reach the droplet's VPC interface from a
+# rewritten source that ufw's CIDR rule no longer matches). We disable ufw
+# explicitly so this task is idempotent on existing droplets that already
+# had ufw enabled by an older revision of this role.
+- name: Check whether ufw is installed
+  ansible.builtin.stat:
+    path: /usr/sbin/ufw
+  register: common_ufw_binary
 
-- name: Allow MySQL from VPC through ufw
+- name: Disable ufw (rely solely on DO cloud firewall)
   community.general.ufw:
-    rule: allow
-    src: "{{ vpc_ip_range }}"
-    port: "3306"
-    proto: tcp
-
-- name: Allow Redis from VPC through ufw
-  community.general.ufw:
-    rule: allow
-    src: "{{ vpc_ip_range }}"
-    port: "6379"
-    proto: tcp
-
-- name: Set default ufw policies (deny incoming, allow outgoing)
-  community.general.ufw:
-    direction: "{{ item.direction }}"
-    policy: "{{ item.policy }}"
-  loop:
-    - { direction: incoming, policy: deny }
-    - { direction: outgoing, policy: allow }
-
-- name: Enable ufw
-  community.general.ufw:
-    state: enabled
-    logging: "on"
+    state: disabled
+  when: common_ufw_binary.stat.exists
 
 # --- fail2ban --------------------------------------------------------------
 - name: Configure fail2ban for sshd (jail.local)

--- a/infra/ansible/roles/mysql/templates/my.cnf.j2
+++ b/infra/ansible/roles/mysql/templates/my.cnf.j2
@@ -1,7 +1,7 @@
 {# Custom overrides loaded from /etc/mysql/mysql.conf.d/. The Ubuntu MySQL #}
 {# package's main config includes this directory by default. #}
 {# bind-address = 0.0.0.0 because MySQL 8 only honours one bind-address; #}
-{# the DO Cloud Firewall + ufw together enforce VPC-only access. #}
+{# the DO Cloud Firewall (pfv-data-fw) enforces VPC-only access. #}
 [mysqld]
 bind-address = 0.0.0.0
 default-authentication-plugin = mysql_native_password


### PR DESCRIPTION
## Summary

Removes UFW from the `common` Ansible role and consolidates inbound firewalling to a single layer: the DigitalOcean cloud firewall `pfv-data-fw`.

- `roles/common/tasks/main.yml`: drop the `ufw` package, the 4 UFW rule tasks, default-policy task, and `Enable ufw` task. Replace with one idempotent disable task gated on `/usr/sbin/ufw` existing (so it's safe on fresh droplets that never had UFW installed and on existing droplets that do).
- `roles/common/handlers/main.yml`: drop the unused `Reload ufw` handler.
- `roles/common/defaults/main.yml` + `inventory.yml.example`: drop `vpc_ip_range` (no longer referenced).
- `roles/mysql/templates/my.cnf.j2`: comment now says cloud firewall `pfv-data-fw` enforces VPC-only access instead of "DO Cloud Firewall + ufw".
- New `infra/ansible/README.md` explains the single-layer decision and the cloud firewall rule set.

## Why

UFW was active on `pfv-data-01` allowing TCP 6379 from `10.42.0.0/24`, but App Platform → Redis still saw TCP SYN timeouts. Two firewall layers risks silent drops during DO VPC NAT translation: a SYN can reach the droplet's VPC interface from a rewritten source that UFW's CIDR rule no longer matches. Consolidating to the cloud firewall removes the suspect.

The DO cloud firewall `pfv-data-fw` (id `cd1f4b10-d9e4-48ca-83cd-2d75ab815bce`) already enforces the same rules at the network edge: 3306 + 6379 from `10.42.0.0/24`, ICMP from the VPC subnet, SSH from `0.0.0.0/0`. **No change to the cloud firewall is part of this PR.**

## Interim manual fix (owner can apply now)

Don't wait for the playbook run if you want the suspect removed immediately. On `pfv-data-01`:

```bash
ssh root@165.22.201.167 'ufw disable && ufw --force reset'
```

This PR codifies that into ansible so the change survives re-provisioning.

## Apply after merge

```bash
ansible-playbook -i infra/ansible/inventory.yml infra/ansible/playbooks/site.yml --limit pfv-data-01
```

## Verify

```bash
ssh root@165.22.201.167 'ufw status'
# Expect: Status: inactive
```

## Validation

- `ansible-playbook --syntax-check playbooks/site.yml` — clean.
- `ansible-lint roles/common/` — same 4 pre-existing `var-naming[no-role-prefix]` violations as `main`; no new ones introduced (new `common_ufw_binary` register uses the role prefix).
- `yamllint` — no new errors vs `main`.