### PR TITLE
fix(category): stop AddCategoryModal submit from bubbling into parent form

### DIFF
--- a/frontend/components/ui/AddCategoryModal.tsx
+++ b/frontend/components/ui/AddCategoryModal.tsx
@@ -167,6 +167,15 @@ export default function AddCategoryModal({
         <form
           onSubmit={(e) => {
             e.preventDefault();
+            // React synthetic events bubble through the React tree,
+            // not the DOM tree, so ``createPortal`` does NOT isolate
+            // this submit from a parent <form> in the React tree
+            // (e.g. the floating Add Transaction form). Without
+            // ``stopPropagation`` the parent form's onSubmit fires
+            // with stale/empty state and returns 422 from the
+            // backend. See add-category-modal.test.tsx → "does NOT
+            // bubble its submit event into a parent form".
+            e.stopPropagation();
             handleSubmit();
           }}
           className="space-y-4"

--- a/frontend/tests/components/add-category-modal.test.tsx
+++ b/frontend/tests/components/add-category-modal.test.tsx
@@ -444,4 +444,75 @@ describe("AddCategoryModal", () => {
       ).toBeInTheDocument();
     });
   });
+
+  // Regression: clicking the modal's "Add category" submit emits a
+  // React synthetic submit event. AddCategoryModal renders via
+  // ``createPortal`` to ``document.body``, BUT React synthetic events
+  // bubble through the React component tree, not the DOM tree. So
+  // when this modal lives inside a parent ``<form>`` (e.g. the
+  // floating Add Transaction form), the inner submit bubbles up to
+  // the parent form's onSubmit and fires a stale/empty POST.
+  //
+  // Live reproduction (2026-05-16): typing a name in the Category
+  // field of the Add Transaction modal, hitting "+ Add category",
+  // saving the new subcategory → parent form fires POST
+  // /api/v1/transactions with empty body → 422 with
+  //   "category_id: Input should be a valid integer ..."
+  //   "description: Value error, Description is required"
+  //   "amount: Input should be a valid decimal"
+  //
+  // The fix is ``e.stopPropagation()`` in the modal's onSubmit. This
+  // test wraps the modal inside a parent ``<form>`` whose onSubmit
+  // is a spy and asserts that spy never fires when the modal saves.
+  describe("nested form propagation", () => {
+    it("does NOT bubble its submit event into a parent form", async () => {
+      const newCategory: Category = {
+        id: 99,
+        name: "Happy Hour",
+        type: "expense",
+        parent_id: null,
+        parent_name: null,
+        description: "Late afternoon decompression spend",
+        slug: "happy-hour",
+        is_system: false,
+        transaction_count: 0,
+      };
+      apiFetchMock.mockResolvedValueOnce(newCategory);
+
+      const parentSubmit = vi.fn((e: React.FormEvent<HTMLFormElement>) => {
+        // Mirror the real Add Transaction form's onSubmit: prevent
+        // default so jsdom doesn't try to navigate during the test.
+        e.preventDefault();
+      });
+      const onCreated = vi.fn();
+
+      render(
+        <form onSubmit={parentSubmit} data-testid="parent-form">
+          {/* Real form field present so the parent has valid shape;
+              irrelevant to the submit-propagation invariant. */}
+          <input name="ignored" defaultValue="x" />
+          <AddCategoryModal
+            initialName="Happy Hour"
+            initialType="expense"
+            masterCategories={masterCategories}
+            onCreated={onCreated}
+            onCancel={vi.fn()}
+          />
+        </form>,
+      );
+
+      // Modal renders via createPortal to document.body, but the
+      // React tree still has it as a child of the parent <form>.
+      fireEvent.click(
+        await screen.findByRole("button", { name: /Add category/i }),
+      );
+
+      await waitFor(() => {
+        expect(onCreated).toHaveBeenCalledWith(newCategory);
+      });
+
+      // Load-bearing assertion. Before the fix this is 1.
+      expect(parentSubmit).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Live bug reproduced by operator 2026-05-16. In the floating **Add Transaction** form, typing a name in **Category** → clicking **+ Add category** → filling the new subcategory in the inline modal → clicking **Add category** creates the subcategory but immediately surfaces a 422 banner on the parent transaction form:

```
category_id: Input should be a valid integer, unable to parse string as an integer
description: Value error, Description is required
amount: Input should be a valid decimal
```

## Root cause

`AddCategoryModal` renders via `createPortal(modal, document.body)` (`frontend/components/ui/AddCategoryModal.tsx:312`), which moves the modal's DOM out of the parent form's subtree — but **React synthetic events bubble through the React component tree, not the DOM tree**. So the modal's inner `<form onSubmit={...}>` fires a submit event that propagates up through `CategorySelect` → `TransactionForm` and hits the parent's onSubmit. The parent fires `POST /api/v1/transactions` with empty state → backend 422.

The inner onSubmit already called `e.preventDefault()`, which suppresses the DOM's default navigation but does **not** stop React-tree propagation. `e.stopPropagation()` was the missing call.

## Fix

One-line addition of `e.stopPropagation()` in `AddCategoryModal`'s onSubmit handler. Comment in-line documents the createPortal-vs-React-tree gotcha so it doesn't reoccur.

## Test

`frontend/tests/components/add-category-modal.test.tsx` adds a new `nested form propagation` describe block with one regression case. It wraps the modal inside a parent `<form>` whose onSubmit is a spy, drives the modal through its create flow, and asserts the spy never fires. **Before the fix the spy is invoked once; after the fix it is not.**

## Blast radius

The same root cause affects **every** other callsite that puts `CategorySelect` (and therefore `AddCategoryModal`) inside a `<form>`: the floating `TransferForm`, the `/transactions` add form, `/transactions/batch`, `/import`, `/forecast-plans`, and the `UnpairTransferModal`. Fixing the modal at the source closes all of them at once. No callsite changes needed.

## Verification

```
npm test -- tests/components/add-category-modal.test.tsx
  → 15 passed (14 existing + 1 new)

npm test
  → 959 passed (full suite, no regressions)

npm run lint -- --quiet
  → clean

npx tsc --noEmit
  → clean
```