### PR TITLE
feat(accounts): consolidate balance/opening_balance on AccountCreate (L1.1 L4)

### DIFF
--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -103,11 +103,18 @@ async def create_account(
     # opening_balance_date: caller may omit (and ride the DB default of
     # CURRENT_DATE) or supply an explicit date. We pass it through only
     # when supplied so the column-level server_default applies on omission.
+    #
+    # L1.1 L4: the live ``balance`` field is seeded from the user-stated
+    # ``opening_balance`` rather than from a free-form ``balance`` input
+    # (which would have bypassed the audit trail). Any subsequent change
+    # to ``balance`` flows through transaction_service or the audited
+    # /adjust-balance endpoint, so no path mutates ``Account.balance``
+    # without a corresponding ledger row.
     kwargs = dict(
         org_id=current_user.org_id,
         account_type_id=body.account_type_id,
         name=body.name,
-        balance=body.balance,
+        balance=body.opening_balance,
         currency=body.currency,
         close_day=body.close_day,
         opening_balance=body.opening_balance,

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -32,13 +32,14 @@ class AccountTypeResponse(BaseModel):
 class AccountCreate(BaseModel):
     name: str
     account_type_id: int
-    balance: Decimal = Decimal("0.00")
     currency: str = "EUR"
     close_day: Optional[int] = Field(default=None, ge=1, le=28)
-    # Opening balance (L3.2 Wave 2A). User-stated starting amount.
-    # Defaults to 0 when the caller omits it, matching the migration's
-    # backfill. ``opening_balance_date`` defaults to today on the DB
-    # side; the API surface accepts a caller-provided override.
+    # Opening balance (L3.2 Wave 2A). User-stated starting amount and
+    # the sole entry point for a non-zero starting balance: the live
+    # ``Account.balance`` field is initialised from this value server-
+    # side. L1.1 L4 pentest follow-up removed the previously accepted
+    # free-form ``balance`` create input, which seeded ``Account.balance``
+    # with no transaction backing and no audit row.
     opening_balance: Decimal = Field(
         default=Decimal("0.00"),
         ge=_OPENING_BALANCE_CAP_LO,

--- a/backend/tests/routers/test_accounts_change_type.py
+++ b/backend/tests/routers/test_accounts_change_type.py
@@ -690,7 +690,6 @@ def test_create_account_credit_card_missing_close_day(session_factory, seeded):
             json={
                 "name": "New CC",
                 "account_type_id": seeded["cc_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
             },
         )
@@ -720,7 +719,6 @@ def test_create_account_credit_card_close_day_null(session_factory, seeded):
             json={
                 "name": "New CC Null",
                 "account_type_id": seeded["cc_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
                 "close_day": None,
             },
@@ -738,7 +736,6 @@ def test_create_account_non_credit_card_with_close_day(session_factory, seeded):
             json={
                 "name": "Bad Checking",
                 "account_type_id": seeded["checking_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
                 "close_day": 15,
             },
@@ -756,7 +753,6 @@ def test_create_account_credit_card_with_close_day_succeeds(session_factory, see
             json={
                 "name": "New CC OK",
                 "account_type_id": seeded["cc_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
                 "close_day": 15,
             },
@@ -778,7 +774,6 @@ def test_create_account_non_credit_card_without_close_day_succeeds(
             json={
                 "name": "New Checking",
                 "account_type_id": seeded["checking_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
             },
         )

--- a/backend/tests/test_account_opening_balance.py
+++ b/backend/tests/test_account_opening_balance.py
@@ -146,7 +146,6 @@ def test_create_account_defaults_opening_balance_to_zero(session_factory, seeded
             json={
                 "name": "Secondary",
                 "account_type_id": seeded["account_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
             },
         )
@@ -167,7 +166,6 @@ def test_create_account_with_explicit_opening_balance(session_factory, seeded):
             json={
                 "name": "Savings",
                 "account_type_id": seeded["account_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
                 "opening_balance": "1500.00",
                 "opening_balance_date": "2025-12-31",
@@ -188,7 +186,6 @@ def test_create_account_rejects_oversized_opening_balance(session_factory, seede
             json={
                 "name": "Big",
                 "account_type_id": seeded["account_type_id"],
-                "balance": "0.00",
                 "currency": "EUR",
                 "opening_balance": "99999999999999.99",
             },

--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -56,7 +56,6 @@ export default function AccountsPage() {
   const [showAccountForm, setShowAccountForm] = useState(false);
   const [acctName, setAcctName] = useState("");
   const [acctTypeId, setAcctTypeId] = useState<number | "">("");
-  const [acctBalance, setAcctBalance] = useState("0.00");
   const [acctCurrency, setAcctCurrency] = useState("EUR");
   const [acctCloseDay, setAcctCloseDay] = useState("");
   // L3.2 Wave 2A — opening balance + date on the create form. The date
@@ -166,14 +165,14 @@ export default function AccountsPage() {
       await apiFetch("/api/v1/accounts", {
         method: "POST",
         body: JSON.stringify({
-          name: acctName, account_type_id: acctTypeId, balance: acctBalance,
+          name: acctName, account_type_id: acctTypeId,
           currency: acctCurrency,
           close_day: selectedType?.slug === "credit_card" && acctCloseDay ? Number(acctCloseDay) : null,
           opening_balance: acctOpeningBalance || "0.00",
           opening_balance_date: acctOpeningBalanceDate || null,
         }),
       });
-      setAcctName(""); setAcctTypeId(""); setAcctBalance("0.00"); setAcctCloseDay("");
+      setAcctName(""); setAcctTypeId(""); setAcctCloseDay("");
       setAcctOpeningBalance("0.00"); setAcctOpeningBalanceDate(todayIso);
       setShowAccountForm(false);
       await reload();
@@ -439,16 +438,6 @@ export default function AccountsPage() {
                       {accountTypes.map((at) => <option key={at.id} value={at.id}>{at.name}</option>)}
                     </select>
                   </div>
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-                    <div className="w-full sm:flex-1">
-                      <label htmlFor="acct-balance" className={label}>Initial balance</label>
-                      <input id="acct-balance" type="number" step="0.01" value={acctBalance} onChange={(e) => setAcctBalance(e.target.value)} className={input} />
-                    </div>
-                    <div className="w-full sm:w-20">
-                      <label htmlFor="acct-currency" className={label}>Currency</label>
-                      <input id="acct-currency" type="text" maxLength={3} value={acctCurrency} onChange={(e) => setAcctCurrency(e.target.value.toUpperCase())} className={`sm:text-center ${input}`} />
-                    </div>
-                  </div>
                   {selectedType?.slug === "credit_card" && (
                     <div>
                       <label htmlFor="acct-close" className={label}>Bill close day (1-28)</label>
@@ -475,6 +464,10 @@ export default function AccountsPage() {
                         onChange={(e) => setAcctOpeningBalance(e.target.value)}
                         className={input}
                       />
+                    </div>
+                    <div className="w-full sm:w-20">
+                      <label htmlFor="acct-currency" className={label}>Currency</label>
+                      <input id="acct-currency" type="text" maxLength={3} value={acctCurrency} onChange={(e) => setAcctCurrency(e.target.value.toUpperCase())} className={`sm:text-center ${input}`} />
                     </div>
                     <div className="w-full sm:w-44">
                       <label htmlFor="acct-opening-balance-date" className={label}>Starting from</label>

--- a/frontend/components/onboarding/OnboardingPageBody.tsx
+++ b/frontend/components/onboarding/OnboardingPageBody.tsx
@@ -156,8 +156,8 @@ export default function OnboardingPageBody() {
         body: JSON.stringify({
           name: accountName.trim() || "Main Checking",
           account_type_id: selectedTypeId,
-          balance: "0.00",
           currency: "EUR",
+          opening_balance: "0.00",
         }),
       });
       goNext();

--- a/frontend/tests/components/onboarding-flow.test.tsx
+++ b/frontend/tests/components/onboarding-flow.test.tsx
@@ -284,4 +284,57 @@ describe("OnboardingPageBody", () => {
     );
     expect(screen.getByText(/Step 3 of 4/)).toBeInTheDocument();
   });
+
+  // L1.1 L4 contract: ``POST /api/v1/accounts`` no longer accepts the
+  // free-form ``balance`` field. The audited ``opening_balance`` field
+  // is the sole entry point for a starting balance. Pin the onboarding
+  // create-account payload to the consolidated shape so the flow
+  // does not regress the moment ``AccountCreate`` flips to
+  // ``extra="forbid"``.
+  it("account-create step posts opening_balance, not balance", async () => {
+    setupAuth(makeUser());
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/account-types") {
+        return Promise.resolve([{ id: 10, name: "Checking", slug: "checking" }]);
+      }
+      return Promise.resolve({});
+    }) as never);
+
+    render(<OnboardingPageBody />);
+    fireEvent.click(screen.getByTestId("onboarding-next"));
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("onboarding-create-account"),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("onboarding-create-account"));
+
+    await waitFor(() => {
+      expect(vi.mocked(apiFetch)).toHaveBeenCalledWith(
+        "/api/v1/accounts",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const createCall = vi
+      .mocked(apiFetch)
+      .mock.calls.find(([url]) => url === "/api/v1/accounts");
+    expect(createCall).toBeDefined();
+    const body = JSON.parse(
+      (createCall![1] as { body: string }).body,
+    ) as Record<string, unknown>;
+
+    // The whole point: NO ``balance`` key, and the explicit
+    // ``opening_balance: "0.00"`` is preserved so the audited path is
+    // exercised even on the zero-amount onboarding default.
+    expect(body).not.toHaveProperty("balance");
+    expect(body).toEqual(
+      expect.objectContaining({
+        name: expect.any(String),
+        account_type_id: 10,
+        currency: "EUR",
+        opening_balance: "0.00",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes the last open sub-item under roadmap **L1.1 — Auth hardening round 2**. PR #70 deferred this with the note:

> L4 seeded account balance — requires a design decision: reject non-zero balance at create (force users to add an "Opening Balance" transaction), or auto-create an offsetting transaction atomically.

L3.2 (PR #235) effectively chose a third path: ``opening_balance`` + ``opening_balance_date`` as audited first-class columns. But the pentest gap stayed open — ``AccountCreate.balance`` still accepted a free-form Decimal that wrote straight into ``Account.balance`` with **no transaction backing and no audit row**. An attacker (or just the form) could mint $X of starting balance with no ledger trail.

## Changes

| File | Change |
|---|---|
| `backend/app/schemas/account.py` | Drop the `balance` field from `AccountCreate`. Pydantic default `extra="ignore"` means any legacy caller still sending `balance` is silently dropped rather than 422'd — graceful for in-flight clients during rollout. |
| `backend/app/routers/accounts.py` (`create_account`) | Initialise `Account.balance` from `body.opening_balance`. Subsequent mutations flow through `transaction_service` or the audited `/adjust-balance` endpoint, so no path mutates `Account.balance` without a corresponding ledger row. |
| `backend/tests/test_account_opening_balance.py` (3 sites) | Drop the meaningless `"balance": "0.00"` key from create payloads. |
| `backend/tests/routers/test_accounts_change_type.py` (5 sites) | Same. |
| `frontend/app/accounts/page.tsx` | Remove the "Initial balance" input + state + reset; the create form now ships a single starting-balance field labelled "Opening balance". Currency moves into the opening-balance row (`Opening balance | Currency | Starting from`). |

## UX outcome

Unchanged from the user's POV. Type a starting amount, account shows that amount. But the field is the audited one (`opening_balance`) and the live `Account.balance` is seeded from it server-side. No free-form `balance` injection path remains.

## Verification

```
backend pytest tests/                   → 1221 passed, 9 skipped
frontend npm test                       → 946 passed (135 files)
frontend npm run lint -- --quiet        → clean
frontend npx tsc --noEmit               → clean
```

## Out of scope (separate work)

- `extra="forbid"` codebase-wide sweep on create schemas — that's a broader hardening pass, not the L1.1 L4 fix.
- `frontend/tests/app/transactions-page.test.tsx` flake — separate test-infra debt per `project_flaky_transactions_page_test.md`.
- L1.6 ZAP rescan — operator-driven, runbook delivered.