### PR TITLE
chore(compose): pass NEXT_PUBLIC_GOOGLE_SSO_ENABLED to dev frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,9 @@ services:
       # nginx ingress (relative URLs); server-side fetches must hit the
       # backend service directly inside the compose network.
       - BACKEND_INTERNAL_URL=http://backend:8000
+      # Pull NEXT_PUBLIC_* envs from host .env so dev mode mirrors prod.
+      # Add new NEXT_PUBLIC_* envs here too.
+      - NEXT_PUBLIC_GOOGLE_SSO_ENABLED=${NEXT_PUBLIC_GOOGLE_SSO_ENABLED:-}
     depends_on:
       - backend
     volumes:


### PR DESCRIPTION
## Summary

Local dev counterpart to PR #262. The frontend service's `environment:` block in `docker-compose.yml` only forwards envs it explicitly lists (no `env_file: .env` on this service). Without listing `NEXT_PUBLIC_GOOGLE_SSO_ENABLED`, a developer setting it in `.env` hits a dead end: the container never sees the var and `next dev` renders the SSO button as disabled.

Verified locally: after this change + `docker compose up -d --force-recreate frontend`, `curl http://localhost/login` returns HTML with "Sign in with Google".

## Scope

- 3 lines added to the frontend service `environment:` block.
- Comment lines document that any new `NEXT_PUBLIC_*` env must be added here too (matches the `frontend/Dockerfile` ARG list shipped in #262).