### PR TITLE
fix(admin): retire misleading Remove affordance, keep Deactivate honest

### DIFF
--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -856,71 +856,12 @@ async def update_org_member(
     return member_payload
 
 
-@router.delete(
-    "/{org_id}/members/{user_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
-)
-async def remove_org_member(
-    org_id: int,
-    user_id: int,
-    request: Request,
-    current_user: User = Depends(require_permission("orgs.manage")),
-    db: AsyncSession = Depends(get_db),
-    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
-):
-    org = await _ensure_target_org(db, org_id)
-    target_org_name = org.name
-
-    try:
-        target, snapshot = await admin_org_members_service.remove_member(
-            db,
-            org_id=org_id,
-            user_id=user_id,
-            actor=current_user,
-        )
-    except NotFoundError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Member not found",
-        )
-    except ValidationError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except ConflictError as e:
-        msg = str(e)
-        if "superadmin" in msg.lower():
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail=msg
-            )
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT, detail=msg
-        )
-
-    await db.commit()
-
-    # Idempotent on already-inactive targets — no audit row to avoid
-    # phantom "removed" events for a member who was already removed
-    # previously. The structlog signal is enough for the trace.
-    if snapshot["was_active"]:
-        await logger.ainfo(
-            "admin.org.member.removed",
-            actor_user_id=current_user.id,
-            actor_email=current_user.email,
-            target_org_id=org_id,
-            target_org_name=target_org_name,
-            target_user_id=target.id,
-            snapshot=snapshot,
-        )
-        await audit_service.record_audit_event(
-            session_factory,
-            event_type="admin.org.member.removed",
-            actor_user_id=current_user.id,
-            actor_email=current_user.email,
-            target_org_id=org_id,
-            target_org_name=target_org_name,
-            request_id=_request_id(),
-            ip_address=get_client_ip(request),
-            outcome="success",
-            detail={"snapshot": snapshot},
-        )
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+# Note: the prior ``DELETE /api/v1/admin/orgs/{org_id}/members/{user_id}``
+# endpoint emitted ``admin.org.member.removed`` audit rows but the
+# underlying service merely soft-deactivated the user. To stop
+# the UI from advertising a "Remove" affordance whose effect is a
+# deactivate, both the endpoint and the service helper were removed
+# on 2026-05-14. Callers wanting the same effect should PATCH
+# ``is_active=False`` against the existing member endpoint, which
+# already emits ``admin.org.member.deactivated`` and goes through
+# the same last-owner / self-target / superadmin guards.

