### PR TITLE
feat(auth): refresh jti + sid + Redis primary key + family set (PR 2 of 4)

### DIFF
--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -1,17 +1,19 @@
 """Redis / Valkey client — singleton, lazy-initialized from settings.
 
-Scope today: MFA email-code single-use nonces. Intentionally narrow. More
-features (rate-limit storage, cache, session ACLs) land here when the app
-moves off single-replica on DO App Platform and needs shared state.
+Scope today: MFA email-code single-use nonces + refresh-session primary
+key and family set (``auth:session:{jti}``, ``auth:session:by_sid:{sid}``).
+More features (rate-limit storage, cache) land here when the app moves
+off single-replica on DO App Platform and needs shared state.
 
 Behavior when `settings.redis_url` is empty:
 - Development: `get_client()` returns `None`. Callers must handle None and
   decide whether to skip the Redis-backed check (usually yes in dev).
 - Production: a runtime warning is logged at startup. The security-critical
-  callers (MFA nonce) MUST fail closed if they need Redis and it's missing;
-  see `require_client()` below.
+  callers (MFA nonce, auth-session writes) MUST fail closed if they need
+  Redis and it's missing; see `require_client()` below.
 """
 
+import json
 import logging
 
 from redis.asyncio import Redis
@@ -87,3 +89,103 @@ def require_client() -> Redis:
             "Configure it in DO App Platform secrets or your local .env."
         )
     return client
+
+
+# ── Refresh-session keys (specs/2026-05-17-backend-session-model.md §4) ─────
+#
+# Two key shapes drive the per-session story:
+#
+#   auth:session:{jti}        primary key for ONE refresh JWT (rotates each
+#                             /refresh; value = JSON {"user_id", "sid"};
+#                             TTL = refresh_idle_ttl_days * 86400)
+#   auth:session:by_sid:{sid} family set holding every jti ever issued for
+#                             this session FAMILY (sid is stable across the
+#                             entire rotation chain so per-session logout
+#                             in PR 4 can revoke every successor)
+#
+# Every issue path (login, /refresh rotation, MFA branches, Google
+# callback, invitation accept) MUST write both keys in a single
+# MULTI/EXEC BEFORE setting the cookie. If Redis is unreachable the
+# request returns 503 — never set a cookie that has no Redis row.
+
+SESSION_PRIMARY_KEY = "auth:session:{jti}"
+SESSION_FAMILY_KEY = "auth:session:by_sid:{sid}"
+
+
+def _primary_key(jti: str) -> str:
+    return f"auth:session:{jti}"
+
+
+def _family_key(sid: str) -> str:
+    return f"auth:session:by_sid:{sid}"
+
+
+async def session_issue(jti: str, sid: str, user_id: int, ttl_seconds: int) -> None:
+    """Write the refresh-session primary key + family-set entry atomically.
+
+    Runs one ``MULTI/EXEC`` so a partial write cannot leak — either the
+    primary key AND the family set entry both land, or neither does.
+    Used by every fresh-session issue path (login password, MFA
+    branches, Google callback, invitation accept).
+
+    Fails CLOSED on unreachable Redis via :func:`require_client` —
+    routers that catch ``RedisRequired`` and other ``RedisError``
+    subclasses return 503 and DO NOT set the cookie. See
+    ``specs/2026-05-17-backend-session-model.md`` §7.1.
+    """
+    client = require_client()
+    payload = json.dumps({"user_id": user_id, "sid": sid}, separators=(",", ":"))
+    pipe = client.pipeline(transaction=True)
+    pipe.set(_primary_key(jti), payload, ex=ttl_seconds)
+    pipe.sadd(_family_key(sid), jti)
+    pipe.expire(_family_key(sid), ttl_seconds)
+    await pipe.execute()
+
+
+async def session_validate(jti: str) -> dict | None:
+    """Return the JSON payload at ``auth:session:{jti}`` or None on miss.
+
+    Caller is expected to translate ``None`` into the existing 401
+    ``"Session has been invalidated"`` response. Redis connection errors
+    bubble up unchanged so the router can return 503 (fail closed).
+    """
+    client = require_client()
+    raw = await client.get(_primary_key(jti))
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        # Corrupt key; treat as miss. Belt-and-braces — this should not
+        # happen because session_issue is the only writer and it always
+        # writes valid JSON.
+        return None
+
+
+async def session_rotate(
+    old_jti: str,
+    new_jti: str,
+    sid: str,
+    user_id: int,
+    ttl_seconds: int,
+) -> None:
+    """Sequential rotation: SET new primary, SADD by_sid new_jti,
+    EXPIRE by_sid, DEL old primary — in one ``MULTI/EXEC`` block.
+
+    PR 2 scope: NO Lua, NO EXISTS guards, NO grace key. The architect-
+    acknowledged partial-failure window is tolerated for one PR cycle
+    because in PR 2 there is no concurrent-logout-vs-rotation surface
+    yet (the global-cutoff logout still wipes everything) and no grace
+    key for the race in §4.3 to subvert. PR 3 replaces this with the
+    full Lua script.
+
+    Fails CLOSED on unreachable Redis via :func:`require_client`.
+    """
+    client = require_client()
+    payload = json.dumps({"user_id": user_id, "sid": sid}, separators=(",", ":"))
+    pipe = client.pipeline(transaction=True)
+    pipe.set(_primary_key(new_jti), payload, ex=ttl_seconds)
+    pipe.sadd(_family_key(sid), new_jti)
+    pipe.expire(_family_key(sid), ttl_seconds)
+    pipe.delete(_primary_key(old_jti))
+    await pipe.execute()

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -521,6 +521,32 @@ async def _validate_single_refresh_token(
             detail="Session has been invalidated",
         )
 
+    # Architect P2 finding on PR #306: existence of the Redis row is a
+    # necessary but not sufficient success condition. The row stores
+    # ``{user_id, sid}`` precisely so the resolver can verify the JWT
+    # claims still bind to it; if any of the following diverge, the
+    # session must be rejected as corrupt:
+    #
+    #   * the JWT's ``sub`` (user_id) does not match the row's
+    #     ``user_id`` — could be: a forged JWT signed with a stolen
+    #     key, an admin merged two users, or (in theory) the
+    #     impossible-but-defended-against ``jti`` collision the PR 3
+    #     Lua ``NX`` guard exists to catch;
+    #   * the JWT's ``sid`` (session family) does not match the row's
+    #     ``sid`` — could be: a leaked refresh cookie reused after the
+    #     family was reissued under a different ``sid``, or key-level
+    #     corruption from a future migration / replica lag.
+    #
+    # In either case we want the same terminal 401 the missing-key
+    # path produces; the frontend's classifier needs no new code path.
+    row_user_id = session_row.get("user_id")
+    row_sid = session_row.get("sid")
+    if row_user_id != user.id or row_sid != sid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has been invalidated",
+        )
+
     # Enforce absolute session lifetime (per-org setting or system default)
     session_created_at = payload.get("session_created_at")
     session_start: datetime | None = None
