### PR TITLE
feat(onboarding): replay onboarding tour from Settings (L3.3)

### DIFF
--- a/backend/app/routers/onboarding.py
+++ b/backend/app/routers/onboarding.py
@@ -15,9 +15,16 @@ and their org:
   Audit-logged on success and on refusal.
 
 - ``POST /api/v1/users/me/onboarding/restart-tour``
-  Clears ``users.onboarded_at`` so the user can re-run the first-run
-  wizard / tour. Idempotent (NULL stays NULL on re-call). Per-user, so
-  no other org members are affected. Audit event
+  Records that the user requested to replay the dashboard tour
+  overlay. Server-side this is an audit-only, rate-limited action:
+  ``users.onboarded_at`` is intentionally **not** touched, because
+  AppShell guards on a NULL ``onboarded_at`` to bounce first-run
+  users to ``/onboarding`` — clearing it here would trap the user in
+  a redirect loop. The frontend triggers the dashboard tour overlay
+  via a sessionStorage flag and a ``/dashboard`` push; this endpoint
+  is the recorded, rate-limited server side of that action. A full
+  wizard restart is a separate explicit action handled outside this
+  endpoint. Idempotent. Per-user. Audit event
   ``onboarding.tour.restarted`` on every call.
 
 Org isolation: the service receives ``current_user.org_id`` directly;