--- a/backend/app/services/admin_org_members_service.py
+++ b/backend/app/services/admin_org_members_service.py
@@ -183,52 +183,15 @@ async def update_member(
     return target, before, after, changes
 
 
-async def remove_member(
-    db: AsyncSession,
-    *,
-    org_id: int,
-    user_id: int,
-    actor: User,
-) -> tuple[User, dict]:
-    """Soft-delete a member from ``org_id`` (mirrors the org-side
-    ``invitation_service.remove_member`` semantics — sets
-    ``is_active=False`` and bumps ``sessions_invalidated_at``).
-
-    Returns ``(target, snapshot)`` where ``snapshot`` is the
-    pre-removal identifying fields for the audit detail. Caller
-    commits.
-    """
-    if user_id == actor.id:
-        raise ValidationError("You cannot remove yourself")
-
-    target = await _load_target_member(db, org_id=org_id, user_id=user_id)
-
-    if target.is_superadmin:
-        raise ConflictError(
-            "Cannot remove a platform superadmin via org-member admin"
-        )
-
-    snapshot = {
-        "user_id": target.id,
-        "username": target.username,
-        "email": target.email,
-        "role": target.role.value,
-        "was_active": target.is_active,
-    }
-
-    if not target.is_active:
-        # Already removed — idempotent. Returning the snapshot lets
-        # the router emit a no-op audit event if it wants.
-        return target, snapshot
-
-    if target.role == Role.OWNER:
-        active_owners = await _active_owner_count(db, org_id=org_id)
-        if active_owners <= 1:
-            raise ConflictError(
-                "Cannot remove the last active owner of the organization"
-            )
-
-    target.is_active = False
-    target.sessions_invalidated_at = utcnow_naive()
-    await db.flush()
-    return target, snapshot
+# Note: a separate `remove_member` helper used to live here and was
+# wired to ``DELETE /api/v1/admin/orgs/{org_id}/members/{user_id}``.
+# The semantics it implemented were identical to a PATCH with
+# ``is_active=False`` (it set ``is_active=False`` and bumped
+# ``sessions_invalidated_at``), so exposing both a "Remove" and a
+# "Deactivate" affordance was misleading: callers naturally read
+# "Remove" as detaching the membership and discovered after the fact
+# that the user row was merely deactivated. The UI relabel + endpoint
+# consolidation (2026-05-14) collapses both paths onto the
+# ``update_member`` PATCH with ``is_active=False``. If a true
+# detach-membership semantic is ever required, it should be a new,
+# distinct service call with its own audit event type.

--- a/backend/tests/routers/test_admin_org_members.py
+++ b/backend/tests/routers/test_admin_org_members.py
@@ -6,9 +6,12 @@ Pins:
   `is_superadmin`).
 - PATCH guards: last-owner (deactivate / demote), self-target,
   superadmin target, no-op body.
