### PR TITLE
fix(frontend): expose NEXT_PUBLIC_* envs to Dockerfile build stage

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -278,6 +278,25 @@ scope `RUN_AND_BUILD_TIME` and value `"true"`, then re-deploy
 (`doctl apps update ... --spec .do/app.yaml`). A fresh build is required;
 runtime-only changes do not bake into the JS bundle.
 
+### "NEXT_PUBLIC_* env set in App Platform spec but not visible in client bundle"
+
+Symptom: a `NEXT_PUBLIC_*` env is correctly declared in `.do/app.yaml`
+with `scope: RUN_AND_BUILD_TIME`, `doctl apps update` succeeds, the
+build finishes green, but `process.env.NEXT_PUBLIC_<NAME>` is still
+`undefined` in the served JS bundle (so the feature it gates stays
+hidden). Cause: `frontend/Dockerfile`'s build stage requires an explicit
+`ARG NEXT_PUBLIC_<NAME>` line for every `NEXT_PUBLIC_*` env. Without
+the `ARG`, the build stage does not see the env even though DO App
+Platform's `RUN_AND_BUILD_TIME` scope makes it available to the build
+CONTEXT. Next.js then inlines `undefined === "true"` as `false` and the
+feature stays off. Fix: adding a new `NEXT_PUBLIC_*` env requires
+(a) adding to `.do/app.yaml`, (b) adding an `ARG NEXT_PUBLIC_<NAME>`
+line (and matching `ENV NEXT_PUBLIC_<NAME>=$NEXT_PUBLIC_<NAME>` to
+promote it into the `npm run build` environment) to the build stage of
+`frontend/Dockerfile`, (c) `doctl apps update <APP_ID> --spec .do/app.yaml`
+to trigger a fresh build. This affects every `NEXT_PUBLIC_*` env, not
+just the SSO flag.
+
 ### "Audit log shows ingress IP not user IP in production"
 
 Symptom: `audit_events.ip_address` records `10.x.x.x` or DO ingress IPs.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,24 @@ RUN npm install
 
 COPY . .
 
+# NEXT_PUBLIC_* envs must be declared as ARGs so DO App Platform's
+# RUN_AND_BUILD_TIME scope can inject them at build time. Next.js inlines
+# process.env.NEXT_PUBLIC_* into the static JS bundle at build, not runtime.
+# Adding a new NEXT_PUBLIC_* env requires (a) adding it to .do/app.yaml,
+# (b) adding an ARG + ENV line here, (c) doctl apps update to rebuild.
+# Canonical list lives in ENVIRONMENT.md (Frontend section).
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
+ARG NEXT_PUBLIC_SITE_URL
+ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL
+
+ARG NEXT_PUBLIC_GOOGLE_SSO_ENABLED
+ENV NEXT_PUBLIC_GOOGLE_SSO_ENABLED=$NEXT_PUBLIC_GOOGLE_SSO_ENABLED
+
+ARG NEXT_PUBLIC_APP_VERSION
+ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
+
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 


### PR DESCRIPTION
## Root cause

PR #229 added `GoogleSSOButton` (gated on `process.env.NEXT_PUBLIC_GOOGLE_SSO_ENABLED === "true"`). PR #259 added `NEXT_PUBLIC_GOOGLE_SSO_ENABLED=true` to `.do/app.yaml` at `scope: RUN_AND_BUILD_TIME`. Owner ran `doctl apps update`, the build completed green in ~68s, yet prod `/login` still served HTML with no SSO button.

The missing link: `frontend/Dockerfile`'s build stage had no `ARG NEXT_PUBLIC_*` (or `ENV NEXT_PUBLIC_*`) declarations. DO App Platform's `RUN_AND_BUILD_TIME` scope makes the value available to the build CONTEXT (the `docker build` invocation), but to surface it inside the Dockerfile's build stage you must declare an `ARG` (which DO populates as a `--build-arg`) and promote it to `ENV` for `npm run build` to see it. Without the `ARG`, `process.env.NEXT_PUBLIC_GOOGLE_SSO_ENABLED` was `undefined` at build, Next.js inlined `undefined === "true"` as `false`, and `GoogleSSOButton` rendered `null`.

This affects **every** `NEXT_PUBLIC_*` env we would want to inject in any future feature, not just the SSO flag.

## Fix

Add `ARG NEXT_PUBLIC_<NAME>` + `ENV NEXT_PUBLIC_<NAME>=$NEXT_PUBLIC_<NAME>` pairs to the build stage for the canonical `NEXT_PUBLIC_*` envs documented in `ENVIRONMENT.md` (Frontend section):

| Env var | In `.do/app.yaml` today? | ARG added |
|---|---|---|
| `NEXT_PUBLIC_API_URL` | yes (empty value) | yes |
| `NEXT_PUBLIC_SITE_URL` | no (documented, future) | yes |
| `NEXT_PUBLIC_GOOGLE_SSO_ENABLED` | yes (`"true"`) | yes |
| `NEXT_PUBLIC_APP_VERSION` | no (documented, future) | yes |

An unset `ARG` is harmless (the variable just remains unset), so pre-declaring the documented envs means future flags only need an `.do/app.yaml` change, not a Dockerfile change.

Also adds a "Common failure modes" callout in `ENVIRONMENT.md` so this footgun does not bite again: every new `NEXT_PUBLIC_*` env requires (a) `.do/app.yaml` entry, (b) `ARG` + `ENV` in `frontend/Dockerfile`, (c) `doctl apps update` to rebuild.

## Verification

Built `frontend/` twice with the same `Dockerfile`:

- `docker build --build-arg NEXT_PUBLIC_GOOGLE_SSO_ENABLED=true ...` then `grep "Sign in with Google" .next/server/app/login.html` → count **1** (button is in prerendered HTML).
- `docker build ...` with no arg → count **0** (reproduces the prod bug exactly).

Build succeeds in both cases. No source-code change in `frontend/` so no JS test impact.

## After merge

Owner runs:

```bash
doctl apps update 3bcf70e8-2bae-4918-8297-ce430c79735e --spec .do/app.yaml
```

to trigger a fresh App Platform build that picks up the env vars correctly. Expect ~2 to 3 minute auth-flow downtime during the rebuild.

## Scope

- `frontend/Dockerfile` build stage only. Runtime stage and apex/dev Dockerfiles unchanged.
- `docker-compose.yml` unchanged: local dev uses `Dockerfile.dev` (next dev reads `process.env` at runtime, not via Docker build args).
- No backend changes.