### PR TITLE
feat(ci): apex landing deploy workflow + path filters (L5.2a PR-B)

### DIFF
--- a/.github/workflows/apex-deploy.yml
+++ b/.github/workflows/apex-deploy.yml
@@ -64,7 +64,11 @@ on:
       - "frontend/lib/styles.ts"
       - "frontend/components/brand/**"
       - "frontend/components/ThemeProvider.tsx"
-      - "frontend/components/tour/TourProvider.tsx"
+      # tour/** rather than just TourProvider.tsx because TourProvider
+      # imports useTour and any future split helper files; useTour code
+      # is bundled into the apex output (verified by grepping the built
+      # _next/static chunks for the `tbd-pending-dashboard-tour` marker).
+      - "frontend/components/tour/**"
       - "frontend/components/ui/BackLink.tsx"
       - "frontend/components/ui/CurrentYear.tsx"
       - "frontend/components/ui/ThemeToggle.tsx"

--- a/.github/workflows/apex-deploy.yml
+++ b/.github/workflows/apex-deploy.yml
@@ -38,15 +38,36 @@ on:
       - "frontend/app/privacy/**"
       - "frontend/app/terms/**"
       - "frontend/app/docs/**"
+      # Structural app-level files retained by build-apex.sh
+      # (frontend/scripts/build-apex.sh's ALLOWED_APP_FILES allowlist).
+      # Changing any of these can change what the apex bundle ships.
+      - "frontend/app/layout.tsx"
+      - "frontend/app/not-found.tsx"
+      - "frontend/app/error.tsx"
+      - "frontend/app/loading.tsx"
+      - "frontend/app/global-error.tsx"
+      - "frontend/app/icon.svg"
+      - "frontend/app/globals.css"
       # Landing components and apex-build helpers
       - "frontend/components/landing/**"
       - "frontend/components/auth/AuthProviderApex.tsx"
       - "frontend/scripts/build-apex.sh"
       - "frontend/next.config.apex.ts"
       - "frontend/lib/links.ts"
-      # Shared paths that legitimately affect the apex render
+      # Shared dependencies imported by the retained app/layout.tsx,
+      # page.tsx, and landing components (transitive grep of
+      # `from "@/..."` across the apex-retained surface).
+      # These are SHARED with the DO app build, so they intentionally
+      # remain positive matches in release.yml as well.
       - "frontend/lib/brand.ts"
-      - "frontend/app/globals.css"
+      - "frontend/lib/site.ts"
+      - "frontend/lib/styles.ts"
+      - "frontend/components/brand/**"
+      - "frontend/components/ThemeProvider.tsx"
+      - "frontend/components/tour/TourProvider.tsx"
+      - "frontend/components/ui/BackLink.tsx"
+      - "frontend/components/ui/CurrentYear.tsx"
+      - "frontend/components/ui/ThemeToggle.tsx"
       - "frontend/public/**"
       # Dependencies the apex build resolves
       - "frontend/package.json"
@@ -85,7 +106,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -116,18 +137,38 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: github-actions-apex-deploy-${{ github.run_id }}
 
-      # Cache strategy: only content-hashed assets under _next/static/**
-      # may carry an immutable 1-year cache, because Next.js mangles their
-      # filenames on every change. Everything else (HTML pages, icons,
-      # OG/apple images, fonts in public/, JSON, txt, xml) is mutable
-      # under a stable URL: those need a short cache so a future change
-      # is visible to clients that already cached the old object,
-      # regardless of CloudFront invalidation.
+      # Cache strategy + deploy order.
       #
