### PR TITLE
feat(categories): Layer B preflight + Layer C restore-recommended

### DIFF
--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
+from app.auth.org_permissions import require_org_owner
 from app.database import get_db
 from app.deps import get_current_user
 from app.models.category import Category, CategoryType
@@ -21,8 +22,9 @@ from app.schemas.category import (
     CategoryMoveResult,
     CategoryResponse,
     CategoryUpdate,
+    RestoreRecommendedResult,
 )
-from app.services import audit_service, category_service
+from app.services import audit_service, category_service, org_bootstrap_service
 from app.services.category_service import (
     batch_move_subcategories,
     delete_category_with_migration,
@@ -197,6 +199,49 @@ async def list_categories(
         _to_response(cat, parent_name, count)
         for cat, parent_name, count in result.all()
     ]
+
+
+@router.post(
+    "/restore-recommended",
+    response_model=RestoreRecommendedResult,
+)
+async def restore_recommended_categories_endpoint(
+    request: Request,
+    current_user: User = Depends(require_org_owner),
+    db: AsyncSession = Depends(get_db),
+):
+    """Re-run the system-categories seed for the current org. Idempotent.
+
+    Owner-only (consistent with other tenant setup actions). Skips slugs
+    that already exist with ``is_system=True``. Existing categories
+    (system or user-created) are never modified or removed. Returns the
+    count of newly inserted categories. Audited as
+    ``org.categories.restored`` with the count in ``detail``.
+    Category Fallback design Layer C (post-L3.10).
+    """
+    org_name = await _actor_org_name(db, current_user.org_id)
+    created_count = await org_bootstrap_service.restore_recommended_categories(
+        db, org_id=current_user.org_id,
+    )
+    audit_service.add_audit_event_to_session(
+        db,
+        event_type="org.categories.restored",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=current_user.org_id,
+        target_org_name=org_name,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"created_count": created_count},
+    )
+    await logger.ainfo(
+        "org.categories.restored",
+        org_id=current_user.org_id,
+        created_count=created_count,
+    )
+    await db.commit()
+    return RestoreRecommendedResult(created_count=created_count)
 
 
 @router.post("", response_model=CategoryResponse, status_code=201)

