### PR TITLE
fix(frontend): stamp security headers on app-host root 307 redirect

### DIFF
--- a/frontend/lib/security-headers.ts
+++ b/frontend/lib/security-headers.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared security-header constants for the Next.js frontend.
+ *
+ * Consumed by both ``next.config.ts`` (which applies the pack to
+ * regular page responses via ``headers()``) and ``proxy.ts`` (which
+ * applies them to redirect responses that Next.js's routing pipeline
+ * short-circuits before ``headers()`` would fire).
+ *
+ * Why duplication exists at all: ZAP scan 2026-05-16 confirmed that
+ * the ``/ → /login`` 307 redirect emitted by ``next.config.ts``
+ * ``redirects()`` was NOT receiving the headers from ``headers()``.
+ * Moving the redirect into ``proxy.ts`` and stamping the pack there
+ * closes the cold-cache TLS-downgrade window for first-time visitors.
+ */
+
+const isDev = process.env.NODE_ENV !== "production";
+
+// If the frontend is deployed with a cross-origin API URL (e.g.,
+// separate DO App Platform components), allow that origin in
+// connect-src so api.ts fetch() calls aren't blocked. Empty string →
+// same-origin via nginx, nothing extra to allow.
+function apiOrigin(): string {
+  const raw = process.env.NEXT_PUBLIC_API_URL;
+  if (!raw) return "";
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return "";
+  }
+}
+
+// CSP. Tailwind + styled-jsx + Next's hydration inline scripts force
+// 'unsafe-inline' on both script-src and style-src; dev also needs
+// 'unsafe-eval' and WebSocket connections for Fast Refresh. Google
+// Fonts (Fraunces + Outfit, loaded from app/layout.tsx) need their
+// two origins allowlisted on style-src and font-src.
+export const cspDirectives = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data: https://fonts.gstatic.com",
+  `connect-src 'self'${apiOrigin() ? " " + apiOrigin() : ""}${isDev ? " ws: wss:" : ""}`,
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
+/**
+ * The Next.js ``headers()`` config shape: ``{ key, value }[]``.
+ * Used by ``next.config.ts``.
+ */
+export const securityHeaders: { key: string; value: string }[] = [
+  { key: "Content-Security-Policy", value: cspDirectives },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
+];
+
+/**
+ * Same pack as ``securityHeaders``, exposed as ``[name, value]``
+ * tuples for ergonomic use against the Web Headers API (e.g., inside
+ * ``proxy.ts`` for stamping onto a ``NextResponse``).
+ */
+export const securityHeadersTuples: [string, string][] = securityHeaders.map(
+  ({ key, value }) => [key, value],
+);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,57 +1,15 @@
 import type { NextConfig } from "next";
 
-const isDev = process.env.NODE_ENV !== "production";
+import { securityHeaders } from "./lib/security-headers";
 
