### PR TITLE
chore(apex): default aws_region to eu-central-1 (Frankfurt)

### DIFF
--- a/infra/terraform/apex/providers.tf
+++ b/infra/terraform/apex/providers.tf
@@ -1,6 +1,7 @@
 # Default AWS provider: hosts the S3 bucket, IAM, and Route 53 lookups.
-# Region is configurable via var.aws_region; default eu-west-1 matches the
-# rest of the EU-centric pfv stack.
+# Region is configurable via var.aws_region; default eu-central-1 (Frankfurt)
+# to keep apex resources in an STS-enabled EU region with low latency for
+# EU users.
 provider "aws" {
   region = var.aws_region
 

--- a/infra/terraform/apex/terraform.tfvars.example
+++ b/infra/terraform/apex/terraform.tfvars.example
@@ -7,7 +7,7 @@
 # aws_account_id = "123456789012"
 #
 # Optional overrides (defaults live in variables.tf):
-# aws_region                         = "eu-west-1"
+# aws_region                         = "eu-central-1"
 # domain                             = "thebetterdecision.com"
 # github_repo                        = "flamarion/pfv"
 # github_main_branch                 = "main"

--- a/infra/terraform/apex/variables.tf
+++ b/infra/terraform/apex/variables.tf
@@ -11,7 +11,7 @@ variable "aws_account_id" {
 variable "aws_region" {
   description = "AWS region for the S3 bucket and the home of the default provider. CloudFront is global; ACM for CloudFront is pinned to us-east-1 in providers.tf regardless of this value."
   type        = string
-  default     = "eu-west-1"
+  default     = "eu-central-1"
 }
 
 variable "domain" {


### PR DESCRIPTION
## Summary

Cleanup PR. The pfv-apex TFC workspace already overrides `aws_region` to `eu-central-1`, but the in-code default still said `eu-west-1`. This aligns the default with reality and avoids future clones / preview workspaces inheriting the eu-west-1 STS-regional-activation gotcha.

## Changes

- `variables.tf`: default `aws_region` `eu-west-1` -> `eu-central-1`.
- `providers.tf`: update the comment that explained the default, mention STS-enabled EU region and EU-user latency rationale.
- `terraform.tfvars.example`: update the example value.

## What this does NOT change

- The `us-east-1` provider alias for ACM remains. This is a hard AWS constraint: CloudFront only accepts ACM certificates from `us-east-1`. Removing this pin would break HTTPS on the apex.
- No state changes. Workspace-level variable still wins; this is a default for new clones / preview workspaces.
- No new pins anywhere else in the module.

## Validation

`terraform fmt -check -recursive` clean. No `terraform plan` change against the existing apex state since the workspace variable overrides the default.