--- a/backend/app/routers/import_router.py
+++ b/backend/app/routers/import_router.py
@@ -7,7 +7,7 @@ spec at ``~/.claude/projects/-Users-fjorge-src-pfv/specs/2026-05-12-l3-2-import-
 """
 
 import structlog
-from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_current_user, get_db
@@ -24,7 +24,7 @@ from app.schemas.import_schemas import (
     ImportPreviewResponse,
 )
 from app.services import import_service, reconciliation_service
-from app.services.exceptions import ValidationError
+from app.services.exceptions import MissingCategoryTypeError, ValidationError
 from app.services.import_ofx_service import parse_ofx
 from app.services.import_parser import ParseError, parse_csv
 
@@ -33,6 +33,23 @@ logger = structlog.get_logger()
 MAX_UPLOAD_BYTES = 5 * 1024 * 1024  # 5 MB
 
 router = APIRouter(prefix="/api/v1/import", tags=["import"])
+
+
+def _missing_category_type_response(exc: MissingCategoryTypeError) -> HTTPException:
+    """Translate a Layer B preflight failure into a structured 400.
+
+    Frontend reads ``detail.code`` to render a targeted message (e.g.
+    "you have no expense category"). ``message`` is the fallback copy
+    when the client doesn't recognize the code.
+    """
+    return HTTPException(
+        status_code=400,
+        detail={
+            "code": "missing_category_type",
+            "missing_types": exc.missing_types,
+            "message": exc.message,
+        },
+    )
 
 
 @router.post("/preview", response_model=ImportPreviewResponse)
@@ -59,14 +76,17 @@ async def preview_import(
             detail = f"Row {exc.row_number}: {detail}"
         raise ValidationError(detail)
 
-    return await import_service.build_preview(
-        db,
-        org_id=current_user.org_id,
-        account_id=account_id,
-        file_name=file.filename or "unknown.csv",
-        parsed_rows=parsed_rows,
-        source_format="csv",
-    )
+    try:
+        return await import_service.build_preview(
+            db,
+            org_id=current_user.org_id,
+            account_id=account_id,
+            file_name=file.filename or "unknown.csv",
+            parsed_rows=parsed_rows,
+            source_format="csv",
+        )
+    except MissingCategoryTypeError as exc:
+        raise _missing_category_type_response(exc) from exc
 
 
 @router.post("/confirm", response_model=ImportConfirmResponse)
@@ -116,14 +136,17 @@ async def preview_ofx_import(
         parsed_rows = await parse_ofx(raw)
     except ParseError as exc:
         raise ValidationError(str(exc))
-    return await import_service.build_preview(
-        db,
-        org_id=current_user.org_id,
-        account_id=account_id,
-        file_name=file.filename or "unknown.ofx",
-        parsed_rows=parsed_rows,
-        source_format="ofx",
-    )
+    try:
+        return await import_service.build_preview(
+            db,
+            org_id=current_user.org_id,
+            account_id=account_id,
+            file_name=file.filename or "unknown.ofx",
+            parsed_rows=parsed_rows,
+            source_format="ofx",
+        )
+    except MissingCategoryTypeError as exc:
+        raise _missing_category_type_response(exc) from exc
 
 
 @router.get(

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -67,3 +67,14 @@ class CategoryDeleteResult(BaseModel):
     migrated_recurring_count: int = 0
     migrated_forecast_item_count: int = 0
     deleted_rule_count: int = 0
+
+
+class RestoreRecommendedResult(BaseModel):
+    """Result of POST /api/v1/categories/restore-recommended.
+
+    ``created_count`` is the number of brand-new system-category rows
+    inserted; existing slugs were left untouched (idempotent).
+    Category Fallback design Layer C (post-L3.10).
+    """
+
+    created_count: int

--- a/backend/app/services/exceptions.py
+++ b/backend/app/services/exceptions.py
@@ -21,3 +21,18 @@ class ConflictError(Exception):
     def __init__(self, detail: str):
         self.detail = detail
         super().__init__(detail)
+
+
+class MissingCategoryTypeError(Exception):
+    """Raised by import preflight when the org has no category of a type
+    that the parsed rows require.
+
+    Carries the sorted list of missing types ("income", "expense") so the
+    router can render a structured 400 the frontend can read mechanically.
+    Category Fallback design Layer B (post-L3.10).
+    """
+
+    def __init__(self, missing_types: list[str], message: str):
+        self.missing_types = missing_types
+        self.message = message
+        super().__init__(message)

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -11,6 +11,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
+from app.models.category import Category, CategoryType
 from app.models.settings import OrgSetting
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
 from app.schemas.import_schemas import (
@@ -26,7 +27,12 @@ from app.schemas.transaction import (
     TransferCandidate,
 )
 from app.services import transaction_service
-from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.exceptions import (
+    ConflictError,
+    MissingCategoryTypeError,
+    NotFoundError,
+    ValidationError,
+)
 from app.services.transaction_service import (
     _create_transaction_no_commit,
     _link_pair,
@@ -45,6 +51,74 @@ from app.services.category_rules_service import (
 from app.services.import_parser import ParsedRow
 
 logger = structlog.get_logger()
+
+
+async def _assert_categories_cover_row_types(
+    db: AsyncSession,
+    org_id: int,
+    parsed_rows: list[ParsedRow],
+) -> None:
+    """Raise ``MissingCategoryTypeError`` if the parsed rows include a type
+    the org has no compatible category for.
+
+    For each ``type`` value present in ``parsed_rows`` (``"expense"`` or
+    ``"income"``), the org must have at least one category whose ``type``
+    is either that exact value or ``CategoryType.BOTH``. Mirrors the
+    frontend's category dropdown filter on the import preview page so the
+    user never lands on a preview with no selectable default category.
+
+    Architect-refined Category Fallback Layer B (post-L3.10): scope the
+    requirement to what's actually in the file, not a blanket
+    "income + expense" floor. Empty ``parsed_rows`` is treated as a no-op
+    here; the upstream parser handles the "no rows" case separately.
+    """
+    present_types = {r.type for r in parsed_rows if r.type in ("expense", "income")}
+    if not present_types:
+        return
+
+    # Single SELECT, group by category type. Keeps it to one round-trip
+    # even when both types are present. ``BOTH`` covers either side.
+    type_rows = (await db.execute(
+        select(Category.type).where(Category.org_id == org_id)
+    )).all()
+    org_types = {row[0] for row in type_rows}
+
+    def has_compatible(row_type: str) -> bool:
+        if row_type == "expense":
+            return CategoryType.EXPENSE in org_types or CategoryType.BOTH in org_types
+        if row_type == "income":
+            return CategoryType.INCOME in org_types or CategoryType.BOTH in org_types
+        return True
+
+    missing = sorted(t for t in present_types if not has_compatible(t))
+    if not missing:
+        return
+
+    # Human-readable copy the frontend can surface as a fallback when it
+    # doesn't recognize ``code``. No em-dashes (user-facing copy rule).
+    if missing == ["expense"]:
+        message = (
+            "This import has expense rows but you have no expense category. "
+            "Add one to continue."
+        )
+    elif missing == ["income"]:
+        message = (
+            "This import has income rows but you have no income category. "
+            "Add one to continue."
+        )
+    else:
+        message = (
+            "This import needs income and expense categories, but your "
+            "organization is missing one of each. Add them to continue."
+        )
+
+    await logger.ainfo(
+        "import.preview.missing_category_type",
+        org_id=org_id,
+        missing_types=missing,
+    )
+
+    raise MissingCategoryTypeError(missing_types=missing, message=message)
 
 
 async def build_preview(
@@ -67,6 +141,14 @@ async def build_preview(
     if destination_account is None:
         # Match validate_account semantics: surface the same error shape.
         await transaction_service.validate_account(db, account_id, org_id)
+
+    # ── Layer B preflight: require a compatible category per row type ──
+    # Architect-refined Category Fallback design (post-L3.10): only require
+    # what the parsed rows actually need. Expense-only CSV doesn't require
+    # an income category; vice versa for income-only. Raises
+    # ``MissingCategoryTypeError`` before any duplicate / detector work so
+    # the user gets a fast, targeted 400 on the upload step.
+    await _assert_categories_cover_row_types(db, org_id, parsed_rows)
 
     # ── Batch duplicate check: single query for the CSV date range ──
     min_date = min(r.date for r in parsed_rows)

--- a/backend/app/services/org_bootstrap_service.py
+++ b/backend/app/services/org_bootstrap_service.py
@@ -136,3 +136,79 @@ async def seed_org_defaults(db: AsyncSession, *, org_id: int) -> dict[str, int]:
 
     await db.flush()
     return counts
+
+
+async def restore_recommended_categories(
+    db: AsyncSession, *, org_id: int
+) -> int:
+    """Re-run the system-categories seed for ``org_id``. Idempotent.
+
+    Skips any ``(org_id, slug)`` already present with ``is_system=True``.
+    Existing categories (system or user-created) are never modified or
+    removed. Returns the number of newly inserted Category rows so the
+    UI can render an accurate "Restored N categories" toast.
+
+    Caller (router) owns the transaction boundary and the audit row.
+    Category Fallback design Layer C (post-L3.10).
+    """
+    created = 0
+
+    existing_slugs = set(
+        (await db.scalars(
+            select(Category.slug).where(
+                Category.org_id == org_id,
+                Category.is_system.is_(True),
+            )
+        )).all()
+    )
+
+    for master_def in SYSTEM_CATEGORIES:
+        master: Category | None
+        if master_def["slug"] in existing_slugs:
+            master = await db.scalar(
+                select(Category).where(
+                    Category.org_id == org_id,
+                    Category.slug == master_def["slug"],
+                    Category.is_system.is_(True),
+                )
+            )
+        else:
+            master = Category(
+                org_id=org_id,
+                name=master_def["name"],
+                slug=master_def["slug"],
+                description=master_def["description"],
+                type=CategoryType(master_def["type"]),
+                is_system=True,
+            )
+            db.add(master)
+            created += 1
+            await db.flush()
+
+        for child_def in master_def.get("children", []):
+            if child_def["slug"] in existing_slugs:
+                continue
+            db.add(Category(
+                org_id=org_id,
+                parent_id=master.id if master is not None else None,
+                name=child_def["name"],
+                slug=child_def["slug"],
+                description=child_def["description"],
+                type=CategoryType(master_def["type"]),
+                is_system=True,
+            ))
+            created += 1
+
+    if "transfer" not in existing_slugs:
+        db.add(Category(
+            org_id=org_id,
+            name="Transfer",
+            slug="transfer",
+            description="Internal transfers between accounts",
+            type=CategoryType.BOTH,
+            is_system=True,
+        ))
+        created += 1
+
+    await db.flush()
+    return created

--- a/backend/app/services/org_bootstrap_service.py
+++ b/backend/app/services/org_bootstrap_service.py
@@ -22,6 +22,39 @@ from app.models.account import AccountType, SYSTEM_ACCOUNT_TYPES
 from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
 
 
+# Standalone system categories (no children, `type=both`) seeded
+# alongside the SYSTEM_CATEGORIES master-and-child tree. Defined once
+# here so ``seed_org_defaults`` (registration / reset) and
+# ``restore_recommended_categories`` (Layer C of the Category Fallback
+# design — re-runs the seed against an existing org) cannot drift.
+# Architect feedback on PR #297: before this list existed, ``restore``
+# only seeded ``Transfer`` even though ``seed_org_defaults`` had
+# started seeding ``Credit Card Payment`` via PR #296, leaving two
+# different definitions of "recommended categories" on main.
+STANDALONE_SYSTEM_CATEGORIES: list[dict] = [
+    {
+        "slug": "transfer",
+        "name": "Transfer",
+        "description": "Internal transfers between accounts",
+        "type": CategoryType.BOTH,
+    },
+    {
+        # Paying a credit card bill is a transfer between a payment
+        # account and a credit-card account, NOT an expense. The
+        # expense-only "Debt Repayment / Credit Cards" subcategory
+        # (under Debt Repayment in SYSTEM_CATEGORIES) is intentionally
+        # kept distinct — it tracks the COST of carrying debt
+        # (interest, fees), which is a real expense, not a transfer.
+        # PR #296 added this seed for new/reset orgs; PR #297 brings
+        # the same row to existing orgs via the Restore action.
+        "slug": "credit_card_payment",
+        "name": "Credit Card Payment",
+        "description": "Payments toward a credit-card balance (transfer)",
+        "type": CategoryType.BOTH,
+    },
+]
+
+
 async def seed_org_defaults(db: AsyncSession, *, org_id: int) -> dict[str, int]:
     """Insert system account types and categories for ``org_id``.
 
