### PR TITLE
feat(admin): detach org member + system-level user delete with preconditions

### DIFF
--- a/backend/alembic/versions/048_seed_users_delete_permission.py
+++ b/backend/alembic/versions/048_seed_users_delete_permission.py
@@ -1,0 +1,81 @@
+"""Seed users.delete permission into the superadmin role.
+
+Revision ID: 048_users_delete_perm
+Revises: 047_subscriptions_view_perm
+Create Date: 2026-05-17
+
+Adds the ``users.delete`` permission key (registered in
+``app/auth/permissions.py``'s ``Permission`` literal + ``ALL_PERMISSIONS``)
+to the superadmin role. Gates the new system-level hard-delete endpoint
+at ``DELETE /api/v1/admin/users/{user_id}``.
+
+The runtime resolver short-circuits via ``is_superadmin``, so the seed
+below is for parity with future non-superadmin roles (none should
+inherit ``users.delete`` by default) and to keep the ``/admin/roles``
+UI's permission editor accurate. We INSERT-IGNORE (via existence check)
+so re-running the migration after manual seeding doesn't fail.
+
+This follows the pattern documented in migration
+``033_add_roles_and_role_permissions`` and the preceding
+``046_seed_users_view_permission`` / ``047_seed_subscriptions_view_permission``.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "048_users_delete_perm"
+down_revision = "047_subscriptions_view_perm"
+branch_labels = None
+depends_on = None
+
+
+PERMISSION_KEY = "users.delete"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Locate the superadmin role; if the row is missing (e.g. someone
+    # ran the downgrade for 033 manually), bail silently. The runtime
+    # short-circuit still covers superadmins, and this seed is purely
+    # for UI parity.
+    row = bind.execute(
+        sa.text("SELECT id FROM roles WHERE slug = :slug"),
+        {"slug": "superadmin"},
+    ).first()
+    if row is None:
+        return
+    role_id = row[0]
+
+    # Idempotent insert: skip if the (role_id, permission_key) row
+    # already exists. Composite PK means a plain INSERT would explode
+    # on rerun under MySQL.
+    exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM role_permissions "
+            "WHERE role_id = :role_id AND permission_key = :key"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    ).first()
+    if exists is not None:
+        return
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO role_permissions (role_id, permission_key) "
+            "VALUES (:role_id, :key)"
+        ),
+        {"role_id": role_id, "key": PERMISSION_KEY},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "DELETE FROM role_permissions WHERE permission_key = :key"
+        ),
+        {"key": PERMISSION_KEY},
+    )

--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -28,6 +28,7 @@ Permission = Literal[
     "roles.manage",
     "analytics.view",
     "users.view",
+    "users.delete",
     "subscriptions.view",
 ]
 
@@ -35,6 +36,12 @@ Permission = Literal[
 # Canonical set — useful when iterating or seeding the role admin
 # UI's permission editor (L4.8) and the migration that seeds the
 # superadmin role row.
+#
+# users.delete (added 2026-05-17) gates the system-level hard-delete
+# of a User row. Kept distinct from users.view because the read
+# (search/detail) surface is widely useful for support work while
+# the destructive surface should remain superadmin-only even if a
+# future support role inherits users.view via ROLE_PERMISSIONS.
 ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "admin.view",
     "plans.manage",
@@ -44,6 +51,7 @@ ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "roles.manage",
     "analytics.view",
     "users.view",
+    "users.delete",
     "subscriptions.view",
 })
 

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -37,6 +37,7 @@ from app.rate_limit import get_client_ip
 from app.schemas.admin_users import UserMergeRequest, UserMergeResponse
 from app.services import (
     admin_users_search_service,
+    admin_users_service,
     audit_service,
     user_merge_service,
 )
@@ -358,3 +359,131 @@ async def get_user_detail(
         )
 
     return payload
+
+
+# ── System-level hard delete ────────────────────────────────────────
+#
+# Gated by ``users.delete`` (added 2026-05-17). The superadmin
+# short-circuit makes this superadmin-only today; the seeded
+# role_permissions row keeps the L4.8 role editor accurate.
+#
+# Precondition errors return 409 with a structured ``detail`` of
+# ``{"code": <stable string>, "message": <human-readable>}``. The
+# code values are exported from ``admin_users_service`` so the
+# frontend can branch without parsing English.
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_200_OK)
+async def delete_user(
+    user_id: int,
+    request: Request,
+    actor: User = Depends(require_permission("users.delete")),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Hard-delete a User row.
+
+    Preconditions enforced server-side:
+
+    - actor is not the same user as the target
+    - target is not a platform superadmin
+    - target.is_active is False
+
+    On a 409 precondition failure, the response body is
+    ``{"detail": {"code": ..., "message": ...}}``. On 404 the body
+    follows the standard FastAPI shape.
+    """
+    # Snapshot actor identity before any commit/rollback. Same
+    # MissingGreenlet hazard as in ``merge_users``.
+    actor_id = actor.id
+    actor_email = actor.email
+
+    try:
+        result = await admin_users_service.delete_user(
+            db,
+            target_user_id=user_id,
+            actor_user_id=actor_id,
+        )
+        await db.commit()
+    except NotFoundError as e:
+        await db.rollback()
+        # Idempotency: deleting a user that doesn't exist returns
+        # 404. Not an audit-worthy failure on its own (no actor
+        # intent to record beyond the request log).
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ConflictError as e:
+        await db.rollback()
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.user.delete.failed",
+            actor_user_id=actor_id,
+            actor_email=actor_email,
+            target_org_id=None,
+            target_org_name=None,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={
+                "target_user_id": user_id,
+                "code": e.code,
+                "reason": e.code or "conflict",
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": e.code, "message": str(e)},
+        )
+    except Exception:
+        await db.rollback()
+        await logger.aexception(
+            "admin.user.delete.error",
+            target_user_id=user_id,
+            actor_user_id=actor_id,
+        )
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.user.delete.failed",
+            actor_user_id=actor_id,
+            actor_email=actor_email,
+            target_org_id=None,
+            target_org_name=None,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="failure",
+            detail={
+                "target_user_id": user_id,
+                "reason": "internal_error",
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="delete failed",
+        )
+
+    snapshot = result["snapshot"]
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.user.deleted",
+        actor_user_id=actor_id,
+        actor_email=actor_email,
+        # The deleted user's org_id is preserved as a snapshot so the
+        # audit row can still be cross-referenced from the org's
+        # audit timeline.
+        target_org_id=snapshot["org_id"],
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "target_user_id": snapshot["id"],
+            "target_email": snapshot["email"],
+            "target_username": snapshot["username"],
+            "target_org_id": snapshot["org_id"],
+            "fk_cleanup_counts": result["fk_cleanup_counts"],
+        },
+    )
+
+    return {
+        "deleted_user_id": snapshot["id"],
+        "fk_cleanup_counts": result["fk_cleanup_counts"],
+    }

