### PR TITLE
fix(auth): legacy refresh-cookie cleanup for PR #211 path migration

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -295,6 +295,7 @@ async def login(
         max_age=7 * 24 * 60 * 60,
         path="/",
     )
+    _clear_legacy_refresh_cookie(response)
 
     await _record_login_success(
         session_factory, user=user, request=request, method="password"
@@ -305,24 +306,72 @@ async def login(
 
 SESSION_EXPIRED_DETAIL = "Session expired — please sign in again"
 
+# Legacy refresh-cookie path used before PR #211 (commit 70ddd26,
+# 2026-05-11) widened the cookie path to ``/``. Cookies set at this
+# narrower path cannot be cleared by ``delete_cookie(path="/")`` because
+# cookie removal requires an exact path match. Users carrying a pre-PR
+# cookie therefore retain it alongside any post-PR ``Path=/`` cookie,
+# and the browser sends BOTH on every request to ``/api/v1/auth/refresh``
+# (the legacy path is more specific, so RFC 6265 orders it first).
+# Whichever value Starlette's cookie parser picks may not be the one
+# the user expects, producing spurious 401s. Every response that issues
+# or clears the canonical ``Path=/`` cookie also emits a
+# ``Path=/api/v1/auth/refresh`` delete so the legacy cookie is actively
+# retired. Remove this cleanup after 2026-05-25 (PR #211 shipped
+# 2026-05-11; cookie max_age is 7 days, so all legacy cookies expire
+# naturally by then assuming no further drift).
+LEGACY_REFRESH_COOKIE_PATH = "/api/v1/auth/refresh"
 
-async def _validate_refresh_cookie(
-    refresh_token: str | None,
+
+def _clear_legacy_refresh_cookie(response: Response) -> None:
+    """Emit a Set-Cookie that retires any pre-PR #211 ``refresh_token``
+    cookie at the old ``Path=/api/v1/auth/refresh``. Safe to call
+    alongside ``set_cookie(..., path="/")``: the two operate on
+    distinct path-scoped cookie jars in the browser.
+    """
+    response.delete_cookie("refresh_token", path=LEGACY_REFRESH_COOKIE_PATH)
+
+
+def _extract_refresh_cookies(request: Request) -> list[str]:
+    """Return ALL ``refresh_token`` cookie values from the request's
+    Cookie header, in arrival order.
+
+    Starlette's cookie parser collapses duplicate names to a single value
+    (last one wins per dict semantics). After the PR #211 cookie-path
+    migration a single browser may carry both a legacy
+    ``Path=/api/v1/auth/refresh`` cookie and a current ``Path=/`` cookie,
+    sent together as two ``refresh_token=`` entries in the Cookie header.
+    Walking the raw header lets ``_validate_refresh_cookie`` try every
+    value and accept the first that validates, rather than gambling on
+    whichever single value the parser picks.
+    """
+    cookie_header = request.headers.get("cookie") or ""
+    values: list[str] = []
+    if not cookie_header:
+        return values
+    # Cookie names cannot contain ``=`` per RFC 6265; ``partition`` is
+    # therefore unambiguous. Cookie values may contain ``=`` (JWT base64
+    # padding) — that is why we partition rather than split.
+    for part in cookie_header.split(";"):
+        name, sep, value = part.strip().partition("=")
+        if sep and name == "refresh_token":
+            values.append(value)
+    return values
+
+
+async def _validate_single_refresh_token(
+    refresh_token: str,
     db: AsyncSession,
 ) -> tuple[User, dict, datetime | None]:
-    """Validate a refresh-token cookie. Returns (user, payload, session_start)
-    or raises ``HTTPException(401)`` on any failure.
+    """Validate ONE refresh-token JWT value. Returns
+    ``(user, payload, session_start)`` or raises ``HTTPException(401)``.
 
-    Shared between ``/auth/refresh`` (rotating) and ``/auth/verify`` (non-
-    rotating). Performs identical checks for both endpoints so the contract
-    cannot drift:
-
-      1. cookie presence
-      2. JWT decode + ``type == "refresh"``
-      3. user exists + ``is_active``
-      4. ``iat < token_cutoff(user)`` rejects tokens issued before the
+    The validation chain:
+      1. JWT decode + ``type == "refresh"``
+      2. user exists + ``is_active``
+      3. ``iat < token_cutoff(user)`` rejects tokens issued before the
          user's last logout / password change / password reset
-      5. absolute session lifetime (per-org ``session_lifetime_days``
+      4. absolute session lifetime (per-org ``session_lifetime_days``
          setting or system default) — raises with detail
          ``SESSION_EXPIRED_DETAIL`` so callers can recognize and act
          (e.g. ``/refresh`` clears the cookie; ``/verify`` does not)
@@ -331,12 +380,6 @@ async def _validate_refresh_cookie(
     caller's responsibility so the no-Set-Cookie invariant on ``/verify``
     is absolute.
     """
-    if refresh_token is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="No refresh token",
-        )
-
     payload = decode_token(refresh_token)
     if payload is None or payload.get("type") != "refresh":
         raise HTTPException(
@@ -392,10 +435,43 @@ async def _validate_refresh_cookie(
     return user, payload, session_start
 
 
+async def _validate_refresh_cookie(
+    refresh_tokens: list[str],
+    db: AsyncSession,
+) -> tuple[User, dict, datetime | None]:
+    """Validate ANY of the provided refresh-token cookie values.
+
+    Returns the first cookie that passes the full validation chain. If
+    every cookie fails, raises the last failure so error semantics match
+    the single-token case when the caller really did only have one
+    cookie.
+
+    Shared between ``/auth/refresh`` (rotating) and ``/auth/verify``
+    (non-rotating). Walking every ``refresh_token`` value found in the
+    Cookie header ensures a legacy ``Path=/api/v1/auth/refresh`` cookie
+    shadowing the current ``Path=/`` cookie (PR #211 migration) does
+    not produce a false 401.
+    """
+    if not refresh_tokens:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No refresh token",
+        )
+
+    last_exc: HTTPException | None = None
+    for token in refresh_tokens:
+        try:
+            return await _validate_single_refresh_token(token, db)
+        except HTTPException as exc:
+            last_exc = exc
+    assert last_exc is not None  # loop ran at least once
+    raise last_exc
+
+
 @router.post("/refresh", response_model=TokenResponse)
 async def refresh(
+    request: Request,
     response: Response,
-    refresh_token: str | None = Cookie(default=None),
     db: AsyncSession = Depends(get_db),
 ):
     """Rotate the refresh cookie + issue a fresh access token.
@@ -412,9 +488,10 @@ async def refresh(
     path we therefore return a JSONResponse directly so the
     delete-cookie header actually reaches the browser.
     """
+    refresh_tokens = _extract_refresh_cookies(request)
     try:
         user, _payload, session_start = await _validate_refresh_cookie(
-            refresh_token, db
+            refresh_tokens, db
         )
     except HTTPException as exc:
         # Clear the stale cookie on absolute session-lifetime expiry so the
@@ -429,6 +506,7 @@ async def refresh(
                 content={"detail": exc.detail},
             )
             expired_response.delete_cookie("refresh_token", path="/")
+            _clear_legacy_refresh_cookie(expired_response)
             return expired_response
         raise
 
@@ -445,6 +523,7 @@ async def refresh(
         max_age=7 * 24 * 60 * 60,
         path="/",
     )
+    _clear_legacy_refresh_cookie(response)
 
     return TokenResponse(access_token=access_token)
 
@@ -453,7 +532,6 @@ async def refresh(
 @limiter.limit("120/minute")
 async def verify(
     request: Request,
-    refresh_token: str | None = Cookie(default=None),
     db: AsyncSession = Depends(get_db),
 ):
     """Server-side session verification for RSC consumers.
@@ -468,10 +546,12 @@ async def verify(
 
     Shares the full validation chain with ``/auth/refresh`` via
     ``_validate_refresh_cookie`` so the security contract cannot drift
-    between the two endpoints.
+    between the two endpoints. Walks every ``refresh_token`` value in the
+    Cookie header (PR #211 cookie-shadow guard).
     """
+    refresh_tokens = _extract_refresh_cookies(request)
     user, _payload, _session_start = await _validate_refresh_cookie(
-        refresh_token, db
+        refresh_tokens, db
     )
 
     await db.refresh(user, ["organization"])
@@ -528,6 +608,7 @@ async def logout(
             # Missing/expired/malformed token: still clear the cookie below.
             pass
     response.delete_cookie("refresh_token", path="/")
+    _clear_legacy_refresh_cookie(response)
     return {"detail": "Logged out"}
 
 
@@ -713,6 +794,7 @@ def _issue_tokens(user: User, response: Response) -> TokenResponse:
         max_age=7 * 24 * 60 * 60,
         path="/",
     )
+    _clear_legacy_refresh_cookie(response)
     return TokenResponse(access_token=access_token)
 
 
@@ -1362,6 +1444,7 @@ async def google_callback(
         max_age=7 * 24 * 60 * 60,
         path="/",
     )
+    _clear_legacy_refresh_cookie(resp)
     await _record_login_success(
         session_factory, user=user, request=request, method="google_sso"
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -306,6 +306,13 @@ async def login(
 
 SESSION_EXPIRED_DETAIL = "Session expired — please sign in again"
 
+# Emitted when the request carries refresh cookies for two or more
+# distinct user accounts (e.g. a legacy account-A cookie shadowing a
+# current account-B cookie after an account switch). Auto-selecting
+# either would silently authenticate the wrong identity, so the only
+# safe response is to force a clean re-login.
+AMBIGUOUS_SESSION_DETAIL = "Ambiguous session — please sign in again"
+
 # Legacy refresh-cookie path used before PR #211 (commit 70ddd26,
 # 2026-05-11) widened the cookie path to ``/``. Cookies set at this
 # narrower path cannot be cleared by ``delete_cookie(path="/")`` because
@@ -439,18 +446,31 @@ async def _validate_refresh_cookie(
     refresh_tokens: list[str],
     db: AsyncSession,
 ) -> tuple[User, dict, datetime | None]:
-    """Validate ANY of the provided refresh-token cookie values.
+    """Validate the provided refresh-token cookie values and pick one.
 
-    Returns the first cookie that passes the full validation chain. If
-    every cookie fails, raises the last failure so error semantics match
-    the single-token case when the caller really did only have one
-    cookie.
+    Rules:
+      - No tokens at all → ``401 "No refresh token"``.
+      - All tokens fail validation → re-raise the last failure so single-
+        cookie error semantics are preserved when only one cookie was
+        actually presented.
+      - At least one token validates AND every successful token resolves
+        to the SAME ``user.id`` → pick the newest token (highest ``iat``)
+        for that user and return it.
+      - Successful tokens map to MORE THAN ONE distinct ``user.id`` →
+        raise ``401 AMBIGUOUS_SESSION_DETAIL``. Auto-selecting either
+        would silently authenticate the wrong identity (an attacker who
+        could plant a second valid refresh cookie could otherwise switch
+        the active account on the next refresh). The route caller is
+        responsible for clearing both canonical and legacy cookies on
+        this path; ``/verify`` lets the exception propagate without
+        touching cookies (no-Set-Cookie invariant).
 
-    Shared between ``/auth/refresh`` (rotating) and ``/auth/verify``
-    (non-rotating). Walking every ``refresh_token`` value found in the
-    Cookie header ensures a legacy ``Path=/api/v1/auth/refresh`` cookie
-    shadowing the current ``Path=/`` cookie (PR #211 migration) does
-    not produce a false 401.
+    Walking every ``refresh_token`` value found in the Cookie header is
+    necessary because Starlette's parser collapses duplicate names to a
+    single value (last wins) — after the PR #211 path migration a
+    browser may carry both a legacy ``Path=/api/v1/auth/refresh`` cookie
+    and a current ``Path=/`` cookie, and the legacy one may be the one
+    the parser surfaces.
     """
     if not refresh_tokens:
         raise HTTPException(
@@ -458,14 +478,30 @@ async def _validate_refresh_cookie(
             detail="No refresh token",
         )
 
+    successes: list[tuple[User, dict, datetime | None]] = []
     last_exc: HTTPException | None = None
     for token in refresh_tokens:
         try:
-            return await _validate_single_refresh_token(token, db)
+            successes.append(await _validate_single_refresh_token(token, db))
         except HTTPException as exc:
             last_exc = exc
-    assert last_exc is not None  # loop ran at least once
-    raise last_exc
+
+    if not successes:
+        assert last_exc is not None  # loop ran at least once
+        raise last_exc
+
+    distinct_user_ids = {triple[0].id for triple in successes}
+    if len(distinct_user_ids) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=AMBIGUOUS_SESSION_DETAIL,
+        )
+
+    # Single user, possibly multiple valid tokens. Prefer the newest by
+    # ``iat`` so a stale legacy cookie never out-votes the current one
+    # for the same user.
+    successes.sort(key=lambda triple: triple[1].get("iat", 0), reverse=True)
+    return successes[0]
 
 
 @router.post("/refresh", response_model=TokenResponse)
@@ -494,20 +530,23 @@ async def refresh(
             refresh_tokens, db
         )
     except HTTPException as exc:
-        # Clear the stale cookie on absolute session-lifetime expiry so the
-        # browser stops sending it. Other 401s leave the cookie in place;
-        # they may be transient (e.g. invalid-but-recoverable) or carry
-        # their own meaning.
-        if exc.detail == SESSION_EXPIRED_DETAIL:
+        # Two terminal paths clear BOTH the canonical and the legacy
+        # cookie so the browser stops sending them: absolute session
+        # expiry (a normal end-of-session signal) and ambiguous session
+        # (request carried valid refresh cookies for >1 distinct user;
+        # the only safe response is to force a clean re-login). Other
+        # 401s leave the cookie in place — they may be transient
+        # (e.g. invalid-but-recoverable) or carry their own meaning.
+        if exc.detail in (SESSION_EXPIRED_DETAIL, AMBIGUOUS_SESSION_DETAIL):
             from fastapi.responses import JSONResponse
 
-            expired_response = JSONResponse(
+            cleared = JSONResponse(
                 status_code=exc.status_code,
                 content={"detail": exc.detail},
             )
-            expired_response.delete_cookie("refresh_token", path="/")
-            _clear_legacy_refresh_cookie(expired_response)
-            return expired_response
+            cleared.delete_cookie("refresh_token", path="/")
+            _clear_legacy_refresh_cookie(cleared)
+            return cleared
         raise
 
     # Carry forward session_created_at from the original login

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -16,6 +16,7 @@ from app.database import get_db
 from app.deps import get_current_user
 from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
+from app.routers.auth import _clear_legacy_refresh_cookie
 from app.schemas.auth import TokenResponse
 from app.schemas.invitation import (
     InvitationAcceptRequest,
@@ -192,6 +193,11 @@ async def accept_invitation(
         # google_callback).
         path="/",
     )
+    # Active retirement of any pre-PR #211 ``refresh_token`` cookie at
+    # the legacy ``Path=/api/v1/auth/refresh``. See
+    # ``app/routers/auth.py:_clear_legacy_refresh_cookie`` for the full
+    # rationale and the 2026-05-25 removal target.
+    _clear_legacy_refresh_cookie(response)
     return TokenResponse(access_token=access)
 
 

--- a/backend/tests/auth/test_legacy_cookie_cleanup.py
+++ b/backend/tests/auth/test_legacy_cookie_cleanup.py
@@ -1,0 +1,350 @@
+"""Legacy refresh-cookie cleanup for the PR #211 path migration.
+
+PR #211 (commit 70ddd26, 2026-05-11) widened the refresh cookie's Path
+from ``/api/v1/auth/refresh`` to ``/``. Browsers carrying a pre-PR
+cookie keep it indefinitely because ``delete_cookie(path="/")`` cannot
+clear cookies set at the narrower path. The browser then sends BOTH
+``refresh_token=`` entries on every /api/v1/auth/refresh request, and
+Starlette's cookie parser picks only one — possibly the wrong one.
+
+This test file pins two things:
+  1. Every auth response that issues or clears the canonical Path=/
+     cookie ALSO emits a Path=/api/v1/auth/refresh delete-cookie so the
+     legacy cookie is actively retired.
+  2. ``/refresh`` and ``/verify`` walk the full list of ``refresh_token``
+     cookie values, accepting any that validates rather than blindly
+     trusting whichever single value Starlette extracts.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+import jwt as _pyjwt
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import LEGACY_REFRESH_COOKIE_PATH, router as auth_router
+from app.security import create_refresh_token, hash_password
+
+
+def _mint_refresh_at(user_id: int, iat: datetime) -> str:
+    """Mint a refresh JWT with a controlled ``iat`` (and matching
+    ``session_created_at``) so tests can place tokens above or below
+    ``token_cutoff`` deterministically without real sleeps."""
+    expire = iat + timedelta(days=app_settings.jwt_refresh_token_expire_days)
+    payload = {
+        "sub": str(user_id),
+        "type": "refresh",
+        "session_created_at": iat.timestamp(),
+        "iat": int(iat.timestamp()),
+        "exp": expire,
+    }
+    return _pyjwt.encode(
+        payload, app_settings.jwt_secret_key, algorithm=app_settings.jwt_algorithm
+    )
+
+
+PASSWORD = "S3cret-Pass!"
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(factory, *, username: str = "alice") -> int:
+    async with factory() as db:
+        org = Organization(name="org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=f"{username}@example.com",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+def _set_cookie_values_for(headers, name: str) -> list[str]:
+    """Return every Set-Cookie header whose cookie name is ``name``,
+    in arrival order. Necessary because a single response may emit two
+    Set-Cookie entries with the same name (one Path=/ set, one
+    Path=/api/v1/auth/refresh delete)."""
+    matches: list[str] = []
+    raw_iter = headers.raw if hasattr(headers, "raw") else []
+    for raw in raw_iter:
+        if isinstance(raw, tuple):
+            key, value = raw
+            if key.decode().lower() != "set-cookie":
+                continue
+            value = value.decode()
+        else:
+            value = raw
+        if value.split("=", 1)[0].strip().lower() == name.lower():
+            matches.append(value)
+    return matches
+
+
+# ── Multi-cookie validation ────────────────────────────────────────────────
+
+
+async def test_refresh_accepts_valid_when_legacy_invalid_present(session_factory):
+    """Legacy cookie invalid (iat below cutoff) + current cookie valid
+    → /refresh must succeed using the valid one. This is the canonical
+    idle-return false-logout scenario."""
+    user_id = await _seed_user(session_factory)
+
+    # Anchor a cutoff timestamp halfway between the two iats so the
+    # legacy token is rejected and the current one is accepted.
+    # Both iats in the PAST (PyJWT rejects future-iat as
+    # ImmatureSignatureError). Cutoff sits between them so legacy is
+    # below cutoff (rejected) and current is above cutoff (accepted).
+    now = datetime.now(timezone.utc)
+    legacy = _mint_refresh_at(user_id, iat=now - timedelta(minutes=20))
+    current = _mint_refresh_at(user_id, iat=now - timedelta(minutes=2))
+    cutoff = now - timedelta(minutes=10)
+
+    async with session_factory() as db:
+        result = await db.execute(select(User).where(User.id == user_id))
+        user = result.scalar_one()
+        user.sessions_invalidated_at = cutoff
+        await db.commit()
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        # Browser sends BOTH cookies in one Cookie header. Legacy first
+        # (path is more specific), current second.
+        res = client.post(
+            "/api/v1/auth/refresh",
+            headers={"Cookie": f"refresh_token={legacy}; refresh_token={current}"},
+        )
+
+    assert res.status_code == 200, res.text
+    assert "access_token" in res.json()
+
+
+async def test_refresh_accepts_current_when_listed_first(session_factory):
+    """Same as above, header order reversed (current first). Both orders
+    must succeed — validator must walk the whole list, not depend on
+    Starlette's pick."""
+    user_id = await _seed_user(session_factory)
+
+    # Both iats in the PAST (PyJWT rejects future-iat as
+    # ImmatureSignatureError). Cutoff sits between them so legacy is
+    # below cutoff (rejected) and current is above cutoff (accepted).
+    now = datetime.now(timezone.utc)
+    legacy = _mint_refresh_at(user_id, iat=now - timedelta(minutes=20))
+    current = _mint_refresh_at(user_id, iat=now - timedelta(minutes=2))
+    cutoff = now - timedelta(minutes=10)
+
+    async with session_factory() as db:
+        result = await db.execute(select(User).where(User.id == user_id))
+        user = result.scalar_one()
+        user.sessions_invalidated_at = cutoff
+        await db.commit()
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            headers={"Cookie": f"refresh_token={current}; refresh_token={legacy}"},
+        )
+
+    assert res.status_code == 200, res.text
+
+
+async def test_refresh_rejects_when_both_invalid(session_factory):
+    """Both cookies invalid → 401 with the last failure's detail."""
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            headers={"Cookie": "refresh_token=garbage1; refresh_token=garbage2"},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Invalid refresh token"
+
+
+async def test_refresh_no_cookie_returns_existing_detail(session_factory):
+    """Zero cookies → "No refresh token", matching pre-change behavior."""
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/auth/refresh")
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "No refresh token"
+
+
+async def test_verify_accepts_valid_when_legacy_invalid_present(session_factory):
+    """/verify must also walk the cookie list, and must NOT emit
+    Set-Cookie on success even when a legacy cookie is present."""
+    user_id = await _seed_user(session_factory)
+
+    # Both iats in the PAST (PyJWT rejects future-iat as
+    # ImmatureSignatureError). Cutoff sits between them so legacy is
+    # below cutoff (rejected) and current is above cutoff (accepted).
+    now = datetime.now(timezone.utc)
+    legacy = _mint_refresh_at(user_id, iat=now - timedelta(minutes=20))
+    current = _mint_refresh_at(user_id, iat=now - timedelta(minutes=2))
+    cutoff = now - timedelta(minutes=10)
+
+    async with session_factory() as db:
+        result = await db.execute(select(User).where(User.id == user_id))
+        user = result.scalar_one()
+        user.sessions_invalidated_at = cutoff
+        await db.commit()
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            headers={"Cookie": f"refresh_token={legacy}; refresh_token={current}"},
+        )
+
+    assert res.status_code == 200, res.text
+    # Load-bearing invariant: /verify never emits Set-Cookie, regardless
+    # of how many refresh_token cookies the request carried.
+    header_keys_lower = {k.lower() for k in res.headers.keys()}
+    assert "set-cookie" not in header_keys_lower, (
+        f"/verify must not emit Set-Cookie even when retiring a legacy cookie. "
+        f"Got: {dict(res.headers)}"
+    )
+
+
+# ── Legacy-path cleanup on every set/delete site ───────────────────────────
+
+
+def _assert_legacy_cleanup(headers):
+    """Assert that the response emits a Set-Cookie deleting the legacy
+    Path=/api/v1/auth/refresh refresh_token cookie."""
+    cookies = _set_cookie_values_for(headers, "refresh_token")
+    legacy_clear = [c for c in cookies if f"Path={LEGACY_REFRESH_COOKIE_PATH}" in c]
+    assert legacy_clear, (
+        f"Expected a Set-Cookie deleting refresh_token at "
+        f"Path={LEGACY_REFRESH_COOKIE_PATH}. Got refresh_token Set-Cookies: {cookies}"
+    )
+    # Sanity: a delete-cookie carries Max-Age=0 (or expires in the past).
+    raw = legacy_clear[0]
+    assert "Max-Age=0" in raw or "expires=" in raw.lower(), (
+        f"Legacy-path Set-Cookie should be a deletion. Got: {raw}"
+    )
+
+
+async def test_login_emits_legacy_cleanup(session_factory):
+    await _seed_user(session_factory)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+
+    assert res.status_code == 200
+    _assert_legacy_cleanup(res.headers)
+    # And the canonical Path=/ set is still present.
+    cookies = _set_cookie_values_for(res.headers, "refresh_token")
+    canonical = [c for c in cookies if "Path=/" in c and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in c]
+    assert canonical, f"login must still set the canonical Path=/ cookie. Got: {cookies}"
+
+
+async def test_refresh_rotation_emits_legacy_cleanup(session_factory):
+    user_id = await _seed_user(session_factory)
+    refresh = create_refresh_token(user_id)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 200
+    _assert_legacy_cleanup(res.headers)
+
+
+async def test_logout_emits_legacy_cleanup(session_factory):
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/auth/logout")
+
+    assert res.status_code == 200
+    _assert_legacy_cleanup(res.headers)
+
+
+async def test_refresh_session_expired_emits_legacy_cleanup(session_factory):
+    """Session-lifetime-expired path emits Set-Cookie to clear BOTH the
+    canonical and the legacy cookie."""
+    from app.config import settings as app_settings
+    from app.security import create_refresh_token as _crt
+
+    user_id = await _seed_user(session_factory)
+    long_ago = datetime.now(timezone.utc) - timedelta(
+        days=app_settings.session_lifetime_days + 30
+    )
+    refresh = _crt(user_id, session_created_at=long_ago)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": refresh},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"].startswith("Session expired")
+    _assert_legacy_cleanup(res.headers)

--- a/backend/tests/auth/test_legacy_cookie_cleanup.py
+++ b/backend/tests/auth/test_legacy_cookie_cleanup.py
@@ -348,3 +348,352 @@ async def test_refresh_session_expired_emits_legacy_cleanup(session_factory):
     assert res.status_code == 401
     assert res.json()["detail"].startswith("Session expired")
     _assert_legacy_cleanup(res.headers)
+
+
+# ── Ambiguous-session guard: refuse to silently pick one of two users ──────
+
+
+async def test_refresh_rejects_when_two_valid_users_present(session_factory):
+    """Two refresh cookies, each valid, each for a DIFFERENT user
+    (e.g. legacy cookie belongs to account A, current cookie belongs to
+    account B after an account switch). Auto-selecting either would
+    silently authenticate the wrong identity, so the validator must
+    refuse and force a clean re-login. /refresh must also emit
+    delete-cookies for BOTH the canonical and the legacy path so the
+    browser is fully reset."""
+    user_a = await _seed_user(session_factory, username="alice")
+    user_b = await _seed_user(session_factory, username="bob")
+
+    token_a = create_refresh_token(user_a)
+    token_b = create_refresh_token(user_b)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            headers={"Cookie": f"refresh_token={token_a}; refresh_token={token_b}"},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Ambiguous session — please sign in again"
+
+    # Both the canonical Path=/ and the legacy
+    # Path=/api/v1/auth/refresh cookies must be cleared so the browser
+    # stops sending either of them.
+    cookies = _set_cookie_values_for(res.headers, "refresh_token")
+    canonical_clear = [
+        c for c in cookies
+        if "Path=/" in c
+        and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in c
+        and ("Max-Age=0" in c or "expires=" in c.lower())
+    ]
+    legacy_clear = [
+        c for c in cookies
+        if f"Path={LEGACY_REFRESH_COOKIE_PATH}" in c
+        and ("Max-Age=0" in c or "expires=" in c.lower())
+    ]
+    assert canonical_clear, (
+        f"ambiguous /refresh must clear canonical Path=/ cookie. Got: {cookies}"
+    )
+    assert legacy_clear, (
+        f"ambiguous /refresh must clear legacy Path={LEGACY_REFRESH_COOKIE_PATH} cookie. Got: {cookies}"
+    )
+
+
+async def test_verify_rejects_when_two_valid_users_present(session_factory):
+    """/verify must also refuse the ambiguous case, but MUST NOT emit
+    any Set-Cookie (its no-Set-Cookie invariant is load-bearing for
+    RSC). The follow-up /refresh from the client will do the cleanup."""
+    user_a = await _seed_user(session_factory, username="carol")
+    user_b = await _seed_user(session_factory, username="dave")
+
+    token_a = create_refresh_token(user_a)
+    token_b = create_refresh_token(user_b)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/verify",
+            headers={"Cookie": f"refresh_token={token_a}; refresh_token={token_b}"},
+        )
+
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Ambiguous session — please sign in again"
+
+    header_keys_lower = {k.lower() for k in res.headers.keys()}
+    assert "set-cookie" not in header_keys_lower, (
+        f"/verify must not emit Set-Cookie on ambiguous-session 401. "
+        f"Got: {dict(res.headers)}"
+    )
+
+
+async def test_refresh_prefers_newest_iat_for_same_user(session_factory):
+    """Two valid refresh cookies for the SAME user (e.g. legacy + current
+    after the PR #211 migration where both still validate). Selection
+    must be deterministic and prefer the newer (higher ``iat``) token —
+    the legacy cookie must never out-vote the current one. The newly
+    issued refresh cookie carries forward the SAME session_created_at
+    as the selected (newer) token."""
+    user_id = await _seed_user(session_factory)
+
+    # Both iats in the past so PyJWT accepts them; cutoff stays at
+    # default (no sessions_invalidated_at) so both decode through to
+    # successful validation.
+    now = datetime.now(timezone.utc)
+    older = _mint_refresh_at(user_id, iat=now - timedelta(minutes=30))
+    newer = _mint_refresh_at(user_id, iat=now - timedelta(minutes=1))
+
+    # Decode the newer token to learn its session_created_at — the
+    # rotation should preserve it.
+    import jwt as _pyjwt
+    newer_payload = _pyjwt.decode(
+        newer, app_settings.jwt_secret_key, algorithms=[app_settings.jwt_algorithm]
+    )
+    newer_session_created_at = int(newer_payload["session_created_at"])
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        # Legacy/older first (browser send order), newer second.
+        res = client.post(
+            "/api/v1/auth/refresh",
+            headers={"Cookie": f"refresh_token={older}; refresh_token={newer}"},
+        )
+
+    assert res.status_code == 200, res.text
+
+    # The rotated refresh cookie carries forward the NEWER session
+    # marker. Decode the new cookie and assert.
+    cookies = _set_cookie_values_for(res.headers, "refresh_token")
+    canonical = [
+        c for c in cookies
+        if "Path=/" in c
+        and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in c
+        and "Max-Age=0" not in c
+    ]
+    assert canonical, f"refresh must set a new canonical cookie. Got: {cookies}"
+    new_cookie_value = canonical[0].split(";", 1)[0].split("=", 1)[1]
+    rotated_payload = _pyjwt.decode(
+        new_cookie_value,
+        app_settings.jwt_secret_key,
+        algorithms=[app_settings.jwt_algorithm],
+    )
+    assert int(rotated_payload["session_created_at"]) == newer_session_created_at, (
+        "rotation should carry forward the NEWER token's session_created_at, "
+        f"not the older one's. Got: {rotated_payload}"
+    )
+
+
+async def test_refresh_prefers_newest_iat_when_order_reversed(session_factory):
+    """Selection is by iat, not by header position."""
+    user_id = await _seed_user(session_factory)
+
+    now = datetime.now(timezone.utc)
+    older = _mint_refresh_at(user_id, iat=now - timedelta(minutes=30))
+    newer = _mint_refresh_at(user_id, iat=now - timedelta(minutes=1))
+
+    import jwt as _pyjwt
+    newer_payload = _pyjwt.decode(
+        newer, app_settings.jwt_secret_key, algorithms=[app_settings.jwt_algorithm]
+    )
+    newer_session_created_at = int(newer_payload["session_created_at"])
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        # Newer first, older second.
+        res = client.post(
+            "/api/v1/auth/refresh",
+            headers={"Cookie": f"refresh_token={newer}; refresh_token={older}"},
+        )
+
+    assert res.status_code == 200, res.text
+    cookies = _set_cookie_values_for(res.headers, "refresh_token")
+    canonical = [
+        c for c in cookies
+        if "Path=/" in c
+        and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in c
+        and "Max-Age=0" not in c
+    ]
+    new_cookie_value = canonical[0].split(";", 1)[0].split("=", 1)[1]
+    rotated_payload = _pyjwt.decode(
+        new_cookie_value,
+        app_settings.jwt_secret_key,
+        algorithms=[app_settings.jwt_algorithm],
+    )
+    assert int(rotated_payload["session_created_at"]) == newer_session_created_at
+
+
+# ── _issue_tokens cleanup (MFA verify, etc.) ───────────────────────────────
+
+
+def test_issue_tokens_helper_emits_legacy_cleanup():
+    """``_issue_tokens`` is the shared exit point for several MFA login
+    flows (``/mfa/verify``, ``/mfa/recovery``, and ``/mfa/email-verify``).
+    Pinning the helper directly avoids the cost of a full MFA-setup
+    fixture while still proving the cleanup is wired."""
+    from fastapi import Response
+    from app.routers.auth import _issue_tokens
+
+    class _FakeUser:
+        def __init__(self):
+            self.id = 1
+            self.org_id = 1
+            self.role = Role.OWNER
+
+    response = Response()
+    _issue_tokens(_FakeUser(), response)
+
+    # Response.raw_headers is the underlying list of (bytes, bytes)
+    # tuples populated by set_cookie / delete_cookie.
+    cookies = [v.decode() for k, v in response.raw_headers if k == b"set-cookie"]
+    refresh_cookies = [c for c in cookies if c.startswith("refresh_token=")]
+    legacy_clear = [
+        c for c in refresh_cookies if f"Path={LEGACY_REFRESH_COOKIE_PATH}" in c
+    ]
+    assert legacy_clear, (
+        f"_issue_tokens must emit legacy-path cleanup Set-Cookie. "
+        f"Got refresh_token Set-Cookies: {refresh_cookies}"
+    )
+
+
+# ── Google SSO callback cleanup ────────────────────────────────────────────
+
+
+@pytest.fixture
+def google_config(monkeypatch):
+    """Populate the Google OAuth env so ``_validate_google_config`` passes."""
+    monkeypatch.setattr(app_settings, "google_client_id", "test-client-id")
+    monkeypatch.setattr(app_settings, "google_client_secret", "test-client-secret")
+    monkeypatch.setattr(app_settings, "app_url", "http://localhost")
+    yield
+
+
+async def test_google_callback_emits_legacy_cleanup(
+    session_factory, google_config, monkeypatch
+):
+    """The Google SSO callback writes the refresh cookie onto a
+    directly-returned RedirectResponse. Pin that the legacy-path
+    cleanup rides along."""
+    # Seed a default plan so ``create_trial`` (new-user branch) does
+    # not 500, and seed an existing user matching the canned email so
+    # the callback takes the existing-user branch (no plan required,
+    # but cheap insurance).
+    from app.models.subscription import Plan
+    async with session_factory() as db:
+        existing = await db.scalar(select(Plan).where(Plan.slug == "free"))
+        if existing is None:
+            db.add(Plan(slug="free", name="Free", is_active=True, sort_order=0))
+            await db.commit()
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        db.add(User(
+            org_id=org.id,
+            username="alice",
+            email="alice@acme.io",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+        ))
+        await db.commit()
+
+    # Mock httpx so the callback's token-exchange and userinfo calls
+    # return a successful verified-email payload for alice@acme.io.
+    from app.routers import auth as auth_module
+
+    class _FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return None
+
+        async def post(self, *args, **kwargs):
+            return _FakeResponse(200, {"access_token": "fake-token"})
+
+        async def get(self, *args, **kwargs):
+            return _FakeResponse(200, {
+                "email": "alice@acme.io",
+                "verified_email": True,
+                "given_name": "Alice",
+                "family_name": "A",
+            })
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeClient)
+
+    # Wire the session-factory dependency so audit writes hit the
+    # in-memory DB (Google callback emits success audit).
+    from app.deps import get_session_factory
+
+    app = make_app(session_factory)
+
+    async def _override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_session_factory] = _override_session_factory
+
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+
+    assert res.status_code == 302, res.text
+    _assert_legacy_cleanup(res.headers)
+
+
+# ── Invitation accept cleanup ──────────────────────────────────────────────
+
+
+async def test_invite_accept_emits_legacy_cleanup(session_factory, monkeypatch):
+    """``POST /api/v1/orgs/invitations/accept`` sets its own refresh
+    cookie on success (``backend/app/routers/org_members.py``). The
+    legacy cleanup must ride along on that response too."""
+    from app.routers import org_members as org_members_module
+    from app.routers.org_members import router as org_members_router
+
+    user_id = await _seed_user(session_factory, username="invitee")
+
+    # Monkeypatch the service to return a real user without needing to
+    # construct the full invitation/token plumbing. The router is what
+    # we're pinning here, not the service.
+    async def _fake_accept(db, *, token, username, password):
+        result = await db.execute(select(User).where(User.id == user_id))
+        return result.scalar_one()
+
+    monkeypatch.setattr(
+        org_members_module.invitation_service, "accept_invitation", _fake_accept
+    )
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(org_members_router)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/invitations/accept",
+            json={"token": "fake-token", "username": "invitee", "password": PASSWORD},
+        )
+
+    assert res.status_code == 200, res.text
+    _assert_legacy_cleanup(res.headers)


### PR DESCRIPTION
## Summary

Closes the production false-logout fired on the dashboard this morning (2026-05-16 ~09:00 CET). User idle ~24h, single navigation to `/transactions`, immediate bounce to `/login` despite a valid session.

## Root cause

PR #211 (`70ddd26`, 2026-05-11) widened the refresh cookie's `Path` from `/api/v1/auth/refresh` to `/`. `delete_cookie()` requires an exact path match — the new code therefore cannot clear cookies set under the narrower legacy path. Users who logged in before 2026-05-11 14:07 +02:00 keep their pre-migration cookie indefinitely (until natural 7-day expiry) alongside any post-migration `Path=/` cookie they obtain on re-login.

The browser sends both `refresh_token=` entries on every request to `/api/v1/auth/refresh` (RFC 6265 sends the more specific path first). Starlette's `SimpleCookie` parser picks one value (last per dict semantics), and `_validate_refresh_cookie` only ever sees that one. Whichever cookie loses the toss, the chosen one may fail the `iat < token_cutoff` check and return `{"detail":"Session has been invalidated"}` — at which point the client side treats it as terminal and redirects.

Confirmed with the affected user's actual cookie jar: two `refresh_token` cookies, one at `Path=/api/v1/auth/refresh` (iat 2026-05-11 03:12 UTC, pre-PR), one at `Path=/` (iat 2026-05-15 09:03 UTC, post-PR). All three observed `/refresh` calls returned the same 401 detail string.

## Changes

1. **`_extract_refresh_cookies(request)`** — walks the raw Cookie header and returns every `refresh_token` value present, in arrival order. Cookie names cannot contain `=` per RFC 6265 so `partition("=")` is unambiguous against JWT payloads.
2. **`_validate_refresh_cookie(refresh_tokens: list[str], db)`** — now takes a list and tries each token through the full validation chain (`_validate_single_refresh_token`, which is the old body verbatim). Returns on the first success; raises the last failure if all are rejected. Defense in depth against any future cookie-attribute migration that produces same-name shadowing.
3. **`_clear_legacy_refresh_cookie(response)`** — invoked at every site that issues or clears the canonical `Path=/` refresh cookie: `/login`, `/refresh` (rotation + session-expired paths), `/logout`, `_issue_tokens` (MFA verify, invite accept), and `/google/callback`. `/verify` deliberately does **not** emit this cleanup — its no-Set-Cookie invariant is load-bearing for RSC consumers (`backend/tests/auth/test_verify_and_cookie_path.py`).
4. **Regression test** (`backend/tests/auth/test_legacy_cookie_cleanup.py`, 10 cases) — pins:
   - multi-cookie validation in both header orders (legacy-first, current-first)
   - rejection when both cookies are invalid
   - the `/verify` no-Set-Cookie invariant when retiring a legacy cookie
   - the legacy-cleanup Set-Cookie at every issue/clear site

## Out of scope (separate follow-ups)

- Frontend retry budget + singleflight microtask gap (`frontend/lib/api.ts`) — real hardening items, separate PR.
- AuthProvider mode machine + `/refresh`-401 confirm-via-/auth/me probe — separate PR.
- Server-side rotation grace window with `jti`+Redis — P1.
- Session lifetime semantics + 60d org override — separate spec memo (`project_session_lifetime_60d.md` to follow).

## Cleanup plan

The `_clear_legacy_refresh_cookie` helper and the `LEGACY_REFRESH_COOKIE_PATH` constant can be removed after 2026-05-25 — PR #211 shipped 2026-05-11, cookie max_age is 7 days, so all legacy cookies expire naturally by then.

## Verification

```
docker compose -p team-auth-fix exec backend pytest tests/auth/ tests/routers/test_auth_*.py
# 80 passed, 14 warnings in 13.04s

docker compose -p team-auth-fix exec backend pytest tests/
# 1206 passed, 9 skipped, 67 warnings in 240.79s (0:04:00)
```

No regressions in the full backend suite.