### PR TITLE
chore(voice): drop em-dashes from customer-facing copy + guard test

### DIFF
--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -234,7 +234,7 @@ export default function BudgetsPage() {
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
           </button>
           <span className="text-sm text-text-secondary">
-            {selectedPeriod?.start_date}{selectedPeriod?.end_date ? ` — ${selectedPeriod.end_date}` : ""}
+            {selectedPeriod?.start_date}{selectedPeriod?.end_date ? ` – ${selectedPeriod.end_date}` : ""}
             {isCurrentPeriod && <span className="ml-2 text-xs text-success font-medium">current</span>}
           </span>
           <button onClick={() => setPeriodIdx(Math.max(periodIdx - 1, 0))} disabled={periodIdx <= 0} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded p-1 text-text-muted hover:bg-surface-raised disabled:opacity-30 md:min-h-0 md:min-w-0" aria-label="Next period">
@@ -248,7 +248,7 @@ export default function BudgetsPage() {
 
       {!isCurrentPeriod && periods.length > 0 && (
         <div className="mb-5 rounded-md border border-border-subtle bg-surface-raised px-4 py-3 text-sm text-text-secondary">
-          This period is closed — read-only.
+          This period is closed (read-only).
         </div>
       )}
 
@@ -340,7 +340,7 @@ export default function BudgetsPage() {
               <div className="flex items-center justify-between mb-4">
                 <h2 className={cardTitle}>Budget Overview</h2>
                 <span className="text-xs text-text-muted">
-                  {selectedPeriod && <>{selectedPeriod.start_date}{selectedPeriod.end_date ? ` — ${selectedPeriod.end_date}` : " (open)"}</>}
+                  {selectedPeriod && <>{selectedPeriod.start_date}{selectedPeriod.end_date ? ` – ${selectedPeriod.end_date}` : " (open)"}</>}
                 </span>
               </div>
               <div className="w-full min-w-0 p-4" style={{ height: Math.max(budgets.length * 36, 100) }}>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -694,7 +694,7 @@ export default function DashboardPage() {
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
               </button>
               <span className="text-sm font-medium text-text-primary">
-                {monthFrom}{monthTo ? ` — ${monthTo}` : ""}
+                {monthFrom}{monthTo ? ` – ${monthTo}` : ""}
               </span>
               <button onClick={() => { setPeriodIdx(Math.max(periodIdx - 1, 0)); setChartFilter(null); }} disabled={periodIdx <= 0} className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-text-muted hover:bg-surface-raised disabled:opacity-30" aria-label="Next period">
                 <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>

--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -713,7 +713,7 @@ export default function ForecastPlansClient({
               : "Set up your financial plan for this billing period."}
         {isDraft && hasItems && (
           <span className="ml-1">
-            This plan is a <strong>draft</strong> — finalize it when you&apos;re done editing.
+            This plan is a <strong>draft</strong>. Finalize it when you&apos;re done editing.
           </span>
         )}
         {isActive && (
@@ -751,7 +751,7 @@ export default function ForecastPlansClient({
           <span className="text-sm text-text-secondary">
             {selectedPeriod?.start_date}
             {selectedPeriod?.end_date
-              ? ` — ${selectedPeriod.end_date}`
+              ? ` – ${selectedPeriod.end_date}`
               : ""}
             {isCurrentPeriod && (
               <span className="ml-2 text-xs font-medium text-success">

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -833,7 +833,7 @@ function ImportPageContent() {
                                             })
                                           }
                                         />
-                                        <span className="text-text-secondary">Skip — don't pair</span>
+                                        <span className="text-text-secondary">Skip, don&apos;t pair</span>
                                       </label>
                                     </li>
                                   </ul>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -170,7 +170,7 @@ export default function SettingsProfilePage() {
       // the new verification link.
       setProfileMsg(
         "email" in payload
-          ? "Profile updated. Check your new inbox for a verification link — you'll need to sign in again."
+          ? "Profile updated. Check your new inbox for a verification link. You'll need to sign in again."
           : "Profile updated",
       );
     } catch (err) {

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1229,7 +1229,7 @@ function TransactionsPageContent() {
               <option value="">All periods</option>
               {closedPeriods.map((p) => (
                 <option key={p.id} value={String(p.id)}>
-                  {p.start_date} — {p.end_date}
+                  {p.start_date} – {p.end_date}
                 </option>
               ))}
             </select>

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -236,7 +236,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         <div className="flex items-center justify-between px-5 pt-5 pb-6">
           <Link
             href="/dashboard"
-            aria-label="The Better Decision — Dashboard"
+            aria-label="The Better Decision, Dashboard"
             className="inline-flex items-center text-sidebar-text-bright"
           >
             {/* Sidebar ground is dark; the muted Logo tone keeps the

--- a/frontend/components/auth/LoginPageBody.tsx
+++ b/frontend/components/auth/LoginPageBody.tsx
@@ -186,7 +186,7 @@ export default function LoginPageBody() {
                       {resendState === "sending"
                         ? "Sending..."
                         : resendState === "failed"
-                          ? "Send failed — try again"
+                          ? "Send failed. Try again"
                           : "Resend verification email"}
                     </button>
                   )}

--- a/frontend/components/settings/MembersSection.tsx
+++ b/frontend/components/settings/MembersSection.tsx
@@ -174,7 +174,7 @@ export default function MembersSection({
                   className="flex items-center justify-between py-2 text-sm"
                 >
                   <span className="text-text-secondary">
-                    {inv.email} <span className="text-text-muted">— {inv.role}</span>
+                    {inv.email} <span className="text-text-muted">&middot; {inv.role}</span>
                   </span>
                   <button
                     type="button"

--- a/frontend/tests/voice/no-em-dash-in-customer-copy.test.ts
+++ b/frontend/tests/voice/no-em-dash-in-customer-copy.test.ts
@@ -1,0 +1,144 @@
+// Guard test for the locked customer-copy policy
+// (`feedback_no_em_dashes`). Em-dashes (U+2014) are banned in
+// user-facing prose: page bodies, JSX text, aria-labels, alt text.
+// They remain allowed in:
+//
+//  - Code comments (// and /* */ blocks). Those are dev-facing.
+//  - Single-glyph null placeholders rendered as `?? "—"` and friends.
+//    Those are layout convention, not prose, and the policy explicitly
+//    carves them out as "single character glyph used to mean empty
+//    or N/A".
+//
+// This test walks the frontend tree (excluding tests / node_modules /
+// build outputs), strips comments, and asserts no em-dash remains in
+// the executable source unless the line matches the null-placeholder
+// idiom (`?? "—"`, `: "—"`, JSX `>—<`, attr `="—"`).
+//
+// Long-form pause? Use a period or a parenthetical. The policy leaves
+// no en-dash fallback for prose; en-dashes (U+2013) are only for
+// numeric ranges ("5–6 days", "2024–2025") and are not scanned here.
+//
+// Backend Python email-template strings live in
+// backend/app/services/email_service.py and are already em-dash free;
+// keeping that property is enforced by code review, not this test.
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const EM_DASH = "—"; // —
+const FRONTEND_ROOT = join(__dirname, "..", "..");
+
+// Strip JS/TS comments while preserving line numbers so the reported
+// match offsets remain meaningful. We replace comment characters with
+// spaces (not blanks) so column counts stay aligned. Naive regex
+// passes would corrupt strings that happen to contain "//"; this
+// state-machine walk is short and exact.
+function stripComments(source: string): string {
+  let out = "";
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const ch = source[i];
+    const next = i + 1 < n ? source[i + 1] : "";
+    if (ch === "/" && next === "/") {
+      while (i < n && source[i] !== "\n") {
+        out += source[i] === "\n" ? "\n" : " ";
+        i++;
+      }
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) {
+        out += source[i] === "\n" ? "\n" : " ";
+        i++;
+      }
+      if (i < n) {
+        out += " ";
+        i++;
+      }
+      if (i < n) {
+        out += " ";
+        i++;
+      }
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+// Null-placeholder idioms we allow:
+//   ?? "—"      ?? '—'      : "—"      >—<      ="—"
+const PLACEHOLDER_PATTERNS = [
+  /\?\?\s*["']—["']/g,
+  /:\s*["']—["']/g,
+  />—</g,
+  /["']—["']/g,
+];
+
+function stripPlaceholders(line: string): string {
+  let out = line;
+  for (const re of PLACEHOLDER_PATTERNS) {
+    out = out.replace(re, "");
+  }
+  return out;
+}
+
+const SCAN_DIRS = ["app", "components", "lib"];
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".next",
+  "out",
+  "out-apex",
+  ".next-apex",
+  ".apex-staged-routes",
+  "__snapshots__",
+  "tests",
+  "fixtures",
+]);
+
+function walkSource(dir: string, hits: string[]): string[] {
+  if (!existsSync(dir)) return hits;
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walkSource(full, hits);
+      continue;
+    }
+    if (!/\.(tsx?|jsx?)$/.test(entry)) continue;
+    const source = readFileSync(full, "utf8");
+    if (!source.includes(EM_DASH)) continue;
+    const stripped = stripComments(source);
+    const lines = stripped.split("\n");
+    lines.forEach((line, idx) => {
+      if (!line.includes(EM_DASH)) return;
+      const cleaned = stripPlaceholders(line);
+      if (cleaned.includes(EM_DASH)) {
+        hits.push(`${relative(FRONTEND_ROOT, full)}:${idx + 1}: ${line.trim()}`);
+      }
+    });
+  }
+  return hits;
+}
+
+describe("customer-copy voice policy", () => {
+  it("contains no em-dashes outside comments or null placeholders", () => {
+    const hits: string[] = [];
+    for (const seg of SCAN_DIRS) {
+      walkSource(join(FRONTEND_ROOT, seg), hits);
+    }
+    if (hits.length > 0) {
+      // Surface every offending location so a regression is easy to
+      // pin to a file:line rather than "somewhere in the bundle".
+      // eslint-disable-next-line no-console
+      console.error(
+        "Em-dash policy violations:\n" + hits.map((h) => `  ${h}`).join("\n"),
+      );
+    }
+    expect(hits).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Sweeps remaining em-dashes (U+2014) out of user-visible prose across the authed surface (settings, login, import, budgets, forecasts, member invites) and adds a regression guard test.

## Changes

- Prose em-dashes replaced with periods or parentheses per the locked voice policy (settings reauth notice, login resend retry label, import skip option, forecast-plan draft hint, budget closed-period banner).
- Date-range em-dashes converted to en-dashes (U+2013, the correct glyph for numeric ranges) in dashboard / transactions / budgets / forecasts period nav.
- Member-invite role separator switched from em-dash to middle dot, matching the footer convention.
- AppShell brand link aria-label drops to comma form ("The Better Decision, Dashboard").
- New `frontend/tests/voice/no-em-dash-in-customer-copy.test.ts` walks `app/`, `components/`, `lib/`; strips comments and the allowed null-placeholder idioms (`?? "—"`, `: "—"`, `>—<`, `="—"`); fails on any remaining em-dash.

Closes the L5.6 / brand-voice tail on customer-facing prose. Single brass moment per screen preserved; no theme, layout, or wiring changes.

## Launch risk

Low. Pure text + one new test file. The guard test will catch future regressions automatically and lists offending file:line on failure.