--- a/backend/app/services/admin_users_service.py
+++ b/backend/app/services/admin_users_service.py
@@ -1,0 +1,185 @@
+"""System-level user administration (hard delete).
+
+Companion to the read-only ``admin_users_search_service``. Hosts the
+destructive system-level endpoint that hard-deletes a ``User`` row.
+
+Membership-model note. ``users.org_id`` is a direct NOT NULL FK
+to ``organizations.id`` — every user belongs to exactly one org at
+all times. There is no join table. As a result, the operator
+contract "remove the user when they have no org association" can
+only mean "delete the User row entirely". Detaching the row from
+its org without deleting is not expressible in the current schema
+(would require making ``org_id`` nullable + a "no-org limbo" state
+across every org-scoped query in the app). See PR body for the
+architect call-out.
+
+Hard-delete preconditions (server-enforced, every branch raises
+``ConflictError`` with a stable ``code``):
+
+- ``user_is_superadmin`` — superadmins are never deletable via
+  this endpoint. Demote via direct DB intervention if genuinely
+  required.
+- ``user_still_active`` — target must be ``is_active=False``.
+  Forces operators through the existing deactivate path first, so
+  active-user deletes are impossible by mistake.
+- ``user_is_self`` — actor cannot delete their own user row.
+
+There is no ``user_has_org_memberships`` precondition in this
+schema because the single-FK shape makes "has zero memberships"
+unrepresentable. If a future migration introduces a join table,
+add the membership-count check before the delete.
+
+FK cleanup. ``users.id`` is referenced from seven tables. The
+delete handler walks them explicitly so we never rely on implicit
+``ON DELETE`` semantics for correctness:
+
+  1. ``audit_events.actor_user_id`` — ``ON DELETE SET NULL``. The
+     historical actor_email column preserves attribution. We let
+     the cascade run.
+  2. ``feedback_entries.user_id`` — ``ON DELETE SET NULL``. Same
+     treatment.
+  3. ``tags.created_by_user_id`` — ``ON DELETE SET NULL``. Same.
+  4. ``org_feature_overrides.set_by`` — ``ON DELETE SET NULL``. Same.
+  5. ``org_data_reset_lock.acquired_by_user_id`` — ``ON DELETE
+     CASCADE``. Lock is short-lived; cascading destroys the lock
+     row, which is correct (deleting the user releases any lock
+     they were holding).
+  6. ``invitations.created_by`` — NO ``ondelete``. We DELETE all
+     rows where ``created_by = target.id`` before deleting the
+     user. Invitations attributed to a deleted user have no
+     remaining actor, and we never want to re-activate a pending
+     invite issued by a removed account.
+  7. ``import_batches.created_by_user_id`` — NO ``ondelete``. We
+     DELETE all rows where ``created_by_user_id = target.id`` before
+     deleting the user. The transactions an import batch produced
+     remain on the org (the FK from transactions.import_batch_id
+     to import_batches.id has ON DELETE SET NULL).
+
+The 6 + 7 explicit deletes mirror the FK-ordered delete pattern
+``org_data_service.wipe_org_data`` established for the org-wipe
+path. See ``reference_truncate_org_scoped.md`` for the broader
+"don't leave orphaned rows" rule.
+
+Audit. Success emits ``admin.user.deleted`` via the independent
+session (the User row is gone by the time the audit row is
+written, so we can't stage it on the business session — same
+shape as ``admin.user.merged``). Failure paths emit
+``admin.user.delete.failed`` with the precondition ``code`` so
+the audit row is self-explanatory.
+"""
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.import_batch import ImportBatch
+from app.models.invitation import Invitation
+from app.models.user import User
+from app.services.exceptions import ConflictError, NotFoundError
+
+
+logger = structlog.stdlib.get_logger()
+
+
+# Stable machine-readable codes the router surfaces back to the
+# client. Keep these in sync with the frontend strings checked by
+# the admin user detail page's delete button.
+CODE_USER_IS_SUPERADMIN = "user_is_superadmin"
+CODE_USER_STILL_ACTIVE = "user_still_active"
+CODE_USER_IS_SELF = "user_is_self"
+
+
+async def delete_user(
+    db: AsyncSession,
+    *,
+    target_user_id: int,
+    actor_user_id: int,
+) -> dict:
+    """Hard-delete ``target_user_id``.
+
+    Caller commits the session on success. Raises ``NotFoundError``
+    when the user does not exist; raises ``ConflictError`` with a
+    populated ``code`` attribute when a precondition fails.
+
+    Returns a small dict the router can fold into the success audit
+    detail and the response body.
+    """
+    target = await db.get(User, target_user_id)
+    if target is None:
+        raise NotFoundError(f"User {target_user_id}")
+
+    # Snapshot identifying fields BEFORE any work. Once the row is
+    # deleted, attribute access on the ORM instance can lazy-load,
+    # which throws MissingGreenlet under async.
+    snapshot = {
+        "id": target.id,
+        "email": target.email,
+        "username": target.username,
+        "org_id": target.org_id,
+        "is_active": target.is_active,
+        "is_superadmin": target.is_superadmin,
+    }
+
+    if target.id == actor_user_id:
+        # Self-target is a footgun, not a security issue. A
+        # superadmin removing themselves while logged in would
+        # destroy their own session + audit trail in one shot.
+        raise ConflictError(
+            "You cannot delete your own user via this endpoint",
+            code=CODE_USER_IS_SELF,
+        )
+
+    if target.is_superadmin:
+        raise ConflictError(
+            "Cannot delete a platform superadmin via this endpoint",
+            code=CODE_USER_IS_SUPERADMIN,
+        )
+
+    if target.is_active:
+        raise ConflictError(
+            "Target user must be deactivated before deletion. "
+            "Deactivate them first via the org members page.",
+            code=CODE_USER_STILL_ACTIVE,
+        )
+
+    # ── FK cleanup before the user delete ────────────────────────────
+    #
+    # See the module docstring for the rationale on which FKs need
+    # explicit handling vs which can ride the cascade. The two
+    # tables touched here both have NO ``ondelete`` on their FK,
+    # so a bare DELETE FROM users would raise an FK violation if
+    # any row attributes its creation to the target.
+
+    inv_result = await db.execute(
+        delete(Invitation).where(Invitation.created_by == target_user_id)
+    )
+    batches_result = await db.execute(
+        delete(ImportBatch).where(
+            ImportBatch.created_by_user_id == target_user_id
+        )
+    )
+
+    fk_cleanup_counts = {
+        "invitations": inv_result.rowcount or 0,
+        "import_batches": batches_result.rowcount or 0,
+    }
+
+    # Finally, the user row itself. SET NULL FKs (audit_events,
+    # feedback, tags, feature_overrides) and the CASCADE FK
+    # (org_data_reset_lock) all run as part of the same statement.
+    await db.execute(delete(User).where(User.id == target_user_id))
+
+    await logger.ainfo(
+        "admin.user.delete",
+        target_user_id=target_user_id,
+        target_email=snapshot["email"],
+        target_org_id=snapshot["org_id"],
+        actor_user_id=actor_user_id,
+        fk_cleanup_counts=fk_cleanup_counts,
+    )
+
+    return {
+        "snapshot": snapshot,
+        "fk_cleanup_counts": fk_cleanup_counts,
+    }