@@ -1220,12 +1246,18 @@ async def mfa_recovery(
     if idx is None:
         raise HTTPException(status_code=401, detail="Invalid recovery code")
 
-    # Remove the used code
+    # Remove the used code. Architect P1 finding on PR #306: hold the
+    # commit until AFTER the Redis-backed session-issue inside
+    # ``_issue_tokens`` succeeds. Otherwise a Redis 503 would consume
+    # the recovery code (durable side effect on a tiny finite pool)
+    # without giving the user a session, forcing them to burn another
+    # code on retry.
     hashed_codes.pop(idx)
     user.recovery_codes = ",".join(hashed_codes) if hashed_codes else None
-    await db.commit()
+    await db.flush()
 
     tokens = await _issue_tokens(user, response)
+    await db.commit()
     await _record_login_success(
         session_factory, user=user, request=request, method="mfa_recovery"
     )
@@ -1600,12 +1632,21 @@ async def google_callback(
             password_set=False,
         )
         db.add(user)
-        await db.commit()
+        # Architect P1 finding on PR #306: do NOT commit yet. The Redis
+        # session write below must succeed BEFORE we commit the new
+        # user + trial, otherwise a Redis 503 leaves the user durably
+        # created without a session — the next Google SSO retry would
+        # treat them as existing and skip the ``created_user=true``
+        # first-run disclosure branch entirely.
+        await db.flush()
         await db.refresh(user)
 
-        # Create trial subscription for the new org (same as register)
+        # Create trial subscription for the new org (same as register).
+        # Still no commit — single transaction across user, trial, and
+        # Redis session-issue. Flush only so ``Subscription.id`` is
+        # populated for the audit row that follows.
         await subscription_service.create_trial(db, org.id)
-        await db.commit()
+        await db.flush()
 
     # Issue tokens (or MFA challenge if enabled)
     await db.refresh(user, ["organization"])
@@ -1623,6 +1664,21 @@ async def google_callback(
     # PR 2: write the Redis primary key + family-set entry BEFORE
     # set_cookie. Fails closed (503) on unreachable Redis.
     refresh_token, _jti, _sid = await _issue_refresh_session(user.id)
+
+    # Architect P1 finding on PR #306: on the new-user branch above we
+    # switched ``db.commit()`` to ``db.flush()`` so the user + trial
+    # creation only land in the database AFTER Redis has accepted the
+    # session. A Redis 503 above would have raised before reaching
+    # here, rolling back the entire transaction; the next Google SSO
+    # retry would correctly see no existing user and re-enter the
+    # ``created_user=true`` first-run disclosure branch. Now that
+    # ``_issue_refresh_session`` has succeeded, commit the user +
+    # trial so they survive past this handler.
+    #
+    # The existing-user branch (lines ~1565-1571 above) already
+    # committed any mutated-profile changes earlier, so this second
+    # commit is a no-op for it.
+    await db.commit()
 
     # Redirect to frontend with the access token in the URL fragment. The
     # fragment stays client-side (not sent to servers, not logged), while

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -49,6 +49,8 @@ from app.schemas.auth import (
 )
 from app.config import settings as app_settings
 from app import redis_client
+from app.redis_client import RedisRequired
+from redis.exceptions import RedisError
 from app.security import (
     MFA_EMAIL_TOKEN_TTL_SECONDS,
     create_access_token,
@@ -285,7 +287,10 @@ async def login(
         return MfaChallengeResponse(mfa_token=mfa_token)
 
     access_token = create_access_token(user.id, user.org_id, user.role.value)
-    refresh_token = create_refresh_token(user.id)
+    # PR 2: write the Redis primary key + family-set entry BEFORE
+    # set_cookie. Fails closed (503) on unreachable Redis so we never
+    # emit a cookie that has no corresponding session row.
+    refresh_token, _jti, _sid = await _issue_refresh_session(user.id)
 
     response.set_cookie(
         key="refresh_token",
@@ -306,6 +311,74 @@ async def login(
 
 
 SESSION_EXPIRED_DETAIL = "Session expired — please sign in again"
+
+# Standard 503 response detail returned from any issue / rotation site
+# when Redis is unreachable. The auth-session story fails CLOSED: we
+# refuse to issue a refresh JWT that has no corresponding Redis row,
+# because such a JWT would 401 forever on /refresh. See
+# specs/2026-05-17-backend-session-model.md §7.1.
+SESSION_REDIS_UNAVAILABLE_DETAIL = "Authentication temporarily unavailable"
+
+
+async def _issue_refresh_session(
+    user_id: int,
+    *,
+    session_created_at: datetime | None = None,
+    sid: str | None = None,
+) -> tuple[str, str, str]:
+    """Mint a refresh JWT AND atomically persist its Redis primary key +
+    family-set entry. Returns ``(token, jti, sid)``.
+
+    Fails CLOSED on unreachable / broken Redis by raising
+    ``HTTPException(503)`` — callers MUST let that propagate so no
+    ``Set-Cookie`` is emitted for a session that has no Redis row.
+
+    Used by every fresh-session issue path: login password branch,
+    ``_issue_tokens`` (MFA branches), Google callback, and
+    ``org_members.accept_invitation``. The ``/refresh`` rotation site
+    uses :func:`_rotate_refresh_session` instead.
+    """
+    token, jti, session_id = create_refresh_token(
+        user_id, session_created_at=session_created_at, sid=sid
+    )
+    try:
+        await redis_client.session_issue(
+            jti, session_id, user_id, refresh_cookie_max_age()
+        )
+    except (RedisRequired, RedisError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+        ) from exc
+    return token, jti, session_id
+
+
+async def _rotate_refresh_session(
+    user_id: int,
+    old_jti: str,
+    sid: str,
+    *,
+    session_created_at: datetime | None = None,
+) -> tuple[str, str, str]:
+    """Mint a successor refresh JWT (same ``sid``, fresh ``jti``) AND
+    atomically write the new primary + family entry while deleting the
+    old primary. Returns ``(token, new_jti, sid)``.
+
+    Fails CLOSED on unreachable Redis by raising ``HTTPException(503)``.
+    """
+    token, new_jti, session_id = create_refresh_token(
+        user_id, session_created_at=session_created_at, sid=sid
+    )
+    try:
+        await redis_client.session_rotate(
+            old_jti, new_jti, session_id, user_id, refresh_cookie_max_age()
+        )
+    except (RedisRequired, RedisError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+        ) from exc
+    return token, new_jti, session_id
 
 # Emitted when the request carries refresh cookies for two or more
 # distinct user accounts (e.g. a legacy account-A cookie shadowing a
@@ -415,6 +488,38 @@ async def _validate_single_refresh_token(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Session has been invalidated",
             )
+
+    # PR 2 (specs/2026-05-17-backend-session-model.md §5.1 step 3 +
+    # step 4): both ``jti`` and ``sid`` are mandatory on every refresh
+    # JWT issued after PR 2 ships. Legacy tokens (no jti / no sid) are
+    # rejected with the same 401 string the cutoff check uses so the
+    # frontend's terminal-vs-transient classifier needs no change. The
+    # planned reauth break is operator-decision Q7 — see
+    # infra/PR2_REAUTH_BREAK.md.
+    jti = payload.get("jti")
+    sid = payload.get("sid")
+    if not jti or not sid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has been invalidated",
+        )
+
+    # Redis primary-key probe. Miss => 401 (the jti has been revoked or
+    # has expired before its JWT cousin). Redis-unreachable => 503; we
+    # never silently accept the JWT, because that would defeat the
+    # per-session story (PR 4). See spec §7.1.
+    try:
+        session_row = await redis_client.session_validate(jti)
+    except (RedisRequired, RedisError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+        ) from exc
+    if session_row is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has been invalidated",
+        )
 
     # Enforce absolute session lifetime (per-org setting or system default)
     session_created_at = payload.get("session_created_at")
@@ -528,7 +633,7 @@ async def refresh(
     """
     refresh_tokens = _extract_refresh_cookies(request)
     try:
-        user, _payload, session_start = await _validate_refresh_cookie(
+        user, payload, session_start = await _validate_refresh_cookie(
             refresh_tokens, db
         )
     except HTTPException as exc:
@@ -551,9 +656,17 @@ async def refresh(
             return cleared
         raise
 
-    # Carry forward session_created_at from the original login
+    # PR 2 rotation: preserve the predecessor's ``sid`` so the family
+    # link survives across the rotation chain (per-session logout in
+    # PR 4 walks ``auth:session:by_sid:{sid}``). The validation chain
+    # has already verified that ``jti`` and ``sid`` are present.
+    old_jti = payload["jti"]
+    sid = payload["sid"]
+
     access_token = create_access_token(user.id, user.org_id, user.role.value)
-    new_refresh_token = create_refresh_token(user.id, session_created_at=session_start)
+    new_refresh_token, _new_jti, _sid = await _rotate_refresh_session(
+        user.id, old_jti, sid, session_created_at=session_start
+    )
 
     response.set_cookie(
         key="refresh_token",
@@ -822,10 +935,16 @@ async def _resolve_mfa_user(mfa_token: str, db: AsyncSession) -> User:
     return user
 
 
-def _issue_tokens(user: User, response: Response) -> TokenResponse:
-    """Issue access + refresh tokens and set the refresh cookie."""
+async def _issue_tokens(user: User, response: Response) -> TokenResponse:
+    """Issue access + refresh tokens and set the refresh cookie.
+
+    Shared by every MFA-completion branch (``/mfa/verify``,
+    ``/mfa/recovery``, ``/mfa/email-verify``). Becomes async with PR 2
+    because the Redis primary-key + family-set write happens BEFORE
+    ``set_cookie`` — fail-closed semantics in spec §7.1.
+    """
     access_token = create_access_token(user.id, user.org_id, user.role.value)
-    refresh_token = create_refresh_token(user.id)
+    refresh_token, _jti, _sid = await _issue_refresh_session(user.id)
     response.set_cookie(
         key="refresh_token",
         value=refresh_token,
@@ -1074,7 +1193,7 @@ async def mfa_verify(
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=401, detail="Invalid TOTP code")
 
-    tokens = _issue_tokens(user, response)
+    tokens = await _issue_tokens(user, response)
     await _record_login_success(
         session_factory, user=user, request=request, method="mfa_totp"
     )
@@ -1106,7 +1225,7 @@ async def mfa_recovery(
     user.recovery_codes = ",".join(hashed_codes) if hashed_codes else None
     await db.commit()
 
-    tokens = _issue_tokens(user, response)
+    tokens = await _issue_tokens(user, response)
     await _record_login_success(
         session_factory, user=user, request=request, method="mfa_recovery"
     )
@@ -1200,7 +1319,7 @@ async def mfa_email_verify(
         if not consumed:
             raise HTTPException(status_code=401, detail="Invalid or expired email code")
 
-    tokens = _issue_tokens(user, response)
+    tokens = await _issue_tokens(user, response)
     await _record_login_success(
         session_factory, user=user, request=request, method="mfa_email"
     )
@@ -1501,7 +1620,9 @@ async def google_callback(
         return resp
 
     access_token = create_access_token(user.id, user.org_id, user.role.value)
-    refresh_token = create_refresh_token(user.id)
+    # PR 2: write the Redis primary key + family-set entry BEFORE
+    # set_cookie. Fails closed (503) on unreachable Redis.
+    refresh_token, _jti, _sid = await _issue_refresh_session(user.id)
 
     # Redirect to frontend with the access token in the URL fragment. The
     # fragment stays client-side (not sent to servers, not logged), while

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -179,15 +179,21 @@ async def accept_invitation(
         raise _invitation_unavailable()
     except ConflictError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
-    await db.commit()
 
     access = create_access_token(user.id, user.org_id, user.role.value)
     # PR 2 (specs/2026-05-17-backend-session-model.md §5.4): write the
     # Redis primary key + family-set entry BEFORE set_cookie. Fails
-    # closed (503) on unreachable Redis. This is the fifth issue site
-    # — the one PR #305 missed; the architect explicitly enumerated it
-    # in the PR 2 brief.
+    # closed (503) on unreachable Redis.
+    #
+    # Architect P1 finding on PR #306: the Redis write must also come
+    # BEFORE ``db.commit()``. ``invitation_service.accept_invitation``
+    # flushed (so ``user.id`` is set) but did NOT commit. If Redis is
+    # down here, the 503 raises before commit, the open transaction
+    # rolls back, and the invitation stays unconsumed — the user can
+    # retry. Previous order (commit-then-Redis) consumed the invitation
+    # on every Redis blip, permanently locking the invitee out.
     refresh, _jti, _sid = await _issue_refresh_session(user.id)
+    await db.commit()
     response.set_cookie(
         key="refresh_token",
         value=refresh,

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -16,7 +16,7 @@ from app.database import get_db
 from app.deps import get_current_user
 from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
-from app.routers.auth import _clear_legacy_refresh_cookie
+from app.routers.auth import _clear_legacy_refresh_cookie, _issue_refresh_session
 from app.schemas.auth import TokenResponse
 from app.schemas.invitation import (
     InvitationAcceptRequest,
@@ -28,7 +28,6 @@ from app.schemas.invitation import (
 from app.security import (
     create_access_token,
     create_invitation_token,
-    create_refresh_token,
     refresh_cookie_max_age,
 )
 from app.services import invitation_service
@@ -183,7 +182,12 @@ async def accept_invitation(
     await db.commit()
 
     access = create_access_token(user.id, user.org_id, user.role.value)
-    refresh = create_refresh_token(user.id)
+    # PR 2 (specs/2026-05-17-backend-session-model.md §5.4): write the
+    # Redis primary key + family-set entry BEFORE set_cookie. Fails
+    # closed (503) on unreachable Redis. This is the fifth issue site
+    # — the one PR #305 missed; the architect explicitly enumerated it
+    # in the PR 2 brief.
+    refresh, _jti, _sid = await _issue_refresh_session(user.id)
     response.set_cookie(
         key="refresh_token",
         value=refresh,

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,5 +1,6 @@
 import hmac as _hmac
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
@@ -54,23 +55,65 @@ def refresh_cookie_max_age() -> int:
 def create_refresh_token(
     subject: int,
     session_created_at: datetime | None = None,
-) -> str:
+    sid: str | None = None,
+) -> tuple[str, str, str]:
     """Create a refresh token.
 
-    session_created_at tracks when the original login happened. It is set
+    Returns ``(token, jti, sid)``. The caller is responsible for writing
+    the corresponding Redis primary key (``auth:session:{jti}``) and
+    family-set entry (``auth:session:by_sid:{sid}``) before emitting the
+    ``Set-Cookie`` — see ``specs/2026-05-17-backend-session-model.md`` §5.4.
+
+    ``session_created_at`` tracks when the original login happened. It is set
     on first login and carried forward on every refresh so the backend can
     enforce an absolute session lifetime regardless of activity.
+
+    ``sid`` identifies the session FAMILY (the chain of refresh tokens
+    that descend from a single login). On first login the caller passes
+    ``None`` and a fresh UUID4 hex is minted. On ``/refresh`` rotation
+    the caller MUST pass the predecessor's ``sid`` so the family link
+    survives across the rotation chain — that is what makes per-session
+    logout (PR 4) revoke every successor.
+
+    ``jti`` is always freshly minted via ``secrets.token_urlsafe(16)``
+    (128 bits of entropy). It rotates on every issue and serves as the
+    Redis primary-key suffix.
     """
     now = datetime.now(timezone.utc)
     expire = now + timedelta(days=settings.refresh_idle_ttl_days)
+    jti = secrets.token_urlsafe(16)
+    session_id = sid if sid is not None else uuid.uuid4().hex
     payload = {
         "sub": str(subject),
         "type": "refresh",
         "session_created_at": (session_created_at or now).timestamp(),
         "iat": int(now.timestamp()),
         "exp": expire,
+        "jti": jti,
+        "sid": session_id,
     }
-    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    token = jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    return token, jti, session_id
+
+
+def decode_refresh_jti_sid(token: str) -> tuple[str, str]:
+    """Decode a refresh JWT and return ``(jti, sid)``.
+
+    Raises ``ValueError`` if the token cannot be decoded, is not of type
+    ``refresh``, or is missing either claim. Both claims are mandatory
+    after PR 2 ships — legacy refresh JWTs without ``jti``/``sid`` are
+    rejected by the validation chain in ``auth.py``.
+    """
+    payload = jwt.decode(
+        token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm]
+    )
+    if payload.get("type") != "refresh":
+        raise ValueError("token is not a refresh token")
+    jti = payload.get("jti")
+    sid = payload.get("sid")
+    if not jti or not sid:
+        raise ValueError("refresh token missing jti or sid claim")
+    return jti, sid
 
 
 def create_password_reset_token(user_id: int) -> str:

--- a/backend/tests/auth/test_legacy_cookie_cleanup.py
+++ b/backend/tests/auth/test_legacy_cookie_cleanup.py
@@ -39,23 +39,48 @@ from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
 from app.routers.auth import LEGACY_REFRESH_COOKIE_PATH, router as auth_router
 from app.security import create_refresh_token, hash_password
+from tests.conftest import issue_test_refresh_token
 
 
 def _mint_refresh_at(user_id: int, iat: datetime) -> str:
     """Mint a refresh JWT with a controlled ``iat`` (and matching
     ``session_created_at``) so tests can place tokens above or below
-    ``token_cutoff`` deterministically without real sleeps."""
+    ``token_cutoff`` deterministically without real sleeps.
+
+    PR 2: stamp a fresh ``jti`` + ``sid`` AND seed the autouse fake
+    Redis so the validation chain's primary-key probe accepts the
+    token. Without the seed every legacy/current-cookie test in this
+    file would 401 on ``"Session has been invalidated"`` regardless of
+    the iat-vs-cutoff outcome.
+    """
+    import json
+    import secrets as _secrets
+    import uuid as _uuid
+
+    from app import redis_client as _rc
+
     expire = iat + timedelta(days=app_settings.refresh_idle_ttl_days)
+    jti = _secrets.token_urlsafe(16)
+    sid = _uuid.uuid4().hex
     payload = {
         "sub": str(user_id),
         "type": "refresh",
         "session_created_at": iat.timestamp(),
         "iat": int(iat.timestamp()),
         "exp": expire,
+        "jti": jti,
+        "sid": sid,
     }
-    return _pyjwt.encode(
+    token = _pyjwt.encode(
         payload, app_settings.jwt_secret_key, algorithm=app_settings.jwt_algorithm
     )
+    client = _rc.get_client()
+    if client is not None and hasattr(client, "_kv"):
+        client._kv[f"auth:session:{jti}"] = json.dumps(
+            {"user_id": user_id, "sid": sid}, separators=(",", ":")
+        )
+        client._sets[f"auth:session:by_sid:{sid}"].add(jti)
+    return token
 
 
 PASSWORD = "S3cret-Pass!"
@@ -304,7 +329,7 @@ async def test_login_emits_legacy_cleanup(session_factory):
 
 async def test_refresh_rotation_emits_legacy_cleanup(session_factory):
     user_id = await _seed_user(session_factory)
-    refresh = create_refresh_token(user_id)
+    refresh = issue_test_refresh_token(user_id)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -330,13 +355,12 @@ async def test_refresh_session_expired_emits_legacy_cleanup(session_factory):
     """Session-lifetime-expired path emits Set-Cookie to clear BOTH the
     canonical and the legacy cookie."""
     from app.config import settings as app_settings
-    from app.security import create_refresh_token as _crt
 
     user_id = await _seed_user(session_factory)
     long_ago = datetime.now(timezone.utc) - timedelta(
         days=app_settings.session_lifetime_days + 30
     )
-    refresh = _crt(user_id, session_created_at=long_ago)
+    refresh = issue_test_refresh_token(user_id, session_created_at=long_ago)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -364,8 +388,8 @@ async def test_refresh_rejects_when_two_valid_users_present(session_factory):
     user_a = await _seed_user(session_factory, username="alice")
     user_b = await _seed_user(session_factory, username="bob")
 
-    token_a = create_refresh_token(user_a)
-    token_b = create_refresh_token(user_b)
+    token_a = issue_test_refresh_token(user_a)
+    token_b = issue_test_refresh_token(user_b)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -407,8 +431,8 @@ async def test_verify_rejects_when_two_valid_users_present(session_factory):
     user_a = await _seed_user(session_factory, username="carol")
     user_b = await _seed_user(session_factory, username="dave")
 
-    token_a = create_refresh_token(user_a)
-    token_b = create_refresh_token(user_b)
+    token_a = issue_test_refresh_token(user_a)
+    token_b = issue_test_refresh_token(user_b)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -525,11 +549,18 @@ async def test_refresh_prefers_newest_iat_when_order_reversed(session_factory):
 # ── _issue_tokens cleanup (MFA verify, etc.) ───────────────────────────────
 
 
-def test_issue_tokens_helper_emits_legacy_cleanup():
+@pytest.mark.asyncio
+async def test_issue_tokens_helper_emits_legacy_cleanup():
     """``_issue_tokens`` is the shared exit point for several MFA login
     flows (``/mfa/verify``, ``/mfa/recovery``, and ``/mfa/email-verify``).
     Pinning the helper directly avoids the cost of a full MFA-setup
-    fixture while still proving the cleanup is wired."""
+    fixture while still proving the cleanup is wired.
+
+    PR 2 made ``_issue_tokens`` async because it now writes the Redis
+    primary key + family set before returning. The autouse fake-Redis
+    fixture in ``conftest.py`` keeps this test working without a real
+    Redis dependency.
+    """
     from fastapi import Response
     from app.routers.auth import _issue_tokens
 
@@ -540,7 +571,7 @@ def test_issue_tokens_helper_emits_legacy_cleanup():
             self.role = Role.OWNER
 
     response = Response()
-    _issue_tokens(_FakeUser(), response)
+    await _issue_tokens(_FakeUser(), response)
 
     # Response.raw_headers is the underlying list of (bytes, bytes)
     # tuples populated by set_cookie / delete_cookie.

--- a/backend/tests/auth/test_session_jti_sid.py
+++ b/backend/tests/auth/test_session_jti_sid.py
@@ -837,3 +837,243 @@ async def test_verify_rejects_token_with_missing_redis_row(
             cookies={"refresh_token": token},
         )
     assert res.status_code == 401, res.json()
+
+
+# ── Architect P1 (PR #306 re-review): Redis-failure must not leave durable
+#    one-time state committed without a session. ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_invitation_accept_503_leaves_invitation_unconsumed(
+    session_factory, monkeypatch
+) -> None:
+    """Architect P1.1 on PR #306: invitation accept used to commit the
+    invitation BEFORE calling ``_issue_refresh_session``. A Redis 503
+    therefore returned an error to the user while the invitation was
+    already marked accepted — permanent lockout, no retry possible.
+
+    After the fix: ``accept_invitation`` flushes (so ``user.id`` is
+    available for the JWT), the Redis write runs, and ONLY THEN
+    ``db.commit()`` fires. A 503 must leave the invitation row with
+    ``accepted_at IS NULL`` so the invitee can retry.
+    """
+    from app.models.invitation import Invitation
+    from app.services import invitation_service
+
+    async with session_factory() as db:
+        org = Organization(name="Inv Co", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        owner = User(
+            org_id=org.id, username="owner", email="owner@inv.io",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add(owner)
+        await db.commit()
+        org_id, owner_id = org.id, owner.id
+
+    async with session_factory() as db:
+        inv = await invitation_service.create_invitation(
+            db, org_id=org_id, created_by=owner_id,
+            email="invitee@inv.io", role=Role.MEMBER,
+        )
+        await db.commit()
+        inv_id = inv.id
+        token = create_invitation_token(inv.id, inv.email)
+
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/invitations/accept",
+            json={
+                "token": token,
+                "username": "invitee",
+                "password": "strong-pw-1234",
+            },
+        )
+    assert res.status_code == 503, res.text
+
+    # The invitation MUST still be unconsumed — invitee can retry.
+    async with session_factory() as db:
+        row = await db.get(Invitation, inv_id)
+        assert row is not None
+        assert row.accepted_at is None, (
+            "Architect P1 regression: invitation was marked accepted "
+            "despite the 503 — Redis failure must not consume one-time state"
+        )
+        # And no user row should have been created.
+        any_user = await db.scalar(
+            select(User).where(User.email == "invitee@inv.io")
+        )
+        assert any_user is None, (
+            "Architect P1 regression: user row was committed despite 503"
+        )
+
+
+@pytest.mark.asyncio
+async def test_google_callback_503_does_not_commit_new_user(
+    session_factory, monkeypatch, google_config
+) -> None:
+    """Architect P1.2 on PR #306: first-run Google SSO used to commit
+    the new user + trial BEFORE the Redis-backed session-issue. A 503
+    therefore created the user durably but returned an error; on retry
+    the user was treated as EXISTING (no ``created_user=true``), so
+    the first-run privacy disclosure (Team E) was silently skipped.
+
+    After the fix: user + trial are flushed but not committed; on a
+    503 the transaction rolls back, and the next Google SSO attempt
+    correctly re-enters the new-user branch.
+    """
+    await _seed_default_plan(session_factory)
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    _patch_httpx(monkeypatch, userinfo_email="brand-new-sso@example.com")
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+    # Google callback returns a RedirectResponse on success and an
+    # error redirect on failure. The 503 path here surfaces as the
+    # explicit error handler — but the critical invariant for this
+    # test is the DB state: no committed user / org.
+    async with session_factory() as db:
+        any_user = await db.scalar(
+            select(User).where(User.email == "brand-new-sso@example.com")
+        )
+        assert any_user is None, (
+            "Architect P1 regression: new SSO user was committed "
+            "despite the Redis 503 — next SSO attempt would skip the "
+            "first-run disclosure branch"
+        )
+
+
+@pytest.mark.asyncio
+async def test_mfa_recovery_503_preserves_recovery_code(
+    session_factory, monkeypatch
+) -> None:
+    """Architect P1.3 on PR #306: MFA recovery used to commit the
+    consumed code BEFORE issuing the Redis-backed session. A 503
+    burned one of the user's finite recovery codes without giving
+    them a session, forcing them to burn another on retry. After
+    the fix the commit happens after Redis confirms — on a 503 the
+    transaction rolls back and the code is still usable.
+    """
+    from app.security import create_mfa_challenge_token
+    from app.services.mfa_service import (
+        generate_recovery_codes,
+        hash_recovery_code,
+    )
+
+    codes = generate_recovery_codes(count=3)
+    code = codes[0]
+    seed = await _seed_user(
+        session_factory,
+        mfa_enabled=True,
+        recovery_codes_plaintext=codes,
+    )
+    mfa_token = create_mfa_challenge_token(seed["user_id"])
+
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/mfa/recovery",
+            json={"mfa_token": mfa_token, "code": code},
+        )
+    assert res.status_code == 503, res.text
+
+    # The recovery code MUST still be usable.
+    async with session_factory() as db:
+        user = await db.scalar(select(User).where(User.id == seed["user_id"]))
+        assert user is not None
+        assert user.recovery_codes is not None
+        stored_hashes = user.recovery_codes.split(",")
+        # The hash of the would-be-consumed code is still present.
+        expected_hash = hash_recovery_code(code)
+        assert expected_hash in stored_hashes, (
+            "Architect P1 regression: recovery code was consumed "
+            "despite the 503 — must roll back the DB change too"
+        )
+        # Still have all three codes (none were burned).
+        assert len(stored_hashes) == 3, stored_hashes
+
+
+# ── Architect P2 (PR #306 re-review): Redis row must bind back to JWT
+#    claims, not just exist. ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_jti_with_mismatched_user_id_in_redis(
+    session_factory, fake_redis
+) -> None:
+    """Architect P2 on PR #306: existence of ``auth:session:{jti}`` is
+    not sufficient — the row stores ``{user_id, sid}`` precisely so
+    the resolver can verify the JWT still binds to it. Forge the row
+    to carry a different user_id; the refresh must reject as
+    invalidated/corrupt, NOT happily accept and rotate.
+    """
+    import json
+
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+        jti, sid = decode_refresh_jti_sid(token)
+
+        # Forge the Redis row to point at a different user_id (simulates
+        # key corruption / overwrite / impossible jti collision).
+        fake_redis._kv[f"auth:session:{jti}"] = json.dumps(
+            {"user_id": 999999, "sid": sid}
+        )
+
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": token},
+        )
+    assert res.status_code == 401, res.json()
+    assert "invalidated" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_jti_with_mismatched_sid_in_redis(
+    session_factory, fake_redis
+) -> None:
+    """Architect P2 on PR #306 — sister case to the user_id mismatch.
+    The JWT carries one ``sid``, the Redis row carries a different
+    ``sid``. Could arise from a leaked refresh cookie reused after the
+    session family was reissued under a fresh ``sid``, or from key-
+    level corruption. Resolver must reject.
+    """
+    import json
+
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+        jti, sid = decode_refresh_jti_sid(token)
+
+        # Same user_id (good) but a different sid (bad).
+        row = json.loads(fake_redis._kv[f"auth:session:{jti}"])
+        fake_redis._kv[f"auth:session:{jti}"] = json.dumps(
+            {"user_id": row["user_id"], "sid": "deadbeef-not-the-real-sid"}
+        )
+
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": token},
+        )
+    assert res.status_code == 401, res.json()

--- a/backend/tests/auth/test_session_jti_sid.py
+++ b/backend/tests/auth/test_session_jti_sid.py
@@ -1,0 +1,839 @@
+"""PR 2 — Refresh ``jti`` + ``sid`` + primary key + family set tests.
+
+Pins every architect-emphasized review risk in
+``specs/2026-05-17-backend-session-model.md`` §8 PR 2:
+
+1. New refresh JWT carries both ``jti`` and ``sid`` at every issue site
+   (login, ``/refresh`` rotation, MFA branches via ``_issue_tokens``,
+   Google callback, ``org_members.py`` invitation accept).
+2. ``sid`` is preserved across the rotation chain; only ``jti`` changes.
+3. Every issue site writes ``auth:session:{jti}`` AND
+   ``auth:session:by_sid:{sid}`` to Redis BEFORE emitting the cookie.
+4. Legacy (no-jti or no-sid) refresh JWTs are rejected with 401
+   ``"Session has been invalidated"``.
+5. Manual ``DEL auth:session:{jti}`` produces 401 on next ``/refresh``.
+6. Family set membership matches the issued ``jti`` chain after
+   rotation.
+7. Redis unreachable => 503 on every issue path, no Set-Cookie emitted.
+8. ``MULTI/EXEC`` abort => 503, no Set-Cookie emitted.
+9. Grep-style guard: every ``create_refresh_token`` call site is
+   co-located with a paired Redis write within the same source file.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import jwt
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app import redis_client
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.subscription import Plan
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers import auth as auth_module
+from app.routers.auth import LEGACY_REFRESH_COOKIE_PATH, router as auth_router
+from app.routers.org_members import router as org_members_router
+from app.security import (
+    create_invitation_token,
+    create_mfa_challenge_token,
+    decode_refresh_jti_sid,
+    hash_password,
+)
+from app.services.mfa_service import (
+    generate_recovery_codes,
+    hash_recovery_code,
+)
+
+
+PASSWORD = "starting-password-1"
+
+
+@pytest.fixture
+def fake_redis(_autouse_fake_redis):
+    """Local alias for the autouse fake-Redis defined in
+    ``tests/conftest.py``. Tests assert against its in-memory dicts
+    (``_kv``, ``_sets``) and flip ``abort_pipeline`` to simulate
+    ``MULTI/EXEC`` failures."""
+    yield _autouse_fake_redis
+
+
+# ── DB fixture ──────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    app.include_router(org_members_router)
+    return app
+
+
+async def _seed_user(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    mfa_enabled: bool = False,
+    recovery_codes_plaintext: list[str] | None = None,
+) -> dict:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        recovery_field: str | None = None
+        if recovery_codes_plaintext is not None:
+            recovery_field = ",".join(
+                hash_recovery_code(c) for c in recovery_codes_plaintext
+            )
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@example.com",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+            mfa_enabled=mfa_enabled,
+            recovery_codes=recovery_field,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id}
+
+
+async def _seed_default_plan(factory: async_sessionmaker[AsyncSession]) -> None:
+    async with factory() as db:
+        existing = await db.scalar(select(Plan).where(Plan.slug == "free"))
+        if existing is None:
+            db.add(Plan(slug="free", name="Free", is_active=True, sort_order=0))
+            await db.commit()
+
+
+# ── Set-Cookie parsing helpers ──────────────────────────────────────────────
+
+
+def _set_cookie_values_for(headers, name: str) -> list[str]:
+    matches: list[str] = []
+    raw_iter = headers.raw if hasattr(headers, "raw") else []
+    for raw in raw_iter:
+        if isinstance(raw, tuple):
+            key, value = raw
+            if key.decode().lower() != "set-cookie":
+                continue
+            value = value.decode()
+        else:
+            value = raw
+        if value.split("=", 1)[0].strip().lower() == name.lower():
+            matches.append(value)
+    return matches
+
+
+def _canonical_refresh_cookie(headers) -> str | None:
+    cookies = _set_cookie_values_for(headers, "refresh_token")
+    canonical = [
+        c
+        for c in cookies
+        if "Path=/" in c
+        and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in c
+        and "Max-Age=0" not in c
+    ]
+    return canonical[0] if canonical else None
+
+
+def _refresh_token_from_set_cookie(raw: str) -> str:
+    """Extract the JWT value from a Set-Cookie header."""
+    head = raw.split(";", 1)[0].strip()
+    name, _, value = head.partition("=")
+    assert name == "refresh_token"
+    return value
+
+
+# ── Google SSO httpx mock ───────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def _patch_httpx(monkeypatch, *, userinfo_email: str) -> None:
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return None
+
+        async def post(self, *args, **kwargs):
+            return _FakeResponse(200, {"access_token": "fake-google-token"})
+
+        async def get(self, *args, **kwargs):
+            return _FakeResponse(
+                200,
+                {
+                    "email": userinfo_email,
+                    "verified_email": True,
+                    "given_name": "Existing",
+                    "family_name": "User",
+                },
+            )
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeClient)
+
+
+@pytest.fixture
+def google_config(monkeypatch):
+    monkeypatch.setattr(app_settings, "google_client_id", "test-client-id")
+    monkeypatch.setattr(app_settings, "google_client_secret", "test-client-secret")
+    monkeypatch.setattr(app_settings, "app_url", "http://localhost")
+    yield
+
+
+# ── 1. Every issue site stamps jti + sid in the JWT AND in Redis ────────────
+
+
+def _decode_unverified(token: str) -> dict:
+    return jwt.decode(
+        token, app_settings.jwt_secret_key, algorithms=[app_settings.jwt_algorithm]
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_password_branch_writes_primary_and_family(
+    session_factory, fake_redis
+) -> None:
+    """Login password branch: JWT carries jti+sid AND Redis has both keys
+    before the cookie is set."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+
+    assert res.status_code == 200, res.json()
+    raw = _canonical_refresh_cookie(res.headers)
+    assert raw is not None, "login must set canonical refresh_token cookie"
+    token = _refresh_token_from_set_cookie(raw)
+    payload = _decode_unverified(token)
+    assert payload.get("jti"), "refresh JWT must carry jti claim"
+    assert payload.get("sid"), "refresh JWT must carry sid claim"
+
+    assert f"auth:session:{payload['jti']}" in fake_redis._kv
+    assert payload["jti"] in fake_redis._sets[f"auth:session:by_sid:{payload['sid']}"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_rotation_preserves_sid(session_factory, fake_redis) -> None:
+    """``/refresh`` rotation: new JWT has new jti but SAME sid; new
+    primary key is in Redis, new jti is in the family set."""
+    seed = await _seed_user(session_factory)
+    # Establish a session through the real login flow so the predecessor
+    # JWT has the new shape (jti + sid).
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        login_raw = _canonical_refresh_cookie(login.headers)
+        login_token = _refresh_token_from_set_cookie(login_raw)
+        original_jti, original_sid = decode_refresh_jti_sid(login_token)
+
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": login_token},
+        )
+
+    assert res.status_code == 200, res.json()
+    raw = _canonical_refresh_cookie(res.headers)
+    assert raw is not None
+    new_token = _refresh_token_from_set_cookie(raw)
+    new_jti, new_sid = decode_refresh_jti_sid(new_token)
+
+    assert new_jti != original_jti, "rotation must mint a fresh jti"
+    assert new_sid == original_sid, "rotation must preserve the family sid"
+
+    # New primary key present, old one gone.
+    assert f"auth:session:{new_jti}" in fake_redis._kv
+    assert f"auth:session:{original_jti}" not in fake_redis._kv
+    # Family set carries the new jti.
+    assert new_jti in fake_redis._sets[f"auth:session:by_sid:{new_sid}"]
+    _ = seed
+
+
+@pytest.mark.asyncio
+async def test_sid_preserved_across_five_rotations(
+    session_factory, fake_redis
+) -> None:
+    """The architect-pinned 5-rotation invariant: every rotation issues a
+    fresh jti but reuses the original sid verbatim."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+        original_jti, original_sid = decode_refresh_jti_sid(token)
+
+        seen_jtis = [original_jti]
+        for _ in range(5):
+            res = client.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": token},
+            )
+            assert res.status_code == 200, res.json()
+            raw = _canonical_refresh_cookie(res.headers)
+            token = _refresh_token_from_set_cookie(raw)
+            new_jti, new_sid = decode_refresh_jti_sid(token)
+            assert new_sid == original_sid, (
+                f"sid drifted on rotation: {new_sid!r} != {original_sid!r}"
+            )
+            assert new_jti not in seen_jtis, "jti must rotate every refresh"
+            seen_jtis.append(new_jti)
+
+    # Last successor's primary key is alive in Redis.
+    assert f"auth:session:{seen_jtis[-1]}" in fake_redis._kv
+
+
+@pytest.mark.asyncio
+async def test_mfa_recovery_branch_writes_primary_and_family(
+    session_factory, fake_redis
+) -> None:
+    """MFA recovery branch (one of the ``_issue_tokens`` callers) stamps
+    jti + sid and writes both Redis keys."""
+    codes = generate_recovery_codes(count=3)
+    seed = await _seed_user(
+        session_factory,
+        mfa_enabled=True,
+        recovery_codes_plaintext=codes,
+    )
+    mfa_token = create_mfa_challenge_token(seed["user_id"])
+    app = _make_app(session_factory)
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/mfa/recovery",
+            json={"mfa_token": mfa_token, "code": codes[0]},
+        )
+    assert res.status_code == 200, res.json()
+    raw = _canonical_refresh_cookie(res.headers)
+    assert raw is not None
+    token = _refresh_token_from_set_cookie(raw)
+    jti, sid = decode_refresh_jti_sid(token)
+    assert f"auth:session:{jti}" in fake_redis._kv
+    assert jti in fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+
+@pytest.mark.asyncio
+async def test_google_callback_writes_primary_and_family(
+    session_factory, fake_redis, google_config, monkeypatch
+) -> None:
+    """Google SSO callback (fifth issue site) stamps jti + sid and writes
+    both Redis keys before its RedirectResponse goes out."""
+    await _seed_default_plan(session_factory)
+    _patch_httpx(monkeypatch, userinfo_email="brand-new-sso@example.com")
+    app = _make_app(session_factory)
+
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+
+    assert res.status_code == 302, res.text
+    raw = _canonical_refresh_cookie(res.headers)
+    assert raw is not None
+    token = _refresh_token_from_set_cookie(raw)
+    jti, sid = decode_refresh_jti_sid(token)
+    assert f"auth:session:{jti}" in fake_redis._kv
+    assert jti in fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+
+@pytest.mark.asyncio
+async def test_invitation_accept_writes_primary_and_family(
+    session_factory, fake_redis
+) -> None:
+    """``routers/org_members.py`` invitation accept (the issue site PR 1
+    missed) stamps jti + sid and writes both Redis keys."""
+    from app.services import invitation_service
+
+    # Seed org + owner so the invitation belongs to a real org.
+    async with session_factory() as db:
+        org = Organization(name="Inv Co", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        owner = User(
+            org_id=org.id,
+            username="owner",
+            email="owner@inv.io",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(owner)
+        await db.commit()
+        org_id, owner_id = org.id, owner.id
+
+    async with session_factory() as db:
+        inv = await invitation_service.create_invitation(
+            db,
+            org_id=org_id,
+            created_by=owner_id,
+            email="invitee@inv.io",
+            role=Role.MEMBER,
+        )
+        await db.commit()
+        token = create_invitation_token(inv.id, inv.email)
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/invitations/accept",
+            json={
+                "token": token,
+                "username": "invitee",
+                "password": "strong-pw-1234",
+            },
+        )
+
+    assert res.status_code == 200, res.text
+    raw = _canonical_refresh_cookie(res.headers)
+    assert raw is not None
+    refresh = _refresh_token_from_set_cookie(raw)
+    jti, sid = decode_refresh_jti_sid(refresh)
+    assert f"auth:session:{jti}" in fake_redis._kv
+    assert jti in fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+
+# ── 2. Legacy tokens rejected ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_legacy_no_jti_no_sid_token_rejected(
+    session_factory, fake_redis
+) -> None:
+    """A pre-PR2 refresh JWT (no jti, no sid) is rejected with 401
+    ``Session has been invalidated`` — the planned reauth break."""
+    seed = await _seed_user(session_factory)
+    # Hand-craft a token in the OLD shape (no jti, no sid).
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    legacy_payload = {
+        "sub": str(seed["user_id"]),
+        "type": "refresh",
+        "session_created_at": now.timestamp(),
+        "iat": int(now.timestamp()),
+        "exp": now + timedelta(days=app_settings.refresh_idle_ttl_days),
+    }
+    legacy_token = jwt.encode(
+        legacy_payload,
+        app_settings.jwt_secret_key,
+        algorithm=app_settings.jwt_algorithm,
+    )
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": legacy_token},
+        )
+
+    assert res.status_code == 401, res.json()
+    assert res.json()["detail"] == "Session has been invalidated"
+
+
+@pytest.mark.asyncio
+async def test_manual_redis_del_invalidates_session(
+    session_factory, fake_redis
+) -> None:
+    """Manual ``DEL auth:session:{jti}`` produces 401 on next /refresh
+    — the per-session-revocation primitive PR 4 will use."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+        jti, _sid = decode_refresh_jti_sid(token)
+
+        # Operator yanks the row out of Redis.
+        del fake_redis._kv[f"auth:session:{jti}"]
+
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": token},
+        )
+
+    assert res.status_code == 401, res.json()
+    assert res.json()["detail"] == "Session has been invalidated"
+
+
+@pytest.mark.asyncio
+async def test_family_set_membership_matches_rotation_chain(
+    session_factory, fake_redis
+) -> None:
+    """After N rotations the family set ``auth:session:by_sid:{sid}``
+    holds exactly the union of every issued jti (PR 2: we never remove
+    entries from the family; PR 4 introduces the revoke-by-sid path)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+        first_jti, sid = decode_refresh_jti_sid(token)
+        issued = [first_jti]
+
+        for _ in range(3):
+            res = client.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": token},
+            )
+            assert res.status_code == 200
+            token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(res.headers))
+            jti, _ = decode_refresh_jti_sid(token)
+            issued.append(jti)
+
+    # Every jti ever issued for this sid sits in the family set.
+    assert set(issued).issubset(
+        fake_redis._sets[f"auth:session:by_sid:{sid}"]
+    ), "family set must accumulate every issued jti"
+
+
+# ── 3. Redis unreachable => 503 at every issue site ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_login_503_when_redis_unreachable(
+    session_factory, monkeypatch
+) -> None:
+    """Redis unreachable at login => 503, NO Set-Cookie."""
+    await _seed_user(session_factory)
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+    assert res.status_code == 503, res.json()
+    assert _canonical_refresh_cookie(res.headers) is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_503_when_redis_unreachable(
+    session_factory, fake_redis, monkeypatch
+) -> None:
+    """Redis unreachable at /refresh => 503, NO Set-Cookie."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+
+    # Now make redis disappear and try to rotate.
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh",
+            cookies={"refresh_token": token},
+        )
+    assert res.status_code == 503, res.json()
+    assert _canonical_refresh_cookie(res.headers) is None
+
+
+@pytest.mark.asyncio
+async def test_google_callback_503_when_redis_unreachable(
+    session_factory, google_config, monkeypatch
+) -> None:
+    """Google SSO callback fails closed when Redis is unreachable."""
+    await _seed_default_plan(session_factory)
+    _patch_httpx(monkeypatch, userinfo_email="brand-new-sso@example.com")
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        client.cookies.set("oauth_state", "matching-state")
+        res = client.get(
+            "/api/v1/auth/google/callback",
+            params={"code": "dummy", "state": "matching-state"},
+            follow_redirects=False,
+        )
+    # The callback would normally return 302; on Redis fail it raises
+    # 503 from inside _issue_refresh_session. The handler does not
+    # special-case it, so FastAPI emits the 503 JSON.
+    assert res.status_code == 503, res.text
+    assert _canonical_refresh_cookie(res.headers) is None
+
+
+@pytest.mark.asyncio
+async def test_mfa_recovery_503_when_redis_unreachable(
+    session_factory, monkeypatch
+) -> None:
+    """MFA recovery (one of the _issue_tokens callers) fails closed."""
+    codes = generate_recovery_codes(count=3)
+    seed = await _seed_user(
+        session_factory,
+        mfa_enabled=True,
+        recovery_codes_plaintext=codes,
+    )
+    mfa_token = create_mfa_challenge_token(seed["user_id"])
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/mfa/recovery",
+            json={"mfa_token": mfa_token, "code": codes[0]},
+        )
+    assert res.status_code == 503, res.json()
+    assert _canonical_refresh_cookie(res.headers) is None
+
+
+@pytest.mark.asyncio
+async def test_invitation_accept_503_when_redis_unreachable(
+    session_factory, monkeypatch
+) -> None:
+    """org_members.py invitation accept fails closed — the architect
+    explicitly enumerated this as the missed fifth site."""
+    from app.services import invitation_service
+
+    async with session_factory() as db:
+        org = Organization(name="Inv Co", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        owner = User(
+            org_id=org.id,
+            username="owner",
+            email="owner@inv.io",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(owner)
+        await db.commit()
+        org_id, owner_id = org.id, owner.id
+
+    async with session_factory() as db:
+        inv = await invitation_service.create_invitation(
+            db,
+            org_id=org_id,
+            created_by=owner_id,
+            email="invitee@inv.io",
+            role=Role.MEMBER,
+        )
+        await db.commit()
+        token = create_invitation_token(inv.id, inv.email)
+
+    monkeypatch.setattr(redis_client, "get_client", lambda: None)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/orgs/invitations/accept",
+            json={
+                "token": token,
+                "username": "invitee",
+                "password": "strong-pw-1234",
+            },
+        )
+    assert res.status_code == 503, res.text
+    assert _canonical_refresh_cookie(res.headers) is None
+
+
+# ── 4. MULTI/EXEC abort => 503, no Set-Cookie ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_login_503_on_multi_exec_abort(
+    session_factory, fake_redis
+) -> None:
+    """If the MULTI/EXEC issue pipeline raises, the router must 503 and
+    NOT emit a Set-Cookie. This pins the architect's atomicity rule —
+    no half-written session may surface as a cookie to the browser."""
+    await _seed_user(session_factory)
+    fake_redis.abort_pipeline = True
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+    assert res.status_code == 503, res.json()
+    assert _canonical_refresh_cookie(res.headers) is None
+    # Belt-and-braces: nothing leaked into Redis either.
+    assert not fake_redis._kv
+    assert not fake_redis._sets
+
+
+# ── 5. Grep-style guard: every create_refresh_token site has Redis writes ───
+
+
+def test_every_create_refresh_token_site_pairs_with_redis_write() -> None:
+    """Pin the architect's structural defense: every file that calls
+    ``create_refresh_token`` must also call ``session_issue`` (or
+    ``session_rotate``) within the same file. If a future PR adds a
+    new issue site without the Redis write, this test fails loudly.
+
+    Mirrors ``test_no_hardcoded_seven_day_refresh_cookie_literals_remain``
+    in shape — guard tests beat code review for this class of trap.
+    """
+    app_dir = Path(__file__).resolve().parents[2] / "app"
+    offenders: list[str] = []
+    for py in app_dir.rglob("*.py"):
+        text = py.read_text(encoding="utf-8")
+        # Skip the helpers themselves — security.py DEFINES the function;
+        # redis_client.py implements session_issue/session_rotate.
+        rel = py.relative_to(app_dir.parent)
+        if py.name in {"security.py", "redis_client.py"}:
+            continue
+        if "create_refresh_token(" not in text:
+            continue
+        # The function must be paired with a session_issue / session_rotate
+        # call OR with a wrapper that does so. ``routers/auth.py`` defines
+        # ``_issue_refresh_session`` / ``_rotate_refresh_session`` which
+        # are the in-router wrappers; both expand to the Redis writes.
+        # ``routers/org_members.py`` calls ``_issue_refresh_session``.
+        pairing_signals = (
+            "session_issue",
+            "session_rotate",
+            "_issue_refresh_session",
+            "_rotate_refresh_session",
+        )
+        if not any(sig in text for sig in pairing_signals):
+            offenders.append(
+                f"{rel}: calls create_refresh_token but does not invoke "
+                "session_issue / session_rotate / _issue_refresh_session / "
+                "_rotate_refresh_session"
+            )
+    assert offenders == [], (
+        "Every create_refresh_token call site must pair with the Redis "
+        "primary-key + family-set write before the cookie is set "
+        "(specs/2026-05-17-backend-session-model.md §5.4). Offenders: "
+        + "; ".join(offenders)
+    )
+
+
+# ── 6. /verify accepts a valid jti + sid token ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_accepts_session_with_redis_row(
+    session_factory, fake_redis
+) -> None:
+    """``/auth/verify`` shares the same validation chain as ``/refresh``
+    so the Redis probe lands automatically — pin it explicitly so a
+    future refactor cannot bypass."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": token},
+        )
+    assert res.status_code == 200, res.json()
+    # /verify must NEVER emit Set-Cookie (RSC contract).
+    assert _canonical_refresh_cookie(res.headers) is None
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_token_with_missing_redis_row(
+    session_factory, fake_redis
+) -> None:
+    """``/auth/verify`` rejects a JWT whose primary key has been wiped."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/v1/auth/login",
+            json={"login": "alice", "password": PASSWORD},
+        )
+        token = _refresh_token_from_set_cookie(_canonical_refresh_cookie(login.headers))
+        jti, _sid = decode_refresh_jti_sid(token)
+        del fake_redis._kv[f"auth:session:{jti}"]
+
+        res = client.post(
+            "/api/v1/auth/verify",
+            cookies={"refresh_token": token},
+        )
+    assert res.status_code == 401, res.json()

--- a/backend/tests/auth/test_verify_and_cookie_path.py
+++ b/backend/tests/auth/test_verify_and_cookie_path.py
@@ -29,6 +29,7 @@ from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
 from app.routers.auth import router as auth_router
 from app.security import create_refresh_token, hash_password
+from tests.conftest import issue_test_refresh_token
 
 
 PASSWORD = "S3cret-Pass!"
@@ -104,7 +105,7 @@ async def _seed_user(
 
 async def test_verify_returns_user_and_access_token(session_factory):
     user_id = await _seed_user(session_factory)
-    refresh = create_refresh_token(user_id)
+    refresh = issue_test_refresh_token(user_id)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -133,7 +134,7 @@ async def test_verify_returns_user_and_access_token(session_factory):
 async def test_verify_user_shape_matches_me(session_factory):
     """The user payload must be identical to /auth/me's UserResponse."""
     user_id = await _seed_user(session_factory)
