### PR TITLE
feat(auth): retry budget + singleflight gap fix + /me confirm-before-logout

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,10 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 const API_FETCH_TIMEOUT_MS = 10_000;
+// Retry budget for transient outcomes on POST /api/v1/auth/refresh. Two
+// retries with 250ms exponential backoff (250ms, 500ms). Terminal 401/403
+// is NOT retried -- those mean the refresh cookie is dead, not in transit.
+const REFRESH_TRANSIENT_RETRIES = 2;
+const REFRESH_BACKOFF_BASE_MS = 250;
 
 let accessToken: string | null = null;
 // Discriminated result so callers can distinguish terminal auth death
@@ -10,6 +15,18 @@ type RefreshResult =
   | { ok: false; kind: "transient"; error: Error; status?: number };
 
 let refreshPromise: Promise<RefreshResult> | null = null;
+// Count of awaiters currently holding the in-flight refreshPromise. Used
+// to close the singleflight microtask gap: the original code cleared
+// refreshPromise inside .finally(), which runs BEFORE awaiting callers
+// resume in the next microtask, so a second 401-driven apiFetch could
+// see null and fire a duplicate /refresh. We now keep refreshPromise
+// non-null until every awaiter has consumed it (count returns to 0).
+let refreshAwaiters = 0;
+// /me probe singleflight. After a terminal /refresh, we run one
+// confirmation probe against /api/v1/auth/me to defend against the
+// ambiguous-401 false-logout class. Multiple awaiters of the same
+// terminal refresh share the same probe.
+let mePromise: Promise<boolean> | null = null;
 
 export function setAccessToken(token: string | null) {
   accessToken = token;
@@ -77,7 +94,7 @@ async function fetchWithTimeout(
   }
 }
 