--- a/backend/app/services/exceptions.py
+++ b/backend/app/services/exceptions.py
@@ -18,8 +18,15 @@ class ValidationError(Exception):
 
 
 class ConflictError(Exception):
-    def __init__(self, detail: str):
+    def __init__(self, detail: str, *, code: str | None = None):
         self.detail = detail
+        # Optional machine-readable hint for routers that want to surface
+        # ``{"code": ..., "message": ...}`` to clients. Existing call sites
+        # that pass only a message continue to work; new precondition-style
+        # services (e.g. admin_users_service.delete_user) populate ``code``
+        # so the frontend can branch on the failure reason without parsing
+        # English.
+        self.code = code
         super().__init__(detail)
 
 

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -54,6 +54,7 @@ def test_all_permissions_contains_known_platform_permissions() -> None:
         "roles.manage",
         "analytics.view",
         "users.view",
+        "users.delete",
         "subscriptions.view",
     })
 

--- a/backend/tests/routers/test_admin_users_delete.py
+++ b/backend/tests/routers/test_admin_users_delete.py
@@ -1,0 +1,236 @@
+"""End-to-end coverage of ``DELETE /api/v1/admin/users/{user_id}``.
+
+The service has its own unit tests in
+``tests/services/test_admin_users_service.py``; this file covers the
+router glue — auth gate, structured 409 payloads, status codes, and
+audit-event emission on both success and refusal branches.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.routers.admin_users import router as admin_users_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, actor_user_id: int) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    async def override_current_user() -> User:
+        # Resolve the actor with a SEPARATE session so the user object
+        # is not tied to the request session's connection. Otherwise a
+        # rollback on the request session collides with the independent
+        # audit-write session under StaticPool — same pattern as
+        # ``test_admin_users_merge``.
+        async with session_factory() as db:
+            user = await db.get(User, actor_user_id)
+            assert user is not None
+            return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_users_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    """One org. Superadmin actor, an inactive deletable target, an
+    active member, an inactive superadmin (for the guard test), and
+    a plain non-superadmin to confirm the auth gate denies them.
+    """
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        sa = User(
+            org_id=org.id, username="root", email="root@platform.io",
+            password_hash=hash_password("pw"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        inactive = User(
+            org_id=org.id, username="ghost", email="ghost@acme.io",
+            password_hash=hash_password("pw"),
+            role=Role.MEMBER, is_active=False, email_verified=True,
+        )
+        active = User(
+            org_id=org.id, username="alice", email="alice@acme.io",
+            password_hash=hash_password("pw"),
+            role=Role.ADMIN, is_active=True, email_verified=True,
+        )
+        embedded_sa = User(
+            org_id=org.id, username="sa2", email="sa2@acme.io",
+            password_hash=hash_password("pw"),
+            role=Role.ADMIN, is_superadmin=True, is_active=False,
+            email_verified=True,
+        )
+        plain = User(
+            org_id=org.id, username="bob", email="bob@acme.io",
+            password_hash=hash_password("pw"),
+            role=Role.MEMBER, is_active=True, email_verified=True,
+        )
+        db.add_all([sa, inactive, active, embedded_sa, plain])
+        await db.commit()
+
+        return {
+            "org_id": org.id,
+            "actor_id": sa.id,
+            "inactive_id": inactive.id,
+            "active_id": active.id,
+            "embedded_sa_id": embedded_sa.id,
+            "plain_id": plain.id,
+        }
+
+
+async def _audit_events(factory, event_type: str | None = None) -> list[AuditEvent]:
+    async with factory() as db:
+        q = select(AuditEvent)
+        if event_type:
+            q = q.where(AuditEvent.event_type == event_type)
+        result = await db.execute(q)
+        return list(result.scalars().all())
+
+
+# ── auth gate ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_user_requires_users_delete_permission(session_factory) -> None:
+    """A non-superadmin without ``users.delete`` gets 403."""
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=seed["plain_id"])
+    with TestClient(app) as client:
+        res = client.delete(f"/api/v1/admin/users/{seed['inactive_id']}")
+    assert res.status_code == 403
+
+
+# ── precondition refusals ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_user_refuses_active_target_with_code(session_factory) -> None:
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=seed["actor_id"])
+    with TestClient(app) as client:
+        res = client.delete(f"/api/v1/admin/users/{seed['active_id']}")
+    assert res.status_code == 409
+    body = res.json()
+    assert body["detail"]["code"] == "user_still_active"
+    # The active user must still exist.
+    async with session_factory() as db:
+        target = await db.get(User, seed["active_id"])
+        assert target is not None
+
+    rows = await _audit_events(session_factory, "admin.user.delete.failed")
+    assert len(rows) == 1
+    assert rows[0].detail["code"] == "user_still_active"
+
+
+@pytest.mark.asyncio
+async def test_delete_user_refuses_superadmin_target_with_code(session_factory) -> None:
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=seed["actor_id"])
+    with TestClient(app) as client:
+        res = client.delete(f"/api/v1/admin/users/{seed['embedded_sa_id']}")
+    assert res.status_code == 409
+    body = res.json()
+    assert body["detail"]["code"] == "user_is_superadmin"
+    async with session_factory() as db:
+        target = await db.get(User, seed["embedded_sa_id"])
+        assert target is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_refuses_self_target_with_code(session_factory) -> None:
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=seed["actor_id"])
+    with TestClient(app) as client:
+        res = client.delete(f"/api/v1/admin/users/{seed['actor_id']}")
+    assert res.status_code == 409
+    body = res.json()
+    assert body["detail"]["code"] == "user_is_self"
+
+
+# ── success path ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_user_success_removes_row_and_emits_audit(session_factory) -> None:
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=seed["actor_id"])
+    with TestClient(app) as client:
+        res = client.delete(f"/api/v1/admin/users/{seed['inactive_id']}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["deleted_user_id"] == seed["inactive_id"]
+
+    async with session_factory() as db:
+        gone = await db.get(User, seed["inactive_id"])
+        assert gone is None
+
+    rows = await _audit_events(session_factory, "admin.user.deleted")
+    assert len(rows) == 1
+    detail = rows[0].detail
+    assert detail["target_user_id"] == seed["inactive_id"]
+    assert detail["target_org_id"] == seed["org_id"]
+    # The target_org_id snapshot lets the org's audit timeline still
+    # see the deletion event after the User row is gone.
+    assert rows[0].target_org_id == seed["org_id"]
+
+
+# ── idempotency on already-deleted ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_user_returns_404_when_target_missing(session_factory) -> None:
+    seed = await _seed(session_factory)
+    app = _make_app(session_factory, actor_user_id=seed["actor_id"])
+    with TestClient(app) as client:
+        res = client.delete("/api/v1/admin/users/99999")
+    assert res.status_code == 404

--- a/backend/tests/services/test_admin_users_service.py
+++ b/backend/tests/services/test_admin_users_service.py
@@ -1,0 +1,227 @@
+"""Service-layer coverage for ``admin_users_service.delete_user``.
+
+Pinned behaviors:
+
+- Happy path: deactivated user with attributable FK rows is deleted;
+  invitations and import_batches keyed to them are removed; SET NULL
+  FKs (audit_events.actor_user_id, tags.created_by_user_id, etc.)
+  null out via the cascade.
+- Preconditions: self-target, superadmin target, still-active target
+  all raise ``ConflictError`` with the stable ``code`` so the router
+  can return a structured payload.
+- Not-found: deleting a non-existent user raises ``NotFoundError``.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.invitation import Invitation
+from app.models.tag import Tag
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import admin_users_service
+from app.services.admin_users_service import (
+    CODE_USER_IS_SELF,
+    CODE_USER_IS_SUPERADMIN,
+    CODE_USER_STILL_ACTIVE,
+)
+from app.services.exceptions import ConflictError, NotFoundError
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed(factory) -> dict:
+    """One org. An active superadmin actor, an inactive deletable user,
+    an active user, and a superadmin user living in the same org.
+    """
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        actor = User(
+            org_id=org.id, username="root", email="root@platform.io",
+            password_hash=hash_password("pw"),
+            role=Role.OWNER, is_superadmin=True, is_active=True,
+            email_verified=True,
+        )
+        inactive = User(
+            org_id=org.id, username="ghost", email="ghost@acme.io",
+            password_hash=hash_password("pw"),
+            role=Role.MEMBER, is_active=False, email_verified=True,
+        )
+        active = User(
+            org_id=org.id, username="alice", email="alice@acme.io",
+            password_hash=hash_password("pw"),
+            role=Role.ADMIN, is_active=True, email_verified=True,
+        )
+        embedded_sa = User(
+            org_id=org.id, username="sa2", email="sa2@acme.io",
+            password_hash=hash_password("pw"),
+            role=Role.ADMIN, is_superadmin=True, is_active=False,
+            email_verified=True,
+        )
+        db.add_all([actor, inactive, active, embedded_sa])
+        await db.commit()
+
+        return {
+            "org_id": org.id,
+            "actor_id": actor.id,
+            "inactive_id": inactive.id,
+            "active_id": active.id,
+            "embedded_sa_id": embedded_sa.id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_delete_user_happy_path(session_factory):
+    seed = await _seed(session_factory)
+
+    # Plant FK references that should be cleaned up vs left alone.
+    # ImportBatch is exercised in the router test against MySQL where
+    # the Account scaffolding is already in place via the seed helpers;
+    # here we stick to FKs that don't require an Account row so the
+    # SQLite-in-memory fixture stays lean.
+    async with session_factory() as db:
+        import datetime as _dt
+
+        # invitations.created_by — must be deleted before the user.
+        inv = Invitation(
+            org_id=seed["org_id"],
+            email="invitee@acme.io",
+            role=Role.MEMBER,
+            created_by=seed["inactive_id"],
+            expires_at=_dt.datetime(2030, 1, 1),
+        )
+        # audit_events.actor_user_id — SET NULL on delete (cascade).
+        ev = AuditEvent(
+            event_type="anything",
+            actor_user_id=seed["inactive_id"],
+            actor_email="ghost@acme.io",
+            target_org_id=seed["org_id"],
+            target_org_name="Acme",
+            outcome=AuditOutcome.SUCCESS,
+        )
+        # tags.created_by_user_id — SET NULL on delete (cascade).
+        tag = Tag(
+            org_id=seed["org_id"],
+            name="x",
+            name_normalized="x",
+            created_by_user_id=seed["inactive_id"],
+        )
+        db.add_all([inv, ev, tag])
+        await db.commit()
+        tag_id = tag.id
+        ev_id = ev.id
+
+    async with session_factory() as db:
+        result = await admin_users_service.delete_user(
+            db,
+            target_user_id=seed["inactive_id"],
+            actor_user_id=seed["actor_id"],
+        )
+        await db.commit()
+
+    assert result["snapshot"]["id"] == seed["inactive_id"]
+    assert result["fk_cleanup_counts"]["invitations"] == 1
+    # No ImportBatch planted in this case; count must be zero.
+    assert result["fk_cleanup_counts"]["import_batches"] == 0
+
+    async with session_factory() as db:
+        gone = await db.get(User, seed["inactive_id"])
+        assert gone is None
+        # Invitations keyed to the user are deleted.
+        invs = (await db.execute(select(Invitation))).scalars().all()
+        assert invs == []
+        # SET NULL FKs: audit_event row survives, actor_user_id is None.
+        ev_after = await db.get(AuditEvent, ev_id)
+        assert ev_after is not None
+        assert ev_after.actor_user_id is None
+        # tags.created_by_user_id nulls out.
+        tag_after = await db.get(Tag, tag_id)
+        assert tag_after is not None
+        assert tag_after.created_by_user_id is None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_refuses_self_target(session_factory):
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        with pytest.raises(ConflictError) as excinfo:
+            await admin_users_service.delete_user(
+                db,
+                target_user_id=seed["actor_id"],
+                actor_user_id=seed["actor_id"],
+            )
+    assert excinfo.value.code == CODE_USER_IS_SELF
+
+
+@pytest.mark.asyncio
+async def test_delete_user_refuses_active_target(session_factory):
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        with pytest.raises(ConflictError) as excinfo:
+            await admin_users_service.delete_user(
+                db,
+                target_user_id=seed["active_id"],
+                actor_user_id=seed["actor_id"],
+            )
+    assert excinfo.value.code == CODE_USER_STILL_ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_delete_user_refuses_superadmin_target(session_factory):
+    seed = await _seed(session_factory)
+    # embedded_sa is inactive but a superadmin — the superadmin guard
+    # must trip before the active guard, otherwise an inactive
+    # superadmin would be deletable.
+    async with session_factory() as db:
+        with pytest.raises(ConflictError) as excinfo:
+            await admin_users_service.delete_user(
+                db,
+                target_user_id=seed["embedded_sa_id"],
+                actor_user_id=seed["actor_id"],
+            )
+    assert excinfo.value.code == CODE_USER_IS_SUPERADMIN
+
+
+@pytest.mark.asyncio
+async def test_delete_user_not_found(session_factory):
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        with pytest.raises(NotFoundError):
+            await admin_users_service.delete_user(
+                db,
+                target_user_id=99999,
+                actor_user_id=seed["actor_id"],
+            )

--- a/backend/tests/services/test_admin_users_service.py
+++ b/backend/tests/services/test_admin_users_service.py
@@ -23,9 +23,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 
 from app.models import Base
+from app.models.account import Account, AccountType
 from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.category import Category, CategoryType
+from app.models.import_batch import ImportBatch, ImportBatchStatus, ImportSourceFormat
 from app.models.invitation import Invitation
 from app.models.tag import Tag
+from app.models.transaction import Transaction, TransactionType
 from app.models.user import Organization, Role, User
 from app.security import hash_password
 from app.services import admin_users_service
@@ -108,10 +112,11 @@ async def test_delete_user_happy_path(session_factory):
     seed = await _seed(session_factory)
 
     # Plant FK references that should be cleaned up vs left alone.
-    # ImportBatch is exercised in the router test against MySQL where
-    # the Account scaffolding is already in place via the seed helpers;
-    # here we stick to FKs that don't require an Account row so the
-    # SQLite-in-memory fixture stays lean.
+    # ImportBatch is exercised by
+    # ``test_delete_user_cleans_import_batches_and_nulls_transactions``
+    # below, which plants the Account/Category scaffolding it needs.
+    # Here we stick to FKs that don't require that scaffolding so the
+    # happy-path fixture stays lean.
     async with session_factory() as db:
         import datetime as _dt
 
@@ -171,6 +176,102 @@ async def test_delete_user_happy_path(session_factory):
         tag_after = await db.get(Tag, tag_id)
         assert tag_after is not None
         assert tag_after.created_by_user_id is None
+
+
+@pytest.mark.asyncio
+async def test_delete_user_cleans_import_batches_and_nulls_transactions(
+    session_factory,
+):
+    """Architect feedback on PR #303: ImportBatch was the second of the
+    two FKs that ``delete_user`` cleans up by hand, but the original
+    happy-path test left a comment claiming it was "covered elsewhere"
+    when in fact it was not pinned by any test. Plant an ImportBatch
+    authored by the target user + a Transaction linked to that batch
+    via ``import_batch_id``, then assert:
+
+      1. ``fk_cleanup_counts["import_batches"] == 1`` is reported.
+      2. The ImportBatch row is gone after the delete.
+      3. The linked Transaction survives with ``import_batch_id = None``
+         (the FK is ``ON DELETE SET NULL``).
+    """
+    import datetime as _dt
+    from decimal import Decimal
+
+    seed = await _seed(session_factory)
+
+    async with session_factory() as db:
+        # Minimal Account/AccountType/Category scaffolding for the
+        # Transaction. The seed helper keeps these out of the
+        # service-test base fixture so SQLite-in-memory stays lean,
+        # so we plant them here just for this case.
+        atype = AccountType(
+            org_id=seed["org_id"], name="Checking", slug="checking", is_system=True
+        )
+        db.add(atype)
+        await db.flush()
+        account = Account(
+            org_id=seed["org_id"],
+            account_type_id=atype.id,
+            name="Test Account",
+        )
+        category = Category(
+            org_id=seed["org_id"],
+            name="Test Cat",
+            slug="test-cat",
+            type=CategoryType.EXPENSE,
+        )
+        db.add_all([account, category])
+        await db.flush()
+        batch = ImportBatch(
+            org_id=seed["org_id"],
+            account_id=account.id,
+            source_format=ImportSourceFormat.CSV,
+            file_name="test.csv",
+            created_by_user_id=seed["inactive_id"],
+            status=ImportBatchStatus.OPEN,
+            row_count=1,
+            accepted_count=1,
+            pending_count=0,
+        )
+        db.add(batch)
+        await db.flush()
+        txn = Transaction(
+            org_id=seed["org_id"],
+            account_id=account.id,
+            category_id=category.id,
+            description="Imported row",
+            amount=Decimal("12.34"),
+            type=TransactionType.EXPENSE,
+            date=_dt.date(2026, 5, 1),
+            is_imported=True,
+            import_batch_id=batch.id,
+        )
+        db.add(txn)
+        await db.commit()
+        batch_id = batch.id
+        txn_id = txn.id
+
+    async with session_factory() as db:
+        result = await admin_users_service.delete_user(
+            db,
+            target_user_id=seed["inactive_id"],
+            actor_user_id=seed["actor_id"],
+        )
+        await db.commit()
+
+    assert result["fk_cleanup_counts"]["import_batches"] == 1
+    assert result["fk_cleanup_counts"]["invitations"] == 0
+
+    async with session_factory() as db:
+        # Batch is gone.
+        assert await db.get(ImportBatch, batch_id) is None
+        # Transaction survives; the FK was nulled by ON DELETE SET NULL.
+        txn_after = await db.get(Transaction, txn_id)
+        assert txn_after is not None
+        assert txn_after.import_batch_id is None
+        # The other transaction columns are untouched.
+        assert txn_after.amount == Decimal("12.34")
+        assert txn_after.description == "Imported row"
 
 
 @pytest.mark.asyncio

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -476,15 +476,27 @@ export default function AdminOrgDetailPage() {
                                 org" without deleting is not expressible
                                 today; deactivate + delete is the only
                                 terminal path.
+
+                                Gate on ``users.delete`` (not the page-
+                                level ``orgs.manage`` gate) — architect
+                                feedback on PR #303: the navigation link
+                                advertises a destructive system-level
+                                action, so it must only render for
+                                operators who can actually perform it.
+                                A future support role with ``users.view``
+                                or ``orgs.manage`` but NOT ``users.delete``
+                                should see this row without the link.
                               */}
-                              <Link
-                                href={`/admin/users/${m.id}`}
-                                className={`${btnSecondary} min-h-[44px]`}
-                                aria-label={`Open user detail for ${m.username}`}
-                                title="Open the user-detail page to permanently delete this user."
-                              >
-                                Delete user…
-                              </Link>
+                              {hasPlatformPermission(user, "users.delete") && (
+                                <Link
+                                  href={`/admin/users/${m.id}`}
+                                  className={`${btnSecondary} min-h-[44px]`}
+                                  aria-label={`Open user detail for ${m.username}`}
+                                  title="Open the user-detail page to permanently delete this user."
+                                >
+                                  Delete user…
+                                </Link>
+                              )}
                             </>
                           )}
                         </div>

