### PR TITLE
feat(auth): rotation grace window + Lua rotation + verify fallback (PR 3 of 4)

### DIFF
--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -1,7 +1,8 @@
 """Redis / Valkey client — singleton, lazy-initialized from settings.
 
 Scope today: MFA email-code single-use nonces + refresh-session primary
-key and family set (``auth:session:{jti}``, ``auth:session:by_sid:{sid}``).
+key, grace key, and family set (``auth:session:{jti}``,
+``auth:session:grace:{jti}``, ``auth:session:by_sid:{sid}``).
 More features (rate-limit storage, cache) land here when the app moves
 off single-replica on DO App Platform and needs shared state.
 
@@ -20,6 +21,7 @@ from redis.asyncio import Redis
 from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError as RedisResponseError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from app.config import settings
@@ -93,15 +95,20 @@ def require_client() -> Redis:
 
 # ── Refresh-session keys (specs/2026-05-17-backend-session-model.md §4) ─────
 #
-# Two key shapes drive the per-session story:
+# Three key shapes drive the per-session story:
 #
-#   auth:session:{jti}        primary key for ONE refresh JWT (rotates each
-#                             /refresh; value = JSON {"user_id", "sid"};
-#                             TTL = refresh_idle_ttl_days * 86400)
-#   auth:session:by_sid:{sid} family set holding every jti ever issued for
-#                             this session FAMILY (sid is stable across the
-#                             entire rotation chain so per-session logout
-#                             in PR 4 can revoke every successor)
+#   auth:session:{jti}         primary key for ONE refresh JWT (rotates each
+#                              /refresh; value = JSON {"user_id", "sid"};
+#                              TTL = refresh_idle_ttl_days * 86400)
+#   auth:session:grace:{jti}   30s rotation grace key, written by the Lua
+#                              script BEFORE the old primary is deleted.
+#                              Value JSON {"user_id", "sid", "successor_jti"}.
+#                              Read by /refresh + /verify to absorb cross-tab
+#                              races without forcing a logout.
+#   auth:session:by_sid:{sid}  family set holding every jti ever issued for
+#                              this session FAMILY (sid is stable across the
+#                              entire rotation chain so per-session logout
+#                              in PR 4 can revoke every successor)
 #
 # Every issue path (login, /refresh rotation, MFA branches, Google
 # callback, invitation accept) MUST write both keys in a single
@@ -109,11 +116,21 @@ def require_client() -> Redis:
 # request returns 503 — never set a cookie that has no Redis row.
 
 SESSION_PRIMARY_KEY = "auth:session:{jti}"
+SESSION_GRACE_KEY = "auth:session:grace:{jti}"
 SESSION_FAMILY_KEY = "auth:session:by_sid:{sid}"
+
+# Rotation grace window — see spec §2.5. 30s comfortably above worst-case
+# cross-tab clock skew, well below access-token TTL so a stolen
+# pre-rotation cookie cannot silently extend a session.
+SESSION_GRACE_TTL_SECONDS = 30
 
 
 def _primary_key(jti: str) -> str:
     return f"auth:session:{jti}"
+
+
+def _grace_key(jti: str) -> str:
+    return f"auth:session:grace:{jti}"
 
 
 def _family_key(sid: str) -> str:
@@ -162,30 +179,162 @@ async def session_validate(jti: str) -> dict | None:
         return None
 
 
-async def session_rotate(
+async def session_grace(jti: str) -> dict | None:
+    """Return the JSON payload at ``auth:session:grace:{jti}`` or None on miss.
+
+    Called by ``/refresh`` (app-side step 4) and ``/verify`` (§5.2) when the
+    primary key has been rotated out. Caller must additionally verify that
+    the JWT's ``sid`` matches the grace row's ``sid`` AND that
+    ``auth:session:by_sid:{sid}`` still exists (logout hasn't deleted the
+    family).
+    """
+    client = require_client()
+    raw = await client.get(_grace_key(jti))
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        # Corrupt key; treat as miss. Belt-and-braces — the rotate Lua
+        # script is the only writer of this key and always writes valid
+        # JSON.
+        return None
+
+
+async def session_family_exists(sid: str) -> bool:
+    """Return True iff ``auth:session:by_sid:{sid}`` exists.
+
+    Defence-in-depth check for the grace-acceptance branch (§5.1 step 4
+    and §5.2): a concurrent logout deletes the family set first, so the
+    grace key can outlive the family by up to 30 seconds. The resolver
+    rejects in that window.
+    """
+    client = require_client()
+    return bool(await client.exists(_family_key(sid)))
+
+
+# Lua return tokens — spec §4.2 step 5. The router branch table in
+# §5.1 step 6 maps these to HTTP behaviour. The bare string ``"ok"``
+# is returned on the happy path; the three error tokens come back via
+# ``redis.exceptions.ResponseError`` because py-redis surfaces Lua
+# ``{err = "..."}`` returns as that exception with the err string as
+# the message.
+SESSION_ROTATE_OK = "ok"
+SESSION_ROTATE_REVOKED = "session_revoked"
+SESSION_ROTATE_ALREADY_ROTATED = "already_rotated"
+SESSION_ROTATE_JTI_COLLISION = "jti_collision"
+
+
+# Spec §4.2 step 5. Three guards in order — every guard returns early on
+# failure with NO writes. Lua executes atomically server-side so partial
+# application is not possible.
+ROTATE_SESSION_LUA = """
+-- KEYS[1] = auth:session:{old_jti}
+-- KEYS[2] = auth:session:grace:{old_jti}
+-- KEYS[3] = auth:session:{new_jti}
+-- KEYS[4] = auth:session:by_sid:{sid}
+-- ARGV[1] = grace TTL seconds (30)
+-- ARGV[2] = idle TTL seconds (refresh_idle_ttl_days * 86400)
+-- ARGV[3] = grace JSON value
+-- ARGV[4] = primary JSON value
+-- ARGV[5] = old_jti (string to check SISMEMBER + identify in family)
+-- ARGV[6] = new_jti (string to SADD into family)
+
+-- (1) Family revoked? Concurrent /logout deleted the family set.
+if redis.call("SISMEMBER", KEYS[4], ARGV[5]) == 0 then
+    return {err = "session_revoked"}
+end
+
+-- (2) Already rotated? Concurrent /refresh with the same old_jti won the race.
+--     The earlier app-side GET cannot prevent two requests reaching this
+--     point. This check INSIDE Lua is the authority.
+if redis.call("EXISTS", KEYS[1]) == 0 then
+    return {err = "already_rotated"}
+end
+
+-- (3) Defensive NX on new primary. 128-bit jti collisions are
+--     astronomically unlikely but overwriting a live session is the
+--     wrong failure mode. SET ... NX returns the bulk string "OK" on
+--     success and false (nil bulk) on NX-miss; both ``not result``
+--     and ``== false`` match nil in Lua but explicit ``not`` keeps
+--     the intent unambiguous.
+local set_ok = redis.call("SET", KEYS[3], ARGV[4], "EX", ARGV[2], "NX")
+if not set_ok then
+    return {err = "jti_collision"}
+end
+
+-- (4) Write grace, register the new jti in the family, delete the old primary.
+redis.call("SET", KEYS[2], ARGV[3], "EX", ARGV[1])
+redis.call("SADD", KEYS[4], ARGV[6])
+redis.call("EXPIRE", KEYS[4], ARGV[2])
+redis.call("DEL", KEYS[1])
+return "ok"
+"""
+
+
+async def session_rotate_lua(
     old_jti: str,
     new_jti: str,
     sid: str,
     user_id: int,
-    ttl_seconds: int,
-) -> None:
-    """Sequential rotation: SET new primary, SADD by_sid new_jti,
-    EXPIRE by_sid, DEL old primary — in one ``MULTI/EXEC`` block.
+    idle_ttl_seconds: int,
+    grace_ttl_seconds: int = SESSION_GRACE_TTL_SECONDS,
+) -> str:
+    """Run the atomic rotation Lua script (spec §4.2 step 5).
 
-    PR 2 scope: NO Lua, NO EXISTS guards, NO grace key. The architect-
-    acknowledged partial-failure window is tolerated for one PR cycle
-    because in PR 2 there is no concurrent-logout-vs-rotation surface
-    yet (the global-cutoff logout still wipes everything) and no grace
-    key for the race in §4.3 to subvert. PR 3 replaces this with the
-    full Lua script.
+    Returns the bare string ``"ok"`` on success, or one of the three
+    error tokens (``session_revoked``, ``already_rotated``,
+    ``jti_collision``) when the corresponding guard trips.
 
-    Fails CLOSED on unreachable Redis via :func:`require_client`.
+    Lua errors come back as :class:`redis.exceptions.ResponseError` in
+    py-redis; the message body carries the ``err`` field verbatim. We
+    map back to a string return so the router can dispatch on the four
+    tokens uniformly.
+
+    Fails CLOSED on unreachable Redis via :func:`require_client`. The
+    ``RedisError`` family (connection / timeout / EVAL transport
+    failures) bubbles up unchanged so the router can return 503.
     """
     client = require_client()
