### PR TITLE
feat(landing): How it works section + Hero trust line (L5.1 polish)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import FeatureTiles from "@/components/landing/FeatureTiles";
 import Hero from "@/components/landing/Hero";
+import HowItWorks from "@/components/landing/HowItWorks";
 import LandingAuthRedirect from "@/components/landing/LandingAuthRedirect";
 import LandingFooter from "@/components/landing/LandingFooter";
 import SecondCta from "@/components/landing/SecondCta";
@@ -64,6 +65,7 @@ export default function LandingPage() {
         <main>
           <Hero />
           <FeatureTiles />
+          <HowItWorks />
           <SecondCta />
         </main>
         <LandingFooter />

--- a/frontend/components/landing/FeatureTiles.tsx
+++ b/frontend/components/landing/FeatureTiles.tsx
@@ -26,6 +26,7 @@ export default function FeatureTiles() {
       aria-label="What you can do with The Better Decision"
       className="mx-auto max-w-6xl px-6 py-20 lg:px-10 lg:py-24"
     >
+      <h2 className="sr-only">What The Better Decision does</h2>
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 lg:gap-8">
         {tiles.map((tile, i) => (
           <div

--- a/frontend/components/landing/Hero.tsx
+++ b/frontend/components/landing/Hero.tsx
@@ -42,6 +42,16 @@ export default function Hero() {
               Sign in
             </Link>
           </div>
+          {/* Trust line under the CTAs. Three honest, verifiable claims;
+              the dot separators match the footer convention. No fake
+              urgency, no "limited time" framing (BRAND.md voice rules). */}
+          <p className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-muted">
+            <span>No card required</span>
+            <span aria-hidden className="text-text-muted/60">&middot;</span>
+            <span>EU-hosted</span>
+            <span aria-hidden className="text-text-muted/60">&middot;</span>
+            <span>Cancel anytime</span>
+          </p>
         </div>
         <div className="lg:pl-8">
           <HeroDashboard />

--- a/frontend/components/landing/HowItWorks.tsx
+++ b/frontend/components/landing/HowItWorks.tsx
@@ -1,0 +1,65 @@
+// "How it works" — a three-step concrete journey between FeatureTiles
+// (what you get) and SecondCta (sign up). The point is to lower the
+// "what am I committing to?" friction: visitors who don't yet trust
+// the product see exactly the first thirty minutes of using it.
+//
+// Voice: concrete, second-person sparingly, no "AI-powered", no fake
+// effortlessness (BRAND.md §Voice). No em-dashes in customer copy.
+//
+// Layout: numbered three-up grid, mirrors FeatureTiles spacing so the
+// two sections read as a pair. The numbers in the small kicker reuse
+// the same uppercase-tracked tag treatment as FeatureTiles.
+
+const steps = [
+  {
+    title: "Connect your accounts",
+    body:
+      "Import a CSV from your bank or pull in transactions one by one. The Better Decision keeps the data in your org, never sold, never shared.",
+  },
+  {
+    title: "Categorize as you go",
+    body:
+      "Auto-categorization learns from your edits. Spending breakdowns and budgets update in the same view, so you decide on the page you read.",
+  },
+  {
+    title: "See what comes next",
+    body:
+      "Recurring bills, forecasts, and a single per-period view show what's coming. No surprises at the end of the month.",
+  },
+];
+
+export default function HowItWorks() {
+  return (
+    <section
+      aria-label="How The Better Decision works"
+      className="mx-auto max-w-6xl px-6 py-20 lg:px-10 lg:py-24"
+    >
+      <div className="mb-10 max-w-2xl">
+        <p className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+          How it works
+        </p>
+        <h2 className="font-display text-3xl font-semibold leading-tight text-text-primary lg:text-4xl">
+          Thirty minutes to the first calm view of your money.
+        </h2>
+      </div>
+      <ol className="grid gap-6 md:grid-cols-3 lg:gap-8">
+        {steps.map((step, i) => (
+          <li
+            key={step.title}
+            className="rounded-xl border border-border bg-surface p-6"
+          >
+            <div className="mb-3 font-display text-xs font-semibold uppercase tracking-[0.14em] text-accent">
+              Step {String(i + 1).padStart(2, "0")}
+            </div>
+            <h3 className="mb-2 font-display text-lg font-semibold leading-snug text-text-primary">
+              {step.title}
+            </h3>
+            <p className="text-sm leading-relaxed text-text-secondary">
+              {step.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/frontend/tests/components/landing/HowItWorks.test.tsx
+++ b/frontend/tests/components/landing/HowItWorks.test.tsx
@@ -14,6 +14,20 @@ describe("<HowItWorks />", () => {
     expect(items[2]).toHaveTextContent(/step 03/i);
   });
 
+  it("renders each step title and a distinctive body snippet", () => {
+    render(<HowItWorks />);
+    const items = screen.getAllByRole("listitem");
+
+    expect(items[0]).toHaveTextContent(/connect your accounts/i);
+    expect(items[0]).toHaveTextContent(/import a csv from your bank/i);
+
+    expect(items[1]).toHaveTextContent(/categorize as you go/i);
+    expect(items[1]).toHaveTextContent(/auto-categorization learns from your edits/i);
+
+    expect(items[2]).toHaveTextContent(/see what comes next/i);
+    expect(items[2]).toHaveTextContent(/recurring bills, forecasts/i);
+  });
+
   it("uses a region landmark with an accessible name", () => {
     render(<HowItWorks />);
     expect(

--- a/frontend/tests/components/landing/HowItWorks.test.tsx
+++ b/frontend/tests/components/landing/HowItWorks.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+
+import HowItWorks from "@/components/landing/HowItWorks";
+
+describe("<HowItWorks />", () => {
+  it("renders an ordered list of three numbered steps", () => {
+    render(<HowItWorks />);
+    const list = screen.getByRole("list");
+    expect(list.tagName).toBe("OL");
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+    expect(items[0]).toHaveTextContent(/step 01/i);
+    expect(items[1]).toHaveTextContent(/step 02/i);
+    expect(items[2]).toHaveTextContent(/step 03/i);
+  });
+
+  it("uses a region landmark with an accessible name", () => {
+    render(<HowItWorks />);
+    expect(
+      screen.getByRole("region", { name: /how the better decision works/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("contains no em-dashes (locked voice policy)", () => {
+    render(<HowItWorks />);
+    // toHaveTextContent walks the full subtree; the section root carries
+    // every word the section ships. If a future copy edit introduces an
+    // em-dash, this assertion flags it before the page-level guard does.
+    const section = screen.getByRole("region", {
+      name: /how the better decision works/i,
+    });
+    expect(section.textContent ?? "").not.toMatch(/—/);
+  });
+});


### PR DESCRIPTION
## Summary

Iterates on the apex landing per the L5.1 "Full scope (polish iteration)" track. Adds a concrete three-step journey and a trust line under the Hero CTAs to lower visitor friction without changing the visual identity from PRs #224 / #230.

## Changes

- New `HowItWorks` section between `FeatureTiles` and `SecondCta`. Three numbered steps (Connect, Categorize, See what comes next), brass-accent kickers, same card spacing as FeatureTiles so the two sections read as a pair.
- Hero gains a trust line under the CTAs: "No card required, EU-hosted, Cancel anytime." Dot separators match the footer convention. No fake urgency, no AI-powered framing (BRAND.md voice rules).
- Page wiring: `frontend/app/page.tsx` imports + renders `HowItWorks`.
- Tests: `tests/components/landing/HowItWorks.test.tsx` covers ordered-list structure (`<ol>`), region landmark name, and an em-dash regression check on the section's full text.

`HowItWorks` is a server component (no client imports, no auth, no hooks). Verified against the apex static export build (`scripts/build-apex.sh`): the new copy ("How it works", "Thirty minutes", "No card required", "Connect your accounts") all appear in `out-apex/index.html`. Closes the iteration line on L5.1.

## Launch risk

Low. Pure additive UI on the apex landing; no auth, no API, no theme rewiring. Worst case is a copy edit follow-up after the user reads the new section live.