### PR TITLE
fix(apex-tfc-role): grant route53:ListTagsForResource{,s} on read

### DIFF
--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -628,6 +628,13 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
       "route53:ListHostedZonesByName",
       "route53:GetChange",
       "route53:ListResourceRecordSets",
+      # data.aws_route53_zone calls ListTagsForResource as part of its
+      # read since AWS provider v5.x. Without these, refresh fails with
+      # 403 on every plan/apply that touches the data source. Both
+      # singular and plural variants are distinct IAM permissions; grant
+      # both so future provider changes that switch APIs do not regress.
+      "route53:ListTagsForResource",
+      "route53:ListTagsForResources",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Symptom

Post-OIDC-switchover plan failed with:

\`\`\`
Error: listing Route 53 Hosted Zone (Z00184261MD21LXWLVPHH) tags:
operation error Route 53: ListTagsForResource, https response error
StatusCode: 403, ... AccessDenied: User:
arn:aws:sts::520936160561:assumed-role/tfc-apex-provisioner/...
is not authorized to perform: route53:ListTagsForResource on resource:
arn:aws:route53:::hostedzone/Z00184261MD21LXWLVPHH because no
identity-based policy allows the route53:ListTagsForResource action

  with data.aws_route53_zone.apex
  on main.tf line 45, in data "aws_route53_zone" "apex":
\`\`\`

## Root cause

The AWS provider's \`data "aws_route53_zone"\` source has called \`ListTagsForResource\` as part of its read path since provider v5.x. The \`ReadApexZone\` statement on \`tfc-apex-provisioner\` predates that change; it grants \`GetHostedZone\`, \`ListHostedZones\`, \`ListHostedZonesByName\`, \`GetChange\`, \`ListResourceRecordSets\`, but not the tag-listing action.

Surfaces every time TFC refreshes state on a plan/apply (which is every run).

## Fix

Add \`route53:ListTagsForResource\` and \`route53:ListTagsForResources\` to the \`ReadApexZone\` statement. Both are distinct IAM permissions in Route 53; granting both pre-empts a future provider change that switches between them.

## Audit of other tag-listing permissions

I cross-checked the other service blocks in the same policy:

| Service | Current grant | Tag-list covered? |
|---|---|---|
| S3 | \`s3:*\` on bucket | Yes (wildcards cover GetBucketTagging) |
| CloudFront | \`cloudfront:*\` | Yes |
| ACM | \`acm:*\` on \`arn:aws:acm:us-east-1:ACCOUNT:certificate/*\` | Yes |
| IAM (apex roles) | \`iam:*Role*\`, \`iam:*RolePolic*\`, \`iam:PassRole\`, \`iam:TagRole\`, \`iam:UntagRole\` | Yes (covers ListRoleTags via \`iam:*Role*\`) |
| IAM (OIDC providers) | \`iam:*OpenIDConnectProvider*\` | Yes |
| Route 53 | Explicit allowlist | **No** (this PR) |

Only Route 53 was over-narrowed because its block uses an explicit allowlist rather than wildcards.

## Apply

After merge, TFC \`pfv-apex\` will auto-fire a plan on the merge commit. Confirm & Apply. Expected: \`Plan: 0 to add, 1 to change, 0 to destroy\` (the IAM inline policy update). Sub-1-min apply.

After the apply, re-queue the no-op plan that originally failed and confirm OIDC + refresh + plan all succeed.

## Out of scope

- No other service's IAM permissions touched.
- No Route 53 record types added or condition broadened. Apex \`A\` record write still IAM-blocked; PR-D will widen the CNAME-only condition when DNS cutover lands.