-async function refreshAccessToken(): Promise<RefreshResult> {
+async function refreshAccessTokenOnce(): Promise<RefreshResult> {
   let res: Response;
   try {
     res = await fetchWithTimeout(`${API_URL}/api/v1/auth/refresh`, {
@@ -130,6 +147,43 @@ async function refreshAccessToken(): Promise<RefreshResult> {
   return { ok: true, accessToken: data.access_token };
 }
 
+// Retry budget wrapper. Re-runs refreshAccessTokenOnce up to
+// REFRESH_TRANSIENT_RETRIES times when the outcome is transient
+// (network/timeout/5xx/JSON parse/protocol). Terminal 401/403 short-
+// circuits immediately -- those mean the refresh cookie is dead.
+async function refreshAccessToken(): Promise<RefreshResult> {
+  let last: RefreshResult = await refreshAccessTokenOnce();
+  for (let attempt = 1; attempt <= REFRESH_TRANSIENT_RETRIES; attempt++) {
+    if (last.ok || last.kind === "terminal") return last;
+    // Exponential backoff: 250ms, 500ms.
+    const delay = REFRESH_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+    await new Promise<void>((resolve) => setTimeout(resolve, delay));
+    last = await refreshAccessTokenOnce();
+  }
+  return last;
+}
+
+// One-shot /api/v1/auth/me probe used to disambiguate a terminal /refresh
+// response. If the access token is still in memory and /me returns 200,
+// the session is alive (the /refresh 401 was a backend race / partial
+// outage), so we must NOT dispatch auth:unauthenticated. If /me also
+// fails terminally we proceed with logout. Anything else (network/timeout
+// /5xx) is treated as "cannot confirm" => preserve current behavior and
+// proceed with logout. This is safer than leaving the user wedged.
+async function probeAuthMeAlive(): Promise<boolean> {
+  if (!accessToken) return false;
+  try {
+    const res = await fetchWithTimeout(`${API_URL}/api/v1/auth/me`, {
+      method: "GET",
+      credentials: "include",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    return res.status === 200;
+  } catch {
+    return false;
+  }
+}
+
 export async function apiFetch<T>(
   path: string,
   options: ApiFetchOptions = {}
@@ -164,14 +218,33 @@ export async function apiFetch<T>(
   );
 
   // On 401, attempt one silent refresh (even without a current token --
-  // the refresh cookie may still be valid)
-  if (res.status === 401) {
+  // the refresh cookie may still be valid). Credential-check endpoints
+  // skip the entire silent-refresh flow: a 401 on /login or /mfa/verify
+  // means bad input from the caller, not an expired session, so we just
+  // surface the 401 below without touching refresh/probe/event.
+  const isCredCheck =
+    path.startsWith("/api/v1/auth/login") ||
+    path.startsWith("/api/v1/auth/mfa/verify");
+  if (res.status === 401 && !isCredCheck) {
+    // Singleflight: every concurrent 401-driven caller shares one
+    // refreshPromise. We increment refreshAwaiters BEFORE awaiting and
+    // only clear refreshPromise once the last awaiter has consumed it.
+    // This closes the microtask gap where the old `.finally(null)` ran
+    // before queued awaiters resumed, leaking duplicate /refresh calls.
     if (!refreshPromise) {
-      refreshPromise = refreshAccessToken().finally(() => {
-        refreshPromise = null;
-      });
+      refreshPromise = refreshAccessToken();
     }
-    const refreshResult = await refreshPromise;
+    const sharedPromise = refreshPromise;
+    refreshAwaiters++;
+    let refreshResult: RefreshResult;
+    try {
+      refreshResult = await sharedPromise;
+    } finally {
+      refreshAwaiters--;
+      if (refreshAwaiters === 0 && refreshPromise === sharedPromise) {
+        refreshPromise = null;
+      }
+    }
 
     if (refreshResult.ok) {
       headers.set("Authorization", `Bearer ${refreshResult.accessToken}`);
@@ -186,20 +259,38 @@ export async function apiFetch<T>(
       );
       // Retry attempted; fall through to normal !res.ok handling below.
     } else if (refreshResult.kind === "terminal") {
-      // True auth death: refresh cookie invalid/expired. Clear in-memory
-      // token and notify AuthProvider so AppShell can redirect to /login.
-      // Skip for credential-check endpoints where 401 means bad input,
-      // not an expired session.
-      const isCredCheck =
-        path.startsWith("/api/v1/auth/login") ||
-        path.startsWith("/api/v1/auth/mfa/verify");
-      if (!isCredCheck) {
-        accessToken = null;
-        if (typeof window !== "undefined") {
-          window.dispatchEvent(new Event("auth:unauthenticated"));
+      // Ambiguous-401 defense: before dispatching auth:unauthenticated,
+      // probe /api/v1/auth/me once. If it returns 200 the access token
+      // is still valid and the /refresh 401 was a backend race or
+      // partial outage, NOT auth death. In that case we leave the
+      // session intact and let the caller see the original 401 so SWR
+      // can run its normal retry. All concurrent callers share one
+      // probe via mePromise singleflight.
+      if (!mePromise) {
+        mePromise = probeAuthMeAlive().finally(() => {
+          // /me probe completes once per terminal-refresh batch; clear
+          // immediately so the NEXT terminal /refresh re-probes fresh.
+          mePromise = null;
+        });
+      }
+      const sessionAlive = await mePromise;
+      if (!sessionAlive) {
+        // True auth death. Clear in-memory token and notify
+        // AuthProvider so AppShell can redirect the user to /login.
+        // Dispatch is gated on accessToken !== null so a herd of
+        // concurrent 401 callers only emits one event: whichever
+        // awaiter clears the token first wins; subsequent awaiters
+        // observe accessToken === null and skip the duplicate event.
+        if (accessToken !== null) {
+          accessToken = null;
+          if (typeof window !== "undefined") {
+            window.dispatchEvent(new Event("auth:unauthenticated"));
+          }
         }
       }
       // Fall through: caller sees the original 401 ApiResponseError.
+      // When sessionAlive is true, the session stays intact and SWR
+      // can retry through its normal path.
     } else {
       // refreshResult.kind === "transient": refresh cookie may still be
       // valid; do NOT clear auth state. Throw a recoverable error so SWR

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -212,11 +212,14 @@ describe("apiFetch", () => {
   // with code "refresh_transient" so callers / SWR can retry without the
   // user being kicked back to /login.
 
-  it("primary 401 + refresh 401 dispatches auth:unauthenticated and clears token (terminal)", async () => {
+  it("primary 401 + refresh 401 + /me 401 dispatches auth:unauthenticated and clears token (terminal)", async () => {
+    // Team F 2026-05-17: terminal /refresh now triggers a /me probe before
+    // dispatching auth:unauthenticated. Both must fail for true auth death.
     setAccessToken("stale-token");
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))   // primary
-      .mockResolvedValueOnce(jsonResponse({ detail: "invalid_refresh" }, { status: 401 })); // refresh
+      .mockResolvedValueOnce(jsonResponse({ detail: "invalid_refresh" }, { status: 401 })) // refresh terminal
+      .mockResolvedValueOnce(jsonResponse({ detail: "invalid_token" }, { status: 401 })); // /me confirms
 
     await expect(apiFetch("/api/v1/protected")).rejects.toMatchObject({
       name: "ApiResponseError",
@@ -229,13 +232,60 @@ describe("apiFetch", () => {
     );
   });
 
-  it("primary 401 + refresh timeout does NOT clear token, does NOT dispatch, throws recoverable", async () => {
+  it("primary 401 + refresh 401 + /me 200 does NOT dispatch and preserves token (ambiguous-401 defense)", async () => {
+    // Team F 2026-05-17: this closes the ambiguous-401 false-logout class.
+    // When /refresh terminally 401s but the access token is still valid
+    // (backend race / partial outage), /me confirms the session is alive
+    // and we leave the user signed in. The original 401 falls through so
+    // SWR can run its normal retry path.
+    setAccessToken("still-valid-token");
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))   // primary
+      .mockResolvedValueOnce(jsonResponse({ detail: "invalid_refresh" }, { status: 401 })) // refresh terminal
+      .mockResolvedValueOnce(jsonResponse({ id: 1, email: "x@y.z" })); // /me alive
+
+    await expect(apiFetch("/api/v1/protected")).rejects.toMatchObject({
+      name: "ApiResponseError",
+      status: 401,
+    });
+
+    expect(getAccessToken()).toBe("still-valid-token"); // PRESERVED
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("refresh transient (TypeError, AbortError, then OK) retries within budget without logout", async () => {
+    // Team F 2026-05-17: retry budget on refresh -- 2 retries with 250ms
+    // exponential backoff -- absorbs a flaky network on idle return. With
+    // real timers so the backoff actually elapses; the fetch path itself
+    // resolves synchronously in this test.
+    setAccessToken("stale-token");
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary
+      .mockRejectedValueOnce(new TypeError("fetch failed"))                          // refresh attempt 1 -- transient
+      .mockRejectedValueOnce(new DOMException("aborted", "AbortError"))             // refresh attempt 2 -- transient
+      .mockResolvedValueOnce(jsonResponse({ access_token: "fresh-token" }))         // refresh attempt 3 -- OK
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));                            // retry of primary
+
+    const data = await apiFetch<{ ok: boolean }>("/api/v1/protected");
+
+    expect(data).toEqual({ ok: true });
+    expect(getAccessToken()).toBe("fresh-token");
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    // 1 primary + 3 refresh attempts + 1 retry = 5
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("primary 401 + refresh timeout (all retries) does NOT clear token, does NOT dispatch, throws recoverable", async () => {
     vi.useFakeTimers();
     try {
       setAccessToken("stale-token");
+      // All 3 refresh attempts hang and time out at 10s each, separated by
+      // 250ms then 500ms exponential backoffs.
       fetchMock
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
-        .mockImplementationOnce(neverResolvingFetch());  // refresh hangs
+        .mockImplementationOnce(neverResolvingFetch())   // refresh attempt 1
+        .mockImplementationOnce(neverResolvingFetch())   // refresh attempt 2
+        .mockImplementationOnce(neverResolvingFetch());  // refresh attempt 3
 
       const promise = apiFetch("/api/v1/protected");
       const assertion = expect(promise).rejects.toMatchObject({
@@ -244,6 +294,11 @@ describe("apiFetch", () => {
         code: "refresh_transient",
       });
 
+      // Advance through all three 10s timeouts + 250ms + 500ms backoffs.
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(500);
       await vi.advanceTimersByTimeAsync(10_000);
       await assertion;
 
@@ -254,10 +309,12 @@ describe("apiFetch", () => {
     }
   });
 
-  it("primary 401 + refresh 500 does NOT clear token, does NOT dispatch, throws recoverable", async () => {
+  it("primary 401 + refresh 500 (all retries) does NOT clear token, does NOT dispatch, throws recoverable", async () => {
     setAccessToken("stale-token");
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "server error" }, { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "server error" }, { status: 500 }))
       .mockResolvedValueOnce(jsonResponse({ detail: "server error" }, { status: 500 }));
 
     await expect(apiFetch("/api/v1/protected")).rejects.toMatchObject({
@@ -270,18 +327,20 @@ describe("apiFetch", () => {
     expect(dispatchEventSpy).not.toHaveBeenCalled();
   });
 
-  it("parallel 401 herd with transient refresh does not spam auth events or clear token", async () => {
+  it("parallel 401 herd with transient refresh fires exactly one /refresh (and its retries) across all callers", async () => {
     vi.useFakeTimers();
     try {
       setAccessToken("stale-token");
       // 4 parallel calls, all get 401, only one refresh attempt
-      // (single-flight), refresh hangs (transient).
+      // (single-flight), refresh hangs across all 3 retry attempts.
       fetchMock
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 1
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 2
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 3
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 4
-        .mockImplementationOnce(neverResolvingFetch()); // refresh hangs
+        .mockImplementationOnce(neverResolvingFetch())  // refresh attempt 1
+        .mockImplementationOnce(neverResolvingFetch())  // refresh attempt 2
+        .mockImplementationOnce(neverResolvingFetch()); // refresh attempt 3
 
       const promises = [
         apiFetch("/api/v1/a"),
@@ -295,16 +354,71 @@ describe("apiFetch", () => {
       );
 
       await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(10_000);
       await Promise.all(assertions);
 
       expect(getAccessToken()).toBe("stale-token");
       expect(dispatchEventSpy).not.toHaveBeenCalled();
-      // Only one refresh attempt happened thanks to single-flight
-      // (4 primaries + 1 refresh = 5 fetch calls)
-      expect(fetchMock).toHaveBeenCalledTimes(5);
+      // 4 primaries + 3 refresh attempts (single-flight: shared across
+      // all 4 callers) = 7 fetch calls total. The 4 callers do NOT each
+      // fire their own /refresh.
+      expect(fetchMock).toHaveBeenCalledTimes(7);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("concurrent 401s share exactly one /refresh and one /me probe across all callers", async () => {
+    // Team F 2026-05-17: closes the singleflight microtask gap. Under the
+    // original .finally(() => null) clear, a queued awaiter could resume
+    // AFTER refreshPromise was cleared and fire a duplicate /refresh.
+    // We now hold refreshPromise alive until every awaiter has consumed
+    // it (refreshAwaiters counter returns to 0). The /me probe is also
+    // singleflighted, so 5 concurrent 401-driven callers see one /refresh
+    // and at most one /me.
+    setAccessToken("stale-token");
+    let refreshCount = 0;
+    let meCount = 0;
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/api/v1/auth/refresh")) {
+        refreshCount++;
+        return jsonResponse({ detail: "invalid_refresh" }, { status: 401 });
+      }
+      if (url.endsWith("/api/v1/auth/me")) {
+        meCount++;
+        return jsonResponse({ detail: "invalid_token" }, { status: 401 });
+      }
+      return jsonResponse({ detail: "expired" }, { status: 401 });
+    });
+
+    const promises = [
+      apiFetch("/api/v1/a"),
+      apiFetch("/api/v1/b"),
+      apiFetch("/api/v1/c"),
+      apiFetch("/api/v1/d"),
+      apiFetch("/api/v1/e"),
+    ];
+
+    const settled = await Promise.allSettled(promises);
+    for (const r of settled) {
+      expect(r.status).toBe("rejected");
+      if (r.status === "rejected") {
+        expect(r.reason).toMatchObject({ status: 401 });
+      }
+    }
+
+    expect(refreshCount).toBe(1);  // exactly one /refresh across all 5
+    expect(meCount).toBeLessThanOrEqual(1); // at most one /me probe
+    expect(getAccessToken()).toBeNull();
+    // auth:unauthenticated fires once even though 5 callers hit terminal.
+    const authEvents = dispatchEventSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === "auth:unauthenticated",
+    );
+    expect(authEvents).toHaveLength(1);
   });
 
   it("does not dispatch auth:unauthenticated for login credential failures", async () => {


### PR DESCRIPTION
## Summary

Closes three documented frontend defects in `frontend/lib/api.ts` that combine to cause false logouts on idle return. Backend session model untouched.

1. **Retry budget on `refreshAccessToken`.** Adds 2 retries with 250ms exponential backoff (250ms, 500ms) applied ONLY to transient outcomes (network error, timeout, 5xx, JSON parse, protocol). Terminal 401/403 short-circuits immediately, since those mean the refresh cookie is dead.
2. **Singleflight microtask gap.** The original `.finally(() => null)` on `refreshPromise` cleared the latch before queued awaiters resumed in the next microtask, leaking duplicate `/refresh` calls. Replaced with a `refreshAwaiters` counter that keeps `refreshPromise` alive until every awaiter has consumed it.
3. **Ambiguous-401 defense via `/api/v1/auth/me` probe.** Before dispatching `auth:unauthenticated` on terminal `/refresh`, run one `/me` probe. If `/me` returns 200 the session is still alive (backend race / partial outage), do NOT dispatch and let SWR retry through its normal path. Probe is singleflighted; dispatch is gated on `accessToken !== null` so a herd of concurrent terminal-refresh callers emits exactly one event.

## Changed files

- `frontend/lib/api.ts`
- `frontend/tests/lib/api.test.ts`

## Tests run (verbatim)

```
 Test Files  1 passed (1)
      Tests  22 passed (22)
   Duration  2.02s
---suite---
 Test Files  136 passed (136)
      Tests  962 passed (962)
   Duration  13.84s
---lint---
> eslint . --quiet
(clean)
---tsc---
(clean)
```

Ran in isolated `team-f-auth` compose stack and torn down with `down -v`.

## Known risks

- The `/me` probe issues one extra request on every terminal `/refresh`, capped at one per herd via singleflight. Worst case adds ~10s timeout exposure when both `/refresh` and `/me` are unreachable (probe falls through to logout on network/timeout, preserving today's behavior).
- The retry budget extends the worst-case time-to-logout from one `/refresh` round-trip to three (with backoffs), up to ~31s if every attempt times out. The user stays in-app the whole time and the session is preserved; this is the intended trade.
- AuthProvider's `auth:unauthenticated` listener contract is unchanged. No state-shape changes outside `api.ts`.