### PR TITLE
fix(frontend): timeout API fetches

### DIFF
--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -23,6 +23,12 @@ import type {
 
 type Step = "upload" | "preview" | "results";
 
+// L3.2 OFX parser has a 10s server-side budget. Frontend default 10s
+// races the server and can abort just before a valid response. Give
+// the import flow a 15s margin so a parse near the cap doesn't show
+// the user an ApiTimeoutError when the server actually succeeded.
+const IMPORT_REQUEST_TIMEOUT_MS = 15_000;
+
 // Transfer-pill UI state (parallel map keyed by row_number — UI only,
 // independent of the confirm-payload row state).
 type TransferUiState = {
@@ -197,6 +203,7 @@ function ImportPageContent() {
       const data = await apiFetch<ImportPreviewResponse>("/api/v1/import/preview", {
         method: "POST",
         body: formData,
+        timeoutMs: IMPORT_REQUEST_TIMEOUT_MS,
       });
       setPreview(data);
 
@@ -277,6 +284,7 @@ function ImportPageContent() {
           file_name: preview.file_name,
           source_format: preview.source_format ?? "csv",
         }),
+        timeoutMs: IMPORT_REQUEST_TIMEOUT_MS,
       });
       setResults(data);
       setStep("results");

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -19,9 +19,19 @@ export class ApiTimeoutError extends Error {
   }
 }
 