-    payload = json.dumps({"user_id": user_id, "sid": sid}, separators=(",", ":"))
-    pipe = client.pipeline(transaction=True)
-    pipe.set(_primary_key(new_jti), payload, ex=ttl_seconds)
-    pipe.sadd(_family_key(sid), new_jti)
-    pipe.expire(_family_key(sid), ttl_seconds)
-    pipe.delete(_primary_key(old_jti))
-    await pipe.execute()
+    primary_value = json.dumps(
+        {"user_id": user_id, "sid": sid}, separators=(",", ":")
+    )
+    grace_value = json.dumps(
+        {"user_id": user_id, "sid": sid, "successor_jti": new_jti},
+        separators=(",", ":"),
+    )
+    try:
+        result = await client.eval(
+            ROTATE_SESSION_LUA,
+            4,  # keycount
+            _primary_key(old_jti),
+            _grace_key(old_jti),
+            _primary_key(new_jti),
+            _family_key(sid),
+            grace_ttl_seconds,
+            idle_ttl_seconds,
+            grace_value,
+            primary_value,
+            old_jti,
+            new_jti,
+        )
+    except RedisResponseError as exc:
+        # py-redis surfaces Lua ``{err = "..."}`` returns as ResponseError.
+        msg = str(exc)
+        for token in (
+            SESSION_ROTATE_REVOKED,
+            SESSION_ROTATE_ALREADY_ROTATED,
+            SESSION_ROTATE_JTI_COLLISION,
+        ):
+            if token in msg:
+                return token
+        # Genuine Lua error (script bug, transport corruption). Let it
+        # propagate so the router can return 503.
+        raise
+    # Successful return is the literal string "ok" — bytes when
+    # decode_responses=False, str when True. The client is configured
+    # with decode_responses=True so we expect a str, but accept both
+    # for the test fake.
+    if isinstance(result, bytes):
+        result = result.decode("utf-8")
+    return result

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -359,10 +359,29 @@ async def _rotate_refresh_session(
     sid: str,
     *,
     session_created_at: datetime | None = None,
-) -> tuple[str, str, str]:
-    """Mint a successor refresh JWT (same ``sid``, fresh ``jti``) AND
-    atomically write the new primary + family entry while deleting the
-    old primary. Returns ``(token, new_jti, sid)``.
+) -> tuple[str, str, str, str]:
+    """Mint a successor refresh JWT (same ``sid``, fresh ``jti``) and run
+    the atomic Lua rotation script (spec §4.2 step 5).
+
+    Returns ``(token, new_jti, sid, lua_result)`` where ``lua_result``
+    is one of ``"ok"``, ``"session_revoked"``, ``"already_rotated"``,
+    or ``"jti_collision"``. The router dispatches on the value per
+    §5.1 step 6:
+
+    * ``"ok"`` — issue cookie, emit ``auth.session.rotated`` audit.
+    * ``"session_revoked"`` — concurrent logout deleted the family
+      set; router returns 401, no audit (terminal — frontend redirects).
+    * ``"already_rotated"`` — concurrent ``/refresh`` won the race;
+      router falls into the grace branch, no Set-Cookie, emits
+      ``auth.session.grace_accept {via_already_rotated: true}``.
+    * ``"jti_collision"`` — 128-bit RNG collision (cosmic). The router
+      regenerates ``jti`` and retries once.
+
+    On the ``ok`` path the new primary key is in Redis and the old
+    primary has been replaced by a 30s grace key written inside the
+    Lua transaction. On any non-``ok`` return the JWT is still freshly
+    minted but no Redis writes happened — the router must NOT emit
+    its Set-Cookie because no session row exists for the new jti.
 
     Fails CLOSED on unreachable Redis by raising ``HTTPException(503)``.
     """
@@ -370,15 +389,19 @@ async def _rotate_refresh_session(
         user_id, session_created_at=session_created_at, sid=sid
     )
     try:
-        await redis_client.session_rotate(
-            old_jti, new_jti, session_id, user_id, refresh_cookie_max_age()
+        result = await redis_client.session_rotate_lua(
+            old_jti,
+            new_jti,
+            session_id,
+            user_id,
+            refresh_cookie_max_age(),
         )
     except (RedisRequired, RedisError) as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
         ) from exc
-    return token, new_jti, session_id
+    return token, new_jti, session_id, result
 
 # Emitted when the request carries refresh cookies for two or more
 # distinct user accounts (e.g. a legacy account-A cookie shadowing a
@@ -444,9 +467,18 @@ def _extract_refresh_cookies(request: Request) -> list[str]:
 async def _validate_single_refresh_token(
     refresh_token: str,
     db: AsyncSession,
-) -> tuple[User, dict, datetime | None]:
+) -> tuple[User, dict, datetime | None, str]:
     """Validate ONE refresh-token JWT value. Returns