-    refresh = create_refresh_token(user_id)
+    refresh = issue_test_refresh_token(user_id)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -203,7 +204,7 @@ async def test_verify_access_token_not_accepted_as_refresh(session_factory):
 
 async def test_verify_inactive_user_returns_401(session_factory):
     user_id = await _seed_user(session_factory, is_active=False)
-    refresh = create_refresh_token(user_id)
+    refresh = issue_test_refresh_token(user_id)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -224,7 +225,7 @@ async def test_verify_does_not_rotate_or_set_cookie(session_factory):
     """The whole point of /verify: it is a passive read. Asserting NO
     `Set-Cookie` on the response is the load-bearing test for this PR."""
     user_id = await _seed_user(session_factory)
-    refresh = create_refresh_token(user_id)
+    refresh = issue_test_refresh_token(user_id)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -281,7 +282,7 @@ async def test_cookie_path_is_root_on_login(session_factory):
 
 async def test_cookie_path_is_root_on_refresh_rotation(session_factory):
     user_id = await _seed_user(session_factory)
-    refresh = create_refresh_token(user_id)
+    refresh = issue_test_refresh_token(user_id)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -359,7 +360,7 @@ async def test_verify_rejects_invalidated_refresh_token(session_factory):
 
     # Mint the refresh token first, then bump the cutoff to "after" it.
     user_id = await _seed_user(session_factory)