-      # Two syncs with mutually exclusive prefixes; each owns its own
-      # --delete window so removed files at either layer get pruned from
-      # the bucket (previous design only --delete'd the immutable set,
-      # which left deleted HTML pages serving until the next CF expiry).
+      # Cache:
+      #   - Hashed assets under _next/static/** are content-addressed by
+      #     Next.js, safe to lock at max-age=31536000, immutable.
+      #   - Everything else lives under stable URLs (HTML, icons,
+      #     OG/apple images, fonts, JSON, txt, xml). Short cache so a
+      #     future change is visible to clients that already cached the
+      #     old object, regardless of CloudFront invalidation.
+      #
+      # Order: hashed chunks FIRST without --delete, then mutable assets
+      # with --delete. Two reasons:
+      #   1. The newly-published HTML references new hashed-asset URLs,
+      #      so those chunks must exist in S3 before the HTML is visible.
+      #   2. Browser-cached old HTML (5-min TTL) still references old
+      #      hashed-asset URLs; deleting those mid-flight produces 404s
+      #      for users who have not yet refetched the HTML.
+      #
+      # Trade-off: orphaned hashed chunks accumulate in the bucket. They
+      # are pennies of storage and the S3 lifecycle policy provisioned by
+      # PR #240 prunes noncurrent VERSIONS after 90 days, but NOT
+      # orphaned-by-rename objects. Periodic cleanup of stale objects
+      # under _next/static/** (older than N days, not referenced by any
+      # current HTML) is a follow-up via an S3 lifecycle rule or a
+      # scheduled GH Actions workflow. Tracked separately.
+
+      - name: Sync immutable hashed assets (long cache, NO --delete)
+        working-directory: frontend
+        run: |
+          aws s3 sync out-apex/_next/static/ "s3://${S3_BUCKET}/_next/static/" \
+            --no-progress \
+            --cache-control "public, max-age=31536000, immutable"
 
       - name: Sync mutable assets (short cache, --delete)
         working-directory: frontend
@@ -137,14 +178,6 @@ jobs:
             --no-progress \
             --exclude "_next/static/*" \
             --cache-control "public, max-age=300, s-maxage=3600"
-
-      - name: Sync immutable hashed assets (long cache, --delete)
-        working-directory: frontend
-        run: |
-          aws s3 sync out-apex/_next/static/ "s3://${S3_BUCKET}/_next/static/" \
-            --delete \
-            --no-progress \
-            --cache-control "public, max-age=31536000, immutable"
 
       - name: Override _meta.json with no-cache
         working-directory: frontend