-    ``(user, payload, session_start)`` or raises ``HTTPException(401)``.
+    ``(user, payload, session_start, redis_state)`` or raises
+    ``HTTPException(401)``.
+
+    ``redis_state`` is ``"primary"`` when the active session key
+    ``auth:session:{jti}`` is present, or ``"grace"`` when only the
+    rotation grace key ``auth:session:grace:{jti}`` is present AND the
+    session family ``auth:session:by_sid:{sid}`` still exists. PR 3
+    introduces this state so ``/refresh`` and ``/verify`` can absorb
+    cross-tab rotation races without forcing a logout — see
+    ``specs/2026-05-17-backend-session-model.md`` §5.1 step 4 / §5.2.
 
     The validation chain:
       1. JWT decode + ``type == "refresh"``
@@ -504,12 +536,26 @@ async def _validate_single_refresh_token(
             detail="Session has been invalidated",
         )
 
-    # Redis primary-key probe. Miss => 401 (the jti has been revoked or
-    # has expired before its JWT cousin). Redis-unreachable => 503; we
+    # Redis primary-key probe. Miss => fall back to grace key (spec §5.1
+    # step 4 + §5.2). If both miss => 401. Redis-unreachable => 503; we
     # never silently accept the JWT, because that would defeat the
-    # per-session story (PR 4). See spec §7.1.
+    # per-session story. See spec §7.1.
+    redis_state: str = "primary"
     try:
         session_row = await redis_client.session_validate(jti)
+        if session_row is None:
+            # PR 3: grace fallback. The primary key has been rotated out
+            # but the grace key (30s TTL) may still be alive — that's
+            # the cross-tab race the rotation grace window exists to
+            # absorb. The grace row carries the same ``user_id`` and
+            # ``sid`` so the resolver can still bind back to JWT claims.
+            # Defence-in-depth: ALSO verify the family set still exists
+            # (concurrent logout deletes it before the grace TTL).
+            grace_row = await redis_client.session_grace(jti)
+            if grace_row is not None:
+                if await redis_client.session_family_exists(sid):
+                    session_row = grace_row
+                    redis_state = "grace"
     except (RedisRequired, RedisError) as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -572,13 +618,13 @@ async def _validate_single_refresh_token(
                 detail=SESSION_EXPIRED_DETAIL,
             )
 
-    return user, payload, session_start
+    return user, payload, session_start, redis_state
 
 
 async def _validate_refresh_cookie(
     refresh_tokens: list[str],
     db: AsyncSession,
-) -> tuple[User, dict, datetime | None]:
+) -> tuple[User, dict, datetime | None, str]:
     """Validate the provided refresh-token cookie values and pick one.
 
     Rules:
@@ -611,7 +657,7 @@ async def _validate_refresh_cookie(
             detail="No refresh token",
         )
 
-    successes: list[tuple[User, dict, datetime | None]] = []
+    successes: list[tuple[User, dict, datetime | None, str]] = []
     last_exc: HTTPException | None = None
     for token in refresh_tokens:
         try:
@@ -623,7 +669,7 @@ async def _validate_refresh_cookie(
         assert last_exc is not None  # loop ran at least once
         raise last_exc
 
-    distinct_user_ids = {triple[0].id for triple in successes}
+    distinct_user_ids = {tup[0].id for tup in successes}
     if len(distinct_user_ids) > 1:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -633,7 +679,7 @@ async def _validate_refresh_cookie(
     # Single user, possibly multiple valid tokens. Prefer the newest by
     # ``iat`` so a stale legacy cookie never out-votes the current one
     # for the same user.
-    successes.sort(key=lambda triple: triple[1].get("iat", 0), reverse=True)
+    successes.sort(key=lambda tup: tup[1].get("iat", 0), reverse=True)
     return successes[0]
 
 
@@ -642,6 +688,7 @@ async def refresh(
     request: Request,
     response: Response,
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     """Rotate the refresh cookie + issue a fresh access token.
 
