### PR TITLE
feat(observability): SSR/RSC error logging via instrumentation.ts onRequestError

### DIFF
--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -1,7 +1,14 @@
 /**
- * Next.js instrumentation — runs once on server startup.
- * Logs the server start event in structured JSON format.
+ * Next.js instrumentation — runs once on server startup, and intercepts
+ * SSR/RSC errors via the v15+ onRequestError hook.
+ *
+ * Logs the server start event in structured JSON format, and emits a
+ * sanitized `frontend.ssr.error` event for every SSR/RSC error so the
+ * `error.digest` references that surface in the error boundary become
+ * searchable in App Platform run logs.
  */
+import { logger } from "./lib/logger";
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const entry = {
@@ -15,4 +22,62 @@ export async function register() {
     };
     process.stdout.write(JSON.stringify(entry) + "\n");
   }
+}
+
+/**
+ * Structural shape of the Next.js 15+ onRequestError arguments. We avoid
+ * importing the framework types directly to keep this file portable across
+ * Next minor upgrades; the runtime payload is what matters.
+ */
+interface SsrRequestInfo {
+  path?: string;
+  method?: string;
+  // headers/body intentionally NOT destructured below — see allowlist note.
+  headers?: Record<string, string>;
+}
+
+interface SsrErrorContext {
+  routerKind?: string; // "Pages Router" | "App Router"
+  routePath?: string;
+  routeType?: string; // "route" | "page" | "action"
+  renderSource?: string; // "react-server-components" | "server-action" | ...
+  revalidateReason?: string;
+}
+
+/**
+ * Next.js 15+ hook. Fires on every SSR/RSC error (anything that would
+ * otherwise surface as a digest in the error boundary). We log a
+ * sanitized structured event so digests become searchable and the
+ * underlying error name/message is recoverable from App Platform run logs.
+ *
+ * Privacy invariant: the destructured field list in the `logger.error`
+ * call below is the ENTIRE allowlist. Do not add headers, cookies,
+ * tokens, auth values, request bodies, response bodies, or query
+ * values (which may carry password-reset tokens, magic-link codes,
+ * SSO state, etc.).
+ *
+ * Query-string policy: STRICT. The full query string is stripped from
+ * `request_path` regardless of contents. Selective scrub-listing is a
+ * maintenance trap; the cost of losing query context for SSR errors
+ * is small relative to the risk of leaking a sensitive token.
+ */
+export async function onRequestError(
+  err: Error & { digest?: string },
+  request: SsrRequestInfo,
+  context: SsrErrorContext,
+): Promise<void> {
+  const rawPath = request?.path;
+  const requestPath =
+    typeof rawPath === "string" ? rawPath.split("?")[0] : rawPath;
+
+  logger.error("frontend.ssr.error", {
+    digest: err?.digest,
+    error_name: err?.name ?? "Unknown",
+    error_message: err?.message ?? "",
+    route_path: context?.routePath,
+    route_type: context?.routeType,
+    render_source: context?.renderSource,
+    request_path: requestPath,
+    method: request?.method,
+  });
 }

--- a/frontend/tests/lib/instrumentation.test.ts
+++ b/frontend/tests/lib/instrumentation.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { logger } from "@/lib/logger";
+import { onRequestError } from "@/instrumentation";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("onRequestError", () => {
+  it("emits frontend.ssr.error with only allowlisted fields", async () => {
+    const err = Object.assign(new Error("boom"), { digest: "DIGEST-XYZ" });
+    err.name = "RuntimeError";
+
+    await onRequestError(
+      err,
+      { path: "/forecast-plans", method: "GET" },
+      {
+        routePath: "/forecast-plans",
+        routeType: "page",
+        renderSource: "react-server-components",
+      },
+    );
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const [event, fields] = (logger.error as unknown as { mock: { calls: [string, Record<string, unknown>][] } }).mock.calls[0];
+    expect(event).toBe("frontend.ssr.error");
+
+    // Allowlist assertion — these keys are the entire field set.
+    expect(new Set(Object.keys(fields))).toEqual(
+      new Set([
+        "digest",
+        "error_name",
+        "error_message",
+        "route_path",
+        "route_type",
+        "render_source",
+        "request_path",
+        "method",
+      ]),
+    );
+
+    expect(fields.digest).toBe("DIGEST-XYZ");
+    expect(fields.error_name).toBe("RuntimeError");
+    expect(fields.error_message).toBe("boom");
+    expect(fields.request_path).toBe("/forecast-plans");
+    expect(fields.route_path).toBe("/forecast-plans");
+    expect(fields.route_type).toBe("page");
+    expect(fields.render_source).toBe("react-server-components");
+    expect(fields.method).toBe("GET");
+  });
+
+  it("never logs request headers, cookies, tokens, or sensitive query values", async () => {
+    const SECRET_COOKIE = "SECRET-REFRESH-TOKEN-VALUE";
+    const SECRET_BEARER = "SECRET-AUTH-BEARER-VALUE";
+    const SECRET_QUERY = "SECRET-PASSWORD-RESET-TOKEN";
+
+    const err = new Error("boom");
+    err.name = "RuntimeError";
+
+    await onRequestError(
+      err,
+      {
+        path: `/reset-password?token=${SECRET_QUERY}`,
+        method: "GET",
+        headers: {
+          Cookie: `refresh_token=${SECRET_COOKIE}`,
+          Authorization: `Bearer ${SECRET_BEARER}`,
+        },
+      },
+      {
+        routePath: "/reset-password",
+        routeType: "page",
+        renderSource: "react-server-components",
+      },
+    );
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const payload = (logger.error as unknown as { mock: { calls: [string, Record<string, unknown>][] } }).mock.calls[0][1];
+    const serialized = JSON.stringify(payload);
+
+    expect(serialized).not.toContain(SECRET_COOKIE);
+    expect(serialized).not.toContain(SECRET_BEARER);
+    // Strict policy: full query string stripped from request_path,
+    // so SECRET_QUERY must not appear in the payload at all.
+    expect(serialized).not.toContain(SECRET_QUERY);
+    // Sanity: pathname survived without the query.
+    expect(payload.request_path).toBe("/reset-password");
+  });
+
+  it("handles missing/optional fields without crashing", async () => {
+    const err = new Error("oops");
+
+    await onRequestError(err, {}, {});
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const fields = (logger.error as unknown as { mock: { calls: [string, Record<string, unknown>][] } }).mock.calls[0][1];
+    expect(fields.error_message).toBe("oops");
+    expect(fields.error_name).toBe("Error");
+    expect(fields.digest).toBeUndefined();
+    expect(fields.request_path).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Wires Next.js 15's `onRequestError` hook in `frontend/instrumentation.ts` so SSR/RSC errors emit a sanitized structured `frontend.ssr.error` event via `frontend/lib/logger.ts`. After this lands, error-boundary "Reference: X" failures become searchable in App Platform run logs with route + digest + error name/message context.

## Allowed fields (strict allowlist)

`event`, `digest`, `error_name`, `error_message`, `route_path`, `route_type`, `render_source`, `request_path` (query stripped), `method`.

## Never logged

Request headers, cookies, Authorization values, request bodies, response bodies, query values (entire query string stripped from `request_path`).

## Tests

- Allowlist assertion: exact key set
- Privacy assertion: known-secret markers in cookie / Bearer / query do not appear in the logged payload
- Optional-field handling: missing digest / path / context fields do not crash

## Companion

PR-B (separate, in flight): RSC/server backend fetch helper + convention/AST gate + fault-injection smoke. PR-A is observability; PR-B is prevention.

Closes part of the post-#282 release hardening.