### PR TITLE
docs: CI/CD flow reference + onboarding refresh + infra topology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,86 +1,169 @@
 # Contributing to The Better Decision
 
-This guide covers everything you need to develop, test, and deploy The Better Decision. Start with Quick Start if you're setting up for the first time, then refer to the architecture and API sections as needed.
+This guide gets a new contributor productive in under 30 minutes: local stack up, tests passing, first PR ready to push. For deep references, follow the cross-links instead of reading this file end-to-end.
+
+Sibling docs you will end up at:
+
+- `README.md` for product overview and stack.
+- `ENVIRONMENT.md` for every env var, with scopes, defaults, and failure modes.
+- `DEPLOYMENT.md` for the full CI/CD pipeline (what fires when, how production deploys, smoke tests, apex domain).
+- `infra/README.md` and `infra/MIGRATION.md` for the production data plane and Terraform workflow.
+- `BRAND.md` and `DESIGN.md` for product copy and UI conventions.
 
 ## Prerequisites
 
-- Docker & Docker Compose
-- Git
-- Node.js 18+ (only for local TypeScript checking — the app runs in containers)
+- Docker and Docker Compose.
+- Git.
+- Node.js 22+ on the host (only needed if you want `tsc` outside the container). The app itself runs entirely in containers.
 
-## Quick Start
+## Quickstart (under 30 minutes)
 
 ```bash
 # 1. Clone and configure
-git clone <repo-url> && cd pfv
+git clone https://github.com/flamarion/pfv.git && cd pfv
 cp .env.example .env
 
-# 2. Start the dev stack (MySQL + Redis + Backend + Frontend + Nginx)
+# 2. Generate a real JWT secret. The backend refuses to boot on the placeholder.
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+# Paste that value into JWT_SECRET_KEY in .env
+
+# 3. Start the dev stack (MySQL + Redis + backend + frontend + nginx)
 ./pfv start
 
-# 3. Open the app
+# 4. Open the app
 open http://localhost
 ```
 
-The first user to register becomes the org owner and superadmin.
+The first user to register becomes the org owner and superadmin. No seed data required.
 
-## Seeding Mock Data
-
-The seed script creates a realistic dataset: 5 accounts, 100+ transactions across 3 months, recurring templates, billing periods, and budgets.
-
-**Default seed (creates a "demo" user):**
+Want a realistic dataset (5 accounts, 100+ transactions, recurring templates, budgets)?
 
 ```bash
-./pfv seed
-# Login: demo / demo1234
+./pfv seed                 # creates demo / demo1234
 ```
 
