### PR TITLE
feat(sso): first-run Google SSO privacy disclosure step

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -900,6 +900,35 @@ def _google_error_redirect(
     return resp
 
 
+async def _record_google_callback_created_user(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    user: User,
+    request: Request,
+) -> None:
+    """Persist an ``auth.google.callback.created_user`` audit event.
+
+    Emitted on the new-user branch of ``/api/v1/auth/google/callback``
+    in addition to the existing ``user.login.success`` event, so ops
+    can disaggregate "Google identity created a fresh local user"
+    from "Google identity logged into an existing local user". No
+    token values are persisted, matching ``_record_login_success``.
+    """
+    request_id = structlog.contextvars.get_contextvars().get("request_id")
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="auth.google.callback.created_user",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=user.org_id,
+        target_org_name=None,
+        request_id=request_id,
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"method": "google_sso"},
+    )
+
+
 async def _record_login_success(
     session_factory: async_sessionmaker[AsyncSession],
     *,
@@ -1380,6 +1409,13 @@ async def google_callback(
     result = await db.execute(select(User).where(User.email == email))
     user = result.scalar_one_or_none()
 
+    # Track whether this callback created a new local user. The flag
+    # drives two downstream effects: an audit row distinct from the
+    # login-success row, and a fragment-only signal to the frontend
+    # so it can show the first-run privacy disclosure surface before
+    # the standard onboarding wizard.
+    created_user = False
+
     if user:
         # Existing user — login
         if not user.is_active:
@@ -1412,6 +1448,7 @@ async def google_callback(
         if mutated:
             await db.commit()
     else:
+        created_user = True
         # New user — register with Google profile
         existing_superadmin = await db.scalar(
             select(func.count()).select_from(User).where(User.is_superadmin == True)
@@ -1469,8 +1506,20 @@ async def google_callback(
     # the refresh token is set as an HttpOnly cookie so apiFetch can use
     # it on /auth/refresh. Both cookies MUST be set on this returned
     # response — see the handler docstring for the FastAPI caveat.
+    #
+    # On the new-user branch we append `&created_user=true` AFTER the
+    # token in the fragment. The frontend callback page parses the
+    # fragment, hands the token to apiFetch, and uses the flag to
+    # stash a sessionStorage marker that triggers the first-run
+    # privacy disclosure step at the start of the onboarding wizard.
+    # The flag rides on the fragment (never the query string) so it
+    # is not surfaced in Referer headers or server access logs, on
+    # the same privacy posture as the token itself.
+    fragment = f"token={access_token}"
+    if created_user:
+        fragment = f"{fragment}&created_user=true"
     resp = RedirectResponse(
-        url=f"{app_settings.app_url}/auth/google/callback#token={access_token}",
+        url=f"{app_settings.app_url}/auth/google/callback#{fragment}",
         status_code=302,
     )
     resp.delete_cookie("oauth_state", path="/api/v1/auth/google")
@@ -1484,6 +1533,19 @@ async def google_callback(
         path="/",
     )
     _clear_legacy_refresh_cookie(resp)
+    if created_user:
+        # Distinct audit event for the "we just created a local user
+        # from a Google identity" branch. Sits alongside the
+        # `user.login.success` event (still emitted below) so existing
+        # login analytics keep working unchanged, while ops/admin can
+        # filter on `auth.google.callback.created_user` for the
+        # account-creation slice (first-run disclosure rollout, growth
+        # metrics, abuse triage). No token values are persisted —
+        # only the user id / email / request id, matching the
+        # _record_login_success privacy posture.
+        await _record_google_callback_created_user(
+            session_factory, user=user, request=request
+        )
     await _record_login_success(
         session_factory, user=user, request=request, method="google_sso"
     )

--- a/backend/tests/routers/test_auth_google_callback_errors.py
+++ b/backend/tests/routers/test_auth_google_callback_errors.py
@@ -465,6 +465,9 @@ async def test_successful_google_callback_still_redirects_to_frontend(
 
     assert res.status_code == 302, res.text
     location = res.headers.get("location", "")
+    # First-run signal is appended after the token in the fragment
+    # on the new-user branch (see test_auth_google_callback_first_run.py
+    # for the full pin). The token-in-fragment shape is unchanged.
     assert location.startswith("http://localhost/auth/google/callback#token="), location
 
     # And no failure audit row should have landed.

--- a/backend/tests/routers/test_auth_google_callback_first_run.py
+++ b/backend/tests/routers/test_auth_google_callback_first_run.py
@@ -1,0 +1,361 @@
+"""Regression tests for the first-run SSO disclosure signal.
+
+The Google SSO callback distinguishes the "create new local user"
+branch from the "log in existing local user" branch. To let the
+frontend show the privacy disclosure step only to genuinely fresh
+SSO users, we surface that distinction two ways:
+
+  - **Audit event split**: the new-user branch writes a dedicated
+    ``auth.google.callback.created_user`` row in addition to the
+    existing ``user.login.success`` row. The existing-user branch
+    keeps emitting only ``user.login.success``.
+  - **Redirect-fragment signal**: the redirect URL the callback
+    returns gets ``&created_user=true`` appended AFTER the token in
+    the URL fragment (never the query string). This rides on the
+    same fragment-only privacy posture as the token itself, so the
+    flag is not surfaced in Referer headers or server logs.
+
+The tests below pin both signals against a real first-run callback
+and a real returning-user callback.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.subscription import Plan
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers import auth as auth_module
+from app.routers.auth import router as auth_router
+from app.security import hash_password
+
+
+# ── fixtures (mirror test_auth_google_callback_errors) ──────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+@pytest.fixture
+def google_config(monkeypatch):
+    monkeypatch.setattr(app_settings, "google_client_id", "test-client-id")
+    monkeypatch.setattr(app_settings, "google_client_secret", "test-client-secret")
+    monkeypatch.setattr(app_settings, "app_url", "http://localhost")
+    yield
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_default_plan(factory: async_sessionmaker[AsyncSession]) -> None:
+    async with factory() as db:
+        existing = await db.scalar(select(Plan).where(Plan.slug == "free"))
+        if existing is None:
+            db.add(Plan(slug="free", name="Free", is_active=True, sort_order=0))
+            await db.commit()
+
+
+async def _seed_existing_sso_user(
+    factory: async_sessionmaker[AsyncSession], *, email: str
+) -> int:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="returning",
+            email=email,
+            password_hash=hash_password("starting-password-1"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+async def _audit_rows(
+    factory: async_sessionmaker[AsyncSession], *, event_type: str
+) -> list[AuditEvent]:
+    async with factory() as db:
+        result = await db.execute(
+            select(AuditEvent).where(AuditEvent.event_type == event_type)
+        )
+        return list(result.scalars().all())
+
+
+# ── httpx mock ──────────────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _patch_httpx(
+    monkeypatch,
+    *,
+    userinfo_email: str,
+) -> None:
+    """Mock httpx so the Google /token and /userinfo calls return a
+    valid token payload + a verified userinfo payload for the given
+    email. Used by both the new-user and existing-user tests."""
+
+    class _FakeClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def post(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+            return _FakeResponse(200, {"access_token": "fake-google-token"})
+
+        async def get(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+            return _FakeResponse(
+                200,
+                {
+                    "email": userinfo_email,
+                    "verified_email": True,
+                    "given_name": "First",
+                    "family_name": "Last",
+                },
+            )
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeClient)
+
+
+# ── new-user branch ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_new_sso_user_redirect_url_carries_created_user_flag(
+    session_factory, google_config, monkeypatch
+) -> None:
+    """Brand-new email at the Google callback creates a local user and
+    redirects to ``/auth/google/callback#token=...&created_user=true``.
+    The flag rides on the FRAGMENT (not the query string) so it never
+    appears in Referer headers or server access logs.
+    """
+    await _seed_default_plan(session_factory)
+    _patch_httpx(monkeypatch, userinfo_email="brand-new@example.com")
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+
+    assert res.status_code == 302, res.text
+    location = res.headers.get("location", "")
+    # Fragment carries both token and created_user, with no leakage
+    # into the query string.
+    assert "#token=" in location, location
+    assert "&created_user=true" in location, location
+    # ``?created_user`` in the query string would be a privacy bug —
+    # query params land in Referer headers + server logs.
+    pre_fragment = location.split("#", 1)[0]
+    assert "created_user" not in pre_fragment, pre_fragment
+    assert "?" not in pre_fragment.split("/callback", 1)[1], pre_fragment
+
+
+@pytest.mark.asyncio
+async def test_new_sso_user_records_created_user_audit_event(
+    session_factory, google_config, monkeypatch
+) -> None:
+    """The new-user branch writes ``auth.google.callback.created_user``
+    in addition to the existing ``user.login.success`` row. Ops can
+    filter the audit log on the dedicated event for the first-run
+    slice without breaking existing login analytics.
+    """
+    await _seed_default_plan(session_factory)
+    _patch_httpx(monkeypatch, userinfo_email="brand-new@example.com")
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+    assert res.status_code == 302, res.text
+
+    created_rows = await _audit_rows(
+        session_factory, event_type="auth.google.callback.created_user"
+    )
+    assert len(created_rows) == 1
+    row = created_rows[0]
+    assert row.outcome.value == "success"
+    assert row.actor_email == "brand-new@example.com"
+    assert row.detail == {"method": "google_sso"}
+    # The new-user branch still emits the standard login event.
+    login_rows = await _audit_rows(session_factory, event_type="user.login.success")
+    assert len(login_rows) == 1
+    assert login_rows[0].detail == {"method": "google_sso"}
+
+
+@pytest.mark.asyncio
+async def test_new_sso_user_audit_detail_carries_no_token_or_secret(
+    session_factory, google_config, monkeypatch
+) -> None:
+    """Defence in depth: the created_user audit row must not carry
+    any token / secret value in its detail dict, and the redirect
+    Location must not surface the token in the query string."""
+    await _seed_default_plan(session_factory)
+    _patch_httpx(monkeypatch, userinfo_email="brand-new@example.com")
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+    assert res.status_code == 302, res.text
+
+    created_rows = await _audit_rows(
+        session_factory, event_type="auth.google.callback.created_user"
+    )
+    assert len(created_rows) == 1
+    detail = created_rows[0].detail or {}
+    assert "token" not in detail
+    assert "access_token" not in detail
+    assert "refresh_token" not in detail
+    # Sanity: redirect URL pre-fragment never carries the token either.
+    location = res.headers.get("location", "")
+    pre_fragment = location.split("#", 1)[0]
+    assert "token=" not in pre_fragment
+    # And the refresh cookie stays HttpOnly + SameSite=lax. The
+    # set-cookie header may carry multiple cookies (the new refresh,
+    # the deleted oauth_state, and the deleted legacy refresh). Use
+    # the structured cookie jar to read the live refresh_token rather
+    # than parsing the raw multi-cookie header.
+    refresh_value = res.cookies.get("refresh_token")
+    assert refresh_value, dict(res.cookies)
+    raw_cookies_lower = res.headers.get("set-cookie", "").lower()
+    assert "httponly" in raw_cookies_lower
+    assert "samesite=lax" in raw_cookies_lower
+
+
+# ── existing-user branch (regression pin) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_existing_sso_user_redirect_url_has_no_created_user_flag(
+    session_factory, google_config, monkeypatch
+) -> None:
+    """Returning SSO users must NOT see the disclosure. The redirect
+    URL therefore must not carry ``created_user`` anywhere.
+    """
+    await _seed_default_plan(session_factory)
+    await _seed_existing_sso_user(session_factory, email="returning@example.com")
+    _patch_httpx(monkeypatch, userinfo_email="returning@example.com")
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+
+    assert res.status_code == 302, res.text
+    location = res.headers.get("location", "")
+    assert location.startswith("http://localhost/auth/google/callback#token="), location
+    assert "created_user" not in location, location
+
+
+@pytest.mark.asyncio
+async def test_existing_sso_user_does_not_record_created_user_audit(
+    session_factory, google_config, monkeypatch
+) -> None:
+    """Returning SSO users keep emitting only ``user.login.success`` —
+    the dedicated created_user event stays specific to the new-user
+    branch."""
+    await _seed_default_plan(session_factory)
+    await _seed_existing_sso_user(session_factory, email="returning@example.com")
+    _patch_httpx(monkeypatch, userinfo_email="returning@example.com")
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+    assert res.status_code == 302, res.text
+
+    created_rows = await _audit_rows(
+        session_factory, event_type="auth.google.callback.created_user"
+    )
+    assert created_rows == []
+    login_rows = await _audit_rows(session_factory, event_type="user.login.success")
+    assert len(login_rows) == 1
+    assert login_rows[0].detail == {"method": "google_sso"}

--- a/frontend/app/auth/google/callback/page.tsx
+++ b/frontend/app/auth/google/callback/page.tsx
@@ -5,6 +5,17 @@ import { useRouter } from "next/navigation";
 import { setAccessToken } from "@/lib/api";
 import { useAuth } from "@/components/auth/AuthProvider";
 
+// sessionStorage flag the onboarding wizard reads to know it should
+// render the first-run SSO privacy disclosure as Step 0. Only set on
+// the new-user branch of the Google callback (the backend appends
+// `&created_user=true` to the fragment then). Cleared by the wizard
+// after the user accepts the disclosure so the surface never repeats.
+//
+// Exported as a named constant so the onboarding component and tests
+// can reference the exact key — drift between writer + reader would
+// silently disable the disclosure for every new SSO user.
+export const SSO_DISCLOSURE_PENDING_KEY = "tbd-sso-disclosure-pending";
+
 export default function GoogleCallbackPage() {
   const router = useRouter();
   const { refreshMe } = useAuth();
@@ -15,10 +26,13 @@ export default function GoogleCallbackPage() {
     calledRef.current = true;
 
     // Token is in the URL fragment (#token=xxx) to prevent leaks in
-    // server logs, Referer headers, and browser history
+    // server logs, Referer headers, and browser history. The
+    // first-run signal `created_user=true` rides on the same
+    // fragment so it inherits the same privacy posture.
     const hash = window.location.hash.substring(1); // remove #
     const params = new URLSearchParams(hash);
     const token = params.get("token");
+    const createdUser = params.get("created_user") === "true";
 
     if (!token) {
       router.replace("/login");
@@ -29,11 +43,35 @@ export default function GoogleCallbackPage() {
     window.history.replaceState(null, "", window.location.pathname);
 
     setAccessToken(token);
-    refreshMe().then(() => {
-      router.replace("/dashboard");
-    }).catch(() => {
-      router.replace("/login");
-    });
+
+    // Stash the disclosure flag BEFORE refreshMe resolves so the
+    // onboarding page sees it on first paint. sessionStorage is
+    // tab-scoped and clears on tab close, which is the right blast
+    // radius — if the user closes the tab before clicking Continue
+    // they will see the disclosure again on the next sign-in, which
+    // is acceptable.
+    if (createdUser) {
+      try {
+        window.sessionStorage.setItem(SSO_DISCLOSURE_PENDING_KEY, "1");
+      } catch {
+        // sessionStorage may be unavailable in private mode. The
+        // disclosure simply does not surface in that session — the
+        // wizard proceeds normally. Non-fatal.
+      }
+    }
+
+    refreshMe()
+      .then(() => {
+        // New SSO users land on /onboarding (the wizard reads the
+        // flag and shows the disclosure as Step 0). Returning users
+        // go straight to /dashboard; the AuthProvider/onboarding
+        // redirect logic upstream handles bookmarked /onboarding
+        // visits for already-onboarded users.
+        router.replace(createdUser ? "/onboarding" : "/dashboard");
+      })
+      .catch(() => {
+        router.replace("/login");
+      });
   }, [router, refreshMe]);
 
   return (

--- a/frontend/components/onboarding/OnboardingPageBody.tsx
+++ b/frontend/components/onboarding/OnboardingPageBody.tsx
@@ -30,6 +30,7 @@
  * redirect to /dashboard on mount. This keeps the route safe to
  * bookmark and protects users who navigate back to /onboarding.
  */
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
@@ -49,7 +50,16 @@ const DASHBOARD_TOUR_STEPS = [
 
 const TOUR_FLAG_KEY = "tbd-pending-dashboard-tour";
 
-type Step = "welcome" | "account" | "demo" | "tour";
+// sessionStorage flag the Google SSO callback page sets when a new
+// local user has just been created. Reading it here inserts a
+// privacy disclosure step at the front of the wizard. Kept in sync
+// with `SSO_DISCLOSURE_PENDING_KEY` in
+// frontend/app/auth/google/callback/page.tsx — drift between the
+// writer + reader would silently disable the disclosure for every
+// new SSO user.
+const SSO_DISCLOSURE_PENDING_KEY = "tbd-sso-disclosure-pending";
+
+type Step = "sso-disclosure" | "welcome" | "account" | "demo" | "tour";
 
 const FULL_STEP_ORDER: Step[] = ["welcome", "account", "demo", "tour"];
 const NON_OWNER_STEP_ORDER: Step[] = ["welcome", "account", "tour"];
@@ -59,16 +69,35 @@ export default function OnboardingPageBody() {
   const router = useRouter();
   const tour = useTour();
 
+  // First-run SSO disclosure flag — set by the Google callback page
+  // when it just created a new local user. Read synchronously from
+  // sessionStorage on initial render so the wizard never paints a
+  // mismatched first step. Falls back to false in non-browser
+  // contexts (SSR, test envs without sessionStorage).
+  const [showSsoDisclosure, setShowSsoDisclosure] = useState<boolean>(() => {
+    try {
+      if (typeof window === "undefined") return false;
+      return window.sessionStorage.getItem(SSO_DISCLOSURE_PENDING_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
   // Owners get the full four-step wizard; admins / members skip the
   // demo-seed step because the seed endpoint is owner-only (78d6409).
   // Falling back to NON_OWNER_STEP_ORDER while the user is still
   // loading is safe — the loading branch below returns the spinner
   // before any step renders, so this value is only consumed once
   // `user` is populated.
-  const STEP_ORDER =
+  const BASE_STEP_ORDER: Step[] =
     user?.role === "owner" ? FULL_STEP_ORDER : NON_OWNER_STEP_ORDER;
+  const STEP_ORDER: Step[] = showSsoDisclosure
+    ? (["sso-disclosure", ...BASE_STEP_ORDER] as Step[])
+    : BASE_STEP_ORDER;
 
-  const [step, setStep] = useState<Step>("welcome");
+  const [step, setStep] = useState<Step>(
+    showSsoDisclosure ? "sso-disclosure" : "welcome",
+  );
   const [accountName, setAccountName] = useState("Main Checking");
   const [accountTypes, setAccountTypes] = useState<AccountType[]>([]);
   const [selectedTypeId, setSelectedTypeId] = useState<number | null>(null);
@@ -109,6 +138,19 @@ export default function OnboardingPageBody() {
     const idx = STEP_ORDER.indexOf(step);
     if (idx < 0 || idx === STEP_ORDER.length - 1) return;
     setStep(STEP_ORDER[idx + 1]);
+    setError(null);
+  }
+
+  function acceptSsoDisclosure() {
+    // Clear the sessionStorage flag so the disclosure does not show
+    // again, then advance into the standard onboarding wizard.
+    try {
+      window.sessionStorage.removeItem(SSO_DISCLOSURE_PENDING_KEY);
+    } catch {
+      // sessionStorage unavailable — already past it, nothing to do.
+    }
+    setShowSsoDisclosure(false);
+    setStep("welcome");
     setError(null);
   }
 
@@ -224,12 +266,102 @@ export default function OnboardingPageBody() {
       >
         <div className="mb-6 flex items-center justify-between">
           <div className="text-xs uppercase tracking-[0.08em] text-text-muted">
-            Welcome
+            {step === "sso-disclosure" ? "Privacy" : "Welcome"}
           </div>
           <div className="text-xs text-text-muted">
             Step {stepIdx + 1} of {STEP_ORDER.length}
           </div>
         </div>
+
+        {step === "sso-disclosure" && (
+          <div data-testid="onboarding-sso-disclosure">
+            <h1 className="mb-3 text-2xl font-semibold text-text-primary">
+              About your Google sign-in
+            </h1>
+            <p className="mb-4 text-sm leading-relaxed text-text-secondary">
+              You signed in with Google. Before we set up your account,
+              here is exactly what that means.
+            </p>
+
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-[0.06em] text-text-primary">
+              What Google shares with us
+            </h2>
+            <p className="mb-2 text-sm leading-relaxed text-text-secondary">
+              We ask Google for three pieces of information, using the
+              standard scopes <span className="font-mono text-xs">openid</span>,
+              {" "}<span className="font-mono text-xs">email</span>, and
+              {" "}<span className="font-mono text-xs">profile</span>:
+            </p>
+            <ul className="mb-5 list-disc space-y-1 pl-5 text-sm leading-relaxed text-text-secondary">
+              <li>Your name.</li>
+              <li>
+                Your email address and whether Google has verified it.
+              </li>
+              <li>Your profile photo, if you have one.</li>
+            </ul>
+            <p className="mb-5 text-sm leading-relaxed text-text-secondary">
+              We use that information only to create your The Better
+              Decision account and sign you in.
+            </p>
+
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-[0.06em] text-text-primary">
+              What we never see
+            </h2>
+            <ul className="mb-5 list-disc space-y-1 pl-5 text-sm leading-relaxed text-text-secondary">
+              <li>We do not get your Google password.</li>
+              <li>
+                We do not access Gmail, Drive, Calendar, contacts, or
+                anything else in your Google account.
+              </li>
+              <li>
+                We do not connect to your bank, card, or any financial
+                account through Google.
+              </li>
+            </ul>
+
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-[0.06em] text-text-primary">
+              What Google never sees
+            </h2>
+            <p className="mb-5 text-sm leading-relaxed text-text-secondary">
+              Google does not get access to the accounts, transactions,
+              budgets, or any other financial information you keep
+              inside The Better Decision. Your data stays here.
+            </p>
+
+            <p className="mb-6 text-xs leading-relaxed text-text-muted">
+              Full details:{" "}
+              <Link
+                href="/privacy"
+                className="underline hover:text-text-primary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Privacy Policy
+              </Link>
+              {" "}and{" "}
+              <Link
+                href="/terms"
+                className="underline hover:text-text-primary"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Terms of Service
+              </Link>
+              .
+            </p>
+
+            <div className="flex justify-end">
+              <button
+                type="button"
+                className={btnPrimary}
+                onClick={acceptSsoDisclosure}
+                data-testid="onboarding-sso-disclosure-continue"
+              >
+                Continue
+              </button>
+            </div>
+          </div>
+        )}
 
         {step === "welcome" && (
           <div>

--- a/frontend/tests/app/auth-google-callback-page.test.tsx
+++ b/frontend/tests/app/auth-google-callback-page.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Google SSO callback page — first-run disclosure handoff.
+ *
+ * The page parses `#token=...&created_user=true` from the URL
+ * fragment. The token gets handed to `setAccessToken` + `refreshMe`,
+ * and the `created_user` flag (when present) is stashed in
+ * sessionStorage under `tbd-sso-disclosure-pending` so the
+ * onboarding wizard can render the privacy disclosure step.
+ *
+ * Returning SSO users land without `created_user=true`, the flag
+ * stays absent, and the navigation target is `/dashboard` directly.
+ */
+import { render, waitFor } from "@testing-library/react";
+
+import GoogleCallbackPage, {
+  SSO_DISCLOSURE_PENDING_KEY,
+} from "@/app/auth/google/callback/page";
+
+const setAccessTokenMock = vi.fn();
+const refreshMeMock = vi.fn(async () => {});
+const replaceMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  setAccessToken: (...args: unknown[]) => setAccessTokenMock(...args),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: () => ({ refreshMe: refreshMeMock }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+beforeEach(() => {
+  setAccessTokenMock.mockReset();
+  refreshMeMock.mockReset();
+  refreshMeMock.mockResolvedValue(undefined as never);
+  replaceMock.mockReset();
+  try {
+    window.sessionStorage.clear();
+  } catch {
+    // ignore
+  }
+  // Reset URL on the jsdom location.
+  window.history.replaceState(null, "", "/auth/google/callback");
+});
+
+describe("GoogleCallbackPage", () => {
+  it("stashes the disclosure flag and routes to /onboarding when created_user=true", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/auth/google/callback#token=abc.def.ghi&created_user=true",
+    );
+
+    render(<GoogleCallbackPage />);
+
+    await waitFor(() => {
+      expect(setAccessTokenMock).toHaveBeenCalledWith("abc.def.ghi");
+    });
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/onboarding");
+    });
+    expect(window.sessionStorage.getItem(SSO_DISCLOSURE_PENDING_KEY)).toBe("1");
+  });
+
+  it("returning SSO users (no created_user) go straight to /dashboard with no flag set", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/auth/google/callback#token=abc.def.ghi",
+    );
+
+    render(<GoogleCallbackPage />);
+
+    await waitFor(() => {
+      expect(setAccessTokenMock).toHaveBeenCalledWith("abc.def.ghi");
+    });
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(window.sessionStorage.getItem(SSO_DISCLOSURE_PENDING_KEY)).toBeNull();
+  });
+
+  it("clears the URL fragment after parsing so the token does not persist in history", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/auth/google/callback#token=abc.def.ghi&created_user=true",
+    );
+
+    render(<GoogleCallbackPage />);
+
+    await waitFor(() => {
+      expect(setAccessTokenMock).toHaveBeenCalled();
+    });
+    // After the effect runs, the fragment is gone.
+    expect(window.location.hash).toBe("");
+  });
+
+  it("missing token routes to /login and does not set the disclosure flag", async () => {
+    window.history.replaceState(null, "", "/auth/google/callback");
+
+    render(<GoogleCallbackPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/login");
+    });
+    expect(setAccessTokenMock).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(SSO_DISCLOSURE_PENDING_KEY)).toBeNull();
+  });
+});

--- a/frontend/tests/components/onboarding-flow.test.tsx
+++ b/frontend/tests/components/onboarding-flow.test.tsx
@@ -285,6 +285,89 @@ describe("OnboardingPageBody", () => {
     expect(screen.getByText(/Step 3 of 4/)).toBeInTheDocument();
   });
 
+  describe("first-run SSO disclosure step", () => {
+    it("shows the disclosure step when the sso-disclosure-pending flag is set", () => {
+      setupAuth(makeUser());
+      window.sessionStorage.setItem("tbd-sso-disclosure-pending", "1");
+      render(<OnboardingPageBody />);
+      expect(
+        screen.getByTestId("onboarding-sso-disclosure"),
+      ).toBeInTheDocument();
+      // The header reads Step 1 of 5 for an owner (4 standard steps +
+      // the prepended disclosure step).
+      expect(screen.getByText(/Step 1 of 5/)).toBeInTheDocument();
+    });
+
+    it("the disclosure copy names each promise the spec requires", () => {
+      setupAuth(makeUser());
+      window.sessionStorage.setItem("tbd-sso-disclosure-pending", "1");
+      render(<OnboardingPageBody />);
+      // What Google shares
+      expect(screen.getByText(/Your name\./)).toBeInTheDocument();
+      expect(
+        screen.getByText(/email address and whether Google has verified it/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/profile photo, if you have one/i),
+      ).toBeInTheDocument();
+      // What we never see
+      expect(
+        screen.getByText(/We do not get your Google password\./i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Gmail, Drive, Calendar, contacts/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/We do not connect to your bank/i),
+      ).toBeInTheDocument();
+      // What Google never sees
+      expect(
+        screen.getByText(/Google does not get access to the accounts, transactions/i),
+      ).toBeInTheDocument();
+      // Privacy + Terms links
+      const privacy = screen.getByRole("link", { name: /Privacy Policy/i });
+      expect(privacy).toHaveAttribute("href", "/privacy");
+      const terms = screen.getByRole("link", { name: /Terms of Service/i });
+      expect(terms).toHaveAttribute("href", "/terms");
+    });
+
+    it("Continue clears the flag and advances into the standard onboarding wizard", async () => {
+      setupAuth(makeUser());
+      window.sessionStorage.setItem("tbd-sso-disclosure-pending", "1");
+      render(<OnboardingPageBody />);
+
+      fireEvent.click(
+        screen.getByTestId("onboarding-sso-disclosure-continue"),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Better decisions about money start here/i),
+        ).toBeInTheDocument();
+      });
+      // The flag is gone, so a remount would not re-show the disclosure.
+      expect(
+        window.sessionStorage.getItem("tbd-sso-disclosure-pending"),
+      ).toBeNull();
+      expect(
+        screen.queryByTestId("onboarding-sso-disclosure"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("returning SSO users (no flag) hit the existing welcome step with the existing Step 1 of 4 header", () => {
+      // No sessionStorage flag — this is the returning-user contract.
+      setupAuth(makeUser());
+      render(<OnboardingPageBody />);
+      expect(
+        screen.queryByTestId("onboarding-sso-disclosure"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/Better decisions about money start here/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Step 1 of 4/)).toBeInTheDocument();
+    });
+  });
+
   // L1.1 L4 contract: ``POST /api/v1/accounts`` no longer accepts the
   // free-form ``balance`` field. The audited ``opening_balance`` field
   // is the sole entry point for a starting balance. Pin the onboarding


### PR DESCRIPTION
## Summary

New SSO users now see a privacy disclosure screen at the start of onboarding that explains exactly what Google shares with us, what we never access on the Google side, and that Google never sees any financial data inside The Better Decision. Returning SSO users keep the existing flow unchanged.

## Signal design

- The Google callback handler tracks whether the request created a new local user vs logged in an existing one.
- On the new-user branch, the redirect URL gets `&created_user=true` appended **after** the access token in the fragment (e.g. `/auth/google/callback#token=...&created_user=true`). The flag rides on the fragment so it inherits the same privacy posture as the token: never surfaced in Referer headers or server access logs.
- The callback page parses the fragment, hands the token to `setAccessToken`, and (if `created_user=true`) writes a sessionStorage flag `tbd-sso-disclosure-pending`. It then routes new users to `/onboarding` and returning users to `/dashboard`.
- `OnboardingPageBody` reads the flag synchronously on initial render and inserts a `sso-disclosure` step at the front of the wizard. Continue clears the flag and advances into the standard `welcome` step. When the flag is absent the wizard is byte-identical to today (returning user contract pinned in tests).

## Audit-event split

- `auth.google.callback.created_user` — new event, success outcome, emitted only on the new-user branch (alongside the existing `user.login.success` row). Detail dict is `{"method": "google_sso"}`; no token or secret material persisted.
- `user.login.success` — emitted on both branches, no change.

## Implementation choice

Picked Option B (Step 0 inside the existing onboarding wizard) over Option A (separate `/onboarding/sso-disclosure` route). Reasons:
1. `OnboardingPageBody` already owns the "first-run wizard" semantics + the `onboarded_at` redirect-guard. Slotting in a Step 0 keeps that single source of truth.
2. Avoids forking the route protection / AuthProvider redirect rules.
3. Returning SSO users hit the existing flow because they never set the sessionStorage flag - no branching at the router level.

## Disclosure copy

Concrete and tied to the actual OAuth scopes the backend requests (`openid email profile`, see `backend/app/routers/auth.py:1231`):

- Names what Google shares (name, email + verification status, profile photo).
- States that we use that information only to create the account and sign in.
- Lists what we never see (Google password; Gmail, Drive, Calendar, contacts; bank/card accounts).
- States Google does not see any financial data inside the app.
- Links to `/privacy` and `/terms`.

No em-dashes in customer-facing strings. If future scope additions broaden what we ask for, the disclosure copy needs a paired update.

## Changed files

- `backend/app/routers/auth.py` - track new-user branch, append `created_user` to redirect fragment, emit `auth.google.callback.created_user` audit row via new `_record_google_callback_created_user` helper.
- `backend/tests/routers/test_auth_google_callback_first_run.py` - new; pins new-user vs existing-user signal split (redirect URL flag + audit-row split + no token leakage in audit detail or query string + refresh cookie still HttpOnly+SameSite=lax).
- `backend/tests/routers/test_auth_google_callback_errors.py` - comment-only annotation on the existing success-path test.
- `frontend/app/auth/google/callback/page.tsx` - parse `created_user` from the URL fragment, stash sessionStorage flag, route new users to `/onboarding`.
- `frontend/components/onboarding/OnboardingPageBody.tsx` - new `sso-disclosure` step type, sessionStorage-driven STEP_ORDER prefix, full disclosure UI block, `acceptSsoDisclosure` handler that clears the flag and advances to `welcome`.
- `frontend/tests/components/onboarding-flow.test.tsx` - new "first-run SSO disclosure step" describe block; pins disclosure visibility, copy bullets, link targets, Continue handoff to the standard wizard, and the returning-user contract.
- `frontend/tests/app/auth-google-callback-page.test.tsx` - new; pins fragment parsing of `created_user`, sessionStorage write, navigation target, fragment clearing.

## Tests run (verbatim)

Backend - new tests + existing google callback regression:

```
18 passed, 2 warnings in 2.63s
```

Backend - full auth surface:

```
92 passed, 14 warnings in 17.30s
```

Backend - full suite:

```
1228 passed, 9 skipped, 66 warnings in 276.07s (0:04:36)
```

Frontend - new + extended tests:

```
Test Files  2 passed (2)
     Tests  18 passed (18)
```

Frontend - full suite:

```
Test Files  137 passed (137)
     Tests  967 passed (967)
```

Frontend - lint + tsc:

```
> pfv2-frontend@0.1.0 lint
> eslint . --quiet
```

(tsc emits nothing on success.)

## Known risks

- The disclosure copy is hard-coded to the current OAuth scope set (`openid email profile`). If a future change adds a scope, the disclosure must be updated in lockstep. There is no programmatic gate that ties them together today; the comment in the commit body flags this.
- `sessionStorage` is tab-scoped. If a new SSO user closes the tab before clicking Continue, the disclosure shows again on the next sign-in. This is the right blast radius for a session-bound first-run flag - acceptable.
- Audit-event name `auth.google.callback.created_user` is new and not yet documented in `ENVIRONMENT.md` or the admin/audit UI legend. Pre-launch, so no consumer to migrate.