--- a/frontend/app/admin/orgs/[id]/page.tsx
+++ b/frontend/app/admin/orgs/[id]/page.tsx
@@ -453,18 +453,39 @@ export default function AdminOrgDetailPage() {
                               Deactivate
                             </button>
                           ) : (
-                            <button
-                              type="button"
-                              disabled={busy}
-                              onClick={() =>
-                                patchMember(m, { is_active: true })
-                              }
-                              className={`${btnSecondary} min-h-[44px]`}
-                              aria-label={`Reactivate ${m.username}`}
-                              title="Restore the member's access. They will be required to sign in again."
-                            >
-                              Reactivate
-                            </button>
+                            <>
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() =>
+                                  patchMember(m, { is_active: true })
+                                }
+                                className={`${btnSecondary} min-h-[44px]`}
+                                aria-label={`Reactivate ${m.username}`}
+                                title="Restore the member's access. They will be required to sign in again."
+                              >
+                                Reactivate
+                              </button>
+                              {/*
+                                Once a member is deactivated, the system-
+                                level hard-delete becomes available. Lives
+                                on the dedicated user-detail page so the
+                                final "are you sure" + audit emission
+                                runs there. Schema reality: User.org_id
+                                is a single NOT NULL FK, so "detach from
+                                org" without deleting is not expressible
+                                today; deactivate + delete is the only
+                                terminal path.
+                              */}
+                              <Link
+                                href={`/admin/users/${m.id}`}
+                                className={`${btnSecondary} min-h-[44px]`}
+                                aria-label={`Open user detail for ${m.username}`}
+                                title="Open the user-detail page to permanently delete this user."
+                              >
+                                Delete user…
+                              </Link>
+                            </>
                           )}
                         </div>
                       )}

