### PR TITLE
feat(infra): apex DNS cutover (L5.2a PR-D)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 Audience: a contributor who just cloned the repo and wants to understand what happens between `git push` and a live change at `app.thebetterdecision.com` or `thebetterdecision.com`. Also a triage reference for CI/CD failures.
 
-All four pipelines described here are live on `main` today (`test.yml`, `release.yml`, `deploy.yml`, `apex-deploy.yml`). The apex pipeline ships content to S3 + CloudFront, but the apex DNS swap (PR-D, see Section 5) is still pending; until it lands, the apex landing is reachable only via the CloudFront-assigned hostname, not via `https://thebetterdecision.com`.
+All four pipelines described here are live on `main` today (`test.yml`, `release.yml`, `deploy.yml`, `apex-deploy.yml`). The apex landing is public at `https://thebetterdecision.com` (and `https://www.thebetterdecision.com`, which 301-redirects to the apex).
 
 For "how do I get my code ready to push", read [`CONTRIBUTING.md`](./CONTRIBUTING.md). For the env var matrix, read [`ENVIRONMENT.md`](./ENVIRONMENT.md). For the managed-to-droplet data move, read [`infra/MIGRATION.md`](./infra/MIGRATION.md). This file does not duplicate any of them.
 
@@ -13,7 +13,7 @@ Four production surfaces. Each has its own pipeline. Some changes fan out across
 | Surface | URL | Hosted by | Updated by |
 |---|---|---|---|
 | App (FastAPI + Next.js dashboard) | `https://app.thebetterdecision.com` | DigitalOcean App Platform (`pfv` app) | `release.yml` (auto) or `deploy.yml` (manual) |
-| Apex landing (marketing, privacy, terms, docs) | `https://thebetterdecision.com` (DNS pending PR-D) | AWS S3 + CloudFront | `apex-deploy.yml` (auto) |
+| Apex landing (marketing, privacy, terms, docs) | `https://thebetterdecision.com` | AWS S3 + CloudFront | `apex-deploy.yml` (auto) |
 | Data plane (MySQL 8 + Redis) | private VPC IP `10.42.x.x:3306 / :6379` | Self-hosted DO droplet `pfv-data-01` | TFC workspace `FlamaCorp/pfv` (manual confirm) |
 | Apex CDN + cert + IAM | n/a (control plane) | AWS (S3, CloudFront, ACM, IAM, Route 53) | TFC workspace `FlamaCorp/pfv-apex` (manual confirm) |
 
@@ -222,7 +222,7 @@ For rollback to a prior `main` SHA, see Section 10.
 
 ## 5. Apex landing deploy (`apex-deploy.yml`)
 
