### PR TITLE
fix(rate-limit): fail-open on Redis storage errors (prod hotfix)

### DIFF
--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -53,6 +53,7 @@ from slowapi import Limiter
 from starlette.requests import Request
 
 from app.config import settings
+from app.rate_limit_failopen import wrap_limiter_failopen
 
 logger = structlog.stdlib.get_logger()
 
@@ -190,7 +191,13 @@ def _build_limiter() -> Limiter:
             backend="redis",
             multi_replica_safe=True,
         )
-        return Limiter(key_func=get_client_ip, storage_uri=redis_url)
+        limiter = Limiter(key_func=get_client_ip, storage_uri=redis_url)
+        # Fail-open on Redis storage errors (prod hotfix 2026-05-13). The
+        # wrapper sits below slowapi so transient Redis blips no longer
+        # surface as HTTP 500 from rate-limited auth endpoints. See
+        # app/rate_limit_failopen.py for the design + trade-off note.
+        wrap_limiter_failopen(limiter)
+        return limiter
 
     logger.warning(
         "rate_limit.storage",
@@ -198,6 +205,10 @@ def _build_limiter() -> Limiter:
         multi_replica_safe=False,
         reason="settings.redis_url empty; per-replica counters only",
     )
+    # No fail-open wrap for the in-memory backend: MemoryStorage cannot
+    # raise the storage errors the wrapper guards against, and leaving
+    # it unwrapped keeps construction-time tests (which assert the
+    # storage type) unchanged.
     return Limiter(key_func=get_client_ip)
 
 