-    refresh = create_refresh_token(user_id)
+    refresh = issue_test_refresh_token(user_id)
 
     # Bump sessions_invalidated_at to a future timestamp so any token
     # already in hand has iat < cutoff.
@@ -398,7 +399,6 @@ async def test_verify_rejects_expired_session_lifetime(session_factory):
     from datetime import datetime, timedelta, timezone
 
     from app.config import settings as app_settings
-    from app.security import create_refresh_token as _crt
 
     user_id = await _seed_user(session_factory)
 
@@ -407,7 +407,7 @@ async def test_verify_rejects_expired_session_lifetime(session_factory):
     long_ago = datetime.now(timezone.utc) - timedelta(
         days=app_settings.session_lifetime_days + 30
     )
-    refresh = _crt(user_id, session_created_at=long_ago)
+    refresh = issue_test_refresh_token(user_id, session_created_at=long_ago)
 
     app = make_app(session_factory)
     with TestClient(app) as client:
@@ -435,14 +435,13 @@ async def test_refresh_clears_cookie_on_session_lifetime_expiry(session_factory)
     from datetime import datetime, timedelta, timezone
 
     from app.config import settings as app_settings
-    from app.security import create_refresh_token as _crt
 
     user_id = await _seed_user(session_factory)
 
     long_ago = datetime.now(timezone.utc) - timedelta(
         days=app_settings.session_lifetime_days + 30
     )
