### PR TITLE
fix(hotfix): RSC getServerSession resilience

### DIFF
--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { cookies } from "next/headers";
 import { cache } from "react";
+import { logger } from "./logger";
 import type { User } from "./types";
 
 // Foundation for Server Component migrations. The client-side `apiFetch` in
@@ -44,27 +45,47 @@ export const getServerSession = cache(
     const refresh = cookieStore.get(REFRESH_COOKIE_NAME);
     if (!refresh) return null;
 
-    const res = await fetch(`${SERVER_API_URL}/api/v1/auth/verify`, {
-      method: "POST",
-      headers: {
-        Cookie: `${refresh.name}=${refresh.value}`,
-      },
-      // No credentials: 'include' on server-side fetch — we forward the
-      // cookie explicitly via the Cookie header above. The endpoint does not
-      // issue a Set-Cookie response, so there's nothing to propagate back.
-      cache: "no-store",
-    });
+    try {
+      const res = await fetch(`${SERVER_API_URL}/api/v1/auth/verify`, {
+        method: "POST",
+        headers: {
+          Cookie: `${refresh.name}=${refresh.value}`,
+        },
+        // No credentials: 'include' on server-side fetch — we forward the
+        // cookie explicitly via the Cookie header above. The endpoint does
+        // not issue a Set-Cookie response, so there's nothing to propagate
+        // back.
+        cache: "no-store",
+      });
 
-    if (!res.ok) return null;
+      if (!res.ok) return null;
 
-    const payload = (await res.json()) as {
-      user: User;
-      access_token: string;
-      token_type: string;
-    };
-    if (!payload.access_token || !payload.user) return null;
+      const payload = (await res.json()) as {
+        user: User;
+        access_token: string;
+        token_type: string;
+      };
+      if (!payload.access_token || !payload.user) return null;
 
-    return { user: payload.user, accessToken: payload.access_token };
+      return { user: payload.user, accessToken: payload.access_token };
+    } catch (err) {
+      // Transient fetch/JSON failure during RSC render. Examples: DNS race
+      // during deploy, connection reset, TLS error, malformed response body.
+      // Callers (forecast-plans/page.tsx, reconcile/page.tsx) treat null as
+      // "redirect to /login", where AuthProvider's client-side refresh
+      // recovers a still-valid session into /dashboard. Without this catch,
+      // transient blips surface as the Next.js error boundary with a digest.
+      //
+      // Sanitization is non-negotiable: log ONLY backend_host, error_name,
+      // error_message. Never the refresh cookie value, never any header
+      // value, never any token, never any response body.
+      logger.warn("server_session_verify_failed", {
+        backend_host: new URL(SERVER_API_URL).host,
+        error_name: err instanceof Error ? err.name : "Unknown",
+        error_message: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
   },
 );
 

--- a/frontend/tests/lib/auth-server.test.ts
+++ b/frontend/tests/lib/auth-server.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock next/headers so the module under test doesn't blow up on the
+// server-only `cookies()` import outside a real Next.js request.
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+// Mock the structured logger so we can assert the exact sanitized payload
+// emitted on the catch branch, without writing to stdout/stderr in tests.
+vi.mock("@/lib/logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Stub server-only so the import works in a node/jsdom test env. Without
+// this, `import "server-only"` throws at module load.
+vi.mock("server-only", () => ({}));
+
+import { cookies } from "next/headers";
+
+// `getServerSession` is wrapped in React.cache() which memoizes per call site.
+// To guarantee each test gets a fresh memoization, we re-import the module
+// inside every test after `vi.resetModules()` in beforeEach.
+async function loadModule() {
+  const mod = await import("@/lib/auth-server");
+  const loggerMod = await import("@/lib/logger");
+  return { getServerSession: mod.getServerSession, logger: loggerMod.logger };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("getServerSession", () => {
+  it("returns null and does not fetch when no refresh cookie is present", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => undefined,
+    });
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const { getServerSession } = await loadModule();
+    const session = await getServerSession();
+    expect(session).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null when fetch rejects, does not throw, logs sanitized warning", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "REDACTED-COOKIE-VALUE" }),
+    });
+    vi.spyOn(global, "fetch").mockRejectedValue(
+      new TypeError("Failed to fetch")
+    );
+    const { getServerSession, logger } = await loadModule();
+    const session = await getServerSession();
+    expect(session).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_session_verify_failed",
+      expect.objectContaining({
+        error_name: "TypeError",
+        error_message: expect.stringContaining("Failed to fetch"),
+      })
+    );
+    // Critical privacy assertion: the logged payload must NOT contain the
+    // cookie value, any token, or any header value.
+    const logCallArgs = (logger.warn as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls[0][1];
+    expect(JSON.stringify(logCallArgs)).not.toContain("REDACTED-COOKIE-VALUE");
+  });
+
+  it("returns null when res.json() throws on invalid JSON, does not throw", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+    } as unknown as Response);
+    const { getServerSession, logger } = await loadModule();
+    const session = await getServerSession();
+    expect(session).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_session_verify_failed",
+      expect.objectContaining({ error_name: "SyntaxError" })
+    );
+  });
+
+  it("returns null on non-OK response, does NOT log a warning (normal auth flow)", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: "Invalid" }),
+    } as unknown as Response);
+    const { getServerSession, logger } = await loadModule();
+    const session = await getServerSession();
+    expect(session).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns the session payload on valid 200 response", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        user: {
+          id: 1,
+          username: "alice",
+          email: "a@b.c",
+          first_name: null,
+          last_name: null,
+          phone: null,
+          avatar_url: null,
+          email_verified: true,
+          role: "owner",
+          org_id: 1,
+          org_name: "Acme",
+          billing_cycle_day: 1,
+          is_superadmin: false,
+          is_active: true,
+          mfa_enabled: false,
+          password_set: true,
+        },
+        access_token: "TOK",
+        token_type: "bearer",
+      }),
+    } as unknown as Response);
+    const { getServerSession, logger } = await loadModule();
+    const session = await getServerSession();
+    expect(session).toEqual({
+      user: expect.objectContaining({ id: 1, email: "a@b.c" }),
+      accessToken: "TOK",
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Production-visible Next.js error boundary ("Something went wrong / Reference: ...") was surfacing on RSC pages (forecast-plans, reconcile) when a transient network blip caused the server-component fetch to throw before reaching backend. Wrap the `/api/v1/auth/verify` call in `try/catch`, log a sanitized structured warning, return null. Both RSC callers already redirect to `/login` on null; AuthProvider then recovers a valid session client-side.

## What changed

- `frontend/lib/auth-server.ts`: try/catch around the `/auth/verify` `fetch()` and `res.json()`. Sanitized `logger.warn("server_session_verify_failed", {backend_host, error_name, error_message})` on catch, no cookie/token/header values.
- `frontend/tests/lib/auth-server.test.ts`: 5 tests covering no-cookie, fetch rejection, JSON parse error, non-OK response, valid payload.

## Follow-up (separate PR)

`frontend/instrumentation.ts` should add an `onRequestError` handler so future RSC errors are captured in App Platform run logs with stack traces, not just digest references. Out of scope here.