--- a/backend/app/rate_limit_failopen.py
+++ b/backend/app/rate_limit_failopen.py
@@ -1,0 +1,287 @@
+"""Fail-open wrapper for slowapi's Redis-backed rate-limit storage.
+
+Production incident 2026-05-13: ``redis.exceptions.TimeoutError`` raised by
+the underlying ``limits.storage.RedisStorage.incr`` (EVALSHA) propagated
+up through ``slowapi.extension._check_request_limit`` and surfaced as
+HTTP 500 on every rate-limited auth endpoint (forgot-password, login,
+register, refresh, etc.). slowapi only swallows storage errors if
+``in_memory_fallback_enabled=True`` is passed to ``Limiter``, and even
+then it only falls back the SECOND time the dead-storage flag is checked.
+The first request after Redis hiccups still 500s.
+
+This module installs a thin wrapper around the limits-library storage
+object so the failure never reaches slowapi. The protected endpoint
+serves its normal response (200 / 401 / etc.) when Redis is unreachable.
+A structured ``rate_limit.degraded`` warning is emitted once per failed
+request so the outage is visible in logs.
+
+Trade-off (intentional): rate limiting is BYPASSED during a Redis outage.
+This is the correct bias for production auth availability — a brief
+Redis blip should not lock everyone out of the password-reset flow. The
+window is small (seconds, bounded by Redis recovery) and the
+``rate_limit.degraded`` event surfaces in DO logs so the incident is
+investigable. Healthy-state behaviour is unchanged.
+
+Shape: a forwarding proxy that exposes the same surface as
+``limits.storage.RedisStorage`` (the methods slowapi's ``RateLimiter``
+strategies call: ``incr``, ``get``, ``get_expiry``, ``clear``, ``check``,
+``reset``). Each method catches the storage-error family and returns a
+safe default. Non-storage methods (eg. limits-library internals) are
+forwarded with ``__getattr__`` so subclass / isinstance checks against
+``MovingWindowSupport`` etc. still work via ``_inner``'s MRO.
+"""
+
+from __future__ import annotations
+
+import time
+from contextvars import ContextVar
+from typing import Any
+
+import structlog
+from redis.exceptions import RedisError
+from slowapi import Limiter
+from starlette.requests import Request
+
+logger = structlog.stdlib.get_logger()
+
+
+# Set by ``Limiter._check_request_limit`` (wrapped below) so the storage
+# layer can recover the request path for the ``rate_limit.degraded``
+# log without slowapi having to pass the request down through the limits
+# library API. Reset back to None in the same wrapper after the call.
+_current_request_cv: ContextVar[Request | None] = ContextVar(
+    "_rate_limit_failopen_request", default=None
+)
+
+
+# The set of exception types we treat as "storage degraded — fail open".
+# ``RedisError`` covers the redis-py family (TimeoutError, ConnectionError,
+# ResponseError, etc.). ``ConnectionError``/``TimeoutError`` are the
+# builtin ones surfaced by the socket layer when redis-py is misbehaving.
+# ``OSError`` catches the lowest-level socket failures (eg. ECONNREFUSED
+# when Redis is fully down).
+_STORAGE_ERRORS: tuple[type[BaseException], ...] = (
+    RedisError,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+
+
+def _request_path(request: Request | None) -> str:
+    """Return ``request.url.path`` with query string stripped, or empty
+    string when no request is bound. Query strings can carry
+    password-reset tokens, MFA codes, etc. — never log them.
+    """
+    if request is None:
+        return ""
+    try:
+        return request.url.path
+    except Exception:  # pragma: no cover — defensive
+        return ""
+
+
+def _current_request() -> Request | None:
+    """Look up the in-flight request bound by the wrapped
+    ``Limiter._check_request_limit`` (see ``wrap_limiter_failopen``).
+    """
+    return _current_request_cv.get()
+
+
+def _log_degraded(error: BaseException, method: str) -> None:
+    """Emit the ``rate_limit.degraded`` structured warning.
+
+    Called from the storage method that detected the Redis failure.
+    Only the write-path method (``incr``) calls this — the read-path
+    methods (``get``, ``get_expiry``) silently fail open without
+    re-logging, since they are downstream of the same failed request
+    and would otherwise produce 2-3 duplicate log lines per request as
+    slowapi computes counters + injects rate-limit response headers.
+    This gives exactly one ``rate_limit.degraded`` event per request
+    by construction — no contextvar bookkeeping required.
+    """
+    request = _current_request()
+    logger.warning(
+        "rate_limit.degraded",
+        error_type=type(error).__name__,
+        error_message=str(error),
+        path=_request_path(request),
+        method=method,
+        backend="redis",
+    )
+
+
+class FailOpenRedisStorage:
+    """Forwarding proxy over a ``limits.storage.RedisStorage`` instance
+    that catches storage-layer exceptions and returns safe defaults.
+
+    Safe defaults are chosen so that, from slowapi's perspective, the
+    limit is NOT exceeded:
+
+    - ``incr`` returns ``0``. slowapi compares ``incr_result <= item.amount``;
+      ``0 <= anything`` permits the request.
+    - ``get`` returns ``0`` (same reasoning, used by the ``test`` path).
+    - ``get_expiry`` returns the current epoch — header injection then
+      encodes "no remaining wait" rather than a corrupt value.
+    - ``clear`` / ``reset`` are no-ops on failure.
+    - ``check`` returns ``True`` (storage is "ok enough to keep using").
+
+    Subclass / isinstance checks against ``limits.storage.base`` mixins
+    (``MovingWindowSupport``, ``SlidingWindowCounterSupport``) are
+    forwarded via ``__getattr__``, so slowapi's strategy selection still
+    sees the underlying storage's capabilities.
+    """
+
+    __slots__ = ("_inner",)
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    # ── Fixed-window strategy hot paths ────────────────────────────────
+
+    def incr(self, key: str, expiry: int, amount: int = 1) -> int:
+        try:
+            return self._inner.incr(key, expiry, amount=amount)
+        except _STORAGE_ERRORS as exc:
+            _log_degraded(exc, "incr")
+            return 0
+
+    # Read-path methods silently fail open: they run downstream of
+    # ``incr`` within the SAME request after ``incr`` already logged
+    # and returned 0. Re-logging here would produce 2-3 duplicate
+    # ``rate_limit.degraded`` lines per failed request as slowapi
+    # computes window stats and injects response headers.
+
+    def get(self, key: str) -> int:
+        try:
+            return self._inner.get(key)
+        except _STORAGE_ERRORS:
+            return 0
+
+    def get_expiry(self, key: str) -> float:
+        try:
+            return self._inner.get_expiry(key)
+        except _STORAGE_ERRORS:
+            # Current epoch so header injection encodes "no remaining
+            # wait" instead of corrupt data.
+            return time.time()
+
+    def clear(self, key: str) -> None:
+        try:
+            self._inner.clear(key)
+        except _STORAGE_ERRORS:
+            pass
+
+    def check(self) -> bool:
+        try:
+            return bool(self._inner.check())
+        except _STORAGE_ERRORS:
+            return True
+
+    def reset(self) -> None:
+        # ``reset()`` is called from test fixtures (``limiter.reset()``)
+        # and is best-effort in production. Swallow storage errors so
+        # tests against a dead Redis do not crash.
+        try:
+            self._inner.reset()
+        except _STORAGE_ERRORS:
+            pass
+
+    # ── Moving-window strategy support ─────────────────────────────────
+
+    def acquire_entry(
+        self, key: str, limit: int, expiry: int, amount: int = 1
+    ) -> bool:
+        try:
+            return bool(
+                self._inner.acquire_entry(key, limit, expiry, amount=amount)
+            )
+        except _STORAGE_ERRORS as exc:
+            _log_degraded(exc, "acquire_entry")
+            return True  # permit the request
+
+    def get_moving_window(
+        self, key: str, limit: int, expiry: int
+    ) -> tuple[int, int]:
+        try:
+            return self._inner.get_moving_window(key, limit, expiry)
+        except _STORAGE_ERRORS:
+            return (int(time.time()), 0)
+
+    # ── Sliding-window-counter support ─────────────────────────────────
+
+    def acquire_sliding_window_entry(
+        self, key: str, limit: int, expiry: int, amount: int = 1
+    ) -> bool:
+        try:
+            return bool(
+                self._inner.acquire_sliding_window_entry(
+                    key, limit, expiry, amount=amount
+                )
+            )
+        except _STORAGE_ERRORS as exc:
+            _log_degraded(exc, "acquire_sliding_window_entry")
+            return True
+
+    def get_sliding_window(
+        self, key: str, expiry: int
+    ) -> tuple[int, float, int, float]:
+        try:
+            return self._inner.get_sliding_window(key, expiry)
+        except _STORAGE_ERRORS:
+            return (0, 0.0, 0, 0.0)
+
+    # ── Forward everything else ────────────────────────────────────────
+
+    def __getattr__(self, name: str) -> Any:
+        # __getattr__ is only called when normal lookup fails (ie. for
+        # attributes we didn't override). Forward to the inner storage.
+        return getattr(self._inner, name)
+
+
+def wrap_limiter_failopen(limiter: Limiter) -> Limiter:
+    """Replace ``limiter._storage`` with a ``FailOpenRedisStorage`` wrapper
+    and rebuild the underlying ``RateLimiter`` strategy against it. Also
+    wrap ``Limiter._check_request_limit`` so the in-flight ``Request`` is
+    available to the storage layer (for ``rate_limit.degraded`` log
+    context) without slowapi having to pass it down.
+
+    Call this once after constructing the ``Limiter`` (at module import
+    time in ``rate_limit.py``). The wrapper is applied unconditionally —
+    even for in-memory storage in local dev, the layer is a no-op cost
+    when the inner storage does not raise.
+    """
+    # Touch ``_storage`` to force slowapi's lazy storage init.
+    inner = limiter._storage
+    if isinstance(inner, FailOpenRedisStorage):  # idempotent
+        return limiter
+
+    wrapped = FailOpenRedisStorage(inner)
+    limiter._storage = wrapped
+
+    # The strategy (FixedWindow / MovingWindow / SlidingWindow) holds a
+    # reference to the original storage in ``self.storage``. Repoint it
+    # so all hot-path calls go through the wrapper.
+    if hasattr(limiter, "_limiter") and limiter._limiter is not None:
+        limiter._limiter.storage = wrapped
+
+    # Wrap ``_check_request_limit`` so we can bind the current request to
+    # a contextvar for log context. slowapi's storage API does not pass
+    # the request down to ``incr`` / ``hit``, so without this we have no
+    # way to recover the path / method for the degraded warning.
+    original_check = limiter._check_request_limit
+
+    def check_with_request_bound(
+        request: Request,
+        endpoint_func: Any,
+        in_middleware: bool = True,
+    ) -> None:
+        token = _current_request_cv.set(request)
+        try:
+            return original_check(request, endpoint_func, in_middleware)
+        finally:
+            _current_request_cv.reset(token)
+
+    limiter._check_request_limit = check_with_request_bound  # type: ignore[assignment]
+
+    return limiter

--- a/backend/tests/test_rate_limit_failopen.py
+++ b/backend/tests/test_rate_limit_failopen.py
@@ -1,0 +1,250 @@
+"""Regression tests for slowapi fail-open behaviour on Redis storage errors.
+
+Prod 2026-05-13 incident: ``redis.exceptions.TimeoutError`` raised by the
+underlying ``limits.storage.RedisStorage.incr`` (EVALSHA) propagated up
+through ``slowapi.extension._check_request_limit`` and surfaced as HTTP 500
+on every rate-limited auth endpoint (reset-password, login, etc.).
+
+This module pins:
+
+1. ``RateLimitExceeded`` continues to raise 429 (legitimate limits preserved).
+2. Redis-storage errors (``TimeoutError`` / ``ConnectionError`` / generic
+   ``RedisError``) on ``.incr()`` are caught and the protected endpoint
+   returns its normal response (NOT 500).
+3. A structured ``rate_limit.degraded`` warning is emitted exactly once per
+   failed request with ``error_type``, ``path``, and ``backend="redis"``.
+4. The wrapper does not interfere when Redis is healthy.
+"""
+from __future__ import annotations
+
+import json
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError, TimeoutError as RedisTimeoutError
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.extension import _rate_limit_exceeded_handler
+
+from app import rate_limit
+from app.rate_limit_failopen import FailOpenRedisStorage, wrap_limiter_failopen
+
+
+# ── Unit: storage-level fail-open ──────────────────────────────────────────
+
+
+class _ExplodingRedisStorage:
+    """Stand-in for ``limits.storage.RedisStorage`` that raises the given
+    exception from every read/write method. Used to feed ``FailOpenRedisStorage``
+    a deterministic failure source without standing up a broken Redis.
+    """
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+        self.calls: list[str] = []
+
+    def incr(self, key, expiry, amount=1):
+        self.calls.append("incr")
+        raise self._exc
+
+    def get(self, key):
+        self.calls.append("get")
+        raise self._exc
+
+    def get_expiry(self, key):
+        self.calls.append("get_expiry")
+        raise self._exc
+
+    def clear(self, key):
+        self.calls.append("clear")
+        raise self._exc
+
+    def check(self):
+        self.calls.append("check")
+        raise self._exc
+
+    def reset(self):
+        self.calls.append("reset")
+        raise self._exc
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        RedisTimeoutError("Timeout reading from socket"),
+        RedisConnectionError("Connection refused"),
+    ],
+    ids=["timeout", "connection"],
+)
+def test_failopen_storage_incr_returns_zero_on_redis_error(exc):
+    """``incr`` is the write path. Returning ``0`` means slowapi sees
+    "current count is 0 <= limit", so the request is permitted (fail open).
+    """
+    wrapped = FailOpenRedisStorage.__new__(FailOpenRedisStorage)
+    wrapped._inner = _ExplodingRedisStorage(exc)
+
+    result = wrapped.incr("k", 60, amount=1)
+
+    assert result == 0, "fail-open incr must return 0 to permit the request"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [RedisTimeoutError("t"), RedisConnectionError("c"), OSError("os")],
+)
+def test_failopen_storage_get_returns_zero_on_storage_error(exc):
+    wrapped = FailOpenRedisStorage.__new__(FailOpenRedisStorage)
+    wrapped._inner = _ExplodingRedisStorage(exc)
+    assert wrapped.get("k") == 0
+
+
+def test_failopen_storage_get_expiry_returns_none_on_error():
+    wrapped = FailOpenRedisStorage.__new__(FailOpenRedisStorage)
+    wrapped._inner = _ExplodingRedisStorage(RedisTimeoutError("t"))
+    # ``get_expiry`` returning a low number is the safest default — slowapi
+    # only uses this for header injection. Return ``time.time()`` so headers
+    # encode "no remaining wait" rather than corrupting the response.
+    assert wrapped.get_expiry("k") is not None
+
+
+def test_failopen_storage_passes_through_when_inner_succeeds():
+    """When the inner storage returns a value, the wrapper passes it
+    through verbatim. No fail-open path taken when Redis is healthy.
+    """
+
+    class _GoodStorage:
+        def incr(self, key, expiry, amount=1):
+            return 7
+
+        def get(self, key):
+            return 3
+
+        def get_expiry(self, key):
+            return 1234.5
+
+    wrapped = FailOpenRedisStorage.__new__(FailOpenRedisStorage)
+    wrapped._inner = _GoodStorage()
+    assert wrapped.incr("k", 60) == 7
+    assert wrapped.get("k") == 3
+    assert wrapped.get_expiry("k") == 1234.5
+
+
+# ── Integration: endpoint stays 200 + structured warning fires ─────────────
+
+
+def _build_app_with_exploding_limiter(exc: Exception) -> FastAPI:
+    """Build a tiny FastAPI app whose Limiter's storage raises ``exc`` on
+    ``incr``. Mirrors the production wiring path: the wrapper sits below
+    slowapi so ``_check_request_limit`` never sees the underlying error.
+    """
+    limiter = Limiter(
+        key_func=lambda: "test-client",
+        storage_uri="memory://",  # placeholder; we overwrite _storage next
+    )
+    # Force storage creation so we can inspect/replace it.
+    _ = limiter._storage
+    wrap_limiter_failopen(limiter)
+    # Swap the inner storage for one that always raises.
+    limiter._storage._inner = _ExplodingRedisStorage(exc)
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    @app.post("/probe")
+    @limiter.limit("5/minute")
+    async def probe(request: Request):
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        RedisTimeoutError("Timeout reading from socket"),
+        RedisConnectionError("Connection refused"),
+    ],
+    ids=["timeout", "connection"],
+)
+def test_endpoint_returns_200_when_redis_storage_raises(exc):
+    """Acceptance criterion 1+3: rate-limited endpoint returns its normal
+    200 response when the underlying Redis storage raises
+    ``TimeoutError`` / ``ConnectionError`` on ``.incr()`` — NOT 500.
+    """
+    app = _build_app_with_exploding_limiter(exc)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/probe")
+    assert resp.status_code == 200, (
+        f"expected fail-open 200, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json() == {"ok": True}
+
+
+def test_degraded_log_event_emitted_with_required_fields(capsys):
+    """Acceptance criterion 2: a structured ``rate_limit.degraded`` warning
+    surfaces with ``error_type``, ``path`` (query stripped), and
+    ``backend="redis"``. Emitted exactly once per failed request.
+    """
+    app = _build_app_with_exploding_limiter(RedisTimeoutError("Timeout"))
+    with TestClient(app, raise_server_exceptions=False) as client:
+        # Include a query string to confirm we strip it from the logged path.
+        resp = client.post("/probe?secret=abc")
+    assert resp.status_code == 200
+
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    # structlog renders JSON when configured by the app; in test context it
+    # may render key=value. Tolerate both shapes — assert on the substrings.
+    assert "rate_limit.degraded" in out, (
+        "expected a rate_limit.degraded log event"
+    )
+    assert "error_type" in out and "TimeoutError" in out
+    assert 'backend' in out and 'redis' in out
+    assert "/probe" in out
+    assert "secret=abc" not in out, (
+        "query string must be stripped from logged path"
+    )
+    # Exactly one degraded event per request (no retry spam).
+    assert out.count("rate_limit.degraded") == 1
+
+
+def test_rate_limit_exceeded_still_raises_429():
+    """Acceptance criterion 1 (the OTHER half): ``RateLimitExceeded`` is
+    NOT swallowed by the fail-open wrapper. Legitimate 429s preserved.
+
+    We use a healthy in-memory storage wrapped by the fail-open layer and
+    hammer the endpoint past its limit. The wrapper passes through, the
+    counter increments past the limit, and slowapi raises 429.
+    """
+    limiter = Limiter(
+        key_func=lambda: "rate-test-client",
+        storage_uri="memory://",
+    )
+    _ = limiter._storage
+    wrap_limiter_failopen(limiter)
+    # Leave the healthy MemoryStorage as inner — no exception path.
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    @app.get("/tight")
+    @limiter.limit("2/minute")
+    async def tight(request: Request):
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        first = client.get("/tight")
+        second = client.get("/tight")
+        third = client.get("/tight")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429, (
+        f"expected legitimate 429 on third call, got {third.status_code}"
+    )

--- a/backend/tests/test_rate_limit_storage.py
+++ b/backend/tests/test_rate_limit_storage.py
@@ -31,6 +31,11 @@ def test_limiter_uses_redis_storage_when_redis_url_set(monkeypatch):
     """K8S-1: with ``settings.redis_url`` set, the Limiter is built
     against the Redis storage backend so counters are shared across
     replicas.
+
+    The Redis storage is wrapped by ``FailOpenRedisStorage`` (prod
+    hotfix 2026-05-13) so transient Redis blips do not surface as
+    HTTP 500. Assert on both the wrapper presence AND the wrapped
+    inner type so both layers stay pinned.
     """
     monkeypatch.setattr(settings, "redis_url", "redis://example:6379/0")
 
@@ -39,9 +44,15 @@ def test_limiter_uses_redis_storage_when_redis_url_set(monkeypatch):
     # slowapi defers storage creation until first access via the
     # ``_storage`` property. Touching it forces the limits library to
     # resolve the URI; we then assert it picked the Redis backend.
+    from app.rate_limit_failopen import FailOpenRedisStorage
+
     storage = limiter._storage
-    assert type(storage).__name__ == "RedisStorage", (
-        f"expected Redis-backed storage, got {type(storage).__name__}"
+    assert isinstance(storage, FailOpenRedisStorage), (
+        f"expected fail-open wrapper, got {type(storage).__name__}"
+    )
+    inner = storage._inner
+    assert type(inner).__name__ == "RedisStorage", (
+        f"expected Redis-backed inner storage, got {type(inner).__name__}"
     )
 
 


### PR DESCRIPTION
## Failure mode

Production logs 2026-05-13:

```
redis.exceptions.TimeoutError: Timeout reading from socket
  at slowapi.extension._check_request_limit
  at limits.storage.redis.incr (EVALSHA)
```

`redis.exceptions.TimeoutError` raised by `limits.storage.RedisStorage.incr` (EVALSHA) propagates up through `slowapi.extension._check_request_limit` and surfaces as HTTP 500 on every rate-limited auth endpoint (`/forgot-password`, `/login`, `/register`, `/refresh`, MFA verify, etc.). slowapi's built-in in-memory fallback only engages on the SECOND request after the dead-storage flag flips, so the first Redis blip still 500s. With Redis unreachable, every request 500s.

## Wrapper shape: Pattern A (subclass-shaped forwarding proxy)

Picked over Pattern B (wrap `Limiter._check_request_limit` in a try/except) because:

1. **Surgical.** Lives BELOW slowapi, doesn't fight slowapi's API or `RateLimitExceeded` propagation. The exception never reaches slowapi.
2. **Correct boundary.** Distinguishes "storage degraded" (catch, fail open) from "rate limit exceeded" (slowapi raises this from `__evaluate_limits` AFTER the storage returned its count, never from inside storage).
3. **Strategy-agnostic.** Covers FixedWindow, MovingWindow, and SlidingWindowCounter strategies in one wrapper.

`FailOpenRedisStorage` is a thin forwarding proxy over the `limits.storage.RedisStorage` instance:

- `incr` returns `0` on storage error (slowapi compares `0 <= item.amount` → request permitted).
- `get` returns `0`.
- `get_expiry` returns `time.time()` (header injection encodes "no remaining wait" rather than corrupt data).
- `clear`, `check`, `reset` swallow errors and no-op.
- `acquire_entry` / `acquire_sliding_window_entry` return `True` (permit).
- `__getattr__` forwards everything else so isinstance checks against `MovingWindowSupport` etc. still resolve via the inner storage's MRO.

Caught exception family: `(RedisError, ConnectionError, TimeoutError, OSError)`.

### Wiring

[`backend/app/rate_limit.py:194-200`](backend/app/rate_limit.py#L194) — after constructing the `Limiter` with `storage_uri=redis_url`, call `wrap_limiter_failopen(limiter)`. The wrapper swaps `_storage`, repoints the strategy's `storage` reference, and instruments `_check_request_limit` to bind the in-flight `Request` to a `ContextVar` so the storage layer can recover path/method for the log without slowapi passing the request down through the limits library API.

The in-memory fallback path is left unwrapped: `MemoryStorage` cannot raise the storage errors the wrapper guards against, and leaving it unwrapped keeps construction-time tests unchanged.

## Trade-off (intentional)

**Rate limiting is bypassed during a Redis outage.** This is the correct bias for production auth availability — a brief Redis blip should not lock everyone out of the password-reset flow. The window is small (seconds, bounded by Redis recovery) and the `rate_limit.degraded` event surfaces in DO logs so the incident is investigable.

## Acceptance criteria mapped to test names

All 4 acceptance criteria are explicitly demonstrated:

1. **Fail open ONLY on Redis/limits storage errors, NOT on `RateLimitExceeded`.**
   - `test_failopen_storage_incr_returns_zero_on_redis_error[timeout|connection]` (storage-level unit)
   - `test_endpoint_returns_200_when_redis_storage_raises[timeout|connection]` (end-to-end)
   - `test_rate_limit_exceeded_still_raises_429` (the other half: legitimate 429s preserved through the wrapper)

2. **Structured `rate_limit.degraded` warning, exactly once per failed request.**
   - `test_degraded_log_event_emitted_with_required_fields` — asserts `error_type`, `path` (with query string stripped), `backend=redis`, and `out.count("rate_limit.degraded") == 1`.

3. **Regression test: storage `TimeoutError` / `ConnectionError` → endpoint returns normal response, not 500.**
   - `test_endpoint_returns_200_when_redis_storage_raises` parameterized over both error types.

4. **Redis-backed rate limiting unchanged when Redis is healthy. All current PR #245 tests pass.**
   - `test_failopen_storage_passes_through_when_inner_succeeds` — pass-through verified.
   - `test_limiter_uses_redis_storage_when_redis_url_set` (updated, PR #245) — asserts wrapper presence AND inner `RedisStorage` type.
   - `test_limiter_falls_back_to_memory_when_redis_url_empty` (PR #245, untouched) — fallback warning still fires.
   - `test_module_level_limiter_built_at_import_time` (PR #245, untouched).

## Validation

- Full backend pytest suite (1106 passed, 9 skipped) green in isolated `team-slowapi-fail-open` stack.
- 11 new tests in `test_rate_limit_failopen.py`, all passing.
- Manual smoke test against an actually unreachable Redis (`redis://127.0.0.1:1/0`) confirmed end-to-end: status 200, normal body, `rate_limit.degraded` event with `error_type=ConnectionError`, `path=/probe`, `backend=redis`, `method=incr`.

## Strictly out of scope (per spec)

- `get_client_ip` and any PR #233 helpers (frozen).
- nginx config (frozen post-#233).
- Redis client config (frozen).
- Investigating WHY Redis is unreachable (coordinator handles that in parallel).
- Any frontend code.