@@ -102,37 +135,20 @@ async def seed_org_defaults(db: AsyncSession, *, org_id: int) -> dict[str, int]:
             ))
             counts["categories"] += 1
 
-    # Transfer system category (CategoryType.BOTH; no children).
-    if "transfer" not in existing_cat_slugs:
-        db.add(Category(
-            org_id=org_id,
-            name="Transfer",
-            slug="transfer",
-            description="Internal transfers between accounts",
-            type=CategoryType.BOTH,
-            is_system=True,
-        ))
-        counts["categories"] += 1
-
-    # Credit Card Payment system category (CategoryType.BOTH; no
-    # children). Paying a credit card bill is a transfer between a
-    # payment account and a credit-card account, NOT an expense. This
-    # gives users a ready-made transfer-compatible category so they do
-    # not have to create one on first use. The existing expense-only
-    # "Debt Repayment / Credit Cards" subcategory under Debt Repayment
-    # is intentionally kept distinct — it tracks the cost of carrying
-    # debt (interest, fees), which is a real expense and not a
-    # transfer.
-    if "credit_card_payment" not in existing_cat_slugs:
-        db.add(Category(
-            org_id=org_id,
-            name="Credit Card Payment",
-            slug="credit_card_payment",
-            description="Payments toward a credit-card balance (transfer)",
-            type=CategoryType.BOTH,
-            is_system=True,
-        ))
-        counts["categories"] += 1
+    # Standalone system categories (Transfer, Credit Card Payment).
+    # Defined once at module level so ``restore_recommended_categories``
+    # cannot drift from this seed.
+    for spec in STANDALONE_SYSTEM_CATEGORIES:
+        if spec["slug"] not in existing_cat_slugs:
+            db.add(Category(
+                org_id=org_id,
+                name=spec["name"],
+                slug=spec["slug"],
+                description=spec["description"],
+                type=spec["type"],
+                is_system=True,
+            ))
+            counts["categories"] += 1
 
     await db.flush()
     return counts
@@ -199,16 +215,24 @@ async def restore_recommended_categories(
             ))
             created += 1
 
-    if "transfer" not in existing_slugs:
-        db.add(Category(
-            org_id=org_id,
-            name="Transfer",
-            slug="transfer",
-            description="Internal transfers between accounts",
-            type=CategoryType.BOTH,
-            is_system=True,
-        ))
-        created += 1
+    # Standalone system categories (Transfer, Credit Card Payment).
+    # Source list is ``STANDALONE_SYSTEM_CATEGORIES`` at module level so
+    # this stays in lockstep with ``seed_org_defaults``. Architect
+    # feedback on PR #297: previous version restored only Transfer and
+    # missed Credit Card Payment (which #296 added to seed_org_defaults
+    # before this PR landed), creating two different definitions of
+    # "recommended categories".
+    for spec in STANDALONE_SYSTEM_CATEGORIES:
+        if spec["slug"] not in existing_slugs:
+            db.add(Category(
+                org_id=org_id,
+                name=spec["name"],
+                slug=spec["slug"],
+                description=spec["description"],
+                type=spec["type"],
+                is_system=True,
+            ))
+            created += 1
 
     await db.flush()
     return created

