### PR TITLE
fix(rsc): bounded serverFetch timeout + discriminated getServerSession result

### DIFF
--- a/frontend/app/forecast-plans/ForecastPlansClient.tsx
+++ b/frontend/app/forecast-plans/ForecastPlansClient.tsx
@@ -275,6 +275,35 @@ export default function ForecastPlansClient({
     })();
   }, []);
 
+  // Client-side categories recovery (PR #288). Categories are seeded
+  // from `initialCategories` only — there is no SWR for the categories
+  // list, because they're treated as stable per session. If the RSC
+  // shell rendered with an empty categories array (transient /auth/verify
+  // or transient /api/v1/categories), the user would see an empty
+  // category picker and be unable to add plan items. Fire a one-shot
+  // recovery fetch on mount when categories are empty so the page
+  // self-heals after a transient server-side fetch failure. Single
+  // attempt, no retry loop — `apiFetch` has its own bounded timeout
+  // (#286) and the user can always reload.
+  const categoriesRecoveryAttempted = useRef(false);
+  useEffect(() => {
+    if (categoriesRecoveryAttempted.current) return;
+    if (categories.length > 0) return;
+    categoriesRecoveryAttempted.current = true;
+    (async () => {
+      try {
+        const fresh = await apiFetch<Category[]>("/api/v1/categories");
+        if (Array.isArray(fresh) && fresh.length > 0) {
+          setCategories(fresh);
+        }
+      } catch {
+        // Quiet on failure — the user can reload, and the picker still
+        // exposes the inline "create new category" path that calls
+        // /api/v1/categories on demand.
+      }
+    })();
+  }, [categories.length]);
+
   // After a write from the AppShell-level "+ New Transaction" CTA the
   // forecast page must reload the plan so per-category actuals and
   // variance reflect the new transaction. We don't reload refs here:

--- a/frontend/app/forecast-plans/page.tsx
+++ b/frontend/app/forecast-plans/page.tsx
@@ -1,14 +1,23 @@
 import { redirect } from "next/navigation";
-import { getServerSession } from "@/lib/auth-server";
+import { getServerSessionResult } from "@/lib/auth-server";
 import { serverFetch } from "@/lib/server-fetch";
 import ForecastPlansClient from "./ForecastPlansClient";
 import type { BillingPeriod, Category, ForecastPlan } from "@/lib/types";
 
 // First consumer of the RSC auth foundation (PR #210 / #211 / #212).
-// `getServerSession()` reads the refresh cookie, validates it server-side
-// against the backend, and returns `{ user, accessToken }` or null. If
-// null, we bounce to /login here so the protected client component never
-// has to deal with an unauthenticated state.
+// `getServerSessionResult()` reads the refresh cookie, validates it
+// server-side against the backend, and returns a discriminated result:
+//
+//   - "authenticated" → render the happy path with server-fetched
+//     initial data as SWR fallbackData.
+//   - "unauthenticated" (401/403 from /auth/verify) → redirect to /login.
+//   - "transient" (timeout / 5xx / network / invalid payload) → render
+//     the client island with empty fallback data so the page exits the
+//     loading.tsx Suspense and the client-side SWR layer can re-fetch
+//     after hydration with its own bounded-timeout `apiFetch` and
+//     refresh contract. This prevents the "stuck on spinner forever"
+//     class of bug (#288) without producing a false-logout during a
+//     backend hiccup.
 //
 // We then issue the three initial reads in parallel (categories, billing
 // periods, and the plan for the visible period) via the sanctioned
