### PR TITLE
feat(security): RSC/server backend fetch helper + convention gate

### DIFF
--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getServerSession } from "@/lib/auth-server";
+import { serverFetch } from "@/lib/server-fetch";
 import ForecastPlansClient from "./ForecastPlansClient";
 import type { BillingPeriod, Category, ForecastPlan } from "@/lib/types";
 
@@ -10,41 +11,16 @@ import type { BillingPeriod, Category, ForecastPlan } from "@/lib/types";
 // has to deal with an unauthenticated state.
 //
 // We then issue the three initial reads in parallel (categories, billing
-// periods, and the plan for the visible period) with the access token, and
-// hand the results down as initial props. The client uses them as SWR
-// `fallbackData` for the plan so the page paints immediately and only
-// re-fetches when the user navigates periods or mutates the plan.
+// periods, and the plan for the visible period) via the sanctioned
+// `serverFetch` helper, and hand the results down as initial props. The
+// client uses them as SWR `fallbackData` for the plan so the page paints
+// immediately and only re-fetches when the user navigates periods or
+// mutates the plan.
 //
 // The `ensure-future` POST (a side-effect write that pre-creates forward
 // billing-period stubs) intentionally stays in the client. RSC fetches
 // should be idempotent reads, and the existing client already runs
 // ensure-future once-per-session before loading periods.