@@ -649,6 +696,18 @@ async def refresh(
     ``_validate_refresh_cookie``. On session-lifetime expiry this endpoint
     additionally clears the stale cookie before returning 401; ``/verify``
     deliberately does not (it must never emit Set-Cookie).
+
+    PR 3 dispatch (spec §5.1 step 6):
+
+    - If the validation chain says ``redis_state == "grace"`` we're on
+      the grace branch already (primary key gone, grace key alive,
+      family set alive). Issue an access token only; no Set-Cookie, no
+      rotation. Emit ``auth.session.grace_accept``.
+    - Otherwise run the Lua rotation script and dispatch on its return:
+      ``ok`` issues a new cookie; ``session_revoked`` returns 401;
+      ``already_rotated`` falls into the grace branch (re-probe + check
+      family set); ``jti_collision`` regenerates and retries once, with
+      a 503 on the second collision.
 
     NOTE: FastAPI does NOT merge cookies set on the injected ``response``
     parameter into the JSONResponse it builds from a raised HTTPException
@@ -659,7 +718,7 @@ async def refresh(
     """
     refresh_tokens = _extract_refresh_cookies(request)
     try:
-        user, payload, session_start = await _validate_refresh_cookie(
+        user, payload, session_start, redis_state = await _validate_refresh_cookie(
             refresh_tokens, db
         )
     except HTTPException as exc:
@@ -690,10 +749,89 @@ async def refresh(
     sid = payload["sid"]
 
     access_token = create_access_token(user.id, user.org_id, user.role.value)
-    new_refresh_token, _new_jti, _sid = await _rotate_refresh_session(
+
+    # ── Grace-path early return (spec §5.1 step 4) ──────────────────────
+    # The validator already confirmed the grace key + family set are both
+    # alive AND the JWT's sid matches the grace row's sid (the user_id /
+    # sid mismatch check on the row catches forged JWTs). No new refresh
+    # cookie, no rotation oracle.
+    if redis_state == "grace":
+        await _record_session_grace_accept(
+            session_factory,
+            user=user,
+            request=request,
+            old_jti=old_jti,
+            sid=sid,
+            via_already_rotated=False,
+        )
+        return TokenResponse(access_token=access_token)
+
+    # ── Normal rotation path: Lua script is the authority ───────────────
+    new_refresh_token, new_jti, _sid, lua_result = await _rotate_refresh_session(
         user.id, old_jti, sid, session_created_at=session_start
     )
 
+    if lua_result == redis_client.SESSION_ROTATE_JTI_COLLISION:
+        # 128-bit collision — regenerate jti once and retry. If the second
+        # attempt also collides, the RNG is broken: 503 + structlog flag.
+        new_refresh_token, new_jti, _sid, lua_result = await _rotate_refresh_session(
+            user.id, old_jti, sid, session_created_at=session_start
+        )
+        if lua_result == redis_client.SESSION_ROTATE_JTI_COLLISION:
+            await _record_session_rotated_failed(
+                session_factory,
+                user=user,
+                request=request,
+                old_jti=old_jti,
+                sid=sid,
+                reason="double_jti_collision",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+            )
+
+    if lua_result == redis_client.SESSION_ROTATE_REVOKED:
+        # Concurrent /logout deleted the family set. Terminal 401 — the
+        # frontend's classifier already handles this string.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has been invalidated",
+        )
+
+    if lua_result == redis_client.SESSION_ROTATE_ALREADY_ROTATED:
+        # Concurrent /refresh won the race. The winner just wrote the
+        # grace key inside their Lua transaction — re-probe it AND
+        # confirm the family set still exists, then issue access-only.
+        try:
+            grace_row = await redis_client.session_grace(old_jti)
+            family_alive = await redis_client.session_family_exists(sid)
+        except (RedisRequired, RedisError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+            ) from exc
+        if (
+            grace_row is None
+            or not family_alive
+            or grace_row.get("sid") != sid
+            or grace_row.get("user_id") != user.id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Session has been invalidated",
+            )
+        await _record_session_grace_accept(
+            session_factory,
+            user=user,
+            request=request,
+            old_jti=old_jti,
+            sid=sid,
+            via_already_rotated=True,
+        )
+        return TokenResponse(access_token=access_token)
+
+    # lua_result == "ok"
     response.set_cookie(
         key="refresh_token",
         value=new_refresh_token,
@@ -704,6 +842,14 @@ async def refresh(
         path="/",
     )
     _clear_legacy_refresh_cookie(response)
+    await _record_session_rotated(
+        session_factory,
+        user=user,
+        request=request,
+        old_jti=old_jti,
+        new_jti=new_jti,
+        sid=sid,
+    )
 
     return TokenResponse(access_token=access_token)
 
@@ -730,7 +876,7 @@ async def verify(
     Cookie header (PR #211 cookie-shadow guard).
     """
     refresh_tokens = _extract_refresh_cookies(request)
-    user, _payload, _session_start = await _validate_refresh_cookie(
+    user, _payload, _session_start, _redis_state = await _validate_refresh_cookie(
         refresh_tokens, db
     )
 
@@ -1105,6 +1251,115 @@ async def _record_login_success(
         ip_address=get_client_ip(request),
         outcome="success",
         detail={"method": method},
+    )
+
+
+# ── PR 3 session-rotation audit events (spec §5.1 step 8) ───────────────────
+
+
+async def _record_session_rotated(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    user: User,
+    request: Request,
+    old_jti: str,
+    new_jti: str,
+    sid: str,
+) -> None:
+    """Persist an ``auth.session.rotated`` audit event on the happy-path
+    rotation (Lua returned ``"ok"``).
+
+    Detail carries the predecessor + successor ``jti`` plus the stable
+    ``sid`` so operators can reconstruct the rotation chain offline.
+    """
+    request_id = structlog.contextvars.get_contextvars().get("request_id")
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="auth.session.rotated",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=user.org_id,
+        target_org_name=None,
+        request_id=request_id,
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"old_jti": old_jti, "new_jti": new_jti, "sid": sid},
+    )
+
+
+async def _record_session_grace_accept(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    user: User,
+    request: Request,
+    old_jti: str,
+    sid: str,
+    via_already_rotated: bool,
+) -> None:
+    """Persist an ``auth.session.grace_accept`` audit event.
+
+    Emitted on the grace branch — either entered directly because the
+    app-side primary-key probe missed but the grace key was alive (the
+    typical cross-tab race) or because the Lua rotation script returned
+    ``already_rotated`` (the in-flight rotation race where two requests
+    pass the app-side GET HIT and only one wins). The
+    ``via_already_rotated`` flag lets ops disaggregate the two shapes.
+    """
+    request_id = structlog.contextvars.get_contextvars().get("request_id")
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="auth.session.grace_accept",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=user.org_id,
+        target_org_name=None,
+        request_id=request_id,
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            "old_jti": old_jti,
+            "sid": sid,
+            "via_already_rotated": via_already_rotated,
+        },
+    )
+
+
+async def _record_session_rotated_failed(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    user: User,
+    request: Request,
+    old_jti: str,
+    sid: str,
+    reason: str,
+) -> None:
+    """Persist an ``auth.session.rotated.failed`` audit event.
+
+    Emitted on the double-``jti_collision`` 503 path only. Two 128-bit
+    collisions in a row signals an RNG problem worth alerting on. The
+    structlog event below mirrors the audit row so log-based alerts
+    can fire even if the DB write fails.
+    """
+    request_id = structlog.contextvars.get_contextvars().get("request_id")
+    logger = structlog.stdlib.get_logger()
+    await logger.aerror(
+        "auth.session.rotated.failed",
+        user_id=user.id,
+        sid=sid,
+        old_jti=old_jti,
+        reason=reason,
+    )
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="auth.session.rotated.failed",
+        actor_user_id=user.id,
+        actor_email=user.email,
+        target_org_id=user.org_id,
+        target_org_name=None,
+        request_id=request_id,
+        ip_address=get_client_ip(request),
+        outcome="failure",
+        detail={"old_jti": old_jti, "sid": sid, "reason": reason},
     )
 
 