-> Workflow is live on `main` (shipped in PR #267). It deploys to S3 + CloudFront on every push to `main` whose paths match the filter below. The apex hostname `https://thebetterdecision.com` is not wired to DNS yet (that lands with PR-D); until then, verify deploys against the CloudFront-assigned hostname from the TFC output `cloudfront_distribution_domain`.
+> Workflow is live on `main` (shipped in PR #267). It deploys to S3 + CloudFront on every push to `main` whose paths match the filter below. Public traffic reaches the distribution via the apex / www ALIAS records provisioned by PR #270.
 
 The apex landing (`thebetterdecision.com`) is a Next.js static export. `frontend/scripts/build-apex.sh` produces `frontend/out-apex/`. The workflow uploads that directory to an S3 bucket fronted by CloudFront in AWS, using **GitHub OIDC** to assume an IAM role (no long-lived AWS keys committed anywhere). The bucket, distribution, ACM cert, and IAM roles are provisioned by the `FlamaCorp/pfv-apex` TFC workspace (Section 7).
 
@@ -338,15 +338,14 @@ The OIDC trust policy on `github-actions-apex-deploy` (provisioned by PR #240) u
 ### How to verify an apex deploy
 
 1. Watch the workflow run: `https://github.com/flamarion/pfv/actions/workflows/apex-deploy.yml`
-2. Curl `/_meta.json` to confirm the deployed commit SHA. The object is set to `no-cache` so this is always fresh.
-   - **Pre-PR-D (today):** apex DNS is not wired yet. Use the CloudFront-assigned hostname from the TFC output `cloudfront_distribution_domain`:
-     ```bash
-     curl -fsS https://<distribution>.cloudfront.net/_meta.json
-     ```
-   - **Post-PR-D:** apex DNS resolves to CloudFront. The canonical command:
-     ```bash
-     curl -fsS https://thebetterdecision.com/_meta.json
-     ```
+2. Confirm the deployed commit SHA via `/_meta.json` (object is `no-cache`, so the response is always fresh):
+   ```bash
+   curl -fsS https://thebetterdecision.com/_meta.json
+   ```
+   If the apex hostname is unreachable for any reason (incident, DNS misconfiguration), the same probe works against the CloudFront-assigned hostname from the TFC output `cloudfront_distribution_domain`:
+   ```bash
+   curl -fsS https://<distribution>.cloudfront.net/_meta.json
+   ```
 3. CloudFront invalidation status: AWS console -> CloudFront -> Distributions -> select -> Invalidations tab.
 
 ## 6. Terraform: `FlamaCorp/pfv` (DO data droplet)
@@ -405,7 +404,7 @@ Separate TFC workspace because the auth path is different (AWS OIDC rather than 
 | `aws_cloudfront_function` | Viewer-request: www -> apex 301 redirect, then S3 directory-index rewrite (`/privacy/` -> `/privacy/index.html`) |
 | `aws_cloudfront_response_headers_policy` | HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy |
 | `aws_acm_certificate` + `_validation` | DNS-validated cert in `us-east-1` for apex + www (CloudFront requirement) |
-| `aws_route53_record.apex_acm_validation` | ACM `_<token>` CNAME records in the existing zone (does **not** touch the apex A record until PR-D of the L5.2a sequence) |
+| `aws_route53_record.apex_acm_validation` | ACM `_<token>` CNAME records in the existing zone (separate from the apex / www A + AAAA ALIAS records, which are also managed by this module). |
 | `aws_iam_openid_connect_provider.github` | Trust for GitHub Actions OIDC tokens |
 | `aws_iam_openid_connect_provider.tfc` | Trust for Terraform Cloud workload-identity tokens |
 | `aws_iam_role.github_actions_apex_deploy` | Deploy role: `s3:PutObject`/`s3:DeleteObject`/`s3:ListBucket` scoped to the apex bucket; `cloudfront:CreateInvalidation` scoped to the apex distribution |
@@ -445,9 +444,8 @@ After bootstrap, TFC runs use workload identity. Long-lived AWS keys exist nowhe
 
 ### What this workspace does **not** do
 
-- It does **not** swap the apex `A` ALIAS to CloudFront. That is PR-D of the L5.2a sequence; until then the apex stays parked.
 - It does **not** manage the dashboard surface (`app.thebetterdecision.com`). That DNS lives on Cloudflare and points at App Platform.
-- It is read-only on Route 53, except for ACM validation **CNAME** writes scoped by IAM condition. Apex `A` record writes are IAM-blocked, not just code-discipline blocked.
+- Route 53 writes are split into two narrowly-scoped IAM statements: `A` and `AAAA` on exactly the apex and www FQDNs, and `CNAME` on the exact ACM validation names exposed by `aws_acm_certificate.apex.domain_validation_options`. Every other record type and every other name in the zone is IAM-blocked.
 
 ## 8. Database migrations
 
@@ -642,7 +640,7 @@ Triage shortcuts:
 | Merge to `main` happened, prod didn't update | `release.yml` -> did `release` job set `new_release_published=true`? Conventional commit type may be `chore` |
 | Deploy went green, app still broken | Smoke-test job output, then DO Runtime Logs on the failing component |
 | Migrate job hung or failed | DO Activity -> latest deploy -> migrate job. Grep for `migrate.start`, `migrate.failed`, `migrate.step.start`. Multi-head? Driver error? |
-| Apex site shows stale content | Confirm `apex-deploy.yml` ran for the SHA; check CloudFront invalidation completed; `curl /_meta.json` (must be no-cache). Pre-PR-D, hit the CloudFront-assigned hostname from TFC output `cloudfront_distribution_domain`; post-PR-D, hit `https://thebetterdecision.com/_meta.json` |
+| Apex site shows stale content | Confirm `apex-deploy.yml` ran for the SHA; check CloudFront invalidation completed; `curl https://thebetterdecision.com/_meta.json` (object is no-cache). If the apex hostname is itself unreachable, fall back to the TFC output `cloudfront_distribution_domain` to probe the distribution directly. |
 | Apex 404 on a known route | The CloudFront Function rewrites `/path/` -> `/path/index.html`. Check the function's invocation logs in CloudFront Functions console |
 | Apex deploy failed at OIDC step | Trust policy on `github-actions-apex-deploy` pinned to `repo:flamarion/pfv:ref:refs/heads/main`. PR-context, forks, non-main branches are rejected by design |
 | App can't reach MySQL or Redis | Confirm `.do/app.yaml`'s top-level `vpc.id` matches the TFC output, and `DATABASE_URL` / `REDIS_URL` point at the droplet's `10.42.x.x` private IP |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -426,7 +426,7 @@ flowchart LR
   tfcapp --> hold[Waiting on Confirm and Apply]
   hold --> apply[Apply runs via OIDC -> tfc-apex-provisioner role]
   apply --> done[AWS resources updated]
-  apply -.->|outputs| consumers[github_actions_role_arn -> apex-deploy.yml<br/>s3_bucket_name -> apex-deploy.yml<br/>cloudfront_distribution_id -> apex-deploy.yml<br/>cloudfront_distribution_domain -> verify URL pre-cutover]
+  apply -.->|outputs| consumers[github_actions_role_arn -> apex-deploy.yml<br/>s3_bucket_name -> apex-deploy.yml<br/>cloudfront_distribution_id -> apex-deploy.yml<br/>cloudfront_distribution_domain -> diagnostic / fallback probe]
 ```
 
 ### Bootstrap (one-time)

--- a/infra/README.md
+++ b/infra/README.md
@@ -107,8 +107,8 @@ App Platform's ingress. Mixed-zone setup is intentional, not transitional.
 
 | Hostname | Authoritative DNS | Behind | Notes |
 |---|---|---|---|
-| `thebetterdecision.com` (apex) | Route 53 | CloudFront -> S3 | A and AAAA ALIAS records to CloudFront land in PR-D. Until then, apex is parked. |
-| `www.thebetterdecision.com` | Route 53 | CloudFront -> S3 | A and AAAA ALIAS records to the same CloudFront distribution land in PR-D. Until then, `www` is parked too. CloudFront Function 301-redirects www traffic to apex after the TLS handshake. |
+| `thebetterdecision.com` (apex) | Route 53 | CloudFront -> S3 | A + AAAA ALIAS records to CloudFront, provisioned by `infra/terraform/apex/main.tf`. |
+| `www.thebetterdecision.com` | Route 53 | CloudFront -> S3 | A + AAAA ALIAS records to the same CloudFront distribution. CloudFront viewer-request function 301-redirects www traffic to apex after the TLS handshake. |
 | `app.thebetterdecision.com` | Cloudflare | DO App Platform ingress | PRIMARY domain declared in `.do/app.yaml`. Cloudflare origin TLS handshake assumes this stays declared on the App Platform side; do not strip it from the spec. |
 | `m.thebetterdecision.com` | Cloudflare | Mailgun EU | Outbound email only. |
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -163,7 +163,7 @@ flowchart LR
 | `aws_iam_openid_connect_provider.github` | GitHub Actions OIDC trust. SHA-1 thumbprint computed at plan time via `tls_certificate` data source (AWS does not auto-rotate OIDC thumbprints). |
 | `aws_iam_openid_connect_provider.tfc` | Terraform Cloud workload identity trust. Same thumbprint pattern. |
 | `aws_iam_role.github_actions_apex_deploy` | Trust pinned via `StringEquals` to `repo:flamarion/pfv:ref:refs/heads/main`. PR-context tokens have a different `sub` and are rejected at the trust level (workflow `if:` guards alone are insufficient because PR authors can edit the workflow). Permissions scoped to this bucket + this distribution only. |
-| `aws_iam_role.tfc_apex_provisioner` | Trust pinned to `FlamaCorp` org + `pfv-apex*` workspace pattern. Manages apex bucket + distribution + ACM cert + IAM role chain. Route 53 is read-only except for CNAME writes (IAM-enforced via `route53:ChangeResourceRecordSetsRecordTypes` condition); apex A record writes widen in PR-D. |
+| `aws_iam_role.tfc_apex_provisioner` | Trust pinned to `FlamaCorp` org + `pfv-apex*` workspace pattern. Manages apex bucket + distribution + ACM cert + IAM role chain + Route 53 records. Route 53 writes are split into two narrow IAM statements (each pairs `route53:ChangeResourceRecordSetsRecordTypes` with `route53:ChangeResourceRecordSetsNormalizedRecordNames`): `A`/`AAAA` on exactly apex + www, and `CNAME` on the exact ACM validation names from `domain_validation_options`. Any other record type or name in the zone is IAM-blocked. |
 
 ### Why `us-east-1` for ACM
 
@@ -431,10 +431,11 @@ console OIDC setup).
 
 ### Apex landing
 
-- **Verify**: browse the CloudFront-assigned `dXXX.cloudfront.net`
-  hostname (output `cloudfront_distribution_domain`). Until PR-D
-  flips the apex A record, this is the only way to see the live
-  distribution.
+- **Verify**: browse `https://thebetterdecision.com/` (or its
+  `_meta.json` probe for a no-cache deploy-SHA echo). The
+  CloudFront-assigned `dXXX.cloudfront.net` hostname from output
+  `cloudfront_distribution_domain` remains available as a diagnostic
+  / fallback path when the apex hostname is itself unreachable.
 - **Invalidate cache**: GitHub Actions workflow invalidates on every
   deploy. Manual: `aws cloudfront create-invalidation
   --distribution-id <id> --paths '/*'`.
@@ -468,12 +469,14 @@ console OIDC setup).
 
 ### Apex (`FlamaCorp/pfv-apex`)
 
-Every resource in the apex module is `terraform destroy`-able. Removing
-the module leaves no Route 53 apex-A change behind (PR-A never wrote one
-in the first place; the apex A swap lives in PR-D). ACM validation
-CNAMEs are deleted with the cert. Path: open a PR removing the
-resources, merge, Confirm & Apply in TFC. Or queue a Destroy plan from
-the TFC workspace UI.
+Every resource in the apex module is `terraform destroy`-able. A full
+teardown removes the apex / www `A` + `AAAA` ALIAS records, the ACM
+validation CNAMEs, the bucket and distribution, the IAM roles, and the
+OIDC providers. The apex hosted zone is data-sourced, not managed, so
+it survives untouched. After teardown DNS for apex and www returns to
+"no answer", and a fresh apply recreates everything end to end. Path:
+open a PR removing the resources, merge, Confirm & Apply in TFC. Or
+queue a Destroy plan from the TFC workspace UI.
 
 ### Data droplet (`FlamaCorp/pfv`)
 

--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -5,11 +5,12 @@ infrastructure for the `thebetterdecision.com` apex marketing site.
 `app.thebetterdecision.com` stays on DigitalOcean App Platform. State and
 runs live in TFC; this directory holds the configuration.
 
-This is PR-A of the L5.2a apex split. **No Route 53 A-record changes are
-made here.** PR-D performs the apex `A` ALIAS swap to CloudFront after
-PR-B (GitHub Actions deploy workflow) and PR-C (Next.js static export)
-have landed and been validated against the CloudFront-assigned
-`dXXX.cloudfront.net` hostname.
+This module is the AWS side of the L5.2a apex split. It manages the S3
+bucket, CloudFront distribution, ACM cert in `us-east-1`, the two IAM
+OIDC providers (GitHub Actions + TFC), the apex-deploy and provisioner
+IAM roles, and the Route 53 records that point the apex hostnames at
+the distribution (`A` and `AAAA` ALIAS records for the apex and `www`,
+plus the ACM-emitted validation CNAMEs).
 
 ## Resources managed
 
@@ -47,19 +48,27 @@ Defaults for `aws_region`, `domain`, `github_repo`, `tfc_organization`,
 
 Read from TFC -> Workspace -> Outputs after apply.
 
-- `github_actions_role_arn` -> **PR-B** sets this as `role-to-assume` in
-  the `aws-actions/configure-aws-credentials` step of the deploy workflow.
-- `s3_bucket_name` -> **PR-B** uses for `aws s3 sync .out s3://<bucket>`.
-- `cloudfront_distribution_id` -> **PR-B** uses for
-  `aws cloudfront create-invalidation`. **PR-D** uses for the apex A
-  ALIAS target.
-- `cloudfront_distribution_domain` -> Pre-cutover verification URL.
-  Browse this `dXXX.cloudfront.net` hostname end-to-end before PR-D fires.
-- `cloudfront_distribution_hosted_zone_id` -> **PR-D** uses when
-  constructing the `aws_route53_record` apex A ALIAS.
-- `route53_zone_id` -> **PR-D** uses to target the apex zone.
-- `tfc_role_arn` -> Set as `TFC_AWS_RUN_ROLE_ARN` env variable in this
-  workspace after the bootstrap apply. Lets TFC drop static keys.
+- `github_actions_role_arn` -> the `apex-deploy.yml` workflow consumes
+  this as `role-to-assume` in `aws-actions/configure-aws-credentials`.
+  Surfaced to GitHub as the repo variable `AWS_APEX_DEPLOY_ROLE_ARN`.
+- `s3_bucket_name` -> consumed by the deploy workflow for
+  `aws s3 sync out-apex/ s3://<bucket>/`. GitHub variable
+  `AWS_APEX_BUCKET`.
+- `cloudfront_distribution_id` -> consumed by the deploy workflow for
+  `aws cloudfront create-invalidation`. GitHub variable
+  `AWS_APEX_DISTRIBUTION_ID`. Also the alias target referenced by the
+  apex/www ALIAS records.
+- `cloudfront_distribution_domain` -> the `dXXX.cloudfront.net`
+  hostname. Useful for diagnostics (pinging the distribution directly,
+  bypassing DNS) and as a fallback verification path during incidents.
+- `cloudfront_distribution_hosted_zone_id` -> referenced internally by
+  the apex/www ALIAS records (`alias.zone_id`). Stable AWS constant
+  (`Z2FDTNDATAQYW2`), exposed as an output for visibility.
+- `route53_zone_id` -> the apex hosted zone ID. Used by the validation
+  CNAMEs and the apex/www ALIAS records in this module.
+- `tfc_role_arn` -> set as `TFC_AWS_RUN_ROLE_ARN` env variable in the
+  `pfv-apex` workspace after the bootstrap apply. Lets TFC drop static
+  keys.
 
 ## Workflow
 
@@ -240,13 +249,19 @@ follow-up to the response-headers policy.
 
 ## Rollback
 
-Every resource in this module is `terraform destroy`-able. Removing the
-module leaves no Route 53 record changes behind (the apex A record is
-untouched). The ACM validation CNAMEs are deleted with the cert. If
-emergency teardown is needed during the bootstrap window, the owner can
-also destroy from CLI against the `pfv-apex` workspace (state lives in
-TFC, so `terraform login && terraform -chdir=infra/terraform/apex
-destroy` is sufficient).
+Every resource in this module is `terraform destroy`-able. A full
+teardown removes the apex / www ALIAS records, the ACM validation
+CNAMEs, the bucket and distribution, the IAM roles and OIDC providers.
+The apex hosted zone itself is data-sourced, not managed, so it
+survives untouched. After teardown DNS for the apex and www returns
+to "no answer", and rerunning a fresh apply recreates everything end
+to end.
+
+For a partial rollback that only undoes the DNS cutover (keeping the
+bucket / distribution / cert / roles intact so the apex-deploy
+pipeline keeps working against `cloudfront_distribution_domain`),
+revert PR-D via `git revert` and let TFC apply the inverse. The
+break-glass CLI path is documented in PR-D's PR body.
 
 ## Cost
 

--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -179,9 +179,11 @@ targets; apex has no such reuse story.
     - `A` and `AAAA` ALIAS writes are allowed ONLY on
       `thebetterdecision.com` and `www.thebetterdecision.com` (the
       apex / www CloudFront ALIASes).
-    - `CNAME` writes are allowed ONLY on names matching
-      `_*.thebetterdecision.com` or `_*.www.thebetterdecision.com` (the
-      ACM validation pattern).
+    - `CNAME` writes are allowed ONLY on the exact ACM validation
+      names derived from `aws_acm_certificate.apex.domain_validation_options`,
+      normalized to lowercase and no trailing dot. AWS reuses these
+      names across cert renewals, so the policy stays stable; on a SAN
+      change or cert recreate the policy re-derives automatically.
   Any other record type or any other name in the zone is **IAM-blocked**,
   so a leaked role token cannot rewrite MX records, NS delegations,
   arbitrary subdomain A records, or any other zone content.

--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -163,12 +163,19 @@ targets; apex has no such reuse story.
     scope for PR-A.
 - The **TFC apex provisioner role** can manage the apex bucket and
   distribution, ACM certs in `us-east-1`, the two IAM OIDC providers,
-  and its own + the GH Actions role. Route 53 is **read-only** with the
-  single exception of ACM validation **CNAME** writes, which are scoped
-  to the apex hosted zone AND restricted by an IAM condition on
-  `route53:ChangeResourceRecordSetsRecordTypes` to the `CNAME` type only.
-  Apex `A` record writes are **IAM-blocked**, not just code-discipline
-  blocked. PR-D widens the IAM condition to add `A` at cutover.
+  and its own + the GH Actions role. Route 53 writes are split into two
+  narrowly-scoped IAM statements, each pairing
+  `route53:ChangeResourceRecordSetsRecordTypes` with
+  `route53:ChangeResourceRecordSetsNormalizedRecordNames`:
+    - `A` and `AAAA` ALIAS writes are allowed ONLY on
+      `thebetterdecision.com` and `www.thebetterdecision.com` (the
+      apex / www CloudFront ALIASes).
+    - `CNAME` writes are allowed ONLY on names matching
+      `_*.thebetterdecision.com` or `_*.www.thebetterdecision.com` (the
+      ACM validation pattern).
+  Any other record type or any other name in the zone is **IAM-blocked**,
+  so a leaked role token cannot rewrite MX records, NS delegations,
+  arbitrary subdomain A records, or any other zone content.
 - The **S3 bucket** has all four public-access-block flags ON. Read
   access is granted exclusively to the apex CloudFront distribution
   service-principal, scoped by `SourceArn` condition.

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -185,6 +185,14 @@ resource "aws_route53_record" "apex_acm_validation" {
   ttl             = 60
   type            = each.value.type
   zone_id         = data.aws_route53_zone.apex.zone_id
+
+  # The WriteAcmValidationCnames IAM statement (further down in this
+  # file) pins the allowed CNAME names to exactly what ACM exposes via
+  # aws_acm_certificate.apex.domain_validation_options. If the cert
+  # rotates (new SAN, recreate) the policy values change. Make this
+  # record depend on the policy resource so on the same-run apply that
+  # widens the policy, the write attempt happens AFTER the policy lands.
+  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
 }
 
 resource "aws_acm_certificate_validation" "apex" {
@@ -766,10 +774,21 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     }
   }
 
-  # Statement 2: ACM DNS-validation CNAMEs. ACM emits CNAMEs at
-  # _<token>.<domain> and _<token>.www.<domain>. The token portion is
-  # rotation-dependent (ACM regenerates on cert renewal), so the name
-  # condition uses StringLike with a leading-underscore wildcard.
+  # Statement 2: ACM DNS-validation CNAMEs. ACM emits CNAMEs at exact
+  # names exposed in aws_acm_certificate.apex.domain_validation_options.
+  # AWS reuses these names across cert renewals, so they are stable for
+  # the life of the cert (and re-derive automatically on plan if a SAN
+  # is added or the cert is recreated).
+  #
+  # Earlier revision used StringLike on "_*.<domain>", but IAM string
+  # wildcards are NOT DNS-label-bounded: "_*.thebetterdecision.com"
+  # would also match "_acme-challenge.foo.thebetterdecision.com" and
+  # any other underscore-prefixed name elsewhere in the zone. Pinning
+  # to the exact names ACM is currently asking for removes that gap.
+  #
+  # NormalizedRecordNames comparison is case-insensitive; AWS lowercases
+  # and trims any trailing dot before evaluating. We pre-normalize here
+  # so the rendered policy matches what AWS will compare against.
   statement {
     sid    = "WriteAcmValidationCnames"
     effect = "Allow"
@@ -785,11 +804,11 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     }
 
     condition {
-      test     = "ForAllValues:StringLike"
+      test     = "ForAllValues:StringEquals"
       variable = "route53:ChangeResourceRecordSetsNormalizedRecordNames"
       values = [
-        "_*.${var.domain}",
-        "_*.www.${var.domain}",
+        for dvo in aws_acm_certificate.apex.domain_validation_options :
+        trimsuffix(lower(dvo.resource_record_name), ".")
       ]
     }
   }

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -187,6 +187,70 @@ resource "aws_acm_certificate_validation" "apex" {
   validation_record_fqdns = [for r in aws_route53_record.apex_acm_validation : r.fqdn]
 }
 
