### PR TITLE
fix(infra): IAM propagation grace via time_sleep gate (apex)

### DIFF
--- a/infra/terraform/apex/.terraform.lock.hcl
+++ b/infra/terraform/apex/.terraform.lock.hcl
@@ -24,6 +24,27 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.11"
+  hashes = [
+    "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.2.1"
   constraints = "~> 4.0"

--- a/infra/terraform/apex/main.tf
+++ b/infra/terraform/apex/main.tf
@@ -189,10 +189,12 @@ resource "aws_route53_record" "apex_acm_validation" {
   # The WriteAcmValidationCnames IAM statement (further down in this
   # file) pins the allowed CNAME names to exactly what ACM exposes via
   # aws_acm_certificate.apex.domain_validation_options. If the cert
-  # rotates (new SAN, recreate) the policy values change. Make this
-  # record depend on the policy resource so on the same-run apply that
-  # widens the policy, the write attempt happens AFTER the policy lands.
-  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
+  # rotates (new SAN, recreate) the policy values change. The
+  # time_sleep.iam_policy_propagation gate (defined alongside the IAM
+  # resource) sequences this record after both the policy modification
+  # AND the IAM eventual-consistency window, so a same-run apply does
+  # not 403 against a cached pre-update policy.
+  depends_on = [time_sleep.iam_policy_propagation]
 }
 
 resource "aws_acm_certificate_validation" "apex" {
@@ -218,14 +220,16 @@ resource "aws_acm_certificate_validation" "apex" {
 # evaluate_target_health = false is required for CloudFront aliases;
 # CloudFront does its own health checking internally.
 #
-# depends_on on aws_iam_role_policy.tfc_apex_provisioner is required for
-# the first apply only: this apply widens the inline policy AND creates
-# these records in the same run. Without the explicit dependency,
-# Terraform parallelizes and can try to write the records before the
-# updated policy lands. IAM is eventually consistent (seconds), so if
-# the first apply still 403s due to propagation, re-running the apply
-# succeeds idempotently. On subsequent applies the dependency is a
-# no-op.
+# depends_on on time_sleep.iam_policy_propagation (defined alongside
+# the IAM resource further down) is required for any same-run apply
+# that widens the policy AND creates these records. Without it,
+# Terraform parallelizes and writes the records before the updated
+# policy has propagated through IAM, producing 403 "no identity-based
+# policy allows" denials even though the put-role-policy call itself
+# returned success. The time_sleep gate inserts a 30s grace window
+# between the IAM mutation and any record write. On subsequent applies
+# where the policy is unchanged, the gate is a no-op (sleep does not
+# re-fire because its trigger hash is stable).
 
 resource "aws_route53_record" "apex_a" {
   zone_id = data.aws_route53_zone.apex.zone_id
@@ -238,7 +242,7 @@ resource "aws_route53_record" "apex_a" {
     evaluate_target_health = false
   }
 
-  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
+  depends_on = [time_sleep.iam_policy_propagation]
 }
 
 resource "aws_route53_record" "apex_aaaa" {
@@ -252,7 +256,7 @@ resource "aws_route53_record" "apex_aaaa" {
     evaluate_target_health = false
   }
 
-  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
+  depends_on = [time_sleep.iam_policy_propagation]
 }
 
 resource "aws_route53_record" "www_a" {
@@ -266,7 +270,7 @@ resource "aws_route53_record" "www_a" {
     evaluate_target_health = false
   }
 
-  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
+  depends_on = [time_sleep.iam_policy_propagation]
 }
 
 resource "aws_route53_record" "www_aaaa" {
@@ -280,7 +284,7 @@ resource "aws_route53_record" "www_aaaa" {
     evaluate_target_health = false
   }
 
-  depends_on = [aws_iam_role_policy.tfc_apex_provisioner]
+  depends_on = [time_sleep.iam_policy_propagation]
 }
 
 ###############################################################################
@@ -848,4 +852,29 @@ resource "aws_iam_role_policy" "tfc_apex_provisioner" {
   name   = "tfc-apex-provisioner-inline"
   role   = aws_iam_role.tfc_apex_provisioner.id
   policy = data.aws_iam_policy_document.tfc_apex_provisioner.json
+}
+
+# Same-run grace window between an IAM policy update and any Route 53
+# write made by the assumed role. AWS IAM is eventually consistent: the
+# put-role-policy call returns success within milliseconds, but the
+# assumed-role session evaluating subsequent requests can still see the
+# OLD policy for several seconds afterward. Without this grace, a
+# same-run apply that widens the policy AND creates a record can fail
+# the record creation with "no identity-based policy allows", because
+# the role session is still using the pre-update policy.
+#
+# This was the failure mode on the first PR #270 apply (run
+# Fd4y4Y5JyFkKQoLL, 2026-05-14): the IAM update completed at 13:46:20.45
+# and the 4 Route 53 creates all 403'd between 13:46:20.64 and 13:46:20.95.
+#
+# Triggers on a hash of the rendered policy JSON so the sleep only
+# re-fires when the policy actually changes; steady-state applies are
+# no-ops here. Duration is the AWS-recommended starting point for IAM
+# propagation in same-account / same-region patterns.
+resource "time_sleep" "iam_policy_propagation" {
+  triggers = {
+    policy_hash = sha256(aws_iam_role_policy.tfc_apex_provisioner.policy)
+  }
+
+  create_duration = "30s"
 }

--- a/infra/terraform/apex/versions.tf
+++ b/infra/terraform/apex/versions.tf
@@ -28,5 +28,9 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.11"
+    }
   }
 }