@@ -33,10 +42,37 @@ function pickCurrentPeriod(periods: BillingPeriod[]): BillingPeriod | null {
 }
 
 export default async function ForecastPlansPage() {
-  const session = await getServerSession();
-  if (!session) redirect("/login");
+  const sessionResult = await getServerSessionResult();
+  if (sessionResult.kind === "unauthenticated") {
+    redirect("/login");
+  }
 
-  const [categories, periods] = await Promise.all([
+  // Transient verify failure: render the client island with safe empty
+  // fallback data. The client uses `apiFetch` (#286) with its own
+  // bounded timeout + the discriminated `RefreshResult` (#287) so it
+  // will retry after hydration without false-logout. This is the
+  // architect-locked direction for the #288 hotfix: expected-error
+  // fallback handling rather than throwing to an error.tsx boundary.
+  if (sessionResult.kind === "transient") {
+    return (
+      <ForecastPlansClient
+        initialPeriods={[]}
+        initialCategories={[]}
+        initialPlan={null}
+      />
+    );
+  }
+
+  const { session } = sessionResult;
+
+  // `Promise.allSettled` so a single fetch transient (e.g. the
+  // categories endpoint is rate-limited but billing-periods responds
+  // fine) doesn't strand the whole render in the loading state. We
+  // pull `data` for fulfilled OKs and pass empty arrays for
+  // rejected/null entries; the client island re-fetches on hydration
+  // anyway, so a partial first paint is strictly better than the
+  // previous "any one fetch hangs → entire page hangs" coupling.
+  const [categoriesSettled, periodsSettled] = await Promise.allSettled([
     serverFetch<Category[]>("/api/v1/categories", {
       accessToken: session.accessToken,
     }),
@@ -45,12 +81,23 @@ export default async function ForecastPlansPage() {
     }),
   ]);
 
-  const periodList = periods ?? [];
+  const categories =
+    categoriesSettled.status === "fulfilled"
+      ? (categoriesSettled.value ?? [])
+      : [];
+  const periodList =
+    periodsSettled.status === "fulfilled"
+      ? (periodsSettled.value ?? [])
+      : [];
+
   const initialPeriod = pickCurrentPeriod(periodList);
 
   // The plan endpoint is `get_or_create` — passing a period that doesn't
   // yet have a plan auto-creates a draft. That matches the pre-RSC
   // client's first-load behavior; preserving UX is the goal of this PR.
+  // Wrapped in a try/catch via `serverFetch`'s null contract: a null
+  // here just means the client island gets no fallbackData and SWR
+  // will fetch on hydration.
   const initialPlan = initialPeriod
     ? await serverFetch<ForecastPlan>(
         `/api/v1/forecast-plans?period_start=${initialPeriod.start_date}`,
@@ -61,7 +108,7 @@ export default async function ForecastPlansPage() {
   return (
     <ForecastPlansClient
       initialPeriods={periodList}
-      initialCategories={categories ?? []}
+      initialCategories={categories}
       initialPlan={initialPlan}
     />
   );

--- a/frontend/app/import/[import_id]/reconcile/page.tsx
+++ b/frontend/app/import/[import_id]/reconcile/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getServerSession } from "@/lib/auth-server";
+import { getServerSessionResult } from "@/lib/auth-server";
 import { serverFetch } from "@/lib/server-fetch";
 import ReconcileClient from "./ReconcileClient";
 import type { ImportBatchDetail } from "@/lib/types";
@@ -13,14 +13,23 @@ import type { ImportBatchDetail } from "@/lib/types";
 // client island as SWR fallbackData; the client re-fetches on action so
 // the UI stays in sync with the server-side state machine after every
 // transition.
+//
+// Session triage (PR #288): a 401/403 from /auth/verify means
+// unauthenticated → redirect. A timeout / 5xx / network error is
+// transient and renders the client island with `initialBatch=null` so
+// SWR can re-fetch the batch detail after hydration. Without this
+// triage, the previous code path either hung on loading.tsx or
+// false-logged-out a user during a transient backend hiccup.
 
 export default async function ReconcilePage({
   params,
 }: {
   params: Promise<{ import_id: string }>;
 }) {
-  const session = await getServerSession();
-  if (!session) redirect("/login");
+  const sessionResult = await getServerSessionResult();
+  if (sessionResult.kind === "unauthenticated") {
+    redirect("/login");
+  }
 
   const { import_id } = await params;
   const batchId = Number(import_id);
@@ -28,12 +37,19 @@ export default async function ReconcilePage({
     redirect("/import");
   }
 
+  // Transient verify: render the client island with no seed data. The
+  // client-side SWR layer (with apiFetch + bounded timeout from #286)
+  // will issue the read after hydration. Better UX than spinning
+  // forever or bouncing a logged-in user to /login on a transient
+  // backend hiccup.
+  if (sessionResult.kind === "transient") {
+    return <ReconcileClient batchId={batchId} initialBatch={null} />;
+  }
+
   const initialBatch = await serverFetch<ImportBatchDetail>(
     `/api/v1/import/${batchId}`,
-    { accessToken: session.accessToken },
+    { accessToken: sessionResult.session.accessToken },
   );
 
-  return (
-    <ReconcileClient batchId={batchId} initialBatch={initialBatch} />
-  );
+  return <ReconcileClient batchId={batchId} initialBatch={initialBatch} />;
 }

--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { cookies } from "next/headers";
 import { cache } from "react";
-import { serverFetch } from "./server-fetch";
+import { serverFetchResult } from "./server-fetch";
 import type { User } from "./types";
 
 // Foundation for Server Component migrations. The client-side `apiFetch` in
@@ -19,28 +19,60 @@ import type { User } from "./types";
 // Results are cached per request via React's `cache` so multiple RSCs in a
 // single render only pay the network cost once.
 //
-// All transport (rejected fetch / non-OK / invalid JSON / sanitized logging)
-// goes through `serverFetch`. A 401 from /auth/verify is part of normal
-// auth flow (no refresh cookie → 401), so we pass `silentStatuses: [401]`
-// to avoid noisy warns for that one expected case. Real backend outages
-// (500/503) still emit `server_fetch_non_ok` so on-call can see them.
-// Transient fetch failures still log a sanitized `server_fetch_failed`
-// event from inside the helper.
+// All transport (rejected fetch / non-OK / invalid JSON / timeout /
+// sanitized logging) goes through `serverFetchResult`, which returns a
+// discriminated result so this module can distinguish:
+//
+//   - 401 / 403          → unauthenticated (refresh cookie invalid or
+//                          missing on the backend; redirect to /login).
+//   - timeout / abort /  → transient (backend wedged or unreachable;
+//     network_error /     callers should render a recoverable fallback
+//     invalid_json /      shell rather than redirect to /login, so a
+//     5xx                 transient outage doesn't false-logout a user).
+//
+// This taxonomy is the fix for PR #288: before, ANY non-200 from
+// /auth/verify (including timeout and 5xx) was treated as "no session"
+// and the page redirected to /login, OR the request hung forever and
+// the page stayed on loading.tsx indefinitely. Neither is correct.
+// 401 from /auth/verify is part of normal auth flow (no refresh cookie
+// validated → 401), so we pass `silentStatuses: [401]` to avoid noisy
+// warns for that one expected case. Real backend outages (500/503) and
+// timeouts still emit `server_fetch_non_ok` / `server_fetch_failed` so
+// on-call can see them.
 
 const REFRESH_COOKIE_NAME = "refresh_token";
+
+// Per-call timeout for the verify hot path. The default 5s budget in
+// `serverFetch` is fine; we set it explicitly here so the value is
+// reviewable next to the auth flow it gates. If we ever want a tighter
+// budget for verify specifically, this is the dial.
+const VERIFY_TIMEOUT_MS = 5_000;
 
 export type ServerSession = {
   user: User;
   accessToken: string;
 };
 
-export const getServerSession = cache(
-  async (): Promise<ServerSession | null> => {
+// Discriminated result so RSC callers can triage transient backend
+// trouble (timeout / 5xx / network error) without false-logout. The
+// "transient" branch carries a coarse-grained reason so callers can
+// surface different fallback copy if they choose; today all transient
+// reasons render the same "data unavailable, retrying" empty shell.
+export type ServerSessionResult =
+  | { kind: "authenticated"; session: ServerSession }
+  | { kind: "unauthenticated" }
+  | {
+      kind: "transient";
+      reason: "timeout" | "network" | "server_error" | "invalid_payload";
+    };
+
+export const getServerSessionResult = cache(
+  async (): Promise<ServerSessionResult> => {
     const cookieStore = await cookies();
     const refresh = cookieStore.get(REFRESH_COOKIE_NAME);
-    if (!refresh) return null;
+    if (!refresh) return { kind: "unauthenticated" };
 
-    const payload = await serverFetch<{
+    const result = await serverFetchResult<{
       user: User;
       access_token: string;
       token_type: string;
@@ -51,15 +83,44 @@ export const getServerSession = cache(
       // logging for that exact status; rejected-fetch, invalid-JSON, and
       // other non-OK statuses (e.g. 500/503) still log.
       silentStatuses: [401],
+      timeoutMs: VERIFY_TIMEOUT_MS,
     });
 
-    if (!payload || !payload.access_token || !payload.user) return null;
-
-    return { user: payload.user, accessToken: payload.access_token };
+    switch (result.kind) {
+      case "ok": {
+        const payload = result.data;
+        if (!payload || !payload.access_token || !payload.user) {
+          return { kind: "transient", reason: "invalid_payload" };
+        }
+        return {
+          kind: "authenticated",
+          session: {
+            user: payload.user,
+            accessToken: payload.access_token,
+          },
+        };
+      }
+      case "http_error":
+        // 401/403 = no session. Anything else (5xx, unexpected 4xx) is
+        // a backend signal we cannot interpret as auth death without
+        // risking false-logout during an outage.
+        if (result.status === 401 || result.status === 403) {
+          return { kind: "unauthenticated" };
+        }
+        return { kind: "transient", reason: "server_error" };
+      case "timeout":
+      case "abort":
+        return { kind: "transient", reason: "timeout" };
+      case "network_error":
+        return { kind: "transient", reason: "network" };
+      case "invalid_json":
+        return { kind: "transient", reason: "invalid_payload" };
+    }
   },
 );
 
-export const getServerUser = async (): Promise<User | null> => {
-  const session = await getServerSession();
-  return session?.user ?? null;
-};
+// Pre-launch state means no deprecation shims (see CLAUDE.md). All RSC
+// callers were migrated to `getServerSessionResult` in PR #288. If you
+// need a "session-or-null" shape, switch on `result.kind` at the call
+// site so transient (timeout / 5xx) doesn't collapse into the same path
+// as unauthenticated.

--- a/frontend/lib/server-fetch.ts
+++ b/frontend/lib/server-fetch.ts
@@ -16,6 +16,13 @@ import { logger } from "./logger";
 //   - The sanitized log payload is bounded by construction (see invariants
 //     below). Direct callers tend to log `err`, which on a fetch failure
 //     can contain request headers including cookies and bearer tokens.
+//   - Native `fetch` has no built-in timeout, and Next.js does not inject
+//     one. When the backend wedges (e.g. Redis socket half-broken cascading
+//     through the rate-limit path) an awaited fetch inside an RSC never
+//     resolves, the render never completes, and the page stays on its
+//     loading.tsx Suspense fallback forever. This helper bounds every
+//     request with an `AbortController`-based timeout (5s default) so a
+//     stuck backend can never produce an indefinite spinner. PR #288.
 //
 // URL resolution mirrors `lib/auth-server.ts`. The browser uses relative
 // URLs proxied by nginx; the server needs an absolute URL. In dev compose
@@ -27,6 +34,13 @@ const SERVER_API_URL =
   process.env.BACKEND_INTERNAL_URL ||
   process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8000";
+
+// Default bounded budget for every server-side fetch. Tighter than the
+// client-side `apiFetch` 10s default (#286) because a server-side hang
+// strands the RSC render and keeps `loading.tsx` mounted, which is a
+// worse UX than the client surface (which can still react to user
+// input). Callers can override per-call via `ServerFetchOptions.timeoutMs`.
+const DEFAULT_SERVER_FETCH_TIMEOUT_MS = 5_000;
 
 // Wrap the URL parse so a malformed SERVER_API_URL (env typo, missing
 // scheme, etc.) cannot make the failure-logging path itself throw. If the
@@ -75,11 +89,53 @@ export type ServerFetchOptions = {
   // still emit `server_fetch_non_ok` so backend outages (500/503) are
   // never accidentally silenced.
   silentStatuses?: number[];
+  // Per-call timeout budget in milliseconds. Defaults to 5s. Set this
+  // tighter for hot-path verify calls or looser for known-slow reads.
+  // The helper aborts the underlying fetch via AbortController when the
+  // budget elapses; the failure surfaces as a null return with a
+  // `server_fetch_failed` log carrying `reason: "timeout"`.
+  //
+  // SIDE EFFECT: passing an AbortController signal to `fetch` opts the
+  // request OUT of Next.js 16's automatic fetch memoization across a
+  // single render pass. Two RSCs calling the same URL through this
+  // helper will issue two upstream requests instead of sharing one. For
+  // this codebase the trade-off is acceptable: no two RSCs share a URL
+  // today, and the "no infinite spinner" guarantee is non-negotiable.
+  timeoutMs?: number;
 };
 
-// Returns parsed JSON on success, `null` on any failure (rejected fetch,
-// invalid JSON, non-OK status). Failures emit a sanitized structured
-// warning via the project logger.
+// Discriminated result from `serverFetchResult`. Callers that need to
+// distinguish "401 means no session" from "timeout / 5xx / network error
+// means the backend is wedged" should use `serverFetchResult` and switch
+// on `kind`. Most call sites just want JSON-or-null and should keep using
+// the thin `serverFetch` wrapper below.
+//
+// `kind` taxonomy:
+//   - "ok"            — 2xx, JSON parsed, payload returned in `data`.
+//   - "http_error"    — non-2xx response (status carried in `status`).
+//     401/403 typically mean "unauthenticated"; 5xx typically means
+//     transient backend trouble; callers decide per route.
+//   - "timeout"       — our AbortController fired because the budget
+//     elapsed. Treat as transient.
+//   - "abort"         — AbortError raised outside of our timeout (e.g.
+//     a caller-supplied signal was aborted). Treat as transient.
+//   - "network_error" — fetch rejected (DNS, ECONNREFUSED, TLS, etc.).
+//     Treat as transient.
+//   - "invalid_json"  — 2xx response but `res.json()` threw. Treat as
+//     transient (backend contract drifted, partial response, etc.).
+export type ServerFetchResult<T> =
+  | { kind: "ok"; data: T }
+  | { kind: "http_error"; status: number }
+  | { kind: "timeout" }
+  | { kind: "abort" }
+  | { kind: "network_error" }
+  | { kind: "invalid_json" };
+
+// Returns the full discriminated result. Use this from `lib/auth-server.ts`
+// and any other caller that needs to triage transient vs terminal failure
+// modes. The thin `serverFetch` wrapper below discards the discriminant
+// and returns `T | null` for the (still common) case where the caller
+// simply wants JSON-or-fallback.
 //
 // PRIVACY INVARIANTS (must hold by construction):
 //   - The catch / non-OK paths NEVER reference the request `headers`,
@@ -90,10 +146,12 @@ export type ServerFetchOptions = {
 //   - `path` is the caller-provided URL path. The helper does NOT inject
 //     query params, so callers MUST NOT put tokens or other secrets in
 //     the path itself. Bearer tokens belong in `accessToken`.
-export async function serverFetch<T>(
+//   - The `signal` field on the request init is OURS — it never carries
+//     a caller's AbortSignal, only the timeout controller.
+export async function serverFetchResult<T>(
   path: string,
   options: ServerFetchOptions = {},
-): Promise<T | null> {
+): Promise<ServerFetchResult<T>> {
   const headers: Record<string, string> = {};
   if (options.accessToken) {
     headers["Authorization"] = `Bearer ${options.accessToken}`;
@@ -105,12 +163,21 @@ export async function serverFetch<T>(
     headers["Content-Type"] = "application/json";
   }
 
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SERVER_FETCH_TIMEOUT_MS;
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
   try {
     const res = await fetch(`${SERVER_API_URL}${path}`, {
       method: options.method ?? "GET",
       headers,
       body: options.body,
       cache: "no-store",
+      signal: controller.signal,
     });
 
     if (!res.ok) {
@@ -122,20 +189,71 @@ export async function serverFetch<T>(
           status: res.status,
         });
       }
-      return null;
+      return { kind: "http_error", status: res.status };
     }
 
-    return (await res.json()) as T;
+    try {
+      const data = (await res.json()) as T;
+      return { kind: "ok", data };
+    } catch (jsonErr) {
+      const errorName = jsonErr instanceof Error ? jsonErr.name : "Unknown";
+      const rawMessage =
+        jsonErr instanceof Error ? jsonErr.message : String(jsonErr);
+      logger.warn("server_fetch_failed", {
+        backend_host: safeBackendHost(),
+        method: options.method ?? "GET",
+        path: path.split("?")[0],
+        error_name: errorName,
+        error_message: sanitizeErrorMessage(rawMessage),
+        reason: "invalid_json",
+        timeout_ms: timeoutMs,
+      });
+      return { kind: "invalid_json" };
+    }
   } catch (err) {
     const errorName = err instanceof Error ? err.name : "Unknown";
     const rawMessage = err instanceof Error ? err.message : String(err);
+    // Timeout (AbortError raised by our own setTimeout) is its own
+    // log reason so on-call can distinguish wedged-backend hangs from
+    // raw network failures. Any other AbortError that didn't come from
+    // our timeout is currently unreachable (we never expose our
+    // controller upstream) but is taxonomically distinct.
+    let reason: "timeout" | "abort" | "network_error";
+    let resultKind: "timeout" | "abort" | "network_error";
+    if (timedOut) {
+      reason = "timeout";
+      resultKind = "timeout";
+    } else if (errorName === "AbortError" || errorName === "TimeoutError") {
+      reason = "abort";
+      resultKind = "abort";
+    } else {
+      reason = "network_error";
+      resultKind = "network_error";
+    }
     logger.warn("server_fetch_failed", {
       backend_host: safeBackendHost(),
       method: options.method ?? "GET",
       path: path.split("?")[0],
       error_name: errorName,
       error_message: sanitizeErrorMessage(rawMessage),
+      reason,
+      timeout_ms: timeoutMs,
     });
-    return null;
+    return { kind: resultKind };
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
+
+// Thin convenience wrapper: discards the discriminant and returns parsed
+// JSON on success, `null` on any failure. Existing RSC callers that just
+// want "data or empty fallback" should keep using this. Callers that need
+// to distinguish 401 from timeout (notably `lib/auth-server.ts`) must use
+// `serverFetchResult` and switch on `kind`.
+export async function serverFetch<T>(
+  path: string,
+  options: ServerFetchOptions = {},
+): Promise<T | null> {
+  const result = await serverFetchResult<T>(path, options);
+  return result.kind === "ok" ? result.data : null;
 }

--- a/frontend/tests/app/forecast-plans-page-rsc.test.tsx
+++ b/frontend/tests/app/forecast-plans-page-rsc.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// RSC-level tests for `app/forecast-plans/page.tsx` (PR #288).
+//
+// The page is an async Server Component. It calls
+// `getServerSessionResult()` and switches on the three result kinds:
+//
+//   - "unauthenticated" → `redirect('/login')`.
+//   - "transient"       → render the client island with empty fallback
+//     data (no redirect, no throw, no spinner-forever).
+//   - "authenticated"   → fetch initial categories/periods/plan via
+//     `serverFetch` and hand them down to the client.
+//
+// We assert by inspecting the React element returned by the page. JSX
+// in an RSC is lazy: `<ForecastPlansClient ... />` produces a React
+// element object whose `.props` carry the fallback data. The element
+// is not invoked unless something downstream renders it (Next.js does
+// this in production; in test, inspecting `.props` is sufficient).
+
+vi.mock("server-only", () => ({}));
+
+// Mock the auth-server module directly. We're testing the page's
+// orchestration logic, not the auth-server triage logic (which has its
+// own test file under tests/lib/auth-server.test.ts).
+const getServerSessionResultMock = vi.fn();
+vi.mock("@/lib/auth-server", () => ({
+  getServerSessionResult: getServerSessionResultMock,
+}));
+
+const serverFetchMock = vi.fn(async () => null);
+vi.mock("@/lib/server-fetch", () => ({
+  serverFetch: serverFetchMock,
+  serverFetchResult: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const redirectMock = vi.fn((_target: string) => {
+  throw new Error("NEXT_REDIRECT");
+});
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+// Quietly stub the client island so the page's JSX import resolves
+// without dragging in recharts / SWR.
+vi.mock("@/app/forecast-plans/ForecastPlansClient", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  redirectMock.mockImplementation((_target: string) => {
+    throw new Error("NEXT_REDIRECT");
+  });
+});
+
+describe("ForecastPlansPage RSC orchestration (PR #288)", () => {
+  it("unauthenticated session → redirect('/login') and no data fetches", async () => {
+    getServerSessionResultMock.mockResolvedValue({ kind: "unauthenticated" });
+    const { default: ForecastPlansPage } = await import(
+      "@/app/forecast-plans/page"
+    );
+    await expect(ForecastPlansPage()).rejects.toThrow("NEXT_REDIRECT");
+    expect(redirectMock).toHaveBeenCalledWith("/login");
+    expect(serverFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("transient session → renders client island with empty fallback data, NO redirect, NO data fetches", async () => {
+    getServerSessionResultMock.mockResolvedValue({
+      kind: "transient",
+      reason: "timeout",
+    });
+    const { default: ForecastPlansPage } = await import(
+      "@/app/forecast-plans/page"
+    );
+    const element = await ForecastPlansPage();
+    expect(element).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalledWith("/login");
+    expect(serverFetchMock).not.toHaveBeenCalled();
+    // React element props expose the initial fallback shape.
+    const props = (element as { props: Record<string, unknown> }).props;
+    expect(props.initialPeriods).toEqual([]);
+    expect(props.initialCategories).toEqual([]);
+    expect(props.initialPlan).toBeNull();
+  });
+
+  it("authenticated session → fetches categories + periods + plan, no redirect", async () => {
+    getServerSessionResultMock.mockResolvedValue({
+      kind: "authenticated",
+      session: { user: { id: 1 }, accessToken: "TOK" },
+    });
+    serverFetchMock.mockResolvedValueOnce([
+      { id: 10, name: "Salary" },
+    ] as never);
+    serverFetchMock.mockResolvedValueOnce([
+      { id: 1, start_date: "2026-05-01", end_date: null },
+    ] as never);
+    serverFetchMock.mockResolvedValueOnce({ id: 100, items: [] } as never);
+    const { default: ForecastPlansPage } = await import(
+      "@/app/forecast-plans/page"
+    );
+    const element = await ForecastPlansPage();
+    expect(element).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalled();
+    const props = (element as { props: Record<string, unknown> }).props;
+    expect(props.initialCategories).toEqual([{ id: 10, name: "Salary" }]);
+    expect(props.initialPeriods).toEqual([
+      { id: 1, start_date: "2026-05-01", end_date: null },
+    ]);
+    expect(props.initialPlan).toEqual({ id: 100, items: [] });
+  });
+
+  it("authenticated session with one fetch rejecting → uses Promise.allSettled to recover, renders with partial data", async () => {
+    getServerSessionResultMock.mockResolvedValue({
+      kind: "authenticated",
+      session: { user: { id: 1 }, accessToken: "TOK" },
+    });
+    // categories rejects (Promise.all would have re-thrown; Promise.allSettled
+    // lets us swallow it and pass [] to the client).
+    serverFetchMock.mockRejectedValueOnce(new Error("Boom"));
+    // billing-periods OK
+    serverFetchMock.mockResolvedValueOnce([
+      { id: 1, start_date: "2026-05-01", end_date: null },
+    ] as never);
+    // plan OK
+    serverFetchMock.mockResolvedValueOnce({ id: 100, items: [] } as never);
+    const { default: ForecastPlansPage } = await import(
+      "@/app/forecast-plans/page"
+    );
+    const element = await ForecastPlansPage();
+    expect(element).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalled();
+    const props = (element as { props: Record<string, unknown> }).props;
+    expect(props.initialCategories).toEqual([]);
+    expect(props.initialPeriods).toEqual([
+      { id: 1, start_date: "2026-05-01", end_date: null },
+    ]);
+  });
+});

--- a/frontend/tests/app/rsc-error-boundary-smoke.test.tsx
+++ b/frontend/tests/app/rsc-error-boundary-smoke.test.tsx
@@ -1,21 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Fault-injection smoke test against the #282 class of bug.
+// Fault-injection smoke test against the #282 / #288 class of bug.
 //
-// When serverFetch returns null (simulating transient backend
-// unavailability) during RSC render, the page MUST redirect to /login
-// rather than surface as the Next.js error boundary. We assert this by
-// mocking serverFetch to return null, and asserting the page invokes
-// `next/navigation`'s `redirect("/login")`, which throws NEXT_REDIRECT
-// — Next.js's documented short-circuit mechanism.
+// Two correctness properties:
+//   1. Unauthenticated (401/403 from /auth/verify) → redirect to /login.
+//      The Next.js error boundary must not be reached.
+//   2. Transient (timeout / 5xx / network error / invalid payload from
+//      /auth/verify) → DO NOT redirect. Render a recoverable client
+//      island with empty fallback data so the client-side SWR layer
+//      can re-fetch after hydration. This is the #288 fix: pre-PR,
+//      any serverFetch failure on the verify path either hung the
+//      render or false-logged-out the user.
 
 // Stub server-only so module imports work outside a real server context.
 vi.mock("server-only", () => ({}));
 
-// Mock serverFetch to return null unconditionally — simulates a backend
-// outage where /auth/verify rejects or returns non-OK.
+// Mock both flavors of the helper. The page-level data reads use
+// `serverFetch` (T | null); the verify path inside `getServerSessionResult`
+// uses `serverFetchResult` (the discriminated form). Tests below stub
+// each as needed.
+const serverFetchMock = vi.fn(async () => null);
+const serverFetchResultMock = vi.fn(async () => ({ kind: "ok", data: {} }));
 vi.mock("@/lib/server-fetch", () => ({
-  serverFetch: vi.fn(async () => null),
+  serverFetch: serverFetchMock,
+  serverFetchResult: serverFetchResultMock,
 }));
 
 // Mock the logger to keep test output quiet and isolated.
@@ -23,9 +31,8 @@ vi.mock("@/lib/logger", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-// Mock next/headers — getServerSession reads cookies; without a refresh
-// cookie it returns null before serverFetch is reached. We provide one so
-// the path under test (serverFetch returns null → redirect) is exercised.
+// Mock next/headers — getServerSessionResult reads cookies; we provide one
+// so the verify path is exercised in every test.
 vi.mock("next/headers", () => ({
   cookies: async () => ({
     get: () => ({ name: "refresh_token", value: "x" }),
@@ -44,28 +51,83 @@ vi.mock("next/navigation", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.resetModules();
   redirectMock.mockImplementation((_target: string) => {
     throw new Error("NEXT_REDIRECT");
   });
 });
 
-describe("RSC error-boundary smoke", () => {
-  it("/forecast-plans redirects to /login when serverFetch returns null (no error boundary)", async () => {
+describe("RSC error-boundary smoke — unauthenticated redirects to /login", () => {
+  it("/forecast-plans: 401 on /auth/verify → redirect('/login')", async () => {
+    serverFetchResultMock.mockResolvedValue({
+      kind: "http_error",
+      status: 401,
+    } as never);
     const mod = await import("@/app/forecast-plans/page");
     const ForecastPlansPage = mod.default;
     await expect(ForecastPlansPage()).rejects.toThrow("NEXT_REDIRECT");
     expect(redirectMock).toHaveBeenCalledWith("/login");
   });
 
-  // /import/[import_id]/reconcile uses the same getServerSession →
-  // serverFetch → redirect("/login") path. We exercise it here with a
-  // synthetic params promise to cover the second server-surface caller.
-  it("/import/[import_id]/reconcile redirects to /login when serverFetch returns null (no error boundary)", async () => {
+  it("/import/[id]/reconcile: 403 on /auth/verify → redirect('/login')", async () => {
+    serverFetchResultMock.mockResolvedValue({
+      kind: "http_error",
+      status: 403,
+    } as never);
     const mod = await import("@/app/import/[import_id]/reconcile/page");
     const ReconcilePage = mod.default;
     await expect(
       ReconcilePage({ params: Promise.resolve({ import_id: "1" }) }),
     ).rejects.toThrow("NEXT_REDIRECT");
     expect(redirectMock).toHaveBeenCalledWith("/login");
+  });
+});
+
+describe("RSC error-boundary smoke — transient verify does NOT redirect (PR #288)", () => {
+  it("/forecast-plans: 503 on /auth/verify → no redirect, renders client island", async () => {
+    serverFetchResultMock.mockResolvedValue({
+      kind: "http_error",
+      status: 503,
+    } as never);
+    const mod = await import("@/app/forecast-plans/page");
+    const ForecastPlansPage = mod.default;
+    // Must resolve to a React element rather than throwing NEXT_REDIRECT.
+    const out = await ForecastPlansPage();
+    expect(out).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalledWith("/login");
+  });
+
+  it("/forecast-plans: timeout on /auth/verify → no redirect, renders client island", async () => {
+    serverFetchResultMock.mockResolvedValue({ kind: "timeout" } as never);
+    const mod = await import("@/app/forecast-plans/page");
+    const ForecastPlansPage = mod.default;
+    const out = await ForecastPlansPage();
+    expect(out).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalledWith("/login");
+  });
+
+  it("/forecast-plans: network_error on /auth/verify → no redirect, renders client island", async () => {
+    serverFetchResultMock.mockResolvedValue({
+      kind: "network_error",
+    } as never);
+    const mod = await import("@/app/forecast-plans/page");
+    const ForecastPlansPage = mod.default;
+    const out = await ForecastPlansPage();
+    expect(out).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalledWith("/login");
+  });
+
+  it("/import/[id]/reconcile: 500 on /auth/verify → no redirect, renders client island", async () => {
+    serverFetchResultMock.mockResolvedValue({
+      kind: "http_error",
+      status: 500,
+    } as never);
+    const mod = await import("@/app/import/[import_id]/reconcile/page");
+    const ReconcilePage = mod.default;
+    const out = await ReconcilePage({
+      params: Promise.resolve({ import_id: "1" }),
+    });
+    expect(out).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalledWith("/login");
   });
 });

--- a/frontend/tests/lib/auth-server.test.ts
+++ b/frontend/tests/lib/auth-server.test.ts
@@ -18,13 +18,16 @@ vi.mock("server-only", () => ({}));
 
 import { cookies } from "next/headers";
 
-// `getServerSession` is wrapped in React.cache() which memoizes per call site.
-// To guarantee each test gets a fresh memoization, we re-import the module
-// inside every test after `vi.resetModules()` in beforeEach.
+// `getServerSessionResult` is wrapped in React.cache() which memoizes per
+// call site. To guarantee each test gets a fresh memoization, we re-import
+// the module inside every test after `vi.resetModules()` in beforeEach.
 async function loadModule() {
   const mod = await import("@/lib/auth-server");
   const loggerMod = await import("@/lib/logger");
-  return { getServerSession: mod.getServerSession, logger: loggerMod.logger };
+  return {
+    getServerSessionResult: mod.getServerSessionResult,
+    logger: loggerMod.logger,
+  };
 }
 
 beforeEach(() => {
@@ -32,36 +35,35 @@ beforeEach(() => {
   vi.resetModules();
 });
 
-describe("getServerSession", () => {
-  it("returns null and does not fetch when no refresh cookie is present", async () => {
+describe("getServerSessionResult", () => {
+  it("returns kind=unauthenticated when no refresh cookie is present, does not fetch", async () => {
     (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       get: () => undefined,
     });
     const fetchSpy = vi.spyOn(global, "fetch");
-    const { getServerSession } = await loadModule();
-    const session = await getServerSession();
-    expect(session).toBeNull();
+    const { getServerSessionResult } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "unauthenticated" });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("returns null when fetch rejects, does not throw, logs sanitized warning", async () => {
+  it("returns kind=transient(network) when fetch rejects, does not throw, logs sanitized warning", async () => {
     (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       get: () => ({ name: "refresh_token", value: "REDACTED-COOKIE-VALUE" }),
     });
     vi.spyOn(global, "fetch").mockRejectedValue(
-      new TypeError("Failed to fetch")
+      new TypeError("Failed to fetch"),
     );
-    const { getServerSession, logger } = await loadModule();
-    const session = await getServerSession();
-    expect(session).toBeNull();
-    // Post-PR-B: catch path emits `server_fetch_failed` from inside the
-    // serverFetch helper instead of `server_session_verify_failed`.
+    const { getServerSessionResult, logger } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "transient", reason: "network" });
     expect(logger.warn).toHaveBeenCalledWith(
       "server_fetch_failed",
       expect.objectContaining({
         error_name: "TypeError",
         error_message: expect.stringContaining("Failed to fetch"),
-      })
+        reason: "network_error",
+      }),
     );
     // Critical privacy assertion: the logged payload must NOT contain the
     // cookie value, any token, or any header value.
@@ -70,7 +72,7 @@ describe("getServerSession", () => {
     expect(JSON.stringify(logCallArgs)).not.toContain("REDACTED-COOKIE-VALUE");
   });
 
-  it("returns null when res.json() throws on invalid JSON, does not throw", async () => {
+  it("returns kind=transient(invalid_payload) when res.json() throws on 200", async () => {
     (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       get: () => ({ name: "refresh_token", value: "x" }),
     });
@@ -80,16 +82,32 @@ describe("getServerSession", () => {
         throw new SyntaxError("Unexpected token < in JSON");
       },
     } as unknown as Response);
-    const { getServerSession, logger } = await loadModule();
-    const session = await getServerSession();
-    expect(session).toBeNull();
+    const { getServerSessionResult, logger } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "transient", reason: "invalid_payload" });
     expect(logger.warn).toHaveBeenCalledWith(
       "server_fetch_failed",
-      expect.objectContaining({ error_name: "SyntaxError" })
+      expect.objectContaining({ error_name: "SyntaxError" }),
     );
   });
 
-  it("returns null on non-OK response, does NOT log a warning (normal auth flow)", async () => {
+  it("returns kind=transient(invalid_payload) when 200 response is missing access_token or user", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      // Payload shape that 2xx-parses but doesn't carry the required
+      // session fields. Pre-PR-#288 this collapsed to "null" which the
+      // page mapped to /login → false-logout on a server contract drift.
+      json: async () => ({ token_type: "bearer" }),
+    } as unknown as Response);
+    const { getServerSessionResult } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "transient", reason: "invalid_payload" });
+  });
+
+  it("returns kind=unauthenticated on 401 (normal auth flow, no logged warning)", async () => {
     (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       get: () => ({ name: "refresh_token", value: "x" }),
     });
@@ -98,16 +116,107 @@ describe("getServerSession", () => {
       status: 401,
       json: async () => ({ detail: "Invalid" }),
     } as unknown as Response);
-    const { getServerSession, logger } = await loadModule();
-    const session = await getServerSession();
-    expect(session).toBeNull();
+    const { getServerSessionResult, logger } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "unauthenticated" });
     // silentStatuses=[401] is passed by getServerSession for /auth/verify,
     // so the helper suppresses the warn for the 401 normal-flow case.
-    // 500/503 would still emit `server_fetch_non_ok`.
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it("returns the session payload on valid 200 response", async () => {
+  it("returns kind=unauthenticated on 403", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Forbidden" }),
+    } as unknown as Response);
+    const { getServerSessionResult } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "unauthenticated" });
+  });
+
+  it("returns kind=transient(server_error) on 500 (does NOT redirect to /login)", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "Internal" }),
+    } as unknown as Response);
+    const { getServerSessionResult, logger } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "transient", reason: "server_error" });
+    // 500 is NOT in silentStatuses; the non-OK warn must fire so on-call
+    // sees the backend outage signal.
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_non_ok",
+      expect.objectContaining({ status: 500 }),
+    );
+  });
+
+  it("returns kind=transient(server_error) on 503", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ detail: "Unavailable" }),
+    } as unknown as Response);
+    const { getServerSessionResult } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result).toEqual({ kind: "transient", reason: "server_error" });
+  });
+
+  it("returns kind=transient(timeout) when /auth/verify never responds within the budget (no hang)", async () => {
+    (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      get: () => ({ name: "refresh_token", value: "x" }),
+    });
+    // Simulate a wedged backend: fetch hangs until aborted.
+    vi.spyOn(global, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal;
+          if (signal) {
+            const onAbort = () => {
+              const err = new Error("Aborted");
+              err.name = "AbortError";
+              reject(err);
+            };
+            if (signal.aborted) onAbort();
+            else signal.addEventListener("abort", onAbort, { once: true });
+          }
+        }),
+    );
+    // Stub the verify timeout to be tight so the test doesn't burn 5s.
+    // We do this by relying on the default 5s being abortable; instead
+    // of swapping it out, we use a short race against a node-level
+    // timer in the test runner to validate "no hang" rather than the
+    // exact budget.
+    const { getServerSessionResult } = await loadModule();
+    // Race the session result against a 2s timer. The default verify
+    // budget is 5s, but our mock fetch will be aborted by the helper's
+    // AbortController as soon as the budget elapses; we only need to
+    // confirm the test doesn't hang. To keep this fast, we instead
+    // stub `setTimeout` so the helper's abort fires immediately.
+    // The simpler shape: assert the helper returns transient(timeout)
+    // when the budget is short. Re-import with a custom budget by
+    // mocking the constant indirectly is overkill; we run the actual
+    // 5s timer here but with Vitest's fake timers.
+    vi.useFakeTimers();
+    const promise = getServerSessionResult();
+    // Advance past the 5s verify budget.
+    await vi.advanceTimersByTimeAsync(5_001);
+    const result = await promise;
+    vi.useRealTimers();
+    expect(result).toEqual({ kind: "transient", reason: "timeout" });
+  });
+
+  it("returns kind=authenticated on a valid 200 response", async () => {
     (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       get: () => ({ name: "refresh_token", value: "x" }),
     });
@@ -136,12 +245,14 @@ describe("getServerSession", () => {
         token_type: "bearer",
       }),
     } as unknown as Response);
-    const { getServerSession, logger } = await loadModule();
-    const session = await getServerSession();
-    expect(session).toEqual({
-      user: expect.objectContaining({ id: 1, email: "a@b.c" }),
-      accessToken: "TOK",
-    });
+    const { getServerSessionResult, logger } = await loadModule();
+    const result = await getServerSessionResult();
+    expect(result.kind).toBe("authenticated");
+    if (result.kind === "authenticated") {
+      expect(result.session.accessToken).toBe("TOK");
+      expect(result.session.user.id).toBe(1);
+      expect(result.session.user.email).toBe("a@b.c");
+    }
     expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/lib/server-fetch.test.ts
+++ b/frontend/tests/lib/server-fetch.test.ts
@@ -13,7 +13,11 @@ vi.mock("server-only", () => ({}));
 async function loadModule() {
   const mod = await import("@/lib/server-fetch");
   const loggerMod = await import("@/lib/logger");
-  return { serverFetch: mod.serverFetch, logger: loggerMod.logger };
+  return {
+    serverFetch: mod.serverFetch,
+    serverFetchResult: mod.serverFetchResult,
+    logger: loggerMod.logger,
+  };
 }
 
 beforeEach(() => {
@@ -219,6 +223,216 @@ describe("safeBackendHost", () => {
     const mod = await import("@/lib/server-fetch");
     expect(mod.safeBackendHost()).toBe("backend:8000");
     vi.unstubAllEnvs();
+  });
+});
+
+describe("serverFetch timeout (PR #288)", () => {
+  it("aborts a never-resolving fetch within the configured timeoutMs and returns null", async () => {
+    // The fetch promise never resolves. Without an AbortController the
+    // helper would hang forever; with PR #288's timeout it must abort
+    // and return null. We use a tight 50ms budget so the test stays
+    // fast.
+    vi.spyOn(global, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal;
+          if (signal) {
+            const onAbort = () => {
+              const err = new Error("Aborted");
+              err.name = "AbortError";
+              reject(err);
+            };
+            if (signal.aborted) onAbort();
+            else signal.addEventListener("abort", onAbort, { once: true });
+          }
+          // No resolve path — fetch hangs unless aborted.
+        }),
+    );
+    const { serverFetch, logger } = await loadModule();
+    const t0 = Date.now();
+    const result = await serverFetch<{ ok: boolean }>("/api/v1/slow", {
+      timeoutMs: 50,
+    });
+    const elapsed = Date.now() - t0;
+    expect(result).toBeNull();
+    // We can't be super tight on the upper bound in CI, but a 5000ms
+    // hang would dwarf this — assert the helper aborted well before
+    // the next test's default budget.
+    expect(elapsed).toBeLessThan(2_000);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "server_fetch_failed",
+      expect.objectContaining({
+        reason: "timeout",
+        timeout_ms: 50,
+        path: "/api/v1/slow",
+      }),
+    );
+  });
+
+  it("serverFetchResult returns kind=timeout on abort and does not leak query string or token", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal;
+          if (signal) {
+            const onAbort = () => {
+              const err = new Error("Aborted");
+              err.name = "AbortError";
+              reject(err);
+            };
+            if (signal.aborted) onAbort();
+            else signal.addEventListener("abort", onAbort, { once: true });
+          }
+        }),
+    );
+    const { serverFetchResult, logger } = await loadModule();
+    const result = await serverFetchResult<{ ok: boolean }>(
+      "/api/v1/slow?leak_token=SECRET-QUERY-VALUE",
+      {
+        timeoutMs: 30,
+        accessToken: "SECRET-BEARER-VALUE",
+        cookie: "refresh_token=SECRET-COOKIE-VALUE",
+      },
+    );
+    expect(result).toEqual({ kind: "timeout" });
+    const payload = (logger.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(payload.reason).toBe("timeout");
+    expect(payload.path).toBe("/api/v1/slow");
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("SECRET-QUERY-VALUE");
+    expect(serialized).not.toContain("SECRET-BEARER-VALUE");
+    expect(serialized).not.toContain("SECRET-COOKIE-VALUE");
+    expect(serialized).not.toContain("Bearer ");
+  });
+
+  it("timeoutMs override actually changes the budget (50ms aborts a 200ms-delayed promise)", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((resolve, reject) => {
+          const signal = (init as RequestInit | undefined)?.signal;
+          const t = setTimeout(() => {
+            resolve({
+              ok: true,
+              json: async () => ({ ok: true }),
+            } as unknown as Response);
+          }, 200);
+          if (signal) {
+            const onAbort = () => {
+              clearTimeout(t);
+              const err = new Error("Aborted");
+              err.name = "AbortError";
+              reject(err);
+            };
+            if (signal.aborted) onAbort();
+            else signal.addEventListener("abort", onAbort, { once: true });
+          }
+        }),
+    );
+    const { serverFetch } = await loadModule();
+    const t0 = Date.now();
+    const result = await serverFetch<{ ok: boolean }>("/api/v1/slow", {
+      timeoutMs: 50,
+    });
+    const elapsed = Date.now() - t0;
+    expect(result).toBeNull();
+    // Aborted before the 200ms delay would have resolved.
+    expect(elapsed).toBeLessThan(180);
+  });
+
+  it("default timeout is 5000ms when no override is supplied", async () => {
+    // Spy on setTimeout to confirm the helper schedules the abort at the
+    // documented default. This avoids actually waiting 5s in the test.
+    const setTimeoutSpy = vi
+      .spyOn(global, "setTimeout")
+      .mockImplementation(
+        // Return a fake handle; the test doesn't await the resolution,
+        // it just inspects how the helper armed the timer.
+        ((..._args: unknown[]) => 0) as unknown as typeof global.setTimeout,
+      );
+    // fetch resolves immediately so the helper unwinds cleanly through
+    // the finally{ clearTimeout } branch.
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as unknown as Response);
+    const { serverFetch } = await loadModule();
+    await serverFetch<{ ok: boolean }>("/api/v1/probe", {});
+    // The first setTimeout call inside serverFetchResult schedules the
+    // abort with the default budget.
+    const firstCall = setTimeoutSpy.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    expect(firstCall[1]).toBe(5000);
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("clearTimeout is invoked on the success path so the abort never fires after the response lands", async () => {
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: 1 }),
+    } as unknown as Response);
+    const { serverFetch } = await loadModule();
+    const result = await serverFetch<{ value: number }>("/api/v1/probe", {});
+    expect(result).toEqual({ value: 1 });
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});
+
+describe("serverFetchResult discriminated kinds (PR #288)", () => {
+  it("returns kind=ok with parsed JSON on 200", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: 42 }),
+    } as unknown as Response);
+    const { serverFetchResult } = await loadModule();
+    const result = await serverFetchResult<{ value: number }>("/api/v1/probe");
+    expect(result).toEqual({ kind: "ok", data: { value: 42 } });
+  });
+
+  it("returns kind=http_error with status on 401", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: "Unauthorized" }),
+    } as unknown as Response);
+    const { serverFetchResult } = await loadModule();
+    const result = await serverFetchResult<{ ok: boolean }>(
+      "/api/v1/auth/verify",
+      { silentStatuses: [401] },
+    );
+    expect(result).toEqual({ kind: "http_error", status: 401 });
+  });
+
+  it("returns kind=http_error with status on 503", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ detail: "Unavailable" }),
+    } as unknown as Response);
+    const { serverFetchResult } = await loadModule();
+    const result = await serverFetchResult<{ ok: boolean }>("/api/v1/probe");
+    expect(result).toEqual({ kind: "http_error", status: 503 });
+  });
+
+  it("returns kind=network_error on a TypeError from fetch", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
+    const { serverFetchResult } = await loadModule();
+    const result = await serverFetchResult<{ ok: boolean }>("/api/v1/probe");
+    expect(result).toEqual({ kind: "network_error" });
+  });
+
+  it("returns kind=invalid_json when res.json() throws on 200", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    } as unknown as Response);
+    const { serverFetchResult } = await loadModule();
+    const result = await serverFetchResult<{ ok: boolean }>("/api/v1/probe");
+    expect(result).toEqual({ kind: "invalid_json" });
   });
 });
 


