### PR TITLE
fix(hotfix): cap slowapi Redis socket timeouts (prod incident 2026-05-15)

### DIFF
--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -191,7 +191,36 @@ def _build_limiter() -> Limiter:
             backend="redis",
             multi_replica_safe=True,
         )
-        limiter = Limiter(key_func=get_client_ip, storage_uri=redis_url)
+        # Production hotfix 2026-05-15. slowapi's Limiter passes storage_options
+        # through to limits-library's redis.from_url(). Without these, the
+        # library defaults to socket_timeout=None — infinite blocking read on
+        # the sync Redis storage path. Since slowapi evaluates limits
+        # synchronously inside async request handlers, a single flaky socket
+        # parks the entire uvicorn event loop. /health and every other route
+        # stop responding until the container is restarted.
+        #
+        # Rate limiting fails open via FailOpenRedisStorage (see
+        # rate_limit_failopen.py), so blocking the event loop here buys
+        # nothing — we want the shortest practical socket cap. 1 second is the
+        # ceiling; redis-py raises TimeoutError, the wrapper catches it,
+        # emits rate_limit.degraded, and the request proceeds via fail-open.
+        #
+        # No retry kwarg here: retry on the sync path multiplies event-loop
+        # blocking time. (The singleton async client at app/redis_client.py
+        # does have retry because async retries don't block the loop.)
+        #
+        # Async storage (async+redis://) is the longer-term fix — separate PR;
+        # requires coredis dependency review + async fail-open wrapper rewrite.
+        limiter = Limiter(
+            key_func=get_client_ip,
+            storage_uri=redis_url,
+            storage_options={
+                "socket_connect_timeout": 1,
+                "socket_timeout": 1,
+                "socket_keepalive": True,
+                "health_check_interval": 30,
+            },
+        )
         # Fail-open on Redis storage errors (prod hotfix 2026-05-13). The
         # wrapper sits below slowapi so transient Redis blips no longer
         # surface as HTTP 500 from rate-limited auth endpoints. See

--- a/backend/tests/test_rate_limit_storage.py
+++ b/backend/tests/test_rate_limit_storage.py
@@ -55,6 +55,33 @@ def test_limiter_uses_redis_storage_when_redis_url_set(monkeypatch):
         f"expected Redis-backed inner storage, got {type(inner).__name__}"
     )
 
+    # Production hotfix 2026-05-15. Without these socket-level options the
+    # limits-library Redis client defaults to socket_timeout=None — an
+    # infinite blocking read on the sync slowapi storage path. Since
+    # slowapi evaluates limits synchronously inside async request handlers,
+    # one flaky Redis socket parks the entire uvicorn event loop and every
+    # route (including /health) stops responding. Pin connection_kwargs
+    # here so future refactors cannot silently regress the cap. See
+    # ``app/rate_limit.py:_build_limiter`` for the full rationale.
+    redis_client = inner.storage
+    kwargs = redis_client.connection_pool.connection_kwargs
+    assert kwargs["socket_timeout"] == 1, (
+        f"socket_timeout must be 1s to prevent event-loop block, "
+        f"got {kwargs.get('socket_timeout')!r}"
+    )
+    assert kwargs["socket_connect_timeout"] == 1, (
+        f"socket_connect_timeout must be 1s to prevent event-loop block, "
+        f"got {kwargs.get('socket_connect_timeout')!r}"
+    )
+    assert kwargs["socket_keepalive"] is True, (
+        f"socket_keepalive must be True for connection hygiene, "
+        f"got {kwargs.get('socket_keepalive')!r}"
+    )
+    assert kwargs["health_check_interval"] == 30, (
+        f"health_check_interval must be 30s, "
+        f"got {kwargs.get('health_check_interval')!r}"
+    )
+
 
 def test_limiter_falls_back_to_memory_when_redis_url_empty(monkeypatch, capsys):
     """When ``settings.redis_url`` is empty (e.g. local dev without


### PR DESCRIPTION
## Summary

Production hotfix for a ~14-minute outage at 2026-05-15 ~10:13 UTC: `app.thebetterdecision.com` returned 504 `no_healthy_upstream` after one Redis socket entered a half-broken state and slowapi's sync Redis storage blocked the event loop with `socket_timeout=None`. Container stayed alive but unresponsive on every route.

## What changed

`backend/app/rate_limit.py` — `_build_limiter()` now passes `storage_options` to slowapi's `Limiter` so the underlying limits-library Redis client has:

- `socket_connect_timeout: 1`
- `socket_timeout: 1`
- `socket_keepalive: True`
- `health_check_interval: 30`

Rate limiting still fails open via the existing `FailOpenRedisStorage` wrapper (unchanged). The timeouts just ensure the wrapper actually gets to run instead of the worker hanging on a sync socket read.

## What did NOT change

- No retry kwarg on the slowapi sync path (would multiply event-loop blocking time)
- No switch to `async+redis://` — that requires `coredis` dependency review + an async-compatible fail-open wrapper rewrite. Tracked as a separate follow-up.

## Post-merge monitoring

- App Platform log volume for `rate_limit.degraded` events
- Auth-endpoint p95 / p99 latency
- `/health` 504 rate during any future Redis hiccup