-// If the frontend is deployed with a cross-origin API URL (e.g., separate
-// DO App Platform components), allow that origin in connect-src so
-// api.ts fetch() calls aren't blocked. Empty string → same-origin via
-// nginx, nothing extra to allow.
-function apiOrigin(): string {
-  const raw = process.env.NEXT_PUBLIC_API_URL;
-  if (!raw) return "";
-  try {
-    return new URL(raw).origin;
-  } catch {
-    return "";
-  }
-}
-const extraConnectSrc = apiOrigin();
-
-// CSP. Tailwind + styled-jsx + Next's hydration inline scripts force
-// 'unsafe-inline' on both script-src and style-src; dev also needs
-// 'unsafe-eval' and WebSocket connections for Fast Refresh. Google Fonts
-// (Fraunces + Outfit, loaded from app/layout.tsx) need their two origins
-// allowlisted on style-src and font-src.
-const cspDirectives = [
-  "default-src 'self'",
-  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  "img-src 'self' data: blob:",
-  "font-src 'self' data: https://fonts.gstatic.com",
-  `connect-src 'self'${extraConnectSrc ? " " + extraConnectSrc : ""}${isDev ? " ws: wss:" : ""}`,
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "object-src 'none'",
-  "upgrade-insecure-requests",
-].join("; ");
-
-const securityHeaders = [
-  { key: "Content-Security-Policy", value: cspDirectives },
-  { key: "X-Frame-Options", value: "DENY" },
-  { key: "X-Content-Type-Options", value: "nosniff" },
-  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-  {
-    key: "Permissions-Policy",
-    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
-  },
-  {
-    key: "Strict-Transport-Security",
-    value: "max-age=63072000; includeSubDomains; preload",
-  },
-  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
-  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
-];
+// The app-host root → /login redirect previously lived here in
+// ``redirects()``. ZAP scan 2026-05-16 surfaced that Next.js's
+// ``redirects()`` short-circuits before ``headers()`` applies, so the
+// 307 response was emitted without the security pack (no HSTS, no
+// nosniff, no Referrer-Policy, etc.). The redirect was moved into
+// ``frontend/proxy.ts`` where it stamps the headers on the response
+// directly. See PR #292 + the May 16 entry in
+// memory/audit_zap_2026_05_14.md.
 
 const nextConfig: NextConfig = {
   output: "standalone",
@@ -66,24 +24,6 @@ const nextConfig: NextConfig = {
       {
         source: "/:path*",
         headers: securityHeaders,
-      },
-    ];
-  },
-  async redirects() {
-    // App host root → /login. frontend/app/page.tsx is shared between
-    // the DO runtime (app.thebetterdecision.com) and the apex static
-    // export (thebetterdecision.com, built via next.config.apex.ts +
-    // scripts/build-apex.sh). Apex serves landing; the DO runtime must
-    // not. Host-scope the rule via `has` so it only fires on the app
-    // host even if some other build ever points at this config.
-    return [
-      {
-        source: "/",
-        has: [
-          { type: "host", value: "app.thebetterdecision.com" },
-        ],
-        destination: "/login",
-        permanent: false, // 307; keep flexible during early launch
       },
     ];
   },

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -1,11 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { securityHeadersTuples } from "./lib/security-headers";
+
 /**
  * Next.js middleware — logs every request in structured JSON format
- * matching the backend/nginx log style for unified observability.
+ * matching the backend/nginx log style for unified observability, and
+ * stamps the security header pack onto every response.
  *
  * Sensitive query parameters (tokens, codes) are stripped from logs.
+ *
+ * Why headers stamping lives here in addition to ``next.config.ts``
+ * ``headers()``: Next.js's routing pipeline emits redirect responses
+ * (e.g. the app-host ``/ → /login`` 307) BEFORE ``headers()`` applies,
+ * so those redirects ship without HSTS / nosniff / Referrer-Policy.
+ * ZAP scan 2026-05-16 confirmed the gap. Stamping here covers the
+ * redirect path; ``headers()`` covers the rest, and double-stamping
+ * the same values on non-redirect responses is idempotent.
  */
