### PR TITLE
fix(api): distinguish transient vs terminal refresh failures (no false logout)

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,7 +2,14 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 const API_FETCH_TIMEOUT_MS = 10_000;
 
 let accessToken: string | null = null;
-let refreshPromise: Promise<string | null> | null = null;
+// Discriminated result so callers can distinguish terminal auth death
+// from transient refresh failure. Architect-locked 2026-05-15.
+type RefreshResult =
+  | { ok: true; accessToken: string }
+  | { ok: false; kind: "terminal"; status: number }
+  | { ok: false; kind: "transient"; error: Error; status?: number };
+
+let refreshPromise: Promise<RefreshResult> | null = null;
 
 export function setAccessToken(token: string | null) {
   accessToken = token;
@@ -70,19 +77,57 @@ async function fetchWithTimeout(
   }
 }
 
-async function refreshAccessToken(): Promise<string | null> {
+async function refreshAccessToken(): Promise<RefreshResult> {
+  let res: Response;
   try {
-    const res = await fetchWithTimeout(`${API_URL}/api/v1/auth/refresh`, {
+    res = await fetchWithTimeout(`${API_URL}/api/v1/auth/refresh`, {
       method: "POST",
       credentials: "include",
     });
-    if (!res.ok) return null;
-    const data = await res.json();
-    accessToken = data.access_token;
-    return accessToken;
-  } catch {
-    return null;
+  } catch (err) {
+    // ApiTimeoutError, TypeError (network), AbortError -- all transient.
+    return {
+      ok: false,
+      kind: "transient",
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
   }
+
+  if (res.status === 401 || res.status === 403) {
+    return { ok: false, kind: "terminal", status: res.status };
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      kind: "transient",
+      error: new Error(`refresh returned ${res.status}`),
+      status: res.status,
+    };
+  }
+
+  let data: { access_token?: string };
+  try {
+    data = await res.json();
+  } catch (err) {
+    return {
+      ok: false,
+      kind: "transient",
+      error: err instanceof Error ? err : new Error("invalid JSON"),
+    };
+  }
+
+  if (!data.access_token) {
+    // 200 OK but no access_token: protocol failure, not auth death.
+    return {
+      ok: false,
+      kind: "transient",
+      error: new Error("refresh succeeded without access_token"),
+    };
+  }
+
+  accessToken = data.access_token;
+  return { ok: true, accessToken: data.access_token };
 }
 
 export async function apiFetch<T>(
@@ -118,7 +163,7 @@ export async function apiFetch<T>(
     effectiveTimeout,
   );
 
-  // On 401, attempt one silent refresh (even without a current token —
+  // On 401, attempt one silent refresh (even without a current token --
   // the refresh cookie may still be valid)
   if (res.status === 401) {
     if (!refreshPromise) {
@@ -126,10 +171,10 @@ export async function apiFetch<T>(
         refreshPromise = null;
       });
     }
-    const newToken = await refreshPromise;
+    const refreshResult = await refreshPromise;
 
-    if (newToken) {
-      headers.set("Authorization", `Bearer ${newToken}`);
+    if (refreshResult.ok) {
+      headers.set("Authorization", `Bearer ${refreshResult.accessToken}`);
       res = await fetchWithTimeout(
         `${API_URL}${path}`,
         {
@@ -139,13 +184,12 @@ export async function apiFetch<T>(
         },
         effectiveTimeout,
       );
-    }
-
-    // If still 401 after refresh attempt, the session is dead. Clear the
-    // in-memory token and notify AuthProvider so AppShell can redirect to
-    // /login. Skip for credential-check endpoints where 401 means bad input,
-    // not an expired session.
-    if (res.status === 401) {
+      // Retry attempted; fall through to normal !res.ok handling below.
+    } else if (refreshResult.kind === "terminal") {
+      // True auth death: refresh cookie invalid/expired. Clear in-memory
+      // token and notify AuthProvider so AppShell can redirect to /login.
+      // Skip for credential-check endpoints where 401 means bad input,
+      // not an expired session.
       const isCredCheck =
         path.startsWith("/api/v1/auth/login") ||
         path.startsWith("/api/v1/auth/mfa/verify");
@@ -155,6 +199,17 @@ export async function apiFetch<T>(
           window.dispatchEvent(new Event("auth:unauthenticated"));
         }
       }
+      // Fall through: caller sees the original 401 ApiResponseError.
+    } else {
+      // refreshResult.kind === "transient": refresh cookie may still be
+      // valid; do NOT clear auth state. Throw a recoverable error so SWR
+      // / the caller can show a retry path. User stays in-app.
+      throw new ApiResponseError(
+        503,
+        "Session refresh temporarily unavailable. Please try again.",
+        "refresh_transient",
+        refreshResult.error.message,
+      );
     }
   }
 

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -180,34 +180,13 @@ describe("apiFetch", () => {
     expect(fetchInit).not.toHaveProperty("timeoutMs");
   });
 
-  it("times out a hung refresh attempt and clears auth state", async () => {
-    vi.useFakeTimers();
-    try {
-      setAccessToken("stale-token");
-      fetchMock
-        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
-        .mockImplementationOnce(neverResolvingFetch());
-
-      const promise = apiFetch("/api/v1/protected");
-      const assertion = expect(promise).rejects.toMatchObject({
-        name: "ApiResponseError",
-        status: 401,
-        message: "expired",
-      });
-
-      await vi.advanceTimersByTimeAsync(10_000);
-      await assertion;
-      expect(getAccessToken()).toBeNull();
-      expect(dispatchEventSpy).toHaveBeenCalledWith(expect.any(Event));
-      const event = dispatchEventSpy.mock.calls[0]?.[0];
-      expect(event?.type).toBe("auth:unauthenticated");
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("clears auth state and dispatches an event after terminal 401s", async () => {
+  it("primary 401 + refresh OK + retry 401 propagates 401 without clearing token (new contract)", async () => {
+    // Under the architect-locked 2026-05-15 contract, terminal auth death
+    // is detected by the REFRESH endpoint returning 401/403, not by a
+    // retry-after-refresh returning 401. If refresh handed back a fresh
+    // token but the retry still 401s, the caller sees the original 401
+    // ApiResponseError and the token stays in memory (next call will go
+    // through the refresh path again as a fresh attempt).
     setAccessToken("stale-token");
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
@@ -220,10 +199,112 @@ describe("apiFetch", () => {
       message: "still expired",
     });
 
+    expect(getAccessToken()).toBe("fresh-token");
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+  });
+
+  // Architect-locked 2026-05-15: refreshAccessToken() now returns a
+  // discriminated RefreshResult that distinguishes terminal auth death
+  // (401/403 on the refresh endpoint) from transient failures (timeout,
+  // 5xx, network, JSON parse, 200 OK without access_token). Only the
+  // terminal branch clears the in-memory token and dispatches
+  // auth:unauthenticated. Transient failures throw an ApiResponseError
+  // with code "refresh_transient" so callers / SWR can retry without the
+  // user being kicked back to /login.
+
+  it("primary 401 + refresh 401 dispatches auth:unauthenticated and clears token (terminal)", async () => {
+    setAccessToken("stale-token");
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))   // primary
+      .mockResolvedValueOnce(jsonResponse({ detail: "invalid_refresh" }, { status: 401 })); // refresh
+
+    await expect(apiFetch("/api/v1/protected")).rejects.toMatchObject({
+      name: "ApiResponseError",
+      status: 401,
+    });
+
     expect(getAccessToken()).toBeNull();
-    expect(dispatchEventSpy).toHaveBeenCalledWith(expect.any(Event));
-    const event = dispatchEventSpy.mock.calls[0]?.[0];
-    expect(event?.type).toBe("auth:unauthenticated");
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "auth:unauthenticated" }),
+    );
+  });
+
+  it("primary 401 + refresh timeout does NOT clear token, does NOT dispatch, throws recoverable", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+        .mockImplementationOnce(neverResolvingFetch());  // refresh hangs
+
+      const promise = apiFetch("/api/v1/protected");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiResponseError",
+        status: 503,
+        code: "refresh_transient",
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+
+      expect(getAccessToken()).toBe("stale-token");  // PRESERVED
+      expect(dispatchEventSpy).not.toHaveBeenCalled();  // NO event
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("primary 401 + refresh 500 does NOT clear token, does NOT dispatch, throws recoverable", async () => {
+    setAccessToken("stale-token");
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "server error" }, { status: 500 }));
+
+    await expect(apiFetch("/api/v1/protected")).rejects.toMatchObject({
+      name: "ApiResponseError",
+      status: 503,
+      code: "refresh_transient",
+    });
+
+    expect(getAccessToken()).toBe("stale-token");
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("parallel 401 herd with transient refresh does not spam auth events or clear token", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("stale-token");
+      // 4 parallel calls, all get 401, only one refresh attempt
+      // (single-flight), refresh hangs (transient).
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 1
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 2
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 3
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 4
+        .mockImplementationOnce(neverResolvingFetch()); // refresh hangs
+
+      const promises = [
+        apiFetch("/api/v1/a"),
+        apiFetch("/api/v1/b"),
+        apiFetch("/api/v1/c"),
+        apiFetch("/api/v1/d"),
+      ];
+
+      const assertions = promises.map((p) =>
+        expect(p).rejects.toMatchObject({ status: 503, code: "refresh_transient" }),
+      );
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await Promise.all(assertions);
+
+      expect(getAccessToken()).toBe("stale-token");
+      expect(dispatchEventSpy).not.toHaveBeenCalled();
+      // Only one refresh attempt happened thanks to single-flight
+      // (4 primaries + 1 refresh = 5 fetch calls)
+      expect(fetchMock).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not dispatch auth:unauthenticated for login credential failures", async () => {


### PR DESCRIPTION
## Summary

Closes a real client-side auth-contract bug: `refreshAccessToken()` returned `null` for every failure mode (4xx, 5xx, network, timeout, JSON parse). `apiFetch` treated null as terminal auth death and dispatched `auth:unauthenticated` → AppShell redirected to `/login`. That redirect could fire on a transient Redis blip or network hiccup even when the refresh cookie was still valid.

User-reported symptom 2026-05-15 (idle on /dashboard → click /transactions → spinner stuck → back → /login → hard refresh restores session) is consistent with this conflation.

## What changes

`refreshAccessToken()` returns a discriminated `RefreshResult`:

| Outcome | Classification |
|---|---|
| res.status 401 or 403 | terminal |
| other !res.ok (5xx, 429, 408) | transient |
| ApiTimeoutError / TypeError / AbortError / JSON parse | transient |
| 200 OK without access_token | transient (protocol failure) |
| 200 OK + access_token | ok |

`apiFetch` 401 branch:
- refresh ok → retry original request
- refresh terminal → clear token + dispatch `auth:unauthenticated` (true auth death only)
- refresh transient → throw `ApiResponseError(503, code='refresh_transient')` without clearing auth

## Five regression tests pin the contract

1. primary 401 + refresh 401 → terminal (dispatch + clear)
2. primary 401 + refresh timeout → transient (no dispatch, no clear, recoverable error)
3. primary 401 + refresh 500 → transient (no dispatch, no clear, recoverable error)
4. primary 401 + refresh succeeds + retry hangs → existing #286 behavior preserved (no logout)
5. parallel 401 herd + refresh transient → no event spam, token preserved, single-flight upheld

Scope intentionally tight: `frontend/lib/api.ts` + `frontend/tests/lib/api.test.ts` only. Backend unchanged. No telemetry endpoint changes. No ZAP / async slowapi / OFX scale work touched.