### PR TITLE
fix(hotfix): app host root redirects to /login (L5.2a follow-up)

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -69,6 +69,24 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async redirects() {
+    // App host root → /login. frontend/app/page.tsx is shared between
+    // the DO runtime (app.thebetterdecision.com) and the apex static
+    // export (thebetterdecision.com, built via next.config.apex.ts +
+    // scripts/build-apex.sh). Apex serves landing; the DO runtime must
+    // not. Host-scope the rule via `has` so it only fires on the app
+    // host even if some other build ever points at this config.
+    return [
+      {
+        source: "/",
+        has: [
+          { type: "host", value: "app.thebetterdecision.com" },
+        ],
+        destination: "/login",
+        permanent: false, // 307; keep flexible during early launch
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/tests/next-config-redirects.test.ts
+++ b/frontend/tests/next-config-redirects.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import nextConfig from "@/next.config";
+
+// next-config-redirects.test.ts — guards the host-scoped root redirect
+// that prevents app.thebetterdecision.com from serving the marketing
+// landing page (which is hosted on the apex via S3 + CloudFront via
+// next.config.apex.ts). If somebody removes or mutates the rule, this
+// test fails loudly. See PR comments on the L5.2a follow-up hotfix.
+
+describe("next.config.ts redirects", () => {
+  it("redirects app-host root to /login with host-scoping", async () => {
+    if (typeof nextConfig.redirects !== "function") {
+      throw new Error("redirects() not configured");
+    }
+    const rules = await nextConfig.redirects();
+    const appHostRule = rules.find(
+      (r) =>
+        r.source === "/" &&
+        Array.isArray(r.has) &&
+        r.has.some(
+          (h) =>
+            h.type === "host" && h.value === "app.thebetterdecision.com",
+        ),
+    );
+    expect(appHostRule).toBeDefined();
+    expect(appHostRule!.destination).toBe("/login");
+    // 307, not 308 — flexible during early launch.
+    expect(appHostRule!.permanent).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`app.thebetterdecision.com/` was still serving the marketing landing HTML, duplicating the apex (thebetterdecision.com, served by S3+CloudFront). Add a host-scoped 307 redirect in `frontend/next.config.ts` so the DO runtime sends app-host root visitors to `/login`. The apex static export (`next.config.apex.ts`) is untouched.

## What changed

- `frontend/next.config.ts`: new `redirects()` rule scoped via `has: [{type: 'host', value: 'app.thebetterdecision.com'}]` -> `/login` (307).
- `frontend/tests/next-config-redirects.test.ts`: asserts the rule shape so future config edits can't silently break it.

## Post-deploy verification

- `curl -I https://app.thebetterdecision.com/` -> 307 Location: /login
- `curl -I https://thebetterdecision.com/` -> 200 from CloudFront
- `curl -I https://www.thebetterdecision.com/` -> 301 to apex

Closes L5.2a follow-up: app-host root no longer serves marketing.