+// Per-call options for apiFetch. Extends RequestInit so callers keep
+// passing the same method/body/headers shape they always have. The
+// optional ``timeoutMs`` lets callers override the default 10s budget
+// per-request (e.g. import preview/confirm, which intentionally race a
+// 10s server-side parser cap).
+export type ApiFetchOptions = RequestInit & {
+  timeoutMs?: number;
+};
+
 async function fetchWithTimeout(
   input: RequestInfo | URL,
   init: RequestInit = {},
+  timeoutMs: number = API_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
   const controller = new AbortController();
   const upstreamSignal = init.signal;
@@ -42,7 +52,7 @@ async function fetchWithTimeout(
   const timeoutId = setTimeout(() => {
     timedOut = true;
     controller.abort();
-  }, API_FETCH_TIMEOUT_MS);
+  }, timeoutMs);
 
   try {
     return await fetch(input, {
@@ -77,27 +87,36 @@ async function refreshAccessToken(): Promise<string | null> {
 
 export async function apiFetch<T>(
   path: string,
-  options: RequestInit = {}
+  options: ApiFetchOptions = {}
 ): Promise<T> {
-  const headers = new Headers(options.headers);
+  // Pull timeoutMs out of options BEFORE passing the rest to native fetch
+  // so it doesn't pollute the RequestInit. The same caller-provided value
+  // applies to both the primary request and the retry-after-refresh.
+  const { timeoutMs, ...fetchInit } = options;
+  const effectiveTimeout = timeoutMs ?? API_FETCH_TIMEOUT_MS;
+  const headers = new Headers(fetchInit.headers);
 
   if (accessToken) {
     headers.set("Authorization", `Bearer ${accessToken}`);
   }
 
   if (
-    options.body &&
-    typeof options.body === "string" &&
+    fetchInit.body &&
+    typeof fetchInit.body === "string" &&
     !headers.has("Content-Type")
   ) {
     headers.set("Content-Type", "application/json");
   }
 
-  let res = await fetchWithTimeout(`${API_URL}${path}`, {
-    ...options,
-    headers,
-    credentials: "include",
-  });
+  let res = await fetchWithTimeout(
+    `${API_URL}${path}`,
+    {
+      ...fetchInit,
+      headers,
+      credentials: "include",
+    },
+    effectiveTimeout,
+  );
 
   // On 401, attempt one silent refresh (even without a current token —
   // the refresh cookie may still be valid)
@@ -111,11 +130,15 @@ export async function apiFetch<T>(
 
     if (newToken) {
       headers.set("Authorization", `Bearer ${newToken}`);
-      res = await fetchWithTimeout(`${API_URL}${path}`, {
-        ...options,
-        headers,
-        credentials: "include",
-      });
+      res = await fetchWithTimeout(
+        `${API_URL}${path}`,
+        {
+          ...fetchInit,
+          headers,
+          credentials: "include",
+        },
+        effectiveTimeout,
+      );
     }
 
     // If still 401 after refresh attempt, the session is dead. Clear the

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,5 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+const API_FETCH_TIMEOUT_MS = 10_000;
 
 let accessToken: string | null = null;
 let refreshPromise: Promise<string | null> | null = null;
@@ -11,9 +12,57 @@ export function getAccessToken(): string | null {
   return accessToken;
 }
 
+export class ApiTimeoutError extends Error {
+  constructor() {
+    super("Request timed out. Try again.");
+    this.name = "ApiTimeoutError";
+  }
+}
+
+async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const controller = new AbortController();
+  const upstreamSignal = init.signal;
+  let timedOut = false;
+
+  const abortFromUpstream = () => {
+    controller.abort(upstreamSignal?.reason);
+  };
+
+  if (upstreamSignal?.aborted) {
+    abortFromUpstream();
+  } else {
+    upstreamSignal?.addEventListener("abort", abortFromUpstream, {
+      once: true,
+    });
+  }
+
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, API_FETCH_TIMEOUT_MS);
+
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (timedOut) {
+      throw new ApiTimeoutError();
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+    upstreamSignal?.removeEventListener("abort", abortFromUpstream);
+  }
+}
+
 async function refreshAccessToken(): Promise<string | null> {
   try {
-    const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+    const res = await fetchWithTimeout(`${API_URL}/api/v1/auth/refresh`, {
       method: "POST",
       credentials: "include",
     });
@@ -44,7 +93,7 @@ export async function apiFetch<T>(
     headers.set("Content-Type", "application/json");
   }
 
-  let res = await fetch(`${API_URL}${path}`, {
+  let res = await fetchWithTimeout(`${API_URL}${path}`, {
     ...options,
     headers,
     credentials: "include",
@@ -62,7 +111,7 @@ export async function apiFetch<T>(
 
     if (newToken) {
       headers.set("Authorization", `Bearer ${newToken}`);
-      res = await fetch(`${API_URL}${path}`, {
+      res = await fetchWithTimeout(`${API_URL}${path}`, {
         ...options,
         headers,
         credentials: "include",

--- a/frontend/tests/app/import-page.test.tsx
+++ b/frontend/tests/app/import-page.test.tsx
@@ -849,4 +849,53 @@ describe("ImportPage transfer pill column", () => {
     expect(pill).toHaveTextContent(/Will create transfer from Savings/i);
     expect(pill).not.toHaveTextContent(/Will create transfer to Savings/i);
   });
+
+  it("import preview is called with IMPORT_REQUEST_TIMEOUT_MS (15s)", async () => {
+    const preview = basePreview([baseRow({ row_number: 1 })]);
+
+    await renderAndPreview(preview);
+
+    const apiFetchMock = vi.mocked(apiFetch);
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/import/preview"),
+      expect.objectContaining({ timeoutMs: 15_000 }),
+    );
+  });
+
+  it("import confirm is called with IMPORT_REQUEST_TIMEOUT_MS (15s)", async () => {
+    const preview = basePreview([baseRow({ row_number: 1 })]);
+
+    await renderAndPreview(preview);
+
+    // Provide a default category so confirm is enabled.
+    const selects = document.querySelectorAll("select");
+    const defaultCatSelect = selects[selects.length - 1] as HTMLSelectElement;
+    fireEvent.change(defaultCatSelect, { target: { value: "5" } });
+
+    // Stub the confirm response so the click resolves cleanly.
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockResolvedValueOnce({
+      imported_count: 1,
+      paired_count: 0,
+      dropped_duplicate_count: 0,
+      skipped_count: 0,
+      error_count: 0,
+      errors: [],
+    } as never);
+
+    const confirmBtn = screen.getByRole("button", { name: /import 1 transaction/i });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const confirmCall = apiFetchMock.mock.calls.find(
+        ([url]) => url === "/api/v1/import/confirm",
+      );
+      expect(confirmCall).toBeDefined();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/import/confirm"),
+      expect.objectContaining({ timeoutMs: 15_000 }),
+    );
+  });
 });

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -36,6 +36,16 @@ describe("apiFetch", () => {
     dispatchEventSpy.mockRestore();
   });
 
+  function neverResolvingFetch() {
+    return (_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+  }
+
   it("adds auth and JSON headers for string request bodies", async () => {
     setAccessToken("access-123");
     fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
@@ -67,6 +77,51 @@ describe("apiFetch", () => {
     const retryHeaders = fetchMock.mock.calls[2][1]?.headers as Headers;
     expect(retryHeaders.get("Authorization")).toBe("Bearer fresh-token");
     expect(getAccessToken()).toBe("fresh-token");
+  });
+
+  it("times out an unresponsive initial request instead of hanging forever", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockImplementationOnce(neverResolvingFetch());
+
+      const promise = apiFetch("/api/v1/accounts");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiTimeoutError",
+        message: "Request timed out. Try again.",
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a hung refresh attempt and clears auth state", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+        .mockImplementationOnce(neverResolvingFetch());
+
+      const promise = apiFetch("/api/v1/protected");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiResponseError",
+        status: 401,
+        message: "expired",
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+      expect(getAccessToken()).toBeNull();
+      expect(dispatchEventSpy).toHaveBeenCalledWith(expect.any(Event));
+      const event = dispatchEventSpy.mock.calls[0]?.[0];
+      expect(event?.type).toBe("auth:unauthenticated");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("clears auth state and dispatches an event after terminal 401s", async () => {

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -80,6 +80,8 @@ describe("apiFetch", () => {
   });
 
   it("times out an unresponsive initial request instead of hanging forever", async () => {
+    // Exercises the default 10s budget — no timeoutMs override on the call,
+    // so fetchWithTimeout falls back to API_FETCH_TIMEOUT_MS.
     vi.useFakeTimers();
     try {
       fetchMock.mockImplementationOnce(neverResolvingFetch());
@@ -95,6 +97,87 @@ describe("apiFetch", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("times out a hung retry-after-refresh and rejects with ApiTimeoutError without clearing auth", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))      // primary 401
+        .mockResolvedValueOnce(jsonResponse({ access_token: "fresh-token" }))             // refresh OK
+        .mockImplementationOnce(neverResolvingFetch());                                   // retry hangs
+
+      const promise = apiFetch("/api/v1/protected");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiTimeoutError",
+        message: "Request timed out. Try again.",
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+
+      // Refresh succeeded -> token IS saved, retry hung -> ApiTimeoutError
+      // but the session is intact, so the user can simply retry the same
+      // call without being kicked back to /login.
+      expect(getAccessToken()).toBe("fresh-token");
+      expect(dispatchEventSpy).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(3);  // primary + refresh + retry
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("custom timeoutMs aborts at the configured value, not the default", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("access-123");
+      fetchMock.mockImplementationOnce(neverResolvingFetch());
+
+      const promise = apiFetch("/api/v1/slow-endpoint", { timeoutMs: 5_000 });
+      const assertion = expect(promise).rejects.toMatchObject({ name: "ApiTimeoutError" });
+
+      // Advance to 4999ms — should NOT have aborted yet.
+      await vi.advanceTimersByTimeAsync(4_999);
+      // Promise still pending; expect.rejects has not fired yet.
+
+      // Advance the last 1ms — aborts at exactly 5000ms.
+      await vi.advanceTimersByTimeAsync(1);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("custom timeoutMs longer than default does not abort at 10s", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("access-123");
+      fetchMock.mockImplementationOnce(neverResolvingFetch());
+
+      const promise = apiFetch("/api/v1/import/preview", { timeoutMs: 15_000 });
+      const assertion = expect(promise).rejects.toMatchObject({ name: "ApiTimeoutError" });
+
+      // Advance to 10000ms — should NOT have aborted at the default.
+      await vi.advanceTimersByTimeAsync(10_000);
+      // Promise still pending.
+
+      // Advance another 5000ms — aborts at 15000ms total.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not forward timeoutMs to native fetch", async () => {
+    setAccessToken("access-123");
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await apiFetch("/api/v1/anything", { timeoutMs: 5_000 });
+
+    const fetchInit = fetchMock.mock.calls[0][1];
+    expect(fetchInit).not.toHaveProperty("timeoutMs");
   });
 
   it("times out a hung refresh attempt and clears auth state", async () => {


### PR DESCRIPTION
## Summary
- add a 10s timeout wrapper for browser API fetches, refresh calls, and post-refresh retries
- surface timed-out foreground requests as ApiTimeoutError instead of leaving pages stuck in loading state
- let a hung refresh attempt fall through the existing terminal-401 path so auth state clears and AppShell redirects

## Verification
- npm test -- tests/lib/api.test.ts
- npm test -- tests/lib/api.test.ts tests/components/auth-provider.test.tsx tests/app/transactions-page.test.tsx
- npx tsc --noEmit
- npm test

Launch-risk statement: Low risk; central API client change, covered by timeout-specific unit tests plus full frontend suite.