+# Apex cutover (L5.2a PR-D). A and AAAA ALIAS records pointing the apex
+# and www hostnames at the CloudFront distribution. Both record types
+# are needed because the distribution has is_ipv6_enabled = true; an
+# IPv6-only client otherwise cannot resolve the apex.
+#
+# The www records point at the SAME distribution (not at the apex name)
+# because CloudFront has both hostnames in its `aliases` list and the
+# viewer-request function performs the www -> apex 301 redirect at the
+# edge after the TLS handshake. Sending www to CloudFront first lets the
+# redirect happen with HTTPS already established; sending www somewhere
+# else (e.g. CNAME to apex) would force a second DNS lookup and an
+# extra TLS handshake for every www visitor.
+#
+# evaluate_target_health = false is required for CloudFront aliases;
+# CloudFront does its own health checking internally.
+
+resource "aws_route53_record" "apex_a" {
+  zone_id = data.aws_route53_zone.apex.zone_id
+  name    = var.domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.apex.domain_name
+    zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "apex_aaaa" {
+  zone_id = data.aws_route53_zone.apex.zone_id
+  name    = var.domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.apex.domain_name
+    zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_a" {
+  zone_id = data.aws_route53_zone.apex.zone_id
+  name    = "www.${var.domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.apex.domain_name
+    zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "www_aaaa" {
+  zone_id = data.aws_route53_zone.apex.zone_id
+  name    = "www.${var.domain}"
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.apex.domain_name
+    zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
 ###############################################################################
 # CLOUDFRONT. Origin Access Control (OAC, NOT legacy OAI), response-headers
 # policy with HSTS et al., CloudFront Function for www -> apex 301 redirect.
@@ -639,16 +703,17 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     resources = ["*"]
   }
 
-  # ACM validation creates _<token>.<domain> CNAMEs in the zone. Without
-  # write access to the zone, PR-A's apply cannot complete. The
-  # ForAllValues:StringEquals condition on route53:ChangeResourceRecordSetsRecordTypes
-  # restricts the role to CNAME writes ONLY. The apex A record (and any
-  # other record type) is unreachable through this role. PR-D will widen
-  # the condition to add "A" when it ships the apex ALIAS swap. This
-  # makes "no A records in PR-A" an IAM-enforced invariant, not just a
-  # Terraform code-discipline one.
+  # ACM validation creates _<token>.<domain> CNAMEs in the zone. The apex
+  # cutover (this PR, L5.2a PR-D) adds A and AAAA ALIAS records for the
+  # apex and www hostnames pointing at the CloudFront distribution. The
+  # ForAllValues:StringEquals condition on
+  # route53:ChangeResourceRecordSetsRecordTypes restricts the role to
+  # CNAME, A, and AAAA writes ONLY. Any other record type (MX, TXT, NS,
+  # SOA, SRV) is unreachable through this role, so the worst a leaked
+  # OIDC token can do is overwrite an existing apex / www / validation
+  # record, not pivot to email or zone delegation.
   statement {
-    sid    = "WriteAcmValidationRecordsCnameOnly"
+    sid    = "WriteApexAndValidationRecords"
     effect = "Allow"
     actions = [
       "route53:ChangeResourceRecordSets",
@@ -658,7 +723,7 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     condition {
       test     = "ForAllValues:StringEquals"
       variable = "route53:ChangeResourceRecordSetsRecordTypes"
-      values   = ["CNAME"]
+      values   = ["CNAME", "A", "AAAA"]
     }
   }
 

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -1,15 +1,22 @@
 ###############################################################################
 # pfv apex landing: S3 (private) + CloudFront (OAC) + ACM (us-east-1) +
-# IAM OIDC roles (GitHub Actions deploy, TFC apex provisioner).
+# IAM OIDC roles (GitHub Actions deploy, TFC apex provisioner) +
+# Route 53 ALIAS records for the apex and www hostnames.
 #
-# PR-A of the L5.2a apex split. NO Route 53 A-record changes here. The apex
-# stays parked through this PR. ACM DNS-validation records ARE written into
-# the existing Route 53 zone (they don't touch the apex itself, only the
-# _acme-challenge style validation CNAMEs ACM emits).
-#
-# Cutover (apex A ALIAS swap, TTL drop) is PR-D. PR-B consumes
-# github_actions_role_arn from outputs.tf; PR-C produces the static export
-# that gets s3-synced into the bucket.
+# Shipped across L5.2a's four-PR sequence:
+#   PR-A (#240): S3 bucket, CloudFront distribution, ACM cert, IAM OIDC
+#                trust + roles, ACM DNS-validation CNAMEs. No apex A
+#                record yet; the IAM-enforced invariant was CNAME-only.
+#   PR-B (#267): GitHub Actions deploy workflow that builds and pushes
+#                the static export into the bucket, with CloudFront
+#                invalidation. Mutually exclusive path-filters in
+#                release.yml so landing-only commits skip the DO redeploy.
+#   PR-C (#241): Next.js apex build target (npm run build:apex) producing
+#                out-apex/ from an allowlisted slice of frontend/app/.
+#   PR-D (#270): Apex cutover. Adds A + AAAA ALIAS records for apex and
+#                www pointing at the CloudFront distribution. Widens the
+#                TFC role's Route 53 write scope to include A/AAAA on the
+#                apex/www names and CNAME on the ACM validation pattern.
 ###############################################################################
 
 locals {
@@ -202,6 +209,15 @@ resource "aws_acm_certificate_validation" "apex" {
 #
 # evaluate_target_health = false is required for CloudFront aliases;
 # CloudFront does its own health checking internally.
+#
+# depends_on on aws_iam_role_policy.tfc_apex_provisioner is required for
+# the first apply only: this apply widens the inline policy AND creates
+# these records in the same run. Without the explicit dependency,
+# Terraform parallelizes and can try to write the records before the
+# updated policy lands. IAM is eventually consistent (seconds), so if
+# the first apply still 403s due to propagation, re-running the apply
+# succeeds idempotently. On subsequent applies the dependency is a
+# no-op.
 
 resource "aws_route53_record" "apex_a" {
   zone_id = data.aws_route53_zone.apex.zone_id
@@ -213,6 +229,8 @@ resource "aws_route53_record" "apex_a" {
     zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
     evaluate_target_health = false
   }
+
+  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
 }
 
 resource "aws_route53_record" "apex_aaaa" {
@@ -225,6 +243,8 @@ resource "aws_route53_record" "apex_aaaa" {
     zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
     evaluate_target_health = false
   }
+
+  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
 }
 
 resource "aws_route53_record" "www_a" {
@@ -237,6 +257,8 @@ resource "aws_route53_record" "www_a" {
     zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
     evaluate_target_health = false
   }
+
+  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
 }
 
 resource "aws_route53_record" "www_aaaa" {
@@ -249,6 +271,8 @@ resource "aws_route53_record" "www_aaaa" {
     zone_id                = aws_cloudfront_distribution.apex.hosted_zone_id
     evaluate_target_health = false
   }
+
+  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
 }
 
 ###############################################################################
@@ -594,9 +618,11 @@ resource "aws_iam_role_policy" "github_actions_apex_deploy" {
 # Assumable from TFC workload identity tokens originating in the pfv-apex
 # workspace (or any workspace matching var.tfc_workspace_pattern). Has full
 # management of THIS module's resources: S3 bucket, CloudFront distribution,
-# ACM cert, IAM role chain. Route 53 access is READ-ONLY (Get* on the apex
-# zone) so PR-A cannot accidentally write A records; PR-D adds the write
-# permissions when the cutover Terraform lands.
+# ACM cert, IAM role chain, and the Route 53 records this module manages.
+# Route 53 writes are narrowly scoped via two IAM condition pairs (see the
+# WriteApexAndWwwAliasRecords and WriteAcmValidationCnames statements below)
+# so the role can ONLY write A/AAAA on the apex+www names and CNAME on the
+# ACM validation pattern, never anything else in the zone.
 ###############################################################################
 
 data "aws_iam_policy_document" "tfc_trust" {
@@ -680,9 +706,9 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     resources = ["arn:aws:acm:us-east-1:${var.aws_account_id}:certificate/*"]
   }
 
-  # Route 53 READ-ONLY on the apex zone. ACM validation CNAMEs and the
-  # data lookup need Get/List; PR-A intentionally CANNOT write A records.
-  # PR-D will widen this to ChangeResourceRecordSets when cutover lands.
+  # Route 53 read access on the apex zone. The two ChangeResourceRecordSets
+  # writes below (apex/www ALIAS + ACM validation CNAME) are narrowly scoped
+  # by record name AND type via separate statements.
   statement {
     sid    = "ReadApexZone"
     effect = "Allow"
@@ -703,17 +729,21 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     resources = ["*"]
   }
 
-  # ACM validation creates _<token>.<domain> CNAMEs in the zone. The apex
-  # cutover (this PR, L5.2a PR-D) adds A and AAAA ALIAS records for the
-  # apex and www hostnames pointing at the CloudFront distribution. The
-  # ForAllValues:StringEquals condition on
-  # route53:ChangeResourceRecordSetsRecordTypes restricts the role to
-  # CNAME, A, and AAAA writes ONLY. Any other record type (MX, TXT, NS,
-  # SOA, SRV) is unreachable through this role, so the worst a leaked
-  # OIDC token can do is overwrite an existing apex / www / validation
-  # record, not pivot to email or zone delegation.
+  # Route 53 write scope is split into two narrow statements. Each restricts
+  # both record type AND record name, so the role cannot pivot to other
+  # records in the zone even if an attacker reaches the OIDC role.
+  #
+  # AWS condition keys used here:
+  #   route53:ChangeResourceRecordSetsRecordTypes  -> record type allowlist
+  #   route53:ChangeResourceRecordSetsNormalizedRecordNames -> record name allowlist
+  #   route53:ChangeResourceRecordSetsActions      -> CREATE/UPSERT/DELETE
+  # The "Normalized" name comparison is case-insensitive and trims any trailing
+  # dot, so values are written here as the bare FQDNs.
+
+  # Statement 1: apex + www ALIAS records, A and AAAA only. The two ALIAS
+  # records pointing at the apex CloudFront distribution are the cutover.
   statement {
-    sid    = "WriteApexAndValidationRecords"
+    sid    = "WriteApexAndWwwAliasRecords"
     effect = "Allow"
     actions = [
       "route53:ChangeResourceRecordSets",
@@ -723,7 +753,44 @@ data "aws_iam_policy_document" "tfc_apex_provisioner" {
     condition {
       test     = "ForAllValues:StringEquals"
       variable = "route53:ChangeResourceRecordSetsRecordTypes"
-      values   = ["CNAME", "A", "AAAA"]
+      values   = ["A", "AAAA"]
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "route53:ChangeResourceRecordSetsNormalizedRecordNames"
+      values = [
+        var.domain,
+        "www.${var.domain}",
+      ]
+    }
+  }
+
+  # Statement 2: ACM DNS-validation CNAMEs. ACM emits CNAMEs at
+  # _<token>.<domain> and _<token>.www.<domain>. The token portion is
+  # rotation-dependent (ACM regenerates on cert renewal), so the name
+  # condition uses StringLike with a leading-underscore wildcard.
+  statement {
+    sid    = "WriteAcmValidationCnames"
+    effect = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.apex.zone_id}"]
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "route53:ChangeResourceRecordSetsRecordTypes"
+      values   = ["CNAME"]
+    }
+
+    condition {
+      test     = "ForAllValues:StringLike"
+      variable = "route53:ChangeResourceRecordSetsNormalizedRecordNames"
+      values = [
+        "_*.${var.domain}",
+        "_*.www.${var.domain}",
+      ]
     }
   }
 

--- a/infra/terraform/apex/outputs.tf
+++ b/infra/terraform/apex/outputs.tf
@@ -1,5 +1,5 @@
 output "s3_bucket_name" {
-  description = "Name of the apex landing S3 bucket. Consumed by PR-B's GitHub Actions workflow for `aws s3 sync`."
+  description = "Name of the apex landing S3 bucket. Consumed by `apex-deploy.yml` (GitHub repo variable `AWS_APEX_BUCKET`) for `aws s3 sync`."
   value       = aws_s3_bucket.apex.id
 }
 
@@ -14,7 +14,7 @@ output "s3_bucket_regional_domain_name" {
 }
 
 output "cloudfront_distribution_id" {
-  description = "CloudFront distribution ID. Consumed by PR-B's workflow for `aws cloudfront create-invalidation`. Also the target for PR-D's apex A ALIAS record."
+  description = "CloudFront distribution ID. Consumed by `apex-deploy.yml` (GitHub repo variable `AWS_APEX_DISTRIBUTION_ID`) for `aws cloudfront create-invalidation`. Also the alias target for the apex / www A and AAAA ALIAS records in this module."
   value       = aws_cloudfront_distribution.apex.id
 }
 
@@ -24,12 +24,12 @@ output "cloudfront_distribution_arn" {
 }
 
 output "cloudfront_distribution_domain" {
-  description = "CloudFront-assigned dXXX.cloudfront.net hostname. This is the pre-cutover verification URL: PR-C's static export is browsable here once PR-B has synced it. PR-D's Route 53 ALIAS will point to this distribution by its ID, not this hostname."
+  description = "CloudFront-assigned dXXX.cloudfront.net hostname. Diagnostic / fallback path: the apex / www ALIAS records send public traffic via DNS to this distribution, but the dXXX hostname stays reachable for probing the distribution directly when the apex hostname is itself unreachable."
   value       = aws_cloudfront_distribution.apex.domain_name
 }
 
 output "cloudfront_distribution_hosted_zone_id" {
-  description = "CloudFront's fixed hosted zone ID (Z2FDTNDATAQYW2). PR-D will need this when constructing the apex A ALIAS record."
+  description = "CloudFront's fixed hosted zone ID (`Z2FDTNDATAQYW2`). Referenced internally by this module's apex / www ALIAS records via `alias.zone_id`. Exposed as an output for visibility and for any future consumer that needs to construct a Route 53 ALIAS targeting this distribution."
   value       = aws_cloudfront_distribution.apex.hosted_zone_id
 }
 
@@ -39,12 +39,12 @@ output "acm_certificate_arn" {
 }
 
 output "route53_zone_id" {
-  description = "Hosted zone ID for the apex domain. Consumed by PR-D for the apex A ALIAS swap."
+  description = "Hosted zone ID for the apex domain. Referenced internally by the ACM validation CNAMEs and the apex / www ALIAS records in this module."
   value       = data.aws_route53_zone.apex.zone_id
 }
 
 output "github_actions_role_arn" {
-  description = "ARN of the IAM role GitHub Actions assumes via OIDC. PR-B sets this as `role-to-assume` in aws-actions/configure-aws-credentials."
+  description = "ARN of the IAM role GitHub Actions assumes via OIDC. `apex-deploy.yml` consumes this (GitHub repo variable `AWS_APEX_DEPLOY_ROLE_ARN`) as `role-to-assume` in aws-actions/configure-aws-credentials."
   value       = aws_iam_role.github_actions_apex_deploy.arn
 }
 


### PR DESCRIPTION
## Scope

End of the L5.2a apex split. After this lands, `https://thebetterdecision.com` and `https://www.thebetterdecision.com` resolve to the AWS CloudFront distribution that's been serving the static landing since PR #267.

Pre-cutover state (verified today): the apex deploy works end-to-end via the CloudFront-assigned hostname. `_meta.json` returns the live commit SHA; the page renders with HTTP/2 200, HSTS, X-Frame-Options DENY, Referrer-Policy strict-origin-when-cross-origin, and the rest of the configured security-headers policy. The only thing missing is the DNS record pointing public traffic at it. This PR adds it.

## Diff at a glance

| Change | What |
|---|---|
| 4 new `aws_route53_record` resources | A + AAAA ALIAS pairs for both `thebetterdecision.com` and `www.thebetterdecision.com`, all pointing at `aws_cloudfront_distribution.apex`. Each has an explicit `depends_on = [aws_iam_role_policy.tfc_apex_provisioner]` so the records create AFTER the inline policy widening lands. |
| IAM Route 53 write scope split into two name-scoped statements | The single `WriteAcmValidationRecordsCnameOnly` statement is replaced with `WriteApexAndWwwAliasRecords` (A/AAAA only, names `StringEquals` on apex + www FQDNs) and `WriteAcmValidationCnames` (CNAME only, names `StringLike` on `_*.<domain>` and `_*.www.<domain>`). Any other record type or name in the zone is IAM-blocked. |
| Module + README docs refreshed | Header comment now describes the full four-PR L5.2a sequence as shipped. The `ReadApexZone` "PR-D will widen later" note is gone. README security-model section rewrites the IAM scope description to match the two-statement design. |

## Why two narrow statements instead of one

The first revision of this PR restricted record TYPES (CNAME / A / AAAA) but NOT record NAMES, so the role could have rewritten any A / AAAA / CNAME anywhere in the zone, including arbitrary subdomains. The refactor combines `route53:ChangeResourceRecordSetsRecordTypes` AND `route53:ChangeResourceRecordSetsNormalizedRecordNames` so each statement is narrow on both axes. Worst case from a leaked OIDC token now: rewriting the apex ALIAS or an in-flight ACM validation record. No path to MX, NS delegations, arbitrary subdomain A records, or any other zone content.

## Why A + AAAA (not just A)

The CloudFront distribution has `is_ipv6_enabled = true`. Without AAAA records, IPv6-only clients cannot resolve the apex. Adding both keeps the v4/v6 surface symmetric and matches what every CloudFront-fronted static site looks like in production.

## Why www points at CloudFront (not at the apex)

CloudFront's `aliases` list includes BOTH `thebetterdecision.com` and `www.thebetterdecision.com`, and the viewer-request function does the `www -> apex` 301 at the edge. Sending www at CloudFront first means the redirect happens with TLS already established. A CNAME `www -> apex` would force an additional DNS lookup and TLS handshake for every www visitor.

## TFC plan output to expect

```
Plan: 4 to add, 1 to change, 0 to destroy.

aws_route53_record.apex_a       (new)
aws_route53_record.apex_aaaa    (new)
aws_route53_record.www_a        (new)
aws_route53_record.www_aaaa     (new)
aws_iam_role_policy.tfc_apex_provisioner  (update)  -- two-statement policy
```

Sub-minute apply.

## IAM eventual-consistency note

This apply widens the inline policy AND creates the four DNS records in the same run. Each new record has an explicit `depends_on` on `aws_iam_role_policy.tfc_apex_provisioner` so Terraform serializes them after the IAM update. IAM is eventually consistent: if the first apply 403s due to a propagation lag, re-running the apply succeeds idempotently. On subsequent applies the dependency is a no-op.

## Verify after TFC apply

DNS first (propagation is fast for Route 53 ALIAS, typically under a minute):

```bash
dig +short thebetterdecision.com A
dig +short thebetterdecision.com AAAA
dig +short www.thebetterdecision.com A
dig +short www.thebetterdecision.com AAAA
```

Each `dig` should return CloudFront-edge IPs. Then HTTP:

```bash
curl -s https://thebetterdecision.com/_meta.json
curl -sI https://thebetterdecision.com/
curl -sI https://www.thebetterdecision.com/    # expect HTTP/2 301 to https://thebetterdecision.com/
```

`_meta.json` should show `"commit": "d608fe1..."` (the PR #267 merge SHA) until the next landing deploy fires.

## Rollback

DNS swap is the only irreversible step in L5.2a's design, so rollback gets a dedicated note. Two paths, both VCS-driven via TFC per the project's "Terraform is VCS-driven; CLI is debug-only" rule.

**Standard rollback (preferred):**

`git revert` this PR's merge commit, push to `main`. TFC `pfv-apex` plans the inverse (4 destroys + 1 IAM update reverting the two-statement split back to the prior shape), owner clicks Confirm & Apply. Apex returns to its pre-cutover "no answer" state in seconds (Route 53 ALIAS records propagate fast in both directions). Bucket, distribution, cert, and IAM OIDC providers stay intact, so the apex-deploy pipeline keeps working against the CloudFront-assigned hostname while you investigate.

**Emergency-only path (owner-approved, not the default):**

If incident pressure does not permit a revert merge cycle, the owner may run a targeted local destroy:

```bash
terraform -chdir=infra/terraform/apex destroy \
  -target=aws_route53_record.apex_a \
  -target=aws_route53_record.apex_aaaa \
  -target=aws_route53_record.www_a \
  -target=aws_route53_record.www_aaaa
```

This is faster but leaves the repo and TFC state out of sync until a follow-up revert PR lands; without that follow-up, the next TFC apply will recreate the records. Treat this as break-glass only, not as the documented rollback path.

## What this PR does NOT do

- No CloudFront, S3, ACM, or IAM-OIDC-provider changes. All four were provisioned by PR #240; this PR only writes Route 53 records and reshapes one IAM inline policy.
- No Cloudflare changes. The app subdomain (`app.thebetterdecision.com`) keeps using Cloudflare; only the apex is moving.
- No GitHub Actions changes. PR-B's `apex-deploy.yml` continues to deploy the landing into S3 on every landing-path commit, independent of which DNS layer fronts the apex.

## Sequence reference

| PR | What | State |
|---|---|---|
| #240 PR-A | apex AWS Terraform (S3 + CloudFront + ACM + IAM OIDC) | merged |
| #241 PR-C | Next.js static export build target | merged |
| #267 PR-B | apex deploy workflow + path-filter mutual exclusion | merged, first deploy verified via CloudFront-assigned hostname |
| **this PR (PR-D)** | DNS cutover (A + AAAA ALIAS for apex and www, name-scoped IAM widening) | open |

After this lands, L5.2a is fully cut over.