-//
-// URL resolution mirrors `lib/auth-server.ts` so this module works in
-// docker-compose (BACKEND_INTERNAL_URL=http://backend:8000), in DO App
-// Platform (BACKEND_INTERNAL_URL=${backend.PRIVATE_URL}), and from a
-// developer's host shell against a locally-running backend.
-
-const SERVER_API_URL =
-  process.env.BACKEND_INTERNAL_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  "http://localhost:8000";
-
-async function fetchJSON<T>(
-  path: string,
-  accessToken: string,
-): Promise<T | null> {
-  try {
-    const res = await fetch(`${SERVER_API_URL}${path}`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      cache: "no-store",
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as T;
-  } catch {
-    return null;
-  }
-}
 
 // The existing client picks the "current" period (the open one with
 // end_date === null) and falls back to index 0 when there isn't one. We
@@ -61,11 +37,12 @@ export default async function ForecastPlansPage() {
   if (!session) redirect("/login");
 
   const [categories, periods] = await Promise.all([
-    fetchJSON<Category[]>("/api/v1/categories", session.accessToken),
-    fetchJSON<BillingPeriod[]>(
-      "/api/v1/settings/billing-periods",
-      session.accessToken,
-    ),
+    serverFetch<Category[]>("/api/v1/categories", {
+      accessToken: session.accessToken,
+    }),
+    serverFetch<BillingPeriod[]>("/api/v1/settings/billing-periods", {
+      accessToken: session.accessToken,
+    }),
   ]);
 
   const periodList = periods ?? [];
@@ -75,9 +52,9 @@ export default async function ForecastPlansPage() {
   // yet have a plan auto-creates a draft. That matches the pre-RSC
   // client's first-load behavior; preserving UX is the goal of this PR.
   const initialPlan = initialPeriod
-    ? await fetchJSON<ForecastPlan>(
+    ? await serverFetch<ForecastPlan>(
         `/api/v1/forecast-plans?period_start=${initialPeriod.start_date}`,
-        session.accessToken,
+        { accessToken: session.accessToken },
       )
     : null;
 

--- a/frontend/app/import/[import_id]/reconcile/page.tsx
+++ b/frontend/app/import/[import_id]/reconcile/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getServerSession } from "@/lib/auth-server";
+import { serverFetch } from "@/lib/server-fetch";
 import ReconcileClient from "./ReconcileClient";
 import type { ImportBatchDetail } from "@/lib/types";
 
@@ -8,34 +9,10 @@ import type { ImportBatchDetail } from "@/lib/types";
 // The route lives at /import/[import_id]/reconcile and is authed-only;
 // the RSC shell rejects unauthenticated requests at the server boundary
 // (no flash of a protected screen). We fetch the batch detail once on
-// the server with the access token and hand it to the client island as
-// SWR fallbackData; the client re-fetches on action so the UI stays in
-// sync with the server-side state machine after every transition.
-//
-// URL resolution mirrors the existing forecast-plans page so this
-// module works in docker-compose, in DO App Platform, and from a
-// developer's host shell against a locally-running backend.
-
-const SERVER_API_URL =
-  process.env.BACKEND_INTERNAL_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  "http://localhost:8000";
-
-async function fetchJSON<T>(
-  path: string,
-  accessToken: string,
-): Promise<T | null> {
-  try {
-    const res = await fetch(`${SERVER_API_URL}${path}`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      cache: "no-store",
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as T;
-  } catch {
-    return null;
-  }
-}
+// the server via the sanctioned `serverFetch` helper and hand it to the
+// client island as SWR fallbackData; the client re-fetches on action so
+// the UI stays in sync with the server-side state machine after every
+// transition.
 
 export default async function ReconcilePage({
   params,
@@ -51,9 +28,9 @@ export default async function ReconcilePage({
     redirect("/import");
   }
 
-  const initialBatch = await fetchJSON<ImportBatchDetail>(
+  const initialBatch = await serverFetch<ImportBatchDetail>(
     `/api/v1/import/${batchId}`,
-    session.accessToken,
+    { accessToken: session.accessToken },
   );
 
   return (

--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -20,10 +20,12 @@ import type { User } from "./types";
 // single render only pay the network cost once.
 //
 // All transport (rejected fetch / non-OK / invalid JSON / sanitized logging)
-// goes through `serverFetch`. A non-OK from /auth/verify is part of normal
-// auth flow (no refresh cookie → 401), so we pass `silentNonOk: true` to
-// avoid noisy warns. Transient fetch failures still log a sanitized
-// `server_fetch_failed` event from inside the helper.
+// goes through `serverFetch`. A 401 from /auth/verify is part of normal
+// auth flow (no refresh cookie → 401), so we pass `silentStatuses: [401]`
+// to avoid noisy warns for that one expected case. Real backend outages
+// (500/503) still emit `server_fetch_non_ok` so on-call can see them.
+// Transient fetch failures still log a sanitized `server_fetch_failed`
+// event from inside the helper.
 
 const REFRESH_COOKIE_NAME = "refresh_token";
 
@@ -46,8 +48,9 @@ export const getServerSession = cache(
       method: "POST",
       cookie: `${refresh.name}=${refresh.value}`,
       // 401 here means "no session", not an outage. Suppress warn-level
-      // logging in that case; rejected-fetch / invalid-JSON still log.
-      silentNonOk: true,
+      // logging for that exact status; rejected-fetch, invalid-JSON, and
+      // other non-OK statuses (e.g. 500/503) still log.
+      silentStatuses: [401],
     });
 
     if (!payload || !payload.access_token || !payload.user) return null;

--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { cookies } from "next/headers";
 import { cache } from "react";
-import { logger } from "./logger";
+import { serverFetch } from "./server-fetch";
 import type { User } from "./types";
 
 // Foundation for Server Component migrations. The client-side `apiFetch` in
@@ -19,18 +19,11 @@ import type { User } from "./types";
 // Results are cached per request via React's `cache` so multiple RSCs in a
 // single render only pay the network cost once.
 //
-// URL resolution. The browser uses relative URLs and nginx routes them. The
-// server (this module) needs an absolute URL to reach the backend. In
-// docker-compose dev and prod, BACKEND_INTERNAL_URL points at the backend
-// service (`http://backend:8000`). On DO App Platform it resolves to the
-// inter-service private URL. Fallback chain ends at `http://localhost:8000`
-// so a developer running the backend directly outside docker can still
-// import this module and have it work.
-
-const SERVER_API_URL =
-  process.env.BACKEND_INTERNAL_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  "http://localhost:8000";
+// All transport (rejected fetch / non-OK / invalid JSON / sanitized logging)
+// goes through `serverFetch`. A non-OK from /auth/verify is part of normal
+// auth flow (no refresh cookie → 401), so we pass `silentNonOk: true` to
+// avoid noisy warns. Transient fetch failures still log a sanitized
+// `server_fetch_failed` event from inside the helper.
 
 const REFRESH_COOKIE_NAME = "refresh_token";
 
@@ -45,47 +38,21 @@ export const getServerSession = cache(
     const refresh = cookieStore.get(REFRESH_COOKIE_NAME);
     if (!refresh) return null;
 
-    try {
-      const res = await fetch(`${SERVER_API_URL}/api/v1/auth/verify`, {
-        method: "POST",
-        headers: {
-          Cookie: `${refresh.name}=${refresh.value}`,
-        },
-        // No credentials: 'include' on server-side fetch — we forward the
-        // cookie explicitly via the Cookie header above. The endpoint does
-        // not issue a Set-Cookie response, so there's nothing to propagate
-        // back.
-        cache: "no-store",
-      });
+    const payload = await serverFetch<{
+      user: User;
+      access_token: string;
+      token_type: string;
+    }>("/api/v1/auth/verify", {
+      method: "POST",
+      cookie: `${refresh.name}=${refresh.value}`,
+      // 401 here means "no session", not an outage. Suppress warn-level
+      // logging in that case; rejected-fetch / invalid-JSON still log.
+      silentNonOk: true,
+    });
 
-      if (!res.ok) return null;
+    if (!payload || !payload.access_token || !payload.user) return null;
 
-      const payload = (await res.json()) as {
-        user: User;
-        access_token: string;
-        token_type: string;
-      };
-      if (!payload.access_token || !payload.user) return null;
-
-      return { user: payload.user, accessToken: payload.access_token };
-    } catch (err) {
-      // Transient fetch/JSON failure during RSC render. Examples: DNS race
-      // during deploy, connection reset, TLS error, malformed response body.
-      // Callers (forecast-plans/page.tsx, reconcile/page.tsx) treat null as
-      // "redirect to /login", where AuthProvider's client-side refresh
-      // recovers a still-valid session into /dashboard. Without this catch,
-      // transient blips surface as the Next.js error boundary with a digest.
-      //
-      // Sanitization is non-negotiable: log ONLY backend_host, error_name,
-      // error_message. Never the refresh cookie value, never any header
-      // value, never any token, never any response body.
-      logger.warn("server_session_verify_failed", {
-        backend_host: new URL(SERVER_API_URL).host,
-        error_name: err instanceof Error ? err.name : "Unknown",
-        error_message: err instanceof Error ? err.message : String(err),
-      });
-      return null;
-    }
+    return { user: payload.user, accessToken: payload.access_token };
   },
 );
 

--- a/frontend/lib/server-fetch.ts
+++ b/frontend/lib/server-fetch.ts
@@ -28,15 +28,30 @@ const SERVER_API_URL =
   process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8000";
 
+// Wrap the URL parse so a malformed SERVER_API_URL (env typo, missing
+// scheme, etc.) cannot make the failure-logging path itself throw. If the
+// catch block threw while building its log payload, we'd re-open the exact
+// "server render hits error boundary" class this helper was meant to
+// prevent. Exported for direct unit-testing.
+export function safeBackendHost(): string {
+  try {
+    return new URL(SERVER_API_URL).host;
+  } catch {
+    return "invalid-backend-url";
+  }
+}
+
 export type ServerFetchOptions = {
   method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   body?: BodyInit;
   accessToken?: string;
   cookie?: string;
-  // Allow callers to opt out of warn-level logging on non-OK responses
-  // when a non-OK status is part of normal flow (e.g. 401 from /auth/verify
-  // simply means "no session", not an outage).
-  silentNonOk?: boolean;
+  // Allow callers to opt out of warn-level logging for specific non-OK
+  // statuses that are part of normal flow (e.g. 401 from /auth/verify
+  // simply means "no session", not an outage). Statuses NOT in this list
+  // still emit `server_fetch_non_ok` so backend outages (500/503) are
+  // never accidentally silenced.
+  silentStatuses?: number[];
 };
 
 // Returns parsed JSON on success, `null` on any failure (rejected fetch,
@@ -76,11 +91,11 @@ export async function serverFetch<T>(
     });
 
     if (!res.ok) {
-      if (!options.silentNonOk) {
+      if (!options.silentStatuses?.includes(res.status)) {
         logger.warn("server_fetch_non_ok", {
-          backend_host: new URL(SERVER_API_URL).host,
+          backend_host: safeBackendHost(),
           method: options.method ?? "GET",
-          path,
+          path: path.split("?")[0],
           status: res.status,
         });
       }
@@ -90,9 +105,9 @@ export async function serverFetch<T>(
     return (await res.json()) as T;
   } catch (err) {
     logger.warn("server_fetch_failed", {
-      backend_host: new URL(SERVER_API_URL).host,
+      backend_host: safeBackendHost(),
       method: options.method ?? "GET",
-      path,
+      path: path.split("?")[0],
       error_name: err instanceof Error ? err.name : "Unknown",
       error_message: err instanceof Error ? err.message : String(err),
     });

--- a/frontend/lib/server-fetch.ts
+++ b/frontend/lib/server-fetch.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+import { logger } from "./logger";
+
+// Sanctioned chokepoint for server-side (RSC, server-only library, server
+// action) backend fetches. Every server surface MUST use this helper rather
+// than calling `fetch` directly; the convention test at
+// `frontend/tests/convention/rsc-fetch-guards.test.ts` enforces it in CI.
+//
+// Why a chokepoint:
+//   - Unhandled rejected fetch or thrown JSON parse during RSC render
+//     surfaces as the Next.js error boundary with an opaque digest
+//     (`Reference: <digest>`). #282 is the prior incident this class of bug
+//     produced. The helper returns `null` instead, so callers can redirect
+//     to /login or fall back to a graceful empty state.
+//   - The sanitized log payload is bounded by construction (see invariants
+//     below). Direct callers tend to log `err`, which on a fetch failure
+//     can contain request headers including cookies and bearer tokens.
+//
+// URL resolution mirrors `lib/auth-server.ts`. The browser uses relative
+// URLs proxied by nginx; the server needs an absolute URL. In dev compose
+// and prod the BACKEND_INTERNAL_URL env var points at the backend service;
+// the fallbacks let a developer running the backend directly outside docker
+// import this module and have it work.
+
+const SERVER_API_URL =
+  process.env.BACKEND_INTERNAL_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8000";
+
+export type ServerFetchOptions = {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  body?: BodyInit;
+  accessToken?: string;
+  cookie?: string;
+  // Allow callers to opt out of warn-level logging on non-OK responses
+  // when a non-OK status is part of normal flow (e.g. 401 from /auth/verify
+  // simply means "no session", not an outage).
+  silentNonOk?: boolean;
+};
+
+// Returns parsed JSON on success, `null` on any failure (rejected fetch,
+// invalid JSON, non-OK status). Failures emit a sanitized structured
+// warning via the project logger.
+//
+// PRIVACY INVARIANTS (must hold by construction):
+//   - The catch / non-OK paths NEVER reference the request `headers`,
+//     `options.cookie`, `options.accessToken`, `options.body`,
+//     `res.text()`, or `res.headers`. The fields logged are bounded.
+//   - `backend_host` is the host of the BACKEND URL, not the request
+//     path — internal DNS info, not user-routable.
+//   - `path` is the caller-provided URL path. The helper does NOT inject
+//     query params, so callers MUST NOT put tokens or other secrets in
+//     the path itself. Bearer tokens belong in `accessToken`.
+export async function serverFetch<T>(
+  path: string,
+  options: ServerFetchOptions = {},
+): Promise<T | null> {
+  const headers: Record<string, string> = {};
+  if (options.accessToken) {
+    headers["Authorization"] = `Bearer ${options.accessToken}`;
+  }
+  if (options.cookie) {
+    headers["Cookie"] = options.cookie;
+  }
+  if (options.body && !(options.body instanceof FormData)) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  try {
+    const res = await fetch(`${SERVER_API_URL}${path}`, {
+      method: options.method ?? "GET",
+      headers,
+      body: options.body,
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      if (!options.silentNonOk) {
+        logger.warn("server_fetch_non_ok", {
+          backend_host: new URL(SERVER_API_URL).host,
+          method: options.method ?? "GET",
+          path,
+          status: res.status,
+        });
+      }
+      return null;
+    }
+
+    return (await res.json()) as T;
+  } catch (err) {
+    logger.warn("server_fetch_failed", {
+      backend_host: new URL(SERVER_API_URL).host,
+      method: options.method ?? "GET",
+      path,
+      error_name: err instanceof Error ? err.name : "Unknown",
+      error_message: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/frontend/lib/server-fetch.ts
+++ b/frontend/lib/server-fetch.ts
@@ -41,6 +41,29 @@ export function safeBackendHost(): string {
   }
 }
 
+// Strip query strings from URL-like tokens so a thrown error message
+// like 'Failed to parse URL from not a url/api?token=SECRET' cannot
+// leak the secret into the structured log. Whitespace-tokenized so
+// we don't over-redact prose containing question marks.
+//
+// Also caps the total length so a runaway error message can't blow
+// up a single log line.
+const MAX_ERROR_MESSAGE_LEN = 500;
+
+function sanitizeErrorMessage(msg: string): string {
+  const tokens = msg.split(/\s+/);
+  const redacted = tokens.map((token) => {
+    const q = token.indexOf("?");
+    if (q === -1) return token;
+    return token.slice(0, q) + "?[REDACTED]";
+  });
+  const joined = redacted.join(" ");
+  if (joined.length > MAX_ERROR_MESSAGE_LEN) {
+    return joined.slice(0, MAX_ERROR_MESSAGE_LEN) + "...[truncated]";
+  }
+  return joined;
+}
+
 export type ServerFetchOptions = {
   method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   body?: BodyInit;
@@ -104,12 +127,14 @@ export async function serverFetch<T>(
 
     return (await res.json()) as T;
   } catch (err) {
+    const errorName = err instanceof Error ? err.name : "Unknown";
+    const rawMessage = err instanceof Error ? err.message : String(err);
     logger.warn("server_fetch_failed", {
       backend_host: safeBackendHost(),
       method: options.method ?? "GET",
       path: path.split("?")[0],
-      error_name: err instanceof Error ? err.name : "Unknown",
-      error_message: err instanceof Error ? err.message : String(err),
+      error_name: errorName,
+      error_message: sanitizeErrorMessage(rawMessage),
     });
     return null;
   }

--- a/frontend/tests/app/rsc-error-boundary-smoke.test.tsx
+++ b/frontend/tests/app/rsc-error-boundary-smoke.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Fault-injection smoke test against the #282 class of bug.
+//
+// When serverFetch returns null (simulating transient backend
+// unavailability) during RSC render, the page MUST redirect to /login
+// rather than surface as the Next.js error boundary. We assert this by
+// mocking serverFetch to return null, and asserting the page invokes
+// `next/navigation`'s `redirect("/login")`, which throws NEXT_REDIRECT
+// — Next.js's documented short-circuit mechanism.
+
+// Stub server-only so module imports work outside a real server context.
+vi.mock("server-only", () => ({}));
+
+// Mock serverFetch to return null unconditionally — simulates a backend
+// outage where /auth/verify rejects or returns non-OK.
+vi.mock("@/lib/server-fetch", () => ({
+  serverFetch: vi.fn(async () => null),
+}));
+
+// Mock the logger to keep test output quiet and isolated.
+vi.mock("@/lib/logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock next/headers — getServerSession reads cookies; without a refresh
+// cookie it returns null before serverFetch is reached. We provide one so
+// the path under test (serverFetch returns null → redirect) is exercised.
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: () => ({ name: "refresh_token", value: "x" }),
+  }),
+}));
+
+// Mock next/navigation's redirect so we can assert it was called. We
+// throw with NEXT_REDIRECT to match the real Next.js behavior, which is
+// what short-circuits RSC render before any error boundary catches it.
+const redirectMock = vi.fn((_target: string) => {
+  throw new Error("NEXT_REDIRECT");
+});
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  redirectMock.mockImplementation((_target: string) => {
+    throw new Error("NEXT_REDIRECT");
+  });
+});
+
+describe("RSC error-boundary smoke", () => {
+  it("/forecast-plans redirects to /login when serverFetch returns null (no error boundary)", async () => {
+    const mod = await import("@/app/forecast-plans/page");
+    const ForecastPlansPage = mod.default;
+    await expect(ForecastPlansPage()).rejects.toThrow("NEXT_REDIRECT");
+    expect(redirectMock).toHaveBeenCalledWith("/login");
+  });
+
+  // /import/[import_id]/reconcile uses the same getServerSession →
+  // serverFetch → redirect("/login") path. We exercise it here with a
+  // synthetic params promise to cover the second server-surface caller.
+  it("/import/[import_id]/reconcile redirects to /login when serverFetch returns null (no error boundary)", async () => {
+    const mod = await import("@/app/import/[import_id]/reconcile/page");
+    const ReconcilePage = mod.default;
+    await expect(
+      ReconcilePage({ params: Promise.resolve({ import_id: "1" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+    expect(redirectMock).toHaveBeenCalledWith("/login");
+  });
+});

--- a/frontend/tests/convention/rsc-fetch-guards.test.ts
+++ b/frontend/tests/convention/rsc-fetch-guards.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Release gate against the #282 class of bug.
+//
+// Surfaces that run on the server during render OR are server-only:
+//   - All RSC pages (app/**/page.tsx) and layouts (app/**/layout.tsx)
+//   - server-only library code (lib/*-server.ts and lib/server-*.ts)
+//   - The instrumentation entry point (instrumentation.ts)
+//
+// In these files a thrown error or rejected promise from `fetch(...)` is
+// not caught by any client-side mechanism and surfaces as the Next.js
+// error boundary with an opaque digest reference. The sanctioned helper
+// `frontend/lib/server-fetch.ts` owns the try/catch + sanitized logging.
+//
+// This test scans the server surface and rejects any direct `fetch(` call
+// outside a small allowlist, so the unguarded-RSC-fetch class that
+// produced "Reference: 1621627876" cannot land again.
+
+const FRONTEND_ROOT = path.resolve(__dirname, "..", "..");
+
+type Walker = { include: (file: string) => boolean; roots: string[] };
+
+const WALKERS: Walker[] = [
+  // app/**/page.tsx and app/**/layout.tsx
+  {
+    roots: ["app"],
+    include: (f) => f.endsWith("/page.tsx") || f.endsWith("/layout.tsx"),
+  },
+  // lib/*-server.ts and lib/server-*.ts (NON-recursive: top of lib/ only)
+  {
+    roots: ["lib"],
+    include: (f) => {
+      const base = path.basename(f);
+      // Only the top level of lib/ — depth check below.
+      return (
+        (base.endsWith("-server.ts") || base.startsWith("server-")) &&
+        base.endsWith(".ts")
+      );
+    },
+  },
+];
+
+// Files allowed to call fetch directly with a documented reason. Keep
+// SMALL. Paths are relative to frontend/.
+const ALLOWLIST: { path: string; reason: string }[] = [
+  {
+    path: "lib/server-fetch.ts",
+    reason: "the helper itself owns the sanctioned fetch call",
+  },
+];
+
+function walk(dir: string, depth: number, maxDepth: number): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (depth < maxDepth) {
+        out.push(...walk(full, depth + 1, maxDepth));
+      }
+    } else if (st.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function collectServerSurface(): string[] {
+  const files = new Set<string>();
+
+  // app/**/page.tsx, app/**/layout.tsx — recursive, no depth bound that
+  // would matter for this project.
+  const appRoot = path.join(FRONTEND_ROOT, "app");
+  for (const f of walk(appRoot, 0, 20)) {
+    if (f.endsWith("/page.tsx") || f.endsWith("/layout.tsx")) {
+      files.add(f);
+    }
+  }
+
+  // lib/server-*.ts and lib/*-server.ts at the top of lib/ (NON-recursive).
+  const libRoot = path.join(FRONTEND_ROOT, "lib");
+  if (existsSync(libRoot)) {
+    for (const entry of readdirSync(libRoot)) {
+      const full = path.join(libRoot, entry);
+      const st = statSync(full);
+      if (!st.isFile()) continue;
+      if (!entry.endsWith(".ts")) continue;
+      if (entry.endsWith("-server.ts") || entry.startsWith("server-")) {
+        files.add(full);
+      }
+    }
+  }
+
+  // instrumentation.ts at the frontend root.
+  const inst = path.join(FRONTEND_ROOT, "instrumentation.ts");
+  if (existsSync(inst)) files.add(inst);
+
+  return Array.from(files);
+}
+
+function isAllowlisted(absPath: string): boolean {
+  const rel = path.relative(FRONTEND_ROOT, absPath).split(path.sep).join("/");
+  return ALLOWLIST.some((a) => rel === a.path);
+}
+
+// Find every `fetch(` call site in the source by line number. We strip
+// block and line comments first so a `fetch(` inside a comment doesn't
+// trigger the gate, then walk line-by-line so the reported line number
+// points at the original source.
+function findFetchCallLines(src: string): number[] {
+  // Strip block comments. Preserve newlines so line numbers stay aligned.
+  const noBlock = src.replace(/\/\*[\s\S]*?\*\//g, (m) =>
+    m.replace(/[^\n]/g, " "),
+  );
+  // Strip line comments. Preserve the line itself (the // and after are
+  // blanked, but the newline survives).
+  const noComments = noBlock.replace(/\/\/[^\n]*/g, (m) =>
+    m.replace(/[^\n]/g, " "),
+  );
+
+  const lines = noComments.split("\n");
+  const hits: number[] = [];
+  const re = /\bfetch\s*\(/;
+  for (let i = 0; i < lines.length; i++) {
+    if (re.test(lines[i])) hits.push(i + 1);
+  }
+  return hits;
+}
+
+describe("RSC/server fetch guard", () => {
+  it("rejects direct backend fetch() in server surfaces", () => {
+    void WALKERS; // documentation; actual collection is inlined above
+    const files = collectServerSurface().filter((f) => !isAllowlisted(f));
+
+    const violations: { file: string; lines: number[] }[] = [];
+    for (const file of files) {
+      const src = readFileSync(file, "utf-8");
+      const hits = findFetchCallLines(src);
+      if (hits.length > 0) {
+        const rel = path
+          .relative(FRONTEND_ROOT, file)
+          .split(path.sep)
+          .join("/");
+        violations.push({ file: rel, lines: hits });
+      }
+    }
+
+    if (violations.length > 0) {
+      const detail = violations
+        .map((v) => `  ${v.file}: lines ${v.lines.join(", ")}`)
+        .join("\n");
+      throw new Error(
+        "Direct fetch() in server surface. Use serverFetch from " +
+          "frontend/lib/server-fetch.ts.\n" +
+          detail,
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/frontend/tests/lib/auth-server.test.ts
+++ b/frontend/tests/lib/auth-server.test.ts
@@ -101,8 +101,9 @@ describe("getServerSession", () => {
     const { getServerSession, logger } = await loadModule();
     const session = await getServerSession();
     expect(session).toBeNull();
-    // silentNonOk=true is passed by getServerSession for /auth/verify, so
-    // the helper suppresses the warn even though status is non-OK.
+    // silentStatuses=[401] is passed by getServerSession for /auth/verify,
+    // so the helper suppresses the warn for the 401 normal-flow case.
+    // 500/503 would still emit `server_fetch_non_ok`.
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/frontend/tests/lib/auth-server.test.ts
+++ b/frontend/tests/lib/auth-server.test.ts
@@ -54,8 +54,10 @@ describe("getServerSession", () => {
     const { getServerSession, logger } = await loadModule();
     const session = await getServerSession();
     expect(session).toBeNull();
+    // Post-PR-B: catch path emits `server_fetch_failed` from inside the
+    // serverFetch helper instead of `server_session_verify_failed`.
     expect(logger.warn).toHaveBeenCalledWith(
-      "server_session_verify_failed",
+      "server_fetch_failed",
       expect.objectContaining({
         error_name: "TypeError",
         error_message: expect.stringContaining("Failed to fetch"),
@@ -82,7 +84,7 @@ describe("getServerSession", () => {
     const session = await getServerSession();
     expect(session).toBeNull();
     expect(logger.warn).toHaveBeenCalledWith(
-      "server_session_verify_failed",
+      "server_fetch_failed",
       expect.objectContaining({ error_name: "SyntaxError" })
     );
   });
@@ -99,6 +101,8 @@ describe("getServerSession", () => {
     const { getServerSession, logger } = await loadModule();
     const session = await getServerSession();
     expect(session).toBeNull();
+    // silentNonOk=true is passed by getServerSession for /auth/verify, so
+    // the helper suppresses the warn even though status is non-OK.
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/frontend/tests/lib/server-fetch.test.ts
+++ b/frontend/tests/lib/server-fetch.test.ts
@@ -103,7 +103,7 @@ describe("serverFetch", () => {
     expect(JSON.stringify(logArgs)).not.toContain("SECRET-BEARER-VALUE");
   });
 
-  it("returns null and does NOT warn on non-OK when silentNonOk is true", async () => {
+  it("silentStatuses suppresses listed status codes only", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue({
       ok: false,
       status: 401,
@@ -113,10 +113,75 @@ describe("serverFetch", () => {
     const result = await serverFetch<{ ok: boolean }>("/api/v1/auth/verify", {
       method: "POST",
       cookie: "refresh_token=x",
-      silentNonOk: true,
+      silentStatuses: [401],
     });
     expect(result).toBeNull();
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("silentStatuses does NOT suppress non-listed status codes (outage signal preserved)", async () => {
+    // 503 is a real backend outage; it must still warn even when the call
+    // site has silenced its expected normal-flow status (401).
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ detail: "Service Unavailable" }),
+    } as unknown as Response);
+    const { serverFetch, logger } = await loadModule();
+    const result = await serverFetch<{ ok: boolean }>("/api/v1/auth/verify", {
+      method: "POST",
+      cookie: "refresh_token=x",
+      silentStatuses: [401],
+    });
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_non_ok",
+      expect.objectContaining({ status: 503 }),
+    );
+  });
+
+  it("server_fetch_failed event strips query string from path", async () => {
+    // Defense-in-depth for PR #283's query-stripping policy: even though
+    // the helper documents that callers must not put secrets in the path,
+    // the failure logger strips any query string before logging.
+    vi.spyOn(global, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
+    const { serverFetch, logger } = await loadModule();
+    await serverFetch<{ ok: boolean }>(
+      "/api/v1/auth/something?token=SECRET-QUERY-VALUE",
+      {},
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_failed",
+      expect.objectContaining({
+        path: "/api/v1/auth/something",
+      }),
+    );
+    const payload = (logger.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(JSON.stringify(payload)).not.toContain("SECRET-QUERY-VALUE");
+  });
+
+  it("server_fetch_non_ok event strips query string from path", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ detail: "Service Unavailable" }),
+    } as unknown as Response);
+    const { serverFetch, logger } = await loadModule();
+    await serverFetch<{ ok: boolean }>(
+      "/api/v1/something?reset_token=SECRET-RESET-VALUE",
+      {},
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_non_ok",
+      expect.objectContaining({
+        path: "/api/v1/something",
+        status: 503,
+      }),
+    );
+    const payload = (logger.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(JSON.stringify(payload)).not.toContain("SECRET-RESET-VALUE");
   });
 
   it("returns parsed JSON and does not warn on a 200 response", async () => {
@@ -130,5 +195,35 @@ describe("serverFetch", () => {
     });
     expect(result).toEqual({ value: 42 });
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("safeBackendHost", () => {
+  // Direct unit test of the URL-parse guard. SERVER_API_URL is resolved
+  // once at module load from process.env; rather than monkey-patching that,
+  // we exercise the helper's fallback contract by exporting it and
+  // verifying it returns the sentinel for malformed inputs by simulating
+  // the same try/catch shape.
+  it("returns 'invalid-backend-url' when URL parsing throws", async () => {
+    const { safeBackendHost } = await import("@/lib/server-fetch");
+    // Real signature takes no args; we assert the well-formed case returns
+    // a non-empty host string AND that the guard contract holds when URL
+    // construction would throw. The first half exercises the production
+    // path; the second half guarantees the fallback.
+    expect(typeof safeBackendHost()).toBe("string");
+    expect(safeBackendHost().length).toBeGreaterThan(0);
+
+    // Simulate the guarded shape directly to lock in the contract.
+    const guarded = (raw: string): string => {
+      try {
+        return new URL(raw).host;
+      } catch {
+        return "invalid-backend-url";
+      }
+    };
+    expect(guarded("not a url")).toBe("invalid-backend-url");
+    expect(guarded("")).toBe("invalid-backend-url");
+    expect(guarded("missing-scheme.example.com")).toBe("invalid-backend-url");
+    expect(guarded("http://backend:8000")).toBe("backend:8000");
   });
 });

--- a/frontend/tests/lib/server-fetch.test.ts
+++ b/frontend/tests/lib/server-fetch.test.ts
@@ -199,31 +199,70 @@ describe("serverFetch", () => {
 });
 
 describe("safeBackendHost", () => {
-  // Direct unit test of the URL-parse guard. SERVER_API_URL is resolved
-  // once at module load from process.env; rather than monkey-patching that,
-  // we exercise the helper's fallback contract by exporting it and
-  // verifying it returns the sentinel for malformed inputs by simulating
-  // the same try/catch shape.
-  it("returns 'invalid-backend-url' when URL parsing throws", async () => {
-    const { safeBackendHost } = await import("@/lib/server-fetch");
-    // Real signature takes no args; we assert the well-formed case returns
-    // a non-empty host string AND that the guard contract holds when URL
-    // construction would throw. The first half exercises the production
-    // path; the second half guarantees the fallback.
-    expect(typeof safeBackendHost()).toBe("string");
-    expect(safeBackendHost().length).toBeGreaterThan(0);
+  // SERVER_API_URL is resolved once at module load from process.env, so
+  // these tests use vi.stubEnv + vi.resetModules + a fresh dynamic
+  // import to exercise the exported helper under different env values.
+  // This replaces a previous test that exercised a local `guarded()`
+  // function rather than the actual exported helper.
 
-    // Simulate the guarded shape directly to lock in the contract.
-    const guarded = (raw: string): string => {
-      try {
-        return new URL(raw).host;
-      } catch {
-        return "invalid-backend-url";
-      }
-    };
-    expect(guarded("not a url")).toBe("invalid-backend-url");
-    expect(guarded("")).toBe("invalid-backend-url");
-    expect(guarded("missing-scheme.example.com")).toBe("invalid-backend-url");
-    expect(guarded("http://backend:8000")).toBe("backend:8000");
+  it("safeBackendHost returns 'invalid-backend-url' when BACKEND_INTERNAL_URL is malformed", async () => {
+    vi.stubEnv("BACKEND_INTERNAL_URL", "not a url");
+    vi.resetModules();
+    const mod = await import("@/lib/server-fetch");
+    expect(mod.safeBackendHost()).toBe("invalid-backend-url");
+    vi.unstubAllEnvs();
+  });
+
+  it("safeBackendHost returns parsed host when BACKEND_INTERNAL_URL is well-formed", async () => {
+    vi.stubEnv("BACKEND_INTERNAL_URL", "https://backend:8000");
+    vi.resetModules();
+    const mod = await import("@/lib/server-fetch");
+    expect(mod.safeBackendHost()).toBe("backend:8000");
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("serverFetch privacy regression (end-to-end)", () => {
+  // Combine the two threats: malformed BACKEND_INTERNAL_URL + a path
+  // with a secret query string. Node's fetch throws errors whose
+  // .message can include the full attempted URL (with query) e.g.
+  // 'Failed to parse URL from not a url/api?token=SECRET_QUERY'. The
+  // sanitizeErrorMessage helper must scrub the secret before logging.
+
+  it("serverFetch failure with malformed BACKEND_INTERNAL_URL never logs secrets from path or error", async () => {
+    vi.stubEnv("BACKEND_INTERNAL_URL", "not a url");
+    vi.resetModules();
+    // Reproduce the exact error shape Node's fetch throws when the
+    // assembled URL is unparseable. In jsdom test env, fetch doesn't
+    // necessarily reject on its own for a malformed URL string, so we
+    // mock it to throw the verified architect shape:
+    //   'Failed to parse URL from not a url/api?token=SECRET_QUERY'
+    vi.spyOn(global, "fetch").mockRejectedValue(
+      new TypeError(
+        "Failed to parse URL from not a url/api/v1/auth/something?token=SECRET-QUERY-VALUE",
+      ),
+    );
+    // The vi.mock("@/lib/logger", ...) declaration at the top of this
+    // file is hoisted and survives resetModules — the freshly-imported
+    // module graph still resolves to the same mocked logger instance.
+    const mod = await import("@/lib/server-fetch");
+    const { logger } = await import("@/lib/logger");
+    (logger.warn as unknown as ReturnType<typeof vi.fn>).mockClear?.();
+
+    await mod.serverFetch(
+      "/api/v1/auth/something?token=SECRET-QUERY-VALUE",
+      {},
+    );
+
+    expect(logger.warn).toHaveBeenCalled();
+    const payload = (logger.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("SECRET-QUERY-VALUE");
+    // Sanity-check: backend_host fell back to the sentinel, proving the
+    // malformed-env path was the one exercised.
+    expect(payload.backend_host).toBe("invalid-backend-url");
+
+    vi.unstubAllEnvs();
   });
 });

--- a/frontend/tests/lib/server-fetch.test.ts
+++ b/frontend/tests/lib/server-fetch.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the structured logger so we can assert the exact sanitized payload
+// emitted on each failure branch, without writing to stdout/stderr in tests.
+vi.mock("@/lib/logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Stub server-only so the import works in a node/jsdom test env. Without
+// this, `import "server-only"` throws at module load.
+vi.mock("server-only", () => ({}));
+
+async function loadModule() {
+  const mod = await import("@/lib/server-fetch");
+  const loggerMod = await import("@/lib/logger");
+  return { serverFetch: mod.serverFetch, logger: loggerMod.logger };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("serverFetch", () => {
+  it("returns null and logs sanitized warn when fetch rejects (no leaks)", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+    const { serverFetch, logger } = await loadModule();
+    const result = await serverFetch<{ ok: boolean }>("/api/v1/probe", {
+      method: "GET",
+      cookie: "refresh_token=SECRET-COOKIE-VALUE",
+      accessToken: "SECRET-BEARER-VALUE",
+    });
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_failed",
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/v1/probe",
+        error_name: "TypeError",
+        error_message: expect.stringContaining("Failed to fetch"),
+      }),
+    );
+    // backend_host is the host of the BACKEND URL, never user input.
+    const logArgs = (logger.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(logArgs).toHaveProperty("backend_host");
+    // Privacy invariant: no cookie, no bearer token, no header value in
+    // the logged payload.
+    const serialized = JSON.stringify(logArgs);
+    expect(serialized).not.toContain("SECRET-COOKIE-VALUE");
+    expect(serialized).not.toContain("SECRET-BEARER-VALUE");
+    expect(serialized).not.toContain("Bearer ");
+  });
+
+  it("returns null and logs sanitized warn when res.json() throws on invalid JSON", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+    } as unknown as Response);
+    const { serverFetch, logger } = await loadModule();
+    const result = await serverFetch<{ ok: boolean }>("/api/v1/probe", {
+      accessToken: "SECRET-BEARER-VALUE",
+    });
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_failed",
+      expect.objectContaining({
+        path: "/api/v1/probe",
+        error_name: "SyntaxError",
+      }),
+    );
+    const logArgs = (logger.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(JSON.stringify(logArgs)).not.toContain("SECRET-BEARER-VALUE");
+  });
+
+  it("returns null and emits server_fetch_non_ok warn on a non-OK response by default", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ detail: "Service Unavailable" }),
+    } as unknown as Response);
+    const { serverFetch, logger } = await loadModule();
+    const result = await serverFetch<{ ok: boolean }>("/api/v1/probe", {
+      method: "POST",
+      accessToken: "SECRET-BEARER-VALUE",
+    });
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_non_ok",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/probe",
+        status: 503,
+      }),
+    );
+    const logArgs = (logger.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(JSON.stringify(logArgs)).not.toContain("SECRET-BEARER-VALUE");
+  });
+
+  it("returns null and does NOT warn on non-OK when silentNonOk is true", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: "Unauthorized" }),
+    } as unknown as Response);
+    const { serverFetch, logger } = await loadModule();
+    const result = await serverFetch<{ ok: boolean }>("/api/v1/auth/verify", {
+      method: "POST",
+      cookie: "refresh_token=x",
+      silentNonOk: true,
+    });
+    expect(result).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns parsed JSON and does not warn on a 200 response", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: 42 }),
+    } as unknown as Response);
+    const { serverFetch, logger } = await loadModule();
+    const result = await serverFetch<{ value: number }>("/api/v1/probe", {
+      accessToken: "SECRET-BEARER-VALUE",
+    });
+    expect(result).toEqual({ value: 42 });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Release gate against the #282 class of bug (unguarded server-side backend fetch surfacing as the Next.js error boundary with a digest reference).

## What lands

- `frontend/lib/server-fetch.ts` — sanctioned helper. Owns rejected fetch, invalid JSON, non-OK, sanitized logging, typed `null` return.
- Migrations of the three server-side callers (`auth-server.ts`, `forecast-plans/page.tsx`, `import/[import_id]/reconcile/page.tsx`) to use the helper. Client-side `apiFetch` is unchanged.
- `frontend/tests/convention/rsc-fetch-guards.test.ts` — fails CI if any new direct `fetch(` lands in `app/**/page.tsx`, `app/**/layout.tsx`, `lib/*-server.ts`, `lib/server-*.ts`, or `instrumentation.ts` outside a small allowlist.
- `frontend/tests/lib/server-fetch.test.ts` — 5 helper tests covering rejected fetch, invalid JSON, non-OK warn, non-OK silenced, and success, with a privacy assertion that no cookie/token/header value appears in the log payload.
- `frontend/tests/app/rsc-error-boundary-smoke.test.tsx` — fault-injection smoke for `/forecast-plans` and `/import/[import_id]/reconcile`: when `serverFetch` returns null, the page redirects to `/login` and does NOT render the error boundary.

## Companion

PR-A (separate, in flight): `frontend/instrumentation.ts` `onRequestError` with sanitized SSR error logging. PR-A is observability; this PR is prevention. They don't share files.

Closes the post-#282 release-hardening leg.