-    refresh = _crt(user_id, session_created_at=long_ago)
+    refresh = issue_test_refresh_token(user_id, session_created_at=long_ago)
 
     app = make_app(session_factory)
     with TestClient(app) as client:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,11 @@
 import logging
 import os
 import sys
+from collections import defaultdict
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
@@ -24,3 +28,170 @@ os.environ.setdefault("APP_ENV", "development")
 # takes effect before any test session-level fixture imports parser
 # modules.
 logging.getLogger("ofxtools").setLevel(logging.WARNING)
+
+
+# ── Fake in-process Redis (PR 2 — backend session model) ────────────────────
+#
+# After PR 2 of ``specs/2026-05-17-backend-session-model.md`` every refresh
+# JWT issue path writes ``auth:session:{jti}`` and ``auth:session:by_sid:{sid}``
+# to Redis BEFORE the cookie is set, and the validation chain probes the
+# primary key. The spec is explicit (§7.1): Redis unreachable means 503,
+# not silent success. Tests cannot rely on a real Redis being present in
+# every runtime, so an in-process fake stands in.
+#
+# This fake is auto-installed by ``_autouse_fake_redis`` below so every
+# test in the suite that exercises a session-issue path Just Works without
+# needing to opt in. Tests that want to assert Redis-unreachable behaviour
+# (the 503 path) overwrite ``redis_client.get_client`` themselves to
+# return None, which takes precedence.
+
+
+class _FakeRedisPipeline:
+    """In-memory pipeline mirroring the redis.asyncio.client.Pipeline ops
+    used by ``session_issue`` / ``session_rotate``."""
+
+    def __init__(self, store: "_SharedFakeRedis"):
+        self._store = store
+        self._ops: list[tuple[str, tuple, dict]] = []
+
+    def set(self, key, value, ex=None, nx=False, **kwargs):
+        self._ops.append(("set", (key, value), {"ex": ex, "nx": nx, **kwargs}))
+        return self
+
+    def sadd(self, key, *members):
+        self._ops.append(("sadd", (key, *members), {}))
+        return self
+
+    def expire(self, key, ttl):
+        self._ops.append(("expire", (key, ttl), {}))
+        return self
+
+    def delete(self, *keys):
+        self._ops.append(("delete", keys, {}))
+        return self
+
+    async def execute(self):
+        if self._store.abort_pipeline:
+            from redis.exceptions import RedisError
+
+            raise RedisError("simulated MULTI/EXEC abort")
+        results = []
+        for op, args, kwargs in self._ops:
+            if op == "set":
+                key, value = args
+                self._store._kv[key] = value
+            elif op == "sadd":
+                key, *members = args
+                self._store._sets[key].update(members)
+            elif op == "expire":
+                _ = args  # TTL not simulated; would require a clock fixture
+            elif op == "delete":
+                for k in args:
+                    self._store._kv.pop(k, None)
+                    self._store._sets.pop(k, None)
+            results.append(True)
+        return results
+
+
+class _SharedFakeRedis:
+    """Minimum-viable fake of ``redis.asyncio.Redis`` covering the
+    SET / GET / SADD / EXPIRE / DELETE / pipeline / setex /  ops used
+    across the app (auth-session keys + MFA email-jti nonces).
+    """
+
+    def __init__(self):
+        self._kv: dict[str, Any] = {}
+        self._sets: dict[str, set] = defaultdict(set)
+        self.abort_pipeline = False
+
+    # Plain KV
+    async def get(self, key):
+        return self._kv.get(key)
+
+    async def set(self, key, value, ex=None, **kwargs):
+        self._kv[key] = value
+        return True
+
+    async def setex(self, key, ttl, value):
+        self._kv[key] = value
+        return True
+
+    async def delete(self, *keys):
+        n = 0
+        for k in keys:
+            if k in self._kv:
+                del self._kv[k]
+                n += 1
+        return n
+
+    async def exists(self, *keys):
+        return sum(1 for k in keys if k in self._kv)
+
+    # Sets
+    async def smembers(self, key):
+        return set(self._sets.get(key, set()))
+
+    async def sismember(self, key, member):
+        return member in self._sets.get(key, set())
+
+    # Pipelines
+    def pipeline(self, transaction=True):
+        return _FakeRedisPipeline(self)
+
+    # Lifecycle
+    async def aclose(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _autouse_fake_redis(monkeypatch):
+    """Install a fresh in-process fake Redis for every test.
+
+    Tests that want to assert the Redis-unreachable contract overwrite
+    ``redis_client.get_client`` themselves (``lambda: None``); pytest's
+    fixture ordering means their ``monkeypatch.setattr`` runs AFTER this
+    fixture, so the override wins.
+    """
+    from app import redis_client
+
+    fake = _SharedFakeRedis()
+    monkeypatch.setattr(redis_client, "get_client", lambda: fake)
+    monkeypatch.setattr(redis_client, "_client", fake, raising=False)
+    yield fake
+
+
+def issue_test_refresh_token(user_id: int, **kwargs) -> str:
+    """Test helper: mint a refresh JWT AND seed its Redis row in the
+    autouse fake. Replaces direct ``create_refresh_token(user_id)`` calls
+    in pre-PR2 tests that didn't have to worry about Redis state.
+
+    Returns the JWT string. Internal jti/sid are written to the fake
+    Redis so the validation chain (which now probes Redis) accepts the
+    token in subsequent requests.
+
+    PR 2 contract: ``create_refresh_token`` now returns ``(token, jti, sid)``
+    AND every issue path must paired with a Redis primary-key + family
+    write. Tests that hand-mint a refresh JWT to bypass /login should
+    use this helper rather than ``create_refresh_token`` directly.
+    """
+    from app import redis_client as _rc
+    from app.security import create_refresh_token, refresh_cookie_max_age
+    import json
+
+    token, jti, sid = create_refresh_token(user_id, **kwargs)
+    client = _rc.get_client()
+    if client is None:
+        return token
+    # Synchronous write into the autouse fake's backing dicts so callers
+    # do not have to ``await`` from non-async test bodies.
+    key = f"auth:session:{jti}"
+    family_key = f"auth:session:by_sid:{sid}"
+    payload = json.dumps({"user_id": user_id, "sid": sid}, separators=(",", ":"))
+    # The autouse fake stores under ``_kv`` and ``_sets``; real
+    # redis.asyncio.Redis instances don't expose those. The helper
+    # therefore is only useful in tests where ``_autouse_fake_redis``
+    # has installed our fake — which is every test by default.
+    if hasattr(client, "_kv"):
+        client._kv[key] = payload
+        client._sets[family_key].add(jti)
+    return token

--- a/backend/tests/routers/test_auth_cookie_max_age.py
+++ b/backend/tests/routers/test_auth_cookie_max_age.py
@@ -53,6 +53,7 @@ from app.security import (
     create_refresh_token,
     hash_password,
 )
+from tests.conftest import issue_test_refresh_token
 from app.services.mfa_service import (
     generate_recovery_codes,
     hash_recovery_code,
@@ -274,7 +275,7 @@ async def test_refresh_rotation_cookie_max_age_matches_settings(
     """``/auth/refresh`` rotation sets ``Max-Age`` equal to
     ``refresh_idle_ttl_days * 86400``."""
     seed = await _seed_user(session_factory)
-    refresh = create_refresh_token(seed["user_id"])
+    refresh = issue_test_refresh_token(seed["user_id"])
     app = _make_app(session_factory)
 
     with TestClient(app) as client:
@@ -378,7 +379,7 @@ async def test_all_four_sites_emit_same_max_age_when_setting_changes(
     assert _max_age_from_set_cookie(login_raw) == expected, login_raw
 
     # 2. Refresh rotation.
-    refresh = create_refresh_token(seed["user_id"])
+    refresh = issue_test_refresh_token(seed["user_id"])
     with TestClient(app) as client:
         refresh_res = client.post(
             "/api/v1/auth/refresh",

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -47,23 +47,75 @@ def test_create_access_token_roundtrip_decodes_expected_claims() -> None:
 def test_refresh_token_preserves_original_session_created_at() -> None:
     session_start = datetime.now(timezone.utc) - timedelta(days=2)
 
-    token = create_refresh_token(subject=5, session_created_at=session_start)
+    token, jti, sid = create_refresh_token(subject=5, session_created_at=session_start)
     payload = decode_token(token)
 
     assert payload is not None
     assert payload["type"] == "refresh"
     assert payload["sub"] == "5"
     assert payload["session_created_at"] == session_start.timestamp()
+    # PR 2: every refresh JWT carries jti + sid; both stamped on the
+    # token AND surfaced from the helper for the caller's Redis write.
+    assert payload["jti"] == jti
+    assert payload["sid"] == sid
 
 
 def test_refresh_token_defaults_session_created_at_to_now() -> None:
     before = datetime.now(timezone.utc).timestamp()
-    token = create_refresh_token(subject=9)
+    token, _jti, _sid = create_refresh_token(subject=9)
     after = datetime.now(timezone.utc).timestamp()
     payload = decode_token(token)
 
     assert payload is not None
     assert before <= payload["session_created_at"] <= after
+
+
+def test_refresh_token_sid_preserved_when_passed() -> None:
+    """``/refresh`` rotation passes the predecessor's ``sid`` through
+    ``create_refresh_token`` to preserve the family link across the
+    rotation chain."""
+    token, jti, sid = create_refresh_token(subject=5, sid="fixed-sid-abcdef")
+    assert sid == "fixed-sid-abcdef"
+    payload = decode_token(token)
+    assert payload is not None
+    assert payload["sid"] == "fixed-sid-abcdef"
+    assert payload["jti"] == jti
+
+
+def test_refresh_token_sid_minted_fresh_when_none() -> None:
+    """First-login sites pass ``sid=None`` and expect a fresh UUID4 hex."""
+    _, _, sid_a = create_refresh_token(subject=5)
+    _, _, sid_b = create_refresh_token(subject=5)
+    assert sid_a != sid_b, "fresh-session sid must rotate per call"
+    # UUID4 hex is 32 chars, all hex digits.
+    assert len(sid_a) == 32
+    int(sid_a, 16)  # raises if not hex
+
+
+def test_decode_refresh_jti_sid_extracts_both_claims() -> None:
+    from app.security import decode_refresh_jti_sid
+
+    token, expected_jti, expected_sid = create_refresh_token(subject=7)
+    jti, sid = decode_refresh_jti_sid(token)
+    assert jti == expected_jti
+    assert sid == expected_sid
+
+
+def test_decode_refresh_jti_sid_rejects_legacy_token() -> None:
+    """A token missing jti / sid (legacy pre-PR2 shape) must raise."""
+    import jwt as _pyjwt
+    from app.config import settings
+
+    legacy = _pyjwt.encode(
+        {"sub": "7", "type": "refresh"},
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
+    from app.security import decode_refresh_jti_sid
+    import pytest
+
+    with pytest.raises(ValueError):
+        decode_refresh_jti_sid(legacy)
 
 
 def test_create_mfa_email_token_bakes_hmac_and_jti_into_token() -> None:

--- a/infra/PR2_REAUTH_BREAK.md
+++ b/infra/PR2_REAUTH_BREAK.md
@@ -1,0 +1,83 @@
+# PR 2 — Planned reauth break
+
+PR 2 of the backend-session-model rollout
+(`specs/2026-05-17-backend-session-model.md` §8) changes the shape of
+the refresh JWT: every newly issued refresh token now carries
+mandatory `jti` (per-session id) and `sid` (per-family id) claims AND
+a paired Redis row (`auth:session:{jti}` + `auth:session:by_sid:{sid}`).
+The validation chain rejects any refresh JWT that lacks either claim
+or whose Redis primary key is missing.
+
+This is the operator-facing note for the resulting one-shot reauth
+wave.
+
+## What breaks
+
+Every refresh JWT issued **before** PR 2 deploys lacks `jti` and `sid`.
+The new validation chain rejects those tokens with HTTP 401 and the
+detail `"Session has been invalidated"`.
+
+End-user impact:
+
+1. The next `/api/v1/auth/refresh` (or `/api/v1/auth/verify`) request
+   returns 401.
+2. The frontend's terminal-vs-transient classifier (PR #287) marks 401
+   with that detail string as terminal and routes the user to `/login`.
+3. The user re-enters credentials, completes any MFA step, receives a
+   new refresh JWT with `jti` + `sid`, and continues.
+
+The user-visible effect is one extra login.
+
+## When it happens
+
+At the moment PR 2 lands on production (DO App Platform deploy from
+`main`). The break is instant for any session whose refresh JWT was
+issued before the deploy timestamp; pre-existing access tokens remain
+valid until their 15-minute TTL expires, at which point the next API
+call triggers the `/refresh` attempt that surfaces the 401.
+
+Worst-case-experienced delay between deploy and the user seeing the
+login prompt: ~15 minutes (one access-token TTL).
+
+## Why it is acceptable
+
+Operator decision Q7 in
+`specs/2026-05-17-backend-session-model.md` §11: pre-launch, before
+any external user holds a session, a single forced reauth wave for
+QA / dev / SA testers is preferable to carrying a backcompat shim
+that would (a) keep the old non-`jti` validation path alive
+indefinitely, (b) block PR 3's family-set logic from assuming every
+session has a `sid`, and (c) double the surface for the per-session
+logout work in PR 4.
+
+The spec is explicit: **no backcompat, no migration, no shims**.
+Anyone signed in at deploy time gets exactly one 401 and signs back
+in.
+
+## Operator-facing message (if anyone asks)
+
+> We deployed an improvement to how sessions are tracked. As a
+> one-time consequence anyone who was signed in just before the
+> deploy will be asked to sign in again on their next page action.
+> No data is lost. No support action is required — users simply
+> sign in and continue.
+
+Tag: `auth.session.reauth-wave.2026-05-17` (use this in support
+threads so we can correlate any "had to sign in twice" reports).
+
+## What does NOT break
+
+- Password reset emails issued before the deploy.
+- Email verification links issued before the deploy.
+- Invitation links (different JWT type with its own claims).
+- MFA challenge tokens mid-flow (5-minute TTL; completes normally
+  and issues a PR 2-shaped refresh JWT).
+- Any DB row, audit event, or org configuration.
+
+## Reference
+
+- Spec §11 Q7 — operator decision recording the acceptance.
+- Spec §8 PR 2 — scope of the JWT shape change.
+- Spec §3.1 — new claim shape with `jti` and `sid`.
+- Spec §4 — Redis schema for `auth:session:{jti}` and
+  `auth:session:by_sid:{sid}`.

--- a/specs/2026-05-17-backend-session-model.md
+++ b/specs/2026-05-17-backend-session-model.md
@@ -473,7 +473,9 @@ NEW shape (architect feedback on PR #301 — revoke by `sid` family, not by `jti
 7. DO NOT touch `sessions_invalidated_at`.
 8. Emit audit event `auth.session.terminated`. Detail carries `{sid_count, jti_count}` (number of distinct sessions revoked, total `jti` values deleted across all families). Outcome=success even when 0 (anonymous logout is still a clean cookie clear).
 
-### 5.4 `POST /api/v1/auth/login`, `/auth/google/callback`, `_issue_tokens`, `/auth/refresh` (issue side)
+### 5.4 `POST /api/v1/auth/login`, `/auth/google/callback`, `_issue_tokens`, `/auth/refresh` (issue side), `POST /api/v1/orgs/invitations/accept`
+
+All FIVE issue sites — login password, `/refresh` rotation, MFA branches via `_issue_tokens`, Google callback, AND `routers/org_members.py` invitation accept — call `create_refresh_token` and must populate Redis identically. PR #305's review found `org_members.py` had been missed in PR 1; the same trap is structurally easy to fall back into, so the grep-style guard test in §9 pins every `create_refresh_token` call site to a paired Redis write within the same source file.
 
 Every site that calls `create_refresh_token` is updated to:
 


### PR DESCRIPTION
## Summary

PR 2 of the backend-session-model rollout (`specs/2026-05-17-backend-session-model.md` §8). Every refresh JWT now carries mandatory `jti` (per-session id, 16-byte token_urlsafe) and `sid` (per-family id, UUID4 hex) claims, paired with a Redis primary key (`auth:session:{jti}`) and family set (`auth:session:by_sid:{sid}`) written atomically before the cookie is set. Rotation preserves `sid` across the chain so per-session logout (PR 4) can revoke the entire family.

## Scope decision

**Planned reauth break.** After this PR deploys, every refresh JWT issued before the deploy lacks `jti`/`sid` and is rejected. Every signed-in user gets one 401, frontend redirects to `/login`, user re-authenticates. Operator decision Q7 (spec §11) accepts this pre-launch. See `infra/PR2_REAUTH_BREAK.md` for the operator-facing note.

**Strictly PR 2 only.** No grace key, no Lua, no logout behavior change, no `sessions_invalidated_at` allowlist regression, no frontend changes. Those land in PR 3 / PR 4. The architect-acknowledged partial-failure window in the sequential rotation shape (SET new primary / SADD by_sid / DEL old primary in one MULTI/EXEC) is tolerated for one PR cycle because there is no concurrent-logout-vs-rotation surface yet (logout still uses the global-cutoff approach until PR 4) and no grace key for the §4.3 race to subvert. PR 3 replaces the rotation with the production Lua script.

## All five issue sites

- `backend/app/routers/auth.py:293` — login password branch
- `backend/app/routers/auth.py:585` — `/refresh` rotation (preserves `sid` from predecessor)
- `backend/app/routers/auth.py:946` — `_issue_tokens` (MFA verify / MFA recovery / MFA email-verify)
- `backend/app/routers/auth.py:1623` — Google SSO callback
- `backend/app/routers/org_members.py:190` — invitation accept (the fifth site PR #305 missed)

All five write the primary key + family-set entry in one `MULTI/EXEC` BEFORE `set_cookie`. Redis unreachable => 503, no Set-Cookie emitted, fail-closed contract per spec §7.1.

## Changed files

- `backend/app/security.py` — `create_refresh_token` returns `(token, jti, sid)`; mints fresh `jti` always, fresh `sid` when caller passes `None`. New `decode_refresh_jti_sid` helper.
- `backend/app/redis_client.py` — new `session_issue`, `session_validate`, `session_rotate` helpers. All use `require_client()` so Redis-unreachable raises `RedisRequired`.
- `backend/app/routers/auth.py` — new `_issue_refresh_session` / `_rotate_refresh_session` wrappers that mint the JWT, write Redis, and translate Redis errors to 503. `_issue_tokens` is now async. Validation chain rejects missing `jti`/`sid` and probes Redis primary key.
- `backend/app/routers/org_members.py` — invitation accept calls `_issue_refresh_session`.
- `specs/2026-05-17-backend-session-model.md` — §5.4 enumeration updated to include `org_members.py` as the fifth issue site.
- `infra/PR2_REAUTH_BREAK.md` — operator-facing one-pager on the planned reauth wave.
- `backend/tests/conftest.py` — autouse in-process fake Redis fixture (`_SharedFakeRedis`) so every test in the suite that touches an issue path Just Works without a real Redis; helper `issue_test_refresh_token` seeds the fake from non-async test bodies.
- `backend/tests/auth/test_session_jti_sid.py` — new file, 18 tests covering jti+sid stamping at all five sites, sid preservation across 5 rotations, legacy-token rejection, family-set membership, Redis-unreachable 503 at every issue path, MULTI/EXEC abort 503 + no Set-Cookie, and the grep-style guard that every `create_refresh_token` call site pairs with a `session_issue` / `session_rotate` / `_issue_refresh_session` / `_rotate_refresh_session` call.
- Touched tests updated to use `issue_test_refresh_token` (so the new validation-chain Redis probe finds the seeded row) or to handle the new tuple return shape from `create_refresh_token`.

## Tests run (verbatim)

```
$ pytest tests/auth/test_session_jti_sid.py -q
18 passed, 16 warnings in 6.12s

$ pytest tests/auth/ tests/routers/ tests/test_security.py -q
491 passed, 1 skipped, 30 warnings in 157.79s

$ pytest tests/ -q
1294 passed, 9 skipped, 82 warnings in 275.36s

$ npm test -- --run
Test Files  140 passed (140)
     Tests  1000 passed (1000)

$ npx tsc --noEmit
(clean exit)
```

## Spec link

`specs/2026-05-17-backend-session-model.md` §8 "PR 2: Refresh `jti` + `sid` + primary key + family set" (architect-revised shape).

## Out of scope

- Lua rotation script, grace key, `/verify` grace fallback (PR 3)
- `/auth/logout` family revoke + `sessions_invalidated_at` allowlist (PR 4)
- Frontend changes (none required — JWT shape change is backend-only)