### PR TITLE
feat(transfers): clarify CC bill payment as a transfer, not an expense

### DIFF
--- a/backend/app/services/org_bootstrap_service.py
+++ b/backend/app/services/org_bootstrap_service.py
@@ -114,5 +114,25 @@ async def seed_org_defaults(db: AsyncSession, *, org_id: int) -> dict[str, int]:
         ))
         counts["categories"] += 1
 
+    # Credit Card Payment system category (CategoryType.BOTH; no
+    # children). Paying a credit card bill is a transfer between a
+    # payment account and a credit-card account, NOT an expense. This
+    # gives users a ready-made transfer-compatible category so they do
+    # not have to create one on first use. The existing expense-only
+    # "Debt Repayment / Credit Cards" subcategory under Debt Repayment
+    # is intentionally kept distinct — it tracks the cost of carrying
+    # debt (interest, fees), which is a real expense and not a
+    # transfer.
+    if "credit_card_payment" not in existing_cat_slugs:
+        db.add(Category(
+            org_id=org_id,
+            name="Credit Card Payment",
+            slug="credit_card_payment",
+            description="Payments toward a credit-card balance (transfer)",
+            type=CategoryType.BOTH,
+            is_system=True,
+        ))
+        counts["categories"] += 1
+
     await db.flush()
     return counts

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -29,6 +29,7 @@ const sections = [
   { id: "system-health", label: "System health" },
   { id: "dashboard", label: "Dashboard" },
   { id: "transactions", label: "Transactions" },
+  { id: "transfers", label: "Transfers and paying a credit card" },
   { id: "recurring", label: "Recurring transactions" },
   { id: "accounts", label: "Accounts" },
   { id: "categories", label: "Categories" },
@@ -429,6 +430,65 @@ export default function DocsPage() {
               filter by status, account, or category, and to sort the
               columns. Imports land here as a preview first, so nothing
               is committed until you confirm.
+            </p>
+          </section>
+
+          <section>
+            <h2 id="transfers">Transfers and paying a credit card</h2>
+            <p>
+              A transfer is money moving between two of your own
+              accounts (checking to savings, checking to credit card,
+              and so on). Transfers are not income or expense: they do
+              not change your net position, so the app tracks them as a
+              paired movement and keeps them out of category-level
+              spending totals.
+            </p>
+
+            <h3>How transfers are categorized</h3>
+            <p>
+              Both legs of a transfer share one category. That category
+              has to be transfer-compatible (its type is "both"), so it
+              works on the outgoing leg as well as the incoming leg. The
+              transfer form filters the category picker to just these
+              transfer-compatible categories. If you leave the picker
+              empty, the app uses the built-in Transfer category, which
+              is enough for most setups.
+            </p>
+
+            <h3>Paying a credit card bill</h3>
+            <p>
+              A credit card payment is a transfer, not an expense. The
+              spending already happened when you swiped the card. Paying
+              the statement moves cash from your bank account to your
+              credit card account, which clears the card balance back
+              toward zero.
+            </p>
+            <ul>
+              <li>
+                Card purchases (groceries, gas, restaurants) stay as
+                regular expenses on the credit card account. Categorize
+                them the way you would any other purchase.
+              </li>
+              <li>
+                Paying the statement is a single transfer from your
+                bank account to the credit card account. Use Add
+                transfer (or Mark as transfer on an existing pair).
+              </li>
+              <li>
+                If you want to see card payments broken out separately
+                from generic transfers, create a transfer-compatible
+                category like Credit Card Payment or Debt Repayment
+                from the transfer form, then pick it on the transfer.
+                Both legs will use that category.
+              </li>
+            </ul>
+            <p>
+              Heads up: an expense-only category (for example "Debt
+              Repayment / Credit Cards") cannot be used on a transfer.
+              The picker hides those choices on the transfer form, and
+              the backend rejects them on the API, since an
+              expense-only category cannot apply to the incoming leg
+              that lands on the credit card account.
             </p>
           </section>
 

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -476,10 +476,12 @@ export default function DocsPage() {
               </li>
               <li>
                 If you want to see card payments broken out separately
-                from generic transfers, create a transfer-compatible
-                category like Credit Card Payment or Debt Repayment
-                from the transfer form, then pick it on the transfer.
-                Both legs will use that category.
+                from generic transfers, pick Credit Card Payment (or
+                create another transfer-compatible category) from the
+                transfer form. Both legs will use that category. The
+                picker shows only categories that work on both legs,
+                so expense-only categories like Debt Repayment or
+                Credit Cards cannot be used on a transfer.
               </li>
             </ul>
             <p>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1006,9 +1006,9 @@ function TransactionsPageContent() {
             )}
             {formMode === "transfer" && (
               <div>
-                <label className={label}>Category (optional)</label>
-                <CategorySelect id="tx-transfer-cat" categories={categories} value={formTransferCatId} onChange={setFormTransferCatId} className={input} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
-                <p className="mt-1 text-[10px] text-text-muted">Defaults to Transfer. Override to track in budgets.</p>
+                <label htmlFor="tx-transfer-cat" className={label}>Transfer category</label>
+                <CategorySelect id="tx-transfer-cat" categories={categories} value={formTransferCatId} onChange={setFormTransferCatId} typeFilter="BOTH" className={input} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
+                <p className="mt-1 text-[10px] text-text-muted">Transfers use one category shared by both legs. Pick a transfer-compatible category like Transfer, Credit Card Payment, or Debt Repayment. Leave empty to use the default Transfer category.</p>
               </div>
             )}
             <div>

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -1008,7 +1008,7 @@ function TransactionsPageContent() {
               <div>
                 <label htmlFor="tx-transfer-cat" className={label}>Transfer category</label>
                 <CategorySelect id="tx-transfer-cat" categories={categories} value={formTransferCatId} onChange={setFormTransferCatId} typeFilter="BOTH" className={input} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
-                <p className="mt-1 text-[10px] text-text-muted">Transfers use one category shared by both legs. Pick a transfer-compatible category like Transfer, Credit Card Payment, or Debt Repayment. Leave empty to use the default Transfer category.</p>
+                <p className="mt-1 text-[10px] text-text-muted">Transfers use one category shared by both legs. Pick Transfer, Credit Card Payment, or another transfer-compatible category you create. Leave empty to use the default Transfer category.</p>
               </div>
             )}
             <div>

--- a/frontend/components/floating/TransferForm.tsx
+++ b/frontend/components/floating/TransferForm.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, MouseEvent, useEffect, useRef, useState } from "react";
 
 import CategorySelect from "@/components/ui/CategorySelect";
+import HelpAnchor from "@/components/HelpAnchor";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { todayISO } from "@/lib/format";
 import {
@@ -266,19 +267,31 @@ export default function TransferForm({
       </div>
 
       <div>
-        <label htmlFor="fab-xfer-category" className={label}>
-          Category (optional)
-        </label>
+        <div className="flex items-center gap-1">
+          <label htmlFor="fab-xfer-category" className={label}>
+            Transfer category
+          </label>
+          <HelpAnchor
+            section="transfers"
+            label="Transfer category"
+            variant="inline-title"
+            className="mt-0"
+          />
+        </div>
         <CategorySelect
           id="fab-xfer-category"
           categories={categories}
           value={categoryId}
           onChange={setCategoryId}
+          typeFilter="BOTH"
           className={input}
           onCategoryCreated={(cat) => onCategoryCreated?.(cat)}
         />
         <p className="mt-1 text-[10px] text-text-muted">
-          Defaults to Transfer. Override to track in budgets.
+          Transfers use one category shared by both legs. Pick a
+          transfer-compatible category like Transfer, Credit Card
+          Payment, or Debt Repayment. Leave empty to use the default
+          Transfer category.
         </p>
       </div>
 

--- a/frontend/components/floating/TransferForm.tsx
+++ b/frontend/components/floating/TransferForm.tsx
@@ -288,10 +288,10 @@ export default function TransferForm({
           onCategoryCreated={(cat) => onCategoryCreated?.(cat)}
         />
         <p className="mt-1 text-[10px] text-text-muted">
-          Transfers use one category shared by both legs. Pick a
-          transfer-compatible category like Transfer, Credit Card
-          Payment, or Debt Repayment. Leave empty to use the default
-          Transfer category.
+          Transfers use one category shared by both legs. Pick
+          Transfer, Credit Card Payment, or another
+          transfer-compatible category you create. Leave empty to
+          use the default Transfer category.
         </p>
       </div>
 

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -333,7 +333,18 @@ export default function CategorySelect({ id, categories, value, onChange, filter
           masterCategories={masters}
           onCreated={(cat) => {
             setShowAddModal(false);
+            // Always notify upward so other pickers can list the
+            // newly-created category. But in ``bothOnly`` (transfer)
+            // mode the modal's type radio is unlocked — if the user
+            // changed it to income or expense, the new category is
+            // incompatible with the transfer picker. Do NOT
+            // ``handleSelect`` in that case, otherwise the form would
+            // store an id the backend rejects at submit. Architect
+            // feedback on PR #296.
             onCategoryCreated?.(cat);
+            if (bothOnly && cat.type !== "both") {
+              return;
+            }
             handleSelect(cat);
           }}
           onCancel={() => {

--- a/frontend/components/ui/CategorySelect.tsx
+++ b/frontend/components/ui/CategorySelect.tsx
@@ -27,7 +27,14 @@ interface Props {
   value: number | "";
   onChange: (id: number | "") => void;
   filterType?: "income" | "expense";
-  typeFilter?: "INCOME" | "EXPENSE";
+  /**
+   * Uppercase variant used by transfer-related callers
+   * (UnpairTransferModal for income/expense legs, TransferForm for the
+   * shared transfer leg). `"BOTH"` narrows the list to categories whose
+   * `type === "both"`, which is the only kind the backend accepts on a
+   * transfer's shared category slot.
+   */
+  typeFilter?: "INCOME" | "EXPENSE" | "BOTH";
   className?: string;
   "aria-label"?: string;
   onCategoryCreated?: (cat: Category) => void;
@@ -50,6 +57,14 @@ export default function CategorySelect({ id, categories, value, onChange, filter
   // Normalize uppercase `typeFilter` (transfers callers) to internal lowercase
   // so it joins the existing filterType machinery without divergent code paths.
   const effectiveFilterType = filterType ?? (typeFilter === "INCOME" ? "income" : typeFilter === "EXPENSE" ? "expense" : undefined);
+  // `bothOnly` is a separate mode (not a third filterType value) because
+  // the existing semantics for "income"/"expense" mean "show same-type
+  // categories AND the always-compatible `both` ones." Transfers need
+  // the opposite: show ONLY `both`, hiding income- and expense-only
+  // categories that the backend would reject on the shared transfer
+  // leg. The `+ Add category` modal launched from this mode defaults to
+  // `initialType="both"` without locking it.
+  const bothOnly = typeFilter === "BOTH";
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [highlightIdx, setHighlightIdx] = useState(-1);
@@ -70,9 +85,10 @@ export default function CategorySelect({ id, categories, value, onChange, filter
   const rawSelected = categories.find((c) => c.id === value);
   const selected =
     rawSelected &&
-    effectiveFilterType &&
-    rawSelected.type !== effectiveFilterType &&
-    rawSelected.type !== "both"
+    ((bothOnly && rawSelected.type !== "both") ||
+      (effectiveFilterType &&
+        rawSelected.type !== effectiveFilterType &&
+        rawSelected.type !== "both"))
       ? undefined
       : rawSelected;
 
@@ -83,11 +99,12 @@ export default function CategorySelect({ id, categories, value, onChange, filter
       if (c.parent_id !== null) pIds.add(c.parent_id);
     }
     const items = categories.filter((c) => {
+      if (bothOnly && c.type !== "both") return false;
       if (effectiveFilterType && c.type !== effectiveFilterType && c.type !== "both") return false;
       return c.parent_id !== null || !pIds.has(c.id);
     });
     return { selectable: items, parentIds: pIds };
-  }, [categories, effectiveFilterType]);
+  }, [categories, effectiveFilterType, bothOnly]);
 
   const q = query.toLowerCase();
   const filtered = useMemo(() =>
@@ -307,8 +324,12 @@ export default function CategorySelect({ id, categories, value, onChange, filter
       {showAddModal && (
         <AddCategoryModal
           initialName={query}
-          initialType={effectiveFilterType ?? "both"}
-          lockedType={effectiveFilterType}
+          // In `bothOnly` (transfer) mode we default the new category to
+          // "both" without locking the type, so the user can still pick
+          // a different type if they realized the picker context was
+          // wrong. For "income"/"expense" pickers the type stays locked.
+          initialType={bothOnly ? "both" : (effectiveFilterType ?? "both")}
+          lockedType={bothOnly ? undefined : effectiveFilterType}
           masterCategories={masters}
           onCreated={(cat) => {
             setShowAddModal(false);

--- a/frontend/tests/components/floating/transfer-form.test.tsx
+++ b/frontend/tests/components/floating/transfer-form.test.tsx
@@ -308,9 +308,20 @@ describe("TransferForm", () => {
     expect(
       screen.getByText(/Transfers use one category shared by both legs/i),
     ).toBeInTheDocument();
+    // Architect feedback on PR #296: helper copy must NOT suggest
+    // "Debt Repayment" because the seeded Debt Repayment category is
+    // type=expense (in SYSTEM_CATEGORIES) and would be rejected by
+    // the backend on a transfer. Replacement points at Transfer +
+    // Credit Card Payment + "another transfer-compatible category you
+    // create".
     expect(
-      screen.getByText(/Credit Card Payment, or Debt Repayment/i),
+      screen.getByText(
+        /Pick Transfer, Credit Card Payment, or another transfer-compatible category you create/i,
+      ),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Debt Repayment/i),
+    ).not.toBeInTheDocument();
   });
 
   it("hides income- and expense-only categories from the transfer category picker", () => {

--- a/frontend/tests/components/floating/transfer-form.test.tsx
+++ b/frontend/tests/components/floating/transfer-form.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import TransferForm from "@/components/floating/TransferForm";
 import { apiFetch } from "@/lib/api";
@@ -273,6 +273,100 @@ describe("TransferForm", () => {
       ([url]) => url === "/api/v1/transactions/transfer",
     );
     expect(transferCalls).toHaveLength(1);
+  });
+
+  it("labels the category field as 'Transfer category' (not 'Category (optional)')", () => {
+    render(
+      <TransferForm
+        accounts={[CHECKING, SAVINGS]}
+        categories={[TRANSFER_CAT]}
+        onSaved={() => {}}
+      />,
+    );
+    // Architect-locked copy 2026-05-16: the transfer form's category
+    // field must read "Transfer category" so users understand it is
+    // not a generic income/expense category. The matcher is exact to
+    // catch accidental reverts to "Category (optional)".
+    expect(screen.getByText("Transfer category")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Category \(optional\)/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the transfer-compatible helper copy under the category field", () => {
+    render(
+      <TransferForm
+        accounts={[CHECKING, SAVINGS]}
+        categories={[TRANSFER_CAT]}
+        onSaved={() => {}}
+      />,
+    );
+    // Helper text must point users at transfer-compatible categories
+    // (type=both). The previous copy promised "Override to track in
+    // budgets", which gave no hint that arbitrary expense categories
+    // would be rejected by the backend.
+    expect(
+      screen.getByText(/Transfers use one category shared by both legs/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Credit Card Payment, or Debt Repayment/i),
+    ).toBeInTheDocument();
+  });
+
+  it("hides income- and expense-only categories from the transfer category picker", () => {
+    // Mixed-type fixture: only the type=both row should be selectable
+    // in the transfer-form context. The picker uses typeFilter=BOTH,
+    // so income/expense masters and subs are hidden entirely.
+    const EXPENSE_CAT = {
+      id: 200,
+      name: "Groceries",
+      type: "expense" as const,
+      parent_id: null,
+      parent_name: null,
+      description: null,
+      slug: "groceries",
+      is_system: false,
+      transaction_count: 0,
+    };
+    const INCOME_CAT = {
+      id: 300,
+      name: "Salary",
+      type: "income" as const,
+      parent_id: null,
+      parent_name: null,
+      description: null,
+      slug: "salary",
+      is_system: false,
+      transaction_count: 0,
+    };
+    const TRANSFER_BOTH = {
+      ...TRANSFER_CAT,
+      type: "both" as const,
+    };
+
+    render(
+      <TransferForm
+        accounts={[CHECKING, SAVINGS]}
+        categories={[EXPENSE_CAT, INCOME_CAT, TRANSFER_BOTH]}
+        onSaved={() => {}}
+      />,
+    );
+    // Open the transfer category dropdown. The form has both a
+    // <label htmlFor="fab-xfer-category">Transfer category</label> and
+    // a HelpAnchor with aria-label "Help: Transfer category", so we
+    // target the combobox by its explicit name (`Transfer category`)
+    // via the `name` matcher rather than `getByLabelText` (which would
+    // match both the label and the help icon).
+    const combobox = screen.getByRole("combobox", {
+      name: "Transfer category",
+    });
+    fireEvent.focus(combobox);
+    const listbox = screen.getByRole("listbox");
+    // The type=both option is visible.
+    expect(within(listbox).getByText("Transfer")).toBeInTheDocument();
+    // Income-only and expense-only options are NOT visible.
+    expect(within(listbox).queryByText("Groceries")).not.toBeInTheDocument();
+    expect(within(listbox).queryByText("Salary")).not.toBeInTheDocument();
   });
 
   it("omits category_id from the request when no override is picked (server applies the Transfer default)", async () => {

--- a/frontend/tests/components/ui/category-select.test.tsx
+++ b/frontend/tests/components/ui/category-select.test.tsx
@@ -21,6 +21,45 @@ vi.mock("@/components/ui/AddCategoryModal", () => ({
       <button type="button" onClick={() => props.onCancel()}>
         stub-cancel
       </button>
+      {/* Emit category-created with a specific type so tests can
+          exercise both the compatible and the bothOnly-incompatible
+          code paths added in the PR #296 architect-feedback round. */}
+      <button
+        type="button"
+        onClick={() =>
+          props.onCreated({
+            id: 9999,
+            name: props.initialName || "Stub Expense",
+            type: "expense",
+            parent_id: null,
+            parent_name: null,
+            description: null,
+            slug: "stub-expense",
+            is_system: false,
+            transaction_count: 0,
+          })
+        }
+      >
+        stub-create-expense
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          props.onCreated({
+            id: 8888,
+            name: props.initialName || "Stub Transfer",
+            type: "both",
+            parent_id: null,
+            parent_name: null,
+            description: null,
+            slug: "stub-transfer",
+            is_system: false,
+            transaction_count: 0,
+          })
+        }
+      >
+        stub-create-both
+      </button>
     </div>
   ),
 }));
@@ -248,5 +287,65 @@ describe("CategorySelect — value resolution under filterType", () => {
     fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
     expect(screen.getByTestId("modal-initial-type")).toHaveTextContent("both");
     expect(screen.getByTestId("modal-locked-type")).toHaveTextContent("");
+  });
+
+  // Architect feedback on PR #296: in bothOnly mode the modal's type
+  // radio is unlocked, so a user can flip to income/expense. Today the
+  // resulting category lands as the selected value via handleSelect,
+  // even though the picker would later hide it. The form then submits
+  // an id the backend rejects. The fix is to gate handleSelect on
+  // compatibility — onCategoryCreated still fires (so other pickers
+  // can list the new category), but onChange must NOT fire when the
+  // returned category is incompatible with the active typeFilter.
+  it("typeFilter=BOTH: an incompatible (expense) created category is not selected", () => {
+    const onChange = vi.fn();
+    const onCategoryCreated = vi.fn();
+    render(
+      <CategorySelect
+        id="t11"
+        categories={CATEGORIES}
+        value=""
+        onChange={onChange}
+        onCategoryCreated={onCategoryCreated}
+        typeFilter="BOTH"
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    fireEvent.click(screen.getByText("stub-create-expense"));
+
+    // Upward notification fires regardless of compatibility, so other
+    // forms (e.g. /transactions in income/expense mode) can list it.
+    expect(onCategoryCreated).toHaveBeenCalledTimes(1);
+    expect(onCategoryCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "expense" }),
+    );
+
+    // Load-bearing assertion: the picker does NOT select the
+    // incompatible category. Before the fix this fired once with id 9999.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("typeFilter=BOTH: a compatible (both) created category IS selected", () => {
+    const onChange = vi.fn();
+    const onCategoryCreated = vi.fn();
+    render(
+      <CategorySelect
+        id="t12"
+        categories={CATEGORIES}
+        value=""
+        onChange={onChange}
+        onCategoryCreated={onCategoryCreated}
+        typeFilter="BOTH"
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    fireEvent.click(screen.getByText("stub-create-both"));
+
+    expect(onCategoryCreated).toHaveBeenCalledTimes(1);
+    // Compatible: picker selects it as the new value.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(8888);
   });
 });

--- a/frontend/tests/components/ui/category-select.test.tsx
+++ b/frontend/tests/components/ui/category-select.test.tsx
@@ -178,4 +178,75 @@ describe("CategorySelect — value resolution under filterType", () => {
     fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
     expect(screen.getByTestId("modal-locked-type")).toHaveTextContent("");
   });
+
+  it("typeFilter=BOTH narrows the dropdown to type=both categories only", () => {
+    // Transfer context: the only acceptable category type on the shared
+    // transfer leg is `both`. Income- and expense-only options must
+    // disappear, including their subcategories.
+    render(
+      <CategorySelect
+        id="t7"
+        categories={CATEGORIES}
+        value=""
+        onChange={vi.fn()}
+        typeFilter="BOTH"
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("Transfer")).toBeInTheDocument();
+    expect(within(listbox).queryByText("Salary")).not.toBeInTheDocument();
+    expect(within(listbox).queryByText("Groceries")).not.toBeInTheDocument();
+    expect(within(listbox).queryByText("Supermarket")).not.toBeInTheDocument();
+  });
+
+  it("typeFilter=BOTH hides a stale value that points at an incompatible category", () => {
+    // The picker is now type=both only, but value still points at the
+    // expense master (id 20). The selected-chip must clear (input is
+    // empty), the same way `filterType` does for income/expense.
+    render(
+      <CategorySelect
+        id="t8"
+        categories={CATEGORIES}
+        value={20}
+        onChange={vi.fn()}
+        typeFilter="BOTH"
+      />,
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("typeFilter=BOTH keeps a compatible (type=both) value visible as the selected chip", () => {
+    render(
+      <CategorySelect
+        id="t9"
+        categories={CATEGORIES}
+        value={30}
+        onChange={vi.fn()}
+        typeFilter="BOTH"
+      />,
+    );
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.value).toBe("Transfer");
+  });
+
+  it("typeFilter=BOTH defaults the AddCategoryModal to initialType=both without locking it", () => {
+    // The user must be able to override the type from inside the modal
+    // if they realize the picker context was wrong; locking it would
+    // hide the radio group. Only income/expense lock today.
+    render(
+      <CategorySelect
+        id="t10"
+        categories={CATEGORIES}
+        value=""
+        onChange={vi.fn()}
+        typeFilter="BOTH"
+      />,
+    );
+    fireEvent.focus(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Add category/i }));
+    expect(screen.getByTestId("modal-initial-type")).toHaveTextContent("both");
+    expect(screen.getByTestId("modal-locked-type")).toHaveTextContent("");
+  });
 });


### PR DESCRIPTION
## Summary

Architect-locked UX wave for credit-card-payment categorization. A CC bill payment stays a transfer between a payment account and a credit-card account (not an expense), but the transfer-category picker now filters to `type=both` categories only. Users can no longer reach for an expense-only choice like "Debt Repayment / Credit Cards" that the backend would reject. Adds in-app docs explaining the flow, a system "Credit Card Payment" category at `type=both`, and tests.

Refs: `~/.claude/projects/-Users-fjorge-src-pfv/memory/project_transfer_category_ux.md`.

## Changed files

- `frontend/components/floating/TransferForm.tsx` rename field label to "Transfer category", pass `typeFilter="BOTH"`, new helper copy, HelpAnchor pointing at `/docs#transfers`.
- `frontend/app/transactions/page.tsx` mirror the same rename + filter + copy in the inline transfer form on the Transactions page.
- `frontend/components/ui/CategorySelect.tsx` extend `typeFilter` to accept `"BOTH"`. New `bothOnly` internal mode: shows only `type=both`, hides income/expense entirely. `+ Add category` defaults to `initialType="both"` without locking, so the user can still override.
- `frontend/app/docs/page.tsx` new "Transfers and paying a credit card" section covering transfers vs expenses, how categorization works, and the CC payment flow.
- `backend/app/services/org_bootstrap_service.py` seed a new system category `Credit Card Payment` with `type=both` (idempotent, slug-keyed). Pre-launch hard-add (no migration), per `feedback_pre_launch_state.md`.
- `frontend/tests/components/ui/category-select.test.tsx` 4 new tests for `typeFilter="BOTH"`: dropdown filter, stale-value chip clearing, compatible-value resolution, AddCategoryModal default-without-lock.
- `frontend/tests/components/floating/transfer-form.test.tsx` 3 new tests: renamed label, helper copy presence, picker-filters-at-form-level.

## Architect items addressed

1. Rename label to "Transfer category" (both surfaces).
2. Filter picker to `type=both` only (via `typeFilter="BOTH"`).
3. Default `initialType="both"` on inline + Add category (transfer context only; transactions form unchanged).
4. New helper copy with brand-voice (no em-dashes).
5. Docs page section explaining the CC payment flow + HelpAnchor on the transfer form.
6. Optional: seeded system category `Credit Card Payment` (`type=both`).

## Tests run

Targeted (`npm test -- --run` on the three touched files):

```
 RUN  v3.2.4 /app
 ✓ tests/components/ui/category-select.test.tsx (10 tests) 103ms
 ✓ tests/components/ui/category-select-add.test.tsx (5 tests) 104ms
 ✓ tests/components/floating/transfer-form.test.tsx (11 tests) 160ms

 Test Files  3 passed (3)
      Tests  26 passed (26)
```

Full frontend suite (`npm test`):

```
 Test Files  136 passed (136)
      Tests  966 passed (966)
   Duration  13.83s
```

Lint (`npm run lint -- --quiet`): no errors.

Type-check (`npx tsc --noEmit`): no errors.

Full backend suite (`pytest tests/ -q`):

```
1223 passed, 9 skipped, 68 warnings in 275.77s (0:04:35)
```

## Known risks

- The `Credit Card Payment` system seed only seeds new orgs (and orgs that go through the reset path). Existing dev orgs will not get the category until they reset. Per `feedback_pre_launch_state.md` no backfill is required pre-launch; the existing system `Transfer` category already covers the default case so users are not blocked.
- The new `typeFilter="BOTH"` mode hides every income-only and expense-only category from the transfer picker. If a user already has a transfer with a `type=both` value selected on a row pre-change, no impact. If they had somehow attached an income/expense category to a transfer (the backend rejects this on creation; only possible if a category was later re-typed), the chip will now render empty on the form. Treated as correct, since the row is in an invalid state.
- The CC payment fixture / test sweep does NOT exercise the new system-category insertion path end-to-end against the auth/register route; coverage is at the seed-service level (`test_seed_org_defaults_is_idempotent`). Considered sufficient since the seed path is the single source of truth.