+
+export const APP_HOST = "app.thebetterdecision.com";
+
+function applySecurityHeaders(response: NextResponse): NextResponse {
+  for (const [name, value] of securityHeadersTuples) {
+    response.headers.set(name, value);
+  }
+  return response;
+}
 
 const SENSITIVE_PARAMS = new Set([
   "token", "code", "access_token", "refresh_token", "mfa_token", "key", "secret", "password",
@@ -47,6 +67,26 @@ export function proxy(request: NextRequest) {
   const inbound = request.headers.get("x-request-id");
   const requestId = coerceRequestId(inbound);
 
+  // App-host root → /login. Moved here from ``next.config.ts``
+  // ``redirects()`` because that config-level redirect short-circuits
+  // before ``headers()`` applies (ZAP scan 2026-05-16). Stamping the
+  // security pack on the 307 closes the cold-cache TLS-downgrade
+  // window for first-time visitors. ``app/page.tsx`` is shared with
+  // the apex static export (built via ``next.config.apex.ts``); host-
+  // scoping ensures we don't accidentally redirect on the apex
+  // landing page.
+  if (
+    request.nextUrl.pathname === "/" &&
+    request.headers.get("host") === APP_HOST
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    const redirect = NextResponse.redirect(url, 307);
+    redirect.headers.set("x-request-id", requestId);
+    applySecurityHeaders(redirect);
+    return redirect;
+  }
+
   // Forward the id to the backend (or onward to whoever the request
   // is being proxied to). The backend's RequestContextMiddleware
   // uses an inbound X-Request-Id verbatim when reasonable, so this
@@ -55,6 +95,7 @@ export function proxy(request: NextRequest) {
   requestHeaders.set("x-request-id", requestId);
   const response = NextResponse.next({ request: { headers: requestHeaders } });
   response.headers.set("x-request-id", requestId);
+  applySecurityHeaders(response);
 
   const entry = {
     timestamp: new Date().toISOString(),

--- a/frontend/tests/next-config-redirects.test.ts
+++ b/frontend/tests/next-config-redirects.test.ts
@@ -2,16 +2,21 @@ import { describe, expect, it } from "vitest";
 
 import nextConfig from "@/next.config";
 
-// next-config-redirects.test.ts — guards the host-scoped root redirect
-// that prevents app.thebetterdecision.com from serving the marketing
-// landing page (which is hosted on the apex via S3 + CloudFront via
-// next.config.apex.ts). If somebody removes or mutates the rule, this
-// test fails loudly. See PR comments on the L5.2a follow-up hotfix.
+// next-config-redirects.test.ts — pins that the app-host root → /login
+// redirect is NOT defined in next.config.ts's redirects(). It was moved
+// to frontend/proxy.ts so the 307 response can carry the security
+// header pack (HSTS, nosniff, Referrer-Policy, X-Frame-Options,
+// Permissions-Policy). ZAP scan 2026-05-16 surfaced that next.config
+// redirects() short-circuits before headers() applies.
+//
+// Behavior test for the redirect itself + headers stamping lives in
+// frontend/tests/proxy-app-host-redirect.test.ts.
 
 describe("next.config.ts redirects", () => {
-  it("redirects app-host root to /login with host-scoping", async () => {
+  it("does NOT redirect the app-host root from next.config (moved to proxy.ts)", async () => {
     if (typeof nextConfig.redirects !== "function") {
-      throw new Error("redirects() not configured");
+      // No redirects() at all is the desired state.
+      return;
     }
     const rules = await nextConfig.redirects();
     const appHostRule = rules.find(
@@ -23,9 +28,10 @@ describe("next.config.ts redirects", () => {
             h.type === "host" && h.value === "app.thebetterdecision.com",
         ),
     );
-    expect(appHostRule).toBeDefined();
-    expect(appHostRule!.destination).toBe("/login");
-    // 307, not 308 — flexible during early launch.
-    expect(appHostRule!.permanent).toBe(false);
+    expect(
+      appHostRule,
+      "app-host root redirect must live in proxy.ts, not next.config.ts " +
+        "(see PR #292 / ZAP scan 2026-05-16 / proxy-app-host-redirect.test.ts)",
+    ).toBeUndefined();
   });
 });

--- a/frontend/tests/proxy-app-host-redirect.test.ts
+++ b/frontend/tests/proxy-app-host-redirect.test.ts
@@ -1,0 +1,126 @@
+/**
+ * proxy.ts — app-host ``/ → /login`` redirect + security header stamping.
+ *
+ * The redirect previously lived in ``next.config.ts`` ``redirects()`` but
+ * was moved here because Next.js routing short-circuits redirects()
+ * BEFORE ``headers()`` applies, leaving the 307 without HSTS / nosniff /
+ * Referrer-Policy / X-Frame-Options / Permissions-Policy. ZAP scan
+ * 2026-05-16 confirmed the gap. Pinning here so a future move back to
+ * ``redirects()`` would fail loudly.
+ *
+ * Companion: ``security-headers.test.ts`` (if added later) would pin
+ * the constant values; this file pins behavior at the proxy boundary.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { NextRequest } from "next/server";
+
+import { proxy, APP_HOST } from "@/proxy";
+
+// Silence proxy()'s structured-log console.log noise during tests.
+vi.spyOn(console, "log").mockImplementation(() => {});
+
+function makeRequest(url: string, host: string): NextRequest {
+  const req = new NextRequest(new Request(url, { method: "GET" }));
+  // NextRequest preserves the URL's host, but we want to set the
+  // Host header explicitly to match the production routing path.
+  req.headers.set("host", host);
+  return req;
+}
+
+describe("proxy: app-host root redirect", () => {
+  it("redirects / on the app host to /login with status 307", () => {
+    const res = proxy(
+      makeRequest(`https://${APP_HOST}/`, APP_HOST),
+    );
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(`https://${APP_HOST}/login`);
+  });
+
+  it("does NOT redirect / on any other host (apex landing stays untouched)", () => {
+    const res = proxy(
+      makeRequest("https://thebetterdecision.com/", "thebetterdecision.com"),
+    );
+    // 200 from NextResponse.next() — not a redirect.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("does NOT redirect non-root paths on the app host", () => {
+    const res = proxy(
+      makeRequest(`https://${APP_HOST}/dashboard`, APP_HOST),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+  });
+});
+
+describe("proxy: security headers on redirect response", () => {
+  // Load-bearing invariant — the whole point of moving the redirect
+  // out of next.config.ts. ZAP flagged HSTS-missing on this 307 path
+  // before this change.
+  function stampedHeaders() {
+    const res = proxy(
+      makeRequest(`https://${APP_HOST}/`, APP_HOST),
+    );
+    return res.headers;
+  }
+
+  it("stamps Strict-Transport-Security on the 307", () => {
+    const headers = stampedHeaders();
+    const hsts = headers.get("strict-transport-security");
+    expect(hsts).toBeTruthy();
+    expect(hsts).toContain("max-age=63072000");
+    expect(hsts).toContain("includeSubDomains");
+    expect(hsts).toContain("preload");
+  });
+
+  it("stamps X-Content-Type-Options: nosniff on the 307", () => {
+    expect(stampedHeaders().get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("stamps X-Frame-Options: DENY on the 307", () => {
+    expect(stampedHeaders().get("x-frame-options")).toBe("DENY");
+  });
+
+  it("stamps Referrer-Policy on the 307", () => {
+    expect(stampedHeaders().get("referrer-policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  it("stamps Permissions-Policy on the 307", () => {
+    const pp = stampedHeaders().get("permissions-policy");
+    expect(pp).toContain("camera=()");
+    expect(pp).toContain("microphone=()");
+    expect(pp).toContain("geolocation=()");
+    expect(pp).toContain("interest-cohort=()");
+  });
+
+  it("stamps the Cross-Origin pack on the 307", () => {
+    const headers = stampedHeaders();
+    expect(headers.get("cross-origin-opener-policy")).toBe("same-origin");
+    expect(headers.get("cross-origin-resource-policy")).toBe("same-origin");
+  });
+
+  it("stamps Content-Security-Policy on the 307", () => {
+    const csp = stampedHeaders().get("content-security-policy");
+    expect(csp).toBeTruthy();
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+});
+
+describe("proxy: security headers on regular responses", () => {
+  // Defense-in-depth — next.config.ts headers() already covers these,
+  // but stamping here too means a misconfigured headers() block can't
+  // silently strip the pack.
+  it("stamps the security pack on a non-redirect response", () => {
+    const res = proxy(
+      makeRequest(`https://${APP_HOST}/dashboard`, APP_HOST),
+    );
+    expect(res.headers.get("strict-transport-security")).toBeTruthy();
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the only real gap the [2026-05-16 ZAP scan](../tree/main/.claude/projects/-Users-fjorge-src-pfv/memory/audit_zap_2026_05_14.md) found that wasn't already on the Section 6 allow-list.

**Live verification before the fix:**
- `GET https://app.thebetterdecision.com/login` (200) → carries the full pack: CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, COOP, CORP.
- `GET https://app.thebetterdecision.com/` (307 → `/login`) → carried only `cache-control: private` and Cloudflare metadata. **No HSTS, no nosniff, no Referrer-Policy.**

Practical exposure: cold-cache TLS-downgrade window for first-time visitors on a brand-new browser profile. Low risk per ZAP, but cheap to close.

## Root cause

Next.js's `redirects()` in `next.config.ts` short-circuits BEFORE `headers()` applies. The config-level redirect emitted a header-less 307; the `headers()` rule never got to stamp anything.

## Fix

1. **`frontend/lib/security-headers.ts`** — extracted to a shared module so `next.config.ts` and `proxy.ts` can't drift. Exports `securityHeaders` (Next.js `{ key, value }[]` shape) and `securityHeadersTuples` (Web Headers ergonomic shape).
2. **Moved the redirect** from `next.config.ts` `redirects()` into `frontend/proxy.ts`. The proxy builds `NextResponse.redirect(url, 307)` directly and stamps the full security pack before returning.
3. **Pass-through responses** also get the pack stamped (defense-in-depth alongside `next.config.ts` `headers()`). Idempotent.
4. **Host-scoping preserved** — the redirect only fires when `Host: app.thebetterdecision.com`. The apex landing page on `thebetterdecision.com` (built via `next.config.apex.ts`) is untouched.

## Tests

- **`frontend/tests/proxy-app-host-redirect.test.ts`** (NEW, 11 cases) — 307 emission, host-scoping (apex + non-root paths are pass-through), and per-header stamping on both redirect and pass-through responses.
- **`frontend/tests/next-config-redirects.test.ts`** (UPDATED) — now asserts the rule is NOT in `next.config.ts` `redirects()`. A future move back to the config-level redirect fails loudly.

## Verification

```
npm test                         → 957 passed (+11 new vs pre-PR 946)
npm run lint -- --quiet          → clean
npx tsc --noEmit                 → clean
npx next build                   → clean, zero Edge runtime warnings
                                   (PR #290 intact); ƒ Proxy (Middleware) wired
```

## Memory updates

`memory/audit_zap_2026_05_14.md` extended with the 2026-05-16 scan triage (16 alerts: 0 H, 4 M, 5 L, 7 I; 12 on the Section 6 allow-list; 1 real gap = this PR; 1 still open = Info-level "Sensitive Info in URL" pending operator confirmation from ZAP History tab).

## Out of scope (per architect direction)

- CSP nonce work
- Sub Resource Integrity work
- Cloudflare cookie/header findings (`__cf_bm`, `cdn-cgi/*`)
- Authenticated active scan — operator-driven; runbook in hand.

Those are either accepted by the Section 6 allow-list or outside our control.