### PR TITLE
fix(forecast): pin copy_from_period source to MANUAL (L3.11 residual)

### DIFF
--- a/backend/app/services/forecast_plan_service.py
+++ b/backend/app/services/forecast_plan_service.py
@@ -739,13 +739,23 @@ async def copy_from_period(
         key = (src_item.category_id, src_item.type.value)
         if key in existing_keys:
             continue
+        # L3.11 residual cleanup (PR #294, 2026-05-16): copied items
+        # are always MANUAL on the target plan, regardless of the
+        # source-period item's ``source``. ``copy_from_period`` is a
+        # user-initiated action — the user is explicitly choosing to
+        # carry these forecasts forward and will edit them — so the
+        # invariant "MANUAL = user-curated" demands MANUAL here.
+        # Without this pin, copies of items left over from
+        # ``populate_from_sources`` would land as RECURRING/HISTORY
+        # and silently vanish on the next ``refresh_from_sources``
+        # on the target period.
         new_item = ForecastPlanItem(
             plan_id=target_plan.id,
             org_id=org_id,
             category_id=src_item.category_id,
             type=src_item.type,
             planned_amount=src_item.planned_amount,
-            source=src_item.source,
+            source=ItemSource.MANUAL,
         )
         db.add(new_item)
 

--- a/backend/tests/services/test_forecast_plan_source_pinning.py
+++ b/backend/tests/services/test_forecast_plan_source_pinning.py
@@ -7,9 +7,14 @@ item, a malicious or careless caller posting ``source="history"`` could
 make a manually-added line vanish on next refresh.
 
 Fix: drop ``source`` from the public write schemas and pin every public
-write path to ``ItemSource.MANUAL``. Internal pipelines (populate, refresh,
-copy) keep the right to write RECURRING / HISTORY since they're not
-reachable from a public POST body.
+write path to ``ItemSource.MANUAL``. Internal pipelines (``populate``,
+``refresh``) keep the right to write RECURRING / HISTORY since they're
+not reachable from a public POST body — but ``copy_from_period`` IS a
+user-initiated public write, so it must also pin MANUAL on the copied
+items (L3.11 residual cleanup, 2026-05-16, PR #294). Otherwise items
+copied from an auto-populated source period inherit RECURRING/HISTORY
+and get silently wiped by the next ``refresh_from_sources`` on the
+target period.
 """
 from __future__ import annotations
 
@@ -24,7 +29,13 @@ from sqlalchemy.pool import StaticPool
 from app.models import Base
 from app.models.billing import BillingPeriod
 from app.models.category import Category, CategoryType
-from app.models.forecast_plan import ForecastPlan, PlanStatus
+from app.models.forecast_plan import (
+    ForecastItemType,
+    ForecastPlan,
+    ForecastPlanItem,
+    ItemSource,
+    PlanStatus,
+)
 from app.models.user import Organization
 from app.schemas.forecast_plan import (
     BulkUpsertItem,
@@ -158,3 +169,144 @@ async def test_upsert_item_silently_ignores_source_in_payload(session_factory):
         i for i in resp.items if i.category_id == seed["groceries_id"]
     )
     assert item.source == "manual"
+
+
+# ── copy_from_period: the L3.11 residual cleanup ─────────────────────────────
+
+
+async def _seed_source_period_with_auto_items(factory) -> dict:
+    """Seed:
+      - source period (April) with a plan whose items have source=RECURRING
+        and source=HISTORY — i.e. what ``populate_from_sources`` would have
+        produced.
+      - target period (May) with no plan yet (the copy will create one).
+
+    The source-side items represent "leftover auto-populated items" — the
+    canonical case where the L3.11 bug bites: copy them forward, refresh
+    the target, watch them silently disappear.
+    """
+    org_id = 1
+    source_start = datetime.date(2026, 4, 1)
+    source_end = datetime.date(2026, 4, 30)
+    target_start = datetime.date(2026, 5, 1)
+    target_end = datetime.date(2026, 5, 31)
+
+    async with factory() as db:
+        db.add(Organization(id=org_id, name="org", billing_cycle_day=1))
+        await db.commit()
+
+        groceries = Category(
+            org_id=org_id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        salary = Category(
+            org_id=org_id, name="Salary", slug="salary",
+            type=CategoryType.INCOME,
+        )
+        db.add_all([groceries, salary])
+        await db.commit()
+
+        source_period = BillingPeriod(
+            org_id=org_id, start_date=source_start, end_date=source_end
+        )
+        target_period = BillingPeriod(
+            org_id=org_id, start_date=target_start, end_date=target_end
+        )
+        db.add_all([source_period, target_period])
+        await db.commit()
+
+        source_plan = ForecastPlan(
+            org_id=org_id, billing_period_id=source_period.id,
+            status=PlanStatus.DRAFT,
+        )
+        db.add(source_plan)
+        await db.commit()
+
+        # Auto-populated style items — exactly what populate_from_sources
+        # would have written.
+        db.add_all([
+            ForecastPlanItem(
+                plan_id=source_plan.id,
+                org_id=org_id,
+                category_id=groceries.id,
+                type=ForecastItemType.EXPENSE,
+                planned_amount=Decimal("400"),
+                source=ItemSource.HISTORY,
+            ),
+            ForecastPlanItem(
+                plan_id=source_plan.id,
+                org_id=org_id,
+                category_id=salary.id,
+                type=ForecastItemType.INCOME,
+                planned_amount=Decimal("3000"),
+                source=ItemSource.RECURRING,
+            ),
+        ])
+        await db.commit()
+
+        return {
+            "org_id": org_id,
+            "groceries_id": groceries.id,
+            "salary_id": salary.id,
+            "source_start": source_start,
+            "target_start": target_start,
+        }
+
+
+@pytest.mark.asyncio
+async def test_copy_from_period_pins_source_to_manual(session_factory):
+    """``copy_from_period`` is a user-initiated public write. The pre-fix
+    code propagated ``src_item.source`` verbatim, so items copied from an
+    auto-populated source plan landed with ``source=RECURRING`` or
+    ``source=HISTORY``. The fix pins ``ItemSource.MANUAL`` on every
+    copied row. L3.11 residual cleanup."""
+    seed = await _seed_source_period_with_auto_items(session_factory)
+    async with session_factory() as db:
+        resp = await forecast_plan_service.copy_from_period(
+            db,
+            seed["org_id"],
+            target_period_start=seed["target_start"],
+            source_period_start=seed["source_start"],
+        )
+
+    # Both items copied across.
+    by_cat = {item.category_id: item for item in resp.items}
+    assert seed["groceries_id"] in by_cat
+    assert seed["salary_id"] in by_cat
+
+    # The load-bearing invariant: every copied item is MANUAL,
+    # regardless of what the source-period item's source was.
+    assert by_cat[seed["groceries_id"]].source == "manual"
+    assert by_cat[seed["salary_id"]].source == "manual"
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_copy_preserves_copied_items(session_factory):
+    """The downstream consequence of the pinning rule: once a user has
+    copied a previous period's plan, the resulting items must survive a
+    later ``refresh_from_sources`` on the target period. Pre-fix they
+    were dropped (refresh deletes every non-MANUAL item), silently
+    wiping user-curated state."""
+    seed = await _seed_source_period_with_auto_items(session_factory)
+    async with session_factory() as db:
+        await forecast_plan_service.copy_from_period(
+            db,
+            seed["org_id"],
+            target_period_start=seed["target_start"],
+            source_period_start=seed["source_start"],
+        )
+
+    # Now refresh the target period. With the fix, the copied items
+    # stay (they're MANUAL). Without the fix, they evaporate.
+    async with session_factory() as db:
+        resp = await forecast_plan_service.refresh_from_sources(
+            db, seed["org_id"], period_start=seed["target_start"]
+        )
+
+    cats_present = {item.category_id for item in resp.items}
+    assert seed["groceries_id"] in cats_present, (
+        "groceries was copied; refresh must not silently drop it"
+    )
+    assert seed["salary_id"] in cats_present, (
+        "salary was copied; refresh must not silently drop it"
+    )


### PR DESCRIPTION
## Summary

L3.11 residual cleanup. PR #154 closed the bulk of the source-pinning sweep — `ForecastPlanItemCreate` and `BulkUpsertItem` dropped the public `source` field and `upsert_item` / `bulk_upsert` / `update_item` pin `ItemSource.MANUAL` server-side. PR #154's docstring claimed copy was "internal" and exempt; in reality `copy_from_period` is reachable from `POST /api/v1/forecast-plans/copy-from-period` and was the one remaining public path writing a non-MANUAL source from a user action.

## Live consequence

When `copy_from_period` ran against a source period whose plan had any auto-populated items (the canonical case — `populate_from_sources` writes `source=RECURRING` and `source=HISTORY`), the inherited source carried over verbatim. The next `refresh_from_sources` on the target period then **silently dropped those items** (its rule is "drop every non-MANUAL item"), wiping user-curated forecast state.

## Fix

One-line change in `backend/app/services/forecast_plan_service.py:copy_from_period`:

```python
new_item = ForecastPlanItem(
    ...,
-   source=src_item.source,
+   source=ItemSource.MANUAL,
)
```

In-line comment documents the invariant: "`copy_from_period` is a user-initiated action — the user is explicitly choosing to carry these forecasts forward and will edit them — so the invariant 'MANUAL = user-curated' demands MANUAL here."

## Tests

`backend/tests/services/test_forecast_plan_source_pinning.py`:

1. `test_copy_from_period_pins_source_to_manual` — seeds a source period whose items are `RECURRING` + `HISTORY`, copies forward, asserts both copied items land as `MANUAL`.
2. `test_refresh_after_copy_preserves_copied_items` — the downstream consequence: a refresh on the target period MUST NOT drop the copied items. Pre-fix they evaporate; post-fix they stay.

Docstring at the top of the file updated to reflect that `copy_from_period` is a public write path, not an internal pipeline.

## Verification

```
pytest tests/services/test_forecast_plan_source_pinning.py
  → 6 passed (4 existing + 2 new)

pytest tests/
  → 1223 passed, 9 skipped, no regressions
```