-- DELETE guards: last-owner, self-target, superadmin target.
-- Audit events: one row per real change, no row for no-op PATCH or
-  already-inactive DELETE.
+- DELETE on `/members/{user_id}` is gone (2026-05-14): the underlying
+  semantics were always "soft-deactivate", which the PATCH path
+  already covers. The relabel-fix preserves the deactivate behavior
+  via PATCH with ``is_active=False`` and removes the misleading
+  "Remove" affordance from the UI and API.
+- Audit events: one row per real change, no row for no-op PATCH.
 """
 from __future__ import annotations
 
@@ -228,14 +231,22 @@ async def test_patch_member_403_for_non_superadmin(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_delete_member_403_for_non_superadmin(session_factory):
+async def test_delete_member_endpoint_is_removed(session_factory):
+    """The misleading DELETE `/members/{user_id}` was retired on
+    2026-05-14 in favor of PATCH ``is_active=False``. Confirm the
+    method is no longer routed (405) so client code can't accidentally
+    call the old shape.
+    """
     seed = await _seed(session_factory)
-    app = _make_app(session_factory, _plain_user_resolver())
+    app = _make_app(session_factory, _superadmin_resolver())
     with TestClient(app) as client:
         res = client.delete(
             f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['member_id']}"
         )
-    assert res.status_code == 403
+    # FastAPI returns 405 Method Not Allowed when the path matches a
+    # router prefix but the verb isn't bound. Either 404 or 405 is
+    # acceptable; both prove the verb is gone.
+    assert res.status_code in (404, 405)
 
 
 # ── list ───────────────────────────────────────────────────────────────────
@@ -468,85 +479,10 @@ async def test_patch_member_in_wrong_org_404(session_factory):
     assert res.status_code == 404
 
 
-# ── DELETE success + safety ───────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_delete_member_204_writes_audit(session_factory):
-    seed = await _seed(session_factory)
-    app = _make_app(session_factory, _superadmin_resolver())
-    with TestClient(app) as client:
-        res = client.delete(
-            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['member_id']}"
-        )
-    assert res.status_code == 204
-    rows = await _audit_events(session_factory, "admin.org.member.removed")
-    assert len(rows) == 1
-    assert rows[0].detail["snapshot"]["user_id"] == seed["member_id"]
-    assert rows[0].detail["snapshot"]["was_active"] is True
-
-    # is_active flipped to False in the DB.
-    async with session_factory() as db:
-        u = await db.scalar(select(User).where(User.id == seed["member_id"]))
-        assert u.is_active is False
-        assert u.sessions_invalidated_at is not None
-
-
-@pytest.mark.asyncio
-async def test_delete_already_inactive_member_is_idempotent_no_audit(session_factory):
-    seed = await _seed(session_factory)
-    app = _make_app(session_factory, _superadmin_resolver())
-    with TestClient(app) as client:
-        res = client.delete(
-            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['ghost_id']}"
-        )
-    assert res.status_code == 204
-    # No audit row for the no-op delete.
-    rows = await _audit_events(session_factory, "admin.org.member.removed")
-    assert rows == []
-
-
-@pytest.mark.asyncio
-async def test_delete_cannot_target_self(session_factory):
-    seed = await _seed(session_factory)
-    app = _make_app(session_factory, _superadmin_resolver())
-    with TestClient(app) as client:
-        res = client.delete(
-            f"/api/v1/admin/orgs/{seed['admin_org_id']}/members/{seed['admin_user_id']}"
-        )
-    assert res.status_code == 400
-
-
-@pytest.mark.asyncio
-async def test_delete_cannot_remove_last_owner(session_factory):
-    seed = await _seed(session_factory)
-    app = _make_app(session_factory, _superadmin_resolver())
-    with TestClient(app) as client:
-        res = client.delete(
-            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['owner_id']}"
-        )
-    assert res.status_code == 409
-    assert "last active owner" in res.json()["detail"].lower()
-
-
-@pytest.mark.asyncio
-async def test_delete_cannot_target_superadmin(session_factory):
-    seed = await _seed(session_factory)
-    app = _make_app(session_factory, _superadmin_resolver())
-    with TestClient(app) as client:
-        res = client.delete(
-            f"/api/v1/admin/orgs/{seed['target_id']}/members/{seed['embedded_sa_id']}"
-        )
-    assert res.status_code == 403
-    assert "superadmin" in res.json()["detail"].lower()
-
-
-@pytest.mark.asyncio
-async def test_delete_member_404_for_missing_user(session_factory):
-    seed = await _seed(session_factory)
-    app = _make_app(session_factory, _superadmin_resolver())
-    with TestClient(app) as client:
-        res = client.delete(
-            f"/api/v1/admin/orgs/{seed['target_id']}/members/99999"
-        )
-    assert res.status_code == 404
+# ── DELETE retired ─────────────────────────────────────────────────────────
+# The DELETE method on `/members/{user_id}` was removed on 2026-05-14
+# because it shared semantics with PATCH `is_active=False` while
+# emitting a misleading `admin.org.member.removed` audit event. All
+# deactivate flows now route through the PATCH path tested above; the
+# router-removal smoke check lives at
+# ``test_delete_member_endpoint_is_removed`` near the auth gates.

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -93,9 +93,16 @@ export default function AdminOrgDetailPage() {
   const [deleting, setDeleting] = useState(false);
 
   // Member management state (L4.4 slice).
+  //
+  // The "Remove" affordance was retired on 2026-05-14: the underlying
+  // DELETE endpoint shared its effect with PATCH ``is_active=False``
+  // (soft-deactivate) but emitted a misleading
+  // ``admin.org.member.removed`` audit event. Both flows now route
+  // through PATCH and surface the same confirm dialog so the audit
+  // log and the UI agree on what just happened.
   const [memberBusyId, setMemberBusyId] = useState<number | null>(null);
   const [memberError, setMemberError] = useState("");
-  const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
+  const [deactivateTarget, setDeactivateTarget] = useState<Member | null>(null);
 
   useEffect(() => {
     if (loading) return;
@@ -185,20 +192,23 @@ export default function AdminOrgDetailPage() {
     }
   }
 
-  async function confirmRemoveMember() {
-    if (!removeTarget) return;
-    const member = removeTarget;
+  async function confirmDeactivateMember() {
+    if (!deactivateTarget) return;
+    const member = deactivateTarget;
     setMemberError("");
     setMemberBusyId(member.id);
     try {
       await apiFetch(
         `/api/v1/admin/orgs/${orgId}/members/${member.id}`,
-        { method: "DELETE" },
+        {
+          method: "PATCH",
+          body: JSON.stringify({ is_active: false }),
+        },
       );
-      setRemoveTarget(null);
+      setDeactivateTarget(null);
       await refresh();
     } catch (err) {
-      setMemberError(extractErrorMessage(err, "Remove failed"));
+      setMemberError(extractErrorMessage(err, "Deactivate failed"));
     } finally {
       setMemberBusyId(null);
     }
@@ -431,30 +441,31 @@ export default function AdminOrgDetailPage() {
                         </span>
                       ) : (
                         <div className="flex flex-wrap gap-2">
-                          <button
-                            type="button"
-                            disabled={busy}
-                            onClick={() =>
-                              patchMember(m, { is_active: !m.is_active })
-                            }
-                            className={`${btnSecondary} min-h-[44px]`}
-                            aria-label={
-                              m.is_active
-                                ? `Deactivate ${m.username}`
-                                : `Reactivate ${m.username}`
-                            }
-                          >
-                            {m.is_active ? "Deactivate" : "Reactivate"}
-                          </button>
-                          <button
-                            type="button"
-                            disabled={busy || !m.is_active}
-                            onClick={() => setRemoveTarget(m)}
-                            className={`${btnDangerSolid} min-h-[44px]`}
-                            aria-label={`Remove ${m.username} from org`}
-                          >
-                            Remove
-                          </button>
+                          {m.is_active ? (
+                            <button
+                              type="button"
+                              disabled={busy}
+                              onClick={() => setDeactivateTarget(m)}
+                              className={`${btnDangerSolid} min-h-[44px]`}
+                              aria-label={`Deactivate ${m.username}`}
+                              title="Revoke access immediately. Data and audit history are preserved; the member can be reactivated later."
+                            >
+                              Deactivate
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              disabled={busy}
+                              onClick={() =>
+                                patchMember(m, { is_active: true })
+                              }
+                              className={`${btnSecondary} min-h-[44px]`}
+                              aria-label={`Reactivate ${m.username}`}
+                              title="Restore the member's access. They will be required to sign in again."
+                            >
+                              Reactivate
+                            </button>
+                          )}
                         </div>
                       )}
                     </td>
@@ -467,18 +478,18 @@ export default function AdminOrgDetailPage() {
       </section>
 
       <ConfirmModal
-        open={removeTarget !== null}
-        title="Remove member from organization"
+        open={deactivateTarget !== null}
+        title="Deactivate member"
         message={
-          removeTarget
-            ? `Remove ${removeTarget.username} (${removeTarget.email}) from ${detail.name}? They will lose access immediately. This action is recorded in the audit log.`
+          deactivateTarget
+            ? `Deactivate ${deactivateTarget.email}? They will lose access immediately but their data and audit history remain. You can reactivate them later from this page.`
             : ""
         }
-        confirmLabel="Remove"
+        confirmLabel="Deactivate"
         cancelLabel="Cancel"
         variant="danger"
-        onConfirm={confirmRemoveMember}
-        onCancel={() => setRemoveTarget(null)}
+        onConfirm={confirmDeactivateMember}
+        onCancel={() => setDeactivateTarget(null)}
       />
 
       {/* Counts card */}

--- a/frontend/tests/app/admin-org-detail-members.test.tsx
+++ b/frontend/tests/app/admin-org-detail-members.test.tsx
@@ -117,23 +117,29 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
     });
   });
 
-  it("renders the member section with role select and Remove buttons for editable rows", async () => {
+  it("renders the member section with role select and Deactivate buttons for editable rows", async () => {
     installMocks();
     render(<AdminOrgDetailPage />);
 
     await screen.findByRole("heading", { name: "Acme" });
     await screen.findByLabelText(/Role for alice/i);
 
-    // Editable rows get a role-combobox + Remove button.
+    // Editable active rows get a role-combobox + Deactivate button.
     expect(screen.getByLabelText(/Role for owner/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Remove alice from org/i }),
+      screen.getByRole("button", { name: /Deactivate alice/i }),
     ).toBeInTheDocument();
+
+    // The misleading "Remove" affordance is gone — only Deactivate /
+    // Reactivate remain for active / inactive rows.
+    expect(
+      screen.queryByRole("button", { name: /Remove alice from org/i }),
+    ).toBeNull();
 
     // Platform superadmin shows the locked-reason copy, not actions.
     expect(screen.getByText(/Platform superadmin/i)).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Remove platformsa from org/i }),
+      screen.queryByRole("button", { name: /Deactivate platformsa/i }),
     ).toBeNull();
   });
 
@@ -171,12 +177,26 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
     });
   });
 
-  it("PATCHes is_active=false when Deactivate is clicked", async () => {
+  it("Deactivate opens the confirm modal and PATCHes is_active=false on confirm", async () => {
     const apiFetchMock = installMocks();
     render(<AdminOrgDetailPage />);
 
     await screen.findByText("alice");
     fireEvent.click(screen.getByRole("button", { name: /Deactivate alice/i }));
+
+    // Confirm modal opens with the explicit copy locked by the
+    // remove-vs-deactivate fix.
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/Deactivate member/i),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        /lose access immediately but their data and audit history remain/i,
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Deactivate$/i }));
 
     await waitFor(() => {
       expect(apiFetchMock).toHaveBeenCalledWith(
@@ -187,6 +207,28 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
         }),
       );
     });
+  });
+
+  it("Cancel on the deactivate modal closes without calling PATCH", async () => {
+    const apiFetchMock = installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("alice");
+    fireEvent.click(screen.getByRole("button", { name: /Deactivate alice/i }));
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /Cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    const patchCalls = apiFetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        url === "/api/v1/admin/orgs/42/members/10" &&
+        (opts as RequestInit | undefined)?.method === "PATCH",
+    );
+    expect(patchCalls).toHaveLength(0);
   });
 
   it("Reactivate appears on inactive rows and PATCHes is_active=true", async () => {
@@ -207,51 +249,40 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
     });
   });
 
-  it("Remove opens the confirm modal and DELETEs on confirm", async () => {
+  it("never issues a DELETE on the member endpoint (Remove affordance retired)", async () => {
     const apiFetchMock = installMocks();
     render(<AdminOrgDetailPage />);
 
     await screen.findByText("alice");
-    fireEvent.click(
-      screen.getByRole("button", { name: /Remove alice from org/i }),
-    );
-
-    // Confirm modal opens.
+    // The Remove button is gone; deactivating alice should not result
+    // in a DELETE on the legacy /members/{id} endpoint.
+    fireEvent.click(screen.getByRole("button", { name: /Deactivate alice/i }));
     const dialog = await screen.findByRole("dialog");
-    expect(
-      within(dialog).getByText(/Remove member from organization/i),
-    ).toBeInTheDocument();
-
-    fireEvent.click(within(dialog).getByRole("button", { name: /^Remove$/i }));
+    fireEvent.click(within(dialog).getByRole("button", { name: /^Deactivate$/i }));
 
     await waitFor(() => {
-      expect(apiFetchMock).toHaveBeenCalledWith(
-        "/api/v1/admin/orgs/42/members/10",
-        expect.objectContaining({ method: "DELETE" }),
+      const deleteCalls = apiFetchMock.mock.calls.filter(
+        ([url, opts]) =>
+          url === "/api/v1/admin/orgs/42/members/10" &&
+          (opts as RequestInit | undefined)?.method === "DELETE",
       );
+      expect(deleteCalls).toHaveLength(0);
     });
   });
 
-  it("Cancel on the remove modal closes without calling DELETE", async () => {
-    const apiFetchMock = installMocks();
+  it("inactive rows do not surface a Deactivate button", async () => {
+    installMocks();
     render(<AdminOrgDetailPage />);
 
-    await screen.findByText("alice");
-    fireEvent.click(
-      screen.getByRole("button", { name: /Remove alice from org/i }),
-    );
-
-    const dialog = await screen.findByRole("dialog");
-    fireEvent.click(within(dialog).getByRole("button", { name: /Cancel/i }));
-
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).toBeNull();
-    });
-
-    const deleteCalls = apiFetchMock.mock.calls.filter(
-      ([, opts]) => (opts as RequestInit | undefined)?.method === "DELETE",
-    );
-    expect(deleteCalls).toHaveLength(0);
+    await screen.findByText("ghost");
+    // ghost is is_active=false, so the only mutation button on the
+    // row is Reactivate.
+    expect(
+      screen.getByRole("button", { name: /Reactivate ghost/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Deactivate ghost/i }),
+    ).toBeNull();
   });
 
   it("surfaces a 409 last-owner error from the backend in the member-error banner", async () => {
@@ -290,7 +321,7 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
     await screen.findByText(/last active owner/i);
   });
 
-  it("does not render role select or Remove for the actor's own row", async () => {
+  it("does not render role select or Deactivate for the actor's own row", async () => {
     // Inject the actor into the member list so the locked-reason
     // path renders.
     const membersWithSelf = [
@@ -310,7 +341,7 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
       screen.queryByLabelText(/Role for root/i),
     ).toBeNull();
     expect(
-      screen.queryByRole("button", { name: /Remove root from org/i }),
+      screen.queryByRole("button", { name: /Deactivate root/i }),
     ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Reported 2026-05-14: clicking **Remove** on an org member in `/admin/orgs/[id]` did not detach the membership, it merely soft-deactivated the user. Investigation confirmed both **Remove** (DELETE `/api/v1/admin/orgs/{org_id}/members/{user_id}`) and **Deactivate** (PATCH `is_active=false`) routed to the same effect, just with different audit event types (`admin.org.member.removed` vs `admin.org.member.deactivated`). Coordinator-set default for the fix was option (c) relabel — make the UI honest with the service behavior, no migration.

## What changed

**Backend**
- Dropped the DELETE `/members/{user_id}` route from `admin_orgs.py`.
- Removed the now-unused `admin_org_members_service.remove_member` helper.
- All deactivation goes through the existing PATCH `is_active=false` path, which keeps every safety guard (self / superadmin / last active OWNER) and emits the correct `admin.org.member.deactivated` audit event.
- Pre-launch: no compat alias.

**Frontend (`frontend/app/admin/orgs/[id]/page.tsx`)**
- Removed the per-row **Remove** button.
- Active rows now show a single **Deactivate** button. It opens a confirm modal: \"Deactivate {email}? They will lose access immediately but their data and audit history remain. You can reactivate them later from this page.\"
- Inactive rows show **Reactivate** (one-click, unchanged).
- Both buttons have explicit `title` tooltips describing the effect.

**Tests**
- Backend: replaced the six DELETE-success/guard tests with one smoke check that the verb is no longer routed; PATCH-path tests are untouched (18 pass).
- Frontend: updated the existing member-section tests to drive Deactivate through the modal and assert no DELETE call is issued (10 pass).

## Roadmap

Updates L4.4 row (still 🟡 partial) — adds a 2026-05-14 \"Relabel fix\" note clarifying that the misleading DELETE endpoint and `admin.org.member.removed` event are retired. Other L4.4 slices (cross-org search, admin invite, password / email / MFA reset, read-only impersonation) remain open.

## Launch risk

Low. The only deployed call site for the DELETE was the same admin UI being relabeled in this PR; deactivate-flow audit coverage is unchanged and continues through the PATCH path. No data migration, no breaking change to any non-admin surface.