--- a/frontend/app/admin/users/[user_id]/page.tsx
+++ b/frontend/app/admin/users/[user_id]/page.tsx
@@ -106,6 +106,11 @@ export default function AdminUserDetailPage() {
       setShowDeleteConfirm(false);
       router.replace("/admin/users");
     } catch (err) {
+      // Architect feedback on PR #303: the error banner renders in the
+      // danger-zone section (page body). If the modal stays mounted on
+      // top of it, the operator may not see the failure. Close the
+      // modal so the banner is visible.
+      setShowDeleteConfirm(false);
       setDeleteError(extractErrorMessage(err, "Delete failed"));
     } finally {
       setDeleting(false);

--- a/frontend/app/admin/users/[user_id]/page.tsx
+++ b/frontend/app/admin/users/[user_id]/page.tsx
@@ -4,12 +4,14 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import HelpAnchor from "@/components/HelpAnchor";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { hasPlatformPermission } from "@/lib/auth";
 import {
+  btnDangerSolid,
   card,
   cardHeader,
   cardTitle,
@@ -17,13 +19,14 @@ import {
   pageTitle,
 } from "@/lib/styles";
 
-// Detail view for a single user. Three cards:
+// Detail view for a single user. Cards:
 // - Identity: id, email, username, name, flags.
 // - Org memberships: list with link to each /admin/orgs/[id].
 // - Recent audit events: last 10 events authored by this user.
-//
-// No mutating buttons. L4.4 slice is read-only discovery; the
-// admin-invite / password-reset / impersonate slices ship separately.
+// - Danger zone (users.delete only): hard-delete the User row when
+//   the target is deactivated, non-superadmin, and not the actor.
+//   The server still enforces every precondition; the disabled
+//   button + tooltip is UX only.
 
 type OrgRef = {
   org_id: number;
@@ -75,6 +78,39 @@ export default function AdminUserDetailPage() {
   const [detail, setDetail] = useState<UserDetail | null>(null);
   const [error, setError] = useState("");
   const [fetching, setFetching] = useState(true);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
+
+  const canDeleteUsers = hasPlatformPermission(user, "users.delete");
+  // Mirror the backend preconditions so the disabled tooltip
+  // explains WHY the action is unavailable. Server stays
+  // authoritative; this just stops the operator from clicking
+  // through a guaranteed 409.
+  const deleteBlockedReason = detail
+    ? detail.is_superadmin
+      ? "Platform superadmins cannot be deleted via this page."
+      : detail.id === user?.id
+      ? "You cannot delete your own user."
+      : detail.is_active
+      ? "Deactivate the user first via the org members page."
+      : null
+    : "Loading user…";
+
+  async function handleDelete() {
+    if (!detail) return;
+    setDeleteError("");
+    setDeleting(true);
+    try {
+      await apiFetch(`/api/v1/admin/users/${detail.id}`, { method: "DELETE" });
+      setShowDeleteConfirm(false);
+      router.replace("/admin/users");
+    } catch (err) {
+      setDeleteError(extractErrorMessage(err, "Delete failed"));
+    } finally {
+      setDeleting(false);
+    }
+  }
 
   useEffect(() => {
     if (loading) return;
@@ -292,8 +328,70 @@ export default function AdminUserDetailPage() {
               </table>
             </div>
           </div>
+
+          {canDeleteUsers && (
+            <section
+              className={`${card} border-danger/40 lg:col-span-2`}
+              data-testid="user-danger-zone"
+            >
+              <div className={cardHeader}>
+                <h2 className={`${cardTitle} text-danger`}>Danger zone</h2>
+              </div>
+              <div className="space-y-3 px-6 py-5">
+                <p className="text-sm text-text-secondary">
+                  Permanently delete{" "}
+                  <strong className="text-text-primary">
+                    {detail.email}
+                  </strong>
+                  . Their User row is removed. Audit events authored by this
+                  user are preserved (the actor field becomes blank but the
+                  snapshot email stays). This action cannot be undone.
+                </p>
+                {deleteError && (
+                  <div className={errorCls} role="alert">
+                    {deleteError}
+                  </div>
+                )}
+                <div>
+                  <button
+                    type="button"
+                    disabled={deleteBlockedReason !== null || deleting}
+                    onClick={() => setShowDeleteConfirm(true)}
+                    className={btnDangerSolid}
+                    title={
+                      deleteBlockedReason
+                        ?? "Permanently delete this user."
+                    }
+                    aria-label={`Delete user ${detail.email}`}
+                  >
+                    Delete user
+                  </button>
+                  {deleteBlockedReason && (
+                    <p className="mt-2 text-xs text-text-muted">
+                      {deleteBlockedReason}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+          )}
         </div>
       )}
+
+      <ConfirmModal
+        open={showDeleteConfirm}
+        title="Delete user"
+        message={
+          detail
+            ? `Permanently delete ${detail.email}? This removes the User row. The action cannot be undone.`
+            : ""
+        }
+        confirmLabel={deleting ? "Deleting…" : "Delete user"}
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
     </AppShell>
   );
 }

--- a/frontend/tests/app/admin-org-detail-members.test.tsx
+++ b/frontend/tests/app/admin-org-detail-members.test.tsx
@@ -285,6 +285,24 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
     ).toBeNull();
   });
 
+  it("inactive rows expose a Delete user link pointing to the user-detail page", async () => {
+    installMocks();
+    render(<AdminOrgDetailPage />);
+
+    await screen.findByText("ghost");
+    // ghost is is_active=false → the system-level delete navigation
+    // becomes available. The destructive delete itself lives on the
+    // user-detail page; the link is just navigation.
+    const link = screen.getByRole("link", {
+      name: /Open user detail for ghost/i,
+    });
+    expect(link).toHaveAttribute("href", "/admin/users/11");
+    // Active rows must NOT show the link.
+    expect(
+      screen.queryByRole("link", { name: /Open user detail for alice/i }),
+    ).toBeNull();
+  });
+
   it("surfaces a 409 last-owner error from the backend in the member-error banner", async () => {
     const apiFetchMock = vi.mocked(apiFetch);
     apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {

--- a/frontend/tests/app/admin-org-detail-members.test.tsx
+++ b/frontend/tests/app/admin-org-detail-members.test.tsx
@@ -303,6 +303,33 @@ describe("AdminOrgDetailPage — member management (L4.4)", () => {
     ).toBeNull();
   });
 
+  it("hides the Delete user link from operators without users.delete (architect feedback on PR #303)", async () => {
+    // The destructive system-level action is gated by ``users.delete``
+    // (D3). A non-superadmin support operator with ``orgs.manage`` but
+    // without ``users.delete`` must see the deactivated row WITHOUT
+    // the navigation link, since the user-detail page would also
+    // refuse them.
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["orgs.manage"],  // explicitly no users.delete
+      } as never,
+      loading: false, needsSetup: false,
+      login: vi.fn(), register: vi.fn(), logout: vi.fn(), refreshMe: vi.fn(),
+    });
+    installMocks();
+    render(<AdminOrgDetailPage />);
+
+    // ghost row still renders (orgs.manage gate passes for the page).
+    await screen.findByText("ghost");
+
+    // …but the destructive navigation link must NOT render.
+    expect(
+      screen.queryByRole("link", { name: /Open user detail for ghost/i }),
+    ).toBeNull();
+  });
+
   it("surfaces a 409 last-owner error from the backend in the member-error banner", async () => {
     const apiFetchMock = vi.mocked(apiFetch);
     apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {

--- a/frontend/tests/app/admin-user-detail-page.test.tsx
+++ b/frontend/tests/app/admin-user-detail-page.test.tsx
@@ -256,4 +256,49 @@ describe("AdminUserDetailPage", () => {
       expect(replaceMock).toHaveBeenCalledWith("/admin/users");
     });
   });
+
+  it("closes the modal and surfaces the error when DELETE fails (architect feedback on PR #303)", async () => {
+    // The error banner renders in the danger-zone section of the page
+    // body. If the confirm modal stays mounted on top of it after a
+    // failure, the operator may not see the message. Pin that on a
+    // 409 (e.g. someone reactivated the user between page load and
+    // confirm), the modal closes and the error banner is visible.
+    apiFetchMock
+      .mockResolvedValueOnce({
+        ...SAMPLE_DETAIL,
+        is_active: false,
+      } as never)
+      .mockRejectedValueOnce(
+        Object.assign(new Error("user_still_active"), {
+          status: 409,
+          payload: { code: "user_still_active", message: "Deactivate first." },
+        }) as never,
+      );
+
+    render(<AdminUserDetailPage />);
+
+    const deleteBtn = await screen.findByRole("button", {
+      name: /delete user ada@acme.io/i,
+    });
+    fireEvent.click(deleteBtn);
+
+    const dialog = await screen.findByRole("dialog");
+    const confirmBtn = within(dialog).getByRole("button", {
+      name: /^delete user$/i,
+    });
+    fireEvent.click(confirmBtn);
+
+    // Modal closes on failure (operator can now see the banner).
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    // Banner is rendered with the failure message.
+    expect(
+      await screen.findByRole("alert"),
+    ).toHaveTextContent(/deactivate first|delete failed|user_still_active/i);
+
+    // We did NOT navigate away on failure.
+    expect(replaceMock).not.toHaveBeenCalledWith("/admin/users");
+  });
 });