### PR DESCRIPTION
## Why

PR #270's first apply (TFC run `Fd4y4Y5JyFkKQoLL`, 2026-05-14 13:46) failed in a textbook AWS IAM eventual-consistency race:

```
13:46:20.45  IAM put-role-policy returns success (policy widened)
13:46:20.46  Terraform parallelizes four Route 53 ChangeResourceRecordSets calls
13:46:20.64  All four 403 with "no identity-based policy allows ..."
```

Terraform's `depends_on` on the IAM resource sequenced the API calls correctly but cannot wait for IAM to actually propagate the new policy to the assumed-role session. The role session was still evaluating against the pre-update CNAME-only policy when the records were attempted ~17ms after the IAM update returned, and IAM implicit-denied the A/AAAA writes.

This PR adds a `time_sleep` gate so future same-run IAM-then-DNS applies wait for propagation before the DNS calls fire.

## Current state context (read this before reviewing the expected plan)

Since this PR was first opened, the owner re-fired PR #270's apply manually via the TFC UI, and it succeeded (IAM had long since propagated). So as of this PR's tip:

- AWS IAM: the two-statement policy from PR #270 is live
- AWS Route 53: the four apex / www ALIAS records exist and `thebetterdecision.com` is publicly serving the apex landing
- Terraform state: the four record resources are in state, no drift

The race itself is therefore no longer urgent. This PR is durable insurance against the same class of failure on any future same-run apply that touches the apex IAM policy (e.g., adding a SAN, adding a new IAM-conditioned permission, granting an admin override).

## What changes

| File | Change |
|---|---|
| `infra/terraform/apex/versions.tf` | Declare the `hashicorp/time ~> 0.11` provider. |
| `infra/terraform/apex/.terraform.lock.hcl` | Commit the hash block for `hashicorp/time` v0.14.0 (project convention is to commit provider locks). |
| `infra/terraform/apex/main.tf` | Add `time_sleep.iam_policy_propagation` with `triggers = { policy_hash = sha256(... policy ...) }`, `create_duration = "30s"`. Swap `depends_on` on the five Route 53 record resources (apex_a, apex_aaaa, www_a, www_aaaa, apex_acm_validation) from the IAM policy resource to the new sleep gate. Update the relevant comment blocks. |

Total diff: 70 insertions, 16 deletions, three files.

## Why `time_sleep` and not retry-on-failure

Terraform's `retry` block is for transient API errors, not for waiting on side-channel propagation. `time_sleep` with `triggers` is the documented hashicorp pattern for this exact race. The sleep only re-fires when the policy hash changes; steady-state applies are no-ops (the sleep is not re-created if its triggers are unchanged).

## What the next apply will look like (post-cutover)

Now that the four ALIAS records are already in state from the manual re-fire, the next plan against this branch should be:

```
Plan: 1 to add, 0 to change, 0 to destroy.

time_sleep.iam_policy_propagation         (new, sleeps 30s on create)
```

Note: `depends_on` is a meta-argument, not a resource attribute, so swapping it on the five route53 records does not show as a state change. The five records stay in place.

Apply duration: ~32s (the 30s sleep on time_sleep's creation + ~2s of API time).

## Verify after apply

```bash
# Confirm time_sleep is recorded in state
# (TFC -> States -> latest -> filter by time_sleep)
# No new behavior to verify against AWS itself; the apex DNS / cert / records are unchanged.

# Re-verify the post-cutover state to make sure nothing regressed
dig +short thebetterdecision.com A
curl -fsS https://thebetterdecision.com/_meta.json
```

## Reversibility

`git revert` this PR, push to main, TFC plans the inverse (destroy the time_sleep, restore depends_on to the IAM resource on five records). The records remain intact post-revert because `depends_on` changes are state-only, not destructive. Total revert apply: under 5 seconds.