--- a/backend/tests/auth/test_session_grace_lua.py
+++ b/backend/tests/auth/test_session_grace_lua.py
@@ -1,0 +1,591 @@
+"""PR 3 — Rotation grace window + Lua rotation + verify fallback tests.
+
+Pins every architect-emphasized risk in
+``specs/2026-05-17-backend-session-model.md`` §8 PR 3:
+
+1. Cross-tab race produces exactly one rotation + one grace acceptance
+   (the canonical no-double-issue pin — the Lua ``EXISTS old_primary``
+   guard is what makes this pass).
+2. Replay of an already-rotated jti AFTER the 30s grace window fails.
+3. ``jti_collision`` path: under a forced-collision RNG the first Lua
+   call returns ``jti_collision``, the router regenerates, the second
+   call succeeds; under always-collide RNG the router returns 503
+   with the ``auth.session.rotated.failed`` audit row.
+4. Grace branch family-set check: if logout deletes the family set
+   inside the grace window, the grace branch rejects (architect
+   P1.1 — closes the logout-vs-rotation race).
+5. ``/verify`` mirrors ``/refresh`` — accepts a grace ticket when the
+   family is still alive, rejects when the family is gone.
+6. Concurrent rotation produces the correct audit shape: one
+   ``auth.session.rotated`` AND one
+   ``auth.session.grace_accept {via_already_rotated: true}``.
+7. ``sid`` mismatch on the grace branch rejects.
+8. Replay-after-logout class — within the 30s grace window, if logout
+   has deleted the family set, the grace branch must reject.
+
+Concurrency tests use ``asyncio.gather`` + ``asyncio.Event`` gating,
+NEVER ``asyncio.sleep`` — the architect's #1 named concern for flake.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import (
+    LEGACY_REFRESH_COOKIE_PATH,
+    router as auth_router,
+)
+from app.security import decode_refresh_jti_sid, hash_password
+
+
+PASSWORD = "starting-password-1"
+
+
+@pytest.fixture
+def fake_redis(_autouse_fake_redis):
+    yield _autouse_fake_redis
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(factory: async_sessionmaker[AsyncSession]) -> dict:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@example.com",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id}
+
+
+def _set_cookie_values_for(headers, name: str) -> list[str]:
+    matches: list[str] = []
+    raw_iter = headers.raw if hasattr(headers, "raw") else []
+    for raw in raw_iter:
+        if isinstance(raw, tuple):
+            key, value = raw
+            if key.decode().lower() != "set-cookie":
+                continue
+            value = value.decode()
+        else:
+            value = raw
+        if value.split("=", 1)[0].strip().lower() == name.lower():
+            matches.append(value)
+    return matches
+
+
+def _canonical_refresh_cookie(headers) -> str | None:
+    cookies = _set_cookie_values_for(headers, "refresh_token")
+    canonical = [
+        c
+        for c in cookies
+        if "Path=/" in c
+        and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in c
+        and "Max-Age=0" not in c
+    ]
+    return canonical[0] if canonical else None
+
+
+def _refresh_token_from_set_cookie(raw: str) -> str:
+    head = raw.split(";", 1)[0].strip()
+    name, _, value = head.partition("=")
+    assert name == "refresh_token"
+    return value
+
+
+def _login(client: TestClient) -> str:
+    res = client.post(
+        "/api/v1/auth/login",
+        json={"login": "alice", "password": PASSWORD},
+    )
+    assert res.status_code == 200, res.text
+    raw = _canonical_refresh_cookie(res.headers)
+    assert raw is not None
+    return _refresh_token_from_set_cookie(raw)
+
+
+async def _list_audit(
+    factory: async_sessionmaker[AsyncSession], event_type: str
+) -> list[AuditEvent]:
+    async with factory() as db:
+        rows = await db.execute(
+            select(AuditEvent).where(AuditEvent.event_type == event_type)
+        )
+        return list(rows.scalars().all())
+
+
+@asynccontextmanager
+async def _httpx_app_client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    """Run the FastAPI app under ``httpx.AsyncClient`` so two coroutines
+    can hit ``/refresh`` truly concurrently. ``TestClient`` is synchronous
+    so it would serialize the two requests."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+# ── 1. Replay AFTER the grace window (manual expiry) ─────────────────────────
+
+
+async def test_replay_after_grace_window_returns_401(session_factory, fake_redis):
+    """Grace window is 30s. Once both the primary key and the grace key
+    are gone, the old jti must 401.
+
+    We can't wait 31s in unit tests; instead we manually delete the
+    grace key (equivalent to TTL expiry) after the rotation.
+    """
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, _sid = decode_refresh_jti_sid(token)
+
+        # First refresh rotates.
+        first = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert first.status_code == 200
+        # Grace key should exist now.
+        assert f"auth:session:grace:{old_jti}" in fake_redis._kv
+
+        # Simulate TTL expiry: delete the grace key.
+        del fake_redis._kv[f"auth:session:grace:{old_jti}"]
+
+        # Replay the old cookie.
+        second = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+    assert second.status_code == 401
+    assert second.json()["detail"] == "Session has been invalidated"
+
+
+# ── 2. Cross-tab race — gated concurrent /refresh produces 1 + 1 ─────────────
+
+
+async def test_concurrent_refresh_one_winner_one_grace(session_factory, fake_redis):
+    """Two concurrent ``/refresh`` calls with the same pre-rotation cookie
+    produce exactly: one winner (200 + Set-Cookie) and one loser (200,
+    no Set-Cookie). Zero 401s.
+
+    Implementation: gate BOTH coroutines at the Lua entry with an
+    ``asyncio.Event``, release them simultaneously. The serialization
+    lock inside the fake's ``eval`` makes the second call observe the
+    winner's writes (primary gone, grace written, family extended)
+    and return ``already_rotated``. The router then falls into the
+    grace branch and issues an access token only.
+
+    Without the Lua ``EXISTS old_primary`` guard (spec §4.2 check 2),
+    both calls would pass ``SISMEMBER`` and both rotate — the test
+    would observe two distinct successor jtis. This is the canonical
+    no-double-issue pin.
+    """
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+
+    # Boot one TestClient to log in (sync), then drive concurrency with
+    # httpx.AsyncClient.
+    with TestClient(app) as client:
+        token = _login(client)
+    old_jti, sid = decode_refresh_jti_sid(token)
+
+    # Arm the Lua barrier so BOTH coroutines reach the script body
+    # before either runs the guards. Release simultaneously.
+    fake_redis.eval_barrier_target = 2
+
+    async with _httpx_app_client(app) as ac:
+        async def _do_refresh():
+            return await ac.post(
+                "/api/v1/auth/refresh", cookies={"refresh_token": token}
+            )
+
+        task_a = asyncio.create_task(_do_refresh())
+        task_b = asyncio.create_task(_do_refresh())
+        # Wait deterministically until both coroutines have arrived at
+        # the barrier. No ``asyncio.sleep`` — pure event signaling.
+        await fake_redis._eval_arrival_event.wait()
+        fake_redis._eval_release_event.set()
+        res_a, res_b = await asyncio.gather(task_a, task_b)
+
+    # Reset barrier for any later tests.
+    fake_redis.eval_barrier_target = None
+
+    statuses = sorted([res_a.status_code, res_b.status_code])
+    assert statuses == [200, 200], (
+        f"expected two 200s, got {statuses}: A={res_a.text!r} B={res_b.text!r}"
+    )
+
+    cookies_a = _canonical_refresh_cookie(res_a.headers)
+    cookies_b = _canonical_refresh_cookie(res_b.headers)
+    set_cookies = [c for c in (cookies_a, cookies_b) if c is not None]
+    assert len(set_cookies) == 1, (
+        f"expected exactly one Set-Cookie (winner), got {len(set_cookies)}: "
+        f"A={cookies_a!r} B={cookies_b!r}"
+    )
+
+    # Exactly one new jti minted; primary key is in Redis.
+    winner_token = _refresh_token_from_set_cookie(set_cookies[0])
+    winner_jti, winner_sid = decode_refresh_jti_sid(winner_token)
+    assert winner_sid == sid
+    assert winner_jti != old_jti
+    assert f"auth:session:{winner_jti}" in fake_redis._kv
+    # Grace key for old_jti is alive.
+    assert f"auth:session:grace:{old_jti}" in fake_redis._kv
+    # Old primary is gone.
+    assert f"auth:session:{old_jti}" not in fake_redis._kv
+
+
+# ── 3. Audit shape on the cross-tab race ─────────────────────────────────────
+
+
+async def test_concurrent_refresh_emits_one_rotated_and_one_grace_accept(
+    session_factory, fake_redis
+):
+    """The race in the previous test must emit BOTH audit events:
+    one ``auth.session.rotated`` (winner) AND one
+    ``auth.session.grace_accept {via_already_rotated: true}`` (loser)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+
+    with TestClient(app) as client:
+        token = _login(client)
+    old_jti, sid = decode_refresh_jti_sid(token)
+
+    fake_redis.eval_barrier_target = 2
+
+    async with _httpx_app_client(app) as ac:
+        async def _do_refresh():
+            return await ac.post(
+                "/api/v1/auth/refresh", cookies={"refresh_token": token}
+            )
+
+        task_a = asyncio.create_task(_do_refresh())
+        task_b = asyncio.create_task(_do_refresh())
+        await fake_redis._eval_arrival_event.wait()
+        fake_redis._eval_release_event.set()
+        await asyncio.gather(task_a, task_b)
+
+    fake_redis.eval_barrier_target = None
+
+    rotated = await _list_audit(session_factory, "auth.session.rotated")
+    grace = await _list_audit(session_factory, "auth.session.grace_accept")
+    assert len(rotated) == 1, f"expected 1 rotated event, got {len(rotated)}"
+    assert len(grace) == 1, f"expected 1 grace_accept event, got {len(grace)}"
+    assert grace[0].detail["via_already_rotated"] is True
+    assert grace[0].detail["sid"] == sid
+    assert grace[0].detail["old_jti"] == old_jti
+
+
+# ── 4. /verify accepts a grace ticket (family alive) ────────────────────────
+
+
+async def test_verify_accepts_grace_ticket_when_family_alive(
+    session_factory, fake_redis
+):
+    """``/verify`` mirrors ``/refresh`` grace fallback (spec §5.2)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+        # Rotate once to land the grace key.
+        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert r1.status_code == 200
+        assert f"auth:session:grace:{old_jti}" in fake_redis._kv
+
+        # /verify with the OLD cookie — primary gone, grace alive, family alive.
+        res = client.post("/api/v1/auth/verify", cookies={"refresh_token": token})
+    assert res.status_code == 200, res.text
+    # Invariant: no Set-Cookie from /verify.
+    assert _canonical_refresh_cookie(res.headers) is None
+
+
+# ── 5. /verify rejects grace ticket when family deleted ─────────────────────
+
+
+async def test_verify_rejects_grace_ticket_when_family_deleted(
+    session_factory, fake_redis
+):
+    """Grace key alive BUT the family set has been deleted (concurrent
+    logout) — ``/verify`` must reject. Without the family-set check
+    ``/verify`` would accept while ``/refresh`` would reject — exactly
+    the inconsistency the architect called out."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert r1.status_code == 200
+
+        # Simulate concurrent logout: wipe the family set.
+        del fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+        res = client.post("/api/v1/auth/verify", cookies={"refresh_token": token})
+    assert res.status_code == 401
+
+
+# ── 6. /refresh grace branch rejects when family deleted ────────────────────
+
+
+async def test_refresh_grace_branch_rejects_when_family_deleted(
+    session_factory, fake_redis
+):
+    """Architect P1.1 — even within the 30s grace window, if logout has
+    deleted the family set the grace branch must reject. Replay-after-
+    logout class."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+        # Rotate so old_jti has only a grace key.
+        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert r1.status_code == 200
+        assert f"auth:session:grace:{old_jti}" in fake_redis._kv
+
+        # Concurrent logout: wipe the family set.
+        del fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+        res = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+    assert res.status_code == 401, res.text
+    assert res.json()["detail"] == "Session has been invalidated"
+
+
+# ── 7. /refresh grace branch rejects when sid in grace row differs ──────────
+
+
+async def test_refresh_grace_branch_rejects_on_sid_mismatch(
+    session_factory, fake_redis
+):
+    """Defence against an attacker minting a JWT with someone else's
+    jti + their own sid. The grace row's stored sid must match the
+    JWT's sid claim."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert r1.status_code == 200
+        # Corrupt the grace row so its sid mismatches the JWT's sid.
+        fake_redis._kv[f"auth:session:grace:{old_jti}"] = json.dumps(
+            {"user_id": 1, "sid": "deadbeef-not-the-real-sid", "successor_jti": "x"}
+        )
+
+        res = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+    assert res.status_code == 401
+
+
+# ── 8. jti_collision: forced single-collision RNG retries and succeeds ──────
+
+
+async def test_jti_collision_retries_and_succeeds(
+    session_factory, fake_redis, monkeypatch
+):
+    """Forced-collision RNG returns the SAME jti for two successive calls.
+    First Lua call returns ``jti_collision`` (the NX guard fires because
+    that jti is already a live primary). Router regenerates and the
+    second attempt succeeds. Audit ``auth.session.rotated`` emitted ONCE.
+
+    We rig the collision by patching ``secrets.token_urlsafe`` inside
+    ``app.security`` so the FIRST two refresh-token mints get the same
+    jti, then the third (the router's retry) gets a fresh one.
+    """
+    import secrets as _secrets
+
+    real_token_urlsafe = _secrets.token_urlsafe
+    # First call to create_refresh_token returns the colliding jti
+    # (first Lua attempt -> jti_collision). Second call gets a fresh
+    # value from the real RNG so the retry succeeds.
+    sequence = iter(["collide-with-existing-primary"])
+
+    def _patched_token_urlsafe(n: int = 16) -> str:
+        try:
+            return next(sequence)
+        except StopIteration:
+            return real_token_urlsafe(n)
+
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+
+    # Seed a primary key that will collide with the first patched jti
+    # we hand to the rotate call.
+    fake_redis._kv["auth:session:collide-with-existing-primary"] = json.dumps(
+        {"user_id": 999999, "sid": "unrelated"}
+    )
+
+    monkeypatch.setattr(
+        "app.security.secrets.token_urlsafe", _patched_token_urlsafe
+    )
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+    assert res.status_code == 200, res.text
+    assert _canonical_refresh_cookie(res.headers) is not None
+
+    rotated = await _list_audit(session_factory, "auth.session.rotated")
+    assert len(rotated) == 1, f"expected 1 rotated event, got {len(rotated)}"
+    failed = await _list_audit(session_factory, "auth.session.rotated.failed")
+    assert failed == []
+
+
+# ── 9. jti_collision: always-collide RNG => 503 + audit ─────────────────────
+
+
+async def test_jti_collision_double_failure_returns_503(
+    session_factory, fake_redis, monkeypatch
+):
+    """If the RNG collides on BOTH attempts the router returns 503 and
+    emits ``auth.session.rotated.failed`` exactly once."""
+
+    def _always_collide(n: int = 16) -> str:
+        return "collide-with-existing-primary"
+
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+
+    fake_redis._kv["auth:session:collide-with-existing-primary"] = json.dumps(
+        {"user_id": 999999, "sid": "unrelated"}
+    )
+
+    monkeypatch.setattr(
+        "app.security.secrets.token_urlsafe", _always_collide
+    )
+
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+    assert res.status_code == 503, res.text
+    assert _canonical_refresh_cookie(res.headers) is None
+
+    failed = await _list_audit(session_factory, "auth.session.rotated.failed")
+    assert len(failed) == 1, f"expected 1 rotated.failed event, got {len(failed)}"
+    rotated = await _list_audit(session_factory, "auth.session.rotated")
+    assert rotated == []
+
+
+# ── 10. Direct grace path (the typical cross-tab race after the fact) ───────
+
+
+async def test_refresh_direct_grace_path_no_setcookie_and_audit(
+    session_factory, fake_redis
+):
+    """The "boring" cross-tab race: tab A rotates first, tab B's
+    ``/refresh`` arrives later still carrying the old cookie. The
+    primary is already gone, the grace key is alive, the family set
+    is alive — the validator hands us ``redis_state == "grace"`` and
+    the router returns access-only without entering Lua. Audit:
+    ``auth.session.grace_accept {via_already_rotated: false}``.
+    """
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert r1.status_code == 200
+
+        # At this point primary {old_jti} is gone, grace alive, family alive.
+        # Tab B replays the old cookie.
+        res = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+
+    assert res.status_code == 200, res.text
+    assert _canonical_refresh_cookie(res.headers) is None, (
+        "grace branch must NOT emit Set-Cookie (no rotation oracle)"
+    )
+
+    grace = await _list_audit(session_factory, "auth.session.grace_accept")
+    # Exactly one event from the second /refresh (the first /refresh was
+    # a normal rotation and emits auth.session.rotated, not grace).
+    assert len(grace) == 1, f"expected 1 grace_accept event, got {len(grace)}"
+    assert grace[0].detail["via_already_rotated"] is False
+    assert grace[0].detail["old_jti"] == old_jti
+    assert grace[0].detail["sid"] == sid

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -48,7 +48,8 @@ logging.getLogger("ofxtools").setLevel(logging.WARNING)
 
 class _FakeRedisPipeline:
     """In-memory pipeline mirroring the redis.asyncio.client.Pipeline ops
-    used by ``session_issue`` / ``session_rotate``."""
+    used by ``session_issue``. (PR 3 moved rotation to ``EVAL`` —
+    handled by :meth:`_SharedFakeRedis.eval`, not by pipelines.)"""
 
     def __init__(self, store: "_SharedFakeRedis"):
         self._store = store
@@ -95,20 +96,52 @@ class _FakeRedisPipeline:
 
 class _SharedFakeRedis:
     """Minimum-viable fake of ``redis.asyncio.Redis`` covering the
-    SET / GET / SADD / EXPIRE / DELETE / pipeline / setex /  ops used
-    across the app (auth-session keys + MFA email-jti nonces).
+    SET / GET / SADD / EXPIRE / DELETE / pipeline / setex / eval ops
+    used across the app (auth-session keys + MFA email-jti nonces).
+
+    PR 3 added ``eval`` so the rotation Lua script can be exercised
+    end-to-end without a real Redis. The implementation hand-rolls the
+    three guards + write block from the production script — kept
+    narrow on purpose so the fake stays the lowest-blast-radius
+    option per the architect's brief. If we ever need additional Lua
+    scripts in tests, swap to ``fakeredis`` instead of growing this.
+
+    Concurrency model: the production Lua script is atomic on the
+    server (one Lua call = one server-side block). To exercise the
+    race tests in PR 3 the fake serializes ``eval`` calls via an
+    ``asyncio.Lock`` AND provides an ``eval_gate`` (an
+    ``asyncio.Event``-based hook) tests can set to pause execution at
+    well-known points without ``asyncio.sleep``. The gate is a
+    dict[str, asyncio.Event] keyed by old_jti so a single test can
+    gate exactly one of two concurrent calls.
     """
 
     def __init__(self):
         self._kv: dict[str, Any] = {}
         self._sets: dict[str, set] = defaultdict(set)
         self.abort_pipeline = False
+        # PR 3 race-test plumbing. See class docstring.
+        import asyncio
+        self._eval_lock = asyncio.Lock()
+        # Set by tests: when not None, each ``eval`` call increments
+        # ``_eval_arrival_count`` BEFORE acquiring the eval lock, then
+        # waits on ``_eval_release`` (an asyncio.Event) before
+        # continuing. The test arms a barrier of N expected callers
+        # and ``await``s the barrier until the count matches, then
+        # sets the release event. This gives deterministic gating
+        # without ``asyncio.sleep``-based polling on either side.
+        self.eval_barrier_target: int | None = None
+        self._eval_arrival_count: int = 0
+        self._eval_arrival_event = asyncio.Event()
+        self._eval_release_event = asyncio.Event()
 
     # Plain KV
     async def get(self, key):
         return self._kv.get(key)
 
-    async def set(self, key, value, ex=None, **kwargs):
+    async def set(self, key, value, ex=None, nx=False, **kwargs):
+        if nx and key in self._kv:
+            return False
         self._kv[key] = value
         return True
 
@@ -125,7 +158,15 @@ class _SharedFakeRedis:
         return n
 
     async def exists(self, *keys):
-        return sum(1 for k in keys if k in self._kv)
+        # Sets and KV are stored in separate dicts; real Redis EXISTS
+        # is type-agnostic — match that here so callers like
+        # ``session_family_exists`` (which checks
+        # ``auth:session:by_sid:{sid}`` — a SET) behave correctly.
+        return sum(
+            1
+            for k in keys
+            if k in self._kv or self._sets.get(k)
+        )
 
     # Sets
     async def smembers(self, key):
@@ -137,6 +178,71 @@ class _SharedFakeRedis:
     # Pipelines
     def pipeline(self, transaction=True):
         return _FakeRedisPipeline(self)
+
+    # Lua — mimics the ROTATE_SESSION_LUA script in redis_client.py
+    async def eval(self, script: str, numkeys: int, *args):
+        """Execute the rotate-session Lua script.
+
+        Recognises the production script body by the presence of all
+        three guard markers. Any other script raises NotImplementedError
+        so a future caller cannot silently land on a no-op fake.
+
+        Args layout (matches the production call):
+          KEYS[1..4] = primary, grace, new_primary, family
+          ARGV[1..6] = grace_ttl, idle_ttl, grace_val, primary_val,
+                       old_jti, new_jti
+        """
+        # Sanity check: this fake only knows the rotate script.
+        markers = (
+            'SISMEMBER',
+            'EXISTS',
+            'jti_collision',
+            'session_revoked',
+            'already_rotated',
+        )
+        if not all(m in script for m in markers):
+            raise NotImplementedError(
+                "Fake Redis EVAL only supports ROTATE_SESSION_LUA"
+            )
+        keys = list(args[:numkeys])
+        argv = list(args[numkeys:])
+        primary_key, grace_key, new_primary_key, family_key = keys
+        grace_ttl, idle_ttl, grace_val, primary_val, old_jti, new_jti = argv
+
+        # Optional test barrier — when armed with a target N, count
+        # each arrival and block until the test releases. The barrier
+        # MUST be tripped BEFORE the lock is acquired so all N callers
+        # reach the gate concurrently; once released, the lock
+        # serializes the actual script body.
+        if self.eval_barrier_target is not None:
+            self._eval_arrival_count += 1
+            if self._eval_arrival_count >= self.eval_barrier_target:
+                self._eval_arrival_event.set()
+            await self._eval_release_event.wait()
+
+        async with self._eval_lock:
+            # (1) Family revoked?
+            if old_jti not in self._sets.get(family_key, set()):
+                from redis.exceptions import ResponseError as _RE
+
+                raise _RE("session_revoked")
+            # (2) Already rotated?
+            if primary_key not in self._kv:
+                from redis.exceptions import ResponseError as _RE
+
+                raise _RE("already_rotated")
+            # (3) NX on new primary
+            if new_primary_key in self._kv:
+                from redis.exceptions import ResponseError as _RE
+
+                raise _RE("jti_collision")
+            # (4) Writes
+            self._kv[new_primary_key] = primary_val
+            self._kv[grace_key] = grace_val
+            self._sets[family_key].add(new_jti)
+            self._kv.pop(primary_key, None)
+            _ = grace_ttl, idle_ttl  # TTL not simulated
+            return "ok"
 
     # Lifecycle
     async def aclose(self):


### PR DESCRIPTION
## Summary

Replaces the PR 2 sequential rotation with the production Lua script that runs three atomic guards (family revoked, already rotated, jti collision) server-side. Adds a 30-second `auth:session:grace:{jti}` window so cross-tab refresh races no longer surface as false logouts, and mirrors the grace fallback on `/auth/verify`. New audit events `auth.session.rotated`, `auth.session.grace_accept`, and `auth.session.rotated.failed` give ops visibility into the rotation chain.

## Spec authority

`specs/2026-05-17-backend-session-model.md` §4.2 step 5 (Lua), §5.1 step 6 (router dispatch), §5.2 (`/verify` grace), §8 (PR 3 scope).

## Scope decision

**Strict PR 3 only.** No `/auth/logout` behaviour change, no `sessions_invalidated_at` allowlist regression (those land in PR 4). No frontend changes.

## Fake-Redis approach

**Option B — extended `_SharedFakeRedis`.** Reasoning:

- Lowest blast radius per the architect's brief: every existing PR 2 test reaches into `_kv`/`_sets` directly, so swapping the autouse fixture to `fakeredis` would mean rewriting those test bodies AND adding a new dependency.
- The Lua surface we need is small (SISMEMBER / EXISTS / SET NX / SADD / EXPIRE / DEL) and we don't need general `EVAL` for any other path. The fake recognises the rotation script by signature and raises `NotImplementedError` for any other script body, so a future caller cannot silently land on a no-op.
- The fake's `eval` method serializes on an `asyncio.Lock` to model the server-side atomicity, and exposes an `eval_barrier_target` hook so race tests gate via `asyncio.Event` (no `asyncio.sleep`).
- Verified against the actual Redis container — the Lua script returns the three error tokens via `ResponseError` and the wrapper unpacks them correctly. If we ever need additional Lua scripts in tests, swap to `fakeredis` then.

## Lua return-value dispatch

| Lua return | HTTP | Set-Cookie | Audit |
|---|---|---|---|
| `ok` | 200 | new `jti` | `auth.session.rotated` |
| `session_revoked` | 401 | — | (none — terminal, frontend redirects) |
| `already_rotated` | 200 (grace, re-probed) | — | `auth.session.grace_accept {via_already_rotated: true}` |
| `jti_collision` (1st) | retry once internally | — | (none) |
| `jti_collision` (2nd) | 503 | — | `auth.session.rotated.failed` |

The direct grace branch (entered when the app-side primary GET misses but the grace key is alive AND the family set is alive) emits `auth.session.grace_accept {via_already_rotated: false}`.

## Changed files

- `backend/app/redis_client.py` — adds `auth:session:grace:{jti}`, `session_grace()`, `session_family_exists()`, `ROTATE_SESSION_LUA` module-level constant, and `session_rotate_lua()` wrapper that unpacks the four return tokens. Removes the unsafe sequential `session_rotate`.
- `backend/app/routers/auth.py` — `_validate_single_refresh_token` now returns a `redis_state` (`"primary"` or `"grace"`) so callers know whether the primary key was alive. `_rotate_refresh_session` now returns the Lua result token; `/refresh` dispatches on it per §5.1 step 6 (one-retry-on-collision, grace re-probe on `already_rotated`, 401 on `session_revoked`, 503 on double collision). Adds `_record_session_rotated`, `_record_session_grace_accept`, `_record_session_rotated_failed` audit helpers.
- `backend/tests/auth/test_session_grace_lua.py` — new file, 10 tests covering: 30s replay window, cross-tab race (one winner + one grace acceptance + zero 401s), audit shape on the race, `/verify` grace accept+reject, grace family-set check, sid-mismatch rejection, `jti_collision` single-retry-success, double-collision 503, direct grace path no-Set-Cookie + audit.
- `backend/tests/conftest.py` — extends `_SharedFakeRedis` with `eval` (executes the rotate script via Python), `eval_barrier_target` for deterministic race-test gating (no `asyncio.sleep`), and fixes `exists()` to honour set-keys.

## Tests run (verbatim)

```
# PR 3 tests, 3 stability runs:
=== run 1 ===  10 passed, 20 warnings in 4.65s
=== run 2 ===  10 passed, 20 warnings in 4.50s
=== run 3 ===  10 passed, 20 warnings in 4.53s

# Race-test stability, 5 runs of the two concurrent tests:
=== run 1 ===  2 passed, 6 warnings in 1.17s
=== run 2 ===  2 passed, 6 warnings in 1.16s
=== run 3 ===  2 passed, 6 warnings in 1.15s
=== run 4 ===  2 passed, 6 warnings in 1.16s
=== run 5 ===  2 passed, 6 warnings in 1.16s

# PR 2 regression sweep:
tests/auth/test_session_jti_sid.py  23 passed, 18 warnings in 8.39s

# Full backend suite:
1309 passed, 9 skipped, 108 warnings in 308.18s (0:05:08)

# Frontend:
Test Files  140 passed (140)
Tests       1000 passed (1000)

# TypeScript:
(npx tsc --noEmit)  exit 0
```

## Out of scope

- `/auth/logout` family revoke + `sessions_invalidated_at` allowlist (PR 4)
- Frontend changes (none required — the grace branch returns the same `{access_token}` shape as `/refresh` today, just without `Set-Cookie`)

## Worth flagging

- The Lua `SET ... NX` guard is checked with `not set_ok` rather than `== false`. In Lua `nil ~= false`, and Redis's `SET ... NX` returns `nil` (bulk-string nil reply) on NX-miss — `not nil` is true, but `nil == false` is false. Smoke-tested against the real Redis container to confirm the collision path returns `jti_collision`.
- The validator's `_validate_single_refresh_token` signature changed from `(user, payload, session_start)` to `(user, payload, session_start, redis_state)`. Every internal caller is updated; the helper is module-private so no external API drift.
- The direct grace branch (validator returns `redis_state == "grace"`) is exercised by `test_refresh_direct_grace_path_no_setcookie_and_audit` and `test_verify_accepts_grace_ticket_when_family_alive`. The `already_rotated` branch is exercised by `test_concurrent_refresh_one_winner_one_grace`. Both branches converge on the same `_record_session_grace_accept` helper with different `via_already_rotated` values.