### PR TITLE
feat(ai-foundation): provider-neutral service boundary + mock adapter (LAI.5/LAI.6)

### DIFF
--- a/backend/app/services/ai_adapters/__init__.py
+++ b/backend/app/services/ai_adapters/__init__.py
@@ -1,0 +1,7 @@
+"""Provider adapters for the LAI Foundation service boundary.
+
+Only the mock adapter ships in PR-B. Real provider adapters
+(``anthropic_adapter``, ``openai_adapter``) are gated behind the
+privacy-review checklist in the spec (§9) plus per-PR sign-off from
+fjorge, and live in a separate PR.
+"""

--- a/backend/app/services/ai_adapters/mock_adapter.py
+++ b/backend/app/services/ai_adapters/mock_adapter.py
@@ -1,0 +1,77 @@
+"""Mock LLM adapter — deterministic canned responses.
+
+Used by:
+- Every org whose ``org_settings.ai.provider`` is ``"mock"`` (default).
+- Every ``call_llm(..., dry_run=True)`` request, regardless of provider.
+- Backend test suites that exercise LAI surfaces.
+
+The "canned response" is a deterministic function of the prompt's
+``user_context`` so tests can assert on exact return values without
+mocking the adapter directly. Every mock result reports
+``cost_cents=0`` and ``dry_run=True`` so the cap-check (PR-C) treats
+mock dispatches as free.
+
+This module makes zero network calls. It is safe in every environment.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from app.services.ai_service import LLMResult, Prompt
+
+
+# Reserved provider/model identifiers for telemetry. The ledger and
+# structlog event use these strings verbatim so dashboards can tell
+# mock from real-provider rows at a glance.
+MOCK_PROVIDER = "mock"
+MOCK_MODEL = "mock-1"
+
+
+def _canned_content(prompt: "Prompt") -> str:
+    """Return a deterministic string derived from the prompt.
+
+    Hash inputs:
+    - ``system_instructions`` (the prompt template the caller chose).
+    - JSON-serialized ``user_context`` (sorted keys for stability).
+
+    The hash is truncated to a short hex prefix so tests can assert
+    on the exact content without pinning the full digest.
+    """
+    payload = json.dumps(
+        {
+            "sys": prompt.system_instructions,
+            "ctx": prompt.user_context,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+    return f"[mock:{digest}] canned response"
+
+
+def dispatch(*, prompt: "Prompt", request_id: str) -> "LLMResult":
+    """Return a deterministic LLMResult.
+
+    Counts as ``dry_run=True`` so the PR-C cap-check skips it. No tokens
+    consumed, no cost charged, no latency reported.
+    """
+    # Local import to avoid the import cycle with ai_service. Both modules
+    # are stable; the cycle is purely a packaging artefact.
+    from app.services.ai_service import LLMResult, STATUS_DRY_RUN
+
+    return LLMResult(
+        content=_canned_content(prompt),
+        tokens_in=0,
+        tokens_out=0,
+        latency_ms=0,
+        cost_cents=0,
+        dry_run=True,
+        provider=MOCK_PROVIDER,
+        model=MOCK_MODEL,
+        status=STATUS_DRY_RUN,
+        request_id=request_id,
+    )

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,0 +1,293 @@
+"""LAI Foundation — provider-neutral AI service boundary (PR-B).
+
+Spec: ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-14-lai-foundation.md``
+
+This module exposes the single chokepoint ``call_llm()`` that every LAI
+feature surface must call. Three properties this gives us:
+
+1. **Feature gate is defense-in-depth.** Routers should already gate on
+   ``require_feature(key)``; ``call_llm`` re-checks via
+   ``has_feature(db, org_id, feature_key)`` and refuses if the gate is
+   closed. A future caller that forgets the dependency-level check still
+   cannot make an LLM call without an explicit org grant.
+
+2. **Provider is per-org and defaults to mock.** Adapter selection comes
+   from ``org_settings.ai.provider`` (defaults ``"mock"``). PR-B ships
+   only the mock adapter; Anthropic/OpenAI adapters land in a separate
+   sign-off-gated PR. There is no way in this module to reach a real
+   network call.
+
+3. **Prompts are pre-redacted contracts.** ``Prompt`` requires
+   ``redaction_certified=True`` and refuses ``user_context`` containing
+   PII-shaped keys (IBAN, account_number, full_name, ssn, tax_id). The
+   redaction itself is the caller's responsibility; this is the
+   compile-time tripwire.
+
+Cap enforcement and the ``ai_usage`` ledger ship in PR-C (migration
+048). In PR-B the cap-check is a stub that always returns "within
+budget", and the only persisted artifact is the ``ai.call`` structlog
+event.
+
+Privacy invariants (locked by spec §8):
+- No prompt content, no completion content, no API-key fragments in any
+  structlog event from this module.
+- ``user_context`` PII-key rejection is defense-in-depth, not the
+  primary control — callers are still responsible for redaction.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.feature_catalog import ALL_FEATURE_KEYS, FeatureKey
+from app.services import feature_service
+from app.services.ai_adapters import mock_adapter
+from app.services.exceptions import ValidationError
+
+
+logger = structlog.stdlib.get_logger()
+
+
+# Status enumeration matches spec §3 (ai_usage.status). PR-B only emits
+# ``success``, ``dry_run``, and ``rejected_gate_closed`` — the cap and
+# provider-error statuses are reserved for PR-C / the real-adapter PR.
+STATUS_SUCCESS = "success"
+STATUS_DRY_RUN = "dry_run"
+STATUS_REJECTED_GATE_CLOSED = "rejected_gate_closed"
+STATUS_REJECTED_OVER_CAP = "rejected_over_cap"
+STATUS_ERROR_UNCONFIGURED = "error_unconfigured"
+STATUS_ERROR_PROVIDER = "error_provider"
+STATUS_ERROR_TIMEOUT = "error_timeout"
+STATUS_ERROR_CONTENT_POLICY = "error_content_policy"
+
+
+# PII key sentinel — defense-in-depth filter on ``Prompt.user_context``.
+# Matches keys whose name *looks like* it carries raw PII. Adversarial
+# inputs that hide PII in differently-named keys are not caught here;
+# redaction at the caller is the primary control.
+#
+# The pattern matches snake_case (``full_name``) and CamelCase
+# (``FullName``) variants — the optional ``[_]?`` separator lets
+# ``fullname``, ``full_name``, ``FullName`` all trip the filter.
+_PII_KEY_REGEX = re.compile(
+    r"(iban|account[_]?number|full[_]?name|ssn|tax[_]?id)",
+    re.IGNORECASE,
+)
+
+
+class PromptNotRedacted(Exception):
+    """Programmer error: caller forgot to set ``redaction_certified=True``.
+
+    Surfaces as HTTP 500 — bad input from app code is an operational
+    alert, not a user-facing validation error. Same pattern as
+    ``UnknownFeatureKey``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Prompt must be redacted before reaching ai_service")
+
+
+class PromptContainsPII(Exception):
+    """Programmer error: ``Prompt.user_context`` contains a key whose name
+    matches the PII sentinel regex. The caller must redact before the
+    prompt reaches this layer.
+
+    Surfaces as HTTP 500. Same rationale as ``PromptNotRedacted``.
+    """
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        super().__init__(f"Prompt.user_context contains PII-shaped key: {key!r}")
+
+
+class FeatureCapped(Exception):
+    """Org has exceeded its monthly AI usage cap. Reserved for PR-C;
+    PR-B never raises this because the cap-check is a stub. Routers map
+    this to HTTP 402 ("Payment Required") per spec D2.
+    """
+
+    def __init__(self, org_id: int, feature_key: str) -> None:
+        self.org_id = org_id
+        self.feature_key = feature_key
+        super().__init__(
+            f"Org {org_id} is over the monthly AI usage cap for {feature_key}"
+        )
+
+
+class FeatureNotEnabled(Exception):
+    """The feature gate is closed for this org. Routers should already
+    have returned 403 via ``require_feature``; this is the defense-in-
+    depth raise from inside ``call_llm``. Maps to HTTP 403.
+    """
+
+    def __init__(self, org_id: int, feature_key: str) -> None:
+        self.org_id = org_id
+        self.feature_key = feature_key
+        super().__init__(
+            f"Feature {feature_key!r} is not enabled for org {org_id}"
+        )
+
+
+@dataclass(frozen=True)
+class Prompt:
+    """Pre-redacted, typed prompt object.
+
+    ``redaction_certified`` is a contract: the caller asserts that
+    ``system_instructions`` and every value in ``user_context`` has been
+    redacted. The service refuses prompts where this flag is False.
+
+    The contract is intentionally not a runtime audit — we cannot
+    reliably scan adversarial text for IBANs / account numbers / full
+    names. The ``user_context`` PII-key check is defense-in-depth on
+    the *structure* of the dict, not its content.
+    """
+
+    system_instructions: str
+    user_context: dict[str, Any] = field(default_factory=dict)
+    redaction_certified: bool = False
+
+
+@dataclass(frozen=True)
+class LLMResult:
+    """Provider-neutral call result.
+
+    ``request_id`` is a service-generated UUID. It is stamped into the
+    ``ai_usage`` ledger row (PR-C) AND returned to the caller so any
+    downstream ``ai.feedback.*`` audit event (PR-D) can correlate back
+    to the original call.
+    """
+
+    content: str
+    tokens_in: int
+    tokens_out: int
+    latency_ms: int
+    cost_cents: int
+    dry_run: bool
+    provider: str
+    model: str
+    status: str
+    request_id: str
+
+
+def _validate_prompt(prompt: Prompt) -> None:
+    """Compile-time-style tripwire. Raises before any provider dispatch."""
+    if prompt.redaction_certified is not True:
+        raise PromptNotRedacted()
+    for key in prompt.user_context.keys():
+        if _PII_KEY_REGEX.search(key):
+            raise PromptContainsPII(key)
+
+
+async def _resolve_provider(db: AsyncSession, org_id: int) -> tuple[str, str]:
+    """Return ``(provider, model)`` from ``org_settings``.
+
+    PR-B does not read ``org_settings`` yet (the table is reachable but
+    every org defaults to ``"mock"`` until ops explicitly flips it).
+    Returning the default here keeps the call site shaped correctly so
+    PR-C / the real-adapter PR can add the lookup without changing
+    ``call_llm``.
+    """
+    # Reserved for future expansion; PR-B is mock-only.
+    _ = (db, org_id)
+    return ("mock", "")
+
+
+async def call_llm(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: FeatureKey,
+    prompt: Prompt,
+    dry_run: bool = False,
+) -> LLMResult:
+    """Provider-neutral LLM call.
+
+    PR-B behavior (mock-only):
+    1. Validate ``prompt`` (PII keys, redaction certified).
+    2. Fail-closed on the feature gate.
+    3. Dispatch to ``mock_adapter`` (every call is effectively dry-run).
+    4. Emit a single ``ai.call`` structlog event with the whitelisted
+       telemetry fields from spec §6 — never prompt content.
+
+    Future PRs add:
+    - PR-C: cap-check via ``ai_usage`` aggregation + ``ai_usage`` row
+      writes for every outcome (success, gate-closed, over-cap).
+    - Real-adapter PR: dispatch to ``anthropic_adapter`` or
+      ``openai_adapter`` based on ``org_settings.ai.provider``.
+
+    Raises:
+        PromptNotRedacted: ``prompt.redaction_certified is not True``.
+        PromptContainsPII: ``prompt.user_context`` has a PII-shaped key.
+        FeatureNotEnabled: the org's feature gate for ``feature_key``
+            resolves to False.
+        ValidationError: ``feature_key`` is not in the catalog.
+    """
+    if feature_key not in ALL_FEATURE_KEYS:
+        # Catalog unknown — caller bug. Same surfacing rule as
+        # feature_service.UnknownFeatureKey (HTTP 500), but we raise
+        # ValidationError here so it threads through the existing
+        # exception mapper. UnknownFeatureKey is the deeper raise
+        # path inside feature_service.has_feature() below.
+        raise ValidationError(f"Unknown AI feature key: {feature_key!r}")
+
+    _validate_prompt(prompt)
+
+    request_id = uuid.uuid4().hex
+
+    # Defense-in-depth gate check. Even if the router forgot to
+    # `Depends(require_feature(...))`, this raises before any adapter
+    # work happens. The structlog event records the rejection so the
+    # coverage endpoint can see "gate-closed" as a distinct outcome.
+    gate_open = await feature_service.has_feature(db, org_id, feature_key)
+    if not gate_open:
+        await logger.ainfo(
+            "ai.call",
+            org_id=org_id,
+            feature_key=feature_key,
+            provider="(none)",
+            model="(none)",
+            tokens_in=0,
+            tokens_out=0,
+            cost_cents=0,
+            latency_ms=0,
+            dry_run=dry_run,
+            status=STATUS_REJECTED_GATE_CLOSED,
+            error_code=None,
+            request_id=request_id,
+        )
+        raise FeatureNotEnabled(org_id, feature_key)
+
+    provider, model = await _resolve_provider(db, org_id)
+
+    # PR-B is mock-only. ``dry_run`` flag is honored but the mock
+    # adapter does not differentiate — every call is deterministic.
+    # PR-C's cap-check sits between here and the dispatch.
+    if provider == "mock" or dry_run:
+        result = mock_adapter.dispatch(prompt=prompt, request_id=request_id)
+    else:  # pragma: no cover — unreachable in PR-B; the real-adapter PR adds this branch.
+        # Future: dispatch to anthropic_adapter / openai_adapter.
+        # Until then, treat as mock so we cannot accidentally leak.
+        result = mock_adapter.dispatch(prompt=prompt, request_id=request_id)
+
+    await logger.ainfo(
+        "ai.call",
+        org_id=org_id,
+        feature_key=feature_key,
+        provider=result.provider,
+        model=result.model,
+        tokens_in=result.tokens_in,
+        tokens_out=result.tokens_out,
+        cost_cents=result.cost_cents,
+        latency_ms=result.latency_ms,
+        dry_run=result.dry_run,
+        status=result.status,
+        error_code=None,
+        request_id=result.request_id,
+    )
+
+    return result

--- a/backend/tests/services/test_ai_service.py
+++ b/backend/tests/services/test_ai_service.py
@@ -1,0 +1,381 @@
+"""LAI Foundation — PR-B tests for ``app.services.ai_service``.
+
+Spec: ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-14-lai-foundation.md``
+
+PR-B is mock-only. The cap-check is a stub (always within budget) and
+the real-provider adapters are not wired. These tests pin:
+
+- Feature-gate fail-closed: a closed gate raises ``FeatureNotEnabled``
+  and emits a ``rejected_gate_closed`` structlog event.
+- Dry-run path: ``dry_run=True`` returns the deterministic mock content
+  with ``cost_cents=0``.
+- Mock adapter idempotency: the same ``Prompt`` returns the same
+  ``content`` across two calls.
+- Prompt redaction contract: ``redaction_certified is not True`` raises
+  ``PromptNotRedacted``.
+- PII key rejection: ``user_context`` with an IBAN-shaped key raises
+  ``PromptContainsPII``.
+- Structlog privacy: the ``ai.call`` event never contains prompt
+  content under any key.
+
+Test-pattern note: structlog routes through its own renderer, so
+``caplog`` does not see records. We patch ``ai_service.logger.ainfo``
+with ``AsyncMock`` to capture event payloads (same pattern as
+``backend/tests/services/test_import_preview_with_rules.py`` for the
+``smart_rules.preview_built`` event).
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.subscription import (
+    BillingInterval,
+    Plan,
+    Subscription,
+    SubscriptionStatus,
+)
+from app.models.user import Organization
+from app.services import ai_service
+from app.services.ai_service import (
+    FeatureNotEnabled,
+    LLMResult,
+    Prompt,
+    PromptContainsPII,
+    PromptNotRedacted,
+    STATUS_DRY_RUN,
+    STATUS_REJECTED_GATE_CLOSED,
+    STATUS_SUCCESS,
+    call_llm,
+)
+from app.services.exceptions import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — same pattern as test_feature_service.py
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _make_org(db: AsyncSession, *, name: str = "Acme") -> Organization:
+    org = Organization(name=name, billing_cycle_day=1)
+    db.add(org)
+    await db.commit()
+    return org
+
+
+async def _make_plan(db: AsyncSession, *, features: dict[str, bool]) -> Plan:
+    plan = Plan(slug="pro", name="Pro", features=features)
+    db.add(plan)
+    await db.commit()
+    return plan
+
+
+async def _make_sub(db: AsyncSession, *, org_id: int, plan_id: int) -> Subscription:
+    sub = Subscription(
+        org_id=org_id,
+        plan_id=plan_id,
+        status=SubscriptionStatus.ACTIVE,
+        billing_interval=BillingInterval.MONTHLY,
+    )
+    db.add(sub)
+    await db.commit()
+    return sub
+
+
+_ALL_FALSE = {
+    "ai.budget": False,
+    "ai.forecast": False,
+    "ai.smart_plan": False,
+    "ai.autocategorize": False,
+}
+
+
+def _enabled_features(*keys: str) -> dict[str, bool]:
+    out = dict(_ALL_FALSE)
+    for k in keys:
+        out[k] = True
+    return out
+
+
+@pytest.fixture
+def redacted_prompt() -> Prompt:
+    return Prompt(
+        system_instructions="Categorize this merchant.",
+        user_context={"normalized_token": "JUMBO"},
+        redaction_certified=True,
+    )
+
+
+def _capture_ai_calls(spy: AsyncMock) -> list[dict[str, Any]]:
+    """Return kwargs for every ``ai.call`` structlog event the spy saw."""
+    return [
+        c.kwargs
+        for c in spy.call_args_list
+        if c.args and c.args[0] == "ai.call"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_feature_gate_fail_closed(session_factory, redacted_prompt):
+    """Org without ``ai.autocategorize`` -> call_llm raises
+    FeatureNotEnabled and does NOT reach the mock adapter."""
+    async with session_factory() as db:
+        org = await _make_org(db)
+        plan = await _make_plan(db, features=_ALL_FALSE)
+        await _make_sub(db, org_id=org.id, plan_id=plan.id)
+
+        with pytest.raises(FeatureNotEnabled) as exc_info:
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="ai.autocategorize",
+                prompt=redacted_prompt,
+            )
+        assert exc_info.value.org_id == org.id
+        assert exc_info.value.feature_key == "ai.autocategorize"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_returns_canned_mock(session_factory, redacted_prompt):
+    """``dry_run=True`` with an enabled gate returns a deterministic
+    mock result with ``dry_run=True`` and ``cost_cents=0``."""
+    async with session_factory() as db:
+        org = await _make_org(db)
+        plan = await _make_plan(db, features=_enabled_features("ai.autocategorize"))
+        await _make_sub(db, org_id=org.id, plan_id=plan.id)
+
+        result = await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="ai.autocategorize",
+            prompt=redacted_prompt,
+            dry_run=True,
+        )
+
+    assert isinstance(result, LLMResult)
+    assert result.dry_run is True
+    assert result.cost_cents == 0
+    assert result.tokens_in == 0
+    assert result.tokens_out == 0
+    assert result.provider == "mock"
+    # Mock adapter dispatch always reports ``dry_run`` status, even when
+    # the caller did not explicitly request dry-run — every mock call is
+    # by definition a non-billable, non-network operation.
+    assert result.status == STATUS_DRY_RUN
+    assert result.content.startswith("[mock:")
+    assert result.request_id  # service-generated UUID hex
+
+
+@pytest.mark.asyncio
+async def test_mock_adapter_idempotency(session_factory, redacted_prompt):
+    """Same Prompt across two ``call_llm`` invocations returns the same
+    ``content`` (mock adapter is a pure function of the prompt)."""
+    async with session_factory() as db:
+        org = await _make_org(db)
+        plan = await _make_plan(db, features=_enabled_features("ai.autocategorize"))
+        await _make_sub(db, org_id=org.id, plan_id=plan.id)
+
+        r1 = await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="ai.autocategorize",
+            prompt=redacted_prompt,
+        )
+        r2 = await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="ai.autocategorize",
+            prompt=redacted_prompt,
+        )
+
+    assert r1.content == r2.content
+    # request_id differs per call so feedback signals (PR-D) can be
+    # correlated back to a specific invocation.
+    assert r1.request_id != r2.request_id
+
+
+@pytest.mark.asyncio
+async def test_prompt_redaction_certified_required(session_factory):
+    """Prompt without ``redaction_certified=True`` raises
+    PromptNotRedacted before any gate check or adapter dispatch."""
+    async with session_factory() as db:
+        org = await _make_org(db)
+        plan = await _make_plan(db, features=_enabled_features("ai.autocategorize"))
+        await _make_sub(db, org_id=org.id, plan_id=plan.id)
+
+        unredacted = Prompt(
+            system_instructions="x",
+            user_context={"normalized_token": "X"},
+            # redaction_certified defaults to False
+        )
+
+        with pytest.raises(PromptNotRedacted):
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="ai.autocategorize",
+                prompt=unredacted,
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_key",
+    ["iban", "ACCOUNT_NUMBER", "FullName", "ssn", "tax_id"],
+)
+async def test_pii_key_rejection(session_factory, bad_key):
+    """``user_context`` with a PII-shaped key (IBAN, account_number,
+    full_name, ssn, tax_id) raises PromptContainsPII."""
+    async with session_factory() as db:
+        org = await _make_org(db)
+        plan = await _make_plan(db, features=_enabled_features("ai.autocategorize"))
+        await _make_sub(db, org_id=org.id, plan_id=plan.id)
+
+        bad_prompt = Prompt(
+            system_instructions="x",
+            user_context={bad_key: "REDACTED-LOOKING-VALUE"},
+            redaction_certified=True,
+        )
+        with pytest.raises(PromptContainsPII) as exc_info:
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="ai.autocategorize",
+                prompt=bad_prompt,
+            )
+        assert exc_info.value.key == bad_key
+
+
+@pytest.mark.asyncio
+async def test_unknown_feature_key_raises_validation_error(
+    session_factory, redacted_prompt
+):
+    """A feature_key not in ALL_FEATURE_KEYS raises ValidationError."""
+    async with session_factory() as db:
+        org = await _make_org(db)
+
+        with pytest.raises(ValidationError):
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="ai.does_not_exist",  # type: ignore[arg-type]
+                prompt=redacted_prompt,
+            )
+
+
+@pytest.mark.asyncio
+async def test_structlog_event_contains_no_prompt_content(
+    session_factory, redacted_prompt
+):
+    """The ``ai.call`` structlog event must never contain prompt
+    content under any key. Spec §6 / §8 privacy invariant."""
+    secret_marker = "SECRET_PROMPT_BODY_DO_NOT_LOG"
+    prompt = Prompt(
+        system_instructions=secret_marker,
+        user_context={"normalized_token": secret_marker},
+        redaction_certified=True,
+    )
+
+    async with session_factory() as db:
+        org = await _make_org(db)
+        plan = await _make_plan(db, features=_enabled_features("ai.autocategorize"))
+        await _make_sub(db, org_id=org.id, plan_id=plan.id)
+
+        with patch.object(
+            ai_service.logger, "ainfo", new_callable=AsyncMock
+        ) as spy:
+            result = await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="ai.autocategorize",
+                prompt=prompt,
+            )
+
+    # Result content must not echo the secret marker.
+    assert secret_marker not in result.content
+
+    # Every ``ai.call`` event's kwargs (and the positional event name
+    # itself) must be marker-free.
+    events = _capture_ai_calls(spy)
+    assert len(events) == 1, f"expected exactly one ai.call event, got {len(events)}"
+    rendered = repr(events[0])
+    assert secret_marker not in rendered, (
+        f"Prompt content leaked into ai.call event kwargs: {events[0]}"
+    )
+
+    # Telemetry whitelist (spec §6) — must contain the field set, NOT
+    # any prompt/completion content.
+    expected_keys = {
+        "org_id", "feature_key", "provider", "model",
+        "tokens_in", "tokens_out", "cost_cents", "latency_ms",
+        "dry_run", "status", "error_code", "request_id",
+    }
+    assert set(events[0].keys()) == expected_keys
+
+
+@pytest.mark.asyncio
+async def test_gate_closed_emits_structlog_event(session_factory, redacted_prompt):
+    """A gate-closed rejection still emits a structlog ``ai.call`` event
+    with ``status=rejected_gate_closed`` so the coverage endpoint can
+    count rejections as a distinct outcome."""
+    async with session_factory() as db:
+        org = await _make_org(db)
+        plan = await _make_plan(db, features=_ALL_FALSE)
+        await _make_sub(db, org_id=org.id, plan_id=plan.id)
+
+        with patch.object(
+            ai_service.logger, "ainfo", new_callable=AsyncMock
+        ) as spy:
+            with pytest.raises(FeatureNotEnabled):
+                await call_llm(
+                    db,
+                    org_id=org.id,
+                    feature_key="ai.autocategorize",
+                    prompt=redacted_prompt,
+                )
+
+    events = _capture_ai_calls(spy)
+    assert len(events) == 1
+    assert events[0]["status"] == STATUS_REJECTED_GATE_CLOSED
+    assert events[0]["org_id"] == org.id
+    assert events[0]["feature_key"] == "ai.autocategorize"
+    # No tokens charged, no provider dispatched.
+    assert events[0]["tokens_in"] == 0
+    assert events[0]["tokens_out"] == 0
+    assert events[0]["cost_cents"] == 0