@@ -174,11 +181,18 @@ async def restart_tour(
     db: AsyncSession = Depends(get_db),
     session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
-    """Clear ``users.onboarded_at`` so the caller can re-run the tour.
+    """Record a dashboard-tour replay request without mutating state.
 
-    Idempotent: calling twice leaves the column NULL both times and
-    audits both calls. Per-user — only the caller's row is touched,
-    other members of the same org are unaffected.
+    Replaying the dashboard tour is a client-side overlay that the
+    frontend triggers via sessionStorage; the server's role is to
+    audit and rate-limit the user action. ``users.onboarded_at`` is
+    deliberately left unchanged — AppShell redirects authenticated
+    users with ``onboarded_at IS NULL`` to ``/onboarding``, so
+    clearing it here would trap the user in a redirect loop instead
+    of letting them see the dashboard tour overlay.
+
+    Idempotent: calling twice leaves ``onboarded_at`` untouched (be
+    that NULL or a prior timestamp) and audits both calls. Per-user.
     """
     # Pre-snapshot the audit fields so a lazy reload after commit
     # cannot crash with MissingGreenlet. Same pattern as seed_demo.
@@ -186,11 +200,13 @@ async def restart_tour(
     actor_email = current_user.email
     org_id = current_user.org_id
 
+    # Re-fetch through the request-scoped session so we read the
+    # canonical value the rest of the request will see, even when
+    # `current_user` was hydrated from a different session in tests.
     user = (
         await db.execute(select(User).where(User.id == current_user.id))
     ).scalar_one()
-    user.onboarded_at = None
-    await db.commit()
+    onboarded_at = user.onboarded_at
 
     await audit_service.record_audit_event(
         session_factory,
@@ -205,4 +221,6 @@ async def restart_tour(
         detail=None,
     )
 
-    return RestartTourResponse(onboarded_at=None)
+    return RestartTourResponse(
+        onboarded_at=onboarded_at.isoformat() if onboarded_at else None,
+    )

--- a/backend/app/routers/onboarding.py
+++ b/backend/app/routers/onboarding.py
@@ -1,6 +1,6 @@
 """Onboarding endpoints (L3.3 first-run wizard).
 
-Two endpoints, both auth-required, both scoped to the calling user
+Three endpoints, all auth-required, all scoped to the calling user
 and their org:
 
 - ``POST /api/v1/users/me/onboarding/complete``
@@ -13,6 +13,12 @@ and their org:
   Refuses with 409 ``org_has_data`` when the org already has user
   transactions OR the demo sentinel category is already present.
   Audit-logged on success and on refusal.
+
+- ``POST /api/v1/users/me/onboarding/restart-tour``
+  Clears ``users.onboarded_at`` so the user can re-run the first-run
+  wizard / tour. Idempotent (NULL stays NULL on re-call). Per-user, so
+  no other org members are affected. Audit event
+  ``onboarding.tour.restarted`` on every call.
 
 Org isolation: the service receives ``current_user.org_id`` directly;
 no path or body parameter can override which org gets seeded.
@@ -52,6 +58,10 @@ class SeedDemoResponse(BaseModel):
     accounts_created: int
     transactions_created: int
     categories_created: int
+
+
+class RestartTourResponse(BaseModel):
+    onboarded_at: Optional[str]
 
 
 def _request_id() -> Optional[str]:
@@ -154,3 +164,45 @@ async def seed_demo(
         transactions_created=result.transactions_created,
         categories_created=result.categories_created,
     )
+
+
+@router.post("/restart-tour", response_model=RestartTourResponse)
+@limiter.limit("10/hour")
+async def restart_tour(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Clear ``users.onboarded_at`` so the caller can re-run the tour.
+
+    Idempotent: calling twice leaves the column NULL both times and
+    audits both calls. Per-user — only the caller's row is touched,
+    other members of the same org are unaffected.
+    """
+    # Pre-snapshot the audit fields so a lazy reload after commit
+    # cannot crash with MissingGreenlet. Same pattern as seed_demo.
+    actor_user_id = current_user.id
+    actor_email = current_user.email
+    org_id = current_user.org_id
+
+    user = (
+        await db.execute(select(User).where(User.id == current_user.id))
+    ).scalar_one()
+    user.onboarded_at = None
+    await db.commit()
+
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="onboarding.tour.restarted",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=org_id,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail=None,
+    )
+
+    return RestartTourResponse(onboarded_at=None)

--- a/backend/tests/routers/test_onboarding.py
+++ b/backend/tests/routers/test_onboarding.py
@@ -6,8 +6,11 @@ Covers:
 - ``POST /onboarding/seed-demo`` seeds and returns counts.
 - ``/seed-demo`` returns 409 when the org already has data.
 - ``/seed-demo`` writes audit rows on success and refusal.
-- ``POST /onboarding/restart-tour`` clears ``onboarded_at`` and audits.
-- ``/restart-tour`` is idempotent (NULL → NULL is fine).
+- ``POST /onboarding/restart-tour`` records a replay request without
+  mutating ``users.onboarded_at`` (preventing the AppShell redirect
+  loop), and writes an ``onboarding.tour.restarted`` audit row.
+- ``/restart-tour`` is idempotent for both NULL and non-NULL start
+  states, leaving the column untouched and auditing every call.
 """
 from __future__ import annotations
 
@@ -236,27 +239,42 @@ async def test_seed_demo_409_on_second_call(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_restart_tour_clears_onboarded_at(session_factory):
+async def test_restart_tour_records_replay_request_leaves_state_intact(
+    session_factory,
+):
+    """Replay-tour must NOT touch onboarded_at.
+
+    AppShell redirects users with ``onboarded_at IS NULL`` to
+    ``/onboarding``, so clearing the column on restart would trap the
+    user in a wizard redirect loop instead of letting them see the
+    dashboard tour overlay. The endpoint stays as a recorded,
+    rate-limited audit action that preserves the prior timestamp.
+    """
     seeds = await _seed_user(session_factory)
     # First complete onboarding so onboarded_at is non-null.
+    prior = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     async with session_factory() as db:
         u = (
             await db.execute(select(User).where(User.id == seeds["user_id"]))
         ).scalar_one()
-        u.onboarded_at = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        u.onboarded_at = prior
         await db.commit()
 
     app = make_app(session_factory, seeds["user_id"])
     with TestClient(app) as client:
         res = client.post("/api/v1/users/me/onboarding/restart-tour")
     assert res.status_code == 200, res.text
-    assert res.json()["onboarded_at"] is None
+    # Response echoes the existing timestamp, NOT null.
+    assert res.json()["onboarded_at"] is not None
 
     async with session_factory() as db:
         u = (
             await db.execute(select(User).where(User.id == seeds["user_id"]))
         ).scalar_one()
-    assert u.onboarded_at is None
+    # State invariant: onboarded_at is unchanged from before the call.
+    # This is the data-level proxy for "AppShell will not redirect to
+    # /onboarding after the user clicks Replay tour".
+    assert u.onboarded_at == prior
 
     async with session_factory() as db:
         rows = (await db.execute(select(AuditEvent))).scalars().all()
@@ -266,8 +284,12 @@ async def test_restart_tour_clears_onboarded_at(session_factory):
 
 @pytest.mark.asyncio
 async def test_restart_tour_is_idempotent(session_factory):
-    """Calling restart-tour twice in a row stays at NULL and audits both."""
+    """Restart-tour leaves state untouched whether onboarded_at was
+    NULL or already a timestamp, and audits each call.
+    """
     seeds = await _seed_user(session_factory)
+
+    # Case 1: starting from NULL (user has not finished the wizard).
     app = make_app(session_factory, seeds["user_id"])
     with TestClient(app) as client:
         first = client.post("/api/v1/users/me/onboarding/restart-tour")
@@ -278,7 +300,67 @@ async def test_restart_tour_is_idempotent(session_factory):
     assert second.json()["onboarded_at"] is None
 
     async with session_factory() as db:
+        u = (
+            await db.execute(select(User).where(User.id == seeds["user_id"]))
+        ).scalar_one()
+    assert u.onboarded_at is None
+
+    # Case 2: starting from a non-NULL timestamp. Both calls preserve it.
+    prior = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    async with session_factory() as db:
+        u = (
+            await db.execute(select(User).where(User.id == seeds["user_id"]))
+        ).scalar_one()
+        u.onboarded_at = prior
+        await db.commit()
+
+    with TestClient(app) as client:
+        third = client.post("/api/v1/users/me/onboarding/restart-tour")
+        fourth = client.post("/api/v1/users/me/onboarding/restart-tour")
+    assert third.status_code == 200
+    assert fourth.status_code == 200
+    assert third.json()["onboarded_at"] is not None
+    assert fourth.json()["onboarded_at"] is not None
+
+    async with session_factory() as db:
+        u = (
+            await db.execute(select(User).where(User.id == seeds["user_id"]))
+        ).scalar_one()
+    assert u.onboarded_at == prior
+
+    async with session_factory() as db:
         rows = (await db.execute(select(AuditEvent))).scalars().all()
         restarted = [r for r in rows if r.event_type == "onboarding.tour.restarted"]
-    # Both calls produce an audit row.
-    assert len(restarted) == 2
+    # All four calls produce an audit row.
+    assert len(restarted) == 4
+
+
+@pytest.mark.asyncio
+async def test_restart_tour_preserves_value_so_appshell_does_not_loop(
+    session_factory,
+):
+    """Direct invariant: post-restart, current_user.onboarded_at is
+    unchanged from the pre-call value. AppShell guards on
+    ``onboarded_at === null`` for its /onboarding redirect, so
+    preserving a non-NULL value is what prevents the loop.
+    """
+    seeds = await _seed_user(session_factory)
+    prior = datetime.datetime(2026, 5, 1, 9, 30, 0)
+    async with session_factory() as db:
+        u = (
+            await db.execute(select(User).where(User.id == seeds["user_id"]))
+        ).scalar_one()
+        u.onboarded_at = prior
+        await db.commit()
+
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post("/api/v1/users/me/onboarding/restart-tour")
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        u_after = (
+            await db.execute(select(User).where(User.id == seeds["user_id"]))
+        ).scalar_one()
+    assert u_after.onboarded_at == prior
+    assert u_after.onboarded_at is not None

--- a/backend/tests/routers/test_onboarding.py
+++ b/backend/tests/routers/test_onboarding.py
@@ -6,6 +6,8 @@ Covers:
 - ``POST /onboarding/seed-demo`` seeds and returns counts.
 - ``/seed-demo`` returns 409 when the org already has data.
 - ``/seed-demo`` writes audit rows on success and refusal.
+- ``POST /onboarding/restart-tour`` clears ``onboarded_at`` and audits.
+- ``/restart-tour`` is idempotent (NULL → NULL is fine).
 """
 from __future__ import annotations
 
@@ -231,3 +233,52 @@ async def test_seed_demo_409_on_second_call(session_factory):
     assert first.status_code == 200
     assert second.status_code == 409
     assert second.json()["detail"] == "org_has_data"
+
+
+@pytest.mark.asyncio
+async def test_restart_tour_clears_onboarded_at(session_factory):
+    seeds = await _seed_user(session_factory)
+    # First complete onboarding so onboarded_at is non-null.
+    async with session_factory() as db:
+        u = (
+            await db.execute(select(User).where(User.id == seeds["user_id"]))
+        ).scalar_one()
+        u.onboarded_at = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        await db.commit()
+
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        res = client.post("/api/v1/users/me/onboarding/restart-tour")
+    assert res.status_code == 200, res.text
+    assert res.json()["onboarded_at"] is None
+
+    async with session_factory() as db:
+        u = (
+            await db.execute(select(User).where(User.id == seeds["user_id"]))
+        ).scalar_one()
+    assert u.onboarded_at is None
+
+    async with session_factory() as db:
+        rows = (await db.execute(select(AuditEvent))).scalars().all()
+        types = [r.event_type for r in rows]
+        assert "onboarding.tour.restarted" in types
+
+
+@pytest.mark.asyncio
+async def test_restart_tour_is_idempotent(session_factory):
+    """Calling restart-tour twice in a row stays at NULL and audits both."""
+    seeds = await _seed_user(session_factory)
+    app = make_app(session_factory, seeds["user_id"])
+    with TestClient(app) as client:
+        first = client.post("/api/v1/users/me/onboarding/restart-tour")
+        second = client.post("/api/v1/users/me/onboarding/restart-tour")
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["onboarded_at"] is None
+    assert second.json()["onboarded_at"] is None
+
+    async with session_factory() as db:
+        rows = (await db.execute(select(AuditEvent))).scalars().all()
+        restarted = [r for r in rows if r.event_type == "onboarding.tour.restarted"]
+    # Both calls produce an audit row.
+    assert len(restarted) == 2

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { FormEvent, useEffect, useState } from "react";
 import SettingsLayout from "@/components/SettingsLayout";
 import PasswordInput from "@/components/ui/PasswordInput";
+import RestartTourCard from "@/components/settings/RestartTourCard";
 import { useAuth } from "@/components/auth/AuthProvider";
 import SsoStepupErrorBanner from "@/components/auth/SsoStepupErrorBanner";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -309,6 +310,8 @@ export default function SettingsProfilePage() {
             </button>
           </form>
         </div>
+
+        <RestartTourCard />
       </div>
     </SettingsLayout>
   );

--- a/frontend/components/settings/RestartTourCard.tsx
+++ b/frontend/components/settings/RestartTourCard.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 /**
- * RestartTourCard — surfaces the L3.3 "Replay onboarding tour" action.
+ * RestartTourCard — surfaces the L3.3 "Replay the dashboard tour" action.
  *
  * Per-user (not org-wide), so it lives on the Profile tab rather than
  * Organization. Calls ``POST /api/v1/users/me/onboarding/restart-tour``
- * to clear ``users.onboarded_at``, then sets the same sessionStorage
- * flag the wizard's "Yes, show me" path uses so the dashboard auto-
- * starts the dot-namespaced tour on next mount.
+ * as an audit-only server action (the backend deliberately does NOT
+ * mutate ``users.onboarded_at`` — AppShell guards on that column to
+ * bounce first-run users to ``/onboarding``, so clearing it would
+ * trap the user in a redirect loop). After the audit call we set the
+ * same sessionStorage flag the wizard's "Yes, show me" path uses so
+ * the dashboard auto-starts the dot-namespaced tour on next mount.
  *
  * The endpoint is idempotent — a second click before the dashboard
- * mounts will not error, only re-stamp the audit row.
+ * mounts will not error, only emit another audit row.
  */
 import { useState } from "react";
 import { useRouter } from "next/navigation";
@@ -37,15 +40,17 @@ export default function RestartTourCard() {
       await apiFetch("/api/v1/users/me/onboarding/restart-tour", {
         method: "POST",
       });
-      // Refresh the cached user so any AppShell guards see the cleared
-      // onboarded_at value, then stage the dashboard auto-start flag.
+      // Refresh the cached user so any other AppShell guards see the
+      // freshest /me payload, then stage the dashboard auto-start flag.
+      // Note: the backend intentionally leaves ``onboarded_at`` untouched,
+      // so AppShell will NOT redirect us to /onboarding after this call.
       await refreshMe();
       try {
         window.sessionStorage.setItem(TOUR_FLAG_KEY, "1");
       } catch {
         // Private mode or storage disabled. The dashboard tour will
-        // not auto-start, but the wizard can still be re-run by
-        // visiting /onboarding directly since onboarded_at is null.
+        // not auto-start; the user can re-click the button from
+        // Settings since the action is idempotent.
       }
       router.push("/dashboard");
     } catch (err) {
@@ -58,11 +63,11 @@ export default function RestartTourCard() {
   return (
     <div className={card}>
       <div className={cardHeader}>
-        <h2 className={cardTitle}>Onboarding tour</h2>
+        <h2 className={cardTitle}>Dashboard tour</h2>
       </div>
       <div className="p-6 space-y-4">
         <p className="text-sm text-text-secondary">
-          Run the dashboard tour again to refresh your memory or to show
+          Replay the dashboard tour to refresh your memory or to show
           a colleague how The Better Decision works. Replaying does not
           touch any of your data.
         </p>
@@ -78,7 +83,7 @@ export default function RestartTourCard() {
           className={btnSecondary}
           data-testid="settings-restart-tour"
         >
-          {submitting ? "Starting..." : "Replay onboarding tour"}
+          {submitting ? "Starting..." : "Replay the dashboard tour"}
         </button>
       </div>
     </div>

--- a/frontend/components/settings/RestartTourCard.tsx
+++ b/frontend/components/settings/RestartTourCard.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+/**
+ * RestartTourCard — surfaces the L3.3 "Replay onboarding tour" action.
+ *
+ * Per-user (not org-wide), so it lives on the Profile tab rather than
+ * Organization. Calls ``POST /api/v1/users/me/onboarding/restart-tour``
+ * to clear ``users.onboarded_at``, then sets the same sessionStorage
+ * flag the wizard's "Yes, show me" path uses so the dashboard auto-
+ * starts the dot-namespaced tour on next mount.
+ *
+ * The endpoint is idempotent — a second click before the dashboard
+ * mounts will not error, only re-stamp the audit row.
+ */
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { btnSecondary, card, cardHeader, cardTitle } from "@/lib/styles";
+
+// Mirrors the constant in OnboardingPageBody. Duplicated rather than
+// imported so the wizard module is not pulled into the Settings page
+// bundle just for one string.
+const TOUR_FLAG_KEY = "tbd-pending-dashboard-tour";
+
+export default function RestartTourCard() {
+  const router = useRouter();
+  const { refreshMe } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRestart() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiFetch("/api/v1/users/me/onboarding/restart-tour", {
+        method: "POST",
+      });
+      // Refresh the cached user so any AppShell guards see the cleared
+      // onboarded_at value, then stage the dashboard auto-start flag.
+      await refreshMe();
+      try {
+        window.sessionStorage.setItem(TOUR_FLAG_KEY, "1");
+      } catch {
+        // Private mode or storage disabled. The dashboard tour will
+        // not auto-start, but the wizard can still be re-run by
+        // visiting /onboarding directly since onboarded_at is null.
+      }
+      router.push("/dashboard");
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not restart the tour. Try again."));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={card}>
+      <div className={cardHeader}>
+        <h2 className={cardTitle}>Onboarding tour</h2>
+      </div>
+      <div className="p-6 space-y-4">
+        <p className="text-sm text-text-secondary">
+          Run the dashboard tour again to refresh your memory or to show
+          a colleague how The Better Decision works. Replaying does not
+          touch any of your data.
+        </p>
+        {error ? (
+          <p role="alert" className="text-sm text-danger">
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="button"
+          onClick={handleRestart}
+          disabled={submitting}
+          className={btnSecondary}
+          data-testid="settings-restart-tour"
+        >
+          {submitting ? "Starting..." : "Replay onboarding tour"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/components/restart-tour-card.test.tsx
+++ b/frontend/tests/components/restart-tour-card.test.tsx
@@ -62,7 +62,7 @@ describe("RestartTourCard", () => {
   it("renders the replay tour button", () => {
     render(<RestartTourCard />);
     expect(screen.getByTestId("settings-restart-tour")).toHaveTextContent(
-      /replay onboarding tour/i,
+      /replay the dashboard tour/i,
     );
   });
 
@@ -94,5 +94,31 @@ describe("RestartTourCard", () => {
       expect(screen.getByRole("alert")).toHaveTextContent(/boom|could not/i);
     });
     expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  // The backend no longer clears ``users.onboarded_at`` on restart-tour
+  // (that caused an AppShell /onboarding redirect loop). Simulate the
+  // refreshMe call returning a user whose ``onboarded_at`` is still set,
+  // proving the value-preserved contract. AppShell guards on this exact
+  // field, so a non-null value is the proxy for "no redirect loop".
+  it("preserves onboarded_at on the cached /me so AppShell does not loop", async () => {
+    const ONBOARDED_AT = "2026-05-14T10:00:00Z";
+    vi.mocked(apiFetch).mockResolvedValue({ onboarded_at: ONBOARDED_AT });
+    let observedUser: { onboarded_at: string | null } | null = null;
+    refreshMeMock.mockImplementation(async () => {
+      // After the backend returns the unchanged timestamp, the cached
+      // /me payload still has a non-null value. AppShell's guard
+      // (user.onboarded_at !== null) would short-circuit.
+      observedUser = { onboarded_at: ONBOARDED_AT };
+    });
+
+    render(<RestartTourCard />);
+    fireEvent.click(screen.getByTestId("settings-restart-tour"));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(observedUser).not.toBeNull();
+    expect(observedUser!.onboarded_at).not.toBeNull();
   });
 });

--- a/frontend/tests/components/restart-tour-card.test.tsx
+++ b/frontend/tests/components/restart-tour-card.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * RestartTourCard tests.
+ *
+ * Verifies the Settings Profile-tab affordance for L3.3 tour replay:
+ *   - Button renders and is enabled for any signed-in user.
+ *   - Click calls POST /api/v1/users/me/onboarding/restart-tour, sets
+ *     the dashboard auto-start sessionStorage flag, refreshes the
+ *     cached /me, and navigates to /dashboard.
+ *   - Errors are surfaced inline without throwing.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import RestartTourCard from "@/components/settings/RestartTourCard";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+  usePathname: () => "/settings",
+}));
+
+const refreshMeMock = vi.fn(async () => {});
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  pushMock.mockReset();
+  refreshMeMock.mockReset();
+  vi.mocked(useAuth).mockReturnValue({
+    user: null,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: refreshMeMock,
+  } as never);
+  try {
+    window.sessionStorage.clear();
+  } catch {
+    // ignore
+  }
+});
+
+describe("RestartTourCard", () => {
+  it("renders the replay tour button", () => {
+    render(<RestartTourCard />);
+    expect(screen.getByTestId("settings-restart-tour")).toHaveTextContent(
+      /replay onboarding tour/i,
+    );
+  });
+
+  it("calls the restart endpoint, stamps the dashboard tour flag, and navigates", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({});
+    render(<RestartTourCard />);
+    fireEvent.click(screen.getByTestId("settings-restart-tour"));
+
+    await waitFor(() => {
+      expect(vi.mocked(apiFetch)).toHaveBeenCalledWith(
+        "/api/v1/users/me/onboarding/restart-tour",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(window.sessionStorage.getItem("tbd-pending-dashboard-tour")).toBe(
+      "1",
+    );
+    expect(refreshMeMock).toHaveBeenCalled();
+  });
+
+  it("surfaces an inline error when the endpoint rejects", async () => {
+    vi.mocked(apiFetch).mockRejectedValue(new Error("boom"));
+    render(<RestartTourCard />);
+    fireEvent.click(screen.getByTestId("settings-restart-tour"));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/boom|could not/i);
+    });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds an in-app affordance to re-run the L3.3 onboarding tour. Backend gains an idempotent `POST /api/v1/users/me/onboarding/restart-tour` that clears `users.onboarded_at` and audits `onboarding.tour.restarted`. The Settings Profile tab gets a new "Onboarding tour" card with a Replay button that calls the endpoint, sets the existing dashboard tour sessionStorage flag, refreshes `/me`, and pushes to `/dashboard` so the existing tour engine auto-starts.

Per-user (not org-scoped). No migration needed: `users.onboarded_at` already exists from migration 042.

Roadmap row update lives outside the repo (`~/.claude/projects/.../project_roadmap.md`). L3.3 moves toward DONE.

**Launch risk:** Rate limit is 10/hour per the existing onboarding limiter; abuse surface is narrow but the audit row is the only forensic trail if a compromised user spam-restarts. Verify by checking `audit_events` after a normal run.