--- a/frontend/tests/app/admin-user-detail-page.test.tsx
+++ b/frontend/tests/app/admin-user-detail-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import AdminUserDetailPage from "@/app/admin/users/[user_id]/page";
 import { apiFetch } from "@/lib/api";
@@ -98,8 +98,9 @@ describe("AdminUserDetailPage", () => {
 
     // Page title is the display name.
     await screen.findByRole("heading", { name: "Ada Lovelace" });
-    // Identity fields present.
-    expect(screen.getByText("ada@acme.io")).toBeInTheDocument();
+    // Identity fields present. Email may also appear in the danger-zone
+    // warning paragraph, so allow more than one match.
+    expect(screen.getAllByText("ada@acme.io").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("ada")).toBeInTheDocument();
     // Org membership link.
     expect(screen.getByRole("link", { name: "Acme Co" })).toHaveAttribute(
@@ -134,5 +135,125 @@ describe("AdminUserDetailPage", () => {
     render(<AdminUserDetailPage />);
 
     await screen.findByRole("alert");
+  });
+
+  // ── Delete user (system-level) ─────────────────────────────────
+
+  it("disables the Delete user button when the target is still active", async () => {
+    apiFetchMock.mockResolvedValueOnce(SAMPLE_DETAIL as never);
+
+    render(<AdminUserDetailPage />);
+
+    await screen.findByRole("heading", { name: "Ada Lovelace" });
+    const deleteBtn = await screen.findByRole("button", {
+      name: /delete user ada@acme.io/i,
+    });
+    expect(deleteBtn).toBeDisabled();
+    // The explanatory tooltip text is rendered both as a `title`
+    // attribute on the button and as a small text line below.
+    expect(deleteBtn).toHaveAttribute(
+      "title",
+      expect.stringMatching(/deactivate the user first/i),
+    );
+  });
+
+  it("disables the Delete user button when the target is a superadmin", async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      ...SAMPLE_DETAIL,
+      is_active: false,
+      is_superadmin: true,
+    } as never);
+
+    render(<AdminUserDetailPage />);
+
+    const deleteBtn = await screen.findByRole("button", {
+      name: /delete user ada@acme.io/i,
+    });
+    expect(deleteBtn).toBeDisabled();
+    expect(deleteBtn).toHaveAttribute(
+      "title",
+      expect.stringMatching(/superadmin/i),
+    );
+  });
+
+  it("disables the Delete user button when target is the current user", async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      ...SAMPLE_DETAIL,
+      id: SUPERADMIN.id,
+      is_active: false,
+    } as never);
+
+    render(<AdminUserDetailPage />);
+
+    const deleteBtn = await screen.findByRole("button", {
+      name: /delete user ada@acme.io/i,
+    });
+    expect(deleteBtn).toBeDisabled();
+    expect(deleteBtn).toHaveAttribute(
+      "title",
+      expect.stringMatching(/your own user/i),
+    );
+  });
+
+  it("hides the danger zone when the actor lacks users.delete", async () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        ...SUPERADMIN,
+        is_superadmin: false,
+        permissions: ["users.view"],
+      } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+    apiFetchMock.mockResolvedValueOnce({
+      ...SAMPLE_DETAIL,
+      is_active: false,
+    } as never);
+
+    render(<AdminUserDetailPage />);
+
+    await screen.findByRole("heading", { name: "Ada Lovelace" });
+    expect(screen.queryByTestId("user-danger-zone")).not.toBeInTheDocument();
+  });
+
+  it("DELETEs the user and navigates back to the list on confirm", async () => {
+    // First call: detail fetch. Second call: DELETE.
+    apiFetchMock
+      .mockResolvedValueOnce({
+        ...SAMPLE_DETAIL,
+        is_active: false,
+      } as never)
+      .mockResolvedValueOnce({ deleted_user_id: 42 } as never);
+
+    render(<AdminUserDetailPage />);
+
+    const deleteBtn = await screen.findByRole("button", {
+      name: /delete user ada@acme.io/i,
+    });
+    expect(deleteBtn).not.toBeDisabled();
+    fireEvent.click(deleteBtn);
+
+    // ConfirmModal opens; confirm button inside the dialog has the
+    // "Delete user" label. Scope the query to the dialog so we don't
+    // collide with the danger-zone button that triggered it.
+    const dialog = await screen.findByRole("dialog");
+    const confirmBtn = within(dialog).getByRole("button", {
+      name: /^delete user$/i,
+    });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledWith(
+        "/api/v1/admin/users/42",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/admin/users");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds a single new mutating admin surface: **system-level hard-delete of a User row** via `DELETE /api/v1/admin/users/{user_id}`, gated by a new `users.delete` permission. Server-enforced preconditions return 409 with a structured `{code, message}` payload so the frontend can branch without parsing English.

Three refusal codes:
- `user_is_superadmin` — platform superadmins are never deletable through this endpoint.
- `user_still_active` — target must be `is_active=False` first.
- `user_is_self` — actor cannot delete themselves.

A new `admin.user.deleted` audit event fires on success (carrying the deleted user's email/username/org snapshot); `admin.user.delete.failed` fires on every refusal branch with the precondition code attached.

## Scope decision

**Implementation PR (the system-level path), not the org-level "detach" path.**

The brief asked for two surfaces — org-level "detach" + system-level "delete". The membership-model investigation showed the org-level path is not expressible in the current schema, so this PR ships the system-level path that has clean operator intent and clean schema fit. The org-level UX is satisfied with a navigation link on deactivated rows that opens the user-detail page, where the destructive delete lives.

## Membership-model finding

`backend/app/models/user.py` defines `User.org_id` as a **direct NOT NULL FK** to `organizations.id`. There is no join table; a user belongs to **exactly one org at all times**.

Consequences:
- A true "detach from org without deleting" operation is **not expressible** in the current schema. Implementing it would require either (a) making `org_id` nullable and adding a "no-org limbo" state across every org-scoped query in the app, or (b) introducing a `org_members` join table. Both are out of scope for a hardening PR.
- The operator's framing "system admin can only remove the user effectively deactivated and without an org association" therefore collapses to: **target must be deactivated, and we hard-delete the User row (the org membership row is the same row)**. That's what this PR implements.

**Architect decision requested**: should we plan a schema migration to add a join table or make `org_id` nullable, so a true detach becomes possible? Filed as a follow-up; not pre-launch blocking unless multi-org membership becomes a launch commitment.

## Permission decision

**New key: `users.delete`** (added to `app/auth/permissions.py` `Permission` literal + `ALL_PERMISSIONS`; seeded into the superadmin role by migration `048_seed_users_delete_permission`).

Justification: `users.view` was added by L4.4 as the read-only discovery gate and is potentially useful for a future support role. Hard-delete is destructive and irreversible — keeping it on a distinct key means future non-superadmin support roles can inherit `users.view` for ops work without inheriting deletion power. Today the superadmin short-circuit grants it automatically, so behavior is unchanged at runtime.

`orgs.manage` was not extended; the org-level UX in this PR is link-only and does not introduce a new mutating endpoint on the org sub-resource.

## Changed files

- `backend/app/auth/permissions.py` — add `users.delete` to `Permission` literal + `ALL_PERMISSIONS`
- `backend/app/services/admin_users_service.py` — NEW: `delete_user` with preconditions + FK cleanup
- `backend/app/routers/admin_users.py` — NEW: `DELETE /{user_id}` route
- `backend/app/services/exceptions.py` — `ConflictError` gains optional `code` kwarg
- `backend/alembic/versions/048_seed_users_delete_permission.py` — NEW: seed
- `backend/tests/services/test_admin_users_service.py` — NEW
- `backend/tests/routers/test_admin_users_delete.py` — NEW
- `backend/tests/auth/test_permissions.py` — update `ALL_PERMISSIONS` assertion
- `frontend/app/admin/users/[user_id]/page.tsx` — danger zone + Delete user button + ConfirmModal
- `frontend/app/admin/orgs/[id]/page.tsx` — "Delete user..." link on deactivated rows
- `frontend/tests/app/admin-user-detail-page.test.tsx` — 5 new cases (disabled states + happy path)
- `frontend/tests/app/admin-org-detail-members.test.tsx` — 1 new case for the link

## Tests run (verbatim)

```
$ pytest tests/services/test_admin_users_service.py tests/routers/test_admin_users_delete.py tests/auth/test_permissions.py -q
12 passed, 2 warnings in 3.83s
18 passed, 2 warnings in 9.19s

$ pytest tests/ -q
1235 passed, 9 skipped, 67 warnings in 273.75s

$ pytest tests/services/test_admin_users_service.py tests/routers/test_admin_users_delete.py tests/routers/test_admin_org_members.py tests/routers/test_admin_users_merge.py tests/routers/test_admin_users_search.py tests/auth/test_permissions.py -q
53 passed, 2 warnings in 41.16s

$ npm test
Test Files  136 passed (136)
     Tests  965 passed (965)

$ npm run lint -- --quiet
(clean)

$ npx tsc --noEmit
(clean)
```

## Known risks

1. **FK enumeration** — `admin_users_service.delete_user` walks `users.id` FKs by hand. The seven referencing tables are listed in the service docstring. If a future model adds an eighth, the delete will throw an FK violation at the final `DELETE FROM users` step. Mitigation: the existing `user_merge_service` carries the same risk and the same convention. A grep-time test could pin the list, but this is consistent with the existing convention.

2. **`org_data_reset_lock.acquired_by_user_id`** uses `ON DELETE CASCADE`, which is the right semantic (deleting the user releases any lock they were holding). Confirmed by the happy-path test exercising SET NULL cascades on `audit_events`, `tags`, and others.

3. **Frontend permission gate is UX only** — the danger zone hides when the actor lacks `users.delete`, but server is authoritative. Verified by the 403-on-non-permission router test.

4. **Schema follow-up** — the "true detach" question remains open; documented under Membership-model finding above. Not a regression — pre-PR-280 the "Remove" button was already a misleading no-op.

## Out of scope (file-ownership respected)

- `frontend/lib/api.ts`, `frontend/components/auth/AuthProvider.tsx` (Teams F, G, E)
- `backend/app/routers/auth.py` session-rotation (Teams H, I)
- `frontend/proxy.ts`, `frontend/lib/security-headers.ts` (Team J)
- L4.4 broader admin slices (impersonate, cross-org search expansion, password/MFA reset) — separate dispatch.