### PR DESCRIPTION
## Summary

- Production-observed bug: `/forecast-plans` and other RSC pages could remain on `loading.tsx` indefinitely when the backend wedged. Native `fetch` has no timeout and Next.js does not inject one, so an awaited fetch inside an RSC never resolved and the Suspense fallback stayed mounted.
- `serverFetch` now bounds every request with an `AbortController` (5s default, per-call override via `timeoutMs`). Pattern mirrors `apiFetch` from #286.
- `getServerSessionResult` replaces the nullable `getServerSession` shim with a discriminated result so 401/403 maps to `unauthenticated` (redirect to `/login`) while timeout / 5xx / network / invalid payload maps to `transient` (render recoverable fallback, no false-logout).

## What changed

- `frontend/lib/server-fetch.ts`: new `serverFetchResult<T>` exposes the full discriminated kind (`ok` / `http_error` / `timeout` / `abort` / `network_error` / `invalid_json`). Existing `serverFetch<T>` keeps its `T | null` shape as a thin wrapper. New `timeoutMs` option (5s default), `AbortController` plumbed through, `clearTimeout` in a `finally` so the timer never leaks. Privacy invariants preserved: log payload still bounded by `safeBackendHost()` + `sanitizeErrorMessage()`, plus new `reason` and `timeout_ms` fields, no cookies / tokens / bodies / query strings.
- `frontend/lib/auth-server.ts`: `getServerSessionResult` returns `{ kind: 'authenticated', session }` | `{ kind: 'unauthenticated' }` | `{ kind: 'transient', reason }`. The legacy `getServerSession`/`getServerUser` helpers were removed per the pre-launch no-shims rule.
- `frontend/app/forecast-plans/page.tsx`: switches on the discriminated session result. Unauth redirects to `/login`. Transient renders `ForecastPlansClient` with `[] / [] / null` fallback. Authenticated uses `Promise.allSettled` over the two parallel reads so one transient fetch failure does not strand the render.
- `frontend/app/import/[import_id]/reconcile/page.tsx`: same triage. Transient renders `ReconcileClient` with `initialBatch=null`; the client SWR layer picks up the slack.
- `frontend/app/forecast-plans/ForecastPlansClient.tsx`: one-shot client-side categories recovery on mount when `initialCategories` is empty, so the page self-heals after a transient server-side fetch failure (no retry loop; `apiFetch` already has its own bounded timeout).

## Why this fixes the spinner

The pre-PR chain was: dashboard idles a few minutes, the user clicks a sidebar item, the RSC begins rendering `/forecast-plans`, `getServerSession()` awaits a `serverFetch("/api/v1/auth/verify")` that has no timeout, the backend rate-limit path is wedged on a half-broken Redis socket, the fetch never resolves, the RSC never returns, and `loading.tsx` stays mounted forever. With the bounded timeout the verify call aborts after 5s; with the discriminated result the page distinguishes "wedged backend" (render fallback) from "actually unauthenticated" (redirect). The client-side SWR layer then re-fetches after hydration through `apiFetch`'s own bounded timeout and silent-refresh contract.