--- a/backend/tests/routers/test_categories_restore_recommended.py
+++ b/backend/tests/routers/test_categories_restore_recommended.py
@@ -1,0 +1,278 @@
+"""Layer C: POST /api/v1/categories/restore-recommended.
+
+Architect-approved Category Fallback design (post-L3.10). Re-runs the
+``SYSTEM_CATEGORIES`` seed for the current org. Owner-only (gated by
+``require_org_owner``). Idempotent (skips slugs that already exist).
+Audited as ``org.categories.restored``.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, func, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.category import Category, CategoryType, SYSTEM_CATEGORIES
+from app.models.user import Organization, Role, User
+from app.routers.categories import router as categories_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, user_resolver) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(categories_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """Three users in one org: owner / admin / member. Empty categories."""
+    async with factory() as db:
+        org = Organization(name="Restore Co", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        owner = User(
+            org_id=org.id, username="owner", email="o@x.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        admin = User(
+            org_id=org.id, username="admin", email="a@x.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.ADMIN, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        member = User(
+            org_id=org.id, username="member", email="m@x.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([owner, admin, member])
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "owner_id": owner.id,
+            "admin_id": admin.id,
+            "member_id": member.id,
+        }
+
+
+def _expected_seed_row_count() -> int:
+    """Number of rows the seed should add to an empty org: masters +
+    children + the Transfer system category."""
+    total = 0
+    for m in SYSTEM_CATEGORIES:
+        total += 1 + len(m.get("children", []))
+    return total + 1  # +1 for the Transfer category
+
+
+def _user_resolver(role: Role):
+    async def resolver(factory):
+        async with factory() as db:
+            return (
+                await db.execute(select(User).where(User.role == role))
+            ).scalar_one()
+    return resolver
+
+
+@pytest.mark.asyncio
+async def test_owner_seeds_full_set_on_empty_org(session_factory) -> None:
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _user_resolver(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.post("/api/v1/categories/restore-recommended")
+    assert res.status_code == 200
+    body = res.json()
+    expected = _expected_seed_row_count()
+    assert body["created_count"] == expected
+
+    # Categories persisted with is_system=True.
+    async with session_factory() as db:
+        count = await db.scalar(
+            select(func.count()).select_from(Category).where(
+                Category.org_id == seed["org_id"],
+                Category.is_system.is_(True),
+            )
+        )
+        assert count == expected
+
+
+@pytest.mark.asyncio
+async def test_owner_second_call_is_idempotent(session_factory) -> None:
+    """Running restore twice yields the same final state and second call
+    returns ``created_count == 0``."""
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _user_resolver(Role.OWNER))
+
+    with TestClient(app) as client:
+        first = client.post("/api/v1/categories/restore-recommended")
+        second = client.post("/api/v1/categories/restore-recommended")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["created_count"] == _expected_seed_row_count()
+    assert second.json()["created_count"] == 0
+
+    async with session_factory() as db:
+        count = await db.scalar(
+            select(func.count()).select_from(Category).where(
+                Category.org_id == seed["org_id"],
+                Category.is_system.is_(True),
+            )
+        )
+        assert count == _expected_seed_row_count()
+
+
+@pytest.mark.asyncio
+async def test_owner_preserves_user_renamed_system_category(
+    session_factory,
+) -> None:
+    """If the user renamed a system slug (kept is_system=True), restore
+    leaves the row alone — it does not reset the name."""
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        db.add(Category(
+            org_id=seed["org_id"], name="My Income",
+            slug="income", is_system=True, type=CategoryType.INCOME,
+        ))
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/categories/restore-recommended")
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        row = await db.scalar(
+            select(Category).where(
+                Category.org_id == seed["org_id"],
+                Category.slug == "income",
+            )
+        )
+        assert row is not None
+        assert row.name == "My Income"  # not overwritten
+
+
+@pytest.mark.asyncio
+async def test_admin_role_forbidden(session_factory) -> None:
+    await _seed(session_factory)
+    app = _make_app(session_factory, _user_resolver(Role.ADMIN))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/categories/restore-recommended")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_member_role_forbidden(session_factory) -> None:
+    await _seed(session_factory)
+    app = _make_app(session_factory, _user_resolver(Role.MEMBER))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/categories/restore-recommended")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_owner_call_writes_audit_event(session_factory) -> None:
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _user_resolver(Role.OWNER))
+    with TestClient(app) as client:
+        client.post("/api/v1/categories/restore-recommended")
+
+    async with session_factory() as db:
+        events = (await db.execute(
+            select(AuditEvent).where(
+                AuditEvent.event_type == "org.categories.restored",
+                AuditEvent.target_org_id == seed["org_id"],
+            )
+        )).scalars().all()
+    assert len(events) == 1
+    event = events[0]
+    assert event.outcome.value == "success"
+    assert event.actor_user_id == seed["owner_id"]
+    assert event.detail is not None
+    assert event.detail["created_count"] == _expected_seed_row_count()
+
+
+@pytest.mark.asyncio
+async def test_org_isolation_does_not_touch_sibling_org(session_factory) -> None:
+    """Restoring for Org A leaves Org B's categories untouched."""
+    # Org A: empty, will run restore.
+    seed_a = await _seed(session_factory)
+    # Org B: another org with a single user-created category. The
+    # restore for Org A must not create rows under Org B.
+    async with session_factory() as db:
+        other = Organization(name="Other Co", billing_cycle_day=1)
+        db.add(other)
+        await db.flush()
+        db.add(Category(
+            org_id=other.id, name="OtherCat", slug="othercat",
+            type=CategoryType.EXPENSE, is_system=False,
+        ))
+        await db.commit()
+        other_id = other.id
+
+    app = _make_app(session_factory, _user_resolver(Role.OWNER))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/categories/restore-recommended")
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        # Org A got the full seed.
+        count_a = await db.scalar(
+            select(func.count()).select_from(Category).where(
+                Category.org_id == seed_a["org_id"],
+            )
+        )
+        assert count_a == _expected_seed_row_count()
+        # Org B is untouched.
+        count_b = await db.scalar(
+            select(func.count()).select_from(Category).where(
+                Category.org_id == other_id,
+            )
+        )
+        assert count_b == 1