-**Custom seed (your own user):**
+For a custom user, set `SEED_*` env vars before the command. See [Seeding mock data](#seeding-mock-data) below.
+
+Full env var reference, including production-only and feature-flag variables, lives in `ENVIRONMENT.md`. Do not duplicate values here.
+
+## Your first PR
+
+```mermaid
+flowchart TD
+    A[Made a change] --> B{What did you touch?}
+    B -->|backend/**| C[docker compose exec backend pytest]
+    B -->|frontend/**| D[docker compose exec frontend npm test<br/>docker compose exec frontend npx tsc --noEmit]
+    B -->|backend/alembic/versions/**| E[Restart backend so lifespan applies the migration<br/>./pfv restart]
+    B -->|nginx/** or .do/**| F[./pfv prod for a local prod-shaped run<br/>Smoke endpoints by hand]
+    B -->|docs only| G[No tests required.<br/>Use chore: or docs: prefix so semantic-release skips deploy.]
+    C --> H[Commit with Conventional Commits prefix]
+    D --> H
+    E --> H
+    F --> H
+    G --> H
+    H --> I[Push branch, open PR<br/>test.yml runs on PR]
+    I --> J[Merge to main]
+    J --> K{Commit prefix release-eligible?}
+    K -->|feat, fix, perf, revert| L[release.yml ships to production]
+    K -->|chore, docs, refactor, test, style| M[No deploy. Use gh workflow run deploy.yml<br/>if you need to force a redeploy.]
+```
+
+If you touched migrations, run `docker compose exec backend alembic current` and `docker compose exec backend alembic upgrade head` inside the container to confirm. See [Database migrations](#database-migrations).
+
+## Conventional Commits and the deploy gate
+
+This repo is auto-deployed by `semantic-release` on push to `main`. The commit prefix is the deploy decision, not a stylistic detail.
+
+| Prefix | Release? | What ships |
+|--------|----------|------------|
+| `feat:` | Yes (minor bump) | App Platform redeploy + smoke tests |
+| `fix:` | Yes (patch bump) | App Platform redeploy + smoke tests |
+| `perf:` | Yes (patch bump) | App Platform redeploy + smoke tests |
+| `revert:` | Yes (patch bump) | App Platform redeploy + smoke tests |
+| `feat!:`, `BREAKING CHANGE:` footer | Yes (major bump) | App Platform redeploy + smoke tests |
+| `chore:`, `docs:`, `refactor:`, `test:`, `style:`, `ci:`, `build:` | No | Nothing. CI runs `test.yml` only. |
+
+Scope is freeform (`feat(admin):`, `fix(frontend):`, `chore(.do):`). Scope does not change release behavior.
+
+Rules in practice:
+
+- If your change should reach production on merge, use `feat:`, `fix:`, or `perf:`.
+- If your change is internal only (refactor, test fix, doc edit, CI tweak, dependency bump), use `chore:` / `docs:` / `refactor:` / `test:`. The merge will not redeploy. This is the right answer most of the time for non-product changes.
+- Infra-only changes (`chore(.do)`, `chore(infra)`, `chore(nginx)`) sometimes need to ship without a version bump. Use the manual escape hatch: `gh workflow run deploy.yml --ref main`. See `DEPLOYMENT.md` for when this is appropriate.
+
+Full pipeline detail (path filters, gating logic, smoke tests, apex deploy) lives in `DEPLOYMENT.md`. The short version is in [CI on your PR vs CI after merge](#ci-on-your-pr-vs-ci-after-merge) below.
+
+## CI on your PR vs CI after merge
+
+PR push (any branch):
+
+- `.github/workflows/test.yml` runs on changes under `backend/**`, `frontend/**`, or `.github/workflows/test.yml`. Backend: `pytest` + compileall syntax smoke. Frontend: lint, design-token check, `vitest`/`jest`, production build.
+- Nothing deploys. Nothing reaches production.
+
+Merge to `main`:
+
+- `.github/workflows/release.yml` runs on changes under `backend/**`, `frontend/**`, `nginx/**`, `.do/**`, or `Dockerfile*`. It runs `semantic-release`. If (and only if) `semantic-release` decides a new release is warranted, the gated `deploy` job pushes `.do/app.yaml` to DO App Platform, then `scripts/smoke-test.sh` asserts the live app serves traffic.
+- `chore:` / `docs:` / `refactor:` commits inside the allowlist still trigger `release.yml`, but `semantic-release` no-ops and the deploy job is skipped.
+- A future `apex-deploy.yml` (PR #267) will deploy the apex landing site on merges that touch the apex paths.
+
+If you need to force a redeploy of the current production spec without merging a code change, use the manual workflow:
 
 ```bash
-SEED_USERNAME=flamarion \
-SEED_PASSWORD=abcd1234 \
-SEED_EMAIL=flamarion@example.com \
-SEED_FIRST_NAME=Flamarion \
-SEED_LAST_NAME=Jorge \
-SEED_ORG="FJ Consulting" \
-./pfv seed
+gh workflow run deploy.yml --ref main
 ```
 
-**Important:** The seed script will register the user if it doesn't exist, then log in and create data. If the user already exists, it logs in with the provided credentials and adds data to their org.
+`DEPLOYMENT.md` is the authoritative reference.
 
-### Seed Environment Variables
+## Working in parallel agent sessions
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SEED_USERNAME` | `demo` | Username for the seeded user |
-| `SEED_PASSWORD` | `demo1234` | Password |
-| `SEED_EMAIL` | `demo@example.com` | Email address |
-| `SEED_FIRST_NAME` | `Demo` | First name |
-| `SEED_LAST_NAME` | `User` | Last name |
-| `SEED_ORG` | `Demo Household` | Organization name |
+If you dispatch Claude Code agents (or any parallel-process helpers) against this repo, never let them run backend tests or migrations against the default `pfv` Docker Compose project. They will write to your local MySQL volume. Use an isolated compose project name on every command:
 
-## CLI Reference
+```bash
+docker compose -p team-<unique-name> up -d backend mysql redis
+docker compose -p team-<unique-name> exec backend pytest tests/...
+```
+
+A single command that omits `-p team-<name>` falls back to the default `pfv` project and contaminates the user's stack. `./pfv migrate` has no `-p` flag and always targets the default project, so agents must not invoke it either. See `CLAUDE.md` for the full rule and the 2026-05-09 incident this guard prevents.
+
+## Seeding mock data
+
+```bash
+./pfv seed                                       # default demo user
+SEED_USERNAME=alice SEED_PASSWORD=alice1234 \
+SEED_EMAIL=alice@example.com SEED_ORG="Alice LLC" \
+./pfv seed                                       # custom user
+```
+
+The seed script registers the user if it does not exist, logs in, and creates data. If the user already exists, it adds data to their org.
+
+`SEED_*` env var reference:
+
+| Variable | Default |
+|----------|---------|
+| `SEED_USERNAME` | `demo` |
+| `SEED_PASSWORD` | `demo1234` |
+| `SEED_EMAIL` | `demo@example.com` |
+| `SEED_FIRST_NAME` | `Demo` |
+| `SEED_LAST_NAME` | `User` |
+| `SEED_ORG` | `Demo Household` |
+
+## CLI reference
 
 | Command | Description |
 |---------|-------------|
-| `./pfv start` | Build and start all services (development) |
+| `./pfv start` | Build and start all dev services |
 | `./pfv stop` | Stop all services |
 | `./pfv restart` | Restart without rebuild |
 | `./pfv rebuild` | Force rebuild (no cache) and start |
 | `./pfv reset` | Destroy all data, rotate JWT secret, start fresh |
-| `./pfv prod` | Build and start in production mode |
-| `./pfv migrate` | Run pending database migrations |
-| `./pfv logs [svc]` | View logs (backend, frontend, nginx, mysql, redis) |
-| `./pfv status` | Show container status |
-| `./pfv shell [svc]` | Open a shell in a service (default: backend) |
+| `./pfv prod` | Build and start a local prod-shaped stack |
+| `./pfv migrate` | Run pending DB migrations (local only) |
+| `./pfv logs [svc]` | Tail logs (`backend`, `frontend`, `nginx`, `mysql`, `redis`) |
+| `./pfv status` | Container status |
+| `./pfv shell [svc]` | Shell into a service (default: `backend`) |
 | `./pfv seed` | Populate with mock data |
 
----
-
 ## Architecture
-
-### System Diagram
 
 ```
 Browser --> nginx (:80) --> /api/*  --> backend (FastAPI :8000) --> MySQL (:3306)
@@ -88,191 +171,84 @@ Browser --> nginx (:80) --> /api/*  --> backend (FastAPI :8000) --> MySQL (:3306
                                         backend --> Redis (:6379)
 ```
 
-In production (DigitalOcean App Platform), nginx is replaced by DO's built-in ingress routing.
+In production (DigitalOcean App Platform), nginx is replaced by DO's built-in ingress. MySQL and Redis are self-hosted on a single droplet (`pfv-data-01`) in a private VPC. Background and runbook: `infra/README.md`, `infra/MIGRATION.md`.
 
-### Backend (Python / FastAPI)
+### Backend layout
 
 ```
 backend/app/
-├── main.py                  # App factory, lifespan, CORS, router registration, 422 sanitizer
-├── config.py                # pydantic-settings — all config from env vars
-├── database.py              # Async SQLAlchemy engine + session factory
-├── security.py              # JWT creation/decode, bcrypt, MFA token helpers
-├── deps.py                  # FastAPI dependencies: get_db, get_current_user
-├── logging.py               # structlog JSON logging + health check filter
-├── rate_limit.py            # slowapi rate limiter (shared instance)
-├── redis_client.py          # Async Redis singleton (MFA nonce, step-up state)
-├── middleware/              # Pure ASGI middleware (request id / context)
-├── models/                  # SQLAlchemy ORM models
-│   ├── user.py              #   User, Organization, Role enum, password_set flag
-│   ├── account.py           #   Account, AccountType
-│   ├── category.py          #   Category (hierarchical), CategoryType
-│   ├── category_rule.py     #   Per-org auto-categorization rules
-│   ├── merchant_dictionary.py # Shared merchant -> category dictionary
-│   ├── transaction.py       #   Transaction (income/expense/transfer, settled_date)
-│   ├── recurring.py         #   RecurringTransaction templates
-│   ├── billing.py           #   BillingPeriod (org-scoped)
-│   ├── budget.py            #   Budget (per category per period)
-│   ├── forecast_plan.py     #   ForecastPlan + ForecastPlanItem (with ItemSource)
-│   ├── audit_event.py       #   Durable audit log (admin + sensitive ops)
-│   ├── role.py              #   Custom roles + role_permissions
-│   ├── invitation.py        #   Org invitation tokens
-│   ├── subscription.py      #   Org subscription / trial state
-│   ├── feature_override.py  #   Per-org plan-feature overrides
-│   ├── org_data_reset_lock.py # Guard against concurrent org-data wipes
-│   └── settings.py          #   OrgSetting (key-value per org)
-├── schemas/                 # Pydantic request/response models (mirrors models/)
-├── routers/                 # API route handlers
-│   ├── auth.py              #   Login, register, MFA, Google SSO + step-up, password reset
-│   ├── users.py             #   Profile update, password change
-│   ├── accounts.py          #   CRUD accounts
-│   ├── account_types.py     #   CRUD account types
-│   ├── categories.py        #   CRUD categories (hierarchical, type-locked once used)
-│   ├── transactions.py      #   CRUD transactions + transfers (settled_date period bucket)
-│   ├── recurring.py         #   CRUD recurring templates + generation
-│   ├── budgets.py           #   CRUD budgets + transfers between budgets
-│   ├── forecast.py          #   Read-only computed forecast
-│   ├── forecast_plans.py    #   CRUD editable forecast plans (MANUAL on public writes)
-│   ├── import_router.py     #   CSV import: preview + confirm
-│   ├── settings.py          #   Org settings, billing periods, billing cycle
-│   ├── orgs.py              #   Org rename (owner-only, case-insensitive uniqueness)
-│   ├── org_members.py       #   Org membership + invitations
-│   ├── org_data.py          #   Org-data wipe / reset (audited + locked)
-│   ├── plans.py             #   Plan catalog (read)
-│   ├── subscriptions.py     #   Org subscription / trial state
-│   ├── admin.py             #   Superadmin dashboard
-│   ├── admin_orgs.py        #   Superadmin org management + override sweep
-│   ├── admin_audit.py       #   Audit log query API
-│   └── admin_roles.py       #   Custom role + permission editing
-└── services/                # Business logic (called by routers)
-    ├── billing_service.py       # Period management, resolve_period()
-    ├── budget_service.py        # Budget queries with spending calculations
-    ├── transaction_service.py   # Shared validation helpers, category-type guard
-    ├── transaction_filters.py   # effective_period_date_expr() — COALESCE(settled_date, date)
-    ├── recurring_service.py     # Generate transactions from templates
-    ├── forecast_service.py      # Compute forecast from transactions + recurring
-    ├── forecast_plan_service.py # Forecast plan CRUD with actual tracking
-    ├── category_service.py      # Category CRUD with type compatibility checks
-    ├── category_rules_service.py # Per-org auto-categorization rules
-    ├── import_parser.py         # CSV parsing (delimiter, date, amount detection)
-    ├── import_service.py        # Import preview + commit logic
-    ├── email_service.py         # Mailgun (prod) / structlog (dev) email sender
-    ├── mfa_service.py           # TOTP, QR codes, recovery codes, encryption
-    ├── audit_service.py         # Persist audit_event rows (durable admin trail)
-    ├── role_service.py          # Custom role + permission resolution
-    ├── plan_service.py          # Plan catalog
-    ├── subscription_service.py  # Trial creation, plan transitions
-    ├── feature_service.py       # Plan + per-org feature override resolution
-    ├── org_service.py           # Org rename + uniqueness checks
-    ├── org_bootstrap_service.py # First-user-becomes-superadmin bootstrap
-    ├── org_data_service.py      # Org-data wipe with snapshot + audit
-    ├── org_reset_lock_service.py # Concurrency guard for wipes
-    ├── invitation_service.py    # Org-member invitations
-    ├── admin_dashboard_service.py # Superadmin dashboard aggregates
-    ├── admin_orgs_service.py    # Superadmin org list / detail / override sweep
-    ├── exceptions.py            # Domain exception types -> HTTP mappers in main.py
-    └── date_utils.py            # Shared advance_date() for billing calculations
+├── main.py          # FastAPI app, lifespan, CORS, router registration
+├── config.py        # pydantic-settings, all config from env vars
+├── database.py      # async SQLAlchemy engine + session factory
+├── security.py      # JWT encode/decode, bcrypt hash/verify
+├── deps.py          # FastAPI dependencies: get_db, get_current_user
+├── logging.py       # structlog JSON setup
+├── models/          # SQLAlchemy ORM models
+├── schemas/         # Pydantic request/response models
+├── routers/         # API route handlers (one file per resource)
+└── services/        # Business logic called by routers
 ```
 
-### Frontend (Next.js / TypeScript)
+### Frontend layout
 
 ```
 frontend/
-├── app/                     # Next.js App Router pages
-│   ├── dashboard/           #   Main dashboard with charts + summary
-│   ├── transactions/        #   Transaction list (period bucketed by settled_date)
-│   ├── accounts/            #   Account management
-│   ├── recurring/           #   Recurring transaction templates
-│   ├── budgets/             #   Budget management + transfers
-│   ├── forecast-plans/      #   Editable forecast plans
-│   ├── categories/          #   Category hierarchy management (type lock once in use)
-│   ├── import/              #   CSV import wizard
-│   ├── profile/             #   User profile editing
-│   ├── settings/            #   /settings/security, /settings/billing, /settings/organization
-│   ├── admin/               #   /admin (dashboard), /admin/orgs, /admin/audit, /admin/roles, /admin/settings
-│   ├── login/               #   Login page
-│   ├── register/            #   Registration page
-│   ├── setup/               #   First-user / first-org setup
-│   ├── accept-invite/       #   Org invitation acceptance
-│   ├── mfa-verify/          #   MFA challenge during login
-│   ├── forgot-password/     #   Request password reset
-│   ├── reset-password/      #   Complete password reset
-│   ├── verify-email/        #   Email verification
-│   ├── auth/google/         #   Google SSO callback (login + step-up return)
-│   ├── system/              #   Public system / status surface
-│   ├── health/              #   Frontend health probe
-│   ├── privacy/             #   Privacy Policy (public, GDPR-compliant)
-│   └── terms/               #   Terms of Service (public)
-├── components/
-│   ├── AppShell.tsx         #   Sidebar + header + footer layout
-│   ├── SettingsLayout.tsx   #   Sub-nav layout for /settings/*
-│   ├── ThemeProvider.tsx    #   Dark / light theme provider
-│   ├── auth/AuthProvider.tsx #  Auth context, login/logout/silent refresh
-│   ├── admin/               #   Admin-only widgets (orgs table, audit table, roles)
-│   ├── settings/            #   Settings sub-pages (security, billing, organization)
-│   ├── transactions/        #   List + edit row + recurring promotion
-│   ├── dashboard/           #   Dashboard tiles, charts, on-track verdict
-│   ├── landing/             #   Public marketing surface
-│   ├── system/              #   System status widgets
-│   └── ui/                  #   Shared UI primitives
+├── app/             # Next.js App Router pages (one folder per route)
+├── components/      # React components, grouped by feature
 └── lib/
-    ├── api.ts               #   Typed fetch wrapper with silent token refresh
-    ├── types.ts             #   Shared TypeScript interfaces
-    ├── styles.ts            #   Tailwind class constants (btnPrimary, card, input, etc.)
-    ├── auth.ts              #   isAdmin() / role helpers
-    ├── feature-catalog.ts   #   Plan-feature catalog mirror (kept in sync with backend)
-    ├── format.ts            #   Currency / date formatters
-    ├── logger.ts            #   Client+server structured JSON logger
-    ├── pagination.ts        #   Shared list pagination helpers
-    ├── site.ts              #   Public site URL helpers (canonical, OG)
-    └── validation.ts        #   Shared client-side validation (mirrors backend/app/schemas)
+    ├── api.ts       # Typed fetch wrapper with Bearer token + silent refresh
+    ├── types.ts     # Shared TypeScript interfaces
+    ├── styles.ts    # Tailwind class constants (btnPrimary, card, input, ...)
+    ├── auth.ts      # isAdmin() / role helpers
+    └── validation.ts # Client-side validation mirroring backend schemas
 ```
 
-### Key Design Decisions
+For the full router-by-router and service-by-service map, see the live file tree under `backend/app/` and `frontend/app/`. We intentionally do not duplicate the directory listing in this doc because it ages out within weeks.
 
-- **All config via env vars** — pydantic-settings in backend, `NEXT_PUBLIC_` prefix in frontend
-- **Stateless backend** — no in-memory state. JWT for auth, ready for horizontal scaling.
-- **Migrations auto-run on startup** in dev. In production, they run as a `PRE_DEPLOY` job (App Platform) or initContainer (k8s) before the app starts.
-- **First user is superadmin** — no seed data needed for bootstrapping.
-- **Org-scoped data** — every query filters by `org_id`. Users only see their org's data.
-- **Hierarchical categories** — master categories for budgets, subcategories as transaction tags. A category's `type` (income / expense / both) is enforced server-side on writes; once a category has been used the UI locks the type to keep historical aggregates honest.
-- **Transfer category invariant** — transfer legs require a `CategoryType.BOTH` category. The system seeds a `Transfer` master category for this; arbitrary income / expense categories on transfer legs are rejected.
-- **Billing periods** — org-level month close date. `settled_date` (or `COALESCE(settled_date, date)` for hand-keyed pending rows) determines which period a transaction counts against. The transactions list and aggregates both bucket on this effective period date.
-- **Audit trail** — sensitive admin and org actions (org rename, org-data wipe, override sweep, role edits, etc.) write a row to `audit_events` and surface in `/admin/audit`. structlog still emits the same events to stdout, but the durable trail is the table.
-- **Forecast plan source** — public writes always set `ItemSource.MANUAL`. Auto-population marks items as `RECURRING` or `HISTORY`; subsequent edits flip them to `MANUAL`. The HISTORY label surfaces as "Auto" in the UI.
+### Key design decisions
 
----
+- **All config via env vars.** `pydantic-settings` in backend, `NEXT_PUBLIC_` prefix in frontend. See `ENVIRONMENT.md`.
+- **Stateless backend.** No in-memory state. JWT for auth. Ready for horizontal scaling.
+- **Migrations auto-run on startup in dev.** In production they run as a `PRE_DEPLOY` job (App Platform) or initContainer (k8s) before the app starts. See [Database migrations](#database-migrations).
+- **First user is superadmin.** No bootstrap seed needed.
+- **Org-scoped data.** Every query filters by `org_id`.
+- **API versioned at `/api/v1/`.** Breaking changes ship as `/api/v2/` while v1 stays live.
+- **Auth on every endpoint.** Use `get_current_user`. Public endpoints are listed in `backend/app/deps.py`.
+- **Hierarchical categories.** Master categories for budgets, subcategories as transaction tags. Type (income / expense / both) is enforced server-side; once a category is used the UI locks the type.
+- **Transfer category invariant.** Transfer legs require a `CategoryType.BOTH` category (seeded as `Transfer`).
+- **Billing periods.** Org-level month close date. `COALESCE(settled_date, date)` determines which period a transaction counts against.
+- **Audit trail.** Sensitive admin and org actions (rename, wipe, override sweep, role edits) write to `audit_events` and surface at `/admin/audit`.
 
-## Authentication & Security
+## Authentication and security
 
-### Auth Flow
+### Auth flow
 
-1. **Login** — `POST /api/v1/auth/login` with username/email + password, or Google SSO via `/api/v1/auth/google`
-2. **MFA challenge** (if enabled) — returns `mfa_token`, user completes TOTP / recovery / email verification
-3. **Tokens issued** — access token (15 min, in response body) + refresh token (7 day, httpOnly cookie)
-4. **Silent refresh** — frontend auto-refreshes via `POST /api/v1/auth/refresh` on 401
-5. **Absolute session lifetime** — sessions expire after a configurable max duration (default 30 days)
+1. **Login.** `POST /api/v1/auth/login` with username/email + password, or Google SSO via `/api/v1/auth/google`.
+2. **MFA challenge** (if enabled). Returns `mfa_token`, user completes TOTP, recovery code, or email verification.
+3. **Tokens issued.** Access token (15 min, response body) + refresh token (7 day, httpOnly cookie).
+4. **Silent refresh.** Frontend auto-refreshes via `POST /api/v1/auth/refresh` on 401.
+5. **Absolute session lifetime.** Sessions expire after `SESSION_LIFETIME_DAYS` (default 30) regardless of refresh activity.
 
 ### SSO password security
 
-Google-SSO users have `password_set=False` until they explicitly set a password. To prevent an unprompted password from being attached to a hijacked SSO session:
+Google-SSO users have `password_set=False` until they explicitly set a password. To prevent a hijacked SSO session from silently attaching a password:
 
 - **First password set** requires a Google **step-up** verification. The user re-authenticates with the same Google account, the backend issues a 5-minute single-use step-up token, and only then accepts the password write.
-- **Reset password via email token** (the standard `/forgot-password` -> `/reset-password` flow) flips `password_set=True` on success, so future logins can use either Google SSO or the new password.
-- **Step-up callbacks** redirect back through a server-side allowlist of `return_to` keys. Arbitrary URLs are rejected with `400 Malformed step-up state`.
-- **Email change** also takes the step-up path and flips `password_set` back to `False` if the new email belongs to a different identity, forcing a re-set.
+- **Reset password via email token** (the standard `/forgot-password` then `/reset-password` flow) flips `password_set=True` on success.
+- **Step-up callbacks** redirect through a server-side allowlist of `return_to` keys. Arbitrary URLs are rejected with `400 Malformed step-up state`.
+- **Email change** also takes the step-up path and flips `password_set` back to `False` if the new email belongs to a different identity.
 
-### MFA (Two-Factor Authentication)
+### MFA
 
-- TOTP via authenticator app (Google Authenticator, Authy, 1Password, etc.)
-- 8 single-use recovery codes (HMAC-SHA256 hashed, downloadable)
-- Email fallback with 6-digit code (10-minute expiry)
-- TOTP secrets encrypted at rest via Fernet (`MFA_ENCRYPTION_KEY` env var)
-- Setup/disable via `/settings/security` page
+- TOTP via authenticator app (Google Authenticator, Authy, 1Password).
+- 8 single-use recovery codes (HMAC-SHA256 hashed, downloadable).
+- Email fallback with 6-digit code (10-minute expiry).
+- TOTP secrets encrypted at rest via Fernet (`MFA_ENCRYPTION_KEY`).
+- Setup and disable via `/settings/security`.
 
-### Rate Limiting
+### Rate limiting
 
-All limits are per client IP via slowapi's `get_remote_address`. In-memory storage is fine while the backend runs single-replica on DO App Platform; a Redis-backed store is deferred to the K8s migration.
+All limits are per client IP via slowapi. In-memory storage is fine on single-replica App Platform; a Redis-backed store is deferred to the K8s migration.
 
 | Endpoint | Limit |
 |----------|-------|
@@ -287,52 +263,22 @@ All limits are per client IP via slowapi's `get_remote_address`. In-memory stora
 | `POST /api/v1/auth/mfa/email-code` | 3/minute |
 | `POST /api/v1/auth/mfa/email-verify` | 10/minute |
 
-### Public Endpoints (no auth required)
+### Public endpoints (no auth required)
 
-`/health`, `/ready`, `/api/v1/auth/status`, `/api/v1/auth/login`, `/api/v1/auth/register`, `/api/v1/auth/refresh`, `/api/v1/auth/forgot-password`, `/api/v1/auth/reset-password`, `/api/v1/auth/verify-email`, `/api/v1/auth/google`, `/api/v1/auth/google/callback`, `/api/v1/auth/mfa/verify`, `/api/v1/auth/mfa/recovery`, `/api/v1/auth/mfa/email-code`, `/api/v1/auth/mfa/email-verify`
+`/health`, `/ready`, `/api/v1/auth/status`, `/api/v1/auth/login`, `/api/v1/auth/register`, `/api/v1/auth/refresh`, `/api/v1/auth/forgot-password`, `/api/v1/auth/reset-password`, `/api/v1/auth/verify-email`, `/api/v1/auth/google`, `/api/v1/auth/google/callback`, plus the `/api/v1/auth/mfa/*` challenge endpoints.
 
-All other endpoints require a Bearer access token via `get_current_user` dependency.
+All other endpoints require a Bearer access token via the `get_current_user` dependency.
 
----
+## Environment variables
 
-## Environment Variables
+See `ENVIRONMENT.md`. It is the authoritative reference for every backend, frontend, migrate, and CLI variable, with scopes, defaults, deployment paths, and failure modes.
 
-### Required (Backend)
+The minimum to boot locally is:
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `DATABASE_URL` | MySQL connection string | `mysql+aiomysql://user:pass@host:3306/db` |
-| `JWT_SECRET_KEY` | HS256 signing key | `openssl rand -hex 32` |
+- `DATABASE_URL` (preconfigured in `.env.example`).
+- `JWT_SECRET_KEY` (32+ chars). The backend refuses to boot on the placeholder.
 
-### Optional (Backend)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `APP_ENV` | `development` | `development` or `production` |
-| `APP_NAME` | `The Better Decision` | App name (used in TOTP issuer, emails) |
-| `LOG_LEVEL` | `INFO` | Python log level |
-| `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | Access token lifetime |
-| `JWT_REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token (idle timeout) |
-| `SESSION_LIFETIME_DAYS` | `30` | Absolute max session duration |
-| `COOKIE_SECURE` | `true` | Set `false` for local dev (HTTP) |
-| `REDIS_URL` | _(empty)_ | Redis connection (`redis://...`) — used for MFA nonces and SSO step-up state |
-| `MFA_ENCRYPTION_KEY` | _(empty)_ | Fernet key for TOTP secret encryption |
-| `MAILGUN_API_KEY` | _(empty)_ | Mailgun API key (emails logged if empty) |
-| `MAILGUN_DOMAIN` | _(empty)_ | Mailgun sending domain |
-| `EMAIL_FROM` | `The Better Decision <noreply@thebetterdecision.com>` | From address for emails |
-| `APP_URL` | `http://localhost` | Public URL (used in email links) |
-| `GOOGLE_CLIENT_ID` | _(empty)_ | Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | _(empty)_ | Google OAuth client secret |
-| `BACKEND_CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins |
-
-### Frontend
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `NEXT_PUBLIC_API_URL` | _(empty)_ | API base URL (empty = same-origin via nginx) |
-| `HOSTNAME` | `0.0.0.0` | Next.js bind address |
-
-### Generating Keys
+To generate keys:
 
 ```bash
 # JWT secret
@@ -342,159 +288,34 @@ openssl rand -hex 32
 python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ```
 
----
+## Database migrations
 
-## Database Migrations
+Three execution paths, picked by environment:
 
-Migrations run in one of three ways depending on environment:
+- **Local dev (`./pfv start`):** the backend lifespan calls `_run_migrations()` on startup against the local MySQL volume. A branch guard refuses to migrate when the host checkout is off `main` (set `PFV_MIGRATE_OK_OFF_MAIN=1` to override). See `CLAUDE.md`.
+- **Local prod simulation (`./pfv prod`):** a one-shot `migrate` service defined in `docker-compose.prod.yml` runs the wrapper at `/app/scripts/migrate.py` and exits; the backend then starts with `APP_ENV=production` (no lifespan migration).
+- **Production (DO App Platform):** a dedicated `PRE_DEPLOY` job runs the wrapper before any backend replica starts. Secrets (especially `DATABASE_URL`) must be configured against the `migrate` job in the DO console; App Platform does not auto-inherit secrets across components.
 
-- **Development** (`./pfv start`): the backend lifespan calls `_run_migrations()` on startup. Convenient for a single-container local stack.
-- **Local prod simulation** (`./pfv prod`): a one-shot `migrate` service defined in `docker-compose.prod.yml` runs the migrate wrapper at `/app/scripts/migrate.py` and exits; the backend then starts with `APP_ENV=production` which skips the startup migration.
-- **Production (DO App Platform)**: a dedicated `PRE_DEPLOY` job defined in `.do/app.yaml` runs the migrate wrapper at `/app/scripts/migrate.py` before any backend replica starts. The backend skips the startup migration because `APP_ENV=production`. **Operator note:** secrets (especially `DATABASE_URL`) must be configured against the `migrate` job component in the DO console — App Platform does not auto-inherit secrets across components.
-
-The migrate wrapper (`backend/scripts/migrate.py`) does not replace alembic, it wraps it. Internally it drives `alembic upgrade <revision>` one revision at a time and streams alembic's own stdout and stderr through unchanged, while emitting structured JSON events around each step so a deploy log is triageable on its own. Grep for the event names: `migrate.start`, `migrate.step.start`, `migrate.step.end`, `migrate.complete`, `migrate.no_op`, `migrate.failed`. The wrapper's exit code matches alembic's, so the PRE_DEPLOY gate still blocks deploy on a failed migration.
+The wrapper at `backend/scripts/migrate.py` does not replace alembic, it drives it. It runs `alembic upgrade <revision>` one revision at a time and emits structured JSON events around each step (grep `migrate.start`, `migrate.step.start`, `migrate.step.end`, `migrate.complete`, `migrate.no_op`, `migrate.failed`). Exit code matches alembic's, so a `PRE_DEPLOY` failure blocks the deploy.
 
 ```bash
 # Create a new migration
 docker compose exec backend alembic revision -m "description"
 
-# Run pending migrations manually (dev)
+# Apply pending migrations (local dev only)
 ./pfv migrate
 
-# Check current migration state
+# Check the current revision
 docker compose exec backend alembic current
 ```
 
-Migration files are in `backend/alembic/versions/` and follow sequential numbering (001, 002, ...).
-
----
-
-## Development vs Production
-
-| Aspect | Dev (`./pfv start`) | Prod (`./pfv prod`) |
-|--------|-------|------|
-| Frontend | Next.js dev server (hot reload) | Standalone build (`node server.js`) |
-| Backend | uvicorn with `--reload` | uvicorn with 2 workers |
-| Migrations | Auto-run on backend startup | Separate init service (runs first) |
-| Volumes | Source code mounted | Immutable containers |
-| Emails | Logged to console (structlog) | Sent via Mailgun |
-| Entry point | nginx on port 80 | DO App Platform ingress |
-
----
-
-## Branching & Pull Requests
-
-- **Never push directly to `main`** — always branch + PR
-- Feature branches: `feat/<name>`
-- Fix branches: `fix/<name>`
-- Merge to `main` triggers production deployment via GitHub Actions only when the commit is release-eligible (`feat`, `fix`, `perf`, `revert`). `chore`, `docs`, `refactor`, `test`, and similar commits are not auto-deployed; see the Deployment section for the manual escape hatch.
-
----
-
-## Deployment
-
-### DigitalOcean App Platform
-
-The app is deployed on DO App Platform (Amsterdam region). MySQL 8 and Redis are **self-hosted** on a single dedicated DO droplet (`pfv-data-01`) in a private VPC; the App Platform components reach them over the VPC's private IPv4. Background and runbook live in `infra/README.md` and `infra/MIGRATION.md`.
-
-**GitHub Actions workflows (`.github/workflows/`):**
-
-| Workflow | Trigger | What it does |
-|----------|---------|--------------|
-| `release.yml` | Push to `main` (release-eligible commits only) | Runs semantic-release. If a new release is published, deploys `.do/app.yaml` to DO App Platform via `digitalocean/app_action/deploy@v2`, then runs `scripts/smoke-test.sh` against production. |
-| `deploy.yml` | Manual (`workflow_dispatch`) | Emergency redeploy escape hatch. Same DO action and smoke-test job, but not auto-triggered. Use when an infra-only change (`chore(.do)`, `chore(infra)`, `chore(nginx)`) needs to ship without a version bump. |
-
-The orchestration is intentional: semantic-release is the single arbiter of "should we ship". A path filter cannot tell a `chore(frontend)` apart from a real shipping change, which previously caused chore commits to redeploy production. Gating `deploy` on `new_release_published == 'true'` (a job output of the semantic-release step) ensures only release-eligible commits reach App Platform automatically. The naive `on: release: { types: [published] }` shortcut does not work because GitHub does not cascade workflow runs from `GITHUB_TOKEN`-created releases.
-
-**Required GitHub repository secret:**
-
-| Secret | Description |
-|--------|-------------|
-| `DIGITALOCEAN_ACCESS_TOKEN` | DO API token with read/write access to App Platform |
-
-**App spec:** `.do/app.yaml` is the source of truth. Secrets are committed as App Platform's encrypted `EV[...]` blobs (only readable by DO) so they survive every deploy; any secret missing from the file is removed from the live app on push. The `vpc.id` block at the top wires the app to the data-droplet's VPC and must stay populated.
-
-### Manual Deployment
-
-The primary manual path is the `deploy.yml` workflow, which runs the same DO action and smoke-test job as the auto-deploy path:
-
-```bash
-# Trigger the manual workflow on main (preferred for chore(infra), chore(.do), etc.)
-gh workflow run deploy.yml --ref main
-```
-
-If GitHub Actions is unavailable or you need to bypass it entirely (using `doctl` directly):
-
-```bash
-# Install doctl
-brew install doctl
-doctl auth init
-
-# Push the spec (covers vpc, components, env, and secrets)
-doctl apps update <app-id> --spec .do/app.yaml
-
-# Or trigger a redeploy of the current spec
-doctl apps create-deployment <app-id>
-```
-
-### Infrastructure as code
-
-Production infra is split between App Platform (the application) and the data droplet (MySQL + Redis):
-
-- **App Platform** is described by `.do/app.yaml` and pushed via the GH Actions workflow above.
-- **Droplet, VPC, firewall, project attachment** are managed by Terraform under `infra/terraform/`. State and runs live in **HCP Terraform / Terraform Cloud** (workspace `FlamaCorp/pfv`). Workflow is VCS-driven: PRs touching `infra/terraform/**` get a speculative plan; merges to `main` create runs that require **manual Confirm & Apply** in the TFC UI. CLI `terraform plan` / `apply` is debug-only — never the routine path.
-- **Droplet bootstrap** (Ubuntu hardening, MySQL, Redis, nightly mysqldump) is managed by Ansible under `infra/ansible/`.
-
-### Infrastructure components
-
-| Component | Service | Details |
-|-----------|---------|---------|
-| Backend | DO App Service | FastAPI, `basic-xxs`, port 8000 |
-| Frontend | DO App Service | Next.js standalone, `basic-xxs`, port 3000 |
-| Database | Self-hosted MySQL 8 on `pfv-data-01` | `s-1vcpu-2gb` droplet, ams3, private VPC |
-| Cache | Self-hosted Redis on `pfv-data-01` | Same droplet, bound to private IP, `requirepass` set |
-| Backups | Nightly `mysqldump` cron on the droplet (`/var/backups/mysql/`, 7-day retention) | DO droplet snapshots are **off** at the IaC level |
-
----
-
-## API Documentation
-
-- **Swagger UI:** http://localhost/api/docs (development)
-- **OpenAPI spec:** http://localhost/api/openapi.json
-
-All API routes are prefixed with `/api/v1/`. The API is organized by resource:
-
-| Resource | Prefix | Description |
-|----------|--------|-------------|
-| Auth | `/api/v1/auth` | Login, register, MFA, Google SSO + step-up, password reset |
-| Users | `/api/v1/users` | Profile, password change |
-| Accounts | `/api/v1/accounts` | Bank accounts and balances |
-| Account Types | `/api/v1/account-types` | Checking, savings, credit card, etc. |
-| Categories | `/api/v1/categories` | Hierarchical income/expense categories |
-| Transactions | `/api/v1/transactions` | Income, expenses, transfers (period bucketed by `settled_date`) |
-| Recurring | `/api/v1/recurring` | Recurring transaction templates |
-| Budgets | `/api/v1/budgets` | Per-category per-period budgets |
-| Forecast | `/api/v1/forecast` | Computed forecast (read-only) |
-| Forecast Plans | `/api/v1/forecast-plans` | Editable forecast plans |
-| Import | `/api/v1/import` | CSV file import (preview + confirm) |
-| Settings | `/api/v1/settings` | Org settings, billing periods, billing cycle |
-| Orgs | `/api/v1/orgs` | Org rename (owner-only) and per-org actions |
-| Org members | `/api/v1/orgs/members`, `/api/v1/orgs/invitations` | Membership and invitations |
-| Org data | `/api/v1/orgs/data` | Org-data wipe / reset (audited, lock-guarded) |
-| Plans | `/api/v1/plans` | Plan catalog |
-| Subscriptions | `/api/v1/subscriptions` | Trial / subscription state |
-| Admin | `/api/v1/admin` | Superadmin dashboard |
-| Admin orgs | `/api/v1/admin/orgs` | Superadmin org management + override sweep |
-| Admin audit | `/api/v1/admin/audit` | Audit log (durable trail) |
-| Admin roles | `/api/v1/admin/roles` | Custom role + permission editing |
-
----
+Migration files live at `backend/alembic/versions/` and follow sequential numbering (`001_`, `002_`, ...).
 
 ## Testing
 
 ### Backend (pytest)
 
-The backend runs in the `backend` container; tests live in `backend/tests/` and run inside it:
+Run inside the `backend` container. The dev image installs `requirements-dev.txt` because `INSTALL_DEV=true` is set in `docker-compose.yml`. Production and CI builds keep `INSTALL_DEV=false`.
 
 ```bash
 # Full suite
@@ -505,15 +326,14 @@ docker compose exec backend pytest tests/routers/test_auth.py
 docker compose exec backend pytest tests/routers/test_auth.py::test_login_happy_path
 ```
 
-`requirements-dev.txt` is installed in the dev image (`INSTALL_DEV=true` build arg, set in `docker-compose.yml`). Production / CI builds keep `INSTALL_DEV=false`.
+Do not run `pytest` on the host. Dependencies live in the container.
+
+If you are working through a parallel agent session, use `-p team-<name>` on every compose call. See [Working in parallel agent sessions](#working-in-parallel-agent-sessions).
 
 ### Frontend (vitest / jest)
 
 ```bash
-# Full suite
 docker compose exec frontend npm test
-
-# A single test file
 docker compose exec frontend npm test -- tests/lib/api.test.ts
 ```
 
@@ -521,56 +341,69 @@ docker compose exec frontend npm test -- tests/lib/api.test.ts
 
 ```bash
 docker compose exec frontend npx tsc --noEmit
-# or, if you have node locally:
+# or, on the host
 cd frontend && npx tsc --noEmit
 ```
 
 ### Manual smoke testing
 
-The Swagger UI at http://localhost/api/docs is the fastest way to poke a single endpoint by hand. Browser testing covers UI flows; `curl` or httpie cover scripted checks.
+Swagger UI at http://localhost/api/docs is the fastest way to poke a single endpoint. The browser covers UI flows; `curl` or `httpie` cover scripted checks. Production smoke tests live in `scripts/smoke-test.sh` and run automatically after `release.yml` deploys (see `DEPLOYMENT.md`).
 
----
+## Branching and pull requests
+
+- **Never push directly to `main`.** Always branch and open a PR.
+- Branch naming convention: `feat/<name>`, `fix/<name>`, `chore/<name>`.
+- Match the PR title to the commit prefix (`feat:`, `fix:`, ...). The PR title is what semantic-release reads if you squash-merge.
+- Keep PR descriptions concise. No test plan section required.
+
+## Deployment
+
+The full deployment pipeline (release gating, App Platform spec, smoke tests, manual escape hatches, apex pipeline) is in `DEPLOYMENT.md`. The short version contributors need to know:
+
+- Merges to `main` trigger `release.yml`. Whether App Platform redeploys depends on the commit prefix (see [Conventional Commits and the deploy gate](#conventional-commits-and-the-deploy-gate)).
+- `.do/app.yaml` is the source of truth for App Platform config. Secrets are encrypted `EV[...]` blobs committed in-file; any secret missing from this file is removed from the live app on push.
+- Terraform (`infra/terraform/`) is VCS-driven via HCP Terraform Cloud (workspace `FlamaCorp/pfv`). PRs get speculative plans; merges create runs that require manual Confirm and Apply. CLI `terraform plan` / `apply` is debug-only.
+- Droplet bootstrap (`infra/ansible/`) handles MySQL, Redis, hardening, and nightly mysqldump.
+
+## API documentation
+
+- **Swagger UI:** http://localhost/api/docs (development).
+- **OpenAPI spec:** http://localhost/api/openapi.json.
+
+All API routes are prefixed with `/api/v1/`. Each resource has its own router under `backend/app/routers/`; see the live file tree for the current resource list.
 
 ## Troubleshooting
 
-### Backend won't start
+### Backend will not start
 
 ```bash
-# Check logs
 ./pfv logs backend
-
-# Common issues:
-# - MySQL not ready: wait for health check, try ./pfv restart
-# - Missing env var: check .env against .env.example
-# - Migration error: ./pfv migrate
 ```
+
+Common causes:
+
+- MySQL not ready. Wait for the healthcheck, then `./pfv restart`.
+- Missing env var. Diff `.env` against `.env.example`.
+- `JWT_SECRET_KEY` still at the placeholder or shorter than 32 chars. The config validator refuses to boot.
+- Migration error. Run `./pfv migrate`. If the error mentions branch guard, set `PFV_MIGRATE_OK_OFF_MAIN=1` for this session or move to `main`.
 
 ### Frontend build fails
 
 ```bash
-# Check for TypeScript errors
-cd frontend && npx tsc --noEmit
-
-# Rebuild from scratch
-./pfv rebuild
+cd frontend && npx tsc --noEmit       # surface TS errors
+./pfv rebuild                          # rebuild from scratch
 ```
 
 ### Database issues (local dev)
 
 ```bash
-# Connect to MySQL (uses values from .env)
 docker compose exec mysql mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"
-
-# Reset everything (destroys all data, rotates JWT secret)
-./pfv reset
+./pfv reset                            # destroys all data, rotates JWT secret
 ```
 
 ### MFA locked out (local dev)
 
-If you lose access to your authenticator and recovery codes:
-
 ```bash
-# Disable MFA directly in the local database
 docker compose exec mysql mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" \
   -e "UPDATE users SET mfa_enabled=0, totp_secret=NULL, recovery_codes=NULL WHERE username='youruser';"
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Merge to `main`:
 
 - `.github/workflows/release.yml` runs on changes under `backend/**`, `frontend/**`, `nginx/**`, `.do/**`, or `Dockerfile*`. It runs `semantic-release`. If (and only if) `semantic-release` decides a new release is warranted, the gated `deploy` job pushes `.do/app.yaml` to DO App Platform, then `scripts/smoke-test.sh` asserts the live app serves traffic.
 - `chore:` / `docs:` / `refactor:` commits inside the allowlist still trigger `release.yml`, but `semantic-release` no-ops and the deploy job is skipped.
-- A future `apex-deploy.yml` (PR #267) will deploy the apex landing site on merges that touch the apex paths.
+- `.github/workflows/apex-deploy.yml` deploys the apex landing site (`thebetterdecision.com`) to AWS S3 + CloudFront on merges that touch the apex path filter. Independent of the DO release pipeline; landing-only commits never fire the DO redeploy.
 
 If you need to force a redeploy of the current production spec without merging a code change, use the manual workflow:
 
@@ -248,7 +248,7 @@ Google-SSO users have `password_set=False` until they explicitly set a password.
 
 ### Rate limiting
 
-All limits are per client IP via slowapi. In-memory storage is fine on single-replica App Platform; a Redis-backed store is deferred to the K8s migration.
+All limits are per client IP via slowapi. Production and Docker Compose use Redis / Valkey-backed storage (shipped in K8S-1, see `backend/app/rate_limit.py`); in-memory storage is the fallback when `REDIS_URL` is empty. Storage errors fail open so a Redis blip never blocks legitimate traffic.
 
 | Endpoint | Limit |
 |----------|-------|

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -642,7 +642,7 @@ Triage shortcuts:
 | Merge to `main` happened, prod didn't update | `release.yml` -> did `release` job set `new_release_published=true`? Conventional commit type may be `chore` |
 | Deploy went green, app still broken | Smoke-test job output, then DO Runtime Logs on the failing component |
 | Migrate job hung or failed | DO Activity -> latest deploy -> migrate job. Grep for `migrate.start`, `migrate.failed`, `migrate.step.start`. Multi-head? Driver error? |
-| Apex site shows stale content | Confirm `apex-deploy.yml` ran for the SHA; check CloudFront invalidation completed; `curl https://thebetterdecision.com/_meta.json` (must be no-cache) |
+| Apex site shows stale content | Confirm `apex-deploy.yml` ran for the SHA; check CloudFront invalidation completed; `curl /_meta.json` (must be no-cache). Pre-PR-D, hit the CloudFront-assigned hostname from TFC output `cloudfront_distribution_domain`; post-PR-D, hit `https://thebetterdecision.com/_meta.json` |
 | Apex 404 on a known route | The CloudFront Function rewrites `/path/` -> `/path/index.html`. Check the function's invocation logs in CloudFront Functions console |
 | Apex deploy failed at OIDC step | Trust policy on `github-actions-apex-deploy` pinned to `repo:flamarion/pfv:ref:refs/heads/main`. PR-context, forks, non-main branches are rejected by design |
 | App can't reach MySQL or Redis | Confirm `.do/app.yaml`'s top-level `vpc.id` matches the TFC output, and `DATABASE_URL` / `REDIS_URL` point at the droplet's `10.42.x.x` private IP |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,643 @@
+# DEPLOYMENT.md
+
+Audience: a contributor who just cloned the repo and wants to understand what happens between `git push` and a live change at `app.thebetterdecision.com` or `thebetterdecision.com`. Also a triage reference for CI/CD failures.
+
+This document covers the **target architecture**. The apex landing pipeline (Section 5) lands with **PR #267** (in flight, branch `feat/l5-2a-apex-deploy-workflow`). Everything else is live on `main` today.
+
+For "how do I get my code ready to push", read [`CONTRIBUTING.md`](./CONTRIBUTING.md). For the env var matrix, read [`ENVIRONMENT.md`](./ENVIRONMENT.md). For the managed-to-droplet data move, read [`infra/MIGRATION.md`](./infra/MIGRATION.md). This file does not duplicate any of them.
+
+## 1. Overview
+
+Four production surfaces. Each has its own pipeline. Some changes fan out across more than one.
+
+| Surface | URL | Hosted by | Updated by |
+|---|---|---|---|
+| App (FastAPI + Next.js dashboard) | `https://app.thebetterdecision.com` | DigitalOcean App Platform (`pfv` app) | `release.yml` (auto) or `deploy.yml` (manual) |
+| Apex landing (marketing, privacy, terms, docs) | `https://thebetterdecision.com` | AWS S3 + CloudFront | `apex-deploy.yml` (auto), **lands with PR #267** |
+| Data plane (MySQL 8 + Redis) | private VPC IP `10.42.x.x:3306 / :6379` | Self-hosted DO droplet `pfv-data-01` | TFC workspace `FlamaCorp/pfv` (manual confirm) |
+| Apex CDN + cert + IAM | n/a (control plane) | AWS (S3, CloudFront, ACM, IAM, Route 53) | TFC workspace `FlamaCorp/pfv-apex` (manual confirm) |
+
+```mermaid
+flowchart LR
+  dev[Contributor push to main] --> rel[Release workflow]
+  dev --> apex[Apex Deploy workflow]
+  dev --> tfc1[TFC pfv]
+  dev --> tfc2[TFC pfv-apex]
+
+  rel -->|semantic-release published| do[DO App Platform pfv]
+  do --> appurl[app.thebetterdecision.com]
+
+  apex -->|build + S3 sync + CF invalidate| s3[AWS S3]
+  s3 --> cf[CloudFront]
+  cf --> apexurl[thebetterdecision.com]
+
+  tfc1 -->|Confirm and Apply| droplet[pfv-data-01 droplet]
+  droplet --> db[MySQL 8 + Redis]
+  do -.->|VPC private IP| db
+
+  tfc2 -->|Confirm and Apply| awsctl[S3 + CloudFront + ACM + IAM + Route53]
+  awsctl -.- s3
+  awsctl -.- cf
+
+  classDef pipe fill:#eef,stroke:#446
+  class rel,apex,tfc1,tfc2 pipe
+```
+
+The data plane is reached by App Platform over the VPC's private IPv4. The apex CDN bucket is reached by GitHub Actions over the public AWS API using OIDC-issued credentials, not long-lived keys.
+
+## 2. PR lifecycle (`test.yml`)
+
+Source: `.github/workflows/test.yml`.
+
+`test.yml` is the only CI workflow that runs on PRs. It does **not** deploy anything. Its job is to fail loud before code reaches `main`.
+
+Triggers:
+- `pull_request` with path filter on `backend/**`, `frontend/**`, or `.github/workflows/test.yml`
+- `workflow_dispatch` (manual)
+
+`concurrency.group = test-${workflow}-${ref}` with `cancel-in-progress: true`. Pushing a new commit to the PR cancels the prior run.
+
+Two jobs run in parallel:
+
+| Job | Steps | Failure means |
+|---|---|---|
+| **Backend Checks** | Python 3.12, `pip install -r backend/requirements-dev.txt`, `pytest`, then `python -m compileall backend/app` | Pytest failed, or a syntax error slipped in that pytest didn't reach |
+| **Frontend Checks** | Node 22, `npm ci`, `scripts/check-design-tokens.sh`, `npm run lint -- --quiet`, `npm test`, `npm run build` | One of: design-token violation, lint error, test failure, production build failure |
+
+Both must pass for merge (branch protection rule).
+
+```mermaid
+flowchart LR
+  push[PR push] --> filter{Path in backend/<br/>frontend/<br/>test.yml?}
+  filter -->|no| skip[Skip: no checks fire]
+  filter -->|yes| parallel
+  parallel --> be[Backend Checks]
+  parallel --> fe[Frontend Checks]
+  be --> bep[pytest]
+  be --> bec[compileall app/]
+  fe --> fei[npm ci]
+  fe --> fed[check-design-tokens.sh]
+  fe --> fel[npm run lint --quiet]
+  fe --> fet[npm test]
+  fe --> feb[npm run build]
+  bep & bec & fed & fel & fet & feb --> merge[Both jobs green = mergeable]
+```
+
+How to read failures:
+- **Design tokens**: `frontend/scripts/check-design-tokens.sh` scans for hard-coded colors / spacings that should use brand tokens. Output names the file and line.
+- **Lint**: `npm run lint -- --quiet` shows only errors (warnings are tolerated; treat warnings shown in logs as informational).
+- **Frontend build**: a build failure here means it will also fail in production. Test locally with `docker compose exec frontend npm run build`.
+- **Pytest**: known-flaky `tests/app/transactions-page.test.tsx` does not run here (that's a Jest test). For backend flake see `~/.claude/projects/-Users-fjorge-src-pfv/memory/` references; otherwise the failure is real.
+
+Re-run a single job from the PR's Checks tab.
+
+## 3. Backend + Frontend production deploy (`release.yml`)
+
+Source: `.github/workflows/release.yml`. Spec: `.do/app.yaml`.
+
+`release.yml` is the **single arbiter** of "should we ship to prod". It runs on every push to `main` whose changed paths intersect a coarse allowlist, and uses **semantic-release** to decide whether the merge warrants a new version. If yes, the gated `deploy` job pushes `.do/app.yaml` to DO App Platform; DO runs the `PRE_DEPLOY` migrate job, then rolls the backend and frontend services; then `smoke-tests` asserts the live app actually serves traffic.
+
+### Trigger
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "nginx/**"
+      - ".do/**"
+      - "Dockerfile*"
+```
+
+This path filter is a **coarse precheck**, not the deploy gate. Pushes that don't touch any allowlisted path skip the workflow entirely (no CI minutes spent). Pushes that do touch one still run, and then semantic-release inside the workflow makes the real ship/no-ship call based on conventional commit types (`feat:`, `fix:`, etc).
+
+Why this design: pre-PR #178 the workflow shipped on every allowlisted change, which meant a `chore(frontend): tsconfig` merge would redeploy production for no reason. Semantic-release suppresses `chore:`, `perf:`, `docs:`, `refactor:`, etc. and only ships when a `feat:` or `fix:` (or higher) gets merged.
+
+### Job graph
+
+```mermaid
+sequenceDiagram
+  participant Owner
+  participant GH as GitHub Actions
+  participant SR as semantic-release
+  participant DO as DO App Platform
+  participant MIG as PRE_DEPLOY migrate job
+  participant BE as backend service
+  participant FE as frontend service
+  participant SMK as smoke-tests job
+
+  Owner->>GH: merge PR to main (path-filtered)
+  GH->>SR: run release job
+  SR->>SR: analyze conventional commits since last tag
+  alt new_release_published == true
+    SR->>GH: tag v.X.Y.Z, GitHub Release
+    GH->>DO: deploy job: app_action/deploy@v2 with .do/app.yaml
+    DO->>MIG: kind: PRE_DEPLOY, run python /app/scripts/migrate.py
+    MIG-->>DO: rc 0, alembic head reached
+    DO->>BE: roll backend (health probe /health)
+    DO->>FE: roll frontend (health probe /health)
+    BE-->>DO: 200 OK
+    FE-->>DO: 200 OK
+    DO-->>GH: deploy ACTIVE
+    GH->>SMK: smoke-tests job (needs: deploy)
+    SMK->>SMK: scripts/smoke-test.sh against app.thebetterdecision.com
+    alt smoke fails
+      SMK->>GH: open or comment on a GH issue (notify-smoke-failure.sh)
+    end
+  else no_release
+    SR-->>GH: skip deploy and smoke-tests
+  end
+```
+
+### The gate
+
+```yaml
+deploy:
+  needs: release
+  if: needs.release.outputs.new_release_published == 'true'
+```
+
+This is the load-bearing line. Without `new_release_published`, `deploy` does not run, `smoke-tests` does not run, nothing ships. The output is set by `cycjimmy/semantic-release-action@v6` based on whether the conventional-commit analysis produced a new version.
+
+### Why a gated `deploy` job and not `on: release: { types: [published] }`
+
+GitHub does not cascade workflow runs when a release is created by `GITHUB_TOKEN`, which is what semantic-release uses. A separate workflow listening on `release.published` would never fire. So `deploy` lives in the same workflow file and gates on the upstream job's output.
+
+### Deploy step internals
+
+`digitalocean/app_action/deploy@v2` with `app_spec_location: .do/app.yaml` and **no `app_name`**. With both set, the action ignores the file and fetches the live spec by name (that bug let PR #79's migration sit un-applied for hours). The action reads `.do/app.yaml` and picks up the app via its top-level `name: pfv` field. The current spec drives every deploy, which means:
+
+- Every SECRET must be declared in `.do/app.yaml` with its encrypted `EV[...]` value, or it gets removed from the live app on push. (See ENVIRONMENT.md "Spec-sync hazards" and the file's own preamble comment.)
+- Every domain, env var, ingress rule, and component must be present and current in the file.
+
+### `PRE_DEPLOY` migrate job
+
+Declared in `.do/app.yaml` as:
+
+```yaml
+jobs:
+  - name: migrate
+    kind: PRE_DEPLOY
+    source_dir: backend
+    dockerfile_path: backend/Dockerfile
+    run_command: python /app/scripts/migrate.py
+```
+
+App Platform holds the new revision back until this job exits 0. A long migration never causes the backend's serving probe to fail because the backend doesn't start serving until migrate is done. See Section 8 for migration details.
+
+### Smoke tests
+
+`scripts/smoke-test.sh` runs after `deploy` succeeds. Env: `SMOKE_BASE_URL=https://app.thebetterdecision.com`, plus a `SMOKE_USERNAME` / `SMOKE_PASSWORD` for a dedicated smoke user. The smoke user must exist, must be `email_verified`, and must **not** have MFA enabled.
+
+On failure, `scripts/notify-smoke-failure.sh` opens (or comments on an existing) GitHub issue using `GH_TOKEN`. DO marking the deploy `ACTIVE` is necessary but not sufficient: smoke tests assert end-to-end traffic actually works.
+
+### How to verify a deploy
+
+1. Watch the workflow run: `https://github.com/flamarion/pfv/actions/workflows/release.yml`
+2. Watch the DO deploy: DO console -> Apps -> `pfv` -> Activity. The PRE_DEPLOY job logs appear first; structured `migrate.*` JSON events stream there.
+3. Inspect the running app: `curl -fsS https://app.thebetterdecision.com/health` and `curl -fsS https://app.thebetterdecision.com/ready`.
+
+## 4. Manual deploy escape hatch (`deploy.yml`)
+
+Source: `.github/workflows/deploy.yml`.
+
+`deploy.yml` mirrors `release.yml`'s `deploy` + `smoke-tests` jobs. It is triggered exclusively by `workflow_dispatch`:
+
+```bash
+gh workflow run deploy.yml --ref main
+```
+
+When to use it:
+- An infra-only commit shipped (`chore(.do): ...`, `chore(nginx): ...`, `chore(Dockerfile): ...`). semantic-release will not bump for `chore:`, so `release.yml` will not deploy. Run `deploy.yml` to push the new spec.
+- The most recent `release.yml` run failed at the deploy step and the cause is fixed, but no new release will be cut from a follow-up commit.
+- Forcing a redeploy of the current `main` (e.g. to refresh credentials surfaced via the spec).
+
+What it does: same `app_action/deploy@v2` + `.do/app.yaml`, same PRE_DEPLOY migrate, same smoke tests. Auth is the same `DIGITALOCEAN_ACCESS_TOKEN` secret.
+
+What it does NOT do: bump a version, create a tag, or post to a release feed. It is a deploy-only escape hatch.
+
+For rollback to a prior `main` SHA, see Section 10.
+
+## 5. Apex landing deploy (`apex-deploy.yml`), lands with PR #267
+
+> This workflow is on the in-flight branch `feat/l5-2a-apex-deploy-workflow` and is not on `main` yet. The rest of this section describes the target behavior once PR #267 merges. Source viewed via `git show origin/feat/l5-2a-apex-deploy-workflow:.github/workflows/apex-deploy.yml`.
+
+The apex landing (`thebetterdecision.com`) is a Next.js static export. `frontend/scripts/build-apex.sh` produces `frontend/out-apex/`. The workflow uploads that directory to an S3 bucket fronted by CloudFront in AWS, using **GitHub OIDC** to assume an IAM role (no long-lived AWS keys committed anywhere). The bucket, distribution, ACM cert, and IAM roles are provisioned by the `FlamaCorp/pfv-apex` TFC workspace (Section 7).
+
+### Trigger and path filter
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      # Landing surface
+      - "frontend/app/page.tsx"
+      - "frontend/app/privacy/**"
+      - "frontend/app/terms/**"
+      - "frontend/app/docs/**"
+      # Structural retained app files
+      - "frontend/app/layout.tsx"
+      - "frontend/app/not-found.tsx"
+      - "frontend/app/error.tsx"
+      - "frontend/app/loading.tsx"
+      - "frontend/app/global-error.tsx"
+      - "frontend/app/icon.svg"
+      - "frontend/app/globals.css"
+      # Landing components and apex-build helpers
+      - "frontend/components/landing/**"
+      - "frontend/components/auth/AuthProviderApex.tsx"
+      - "frontend/scripts/build-apex.sh"
+      - "frontend/next.config.apex.ts"
+      - "frontend/lib/links.ts"
+      # Shared brand and styling
+      - "frontend/lib/brand.ts"
+      - "frontend/lib/site.ts"
+      - "frontend/lib/styles.ts"
+      - "frontend/components/brand/**"
+      - "frontend/components/ThemeProvider.tsx"
+      - "frontend/components/tour/TourProvider.tsx"
+      - "frontend/components/ui/BackLink.tsx"
+      - "frontend/components/ui/CurrentYear.tsx"
+      - "frontend/components/ui/ThemeToggle.tsx"
+      - "frontend/public/**"
+      # Build inputs
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      # The workflow itself
+      - ".github/workflows/apex-deploy.yml"
+```
+
+Shared paths (`frontend/lib/brand.ts`, `frontend/lib/styles.ts`, `frontend/components/ThemeProvider.tsx`, `frontend/public/**`, `frontend/package.json`, etc.) are also on `release.yml`'s allowlist. A change to any of these legitimately affects both surfaces and triggers both pipelines.
+
+Landing-only paths (`frontend/app/page.tsx`, `frontend/app/privacy/**`, `frontend/components/landing/**`, etc.) are **not** on `release.yml`'s allowlist, so a landing-only commit skips the DO release entirely. That is the intended split.
+
+### Permissions and concurrency
+
+```yaml
+permissions:
+  contents: read
+  id-token: write   # required for OIDC to AWS
+
+concurrency:
+  group: apex-deploy
+  cancel-in-progress: false   # never cancel an in-flight S3 sync
+```
+
+### Repository variables (Settings -> Secrets and variables -> Actions -> Variables tab)
+
+| Variable | Source | Purpose |
+|---|---|---|
+| `AWS_APEX_DEPLOY_ROLE_ARN` | TFC output `github_actions_role_arn` | Role assumed via OIDC |
+| `AWS_APEX_BUCKET` | TFC output `s3_bucket_name` | S3 sync target |
+| `AWS_APEX_DISTRIBUTION_ID` | TFC output `cloudfront_distribution_id` | CloudFront invalidation target |
+| `AWS_APEX_REGION` (optional) | n/a | Defaults to `eu-central-1` in the workflow |
+
+No secrets are needed. These are public-shaped identifiers.
+
+### Pipeline
+
+```mermaid
+sequenceDiagram
+  participant GH as GitHub Actions
+  participant Node as Node 22 runner
+  participant OIDC as GitHub OIDC -> AWS
+  participant S3 as S3 bucket (apex)
+  participant CF as CloudFront distribution
+
+  GH->>Node: actions/checkout, setup-node@22
+  Node->>Node: npm ci --no-audit --no-fund (frontend/)
+  Node->>Node: npm run build:apex (build-apex.sh, NEXT_PUBLIC_BUILD_TARGET=apex)
+  Node->>Node: verify out-apex/index.html and _meta.json exist
+  Node->>OIDC: aws-actions/configure-aws-credentials@v4 (role-to-assume)
+  OIDC-->>Node: short-lived STS creds (sub claim must match repo:flamarion/pfv:ref:refs/heads/main)
+  Note over Node,S3: Order matters, see comments
+  Node->>S3: aws s3 sync out-apex/_next/static/ s3://BUCKET/_next/static/<br/>NO --delete, cache-control max-age=31536000 immutable
+  Node->>S3: aws s3 sync out-apex/ s3://BUCKET/<br/>--delete --exclude "_next/static/*"<br/>cache-control max-age=300 s-maxage=3600
+  Node->>S3: aws s3 cp out-apex/_meta.json s3://BUCKET/_meta.json<br/>cache-control no-cache no-store must-revalidate, content-type application/json
+  Node->>CF: aws cloudfront create-invalidation --paths "/*"
+  CF-->>Node: invalidation id
+  Node->>GH: print summary (commit, bucket, distribution, verify URL)
+```
+
+### Why the sync order is load-bearing
+
+1. **Immutable-first NO `--delete`**: hashed chunks under `_next/static/**` are content-addressed by Next.js. Locked at `max-age=31536000, immutable`. The newly-published HTML references new hashed-asset URLs; those chunks must exist in S3 **before** the HTML is visible to viewers.
+2. **Then mutable WITH `--delete`**: everything outside `_next/static/**` (HTML, icons, OG/apple images, fonts, JSON, txt, xml) gets short-cached and prunes deleted objects. Browser-cached old HTML (5-min TTL) still references old hashed-asset URLs; deleting those mid-flight would produce 404s for users who have not yet refetched the HTML.
+3. **Override `_meta.json` last**: `_meta.json` is the deploy-verification probe. It is re-uploaded with `Cache-Control: no-cache, no-store, must-revalidate` so a curl against the apex always returns the freshest SHA.
+4. **`/*` invalidation**: blanket. CloudFront invalidations are pennies per path; the simpler invariant beats the cost optimization.
+
+Trade-off: orphaned hashed chunks accumulate. PR #240's S3 lifecycle policy prunes noncurrent versions after 90 days, but **not** orphaned-by-rename objects. Periodic cleanup is a tracked follow-up.
+
+### Auth boundary
+
+The OIDC trust policy on `github-actions-apex-deploy` (provisioned by PR #240) uses `StringEquals` on the OIDC `sub` claim, pinned to exactly `repo:flamarion/pfv:ref:refs/heads/main`. PR-context tokens have a different `sub` and are rejected at the IAM trust level. Workflow `if:` guards alone would be insufficient since PR authors can edit the workflow file. The `branches: [main]` trigger is belt-and-suspenders.
+
+### How to verify an apex deploy
+
+1. Watch the workflow run: `https://github.com/flamarion/pfv/actions/workflows/apex-deploy.yml`
+2. `curl -fsS https://thebetterdecision.com/_meta.json` returns JSON containing the deployed commit SHA. The object is set to `no-cache` so this is always fresh.
+3. CloudFront invalidation status: AWS console -> CloudFront -> Distributions -> select -> Invalidations tab.
+
+## 6. Terraform: `FlamaCorp/pfv` (DO data droplet)
+
+Source: `infra/terraform/`, `infra/terraform/README.md`, `infra/README.md`.
+
+This TFC workspace manages the DigitalOcean control plane for the self-hosted MySQL + Redis pair:
+
+| Resource | Purpose |
+|---|---|
+| `digitalocean_vpc` | Dedicated `10.42.0.0/24` VPC in `ams3` |
+| `digitalocean_droplet` | `pfv-data-01`, `s-1vcpu-2gb`, Ubuntu 24.04, runs MySQL 8 + Redis |
+| `digitalocean_firewall` | SSH 22 from anywhere; MySQL 3306 / Redis 6379 / ICMP from VPC only |
+| `digitalocean_project_resources` | Attaches the droplet to the existing DO `pfv` project |
+
+### Workflow
+
+```mermaid
+flowchart LR
+  pr[PR touches infra/terraform/**] --> tfcsp[TFC speculative plan]
+  tfcsp -->|status check on PR| pr
+  pr --> merge[Merge to main]
+  merge --> tfcapp[TFC apply run created]
+  tfcapp --> hold[Status: waiting for confirmation]
+  hold -->|operator clicks Confirm and Apply| apply[Apply runs]
+  apply --> done[Droplet/VPC/firewall updated]
+  apply -.->|outputs| read[droplet_private_ipv4<br/>vpc_id<br/>droplet_public_ipv4]
+```
+
+- **Speculative plan** on every PR that touches `infra/terraform/**`. Posted as a PR status check from TFC's VCS integration. Working directory is `infra/terraform`, trigger pattern is `infra/terraform/**`. (The apex workspace has its own trigger; the two do not collide.)
+- **Apply** on merge. **Manual confirm** in the TFC UI; auto-apply is intentionally off. No infra change ever lands without an operator clicking Confirm & Apply.
+- **Local CLI** is debug-only per the `feedback_terraform_vcs_only` rule. `terraform login` once, then `terraform -chdir=infra/terraform plan` reaches the same remote state for inspection. Never `apply` from CLI.
+
+Workspace variables (set in TFC, never committed):
+- `do_token` (sensitive): scoped DO API token (droplets/vpcs/firewalls/projects RW, ssh_keys R)
+- `ssh_key_name`: name of an SSH key already registered in DO
+
+The provider lock file (`.terraform.lock.hcl`) is committed. TFC and laptop CLIs resolve identical provider versions.
+
+Outputs consumed elsewhere:
+- `droplet_private_ipv4` -> `DATABASE_URL` / `REDIS_URL` in `.do/app.yaml`
+- `vpc_id` -> top-level `vpc.id` block in `.do/app.yaml` (required for App Platform to reach the droplet on its private IP)
+
+After-droplet steps (one-time): Ansible playbook bootstraps the host. See `infra/README.md`.
+
+## 7. Terraform: `FlamaCorp/pfv-apex` (AWS apex control plane)
+
+Source: `infra/terraform/apex/`, `infra/terraform/apex/README.md`.
+
+Separate TFC workspace because the auth path is different (AWS OIDC rather than a DO API token) and the blast radius is contained.
+
+| Resource | Purpose |
+|---|---|
+| `aws_s3_bucket` (+ public-access-block, versioning, SSE, lifecycle, ownership) | Private origin bucket for the static export |
+| `aws_cloudfront_distribution` (+ OAC) | Edge distribution with HTTPS, HSTS, www -> apex redirect |
+| `aws_cloudfront_function` | Viewer-request: www -> apex 301 redirect, then S3 directory-index rewrite (`/privacy/` -> `/privacy/index.html`) |
+| `aws_cloudfront_response_headers_policy` | HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy |
+| `aws_acm_certificate` + `_validation` | DNS-validated cert in `us-east-1` for apex + www (CloudFront requirement) |
+| `aws_route53_record.apex_acm_validation` | ACM `_<token>` CNAME records in the existing zone (does **not** touch the apex A record until PR-D of the L5.2a sequence) |
+| `aws_iam_openid_connect_provider.github` | Trust for GitHub Actions OIDC tokens |
+| `aws_iam_openid_connect_provider.tfc` | Trust for Terraform Cloud workload-identity tokens |
+| `aws_iam_role.github_actions_apex_deploy` | Deploy role: `s3:PutObject`/`s3:DeleteObject`/`s3:ListBucket` scoped to the apex bucket; `cloudfront:CreateInvalidation` scoped to the apex distribution |
+| `aws_iam_role.tfc_apex_provisioner` | TFC-assumed role for managing the resources above |
+
+### Workflow
+
+Same shape as the `pfv` workspace:
+- Speculative plan on every PR that touches `infra/terraform/apex/**`
+- Apply on merge to `main`, **manual Confirm & Apply** in TFC
+- Local CLI plan-only is allowed for debug; never apply from CLI
+
+```mermaid
+flowchart LR
+  pr[PR touches infra/terraform/apex/**] --> tfcsp[TFC apex speculative plan]
+  tfcsp -->|status check on PR| pr
+  pr --> merge[Merge to main]
+  merge --> tfcapp[TFC apex apply run]
+  tfcapp --> hold[Waiting on Confirm and Apply]
+  hold --> apply[Apply runs via OIDC -> tfc-apex-provisioner role]
+  apply --> done[AWS resources updated]
+  apply -.->|outputs| consumers[github_actions_role_arn -> apex-deploy.yml<br/>s3_bucket_name -> apex-deploy.yml<br/>cloudfront_distribution_id -> apex-deploy.yml<br/>cloudfront_distribution_domain -> verify URL pre-cutover]
+```
+
+### Bootstrap (one-time)
+
+Because the OIDC providers and `tfc-apex-provisioner` role only exist after the first apply, the first run uses a single static-credential window:
+
+1. Create IAM user `pfv-apex-bootstrap` with `AdministratorAccess`. Generate an access-key pair.
+2. In TFC -> `FlamaCorp/pfv-apex` -> Variables: set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (both env, sensitive), `aws_account_id` (terraform).
+3. Merge the apex Terraform PR. Confirm & Apply.
+4. Switch TFC to OIDC: set `TFC_AWS_PROVIDER_AUTH=true`, `TFC_AWS_RUN_ROLE_ARN=<tfc_role_arn output>`. Delete `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
+5. Delete (or deactivate the access key of) the bootstrap IAM user within the hour.
+6. Trigger a no-op plan in TFC; an empty plan = OIDC works end-to-end.
+
+After bootstrap, TFC runs use workload identity. Long-lived AWS keys exist nowhere in the repo or in TFC.
+
+### What this workspace does **not** do
+
+- It does **not** swap the apex `A` ALIAS to CloudFront. That is PR-D of the L5.2a sequence; until then the apex stays parked.
+- It does **not** manage the dashboard surface (`app.thebetterdecision.com`). That DNS lives on Cloudflare and points at App Platform.
+- It is read-only on Route 53, except for ACM validation **CNAME** writes scoped by IAM condition. Apex `A` record writes are IAM-blocked, not just code-discipline blocked.
+
+## 8. Database migrations
+
+Three callers, one engine.
+
+```mermaid
+sequenceDiagram
+  participant Dev as Local dev (backend lifespan)
+  participant CLI as ./pfv migrate (local CLI)
+  participant DO as DO PRE_DEPLOY job
+  participant Wrap as backend/scripts/migrate.py
+  participant Alembic as alembic upgrade <rev>
+  participant DB as MySQL 8
+
+  Dev->>Dev: read /app/.git/HEAD; refuse off-main unless PFV_MIGRATE_OK_OFF_MAIN=1
+  Dev->>Wrap: _run_migrations() (in-process import)
+  CLI->>CLI: same branch guard
+  CLI->>Wrap: python backend/scripts/migrate.py
+  DO->>Wrap: python /app/scripts/migrate.py (no branch guard; always head)
+  Wrap->>Alembic: ScriptDirectory.get_heads()
+  alt multi-head
+    Wrap-->>Wrap: log migrate.failed reason=multiple_heads, exit 1
+  else no heads
+    Wrap-->>Wrap: log migrate.no_op, exit 0
+  else single head
+    Wrap->>DB: MigrationContext.get_current_revision()
+    alt current == head
+      Wrap-->>Wrap: log migrate.no_op, exit 0
+    else pending
+      Wrap-->>Wrap: log migrate.start (from, to, step_count)
+      loop each pending rev (oldest first)
+        Wrap-->>Wrap: log migrate.step.start
+        Wrap->>Alembic: subprocess alembic upgrade <rev>
+        Alembic->>DB: apply migration
+        Alembic-->>Wrap: rc 0 + streamed stdout/stderr
+        Wrap-->>Wrap: log migrate.step.end (duration_ms, returncode)
+      end
+      Wrap-->>Wrap: log migrate.complete (applied_count, duration_ms)
+    end
+  end
+```
+
+### The three callers
+
+1. **Local dev (backend lifespan)**: `./pfv start | restart | rebuild` boots the backend. Its FastAPI lifespan calls `_run_migrations()` against the shared MySQL volume in dev. The lifespan reads `/app/.git/HEAD` and **refuses to migrate when the host checkout is on a non-main branch** (or is detached / unreadable). Override with `PFV_MIGRATE_OK_OFF_MAIN=1` in `.env` or the shell.
+2. **`./pfv migrate` (local CLI)**: same branch guard. Runs inside the local backend container. Never invoke from an agent worktree (it always targets the default `pfv` compose project). See `reference_shared_mysql_volume_trap.md`.
+3. **Production (DO App Platform `PRE_DEPLOY` job)**: declared in `.do/app.yaml`, runs `python /app/scripts/migrate.py`. The new revision is held back until this job exits 0. The same wrapper is also used by the K8s init container in `k8s/templates/backend.yaml` and by the `migrate` service in `docker-compose.prod.yml`.
+
+### What the wrapper guarantees
+
+- Same exit code semantics as `alembic upgrade head` (0 on success, alembic's exit code on failure, 1 on safety errors). PRE_DEPLOY contract preserved.
+- Same stdout / stderr from alembic, line-buffered through threaded forwarders. No capture, no reorder.
+- **Multi-head guard**: if `ScriptDirectory.get_heads()` returns >1, the wrapper logs `migrate.failed reason="multiple_heads"` and exits 1. Refuses to auto-pick.
+- **Per-step structured JSON events**: an operator triaging from logs alone can answer "did the migrate job do anything, and if so what?":
+  - `migrate.start` (from_revision, to_revision, step_count, dialect, database)
+  - `migrate.step.start` (revision, step_index, step_count, description)
+  - `migrate.step.end` (revision, duration_ms, returncode=0)
+  - `migrate.complete` (from_revision, to_revision, applied_count, duration_ms)
+  - `migrate.no_op` (when current already equals head)
+  - `migrate.failed` (revision, step_index, returncode, reason, error_type)
+- Redaction: never logs raw connection URLs (driver errors routinely embed credentials). Only `dialect` and `database` name from `safe_url_fields`.
+
+### Migration policy
+
+- **Forward-only in production.** `alembic downgrade` is forbidden in agent contexts per `feedback_agent_destructive_db_ops`. Rollback path is "write a new fix-up migration" (see Section 10).
+- Migrations land via the same PR that uses them. The PRE_DEPLOY job applies them on the next prod deploy, **before** any backend replica with the new code starts.
+
+For env var detail (`DATABASE_URL`, `APP_ENV`, etc.) on the migrate job, see [`ENVIRONMENT.md`](./ENVIRONMENT.md) "Migrate job (DO PRE_DEPLOY)". For the managed-to-droplet data move, see [`infra/MIGRATION.md`](./infra/MIGRATION.md).
+
+## 9. What triggers what (decision tree)
+
+```mermaid
+flowchart TD
+  start[Commit lands on main with type <type> touching path P]
+  start --> back{P in backend/**?}
+  back -- yes --> rel[release.yml fires]
+  back -- no --> front{P in frontend/**?}
+
+  front -- yes --> frontkind{Path matches apex-only?<br/>app/page.tsx, app/privacy/**,<br/>app/terms/**, app/docs/**,<br/>components/landing/**,<br/>scripts/build-apex.sh,<br/>next.config.apex.ts}
+  frontkind -- yes --> apex[apex-deploy.yml fires]
+  frontkind -- no --> frontshared{Path is shared?<br/>lib/brand.ts, lib/styles.ts,<br/>ThemeProvider, public/**,<br/>package.json}
+  frontshared -- yes --> both[release.yml AND apex-deploy.yml fire]
+  frontshared -- no --> rel
+
+  front -- no --> infra{P in .do/** or nginx/** or Dockerfile*?}
+  infra -- yes --> rel
+  infra -- no --> tf1{P in infra/terraform/apex/**?}
+  tf1 -- yes --> tfapex[TFC pfv-apex apply waits on Confirm and Apply]
+  tf1 -- no --> tf2{P in infra/terraform/**?}
+  tf2 -- yes --> tfpfv[TFC pfv apply waits on Confirm and Apply]
+  tf2 -- no --> wf{P in .github/workflows/**?}
+  wf -- yes --> nothing[Workflow file updated.<br/>Next matching trigger uses the new file.]
+  wf -- no --> docs[Docs / memory / root-level only.<br/>Nothing fires.]
+
+  rel --> semrel{Conventional commit type bumps?}
+  semrel -- feat/fix/etc --> deploy[deploy job ships .do/app.yaml]
+  semrel -- chore/docs/perf --> noship[release.yml runs but does not deploy]
+```
+
+Concrete cases:
+
+| You changed | Fires |
+|---|---|
+| `backend/app/routers/transactions.py` (feat) | `release.yml` -> semantic-release publishes -> deploy -> migrate (no-op if no new revs) -> roll backend |
+| `frontend/components/dashboard/Foo.tsx` (feat) | `release.yml` -> publishes -> deploy -> roll frontend |
+| `frontend/app/page.tsx` (feat, landing) | `apex-deploy.yml` (post-#267). `release.yml` does NOT fire (no path match). |
+| `frontend/lib/brand.ts` (feat) | Both `release.yml` AND `apex-deploy.yml`. |
+| `backend/alembic/versions/abc_new_migration.py` | `release.yml` -> deploy -> PRE_DEPLOY migrate applies it -> roll backend |
+| `infra/terraform/main.tf` | TFC `pfv` speculative plan on PR; apply waits on operator Confirm & Apply after merge |
+| `infra/terraform/apex/main.tf` | TFC `pfv-apex` speculative plan on PR; apply waits on operator Confirm & Apply after merge |
+| `.do/app.yaml` (chore) | `release.yml` fires but semantic-release does not bump. Operator must run `gh workflow run deploy.yml --ref main`. |
+| `.github/workflows/test.yml` | Triggers itself on PR (path is on its allowlist). On merge, nothing else fires. |
+| `README.md` or `CLAUDE.md` only | Nothing fires. |
+
+The mutually exclusive apex / DO path-filter split is by design. The DO release watches `backend/`, `frontend/`, `nginx/`, `.do/`, and `Dockerfile*`. The apex deploy watches the apex-only frontend slice plus the shared brand/styling files. A landing-only commit must not redeploy the DO app, because the dashboard build is unchanged.
+
+## 10. Rollback playbook
+
+Forward-only philosophy across the board. "Rollback" means "publish a new state that undoes the bad state", not "revert state in place".
+
+### DO App (`release.yml` / `deploy.yml`)
+
+Option A, revert the merge commit:
+1. `git revert -m 1 <merge-sha>` on a branch, push, PR, merge.
+2. semantic-release sees the revert as a fix or feat (conventional-commit style matters) and publishes a new release.
+3. `deploy` ships, PRE_DEPLOY runs (no-op if the revert did not touch migrations), backend / frontend roll.
+4. Smoke tests confirm.
+
+Option B, redeploy a prior good `main` SHA via `deploy.yml`:
+1. Reset `main` to a prior known-good commit is **not allowed** (PR-only workflow). Instead:
+2. Cherry-pick the inverse of the bad change onto a new branch, PR, merge. This is effectively Option A.
+
+DO console "Rollback" button: avoid. App Platform's rollback rolls the **runtime image** back to a prior build, but the **spec** (`.do/app.yaml`) on the next push still reflects whatever is on `main`. This produces a runtime / spec mismatch that triggers more redeploys to resolve. Always rollback via the repo.
+
+### Apex landing (`apex-deploy.yml`)
+
+Option A, revert the merge commit, push to `main`. The path filter re-triggers `apex-deploy.yml`, which rebuilds and re-syncs. CloudFront `/*` invalidation flushes the edge.
+
+Option B, restore prior S3 object versions. The apex bucket has versioning enabled (provisioned by PR-A). For a surgical undo (e.g. a single `privacy/index.html` regression):
+```bash
+aws s3api list-object-versions --bucket <AWS_APEX_BUCKET> --prefix privacy/index.html
+aws s3api copy-object \
+  --bucket <AWS_APEX_BUCKET> --key privacy/index.html \
+  --copy-source "<AWS_APEX_BUCKET>/privacy/index.html?versionId=<prior-version-id>"
+aws cloudfront create-invalidation --distribution-id <AWS_APEX_DISTRIBUTION_ID> --paths "/privacy/index.html" "/privacy/"
+```
+Prefer Option A for any rollback that affects more than one or two objects; the repo stays the source of truth.
+
+### Terraform (either workspace)
+
+Revert the merge commit in the repo. TFC plans the inverse change on the next merge. Operator clicks Confirm & Apply. State catches up.
+
+For destructive teardown (rare), queue a `Destroy plan` from the TFC workspace UI. Local `terraform destroy` is debug-only.
+
+### Database migrations
+
+Forward-only. **Never `alembic downgrade` in production.** The path to a safe rollback is:
+
+1. Open a PR with a new alembic revision that performs the data and schema fix-up. Conventional title `fix(db): ...`.
+2. Merge. `release.yml` -> semantic-release publishes -> deploy -> PRE_DEPLOY migrate applies the fix-up revision. Backend rolls on top.
+3. Verify via the new revision's `migrate.step.end` event in the PRE_DEPLOY job logs.
+
+If a migration **partially applies** and the job exits non-zero, the PRE_DEPLOY contract halts the rollout. The new backend revision never starts. Diagnose from the streamed alembic output + the `migrate.failed` event (`reason`, `step_index`, `revision`). Fix-up paths:
+- Schema state matches a known earlier revision: stamp it (`alembic stamp <rev>`) via a one-shot ops session and ship a new revision that completes the work. Only the operator should do this; agents must not (`feedback_agent_destructive_db_ops`).
+- Data corruption: write a fix-up migration; ship that.
+
+## 11. Where to look when something breaks
+
+| Surface | Where the logs live |
+|---|---|
+| GitHub Actions runs (all workflows) | `https://github.com/flamarion/pfv/actions` |
+| `release.yml` runs specifically | `https://github.com/flamarion/pfv/actions/workflows/release.yml` |
+| `deploy.yml` runs | `https://github.com/flamarion/pfv/actions/workflows/deploy.yml` |
+| `apex-deploy.yml` runs (post-#267) | `https://github.com/flamarion/pfv/actions/workflows/apex-deploy.yml` |
+| `test.yml` runs | `https://github.com/flamarion/pfv/actions/workflows/test.yml` |
+| TFC `pfv` (DO data droplet) | `https://app.terraform.io/app/FlamaCorp/workspaces/pfv` |
+| TFC `pfv-apex` (AWS apex) | `https://app.terraform.io/app/FlamaCorp/workspaces/pfv-apex` |
+| DO App Platform deploys | DO console -> Apps -> `pfv` -> Activity |
+| Backend access logs (live) | DO console -> Apps -> `pfv` -> Runtime Logs -> backend component |
+| Frontend access logs (live) | DO console -> Apps -> `pfv` -> Runtime Logs -> frontend component |
+| `PRE_DEPLOY migrate` job logs | DO console -> Apps -> `pfv` -> Activity -> select deploy -> migrate job |
+| Apex CloudFront access logs | Not enabled today. `infra/terraform/apex/main.tf` (`aws_cloudfront_distribution.apex`) does not configure `logging_config`. Post-launch follow-up: provision a separate S3 bucket for CloudFront standard logs and add the logging block. For real-time debugging until then, AWS console -> CloudFront -> distribution -> Monitoring tab. |
+| Apex S3 contents | AWS console -> S3 -> `thebetterdecision-com-apex` |
+| MySQL slow query / error log | SSH to `pfv-data-01`: `journalctl -u mysql` or `/var/log/mysql/error.log` |
+| Nightly mysqldump | `pfv-data-01`: `ls -lh /var/backups/mysql/`; log at `/var/log/mysql-backup.log` |
+| Smoke-test failure GitHub issue | Auto-opened by `scripts/notify-smoke-failure.sh`; check open issues in `flamarion/pfv` |
+
+Triage shortcuts:
+
+| Symptom | First look at |
+|---|---|
+| Merge to `main` happened, prod didn't update | `release.yml` -> did `release` job set `new_release_published=true`? Conventional commit type may be `chore` |
+| Deploy went green, app still broken | Smoke-test job output, then DO Runtime Logs on the failing component |
+| Migrate job hung or failed | DO Activity -> latest deploy -> migrate job. Grep for `migrate.start`, `migrate.failed`, `migrate.step.start`. Multi-head? Driver error? |
+| Apex site shows stale content | Confirm `apex-deploy.yml` ran for the SHA; check CloudFront invalidation completed; `curl https://thebetterdecision.com/_meta.json` (must be no-cache) |
+| Apex 404 on a known route | The CloudFront Function rewrites `/path/` -> `/path/index.html`. Check the function's invocation logs in CloudFront Functions console |
+| Apex deploy failed at OIDC step | Trust policy on `github-actions-apex-deploy` pinned to `repo:flamarion/pfv:ref:refs/heads/main`. PR-context, forks, non-main branches are rejected by design |
+| App can't reach MySQL or Redis | Confirm `.do/app.yaml`'s top-level `vpc.id` matches the TFC output, and `DATABASE_URL` / `REDIS_URL` point at the droplet's `10.42.x.x` private IP |
+| Secret env var "disappeared" after deploy | `.do/app.yaml` must declare every SECRET with its `EV[...]` blob. Missing -> stripped on push. Refresh via `doctl apps spec get <app-id>` |
+
+For the env var matrix and common per-variable failures (Google SSO button missing, `NEXT_PUBLIC_*` not in client bundle, audit log shows ingress IP, etc.), see [`ENVIRONMENT.md`](./ENVIRONMENT.md) "Common failure modes".

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -454,11 +454,11 @@ sequenceDiagram
   participant Alembic as alembic upgrade <rev>
   participant DB as MySQL 8
 
-  Dev->>Dev: read /app/.git/HEAD; refuse off-main unless PFV_MIGRATE_OK_OFF_MAIN=1
+  Dev->>Dev: read /app/.git/HEAD, refuse off-main unless PFV_MIGRATE_OK_OFF_MAIN=1
   Dev->>Wrap: _run_migrations() (in-process import)
   CLI->>CLI: same branch guard
   CLI->>Wrap: python backend/scripts/migrate.py
-  DO->>Wrap: python /app/scripts/migrate.py (no branch guard; always head)
+  DO->>Wrap: python /app/scripts/migrate.py (no branch guard, always head)
   Wrap->>Alembic: ScriptDirectory.get_heads()
   alt multi-head
     Wrap-->>Wrap: log migrate.failed reason=multiple_heads, exit 1

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 Audience: a contributor who just cloned the repo and wants to understand what happens between `git push` and a live change at `app.thebetterdecision.com` or `thebetterdecision.com`. Also a triage reference for CI/CD failures.
 
-This document covers the **target architecture**. The apex landing pipeline (Section 5) lands with **PR #267** (in flight, branch `feat/l5-2a-apex-deploy-workflow`). Everything else is live on `main` today.
+All four pipelines described here are live on `main` today (`test.yml`, `release.yml`, `deploy.yml`, `apex-deploy.yml`). The apex pipeline ships content to S3 + CloudFront, but the apex DNS swap (PR-D, see Section 5) is still pending; until it lands, the apex landing is reachable only via the CloudFront-assigned hostname, not via `https://thebetterdecision.com`.
 
 For "how do I get my code ready to push", read [`CONTRIBUTING.md`](./CONTRIBUTING.md). For the env var matrix, read [`ENVIRONMENT.md`](./ENVIRONMENT.md). For the managed-to-droplet data move, read [`infra/MIGRATION.md`](./infra/MIGRATION.md). This file does not duplicate any of them.
 
@@ -13,7 +13,7 @@ Four production surfaces. Each has its own pipeline. Some changes fan out across
 | Surface | URL | Hosted by | Updated by |
 |---|---|---|---|
 | App (FastAPI + Next.js dashboard) | `https://app.thebetterdecision.com` | DigitalOcean App Platform (`pfv` app) | `release.yml` (auto) or `deploy.yml` (manual) |
-| Apex landing (marketing, privacy, terms, docs) | `https://thebetterdecision.com` | AWS S3 + CloudFront | `apex-deploy.yml` (auto), **lands with PR #267** |
+| Apex landing (marketing, privacy, terms, docs) | `https://thebetterdecision.com` (DNS pending PR-D) | AWS S3 + CloudFront | `apex-deploy.yml` (auto) |
 | Data plane (MySQL 8 + Redis) | private VPC IP `10.42.x.x:3306 / :6379` | Self-hosted DO droplet `pfv-data-01` | TFC workspace `FlamaCorp/pfv` (manual confirm) |
 | Apex CDN + cert + IAM | n/a (control plane) | AWS (S3, CloudFront, ACM, IAM, Route 53) | TFC workspace `FlamaCorp/pfv-apex` (manual confirm) |
 
@@ -220,9 +220,9 @@ What it does NOT do: bump a version, create a tag, or post to a release feed. It
 
 For rollback to a prior `main` SHA, see Section 10.
 
-## 5. Apex landing deploy (`apex-deploy.yml`), lands with PR #267
+## 5. Apex landing deploy (`apex-deploy.yml`)
 
-> This workflow is on the in-flight branch `feat/l5-2a-apex-deploy-workflow` and is not on `main` yet. The rest of this section describes the target behavior once PR #267 merges. Source viewed via `git show origin/feat/l5-2a-apex-deploy-workflow:.github/workflows/apex-deploy.yml`.
+> Workflow is live on `main` (shipped in PR #267). It deploys to S3 + CloudFront on every push to `main` whose paths match the filter below. The apex hostname `https://thebetterdecision.com` is not wired to DNS yet (that lands with PR-D); until then, verify deploys against the CloudFront-assigned hostname from the TFC output `cloudfront_distribution_domain`.
 
 The apex landing (`thebetterdecision.com`) is a Next.js static export. `frontend/scripts/build-apex.sh` produces `frontend/out-apex/`. The workflow uploads that directory to an S3 bucket fronted by CloudFront in AWS, using **GitHub OIDC** to assume an IAM role (no long-lived AWS keys committed anywhere). The bucket, distribution, ACM cert, and IAM roles are provisioned by the `FlamaCorp/pfv-apex` TFC workspace (Section 7).
 
@@ -258,7 +258,7 @@ on:
       - "frontend/lib/styles.ts"
       - "frontend/components/brand/**"
       - "frontend/components/ThemeProvider.tsx"
-      - "frontend/components/tour/TourProvider.tsx"
+      - "frontend/components/tour/**"
       - "frontend/components/ui/BackLink.tsx"
       - "frontend/components/ui/CurrentYear.tsx"
       - "frontend/components/ui/ThemeToggle.tsx"
@@ -338,7 +338,15 @@ The OIDC trust policy on `github-actions-apex-deploy` (provisioned by PR #240) u
 ### How to verify an apex deploy
 
 1. Watch the workflow run: `https://github.com/flamarion/pfv/actions/workflows/apex-deploy.yml`
-2. `curl -fsS https://thebetterdecision.com/_meta.json` returns JSON containing the deployed commit SHA. The object is set to `no-cache` so this is always fresh.
+2. Curl `/_meta.json` to confirm the deployed commit SHA. The object is set to `no-cache` so this is always fresh.
+   - **Pre-PR-D (today):** apex DNS is not wired yet. Use the CloudFront-assigned hostname from the TFC output `cloudfront_distribution_domain`:
+     ```bash
+     curl -fsS https://<distribution>.cloudfront.net/_meta.json
+     ```
+   - **Post-PR-D:** apex DNS resolves to CloudFront. The canonical command:
+     ```bash
+     curl -fsS https://thebetterdecision.com/_meta.json
+     ```
 3. CloudFront invalidation status: AWS console -> CloudFront -> Distributions -> select -> Invalidations tab.
 
 ## 6. Terraform: `FlamaCorp/pfv` (DO data droplet)

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 Personal finance management for people who actually want to understand where their money goes.
 
-Track income and expenses across multiple accounts, set budgets per category, forecast future spending, import bank CSVs, and manage recurring transactions — all org-scoped so multiple users can share a household's finances.
+Track income and expenses across multiple accounts, set budgets per category, forecast future spending, import bank CSVs, and manage recurring transactions, all org-scoped so multiple users can share a household's finances.
 
 ## Features
 
 - **Dashboard** with spending breakdown, budget progress, and forecast comparison charts
 - **Transactions** with income, expenses, and linked account-to-account transfers
-- **Hierarchical categories** — master categories for budgets, subcategories for tagging
+- **Hierarchical categories**, master categories for budgets, subcategories for tagging
 - **Budgets** per category per billing period, with inter-budget transfers
-- **Forecast plans** — editable income/expense plans with actual vs. planned tracking
-- **Recurring transactions** — templates that auto-generate future transactions
-- **CSV import** — upload bank exports, preview with duplicate detection, map categories
-- **Billing periods** — org-level month close dates with configurable cycle day
-- **Multi-account** — checking, savings, credit cards, each with balance tracking
-- **Authentication** — email/password, Google SSO, TOTP MFA with recovery codes and email fallback
-- **Org-scoped** — all data isolated per organization, multi-user ready
-- **Responsive** — works on desktop and narrow viewports (tablet, half-screen)
+- **Forecast plans**, editable income / expense plans with actual vs planned tracking
+- **Recurring transactions**, templates that auto-generate future transactions
+- **CSV import**, upload bank exports, preview with duplicate detection, map categories
+- **Billing periods**, org-level month close dates with configurable cycle day
+- **Multi-account**, checking, savings, credit cards, each with balance tracking
+- **Authentication**, email / password, Google SSO, TOTP MFA with recovery codes and email fallback
+- **Org-scoped**, all data isolated per organization, multi-user ready
+- **Responsive**, works on desktop and narrow viewports (tablet, half-screen)
 
 ## Tech Stack
 
@@ -26,10 +26,11 @@ Track income and expenses across multiple accounts, set budgets per category, fo
 | Backend | Python 3.12, FastAPI, SQLAlchemy 2.0 (async), Alembic, Pydantic v2 |
 | Frontend | Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS, Recharts |
 | Database | MySQL 8.0 (self-hosted on a single DO droplet in production) |
-| Cache | Redis 7 (containerized in dev, self-hosted on the same droplet in production) |
+| Cache | Valkey 8 / Redis-compatible (containerized in dev, self-hosted on the same droplet in production) |
 | Auth | JWT (access + refresh), bcrypt, TOTP (pyotp), Google OAuth2 (with step-up for sensitive flows) |
 | Email | Mailgun (production), structlog (development) |
 | Proxy | nginx (development), DO App Platform ingress (production) |
+| Landing (apex) | AWS S3 + CloudFront + ACM + IAM OIDC, separate from the app, see [`DEPLOYMENT.md`](DEPLOYMENT.md) |
 
 ## Quick Start
 
@@ -39,27 +40,75 @@ cp .env.example .env
 ./pfv start
 ```
 
-Open http://localhost. The first user to register becomes the superadmin.
+Open [http://localhost](http://localhost). The first user to register becomes the superadmin.
 
 **Seed mock data** (optional):
 
 ```bash
-./pfv seed          # creates demo/demo1234 user with 100+ transactions
+./pfv seed          # creates demo / demo1234 user with 100+ transactions
 ```
+
+Full first-PR walkthrough (under 30 minutes from clone to push): [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Documentation
+
+Every part of the project has a single authoritative document. Start with the row that matches your task.
+
+### Getting started + day-to-day development
+
+| Doc | When you need it |
+|---|---|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | First-time contributor. 30-minute Quickstart, Conventional Commits + deploy gate, CI on your PR vs after merge, parallel-agent compose-isolation rule, first-PR decision tree. |
+| [ENVIRONMENT.md](ENVIRONMENT.md) | Reference for every env var (backend, frontend, migrate job, CLI). Scope, default, sensitivity, deployment paths, failure modes. Source of truth for `.env`, `.do/app.yaml`, and GitHub Actions secrets. |
+
+### Shipping + operations
+
+| Doc | When you need it |
+|---|---|
+| [DEPLOYMENT.md](DEPLOYMENT.md) | What happens between `git push` and a live change. All CI/CD flows (PR lifecycle, automatic prod deploy, manual escape hatch, apex landing deploy), Terraform workspaces, migrations, what-triggers-what decision tree, per-pipeline rollback playbook, where to look when things break. Diagrams included. |
+
+### Infrastructure
+
+| Doc | When you need it |
+|---|---|
+| [infra/README.md](infra/README.md) | End-to-end topology of both clouds. DigitalOcean App Platform + data droplet (MySQL + Valkey) for the app surface, AWS (S3 + CloudFront + ACM + IAM OIDC) for the apex landing surface. TFC workspace layout, OIDC overview, DNS split between Cloudflare (app subdomain) and Route 53 (apex). |
+| [infra/MIGRATION.md](infra/MIGRATION.md) | Production data-plane migration runbook. Used during the move from DO managed services to the self-hosted droplet, retained as the reference for any future host migration. |
+| [infra/terraform/README.md](infra/terraform/README.md) | Day-2 reference for the `FlamaCorp/pfv` TFC workspace (DO data droplet). Variables, working dir, manual Confirm-and-Apply convention. |
+| [infra/terraform/apex/README.md](infra/terraform/apex/README.md) | Day-2 reference for the `FlamaCorp/pfv-apex` TFC workspace (AWS apex landing). Bootstrap path B (static keys for one apply, then flip to OIDC), GitHub Actions deploy role, ACM in `us-east-1` rationale. |
+| [infra/ansible/README.md](infra/ansible/README.md) | Configuration management for the data droplet (`pfv-data-01`). MySQL + Valkey roles, cloud-firewall coexistence, common role tasks. |
+
+### Product + design
+
+| Doc | When you need it |
+|---|---|
+| [PRODUCT.md](PRODUCT.md) | Target users, primary jobs-to-be-done, the operative product narrative. Background for design and UX decisions. |
+| [BRAND.md](BRAND.md) | Brand kit: product name conventions, voice, palette, logo and favicon usage. Used when writing copy, building landing surfaces, or producing assets. |
+| [DESIGN.md](DESIGN.md) | Design language and component conventions. Used when building or critiquing UI. |
+
+### Working with AI in this repo
+
+| Doc | When you need it |
+|---|---|
+| [CLAUDE.md](CLAUDE.md) | Project-level guidance for Claude Code sessions. Stack, conventions, parallel-agent compose-isolation rule, migration branch guard, lifespan migration guard. |
+| [AGENTS.md](AGENTS.md) | How agents (Claude or otherwise) interact with this repo. Rules of engagement, what is and is not allowed without explicit owner approval. |
 
 ## Architecture
 
 ```
-Browser --> nginx (:80) --> /api/*  --> backend (FastAPI :8000) --> MySQL (:3306)
-                        --> /*      --> frontend (Next.js :3000)
-                                        backend --> Redis (:6379)
+Browser
+  --> app.thebetterdecision.com (DO App Platform ingress)
+        --> /api/*  --> backend  (FastAPI, port 8000)  --> MySQL  (pfv-data-01:3306)
+        --> /*      --> frontend (Next.js, port 3000)  --> Valkey (pfv-data-01:6379)
+  --> thebetterdecision.com (Route 53 -> CloudFront -> S3)
+        --> static landing export (auth-free, no app code in bundle)
 ```
 
-- **Backend** serves a REST API under `/api/v1/`. Stateless, horizontally scalable.
-- **Frontend** is a Next.js App Router SPA. All API calls use Bearer token auth with silent refresh.
-- **nginx** routes traffic in development. In production, DigitalOcean App Platform handles ingress.
+- **App backend** serves a REST API under `/api/v1/`. Stateless, horizontally scalable, ready for K8s.
+- **App frontend** is a Next.js App Router build. All API calls use Bearer token auth with silent refresh.
+- **Apex landing** is a separate Next.js static export built by `npm run build:apex`, deployed to S3 via GitHub Actions with OIDC role assume.
+- **nginx** routes traffic in development. DO App Platform handles ingress for the app in production; CloudFront handles ingress for the apex.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full architecture breakdown, environment variables, deployment guide, and development workflow.
+For the full pipeline mechanics, see [DEPLOYMENT.md](DEPLOYMENT.md). For the cross-cloud topology, see [infra/README.md](infra/README.md).
 
 ## CLI
 
@@ -69,7 +118,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full architecture breakdown, envi
 ./pfv restart           # restart without rebuild
 ./pfv rebuild           # force rebuild (no cache)
 ./pfv reset             # destroy all data and start fresh
-./pfv migrate           # run pending migrations
+./pfv migrate           # run pending migrations (refuses off main without PFV_MIGRATE_OK_OFF_MAIN=1)
 ./pfv logs [service]    # view logs (backend, frontend, nginx, mysql, redis)
 ./pfv status            # container status
 ./pfv shell [service]   # shell into a container (default: backend)
@@ -77,38 +126,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full architecture breakdown, envi
 ./pfv prod              # build and start in production mode
 ```
 
-## API Documentation
+## API
 
-Swagger UI is available at http://localhost/api/docs when running locally.
+Swagger UI: [http://localhost/api/docs](http://localhost/api/docs) (when running locally).
 
-| Resource | Prefix | Description |
-|----------|--------|-------------|
-| Auth | `/api/v1/auth` | Login, register, MFA, Google SSO, password reset, step-up |
-| Users | `/api/v1/users` | Profile, password change |
-| Accounts | `/api/v1/accounts` | Bank accounts and balances |
-| Categories | `/api/v1/categories` | Hierarchical income/expense categories |
-| Transactions | `/api/v1/transactions` | Income, expenses, transfers (period bucketing by `settled_date`) |
-| Recurring | `/api/v1/recurring` | Recurring transaction templates |
-| Budgets | `/api/v1/budgets` | Per-category spending limits |
-| Forecast | `/api/v1/forecast` | Computed forecast (read-only) |
-| Forecast Plans | `/api/v1/forecast-plans` | Editable forecast plans |
-| Import | `/api/v1/import` | CSV import (preview + confirm) |
-| Settings | `/api/v1/settings` | Org settings, billing periods, billing cycle |
-| Orgs | `/api/v1/orgs` | Org rename and per-org actions |
-| Plans / Subscriptions | `/api/v1/plans`, `/api/v1/subscriptions` | Plan catalog and trial / subscription state |
-| Admin | `/api/v1/admin/*` | Superadmin: orgs, audit log, roles |
-
-## Configuration and environment variables
-
-Every environment variable consumed by the app (backend, frontend, migrate job, CLI) is documented in [ENVIRONMENT.md](ENVIRONMENT.md). That file is the source of truth for required vs optional vars, scopes (build vs run), sensitivity, deployment paths (local / CI / production), and common failure modes. Start there before editing `.env`, `.do/app.yaml`, or GitHub Actions secrets.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, architecture details, environment variables, branching workflow, and deployment guide.
-
-## Deployment
-
-Production runs on DigitalOcean App Platform (Amsterdam). Automatic deployment is gated on semantic-release: only commits classified as a release (`feat`, `fix`, `perf`, `revert`) are auto-deployed by GitHub Actions on merge to `main`. `chore`, `docs`, `refactor`, `test`, and similar non-release commits do not auto-deploy. Infra-only changes that need to ship without a version bump use a manual workflow run. See [CONTRIBUTING.md](CONTRIBUTING.md#deployment) for details.
+The full resource catalog and route conventions live in [CONTRIBUTING.md](CONTRIBUTING.md). Versioned under `/api/v1/`. Breaking changes go in `/api/v2/` while `v1` stays operational.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Every part of the project has a single authoritative document. Start with the ro
 | Doc | When you need it |
 |---|---|
 | [CLAUDE.md](CLAUDE.md) | Project-level guidance for Claude Code sessions. Stack, conventions, parallel-agent compose-isolation rule, migration branch guard, lifespan migration guard. |
-| [AGENTS.md](AGENTS.md) | How agents (Claude or otherwise) interact with this repo. Rules of engagement, what is and is not allowed without explicit owner approval. |
 
 ## Architecture
 
@@ -98,7 +97,8 @@ Every part of the project has a single authoritative document. Start with the ro
 Browser
   --> app.thebetterdecision.com (DO App Platform ingress)
         --> /api/*  --> backend  (FastAPI, port 8000)  --> MySQL  (pfv-data-01:3306)
-        --> /*      --> frontend (Next.js, port 3000)  --> Valkey (pfv-data-01:6379)
+        |                                              --> Valkey (pfv-data-01:6379)
+        --> /*      --> frontend (Next.js, port 3000)
   --> thebetterdecision.com (Route 53 -> CloudFront -> S3)
         --> static landing export (auth-free, no app code in bundle)
 ```

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,75 +1,355 @@
 # pfv infra
 
-Self-hosted MySQL + Redis on a single DigitalOcean droplet, replacing the DO
-Managed MySQL + Managed Redis pair (~$30/mo) with one `s-1vcpu-2gb` droplet
-(~$12/mo). DO backups are off; the nightly mysqldump cron is the durability
-floor.
+End-to-end infrastructure for The Better Decision (pfv). Two clouds, two TFC
+workspaces, one app.
 
-This folder owns the cloud and the box. App Platform spec lives elsewhere.
+- **AWS** owns the apex marketing landing site at `thebetterdecision.com`
+  (S3 + CloudFront + ACM + IAM OIDC). Managed by Terraform Cloud workspace
+  `FlamaCorp/pfv-apex` against `infra/terraform/apex/`.
+- **DigitalOcean** owns the app itself at `app.thebetterdecision.com`
+  (App Platform fronting the Next.js frontend and FastAPI backend) plus the
+  self-hosted data plane (`pfv-data-01`: MySQL 8 + Valkey 8) inside a private
+  VPC. Managed by Terraform Cloud workspace `FlamaCorp/pfv` against
+  `infra/terraform/` (root + `modules/`).
+
+App Platform spec lives at `.do/app.yaml`. The migration runbook for the
+managed-DB to self-hosted-droplet cutover lives at `infra/MIGRATION.md`.
+Per-env-var documentation lives at `ENVIRONMENT.md` (repo root). The
+day-to-day deploy walkthrough lives at `DEPLOYMENT.md`.
+
+## Topology
+
+```mermaid
+flowchart LR
+    user([User browser])
+
+    subgraph dns[DNS]
+        r53[Route 53 zone<br/>thebetterdecision.com]
+        cf_dns[Cloudflare zone<br/>app.thebetterdecision.com]
+    end
+
+    subgraph aws[AWS]
+        cfd[CloudFront distribution<br/>apex + www<br/>ACM cert in us-east-1]
+        s3[(S3 bucket<br/>private, OAC)]
+    end
+
+    subgraph do[DigitalOcean]
+        ing[App Platform ingress<br/>app.thebetterdecision.com]
+        fe[frontend<br/>Next.js :3000]
+        be[backend<br/>FastAPI :8000]
+        subgraph vpc[VPC 10.42.0.0/24 ams3]
+            droplet[pfv-data-01<br/>s-1vcpu-2gb]
+            mysql[(MySQL 8<br/>:3306)]
+            valkey[(Valkey 8<br/>:6379)]
+            droplet --- mysql
+            droplet --- valkey
+        end
+    end
+
+    user -->|apex / www| r53
+    user -->|app subdomain| cf_dns
+    r53 -->|A ALIAS| cfd
+    cfd -->|OAC sigv4| s3
+    cf_dns -->|origin TLS| ing
+    ing -->|/api, /health, /ready| be
+    ing -->|/| fe
+    be -->|VPC private IPv4| mysql
+    be -->|VPC private IPv4| valkey
+```
+
+The boundary between AWS (apex landing) and DigitalOcean (app + data plane)
+is a hard one. Different cloud, different auth, different TFC workspace.
+The only thing they share is the `thebetterdecision.com` zone delegation
+target (Route 53 holds the apex, Cloudflare holds the `app.` subdomain).
 
 ## What's here
 
-- `terraform/` — DO VPC, droplet, cloud firewall, project attachment.
-- `ansible/` — Ubuntu 24.04 bootstrap: hardening, MySQL, Redis, nightly backups.
-- `MIGRATION.md` — runbook for moving data off the managed services.
+```
+infra/
+├── README.md                       # this file
+├── MIGRATION.md                    # managed MySQL+Redis -> droplet cutover (historical)
+├── terraform/                      # DO data droplet (TFC: FlamaCorp/pfv)
+│   ├── main.tf
+│   ├── outputs.tf
+│   ├── variables.tf
+│   ├── modules/                    # vpc/, droplet/, firewall/, project/
+│   └── apex/                       # AWS apex landing (TFC: FlamaCorp/pfv-apex)
+│       ├── main.tf
+│       ├── variables.tf
+│       ├── outputs.tf
+│       ├── providers.tf            # default region + us-east-1 alias for ACM
+│       ├── versions.tf
+│       └── README.md               # apex-specific bootstrap + IAM detail
+└── ansible/                        # Ubuntu 24.04 bootstrap for pfv-data-01
+```
 
-## Architecture
+## TFC workspaces
+
+Both workspaces are VCS-driven against this repo, both require manual
+Confirm & Apply on the TFC UI (no auto-apply), both run speculative plans
+on PRs. See `feedback_terraform_vcs_only`: local CLI plan/apply is
+debug-only.
+
+| Workspace | Cloud | Working dir | Trigger pattern | Auth |
+|---|---|---|---|---|
+| `FlamaCorp/pfv` | DigitalOcean | `infra/terraform/` | `infra/terraform/**` (excludes `apex/`) | `do_token` workspace variable |
+| `FlamaCorp/pfv-apex` | AWS | `infra/terraform/apex/` | `infra/terraform/apex/**` | OIDC workload identity (`TFC_AWS_PROVIDER_AUTH=true`, `TFC_AWS_RUN_ROLE_ARN=<tfc_role_arn output>`) |
+
+The two workspaces deliberately have non-overlapping working directories.
+A change under `infra/terraform/apex/` triggers `pfv-apex` only; a change
+under `infra/terraform/main.tf` triggers `pfv` only. State is isolated.
+
+## DNS
+
+The apex moved to Route 53 with PR #240 (L5.2a). The app subdomain stays
+on Cloudflare because it terminates origin TLS and proxies through to DO
+App Platform's ingress. Mixed-zone setup is intentional, not transitional.
+
+| Hostname | Authoritative DNS | Behind | Notes |
+|---|---|---|---|
+| `thebetterdecision.com` (apex) | Route 53 | CloudFront -> S3 | A ALIAS to CloudFront lands in PR-D. Until then, apex is parked. |
+| `www.thebetterdecision.com` | Route 53 | CloudFront -> S3 | CloudFront Function 301-redirects to apex. |
+| `app.thebetterdecision.com` | Cloudflare | DO App Platform ingress | PRIMARY domain declared in `.do/app.yaml`. Cloudflare origin TLS handshake assumes this stays declared on the App Platform side; do not strip it from the spec. |
+| `m.thebetterdecision.com` | Cloudflare | Mailgun EU | Outbound email only. |
+
+Cloudflare was dropped from the apex (and only the apex) when L5.2a
+shipped. It is NOT gone from the project.
+
+## Apex landing (AWS)
+
+Static-export marketing site at `https://thebetterdecision.com` and
+`https://www.thebetterdecision.com`. Built by the Next.js apex export
+(`out-apex/`), synced to S3 by GitHub Actions, served by CloudFront.
+
+```mermaid
+flowchart LR
+    user([User browser])
+    r53[Route 53<br/>A ALIAS]
+    cfd[CloudFront distribution<br/>HTTPS only, HSTS, security headers<br/>viewer-request function: www->apex, dir-index rewrite]
+    acm[ACM certificate<br/>us-east-1<br/>apex + www, DNS validated]
+    s3[(S3 bucket<br/>private, OAC, versioned, SSE-S3)]
+
+    subgraph oidc[IAM OIDC]
+        gh_role[github-actions-apex-deploy<br/>sub: refs/heads/main only]
+        tfc_role[tfc-apex-provisioner<br/>scoped to apex resources]
+    end
+
+    gha[GitHub Actions<br/>deploy workflow]
+    tfc[Terraform Cloud<br/>FlamaCorp/pfv-apex]
+
+    user --> r53 --> cfd
+    cfd -. attaches .-> acm
+    cfd -->|OAC sigv4| s3
+    gha -->|AssumeRoleWithWebIdentity| gh_role
+    gh_role -->|s3 sync + invalidate| s3
+    gh_role -->|invalidate| cfd
+    tfc -->|workload identity| tfc_role
+    tfc_role -.->|manages| cfd
+    tfc_role -.->|manages| s3
+    tfc_role -.->|manages| acm
+```
+
+### Stack
+
+| Resource | Notes |
+|---|---|
+| `aws_s3_bucket` | Private (all four public-access-block flags on), versioned, SSE-S3, lifecycle expires noncurrent versions after 90 days. |
+| `aws_cloudfront_distribution` | `PriceClass_100` (NA + EU PoPs), HTTP/2 + HTTP/3, IPv6 on. CachingOptimized managed cache policy (hashed asset filenames are the cache-busting key). |
+| `aws_cloudfront_origin_access_control` | OAC, not legacy OAI. SigV4 to the bucket. |
+| `aws_cloudfront_function` | Viewer-request: www -> apex 301 redirect (runs first), then S3 directory-index rewrite (`/privacy/` -> `/privacy/index.html`). |
+| `aws_cloudfront_response_headers_policy` | HSTS (`max-age=63072000; includeSubDomains; preload`), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy`. CSP deferred to PR-C. |
+| `aws_acm_certificate` | In `us-east-1`. CloudFront's API requires viewer-attached certs to live in `us-east-1` regardless of where the origin sits (see `infra/terraform/apex/providers.tf` for the alias-provider rationale). DNS validated. |
+| `aws_route53_record.apex_acm_validation` | ACM `_<token>.<domain>` validation CNAMEs in the existing zone. Does NOT touch the apex A record. |
+| `aws_iam_openid_connect_provider.github` | GitHub Actions OIDC trust. SHA-1 thumbprint computed at plan time via `tls_certificate` data source (AWS does not auto-rotate OIDC thumbprints). |
+| `aws_iam_openid_connect_provider.tfc` | Terraform Cloud workload identity trust. Same thumbprint pattern. |
+| `aws_iam_role.github_actions_apex_deploy` | Trust pinned via `StringEquals` to `repo:flamarion/pfv:ref:refs/heads/main`. PR-context tokens have a different `sub` and are rejected at the trust level (workflow `if:` guards alone are insufficient because PR authors can edit the workflow). Permissions scoped to this bucket + this distribution only. |
+| `aws_iam_role.tfc_apex_provisioner` | Trust pinned to `FlamaCorp` org + `pfv-apex*` workspace pattern. Manages apex bucket + distribution + ACM cert + IAM role chain. Route 53 is read-only except for CNAME writes (IAM-enforced via `route53:ChangeResourceRecordSetsRecordTypes` condition); apex A record writes widen in PR-D. |
+
+### Why `us-east-1` for ACM
+
+CloudFront requires viewer certs in `us-east-1`. The bucket is in
+`var.aws_region` (default `eu-central-1`), but the cert provider in
+`apex/providers.tf` uses the `aws.us_east_1` alias for the certificate
+resource only. No other resource is pinned to that region.
+
+### Why a separate TFC workspace
+
+`FlamaCorp/pfv-apex` is split from `FlamaCorp/pfv` because:
+
+- Different cloud (AWS vs DO) and different auth model (IAM OIDC vs DO
+  API token), so the workspace credentials don't overlap.
+- Smaller blast radius. An apex apply that breaks cannot affect MySQL or
+  the App Platform app, and vice versa.
+- The apex IAM role's permissions are tightly scoped; if everything sat
+  in one workspace those scopes would have to widen.
+- Independent run history makes apex incidents easier to triage on the
+  TFC timeline.
+
+### OIDC switchover
+
+The first `pfv-apex` apply needs static AWS credentials to bootstrap the
+OIDC providers themselves (the apex provisioner role doesn't exist
+until this module applies). The sequence:
+
+1. Create a short-lived `pfv-apex-bootstrap` IAM user with
+   `AdministratorAccess`. Set `AWS_ACCESS_KEY_ID` /
+   `AWS_SECRET_ACCESS_KEY` as sensitive env vars on the workspace.
+2. Run the first apply via TFC. Module creates both OIDC providers
+   (GitHub Actions, TFC), both roles (`github-actions-apex-deploy`,
+   `tfc-apex-provisioner`), and the S3 + CloudFront + ACM resources.
+3. Set `TFC_AWS_PROVIDER_AUTH=true` and
+   `TFC_AWS_RUN_ROLE_ARN=<tfc_role_arn output>` on the workspace.
+4. Delete `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the
+   workspace. Delete (or deactivate) the `pfv-apex-bootstrap` IAM user.
+5. Trigger an empty plan to confirm TFC reaches AWS via OIDC.
+
+Full bootstrap detail (including the rationale for path B over a
+manual-OIDC-first path A) lives in `infra/terraform/apex/README.md`.
+
+### Cross-link
+
+`infra/terraform/apex/README.md` is the canonical reference for:
+
+- Bootstrap path (above) with the full owner-side checklist.
+- Per-resource IAM scoping rationale.
+- S3 directory-index handling behaviour matrix (URL -> expected response).
+- Security notes (least privilege, OIDC thumbprint rotation, OAC vs OAI,
+  header rationale).
+- Module layout and rollback path.
+- Cost breakdown (currently ~$1.10/mo new spend).
+
+## DO App Platform
+
+The `pfv` app fronts the live application. App ID and database IDs
+shouldn't really be repeated outside of `reference_digitalocean.md`, but
+the public-facing identifiers below are useful for operators reading this
+file alone.
+
+- **App URL:** `https://app.thebetterdecision.com`
+- **DO-issued URL:** `https://pfv-xccvs.ondigitalocean.app` (still works,
+  redirects)
+- **App ID:** `3bcf70e8-2bae-4918-8297-ce430c79735e`
+- **DO project:** `pfv` (`5c404689-358b-42c5-a8e2-f48a304d8298`)
+- **Region:** `ams3`
+- **VPC attachment:** `694e9d40-a08d-486a-becb-5d068e5ef5c5` (declared at
+  the top of `.do/app.yaml`, required for App Platform to reach
+  `pfv-data-01`'s private IPv4)
+
+### Components
+
+| Component | Kind | Source | Port | Instance | Notes |
+|---|---|---|---|---|---|
+| `backend` | service | `backend/` + `backend/Dockerfile` | 8000 | `basic-xxs` x 1 | FastAPI. Health probe `/health`. |
+| `frontend` | service | `frontend/` + `frontend/Dockerfile` | 3000 | `basic-xxs` x 1 | Next.js standalone build. Health probe `/health`. |
+| `migrate` | PRE_DEPLOY job | `backend/` + `backend/Dockerfile` | n/a | `basic-xxs` x 1 | `python /app/scripts/migrate.py`. Runs once per deploy before any backend replica starts (the canonical init-container pattern for App Platform). New revision is held back until the job exits 0, so a long migration never trips the backend's serving probe. Matching `initContainer` lives in the k8s/ Helm chart `templates/backend.yaml`. See `infra/MIGRATION.md` and the migrate wrapper at `backend/scripts/migrate.py`. |
+
+### Ingress
+
+App Platform handles routing; nginx (used in dev) is not in the prod path.
+
+- `/api/*`, `/health`, `/ready` -> `backend` (with `preserve_path_prefix:
+  true`)
+- `/` (everything else) -> `frontend`
+
+### Secrets
+
+Encrypted (`EV[...]`) directly in `.do/app.yaml`. The encryption is
+per-app, the blobs are unreadable outside DO, and they MUST be committed
+because `app_spec_location: .do/app.yaml` means the deploy workflow pushes
+the entire spec on every deploy. A missing SECRET disappears from the
+live app on the next push (see the 2026-04-25 incident note in
+`.do/app.yaml`).
+
+The currently bound secrets are `DATABASE_URL`, `REDIS_URL`,
+`JWT_SECRET_KEY`, `MFA_ENCRYPTION_KEY`, `MAILGUN_API_KEY`,
+`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`. `ENVIRONMENT.md` is the
+authoritative per-var reference.
+
+### Deployment
+
+Deploys go through GitHub Actions (`.github/workflows/deploy.yml`) on
+merge to `main`. `deploy_on_push` is set to `false` in DO so the spec
+push is exclusively driven by the workflow. See `DEPLOYMENT.md` for the
+full walkthrough.
+
+## DO data droplet (`pfv-data-01`)
+
+Self-hosted MySQL + Valkey on a single DigitalOcean droplet, replacing
+the DO Managed MySQL + Managed Redis pair (~$30/mo) with one
+`s-1vcpu-2gb` droplet (~$12/mo). DO droplet snapshots are off; the
+nightly mysqldump cron is the durability floor.
+
+- **Region:** `ams3`
+- **VPC:** `10.42.0.0/24` (Terraform-managed)
+- **Engines:** MySQL 8 (`:3306`), Valkey 8 (`:6379`, drop-in Redis
+  replacement)
+- **Firewall:** single layer, DO cloud firewall `pfv-data-fw`
+  (id `cd1f4b10-d9e4-48ca-83cd-2d75ab815bce`). UFW on the host is
+  intentionally **disabled** as of PR #260. The previous two-layer
+  setup (UFW + cloud firewall) was suspected of silent drops during
+  VPC NAT translation; consolidating to one layer resolved the issue.
+  The Ansible `common` role keeps UFW disabled idempotently.
+- **Backups:** nightly `mysqldump` on the droplet
+  (`/var/backups/mysql/`, log at `/var/log/mysql-backup.log`).
 
 ```
                      ┌────────────────────────────┐
-                     │  DO App Platform (ams)     │
-                     │   pfv backend / frontend   │
+                     │  DO App Platform (ams3)    │
+                     │   backend + frontend       │
                      └──────────────┬─────────────┘
-                                    │ VPC peering
+                                    │ VPC private IPv4
                                     ▼
               VPC 10.42.0.0/24 ┌────────────────────────────┐
                                │  pfv-data-01 (s-1vcpu-2gb) │
                                │   - MySQL 8 (3306)         │
-                               │   - Redis  (6379)          │
-                               │   - ufw + fail2ban         │
+                               │   - Valkey 8 (6379)        │
+                               │   - cloud FW pfv-data-fw   │
                                │   - nightly mysqldump      │
                                └────────────────────────────┘
                                     ▲
-                                    │ SSH (key auth) — public IPv4
+                                    │ SSH (key auth), public IPv4
                                     │
                                   operator
 ```
 
-DO Cloud Firewall: SSH 22 from any IPv4, MySQL 3306 + Redis 6379 from VPC CIDR
-only. ICMP from VPC. ufw on the host repeats the same restrictions.
+DO Cloud Firewall: SSH 22 from any IPv4, MySQL 3306 + Valkey 6379 from
+VPC CIDR only. ICMP from VPC.
 
-## Prerequisites
+## Prerequisites (DO side, `FlamaCorp/pfv`)
 
-- A DO API token with read/write scope. In normal operation it lives as the
-  `do_token` workspace variable in TFC (`FlamaCorp/pfv`); local CLI debug
-  runs against the same workspace need `TF_VAR_do_token` (or a gitignored
+- A DO API token with read/write scope. In normal operation it lives as
+  the `do_token` workspace variable in TFC; local CLI debug runs against
+  the same workspace need `TF_VAR_do_token` (or a gitignored
   `terraform.tfvars`).
-- An SSH key already registered in DO (Settings -> Security). Note its name.
+- An SSH key already registered in DO (Settings -> Security). Note its
+  name.
 - A DO project named `pfv` (or change `project_name`). Projects must be
-  created from the UI or `doctl` first; we don't manage them in Terraform.
-- Local tooling: `terraform >= 1.5`, `ansible >= 2.16`, `doctl` (optional but
-  handy for sanity checks).
+  created from the UI or `doctl` first; Terraform does not manage them.
+- Local tooling: `terraform >= 1.5`, `ansible >= 2.16`, `doctl`
+  (optional, useful for sanity checks).
 
-## Step-by-step
+## Step-by-step (data droplet)
 
 ### 1. Provision (Terraform Cloud)
 
-State and runs live in Terraform Cloud, workspace `FlamaCorp/pfv`, VCS-driven
-against this repo with the working directory and trigger paths both scoped to
-`infra/terraform/`. Workflow:
+State and runs live in Terraform Cloud, workspace `FlamaCorp/pfv`,
+VCS-driven against this repo with the working directory and trigger
+paths both scoped to `infra/terraform/` (the apex workspace handles
+`infra/terraform/apex/**` independently). Workflow:
 
-1. Open a PR that touches `infra/terraform/**`. TFC posts a speculative plan
-   on the run page.
-2. Merge to `main`. TFC starts an apply run. Apply method is **manual confirm**
-   on the TFC UI for now (flip to auto-apply after a few clean cycles).
+1. Open a PR that touches `infra/terraform/**` (outside `apex/`). TFC
+   posts a speculative plan on the run page.
+2. Merge to `main`. TFC starts an apply run. Apply method is **manual
+   Confirm & Apply** on the TFC UI.
 
 The workspace expects two variables to be set ahead of time:
 
-- `do_token` — sensitive, the DO API token (scoped per `infra/README.md`).
-- `ssh_key_name` — plaintext, the name of an SSH key already registered in DO.
+- `do_token` (sensitive): the DO API token.
+- `ssh_key_name` (plaintext): the name of an SSH key already registered
+  in DO.
 
-After the apply succeeds, fetch the outputs from TFC (Workspace -> Outputs)
-or via the CLI once `terraform login` is configured locally:
+After the apply succeeds, fetch the outputs from TFC (Workspace ->
+Outputs) or via the CLI once `terraform login` is configured locally:
 
 ```bash
 terraform -chdir=infra/terraform output droplet_public_ipv4
@@ -77,10 +357,11 @@ terraform -chdir=infra/terraform output droplet_private_ipv4
 terraform -chdir=infra/terraform output -raw vpc_id
 ```
 
-Local-CLI runs against the same workspace work too; `terraform login` once,
-then `terraform plan` reaches the remote state. `terraform.tfvars` is for
-local runs only and stays gitignored. The `.terraform.lock.hcl` IS committed
-so TFC and laptops resolve identical provider versions.
+Local-CLI runs against the same workspace work too; `terraform login`
+once, then `terraform plan` reaches the remote state.
+`terraform.tfvars` is for local runs only and stays gitignored. The
+`.terraform.lock.hcl` IS committed so TFC and laptops resolve identical
+provider versions.
 
 ### 2. Configure (Ansible)
 
@@ -96,7 +377,7 @@ $EDITOR inventory.yml
 #   redis_password        = <generated>
 #
 # Note: we intentionally do NOT manage a password for root@localhost.
-# Ubuntu MySQL ships with auth_socket on root, and we keep that — local
+# Ubuntu MySQL ships with auth_socket on root, and we keep that. Local
 # maintenance is `sudo mysql`. Cron mysqldump uses the dedicated
 # mysql_backup user via /root/.my.cnf.
 
@@ -104,9 +385,9 @@ ansible-galaxy collection install -r requirements.yml
 ansible-playbook playbooks/site.yml
 ```
 
-Recommended: `ansible-vault encrypt_string` the three passwords or move them
-into a vault-encrypted vars file. `inventory.yml` is gitignored to keep
-plain-text creds out of the repo even by accident.
+Recommended: `ansible-vault encrypt_string` the three passwords or move
+them into a vault-encrypted vars file. `inventory.yml` is gitignored to
+keep plain-text creds out of the repo even by accident.
 
 ### 3. Wire App Platform
 
@@ -119,28 +400,109 @@ REDIS_URL=redis://default:<password>@<droplet_private_ipv4>:6379/0
 
 See `MIGRATION.md` for the full data-move runbook (including rollback).
 
+## OIDC overview
+
+Two OIDC trust relationships live in the apex AWS account:
+
+- **GitHub Actions -> AWS**: `github-actions-apex-deploy` is assumable
+  only by `flamarion/pfv` workflow runs whose token `sub` is exactly
+  `repo:flamarion/pfv:ref:refs/heads/main`. PR-context tokens have a
+  different `sub` and are rejected at the trust level, not just by
+  workflow-level `if:` guards. Scope: `s3:Put/Delete/List` on the apex
+  bucket and `cloudfront:CreateInvalidation` on the apex distribution.
+- **Terraform Cloud -> AWS**: `tfc-apex-provisioner` is assumable only
+  by TFC runs in `FlamaCorp/pfv-apex*` workspaces (any phase). Scope:
+  the apex resource graph (S3 bucket, CloudFront distribution, ACM in
+  `us-east-1`, the two IAM OIDC providers, the two IAM roles, Route 53
+  read-only plus CNAME-only writes for ACM validation).
+
+DO-side (`FlamaCorp/pfv`) does NOT use OIDC; it uses a long-lived
+`do_token` workspace variable. DO Terraform Cloud OIDC for the DO
+provider is not currently supported, so static-token auth is the path
+there until further notice.
+
+Full IAM trust-policy / scoping detail lives in
+`infra/terraform/apex/README.md`. The bootstrap-to-OIDC switchover
+sequence above is the operator-side summary; the apex README documents
+why path B (static-key bootstrap then flip) won over path A (manual
+console OIDC setup).
+
 ## Day-2
 
-- **Inspect droplet metrics**: DO control panel -> Droplets -> pfv-data-01 ->
-  Graphs. CPU, memory, disk, and network are graphed for free.
-- **Watch backups**: `ls -lh /var/backups/mysql/` on the droplet. Logs at
-  `/var/log/mysql-backup.log`.
-- **Apply OS updates**: unattended-upgrades runs daily; reboots are manual.
-  `sudo apt update && sudo apt upgrade && sudo reboot` during a quiet window.
+### Apex landing
+
+- **Verify**: browse the CloudFront-assigned `dXXX.cloudfront.net`
+  hostname (output `cloudfront_distribution_domain`). Until PR-D
+  flips the apex A record, this is the only way to see the live
+  distribution.
+- **Invalidate cache**: GitHub Actions workflow invalidates on every
+  deploy. Manual: `aws cloudfront create-invalidation
+  --distribution-id <id> --paths '/*'`.
+- **Cert rotation**: ACM auto-renews; DNS validation records stay in
+  the zone permanently.
+- **Cost**: ~$1.10/mo at current traffic.
+
+### DO App Platform
+
+- **Logs**: DO control panel -> Apps -> pfv -> Runtime Logs (per
+  component) or `doctl apps logs <APP_ID> <component>`.
+- **Deploys**: GitHub Actions `deploy.yml`. Manual fallback `doctl apps
+  update <APP_ID> --spec .do/app.yaml`, but the GH Action is the
+  documented path; see `reference_do_spec_sync.md` for the
+  `app_action/deploy@v2` gotcha that mandates `app_spec_location`.
+
+### Data droplet
+
+- **Inspect droplet metrics**: DO control panel -> Droplets ->
+  pfv-data-01 -> Graphs. CPU, memory, disk, network all graphed for
+  free.
+- **Watch backups**: `ls -lh /var/backups/mysql/` on the droplet. Logs
+  at `/var/log/mysql-backup.log`.
+- **Apply OS updates**: unattended-upgrades runs daily; reboots are
+  manual. `sudo apt update && sudo apt upgrade && sudo reboot` during
+  a quiet window.
 - **Rotate creds**: re-run the playbook with new vault values; restart
   services as the handlers fire.
 
 ## Teardown
 
+### Apex (`FlamaCorp/pfv-apex`)
+
+Every resource in the apex module is `terraform destroy`-able. Removing
+the module leaves no Route 53 apex-A change behind (PR-A never wrote one
+in the first place; the apex A swap lives in PR-D). ACM validation
+CNAMEs are deleted with the cert. Path: open a PR removing the
+resources, merge, Confirm & Apply in TFC. Or queue a Destroy plan from
+the TFC workspace UI.
+
+### Data droplet (`FlamaCorp/pfv`)
+
 Terraform is VCS-driven via TFC; teardown follows the same path. Either:
 
 - Open a PR that removes (or comments out) the droplet / VPC / firewall
-  resources in `infra/terraform/`. Merge it and run the apply via the TFC
-  UI (Confirm & Apply), same as any other infra change.
+  resources in `infra/terraform/`. Merge it and run the apply via the
+  TFC UI (Confirm & Apply), same as any other infra change.
 - Or, for a one-shot destroy, queue a `Destroy plan` from the TFC
   workspace UI and approve it. Local `terraform destroy` is debug-only.
 
-Warning: this destroys the droplet and its data. DO droplet snapshots are
-disabled at the IaC level, so the only durability floor is the nightly
-`mysqldump` on the droplet — pull a final dump (see `MIGRATION.md` for the
-command and the verify step) before queuing the destroy.
+Warning: this destroys the droplet and its data. DO droplet snapshots
+are disabled at the IaC level, so the only durability floor is the
+nightly `mysqldump` on the droplet. Pull a final dump (see
+`MIGRATION.md` for the command and the verify step) before queuing the
+destroy.
+
+## See also
+
+- `infra/terraform/apex/README.md`: apex AWS workspace bootstrap,
+  per-resource IAM scoping, security notes, behaviour matrix.
+- `infra/MIGRATION.md`: managed-MySQL+Redis to droplet cutover (already
+  executed; kept as the reference writeup).
+- `ENVIRONMENT.md` (repo root): authoritative per-env-var reference for
+  every component.
+- `DEPLOYMENT.md` (repo root): GitHub Actions deploy walkthrough.
+- `~/.claude/projects/-Users-fjorge-src-pfv/memory/reference_digitalocean.md`:
+  DO IDs, gotchas, and operational lore.
+- `~/.claude/projects/-Users-fjorge-src-pfv/memory/project_apex_s3_cloudfront.md`:
+  L5.2a direction lock and decision log.
+- `~/.claude/projects/-Users-fjorge-src-pfv/memory/feedback_terraform_vcs_only.md`:
+  Terraform is VCS-driven; CLI is debug-only.

--- a/infra/README.md
+++ b/infra/README.md
@@ -107,8 +107,8 @@ App Platform's ingress. Mixed-zone setup is intentional, not transitional.
 
 | Hostname | Authoritative DNS | Behind | Notes |
 |---|---|---|---|
-| `thebetterdecision.com` (apex) | Route 53 | CloudFront -> S3 | A ALIAS to CloudFront lands in PR-D. Until then, apex is parked. |
-| `www.thebetterdecision.com` | Route 53 | CloudFront -> S3 | CloudFront Function 301-redirects to apex. |
+| `thebetterdecision.com` (apex) | Route 53 | CloudFront -> S3 | A and AAAA ALIAS records to CloudFront land in PR-D. Until then, apex is parked. |
+| `www.thebetterdecision.com` | Route 53 | CloudFront -> S3 | A and AAAA ALIAS records to the same CloudFront distribution land in PR-D. Until then, `www` is parked too. CloudFront Function 301-redirects www traffic to apex after the TLS handshake. |
 | `app.thebetterdecision.com` | Cloudflare | DO App Platform ingress | PRIMARY domain declared in `.do/app.yaml`. Cloudflare origin TLS handshake assumes this stays declared on the App Platform side; do not strip it from the spec. |
 | `m.thebetterdecision.com` | Cloudflare | Mailgun EU | Outbound email only. |
 


### PR DESCRIPTION
## Why now

CI/CD surface keeps growing. We have `test.yml`, `release.yml`, `deploy.yml`, the in-flight `apex-deploy.yml` (PR #267), two TFC workspaces, the PRE_DEPLOY migrate job, and the local `./pfv` CLI all in active use. A new contributor cannot reason about "what happens when I push my code" from the YAML files alone. This PR centralizes that.

Three coordinated changes; each file scoped tightly so reviews stay tractable.

## What changed

### `DEPLOYMENT.md` (new file)

A single authoritative reference for every CI/CD path. 11 sections, 8 Mermaid diagrams. Covers:

- PR lifecycle (`test.yml`)
- Backend + Frontend production deploy (`release.yml` + DO App Platform + PRE_DEPLOY migrate + smoke tests)
- Manual deploy escape hatch (`deploy.yml`)
- Apex landing deploy (`apex-deploy.yml`, marked as landing with PR #267)
- Two TFC workspaces (`FlamaCorp/pfv` data droplet, `FlamaCorp/pfv-apex` AWS apex)
- Database migrations (three callers, one wrapper, structured events)
- What-triggers-what decision tree
- Rollback playbook per pipeline
- Where to look when something breaks

Diagrams use `flowchart` for topology / decision trees and `sequenceDiagram` for time-ordered flows (release gate ordering, apex sync order, migration callers).

### `CONTRIBUTING.md` (refresh in place)

Tightened from 30.2KB to 20.3KB by replacing aging directory dumps with cross-links to authoritative sources (`ENVIRONMENT.md`, `DEPLOYMENT.md`, the live file tree). New content:

- 30-minute Quickstart from `git clone` to first PR
- Conventional Commits and the deploy gate (the non-obvious one: `chore:` / `docs:` / `refactor:` / `test:` / `style:` do NOT trigger a release; `feat:` / `fix:` / `perf:` do)
- CI on your PR vs CI after merge (distinguishes `test.yml` from `release.yml`, pre-references the upcoming `apex-deploy.yml`)
- Working in parallel agent sessions (`-p team-<name>` rule from the shared MySQL volume incident)
- Your first PR decision tree (Mermaid, the only one in this file, load-bearing for "what should I run for this kind of change")

### `infra/README.md` (refresh in place)

146 to 508 lines. Added the L5.2a apex AWS infrastructure that just shipped, plus a topology Mermaid making the AWS / DigitalOcean boundary explicit. New sections:

- TFC workspaces table (`FlamaCorp/pfv` for data droplet on DO, `FlamaCorp/pfv-apex` for AWS apex; both manual Confirm and Apply)
- Apex landing (AWS) section: S3 + CloudFront + ACM (us-east-1, hard AWS constraint) + IAM OIDC for both GitHub Actions and TFC
- OIDC overview (cross-links to the bootstrap detail in `infra/terraform/apex/README.md`)

Refreshed the existing DO App Platform, data droplet, and DNS sections to reflect 2026-05 reality: cloud-FW-only on the data droplet (UFW disabled per PR #260), `app.thebetterdecision.com` still on Cloudflare while the apex moved to Route 53 + AWS.

## Style + house rules

- No em-dashes anywhere (project rule)
- No AI attribution in content
- No "Test plan" sections
- Mermaid blocks per https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams

## Sequencing note

The apex deploy section in `DEPLOYMENT.md` describes the target state including `apex-deploy.yml` from PR #267. That PR is in flight as of this writing. The doc explicitly marks the apex pipeline as "lands with PR #267" so a contributor reading today does not get confused. After PR #267 merges, no doc edit is needed.

## Follow-ups noted in the docs (not blocking)

- CloudFront access logging is not currently enabled on the apex distribution. Documented as a post-launch follow-up; the `Where to look` table points operators at AWS console -> CloudFront -> Monitoring until then.
- The two-pipeline path-filter design (release.yml negations + apex-deploy.yml positives) is described in DEPLOYMENT.md's decision tree section. There is no automated drift-detection between them; agent 1 noted that as a possible future linter or comment-block-comment.

## Verification

- All three files: zero em-dashes, zero TBD markers, zero AI attribution.
- DEPLOYMENT.md: 643 lines, 8 Mermaid blocks (5 flowchart, 3 sequenceDiagram).
- CONTRIBUTING.md: 409 lines (down from 30.2KB / 1085 lines), 1 Mermaid block (the first-PR decision tree).
- infra/README.md: 508 lines (up from 146), 2 Mermaid topology flowcharts.