### PR DESCRIPTION
Lands the LAI substrate before any external LLM call is wired. Mock-only dispatch; no code path in this PR can reach Anthropic or OpenAI.

## What ships

- `app/services/ai_service.py` — `call_llm(db, *, org_id, feature_key, prompt, dry_run=False) -> LLMResult`. Defense-in-depth feature gate (fail-closed via `has_feature`), pre-redacted `Prompt` contract (`redaction_certified=True`), PII-key sentinel regex rejecting `iban / account[_]?number / full[_]?name / ssn / tax[_]?id` shaped keys in `user_context`. Single `ai.call` structlog event with a whitelisted field set (no prompt or completion content under any key).
- `app/services/ai_adapters/mock_adapter.py` — deterministic canned responses derived from a sha256 of `system_instructions + user_context`. `cost_cents=0`, `tokens=0`, `dry_run=True`. Only adapter wired.
- `tests/services/test_ai_service.py` — 12 tests covering feature-gate fail-closed, dry-run canned response, mock idempotency, prompt redaction contract, parametrized PII-key rejection (snake_case + CamelCase), unknown `feature_key`, structlog privacy whitelist, gate-closed event shape.

## What does NOT ship (deferred)

- Cap enforcement + `ai_usage` ledger -> PR-C (migration 048).
- LAI.6 feedback event emit helpers + router -> PR-D.
- `GET /api/v1/admin/ai/coverage` superadmin endpoint + extended `smart_rules.miss` telemetry -> PR-E.
- Anthropic / OpenAI adapters -> separate PR, gated on the privacy-review checklist in spec §9 plus per-PR sign-off.

## Hard rules respected

- No production LLM call. Mock-only dispatch; `_resolve_provider` returns `("mock", "")` always.
- Default value for every `ai.*` feature key remains `False` on every plan.
- Zero prompt-content fields in any structlog event (test pins the whitelist).

## Spec + plan

- Spec: `~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-14-lai-foundation.md`
- Plan: `~/.claude/projects/-Users-fjorge-src-pfv/plans/2026-05-14-lai-foundation-plan.md`
- Wave coordination memo §C Team 2: `~/.claude/projects/-Users-fjorge-src-pfv/memory/project_wave_2026_05_14_coordination.md`

Closes LAI.5 (spec frozen) and LAI.6 (spec frozen) on the roadmap. Subsequent PRs (PR-C through PR-E) bump these rows toward DONE.

## Launch-risk

Mock-only service boundary, no external network calls. If a future caller forgets to gate the call site via `require_feature`, the in-service defense-in-depth gate is the only protection -- mitigated by the catalog default-false invariant (D13). The PII-key regex is structure-shaped, not content-shaped: callers redact, the service refuses malformed dicts. Wiring a real adapter must walk the spec §9 privacy-review checklist first.