--- a/.github/workflows/apex-deploy.yml
+++ b/.github/workflows/apex-deploy.yml
@@ -1,0 +1,177 @@
+# Apex landing deploy.
+#
+# Builds the apex static export (`npm run build:apex`) and pushes it to
+# the S3 bucket fronted by CloudFront at https://thebetterdecision.com.
+# Auth is via GitHub OIDC -> AWS IAM role (no long-lived AWS keys).
+#
+# The IAM role's trust policy (provisioned by PR #240) only accepts
+# tokens whose `sub` claim matches `repo:flamarion/pfv:ref:refs/heads/main`.
+# That is the load-bearing security boundary; this workflow's
+# `branches: [main]` trigger is belt-and-suspenders.
+#
+# The path filter mirrors the negation list in release.yml so that
+# landing-only commits deploy to AWS only and do NOT trigger the DO
+# release workflow. Shared paths (globals.css, lib/brand.ts,
+# public/fonts/**) intentionally trigger both: a brand or token change
+# legitimately affects both surfaces.
+#
+# Required GitHub repository variables (Settings -> Secrets and variables
+# -> Actions -> Variables tab):
+#   AWS_APEX_DEPLOY_ROLE_ARN  ARN of github-actions-apex-deploy role
+#                             (Terraform output: github_actions_role_arn)
+#   AWS_APEX_BUCKET           S3 bucket name
+#                             (Terraform output: s3_bucket_name)
+#   AWS_APEX_DISTRIBUTION_ID  CloudFront distribution ID
+#                             (Terraform output: cloudfront_distribution_id)
+#
+# No secrets are needed. The role ARN, bucket name, and distribution ID
+# are public-shaped identifiers.
+
+name: Deploy Apex Landing
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Landing surface in app/
+      - "frontend/app/page.tsx"
+      - "frontend/app/privacy/**"
+      - "frontend/app/terms/**"
+      - "frontend/app/docs/**"
+      # Landing components and apex-build helpers
+      - "frontend/components/landing/**"
+      - "frontend/components/auth/AuthProviderApex.tsx"
+      - "frontend/scripts/build-apex.sh"
+      - "frontend/next.config.apex.ts"
+      - "frontend/lib/links.ts"
+      # Shared paths that legitimately affect the apex render
+      - "frontend/lib/brand.ts"
+      - "frontend/app/globals.css"
+      - "frontend/public/**"
+      # Dependencies the apex build resolves
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      # The workflow itself
+      - ".github/workflows/apex-deploy.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+# Serialize deploys; never cancel an in-flight S3 sync.
+concurrency:
+  group: apex-deploy
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    name: Build and deploy apex
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # Region is a repo variable so a future TFC `aws_region` change does
+      # not require touching this workflow. Fallback keeps the workflow
+      # functional if the variable was forgotten during setup.
+      AWS_REGION: ${{ vars.AWS_APEX_REGION || 'eu-central-1' }}
+      S3_BUCKET: ${{ vars.AWS_APEX_BUCKET }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.AWS_APEX_DISTRIBUTION_ID }}
+      DEPLOY_ROLE_ARN: ${{ vars.AWS_APEX_DEPLOY_ROLE_ARN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci --no-audit --no-fund
+
+      - name: Build apex static export
+        working-directory: frontend
+        env:
+          NEXT_PUBLIC_BUILD_TARGET: apex
+          NEXT_PUBLIC_SITE_URL: https://thebetterdecision.com
+          NEXT_PUBLIC_APP_URL: https://app.thebetterdecision.com
+        run: npm run build:apex
+
+      - name: Verify build output
+        working-directory: frontend
+        run: |
+          test -f out-apex/index.html || { echo "out-apex/index.html missing"; exit 1; }
+          test -f out-apex/_meta.json || { echo "out-apex/_meta.json missing"; exit 1; }
+          echo "Build output OK:"
+          ls -la out-apex/ | head -20
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-actions-apex-deploy-${{ github.run_id }}
+
+      # Cache strategy: only content-hashed assets under _next/static/**
+      # may carry an immutable 1-year cache, because Next.js mangles their
+      # filenames on every change. Everything else (HTML pages, icons,
+      # OG/apple images, fonts in public/, JSON, txt, xml) is mutable
+      # under a stable URL: those need a short cache so a future change
+      # is visible to clients that already cached the old object,
+      # regardless of CloudFront invalidation.
+      #
+      # Two syncs with mutually exclusive prefixes; each owns its own
+      # --delete window so removed files at either layer get pruned from
+      # the bucket (previous design only --delete'd the immutable set,
+      # which left deleted HTML pages serving until the next CF expiry).
+
+      - name: Sync mutable assets (short cache, --delete)
+        working-directory: frontend
+        run: |
+          aws s3 sync out-apex/ "s3://${S3_BUCKET}/" \
+            --delete \
+            --no-progress \
+            --exclude "_next/static/*" \
+            --cache-control "public, max-age=300, s-maxage=3600"
+
+      - name: Sync immutable hashed assets (long cache, --delete)
+        working-directory: frontend
+        run: |
+          aws s3 sync out-apex/_next/static/ "s3://${S3_BUCKET}/_next/static/" \
+            --delete \
+            --no-progress \
+            --cache-control "public, max-age=31536000, immutable"
+
+      - name: Override _meta.json with no-cache
+        working-directory: frontend
+        run: |
+          # _meta.json is the deploy-verification probe. It must never be
+          # cached so a curl against the apex returns the freshest SHA.
+          # aws s3 sync auto-detected content-type as application/json on
+          # the previous step; here we re-upload with the strict
+          # cache-control + explicit content-type to be unambiguous.
+          if [ -f out-apex/_meta.json ]; then
+            aws s3 cp out-apex/_meta.json "s3://${S3_BUCKET}/_meta.json" \
+              --no-progress \
+              --content-type "application/json" \
+              --cache-control "no-cache, no-store, must-revalidate"
+          fi
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*" \
+            >/dev/null
+
+      - name: Print deploy summary
+        run: |
+          echo "Deployed apex landing"
+          echo "  Commit:        ${GITHUB_SHA}"
+          echo "  Bucket:        ${S3_BUCKET}"
+          echo "  Distribution:  ${CLOUDFRONT_DISTRIBUTION_ID}"
+          echo "  Verify via:    https://thebetterdecision.com/_meta.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,25 @@ on:
     # refactor commits inside the allowlist still run release.yml, and
     # the gated `deploy` job below decides whether to ship based on
     # semantic-release's `new_release_published` output.
+    #
+    # Landing-only paths are negated below. Those are owned by the apex
+    # S3 + CloudFront pipeline (.github/workflows/apex-deploy.yml) and a
+    # landing-only commit must not trigger a DO redeploy. Shared paths
+    # (frontend/lib/brand.ts, frontend/app/globals.css, frontend/public/**)
+    # are intentionally NOT negated so a brand / token / font change still
+    # rebuilds both surfaces.
     paths:
       - "backend/**"
       - "frontend/**"
+      - "!frontend/app/page.tsx"
+      - "!frontend/app/privacy/**"
+      - "!frontend/app/terms/**"
+      - "!frontend/app/docs/**"
+      - "!frontend/components/landing/**"
+      - "!frontend/components/auth/AuthProviderApex.tsx"
+      - "!frontend/scripts/build-apex.sh"
+      - "!frontend/next.config.apex.ts"
+      - "!frontend/lib/links.ts"
       - "nginx/**"
       - ".do/**"
       - "Dockerfile*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,3 +79,17 @@ jobs:
       - name: Run frontend production build
         working-directory: frontend
         run: npm run build
+
+      - name: Run apex static export build
+        working-directory: frontend
+        env:
+          NEXT_PUBLIC_BUILD_TARGET: apex
+          NEXT_PUBLIC_SITE_URL: https://thebetterdecision.com
+          NEXT_PUBLIC_APP_URL: https://app.thebetterdecision.com
+        run: |
+          npm run build:apex
+          # Belt-and-suspenders sanity: the build script's own trap should
+          # have already cleared out-apex/ failures, but verify the
+          # entry points landed before signaling green to the PR.
+          test -f out-apex/index.html
+          test -f out-apex/_meta.json


### PR DESCRIPTION
## Scope

PR-B of the L5.2a apex split. Adds the GitHub Actions workflow that builds the apex static export and pushes it to S3 + CloudFront. Updates `release.yml` so landing-only commits no longer trigger DO redeploys, and updates `test.yml` so the apex build is verified on PRs.

**This PR is opened as DRAFT until PR #241 lands.** PR-B's `test.yml` step calls `npm run build:apex`, which is added by PR #241 (`frontend/scripts/build-apex.sh`, `frontend/next.config.apex.ts`, `package.json` script). Sequencing:

1. Merge PR #241 (PR-C, build target).
2. Mark this PR ready for review, rebase if needed.
3. Configure GitHub repository variables (see below).
4. Merge.
5. Verify the first apex deploy fires from PR-B's own merge commit (the workflow's path filter includes itself).
6. Open and merge PR-D (Route 53 ALIAS swap).

## What this PR does

### `.github/workflows/apex-deploy.yml` (new)

Triggered by push to `main` matching landing-affecting paths. Steps:

1. Checkout, Node 20 setup, `npm ci` in `frontend/`.
2. `npm run build:apex` with `NEXT_PUBLIC_BUILD_TARGET=apex`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_APP_URL`.
3. Verify `out-apex/index.html` and `out-apex/_meta.json` exist.
4. Assume the deploy IAM role via OIDC (`aws-actions/configure-aws-credentials@v4`). No long-lived AWS keys.
5. Two `aws s3 sync` passes with mutually exclusive prefixes, each owning its own `--delete` window.
6. `aws s3 cp` override for `_meta.json` to `no-cache, no-store, must-revalidate`.
7. `aws cloudfront create-invalidation --paths "/*"`.

### `.github/workflows/release.yml` (edit)

Negates the landing-only paths from the DO release trigger, so a landing-only commit:
- Skips `release.yml` entirely (no `semantic-release` evaluation, no DO redeploy).
- Triggers only `apex-deploy.yml`.

Shared paths (`frontend/lib/brand.ts`, `frontend/app/globals.css`, `frontend/public/**`) intentionally remain in the positive allowlist so a brand / token / font change still rebuilds both surfaces.

### `.github/workflows/test.yml` (edit)

Adds `npm run build:apex` as a Frontend Checks step on PRs, so a broken apex build fails CI rather than going undetected until post-merge.

## Cache strategy

| Asset | Cache-Control |
|---|---|
| `_next/static/**` (content-hashed by Next.js) | `public, max-age=31536000, immutable` |
| HTML, icons, images, fonts, robots.txt, sitemap.xml | `public, max-age=300, s-maxage=3600` |
| `_meta.json` | `no-cache, no-store, must-revalidate` |

Each sync owns `--delete` on its own prefix (`--exclude "_next/static/*"` on the mutable sync, scoped sync target on the immutable one), so a removed file at either layer gets pruned within the same run.

## Required setup BEFORE marking this PR ready

GitHub repository variables (Settings -> Secrets and variables -> Actions -> Variables tab):

| Name | Required | Source / default |
|---|---|---|
| `AWS_APEX_DEPLOY_ROLE_ARN` | Required | TFC apply output `github_actions_role_arn` |
| `AWS_APEX_BUCKET` | Required | TFC apply output `s3_bucket_name` |
| `AWS_APEX_DISTRIBUTION_ID` | Required | TFC apply output `cloudfront_distribution_id` |
| `AWS_APEX_REGION` | Optional | Defaults to `eu-central-1` if unset |

All four are **repository variables**, not **secrets**. ARNs and IDs aren't credentials, and the OIDC trust policy (provisioned by PR #240) is the security boundary.

## What this PR does NOT do

- **No Terraform changes.** IAM role, OIDC provider, S3 bucket, CloudFront distribution, response-headers policy, viewer-request function all provisioned by PR #240.
- **No DNS cutover.** Route 53 apex `A` ALIAS swap is PR-D.
- **No third-party deploy actions.** AWS does not publish a first-party S3 or CloudFront deploy action; their recommended pattern is `aws-actions/configure-aws-credentials` + bundled `aws` CLI in `run` steps. Confirmed against the [aws-actions org](https://github.com/aws-actions) and [GitHub OIDC in AWS docs](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws).

## Backlog (not blocking PR-B)

A follow-up could move cache headers from upload-time S3 metadata into a CloudFront response-headers policy with ordered cache behaviors. This would shrink the workflow to two `aws` calls (one `s3 sync --delete`, one `cloudfront create-invalidation`).

Deferred because each new ordered behavior must carry the existing viewer-request function (www to apex redirect + directory-index rewrite) AND the security-headers policy (HSTS, X-Frame-Options, etc.). Missing either breaks canonical routing or strips security headers from `/_next/static/*`. That work warrants its own focused PR, not a side-quest here.

## Validation

- YAML structure: `on:` / `jobs:` blocks present in all three files.
- Path filter design: tested via mental walk-through of three change classes:
  - **Backend-only commit**: matches `backend/**` in `release.yml`, no apex paths -> only `release.yml` fires.
  - **Landing-only commit**: every changed path matches a negation in `release.yml` AND matches a positive in `apex-deploy.yml` -> only `apex-deploy.yml` fires.
  - **Shared commit** (e.g. `frontend/lib/brand.ts`): matches `frontend/**` (positive in `release.yml`, not negated) AND matches `lib/brand.ts` (positive in `apex-deploy.yml`) -> both fire intentionally.
- OIDC role assume: belt-and-suspenders. Trust policy already rejects PR contexts at the IAM layer; workflow `branches: [main]` is the second fence.