--- a/backend/tests/routers/test_categories_restore_recommended.py
+++ b/backend/tests/routers/test_categories_restore_recommended.py
@@ -103,11 +103,17 @@ async def _seed(factory) -> dict:
 
 def _expected_seed_row_count() -> int:
     """Number of rows the seed should add to an empty org: masters +
-    children + the Transfer system category."""
+    children + the standalone system categories (Transfer + Credit
+    Card Payment). Source for the standalone list is
+    ``STANDALONE_SYSTEM_CATEGORIES`` in ``org_bootstrap_service`` so
+    a future addition to that list cannot silently drift this test
+    away from the production seed."""
+    from app.services.org_bootstrap_service import STANDALONE_SYSTEM_CATEGORIES
+
     total = 0
     for m in SYSTEM_CATEGORIES:
         total += 1 + len(m.get("children", []))
-    return total + 1  # +1 for the Transfer category
+    return total + len(STANDALONE_SYSTEM_CATEGORIES)
 
 
 def _user_resolver(role: Role):
@@ -140,6 +146,42 @@ async def test_owner_seeds_full_set_on_empty_org(session_factory) -> None:
             )
         )
         assert count == expected
+
+
+@pytest.mark.asyncio
+async def test_owner_restore_includes_standalone_categories(session_factory) -> None:
+    """Architect feedback on PR #297: ``restore_recommended_categories``
+    must match ``seed_org_defaults`` exactly. After PR #296 added the
+    ``credit_card_payment`` standalone category to the seed, restore
+    must include it too — otherwise new/reset orgs and existing-org
+    Restore actions produce different recommended sets.
+
+    Pin both standalone slugs explicitly so a future drift (someone
+    adds a new standalone seed but forgets restore, or vice versa)
+    fails this test loudly."""
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, _user_resolver(Role.OWNER))
+
+    with TestClient(app) as client:
+        res = client.post("/api/v1/categories/restore-recommended")
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        restored_slugs = set(
+            (await db.scalars(
+                select(Category.slug).where(
+                    Category.org_id == seed["org_id"],
+                    Category.is_system.is_(True),
+                )
+            )).all()
+        )
+    assert "transfer" in restored_slugs, (
+        "restore must seed the Transfer system category"
+    )
+    assert "credit_card_payment" in restored_slugs, (
+        "restore must seed the Credit Card Payment system category "
+        "(parity with seed_org_defaults — PR #296 added this row)"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_import_missing_category_type.py
+++ b/backend/tests/routers/test_import_missing_category_type.py
@@ -1,0 +1,185 @@
+"""Layer B wire-shape test: POST /api/v1/import/preview returns a
+structured 400 when the org is missing a category type that the parsed
+rows require.
+
+The frontend reads ``detail.code`` and ``detail.missing_types`` to render
+a deep-link to /categories. Both fields are part of the contract.
+"""
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.user import Organization, Role, User
+from app.routers.import_router import router as import_router
+from app.security import hash_password
+from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _r):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory, *, category_types: list[CategoryType]) -> dict:
+    async with factory() as db:
+        org = Organization(name="MCT", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id, username="o", email="o@x.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        atype = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True,
+        )
+        db.add_all([user, atype])
+        await db.flush()
+        acct = Account(
+            org_id=org.id, account_type_id=atype.id, name="Chk",
+            balance=Decimal("0"), currency="EUR",
+        )
+        db.add(acct)
+        for i, ct in enumerate(category_types):
+            db.add(Category(
+                org_id=org.id, name=f"C{i}", slug=f"c_{ct.value}_{i}",
+                type=ct, is_system=False,
+            ))
+        await db.commit()
+        return {"org_id": org.id, "account_id": acct.id}
+
+
+def _make_app(factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        from sqlalchemy import select
+        async with factory() as db:
+            return (
+                await db.execute(select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    @app.exception_handler(NotFoundError)
+    async def _nfe(request, exc):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+
+    @app.exception_handler(ValidationError)
+    async def _vle(request, exc):
+        return JSONResponse(status_code=400, content={"detail": exc.detail})
+
+    @app.exception_handler(ConflictError)
+    async def _cfe(request, exc):
+        return JSONResponse(status_code=409, content={"detail": exc.detail})
+
+    app.include_router(import_router)
+    return app
+
+
+# Minimal valid ING-style CSV with a single expense row.
+EXPENSE_CSV = (
+    "Date;Name / Description;Account;Counterparty;Code;Debit/credit;"
+    "Amount (EUR);Transaction type;Notifications\n"
+    "20260510;Albert Heijn;NL01TEST;NL02OTHER;BA;Debit;12,50;Payment;"
+    "Groceries\n"
+)
+INCOME_CSV = (
+    "Date;Name / Description;Account;Counterparty;Code;Debit/credit;"
+    "Amount (EUR);Transaction type;Notifications\n"
+    "20260510;Salary;NL01TEST;NL02OTHER;BA;Credit;2500,00;Online Banking;"
+    "Salary\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_expense_csv_missing_expense_category_returns_structured_400(
+    session_factory,
+) -> None:
+    seed = await _seed(session_factory, category_types=[CategoryType.INCOME])
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/import/preview",
+            files={"file": ("t.csv", io.BytesIO(EXPENSE_CSV.encode()), "text/csv")},
+            data={"account_id": str(seed["account_id"])},
+        )
+    assert res.status_code == 400, res.text
+    detail = res.json()["detail"]
+    assert detail["code"] == "missing_category_type"
+    assert detail["missing_types"] == ["expense"]
+    assert isinstance(detail["message"], str)
+    assert detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_income_csv_missing_income_category_returns_structured_400(
+    session_factory,
+) -> None:
+    seed = await _seed(session_factory, category_types=[CategoryType.EXPENSE])
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/import/preview",
+            files={"file": ("t.csv", io.BytesIO(INCOME_CSV.encode()), "text/csv")},
+            data={"account_id": str(seed["account_id"])},
+        )
+    assert res.status_code == 400, res.text
+    detail = res.json()["detail"]
+    assert detail["code"] == "missing_category_type"
+    assert detail["missing_types"] == ["income"]
+
+
+@pytest.mark.asyncio
+async def test_csv_with_both_typed_category_passes(session_factory) -> None:
+    """A single ``BOTH`` category satisfies the preflight for expense rows."""
+    seed = await _seed(session_factory, category_types=[CategoryType.BOTH])
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/import/preview",
+            files={"file": ("t.csv", io.BytesIO(EXPENSE_CSV.encode()), "text/csv")},
+            data={"account_id": str(seed["account_id"])},
+        )
+    assert res.status_code == 200, res.text

--- a/backend/tests/routers/test_import_ofx.py
+++ b/backend/tests/routers/test_import_ofx.py
@@ -97,7 +97,15 @@ async def _seed(session_factory) -> dict:
             org_id=org.id, name="Groceries", slug="groceries",
             is_system=True, type=CategoryType.EXPENSE,
         )
-        db.add_all([user, atype, groceries])
+        # Layer B preflight (Category Fallback design, post-L3.10) needs
+        # an income-compatible category because the rabobank/ING fixtures
+        # contain salary rows. Without it, the preview returns a
+        # structured 400 before the OFX-specific assertions run.
+        income = Category(
+            org_id=org.id, name="Salary", slug="salary",
+            is_system=True, type=CategoryType.INCOME,
+        )
+        db.add_all([user, atype, groceries, income])
         await db.flush()
         acct = Account(
             org_id=org.id, account_type_id=atype.id, name="Checking",

--- a/backend/tests/services/test_import_preview_category_preflight.py
+++ b/backend/tests/services/test_import_preview_category_preflight.py
@@ -1,0 +1,239 @@
+"""Layer B preflight: per-row-type category requirement at preview time.
+
+Architect-refined Category Fallback design (post-L3.10). When a CSV /
+OFX parse yields ``type="expense"`` rows the org must have at least one
+EXPENSE-or-BOTH category. Same shape for ``income``. ``BOTH`` covers
+either side. The exception carries a structured ``missing_types`` list
+the router maps to a 400 with code ``missing_category_type``.
+"""
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.category import Category, CategoryType
+from app.models.user import Organization
+from app.services import import_service
+from app.services.exceptions import MissingCategoryTypeError
+from app.services.import_parser import ParsedRow
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _r):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_org(
+    db: AsyncSession, *, category_types: list[CategoryType] | None = None,
+) -> dict:
+    """Seed an org + checking account, plus a category of each requested type.
+
+    ``category_types=None`` means seed NO categories (the empty-org case).
+    """
+    org = Organization(name="Test", billing_cycle_day=1)
+    db.add(org)
+    await db.flush()
+
+    atype = AccountType(
+        org_id=org.id, name="Checking", slug="checking", is_system=True,
+    )
+    db.add(atype)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, account_type_id=atype.id, name="Checking",
+        balance=Decimal("0"),
+    )
+    db.add(acct)
+
+    for i, ct in enumerate(category_types or []):
+        slug = f"cat_{ct.value}_{i}"
+        db.add(Category(
+            org_id=org.id, name=slug.title(), slug=slug,
+            type=ct, is_system=False,
+        ))
+    await db.commit()
+    return {"org_id": org.id, "account_id": acct.id}
+
+
+def _row(row_num: int, *, type: str) -> ParsedRow:
+    return ParsedRow(
+        row_number=row_num,
+        date=datetime.date(2026, 5, 10),
+        description=f"Row {row_num}",
+        amount=Decimal("10.00"),
+        type=type,
+        counterparty=None,
+        transaction_type=None,
+    )
+
+
+# ── Happy paths: required type present ────────────────────────────────────
+
+
+async def test_expense_rows_with_expense_category_passes(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session, category_types=[CategoryType.EXPENSE])
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv", parsed_rows=[_row(1, type="expense")],
+    )
+    assert result.total_rows == 1
+
+
+async def test_expense_rows_with_both_category_passes(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session, category_types=[CategoryType.BOTH])
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv", parsed_rows=[_row(1, type="expense")],
+    )
+    assert result.total_rows == 1
+
+
+async def test_income_rows_with_income_category_passes(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session, category_types=[CategoryType.INCOME])
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv", parsed_rows=[_row(1, type="income")],
+    )
+    assert result.total_rows == 1
+
+
+async def test_mixed_rows_with_both_specific_types_passes(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(
+        db_session,
+        category_types=[CategoryType.EXPENSE, CategoryType.INCOME],
+    )
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv",
+        parsed_rows=[_row(1, type="expense"), _row(2, type="income")],
+    )
+    assert result.total_rows == 2
+
+
+async def test_mixed_rows_with_only_both_category_passes(
+    db_session: AsyncSession,
+) -> None:
+    """A single BOTH-typed category satisfies both row types."""
+    seed = await _seed_org(db_session, category_types=[CategoryType.BOTH])
+    result = await import_service.build_preview(
+        db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+        file_name="t.csv",
+        parsed_rows=[_row(1, type="expense"), _row(2, type="income")],
+    )
+    assert result.total_rows == 2
+
+
+# ── Sad paths: required type missing ──────────────────────────────────────
+
+
+async def test_expense_rows_with_only_income_category_raises(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session, category_types=[CategoryType.INCOME])
+    with pytest.raises(MissingCategoryTypeError) as exc:
+        await import_service.build_preview(
+            db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+            file_name="t.csv", parsed_rows=[_row(1, type="expense")],
+        )
+    assert exc.value.missing_types == ["expense"]
+
+
+async def test_income_rows_with_only_expense_category_raises(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session, category_types=[CategoryType.EXPENSE])
+    with pytest.raises(MissingCategoryTypeError) as exc:
+        await import_service.build_preview(
+            db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+            file_name="t.csv", parsed_rows=[_row(1, type="income")],
+        )
+    assert exc.value.missing_types == ["income"]
+
+
+async def test_mixed_rows_missing_income_raises_for_income_only(
+    db_session: AsyncSession,
+) -> None:
+    """Mixed rows where the org has expense but no income flag only income."""
+    seed = await _seed_org(db_session, category_types=[CategoryType.EXPENSE])
+    with pytest.raises(MissingCategoryTypeError) as exc:
+        await import_service.build_preview(
+            db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+            file_name="t.csv",
+            parsed_rows=[_row(1, type="expense"), _row(2, type="income")],
+        )
+    assert exc.value.missing_types == ["income"]
+
+
+async def test_mixed_rows_with_no_categories_raises_for_both(
+    db_session: AsyncSession,
+) -> None:
+    seed = await _seed_org(db_session, category_types=[])
+    with pytest.raises(MissingCategoryTypeError) as exc:
+        await import_service.build_preview(
+            db_session, org_id=seed["org_id"], account_id=seed["account_id"],
+            file_name="t.csv",
+            parsed_rows=[_row(1, type="expense"), _row(2, type="income")],
+        )
+    assert exc.value.missing_types == ["expense", "income"]
+    # Message is non-empty and contains a hint about what's missing.
+    # (Frontend reads ``code``/``missing_types``; ``message`` is fallback.)
+    assert "income" in exc.value.message.lower()
+    assert "expense" in exc.value.message.lower()
+
+
+async def test_expense_rows_with_other_org_category_raises(
+    db_session: AsyncSession,
+) -> None:
+    """Org-scoping: a category on a sibling org doesn't satisfy our check."""
+    # Org A: has the row, no categories.
+    seed_a = await _seed_org(db_session, category_types=[])
+    # Org B: has the expense category. Should NOT count for Org A.
+    other_org = Organization(name="Other", billing_cycle_day=1)
+    db_session.add(other_org)
+    await db_session.flush()
+    db_session.add(Category(
+        org_id=other_org.id, name="Other Expense", slug="other_exp",
+        type=CategoryType.EXPENSE, is_system=False,
+    ))
+    await db_session.commit()
+
+    with pytest.raises(MissingCategoryTypeError) as exc:
+        await import_service.build_preview(
+            db_session, org_id=seed_a["org_id"], account_id=seed_a["account_id"],
+            file_name="t.csv", parsed_rows=[_row(1, type="expense")],
+        )
+    assert exc.value.missing_types == ["expense"]

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -99,6 +99,14 @@ export default function CategoriesPage() {
   const [showAddMasterModal, setShowAddMasterModal] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
+  // Restore recommended categories (Layer C of the post-L3.10 fallback
+  // design). Owner-only; backend enforces with require_org_owner.
+  // ``restoreSuccess`` carries the count for the success banner.
+  const [showRestoreConfirm, setShowRestoreConfirm] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+  const [restoreSuccess, setRestoreSuccess] = useState<number | null>(null);
+  const isOrgOwner = user?.role === "owner";
+
   // Refresh banner state for the AppShell-level "transaction added" event.
   // Adding a transaction can change `transaction_count` on any category, so
   // the categories list must reload when the global event fires. Mirrors
@@ -275,6 +283,25 @@ export default function CategoriesPage() {
     } catch (err) { setError(extractErrorMessage(err)); }
   }
 
+  async function handleRestoreRecommended() {
+    setShowRestoreConfirm(false);
+    setRestoring(true);
+    setError("");
+    setRestoreSuccess(null);
+    try {
+      const result = await apiFetch<{ created_count: number }>(
+        "/api/v1/categories/restore-recommended",
+        { method: "POST" },
+      );
+      setRestoreSuccess(result?.created_count ?? 0);
+      await reload();
+    } catch (err) {
+      setError(extractErrorMessage(err, "Failed to restore recommended categories"));
+    } finally {
+      setRestoring(false);
+    }
+  }
+
   // -- C2b drag handlers ----------------------------------------------------
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const data = event.active.data.current as
@@ -399,6 +426,17 @@ export default function CategoriesPage() {
               />
             )}
           </span>
+          {isOrgOwner && (
+            <button
+              type="button"
+              onClick={() => setShowRestoreConfirm(true)}
+              disabled={restoring}
+              className={`${btnSecondary} min-h-[44px] sm:min-h-0`}
+              data-testid="restore-recommended-categories"
+            >
+              {restoring ? "Restoring..." : "Restore recommended"}
+            </button>
+          )}
           <span className="inline-flex items-center gap-1">
             <button
               onClick={() => setShowAddMasterModal(true)}
@@ -416,6 +454,27 @@ export default function CategoriesPage() {
       </div>
 
       {error && <div className={`mb-6 ${errorCls}`}>{error}</div>}
+
+      {restoreSuccess !== null && (
+        <div
+          className="mb-6 rounded-md border border-success/30 bg-success/10 p-4 text-sm text-success"
+          role="status"
+          data-testid="restore-recommended-success"
+        >
+          {restoreSuccess === 0
+            ? "All recommended categories were already in place. Nothing added."
+            : `Restored ${restoreSuccess} recommended categor${restoreSuccess === 1 ? "y" : "ies"}.`}
+        </div>
+      )}
+
+      <ConfirmModal
+        open={showRestoreConfirm}
+        title="Restore recommended categories?"
+        message="This adds the starter set of recommended categories for this organization. Existing categories are not modified or removed."
+        confirmLabel="Restore"
+        onConfirm={() => { void handleRestoreRecommended(); }}
+        onCancel={() => setShowRestoreConfirm(false)}
+      />
 
       {refreshError && (
         <div

--- a/frontend/app/import/page.tsx
+++ b/frontend/app/import/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Fragment, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
-import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { apiFetch, ApiResponseError, extractErrorMessage } from "@/lib/api";
 import AppShell from "@/components/AppShell";
 import CategorySelect from "@/components/ui/CategorySelect";
 import Spinner from "@/components/ui/Spinner";
@@ -157,6 +157,11 @@ function ImportPageContent() {
   // ── Step state ───────────────────────────────────────────────────────────
   const [step, setStep] = useState<Step>("upload");
   const [errorMsg, setErrorMsg] = useState("");
+  // Layer B preflight: when the upload returns
+  // ``detail.code === "missing_category_type"`` we render a targeted
+  // empty-state with a deep link to /categories instead of a plain banner.
+  // Cleared on every new upload attempt and when the user navigates back.
+  const [missingTypes, setMissingTypes] = useState<string[] | null>(null);
   const [loading, setLoading] = useState(false);
 
   // Upload step
@@ -193,6 +198,7 @@ function ImportPageContent() {
   const handleUpload = useCallback(async () => {
     if (!file || accountId === "") return;
     setErrorMsg("");
+    setMissingTypes(null);
     setLoading(true);
 
     const formData = new FormData();
@@ -240,7 +246,24 @@ function ImportPageContent() {
 
       setStep("preview");
     } catch (err) {
-      setErrorMsg(extractErrorMessage(err, "Failed to parse file"));
+      // Layer B: structured 400 with code=missing_category_type. The
+      // backend's payload lists exactly which types are missing
+      // (expense, income, or both) so the UI can render a deep link
+      // to /categories without string-matching the message.
+      if (
+        err instanceof ApiResponseError &&
+        err.code === "missing_category_type" &&
+        err.detail &&
+        typeof err.detail === "object" &&
+        Array.isArray((err.detail as { missing_types?: unknown }).missing_types)
+      ) {
+        const types = (err.detail as { missing_types: unknown[] }).missing_types
+          .filter((t): t is string => typeof t === "string");
+        setMissingTypes(types);
+        setErrorMsg("");
+      } else {
+        setErrorMsg(extractErrorMessage(err, "Failed to parse file"));
+      }
     } finally {
       setLoading(false);
     }
@@ -333,6 +356,33 @@ function ImportPageContent() {
       </div>
 
       {errorMsg && <div className={errorCls}>{errorMsg}</div>}
+
+      {missingTypes && missingTypes.length > 0 && (
+        <div
+          className={`${card} p-6`}
+          role="alert"
+          data-testid="missing-category-type-error"
+        >
+          <p className="font-medium text-text-primary">
+            {missingTypes.length === 2
+              ? "Add an income and an expense category to continue."
+              : missingTypes[0] === "expense"
+                ? "This import has expense rows but you have no expense category."
+                : "This import has income rows but you have no income category."}
+          </p>
+          <p className="mt-2 text-sm text-text-secondary">
+            Categories are required so each imported row can land somewhere
+            meaningful. You can restore the starter set from the Categories
+            page, or add your own.
+          </p>
+          <Link
+            href="/categories"
+            className={btnPrimary + " mt-4 inline-flex items-center sm:min-h-0"}
+          >
+            Go to Categories
+          </Link>
+        </div>
+      )}
 
       {categories === undefined && (
         <div className={card}>

--- a/frontend/tests/app/categories-restore-recommended.test.tsx
+++ b/frontend/tests/app/categories-restore-recommended.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import CategoriesPage from "@/app/categories/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/categories",
+}));
+
+const BASE_USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const EMPTY_CATEGORIES_RESPONSE: unknown[] = [];
+
+function setAuth(role: "owner" | "admin" | "member") {
+  vi.mocked(useAuth).mockReturnValue({
+    user: { ...BASE_USER, role } as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  } as never);
+}
+
+describe("CategoriesPage Restore recommended button", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("shows the button for org owners", async () => {
+    setAuth("owner");
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/categories") return Promise.resolve(EMPTY_CATEGORIES_RESPONSE);
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<CategoriesPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("restore-recommended-categories")).toBeInTheDocument();
+    });
+  });
+
+  it("hides the button for non-owners", async () => {
+    setAuth("admin");
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/categories") return Promise.resolve(EMPTY_CATEGORIES_RESPONSE);
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<CategoriesPage />);
+    // Wait for the page to settle past its loading spinner. The Edit
+    // toggle is unconditional, so its presence signals the header rendered.
+    await waitFor(() => {
+      expect(screen.getByTestId("categories-edit-toggle")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("restore-recommended-categories"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("posts to the endpoint and surfaces the created count on success", async () => {
+    setAuth("owner");
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockImplementation(((url: string, init?: RequestInit) => {
+      if (url === "/api/v1/categories" && (!init || init.method === undefined)) {
+        return Promise.resolve(EMPTY_CATEGORIES_RESPONSE);
+      }
+      if (
+        url === "/api/v1/categories/restore-recommended"
+        && init?.method === "POST"
+      ) {
+        return Promise.resolve({ created_count: 42 });
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<CategoriesPage />);
+    const btn = await screen.findByTestId("restore-recommended-categories");
+    fireEvent.click(btn);
+
+    // ConfirmModal renders the "Restore" confirm button.
+    const confirmBtn = await screen.findByRole("button", { name: /^restore$/i });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const successNode = screen.getByTestId("restore-recommended-success");
+      expect(successNode.textContent).toMatch(/restored 42/i);
+    });
+
+    // The endpoint was called.
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/v1/categories/restore-recommended",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/frontend/tests/app/import-missing-category-type.test.tsx
+++ b/frontend/tests/app/import-missing-category-type.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ImportPage from "@/app/import/page";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+
+// Mock Next.js navigation hooks (same shape as import-page.test.tsx).
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const ACCOUNT = {
+  id: 1,
+  name: "Checking",
+  account_type_id: 1,
+  account_type_name: "Bank",
+  account_type_slug: "bank",
+  balance: 100,
+  currency: "EUR",
+  is_active: true,
+  close_day: null,
+  is_default: true,
+};
+
+// At least one category so the upload form (not the empty-state CTA)
+// renders. Without categories the page short-circuits to the L3.10
+// Layer A empty-state — we want to test the Layer B preflight error
+// reaching us from the backend.
+const CATEGORY_INC = {
+  id: 6,
+  name: "Salary",
+  type: "income" as const,
+  parent_id: null,
+  parent_name: null,
+  description: null,
+  slug: "salary",
+  is_system: false,
+  transaction_count: 0,
+};
+
+describe("ImportPage Layer B preflight error", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("renders targeted empty-state when backend returns missing_category_type for expense", async () => {
+    const detailPayload = {
+      code: "missing_category_type",
+      missing_types: ["expense"],
+      message:
+        "This import has expense rows but you have no expense category. Add one to continue.",
+    };
+
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([ACCOUNT]);
+      if (url === "/api/v1/categories") return Promise.resolve([CATEGORY_INC]);
+      if (url === "/api/v1/import/preview") {
+        return Promise.reject(
+          new ApiResponseError(
+            400,
+            detailPayload.message,
+            "missing_category_type",
+            detailPayload,
+          ),
+        );
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<ImportPage />);
+    const uploadButton = await screen.findByRole("button", {
+      name: /upload & preview/i,
+    });
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["x"], "t.csv", { type: "text/csv" })] },
+    });
+    fireEvent.click(uploadButton);
+
+    const node = await screen.findByTestId("missing-category-type-error");
+    expect(node).toBeInTheDocument();
+    // Targeted copy mentions the missing type.
+    expect(node.textContent?.toLowerCase()).toContain("expense");
+    // Deep-link to /categories is present.
+    const link = screen.getByRole("link", { name: /go to categories/i });
+    expect(link.getAttribute("href")).toBe("/categories");
+  });
+
+  it("falls back to generic banner when error is unstructured", async () => {
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/accounts") return Promise.resolve([ACCOUNT]);
+      if (url === "/api/v1/categories") return Promise.resolve([CATEGORY_INC]);
+      if (url === "/api/v1/import/preview") {
+        return Promise.reject(new Error("network down"));
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<ImportPage />);
+    const uploadButton = await screen.findByRole("button", {
+      name: /upload & preview/i,
+    });
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["x"], "t.csv", { type: "text/csv" })] },
+    });
+    fireEvent.click(uploadButton);
+
+    await screen.findByText(/network down/i);
+    // The structured empty-state must NOT appear.
+    expect(
+      screen.queryByTestId("missing-category-type-error"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes Layers B and C of the architect-approved post-L3.10 Category Fallback design (`~/.claude/projects/-Users-fjorge-src-pfv/memory/project_category_fallback_design.md`). Layer A shipped via PR #108; Layer D (category slug aliasing) deferred to P-IL post-launch.

**Layer B (Type-specific category requirement at preview time).** `import_service.build_preview` now runs a preflight check before duplicate detection: it inspects the set of `type` values in the parsed rows and requires `count(categories WHERE type IN (row_type, 'both')) >= 1` for each type present. If a required type is missing, the service raises `MissingCategoryTypeError(missing_types=[...])`, which the router translates into a structured `HTTP 400` with `detail={"code": "missing_category_type", "missing_types": [...], "message": "..."}`. The import page reads `code` + `missing_types` mechanically and renders a targeted empty-state with a deep link to `/categories` instead of a generic banner. Same handling on the OFX preview path.

**Layer C (Restore recommended categories action).** New owner-only endpoint `POST /api/v1/categories/restore-recommended` re-runs the `SYSTEM_CATEGORIES` seed for the current org. Idempotent: skips slugs already present as `is_system=True`; does NOT modify or remove existing rows (user renames are preserved). Audited as `org.categories.restored` with `{created_count}` in the detail. Gated by `require_org_owner` (same Danger Zone gate the data-reset and org-rename endpoints use). A "Restore recommended" button on `/categories` is visible to owners only; clicking opens a `ConfirmModal`, and the success banner shows the created count.

**Layer D deferred.** Category slug aliasing belongs to the P-IL (Localized Import Intelligence) track; this PR does not touch `merchant_dictionary` lookups or add an `alias_slug` field.

## Scope decision

Implement both. Both layers are tightly scoped, touch disjoint code paths (`import_service.build_preview` vs `org_bootstrap_service` + categories router), and the spec is locked. No design ambiguity, no hidden risk, no overlap with concurrent work. Total ~415 LoC including tests. The dedicated `MissingCategoryTypeError` subclass keeps existing `ValidationError.detail.startswith(...)` consumers untouched.

## Changed files

Backend:
- `app/services/exceptions.py` -- new `MissingCategoryTypeError`.
- `app/services/import_service.py` -- new `_assert_categories_cover_row_types` preflight helper, called from `build_preview`.
- `app/services/org_bootstrap_service.py` -- new `restore_recommended_categories` (categories-only re-seed; does not touch account types).
- `app/routers/import_router.py` -- catches `MissingCategoryTypeError` in CSV and OFX preview routes, maps to structured 400 via `_missing_category_type_response`.
- `app/routers/categories.py` -- new `POST /restore-recommended` endpoint (`require_org_owner`, writes `org.categories.restored` audit event).
- `app/schemas/category.py` -- new `RestoreRecommendedResult`.

Frontend:
- `app/import/page.tsx` -- new structured-error branch in `handleUpload`; renders targeted empty-state with deep link to `/categories` when `detail.code === "missing_category_type"`.
- `app/categories/page.tsx` -- owner-only "Restore recommended" button, confirm modal, success banner with created count.

Tests:
- `backend/tests/services/test_import_preview_category_preflight.py` -- 10 unit tests (all type permutations, BOTH coverage, org isolation).
- `backend/tests/routers/test_import_missing_category_type.py` -- 3 router tests pinning the wire shape (CSV preview path, expense-only and income-only payloads, BOTH-category happy path).
- `backend/tests/routers/test_categories_restore_recommended.py` -- 7 router tests (owner full seed, idempotent second call, preserves user-renamed slugs, admin/member 403, audit event written, sibling org isolation).
- `backend/tests/routers/test_import_ofx.py` -- seed fix: the rabobank/ING OFX fixtures contain salary rows, so the seed now includes an INCOME `Salary` category to satisfy the new preflight.
- `frontend/tests/app/import-missing-category-type.test.tsx` -- structured error renders empty-state with link; unstructured errors fall back to the generic banner.
- `frontend/tests/app/categories-restore-recommended.test.tsx` -- owner sees button, non-owner does not, confirm flow posts to the endpoint and surfaces the count.

## Tests run (in isolated `team-cfbc` compose project)

- New backend tests: 20 passed (10 service-level + 3 router wire-shape + 7 restore-recommended).
- Broad backend sweep (`tests/routers/` + `tests/services/`): 957 passed, 1 skipped.
- New frontend tests: 5 passed.
- Categories + import frontend regression sweep: 79 passed across 7 files.
- `tsc --noEmit`: clean.

## Known risks

- The `MissingCategoryTypeError` 400 is mechanically read by `app/import/page.tsx`. Any future tweak to the `detail` shape (renaming `code` or `missing_types`) must update both ends together; the wire shape is locked by `test_import_missing_category_type.py`.
- Existing OFX router tests had to add an INCOME seed category, which is a behavior change (the preflight is the source of truth). Other test suites that exercise `build_preview` already happened to seed a compatible category, so no further test churn was needed; that was verified by the broad sweep.
- The Restore endpoint commits inside the router handler (audit row in the same txn). The seed itself is idempotent, but if the audit insert ever fails the whole restore rolls back. That matches the org-rename / org-reset audit pattern already in `add_audit_event_to_session`.
- The button label "Restore recommended" appears alongside "+ Add Master" in the header. Owners only. Users who deleted system categories deliberately will see this and may rerun it; safe because idempotent and audited.

Spec memo flag: none. The architect's Layer B refinement (require by type actually present, not blanket income + expense) was followed exactly. Spec file in memory needs a status update once this PR lands.