### PR TITLE
feat(auth): per-session logout - family revoke (PR 4 of 4)

### DIFF
--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -338,3 +338,50 @@ async def session_rotate_lua(
     if isinstance(result, bytes):
         result = result.decode("utf-8")
     return result
+
+
+async def session_revoke_family(sid: str) -> list[str]:
+    """Atomically revoke an entire session family (spec §5.3 / §4.2 logout).
+
+    Round A: in one ``MULTI/EXEC`` read every ``jti`` in
+    ``auth:session:by_sid:{sid}`` THEN delete the family set. The atomic
+    delete of the family set is what closes the architect's PR #301
+    follow-up race — any concurrent ``/refresh`` Lua rotation will see
+    ``SISMEMBER`` return 0 after this lands and refuse to write a
+    successor (Section 4.2 step 5 guard 1).
+
+    Round B: for every ``jti`` returned by Round A, delete the primary
+    key ``auth:session:{jti}`` AND the grace key
+    ``auth:session:grace:{jti}`` in one ``MULTI/EXEC``. Strictly cleanup
+    of orphan keys at this point — the family-set delete in Round A is
+    the load-bearing step.
+
+    Returns the list of ``jti`` values that were in the family (the
+    caller uses the length for the ``auth.session.terminated`` audit
+    detail ``jti_count``).
+
+    Fails CLOSED on unreachable Redis via :func:`require_client`.
+    """
+    client = require_client()
+    # Round A — read membership + delete the family set atomically.
+    pipe_a = client.pipeline(transaction=True)
+    pipe_a.smembers(_family_key(sid))
+    pipe_a.delete(_family_key(sid))
+    results_a = await pipe_a.execute()
+    members = results_a[0] if results_a else set()
+    # ``smembers`` may yield ``set`` or ``list`` depending on the client /
+    # fake — normalise to a sorted ``list[str]`` for stable iteration and
+    # audit-detail reproducibility in tests.
+    jtis: list[str] = sorted(str(j) for j in members)
+
+    if not jtis:
+        return []
+
+    # Round B — delete every primary + grace key for the revoked family.
+    # Strict cleanup; no conditional logic required.
+    pipe_b = client.pipeline(transaction=True)
+    for jti in jtis:
+        pipe_b.delete(_primary_key(jti))
+        pipe_b.delete(_grace_key(jti))
+    await pipe_b.execute()
+    return jtis

--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -213,6 +213,34 @@ async def session_family_exists(sid: str) -> bool:
     return bool(await client.exists(_family_key(sid)))
 
 
+async def session_family_member(sid: str, jti: str) -> bool:
+    """Return True iff ``jti`` is still a member of ``auth:session:by_sid:{sid}``.
+
+    Architect P1 finding on PR #308: the per-session logout makes
+    ``DEL auth:session:by_sid:{sid}`` the load-bearing revocation
+    step (Round A of the logout family revoke). Primary keys are
+    cleaned up afterwards in Round B. Between Round A landing and
+    Round B finishing — or if Round B partially fails — a request
+    could find a still-alive ``auth:session:{jti}`` even though the
+    session is logically revoked.
+
+    The Lua rotation script catches this on ``/refresh`` via its own
+    ``SISMEMBER`` guard (spec §4.2 step 5 check 1). But ``/verify``
+    does NOT run the Lua, and the primary-key probe in
+    ``_validate_single_refresh_token`` historically only checked
+    existence + ``{user_id, sid}`` binding. Membership in the
+    family set is the actual authoritative check; this helper
+    mirrors the Lua contract for callers that do not run Lua.
+
+    Stronger than ``session_family_exists`` because it also catches
+    the impossible-but-NX-defended ``jti`` collision case where two
+    sessions happen to share a ``sid`` but only one's ``jti`` is in
+    the family set.
+    """
+    client = require_client()
+    return bool(await client.sismember(_family_key(sid), jti))
+
+
 # Lua return tokens — spec §4.2 step 5. The router branch table in
 # §5.1 step 6 maps these to HTTP behaviour. The bare string ``"ok"``
 # is returned on the happy path; the three error tokens come back via

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -59,6 +59,7 @@ from app.security import (
     create_mfa_email_token,
     create_password_reset_token,
     create_refresh_token,
+    decode_refresh_jti_sid,
     decode_token,
     hash_password,
     refresh_cookie_max_age,
@@ -913,29 +914,156 @@ async def logout(
     request: Request,
     response: Response,
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
-    # Best-effort server-side invalidation: if the caller still has a valid
-    # access token, mark their sessions invalidated so the refresh token and
-    # any sibling access tokens are killed. Regardless of auth state, always
-    # clear the refresh cookie so the browser stops sending it.
+    """Per-session logout — revoke by ``sid`` family (spec §5.3).
+
+    PR 4 of the backend-session-model series. Closes the 2026-05-16
+    false-logout incident class: today's handler writes
+    ``sessions_invalidated_at = now`` which is global (kills every
+    session for the user on every device). The new handler revokes
+    ONLY the session family identified by the refresh cookie's ``sid``,
+    leaving other devices / browser profiles authenticated.
+
+    Steps (mirror spec §5.3 verbatim):
+
+    1. Read every refresh cookie via ``_extract_refresh_cookies``.
+       Decode each value just enough to extract its ``sid`` (and ``jti``
+       for diagnostics) — no validation chain, this endpoint accepts
+       anonymous logout as a successful cookie clear.
+    2. Collect the distinct ``sid`` values (typical case: one).
+    3. For each ``sid`` run the atomic family-revoke from
+       :func:`redis_client.session_revoke_family`. Round A's
+       ``DEL auth:session:by_sid:{sid}`` is what closes the
+       architect's PR #301 follow-up race — a concurrent ``/refresh``
+       Lua script will see ``SISMEMBER`` return 0 and refuse to write
+       a successor.
+    4. Clear the refresh cookie at both ``Path=/`` and the legacy path.
+    5. Emit ``auth.session.terminated`` audit with detail
+       ``{sid_count, jti_count}``. Outcome=success even when 0 (an
+       anonymous logout is still a clean cookie clear).
+
+    Critically does NOT touch ``sessions_invalidated_at`` — that field
+    is the global-invalidation cutoff and stays reserved for the five
+    sites enumerated in spec §6 (password reset / change, email
+    change, invitation accept / role swap, admin deactivate). The
+    grep-style regression test in
+    ``tests/auth/test_sessions_invalidated_at_allowlist.py`` pins that
+    invariant.
+
+    Redis-unavailable behaviour (spec §7.1): if the family revoke
+    raises (``RedisRequired`` or ``RedisError``), still clear the
+    cookie and return 200 — the user-visible effect (cookie out of
+    the browser) is the goal, the orphan ``jti`` rows age out on
+    their own TTL. The audit detail flags ``redis_partial_revoke``
+    so ops can disambiguate the degraded path from the happy path.
+    """
+    # ── 1. Collect every refresh cookie + decode for sid/jti ────────────
+    # Walk the raw Cookie header so duplicate ``refresh_token`` entries
+    # (Path=/ + the legacy Path=/api/v1/auth/refresh after PR #211) are
+    # both inspected. Each value is decoded ONLY to read its claims; the
+    # full validation chain is skipped on logout — even an expired or
+    # post-cutoff token still identifies a session family that should be
+    # cleaned up.
+    refresh_tokens = _extract_refresh_cookies(request)
+    sids: list[str] = []
+    jtis_seen: list[str] = []
+    seen_sids: set[str] = set()
+    for raw in refresh_tokens:
+        try:
+            jti, sid = decode_refresh_jti_sid(raw)
+        except (ValueError, Exception):  # noqa: BLE001 — corrupt/missing JWT is fine
+            continue
+        jtis_seen.append(jti)
+        if sid not in seen_sids:
+            seen_sids.add(sid)
+            sids.append(sid)
+
+    # Best-effort identification of the calling user for the audit row.
+    # The Authorization header is the most reliable signal because the
+    # access token carries ``sub``; falling back to the refresh JWT's
+    # ``sub`` is acceptable when the bearer is missing (the user clicked
+    # log-out from a tab whose access token expired). Decoding errors
+    # are swallowed — anonymous logout is still a clean cookie clear.
+    actor_user_id: int | None = None
+    actor_email: str = ""
     authorization = request.headers.get("Authorization", "")
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() == "bearer" and token:
         try:
             payload = decode_token(token)
-            user_id = payload.get("sub")
-            if user_id is not None:
-                result = await db.execute(select(User).where(User.id == int(user_id)))
-                user = result.scalar_one_or_none()
-                if user is not None:
-                    user.sessions_invalidated_at = datetime.now(timezone.utc)
-                    await db.commit()
+            sub = payload.get("sub") if payload else None
+            if sub is not None:
+                actor_user_id = int(sub)
         except Exception:
-            # Missing/expired/malformed token: still clear the cookie below.
-            pass
+            actor_user_id = None
+    if actor_user_id is None:
+        for raw in refresh_tokens:
+            try:
+                payload = decode_token(raw)
+            except Exception:
+                continue
+            if payload is None:
+                continue
+            sub = payload.get("sub")
+            if sub is not None:
+                try:
+                    actor_user_id = int(sub)
+                except (TypeError, ValueError):
+                    continue
+                break
+    if actor_user_id is not None:
+        try:
+            row = await db.execute(select(User).where(User.id == actor_user_id))
+            user = row.scalar_one_or_none()
+            if user is not None:
+                actor_email = user.email
+        except Exception:
+            actor_email = ""
+
+    # ── 2 + 3. Atomic family revoke per distinct sid ────────────────────
+    jti_count = 0
+    redis_partial_revoke = False
+    for sid in sids:
+        try:
+            revoked = await redis_client.session_revoke_family(sid)
+            jti_count += len(revoked)
+        except (RedisRequired, RedisError):
+            # Fail-open for logout per spec §7.1: clearing the cookie is
+            # the user-visible effect, orphan keys age out on their own
+            # TTL. Flag in the audit detail so ops can spot the
+            # degraded path.
+            redis_partial_revoke = True
+
+    # ── 4. Clear the cookie at Path=/ AND the legacy path ──────────────
     response.delete_cookie("refresh_token", path="/")
     _clear_legacy_refresh_cookie(response)
-    return {"detail": "Logged out"}
+
+    # ── 5. Audit. Always-success, even when sid_count = 0 ───────────────
+    request_id = structlog.contextvars.get_contextvars().get("request_id")
+    detail: dict[str, Any] = {
+        "sid_count": len(sids),
+        "jti_count": jti_count,
+    }
+    if redis_partial_revoke:
+        detail["redis_partial_revoke"] = True
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="auth.session.terminated",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=None,
+        target_org_name=None,
+        request_id=request_id,
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail=detail,
+    )
+
+    body: dict[str, Any] = {"detail": "Logged out"}
+    if redis_partial_revoke:
+        body["redis_partial_revoke"] = True
+    return body
 
 
 # ── Password Reset ───────────────────────────────────────────────────────────

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -594,6 +594,41 @@ async def _validate_single_refresh_token(
             detail="Session has been invalidated",
         )
 
+    # Architect P1 finding on PR #308: family-set membership is the
+    # authoritative revocation contract, not primary-key existence.
+    # The Lua rotation script enforces ``SISMEMBER by_sid {jti}`` on
+    # ``/refresh`` (spec §4.2 step 5 check 1), but ``/verify`` does
+    # NOT run the Lua, so without this check a verify call could
+    # accept a primary key whose family set has already been deleted
+    # by Round A of a concurrent logout.
+    #
+    # The window is small but real:
+    #   * Logout Round A deletes ``auth:session:by_sid:{sid}``.
+    #   * Logout Round B deletes the primary + grace keys for every
+    #     jti, but is a separate MULTI/EXEC; a Redis connection drop
+    #     between the two rounds leaves primary keys orphaned.
+    #   * Any ``/verify`` arriving in that window with the
+    #     pre-logout cookie used to silently succeed.
+    #
+    # Apply only on the primary path; the grace path (above) already
+    # gates on ``session_family_exists``. The membership check is
+    # stronger than family-exists because it also catches the
+    # impossible-but-NX-defended ``jti`` collision where two sessions
+    # share a ``sid`` but only one ``jti`` is in the family set.
+    if redis_state == "primary":
+        try:
+            in_family = await redis_client.session_family_member(sid, jti)
+        except (RedisRequired, RedisError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+            ) from exc
+        if not in_family:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Session has been invalidated",
+            )
+
     # Enforce absolute session lifetime (per-org setting or system default)
     session_created_at = payload.get("session_created_at")
     session_start: datetime | None = None

--- a/backend/tests/auth/test_session_logout_revoke.py
+++ b/backend/tests/auth/test_session_logout_revoke.py
@@ -1,0 +1,659 @@
+"""PR 4 — Per-session logout: family revoke (spec §5.3).
+
+Pins every architect-emphasized risk for the logout-vs-rotation path:
+
+1. Logout-after-rotation revokes the entire family — within the 30s
+   grace window, a sibling tab holding the pre-rotation cookie cannot
+   refresh successfully. The family-set delete in Round A makes any
+   subsequent /refresh see ``SISMEMBER`` return 0 (rotation Lua) or
+   ``EXISTS by_sid`` return 0 (grace branch).
+2. Concurrent logout-vs-rotation produces Lua ``session_revoked`` —
+   gated with ``asyncio.Event`` so the rotate enters the Lua body
+   AFTER logout's Round A lands.
+3. ``/verify`` rejects a grace ticket after logout (mirrors PR 3
+   semantics on the logout side).
+4. Multi-cookie logout (rare but real after PR #211 cookie-path
+   migration): two refresh cookies for two distinct ``sid`` values
+   revoke both families.
+5. Anonymous logout — no cookie at all. 200, audit emitted with
+   ``sid_count=0, jti_count=0``.
+6. Cookie present but undecodable (corrupt JWT). 200, audit emitted,
+   cookie cleared.
+7. Logout does NOT write ``sessions_invalidated_at`` — the 2026-05-16
+   false-logout incident regression.
+
+Concurrency tests use ``asyncio.Event`` gating, NEVER
+``asyncio.sleep`` — the architect's #1 named concern for flake.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import (
+    LEGACY_REFRESH_COOKIE_PATH,
+    router as auth_router,
+)
+from app.security import (
+    create_access_token,
+    decode_refresh_jti_sid,
+    hash_password,
+)
+
+
+PASSWORD = "starting-password-1"
+
+
+@pytest.fixture
+def fake_redis(_autouse_fake_redis):
+    yield _autouse_fake_redis
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(
+    factory: async_sessionmaker[AsyncSession], *, username: str = "alice"
+) -> dict:
+    async with factory() as db:
+        org = Organization(name=f"Acme-{username}", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=f"{username}@example.com",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id, "username": username}
+
+
+def _set_cookie_values_for(headers, name: str) -> list[str]:
+    matches: list[str] = []
+    raw_iter = headers.raw if hasattr(headers, "raw") else []
+    for raw in raw_iter:
+        if isinstance(raw, tuple):
+            key, value = raw
+            if key.decode().lower() != "set-cookie":
+                continue
+            value = value.decode()
+        else:
+            value = raw
+        if value.split("=", 1)[0].strip().lower() == name.lower():
+            matches.append(value)
+    return matches
+
+
+def _canonical_refresh_cookie(headers) -> str | None:
+    cookies = _set_cookie_values_for(headers, "refresh_token")
+    canonical = [
+        c
+        for c in cookies
+        if "Path=/" in c
+        and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in c
+        and "Max-Age=0" not in c
+    ]
+    return canonical[0] if canonical else None
+
+
+def _delete_cookie_headers(headers) -> list[str]:
+    """All Set-Cookie headers for ``refresh_token`` that look like a
+    delete (``Max-Age=0``). PR 4 logout clears at BOTH ``Path=/`` and
+    the legacy ``Path=/api/v1/auth/refresh``."""
+    return [
+        c for c in _set_cookie_values_for(headers, "refresh_token")
+        if "Max-Age=0" in c
+    ]
+
+
+def _refresh_token_from_set_cookie(raw: str) -> str:
+    head = raw.split(";", 1)[0].strip()
+    name, _, value = head.partition("=")
+    assert name == "refresh_token"
+    return value
+
+
+def _login(client: TestClient, *, username: str = "alice") -> str:
+    res = client.post(
+        "/api/v1/auth/login",
+        json={"login": username, "password": PASSWORD},
+    )
+    assert res.status_code == 200, res.text
+    raw = _canonical_refresh_cookie(res.headers)
+    assert raw is not None
+    return _refresh_token_from_set_cookie(raw)
+
+
+async def _list_audit(
+    factory: async_sessionmaker[AsyncSession], event_type: str
+) -> list[AuditEvent]:
+    async with factory() as db:
+        rows = await db.execute(
+            select(AuditEvent).where(AuditEvent.event_type == event_type)
+        )
+        return list(rows.scalars().all())
+
+
+@asynccontextmanager
+async def _httpx_app_client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+# ─── 1. Logout-after-rotation revokes the entire family (architect P1.1) ────
+
+
+async def test_logout_after_rotation_revokes_entire_family(
+    session_factory, fake_redis
+):
+    """Login -> rotate (new_jti primary, old_jti grace). Logout with the
+    new cookie. Old jti must NOT re-authenticate even though its grace
+    key has not yet TTL-expired — the family-set delete in Round A is
+    what closes this race (architect P1.1 + PR #301 follow-up).
+    """
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+        # Rotate so old_jti only has a grace key, new_jti is the primary.
+        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert r1.status_code == 200
+        new_raw = _canonical_refresh_cookie(r1.headers)
+        assert new_raw is not None
+        new_token = _refresh_token_from_set_cookie(new_raw)
+        new_jti, new_sid = decode_refresh_jti_sid(new_token)
+        assert new_sid == sid  # sid is stable across rotation
+
+        # Sanity: both keys + family set are alive before logout.
+        assert f"auth:session:{new_jti}" in fake_redis._kv
+        assert f"auth:session:grace:{old_jti}" in fake_redis._kv
+        assert new_jti in fake_redis._sets[f"auth:session:by_sid:{sid}"]
+        assert old_jti in fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+        # Logout using the CURRENT (rotated) cookie. Authorization header
+        # carries a valid access token so audit binds to the actor.
+        access = create_access_token(
+            seed["user_id"],
+            seed["org_id"],
+            Role.OWNER.value,
+        )
+        logout = client.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": new_token},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert logout.status_code == 200, logout.text
+
+        # Family set is gone — Round A's atomic DEL.
+        assert f"auth:session:by_sid:{sid}" not in fake_redis._sets
+
+        # Primary + grace keys for BOTH jtis are gone too — Round B.
+        assert f"auth:session:{new_jti}" not in fake_redis._kv
+        assert f"auth:session:grace:{old_jti}" not in fake_redis._kv
+
+        # Replay the PRE-rotation cookie. Grace key is gone AND family
+        # is gone, so /refresh must 401.
+        replay = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+    assert replay.status_code == 401
+    assert replay.json()["detail"] == "Session has been invalidated"
+
+
+# ─── 2. Concurrent logout-vs-rotation produces Lua session_revoked ──────────
+
+
+async def test_concurrent_logout_vs_rotation_returns_session_revoked(
+    session_factory, fake_redis
+):
+    """Two coroutines: logout + rotate. Gate the rotate Lua entry with
+    an ``asyncio.Event`` so it ONLY runs AFTER logout's Round A has
+    deleted the family set.
+
+    Expected: the rotate Lua returns ``session_revoked`` (its first
+    guard finds ``SISMEMBER`` = 0), the router maps to 401, NO new
+    primary key is written, NO new family member added.
+    """
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+    # Two events drive the gating:
+    #   * ``logout_done`` — set by the logout coroutine AFTER its
+    #     ``redis_client.session_revoke_family`` call returns.
+    #   * Inside the fake's ``eval`` we monkey-patch a hook that waits
+    #     for ``logout_done`` before the script body executes. That
+    #     ensures the Lua script runs after the family is gone.
+    logout_done = asyncio.Event()
+
+    original_eval = fake_redis.eval
+
+    async def gated_eval(script, numkeys, *args):
+        # Wait until logout's Round A has landed before letting the
+        # rotate Lua proceed. Pure event signaling — no sleeps.
+        await logout_done.wait()
+        return await original_eval(script, numkeys, *args)
+
+    fake_redis.eval = gated_eval
+
+    access = create_access_token(
+        seed["user_id"], seed["org_id"], Role.OWNER.value
+    )
+
+    async with _httpx_app_client(app) as ac:
+        async def _do_refresh():
+            return await ac.post(
+                "/api/v1/auth/refresh", cookies={"refresh_token": token}
+            )
+
+        async def _do_logout():
+            res = await ac.post(
+                "/api/v1/auth/logout",
+                cookies={"refresh_token": token},
+                headers={"Authorization": f"Bearer {access}"},
+            )
+            logout_done.set()
+            return res
+
+        rotate_task = asyncio.create_task(_do_refresh())
+        logout_task = asyncio.create_task(_do_logout())
+        rotate_res, logout_res = await asyncio.gather(rotate_task, logout_task)
+
+    assert logout_res.status_code == 200
+    assert rotate_res.status_code == 401, rotate_res.text
+    assert rotate_res.json()["detail"] == "Session has been invalidated"
+
+    # No successor primary was written.
+    primary_keys = [
+        k for k in fake_redis._kv if k.startswith("auth:session:")
+        and not k.startswith("auth:session:grace:")
+        and not k.startswith("auth:session:by_sid:")
+    ]
+    assert primary_keys == [], (
+        f"expected no primary keys after revoked rotation, got {primary_keys}"
+    )
+    # Family set is gone.
+    assert f"auth:session:by_sid:{sid}" not in fake_redis._sets
+
+
+# ─── 3. /verify rejects a grace ticket after logout ─────────────────────────
+
+
+async def test_verify_rejects_grace_ticket_after_logout(
+    session_factory, fake_redis
+):
+    """Spec §5.2 mirror for the logout side. After logout deletes the
+    family set, /verify must reject even within the 30s grace window."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        old_jti, sid = decode_refresh_jti_sid(token)
+
+        # Rotate so the grace key exists for old_jti.
+        r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
+        assert r1.status_code == 200
+        new_token = _refresh_token_from_set_cookie(
+            _canonical_refresh_cookie(r1.headers)
+        )
+
+        # Logout — family set deleted.
+        access = create_access_token(
+            seed["user_id"], seed["org_id"], Role.OWNER.value
+        )
+        logout = client.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": new_token},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert logout.status_code == 200
+
+        # /verify with the PRE-rotation cookie. Grace key was deleted
+        # by Round B, but even if some grace-only edge case lingered,
+        # the family-set check in the grace branch rejects.
+        verify = client.post(
+            "/api/v1/auth/verify", cookies={"refresh_token": token}
+        )
+    assert verify.status_code == 401
+
+
+# ─── 4. Multi-cookie logout (two distinct sids) ─────────────────────────────
+
+
+async def test_multi_cookie_logout_revokes_each_family(session_factory, fake_redis):
+    """Browser carries two refresh cookies for two distinct ``sid``s
+    (rare but real with the PR #211 cookie-path migration overlap).
+    Logout must revoke BOTH families and the audit detail must reflect
+    ``{sid_count: 2, jti_count: ...}``."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token_a = _login(client)
+        jti_a, sid_a = decode_refresh_jti_sid(token_a)
+
+    # Force a SEPARATE second session (different sid) by logging in
+    # again after clearing the cookie context. The previous family is
+    # still alive in Redis.
+    app2 = _make_app(session_factory)
+    with TestClient(app2) as client2:
+        token_b = _login(client2)
+        jti_b, sid_b = decode_refresh_jti_sid(token_b)
+
+    assert sid_a != sid_b
+    assert f"auth:session:by_sid:{sid_a}" in fake_redis._sets
+    assert f"auth:session:by_sid:{sid_b}" in fake_redis._sets
+
+    # Hand-craft a cookie header with BOTH refresh_token values so the
+    # extractor walks the raw header and decodes both.
+    cookie_header = f"refresh_token={token_a}; refresh_token={token_b}"
+    access = create_access_token(
+        seed["user_id"], seed["org_id"], Role.OWNER.value
+    )
+
+    # Use a fresh TestClient — we need raw header control. Use a third
+    # client + the ASGITransport to bypass cookie-jar collapsing.
+    async with _httpx_app_client(app) as ac:
+        res = await ac.post(
+            "/api/v1/auth/logout",
+            headers={
+                "Authorization": f"Bearer {access}",
+                "Cookie": cookie_header,
+            },
+        )
+
+    assert res.status_code == 200, res.text
+    assert f"auth:session:by_sid:{sid_a}" not in fake_redis._sets
+    assert f"auth:session:by_sid:{sid_b}" not in fake_redis._sets
+
+    audit = await _list_audit(session_factory, "auth.session.terminated")
+    assert len(audit) == 1
+    assert audit[0].detail["sid_count"] == 2
+    assert audit[0].detail["jti_count"] == 2  # one jti per family
+
+
+# ─── 5. Anonymous logout (no cookie) ────────────────────────────────────────
+
+
+async def test_anonymous_logout_succeeds_with_zero_counts(session_factory, fake_redis):
+    """No refresh cookie at all. Logout still returns 200, clears the
+    cookie (no-op since none arrived), emits the audit row with
+    ``sid_count=0, jti_count=0, outcome=success``."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/auth/logout")
+    assert res.status_code == 200
+    assert res.json()["detail"] == "Logged out"
+
+    # Delete-cookie headers still emitted so the browser drops anything
+    # it may still have.
+    deletes = _delete_cookie_headers(res.headers)
+    assert any("Path=/" in d for d in deletes), (
+        f"missing Path=/ delete-cookie among {deletes}"
+    )
+
+    audit = await _list_audit(session_factory, "auth.session.terminated")
+    assert len(audit) == 1
+    assert audit[0].detail["sid_count"] == 0
+    assert audit[0].detail["jti_count"] == 0
+    assert audit[0].outcome == "success"
+
+
+# ─── 6. Cookie present but undecodable (corrupt JWT) ────────────────────────
+
+
+async def test_corrupt_refresh_cookie_logout_still_clears(session_factory, fake_redis):
+    """Cookie value is not a valid refresh JWT. Logout swallows the
+    decode error, clears the cookie, emits a 200 + audit with
+    ``sid_count=0`` (no sids could be extracted)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": "this-is-not-a-jwt"},
+        )
+    assert res.status_code == 200
+    deletes = _delete_cookie_headers(res.headers)
+    assert any(f"Path={LEGACY_REFRESH_COOKIE_PATH}" in d for d in deletes), (
+        f"missing legacy-path delete-cookie among {deletes}"
+    )
+    assert any(
+        "Path=/" in d and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in d
+        for d in deletes
+    )
+
+    audit = await _list_audit(session_factory, "auth.session.terminated")
+    assert len(audit) == 1
+    assert audit[0].detail["sid_count"] == 0
+    assert audit[0].outcome == "success"
+
+
+# ─── 7. Logout does NOT write sessions_invalidated_at ───────────────────────
+
+
+async def test_logout_does_not_write_sessions_invalidated_at(
+    session_factory, fake_redis
+):
+    """The 2026-05-16 false-logout incident regression pin. Capture the
+    user's ``sessions_invalidated_at`` before logout, run logout, assert
+    the field is unchanged (still its pre-logout value)."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        access = create_access_token(
+            seed["user_id"], seed["org_id"], Role.OWNER.value
+        )
+
+        async with session_factory() as db:
+            row = await db.execute(
+                select(User).where(User.id == seed["user_id"])
+            )
+            user_before = row.scalar_one()
+            cutoff_before = user_before.sessions_invalidated_at
+
+        res = client.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": token},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        row = await db.execute(
+            select(User).where(User.id == seed["user_id"])
+        )
+        user_after = row.scalar_one()
+        cutoff_after = user_after.sessions_invalidated_at
+
+    assert cutoff_after == cutoff_before, (
+        "POST /auth/logout MUST NOT touch sessions_invalidated_at — that "
+        "is the global-cutoff mechanism reserved for spec §6 triggers. "
+        f"before={cutoff_before!r}, after={cutoff_after!r}"
+    )
+
+
+# ─── 8. Audit row binds to the calling user when bearer is present ─────────
+
+
+async def test_logout_audit_binds_to_actor_when_bearer_present(
+    session_factory, fake_redis
+):
+    """The audit row records ``actor_user_id`` + ``actor_email`` derived
+    from the Authorization bearer when present. Important so the
+    /admin/audit feed can attribute the logout to the right user."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        access = create_access_token(
+            seed["user_id"], seed["org_id"], Role.OWNER.value
+        )
+        res = client.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": token},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+    assert res.status_code == 200
+
+    audit = await _list_audit(session_factory, "auth.session.terminated")
+    assert len(audit) == 1
+    assert audit[0].actor_user_id == seed["user_id"]
+    assert audit[0].actor_email == f"{seed['username']}@example.com"
+    assert audit[0].detail["sid_count"] == 1
+    assert audit[0].detail["jti_count"] == 1
+
+
+# ─── 9. Logout clears BOTH the canonical and legacy cookie paths ────────────
+
+
+async def test_logout_clears_canonical_and_legacy_cookie_paths(
+    session_factory, fake_redis
+):
+    """PR #211 cookie-shadow trap: even after logout, the browser may
+    still carry a legacy ``Path=/api/v1/auth/refresh`` cookie. Logout
+    must emit delete-cookie headers for BOTH paths."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        access = create_access_token(
+            seed["user_id"], seed["org_id"], Role.OWNER.value
+        )
+        res = client.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": token},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+    assert res.status_code == 200
+    deletes = _delete_cookie_headers(res.headers)
+    has_root = any(
+        "Path=/" in d and f"Path={LEGACY_REFRESH_COOKIE_PATH}" not in d
+        for d in deletes
+    )
+    has_legacy = any(f"Path={LEGACY_REFRESH_COOKIE_PATH}" in d for d in deletes)
+    assert has_root, f"missing Path=/ delete-cookie among {deletes}"
+    assert has_legacy, f"missing legacy-path delete-cookie among {deletes}"
+
+
+# ─── 10. Other devices stay authenticated (AC2 pin) ─────────────────────────
+
+
+async def test_logout_one_device_leaves_other_device_authenticated(
+    session_factory, fake_redis
+):
+    """AC2 from the spec: a second device (separate session, separate
+    sid) must remain authenticated after the first device logs out."""
+    seed = await _seed_user(session_factory)
+
+    # Device A logs in.
+    app_a = _make_app(session_factory)
+    with TestClient(app_a) as client_a:
+        token_a = _login(client_a)
+        jti_a, sid_a = decode_refresh_jti_sid(token_a)
+
+    # Device B logs in — same user, separate cookie jar.
+    app_b = _make_app(session_factory)
+    with TestClient(app_b) as client_b:
+        token_b = _login(client_b)
+        jti_b, sid_b = decode_refresh_jti_sid(token_b)
+
+    assert sid_a != sid_b
+
+    # Device A logs out.
+    access_a = create_access_token(
+        seed["user_id"], seed["org_id"], Role.OWNER.value
+    )
+    with TestClient(app_a) as client_a:
+        logout = client_a.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": token_a},
+            headers={"Authorization": f"Bearer {access_a}"},
+        )
+    assert logout.status_code == 200
+
+    # Device A's family is gone, Device B's is untouched.
+    assert f"auth:session:by_sid:{sid_a}" not in fake_redis._sets
+    assert f"auth:session:by_sid:{sid_b}" in fake_redis._sets
+    assert jti_b in fake_redis._sets[f"auth:session:by_sid:{sid_b}"]
+
+    # Device B can still rotate.
+    with TestClient(app_b) as client_b:
+        rotate = client_b.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token_b}
+        )
+    assert rotate.status_code == 200
+    new_raw = _canonical_refresh_cookie(rotate.headers)
+    assert new_raw is not None

--- a/backend/tests/auth/test_session_logout_revoke.py
+++ b/backend/tests/auth/test_session_logout_revoke.py
@@ -657,3 +657,143 @@ async def test_logout_one_device_leaves_other_device_authenticated(
     assert rotate.status_code == 200
     new_raw = _canonical_refresh_cookie(rotate.headers)
     assert new_raw is not None
+
+
+# ─── 9. Architect P1 (PR #308 re-review): primary-token validation must
+#       gate on family-set membership, not just primary existence. ──────────
+#
+# The logout design makes ``DEL auth:session:by_sid:{sid}`` (Round A) the
+# load-bearing revocation step. Primary keys are cleaned up later in Round
+# B. Without a membership check on the primary path, a token whose family
+# has been deleted but whose primary key is still alive (Round B in flight
+# or partially failed) would pass /verify and /refresh — defeating the
+# revocation contract.
+
+
+async def test_verify_rejects_primary_when_family_set_missing(
+    session_factory, fake_redis
+):
+    """Architect P1 on PR #308. Set up: primary key for ``jti`` exists
+    and binds correctly to ``{user_id, sid}`` — but the family set has
+    been deleted (simulates the gap between logout Round A and Round B,
+    or a partial Round B failure). ``/verify`` must return 401."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        jti, sid = decode_refresh_jti_sid(token)
+
+        # Sanity: family set currently contains the jti, primary key exists.
+        assert jti in fake_redis._sets[f"auth:session:by_sid:{sid}"]
+        assert f"auth:session:{jti}" in fake_redis._kv
+
+        # Simulate Round A: delete the family set ONLY.
+        # Primary + grace keys deliberately remain — that's the bug class.
+        del fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+        verify = client.post(
+            "/api/v1/auth/verify", cookies={"refresh_token": token}
+        )
+    assert verify.status_code == 401, verify.json()
+    assert "invalidated" in verify.json()["detail"].lower()
+
+
+async def test_refresh_rejects_primary_when_family_set_missing(
+    session_factory, fake_redis
+):
+    """Sister regression to the /verify case. Same setup: primary key
+    alive, family set deleted. ``/refresh`` must return 401 AND must
+    NOT emit a Set-Cookie (would otherwise re-mint a session that the
+    Lua rotation guard would have rejected)."""
+    await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        jti, sid = decode_refresh_jti_sid(token)
+
+        # Round A simulation.
+        del fake_redis._sets[f"auth:session:by_sid:{sid}"]
+
+        refresh = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+    assert refresh.status_code == 401, refresh.json()
+    # No Set-Cookie on a rejected refresh.
+    assert _canonical_refresh_cookie(refresh.headers) is None
+
+
+async def test_logout_round_a_succeeds_round_b_fails_revocation_still_holds(
+    session_factory, fake_redis, monkeypatch
+):
+    """Architect P1 follow-up: the strongest version of the regression
+    — simulate the actual interleave the architect named. Logout's
+    Round A lands (family set deleted), but Round B (primary +
+    grace-key cleanup) raises mid-flight, leaving orphaned primary
+    keys behind. The pre-logout cookie MUST NOT verify against the
+    orphan primary."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        token = _login(client)
+        jti, sid = decode_refresh_jti_sid(token)
+
+        # Patch ``session_revoke_family`` so Round A runs (family set
+        # gets deleted) but Round B raises before deleting primaries.
+        import app.redis_client as rc
+        from redis.exceptions import RedisError
+
+        original = rc.session_revoke_family
+
+        async def half_revoke(target_sid: str):
+            # Round A: actually delete the family set (the bug-class
+            # invariant we're testing — primary keys must NOT be the
+            # authority once the family is gone).
+            fake_redis._sets.pop(f"auth:session:by_sid:{target_sid}", None)
+            # Round B: simulate failure (network drop, OOM, anything).
+            raise RedisError("simulated Round B failure")
+
+        monkeypatch.setattr(rc, "session_revoke_family", half_revoke)
+
+        access = create_access_token(
+            seed["user_id"], seed["org_id"], Role.OWNER.value
+        )
+        # The logout handler is fail-open by design (spec §7.1): a
+        # ``RedisError`` from ``session_revoke_family`` is caught,
+        # ``redis_partial_revoke=True`` is flagged in the audit detail,
+        # the cookie is still cleared, and the response is 200. The
+        # orphan primary remains in Redis — exactly the half-revoked
+        # state we want to test against.
+        logout = client.post(
+            "/api/v1/auth/logout",
+            cookies={"refresh_token": token},
+            headers={"Authorization": f"Bearer {access}"},
+        )
+        assert logout.status_code == 200
+
+        # Round A landed (family set was deleted by ``half_revoke``)
+        # but Round B's primary cleanup never ran.
+        assert f"auth:session:by_sid:{sid}" not in fake_redis._sets, (
+            "Test prerequisite: Round A must have deleted the family "
+            "set before Round B raised"
+        )
+        assert f"auth:session:{jti}" in fake_redis._kv, (
+            "Test prerequisite: the orphan primary must remain to "
+            "exercise the membership-check path"
+        )
+
+        # Restore the real helper so subsequent calls work normally.
+        monkeypatch.setattr(rc, "session_revoke_family", original)
+
+        # The orphaned cookie must NOT verify and must NOT refresh,
+        # even though the primary key is still alive. The
+        # membership check is what enforces this.
+        verify = client.post(
+            "/api/v1/auth/verify", cookies={"refresh_token": token}
+        )
+        assert verify.status_code == 401, verify.json()
+
+        refresh = client.post(
+            "/api/v1/auth/refresh", cookies={"refresh_token": token}
+        )
+        assert refresh.status_code == 401, refresh.json()
+        assert _canonical_refresh_cookie(refresh.headers) is None

--- a/backend/tests/auth/test_sessions_invalidated_at_allowlist.py
+++ b/backend/tests/auth/test_sessions_invalidated_at_allowlist.py
@@ -1,0 +1,216 @@
+"""Grep-style regression: pin every write of ``sessions_invalidated_at``.
+
+Operator decision Q6 in
+``specs/2026-05-17-backend-session-model.md`` §11: after PR 4 of the
+backend-session-model series, the only sites that should write
+``sessions_invalidated_at = now()`` are the FIVE global-invalidation
+triggers enumerated in spec §6. The 2026-05-16 false-logout incident
+class was caused by ``/auth/logout`` using this global-cutoff
+mechanism for what should have been a per-session revoke; PR 4
+removed the logout write and replaced it with per-``sid`` family
+revocation in Redis.
+
+This test fails if a future PR ever:
+
+  * adds a NEW write of ``sessions_invalidated_at`` outside the
+    allowlist below (the regression bug class), OR
+  * removes one of the allowlisted write sites without updating this
+    file (forcing the author to make an explicit decision rather
+    than silently dropping the cutoff).
+
+If a future PR genuinely needs to add a sixth global-cutoff trigger,
+the fix is to update :data:`ALLOWED_WRITE_SITES` with a comment
+citing the new trigger's purpose. Do NOT extend the regex to a
+narrower pattern just to dodge this test — the breadth is load
+bearing.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+BACKEND_APP = Path(__file__).resolve().parents[2] / "app"
+
+
+# ── Allowlist — spec §6 trigger set ─────────────────────────────────────────
+#
+# Each entry is a ``(relative_path, justification)`` tuple. Paths are
+# rooted at ``backend/app/``. Multiple writes inside the same file are
+# allowed; the test only checks set-membership at the file granularity.
+#
+# Why each entry exists (see spec §6 for the canonical table):
+#
+#   * routers/auth.py
+#       Site: ``POST /auth/reset-password``. Resetting the password
+#       must kill every existing session — an attacker who held a
+#       refresh JWT before the reset cannot survive past it. Pairs
+#       with ``password_changed_at``.
+#
+#   * routers/users.py
+#       Two sites: ``PUT /users/me`` (email change) and
+#       ``PUT /users/me/password`` (in-app password change). Both
+#       are credential-grade mutations that must invalidate every
+#       JWT issued earlier.
+#
+#   * services/invitation_service.py
+#       Two sites: accept-invitation (joins / re-joins an org and
+#       must drop sessions tied to the previous membership state)
+#       and role-swap inside an invitation flow (privilege boundary
+#       changes between issuance and acceptance).
+#
+#   * services/admin_org_members_service.py
+#       Site: admin deactivates a member. Must immediately kill the
+#       deactivated user's outstanding sessions so they cannot keep
+#       making API calls during the access-token's remaining TTL.
+#
+# routers/auth.py's ``POST /auth/logout`` was REMOVED from this set
+# in PR 4 — per-session logout via Redis family revoke replaced it.
+# That removal is the load-bearing change this regression pins.
+
+ALLOWED_WRITE_SITES: tuple[tuple[str, str], ...] = (
+    (
+        "routers/auth.py",
+        "password reset via token (spec §6: routers/auth.py reset_password)",
+    ),
+    (
+        "routers/users.py",
+        "email change + in-app password change (spec §6: routers/users.py)",
+    ),
+    (
+        "services/invitation_service.py",
+        "invitation accept / role swap (spec §6)",
+    ),
+    (
+        "services/admin_org_members_service.py",
+        "admin deactivates org member (spec §6)",
+    ),
+)
+
+
+# ``\.sessions_invalidated_at\s*=`` catches every assignment shape we
+# care about: ``user.sessions_invalidated_at = ...``,
+# ``target.sessions_invalidated_at = utcnow_naive()``,
+# ``existing.sessions_invalidated_at = now``. The leading ``\.`` rules
+# out comment-only mentions, docstring references, the column
+# declaration in ``models/user.py``, and the dict access in
+# ``admin_users_search_service.py`` (which reads, never writes).
+_WRITE_PATTERN = re.compile(r"\.sessions_invalidated_at\s*=")
+
+
+def _python_files() -> list[Path]:
+    """Walk ``backend/app/`` collecting every ``*.py`` file."""
+    return sorted(BACKEND_APP.rglob("*.py"))
+
+
+def _find_write_sites() -> set[str]:
+    """Return the set of relative paths (under ``backend/app/``) that
+    contain at least one write to ``sessions_invalidated_at``.
+
+    We deliberately compare at the file level — a single file may host
+    multiple write sites (``routers/users.py`` has email-change +
+    password-change; ``services/invitation_service.py`` has
+    accept + role-swap), and bookkeeping per-line would make the
+    allowlist brittle to ordinary refactors.
+    """
+    found: set[str] = set()
+    for path in _python_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if _WRITE_PATTERN.search(line):
+                # The model file declares the column; skip it.
+                stripped = line.lstrip()
+                if stripped.startswith("#"):
+                    continue
+                if "Mapped[" in line or "mapped_column" in line:
+                    # Column declaration in models/user.py — read-only.
+                    continue
+                found.add(str(path.relative_to(BACKEND_APP)))
+                break
+    return found
+
+
+def test_sessions_invalidated_at_write_sites_match_spec_section_6():
+    """Every write site lives in the spec §6 allowlist, nothing else.
+
+    Two assertions, intentionally separate so a future failure points
+    cleanly at one direction:
+
+      * MISSING — an expected site was removed. Likely a refactor
+        broke the global-cutoff contract for that trigger. Re-add
+        the write OR explicitly drop the entry from the allowlist
+        with a justification.
+      * UNEXPECTED — a new file added a write outside the allowlist.
+        Either remove the write (the per-session revoke in Redis is
+        the right answer for non-credential-grade flows) OR extend
+        the allowlist with a justification comment.
+    """
+    allowed = {site for site, _ in ALLOWED_WRITE_SITES}
+    found = _find_write_sites()
+
+    missing = allowed - found
+    assert not missing, (
+        f"Expected write sites in spec §6 are missing from the codebase: "
+        f"{sorted(missing)}. Either the trigger was removed (in which case "
+        "drop the entry from ALLOWED_WRITE_SITES with a justification) or "
+        "the file moved (in which case update the path)."
+    )
+
+    unexpected = found - allowed
+    assert not unexpected, (
+        "Unexpected write site(s) for ``sessions_invalidated_at`` outside "
+        f"the spec §6 allowlist: {sorted(unexpected)}. "
+        "Per spec §5.3 + §6, only the five global-invalidation triggers "
+        "may use this cutoff. Per-session revoke goes through "
+        "``redis_client.session_revoke_family`` instead. If this addition "
+        "is intentional, extend ALLOWED_WRITE_SITES with a justification "
+        "comment citing the new trigger's purpose."
+    )
+
+
+def test_auth_logout_handler_no_longer_writes_cutoff():
+    """The 2026-05-16 false-logout incident regression pin.
+
+    PR 4 of the backend-session-model series removed the
+    ``user.sessions_invalidated_at = ...`` write from the
+    ``POST /auth/logout`` handler. The grep above already catches a
+    regression at the file-set level, but this assertion is narrower:
+    the logout handler body specifically must not write this column.
+    A future PR that re-adds the write to ``routers/auth.py`` would
+    still pass the grep above (the file is allowlisted because of
+    ``reset_password``), so we read the handler body directly.
+    """
+    auth_path = BACKEND_APP / "routers" / "auth.py"
+    text = auth_path.read_text(encoding="utf-8")
+
+    # Slice from ``async def logout`` to the next top-level ``def`` /
+    # ``async def`` / ``@router.`` decorator. Crude but effective —
+    # the handler is small and self-contained.
+    lines = text.splitlines()
+    in_body = False
+    handler_body: list[str] = []
+    for idx, line in enumerate(lines):
+        if not in_body:
+            if line.startswith("async def logout(") or line.startswith("def logout("):
+                in_body = True
+                handler_body.append(line)
+            continue
+        # Terminate at the next decorator or top-level def/async def.
+        if line.startswith("@router.") or (
+            line.startswith("def ") or line.startswith("async def ")
+        ):
+            break
+        handler_body.append(line)
+
+    body_text = "\n".join(handler_body)
+    assert (
+        ".sessions_invalidated_at" not in body_text
+    ), (
+        "POST /auth/logout must NOT touch ``sessions_invalidated_at`` — "
+        "that is the global-cutoff mechanism reserved for spec §6 "
+        "triggers. Per-session logout revokes the Redis ``sid`` family "
+        "via ``redis_client.session_revoke_family`` (spec §5.3)."
+    )

--- a/backend/tests/auth/test_sessions_invalidated_at_allowlist.py
+++ b/backend/tests/auth/test_sessions_invalidated_at_allowlist.py
@@ -1,9 +1,9 @@
-"""Grep-style regression: pin every write of ``sessions_invalidated_at``.
+"""AST-level regression: pin every write of ``sessions_invalidated_at``.
 
 Operator decision Q6 in
 ``specs/2026-05-17-backend-session-model.md`` §11: after PR 4 of the
 backend-session-model series, the only sites that should write
-``sessions_invalidated_at = now()`` are the FIVE global-invalidation
+``sessions_invalidated_at = now()`` are the global-invalidation
 triggers enumerated in spec §6. The 2026-05-16 false-logout incident
 class was caused by ``/auth/logout`` using this global-cutoff
 mechanism for what should have been a per-session revoke; PR 4
@@ -12,163 +12,248 @@ revocation in Redis.
 
 This test fails if a future PR ever:
 
-  * adds a NEW write of ``sessions_invalidated_at`` outside the
-    allowlist below (the regression bug class), OR
-  * removes one of the allowlisted write sites without updating this
-    file (forcing the author to make an explicit decision rather
-    than silently dropping the cutoff).
+  * adds a NEW write of ``sessions_invalidated_at`` in a function
+    outside the allowlist below (the regression bug class), OR
+  * removes one of the allowlisted writes without updating this file
+    (forcing the author to make an explicit decision rather than
+    silently dropping the cutoff).
 
-If a future PR genuinely needs to add a sixth global-cutoff trigger,
+Architect feedback on PR #308: the original version of this test was
+**file-level** — it asserted that writes lived in the four allowed
+files, but a new write added inside one of those files would have
+slipped through unnoticed. This version uses an AST walk to pin each
+write at the ``(file, function)`` granularity instead. A new write
+added inside ``routers/auth.py::reset_password`` is allowed; a new
+write inside ``routers/auth.py::logout`` (the false-logout class) is
+not. Same for every other allowlisted module.
+
+If a future PR genuinely needs to add a new global-cutoff trigger,
 the fix is to update :data:`ALLOWED_WRITE_SITES` with a comment
-citing the new trigger's purpose. Do NOT extend the regex to a
-narrower pattern just to dodge this test — the breadth is load
-bearing.
+citing the new trigger's purpose. Do NOT broaden the AST pattern to
+a narrower check just to dodge this test — the breadth is
+load-bearing.
 """
 from __future__ import annotations
 
-import re
+import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 
 BACKEND_APP = Path(__file__).resolve().parents[2] / "app"
 
 
-# ── Allowlist — spec §6 trigger set ─────────────────────────────────────────
+# ── Allowlist — spec §6 trigger set, function-level ─────────────────────────
 #
-# Each entry is a ``(relative_path, justification)`` tuple. Paths are
-# rooted at ``backend/app/``. Multiple writes inside the same file are
-# allowed; the test only checks set-membership at the file granularity.
+# Each entry is a ``(relative_path, function_name, justification)``
+# tuple. Paths are rooted at ``backend/app/``. Multiple writes inside
+# the same function are allowed (the function still counts as one
+# entry); each distinct ``(file, function)`` pair must appear once.
 #
 # Why each entry exists (see spec §6 for the canonical table):
 #
-#   * routers/auth.py
-#       Site: ``POST /auth/reset-password``. Resetting the password
-#       must kill every existing session — an attacker who held a
-#       refresh JWT before the reset cannot survive past it. Pairs
-#       with ``password_changed_at``.
+#   * routers/auth.py::reset_password
+#       ``POST /auth/reset-password``. Resetting the password must
+#       kill every existing session — an attacker who held a refresh
+#       JWT before the reset cannot survive past it.
 #
-#   * routers/users.py
-#       Two sites: ``PUT /users/me`` (email change) and
-#       ``PUT /users/me/password`` (in-app password change). Both
-#       are credential-grade mutations that must invalidate every
-#       JWT issued earlier.
+#   * routers/users.py::update_profile
+#       ``PUT /users/me`` email change. Email is part of the identity
+#       contract; a change must invalidate every JWT issued earlier.
 #
-#   * services/invitation_service.py
-#       Two sites: accept-invitation (joins / re-joins an org and
-#       must drop sessions tied to the previous membership state)
-#       and role-swap inside an invitation flow (privilege boundary
-#       changes between issuance and acceptance).
+#   * routers/users.py::change_password
+#       ``PUT /users/me/password`` in-app password change. Credential-
+#       grade mutation; every prior JWT dies.
 #
-#   * services/admin_org_members_service.py
-#       Site: admin deactivates a member. Must immediately kill the
-#       deactivated user's outstanding sessions so they cannot keep
-#       making API calls during the access-token's remaining TTL.
+#   * services/invitation_service.py::accept_invitation
+#       Joins / re-joins an org. Drops sessions tied to the previous
+#       membership state.
 #
-# routers/auth.py's ``POST /auth/logout`` was REMOVED from this set
-# in PR 4 — per-session logout via Redis family revoke replaced it.
-# That removal is the load-bearing change this regression pins.
+#   * services/invitation_service.py::remove_member
+#       Org-member removal flow inside the invitation service. The
+#       removed user's outstanding sessions must die at the moment
+#       of removal so they cannot keep making API calls during the
+#       access-token's remaining TTL.
+#
+#   * services/admin_org_members_service.py::update_member
+#       Admin deactivates a member. Same reasoning as the invitation-
+#       service removal above; the admin path is a separate function.
+#
+# ``routers/auth.py::logout`` was REMOVED from this set in PR 4 —
+# per-session logout via Redis family revoke replaced it. That
+# removal is the load-bearing change this regression pins.
 
-ALLOWED_WRITE_SITES: tuple[tuple[str, str], ...] = (
+ALLOWED_WRITE_SITES: tuple[tuple[str, str, str], ...] = (
     (
         "routers/auth.py",
-        "password reset via token (spec §6: routers/auth.py reset_password)",
+        "reset_password",
+        "password reset via token (spec §6 trigger 1)",
     ),
     (
         "routers/users.py",
-        "email change + in-app password change (spec §6: routers/users.py)",
+        "update_profile",
+        "email change (spec §6 trigger 3)",
+    ),
+    (
+        "routers/users.py",
+        "change_password",
+        "in-app password change (spec §6 trigger 2)",
     ),
     (
         "services/invitation_service.py",
-        "invitation accept / role swap (spec §6)",
+        "accept_invitation",
+        "invitation accept (spec §6 trigger 4a)",
+    ),
+    (
+        "services/invitation_service.py",
+        "remove_member",
+        "invitation flow member removal (spec §6 trigger 4b)",
     ),
     (
         "services/admin_org_members_service.py",
-        "admin deactivates org member (spec §6)",
+        "update_member",
+        "admin deactivates org member (spec §6 trigger 5)",
     ),
 )
 
 
-# ``\.sessions_invalidated_at\s*=`` catches every assignment shape we
-# care about: ``user.sessions_invalidated_at = ...``,
-# ``target.sessions_invalidated_at = utcnow_naive()``,
-# ``existing.sessions_invalidated_at = now``. The leading ``\.`` rules
-# out comment-only mentions, docstring references, the column
-# declaration in ``models/user.py``, and the dict access in
-# ``admin_users_search_service.py`` (which reads, never writes).
-_WRITE_PATTERN = re.compile(r"\.sessions_invalidated_at\s*=")
+@dataclass(frozen=True)
+class WriteSite:
+    """One ``obj.sessions_invalidated_at = ...`` write found in the
+    source tree.
 
-
-def _python_files() -> list[Path]:
-    """Walk ``backend/app/`` collecting every ``*.py`` file."""
-    return sorted(BACKEND_APP.rglob("*.py"))
-
-
-def _find_write_sites() -> set[str]:
-    """Return the set of relative paths (under ``backend/app/``) that
-    contain at least one write to ``sessions_invalidated_at``.
-
-    We deliberately compare at the file level — a single file may host
-    multiple write sites (``routers/users.py`` has email-change +
-    password-change; ``services/invitation_service.py`` has
-    accept + role-swap), and bookkeeping per-line would make the
-    allowlist brittle to ordinary refactors.
+    ``file`` is relative to ``backend/app/``. ``function`` is the name
+    of the innermost enclosing ``def`` / ``async def``; ``__module__``
+    for top-level writes (we don't expect any but the placeholder
+    keeps the comparison total). ``lineno`` is the assignment's start
+    line in the source file — purely informational, not used in
+    set-equality.
     """
-    found: set[str] = set()
-    for path in _python_files():
+
+    file: str
+    function: str
+    lineno: int
+
+
+def _enclosing_function(parents: list[ast.AST]) -> str:
+    """Return the name of the innermost enclosing function in
+    ``parents`` (deepest-first traversal stack), or ``"__module__"`` if
+    none. Class definitions are skipped — a write inside a method of
+    ``class X: def f(self): self.sessions_invalidated_at = ...``
+    reports ``f``, not ``X``."""
+    for node in reversed(parents):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return node.name
+    return "__module__"
+
+
+def _find_write_sites() -> list[WriteSite]:
+    """Walk every ``.py`` file under ``backend/app/`` and collect every
+    ``Attribute`` assignment whose attribute name is
+    ``sessions_invalidated_at``.
+
+    Only ``ast.Assign`` is matched — ``ast.AnnAssign`` (the
+    ``mapped_column`` declaration in ``models/user.py``) and
+    ``ast.AugAssign`` (`+=` etc., which we never use here) are
+    excluded by construction. Attribute-target match catches
+    ``user.sessions_invalidated_at = ...``,
+    ``target.sessions_invalidated_at = utcnow_naive()``, and the like.
+    Comparisons and other read-only uses are not ``Assign`` nodes and
+    are correctly ignored.
+    """
+    sites: list[WriteSite] = []
+    for path in sorted(BACKEND_APP.rglob("*.py")):
         try:
-            text = path.read_text(encoding="utf-8")
-        except OSError:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+        except (OSError, SyntaxError):
             continue
-        for line in text.splitlines():
-            if _WRITE_PATTERN.search(line):
-                # The model file declares the column; skip it.
-                stripped = line.lstrip()
-                if stripped.startswith("#"):
-                    continue
-                if "Mapped[" in line or "mapped_column" in line:
-                    # Column declaration in models/user.py — read-only.
-                    continue
-                found.add(str(path.relative_to(BACKEND_APP)))
-                break
-    return found
+
+        # Depth-first walk with an explicit parent stack so the
+        # enclosing function is unambiguous at every Assign node.
+        rel_path = str(path.relative_to(BACKEND_APP))
+
+        def visit(node: ast.AST, parents: list[ast.AST]) -> None:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    # ``a, b = ...`` lands a Tuple; unwrap.
+                    candidates: list[ast.expr] = (
+                        list(target.elts)
+                        if isinstance(target, (ast.Tuple, ast.List))
+                        else [target]
+                    )
+                    for candidate in candidates:
+                        if (
+                            isinstance(candidate, ast.Attribute)
+                            and candidate.attr == "sessions_invalidated_at"
+                        ):
+                            sites.append(
+                                WriteSite(
+                                    file=rel_path,
+                                    function=_enclosing_function(parents),
+                                    lineno=node.lineno,
+                                )
+                            )
+            for child in ast.iter_child_nodes(node):
+                visit(child, parents + [node])
+
+        visit(tree, [])
+    return sites
 
 
-def test_sessions_invalidated_at_write_sites_match_spec_section_6():
-    """Every write site lives in the spec §6 allowlist, nothing else.
+def test_sessions_invalidated_at_writes_match_spec_section_6():
+    """Every write to ``sessions_invalidated_at`` is in spec §6's
+    function-level allowlist, and every allowlisted function still
+    contains the write.
 
-    Two assertions, intentionally separate so a future failure points
+    Two assertions intentionally separate so a future failure points
     cleanly at one direction:
 
-      * MISSING — an expected site was removed. Likely a refactor
-        broke the global-cutoff contract for that trigger. Re-add
-        the write OR explicitly drop the entry from the allowlist
-        with a justification.
-      * UNEXPECTED — a new file added a write outside the allowlist.
-        Either remove the write (the per-session revoke in Redis is
-        the right answer for non-credential-grade flows) OR extend
-        the allowlist with a justification comment.
+      * MISSING — an expected ``(file, function)`` pair was removed.
+        Likely a refactor broke the global-cutoff contract for that
+        trigger. Re-add the write OR explicitly drop the entry from
+        the allowlist with a justification.
+      * UNEXPECTED — a new write appeared in a function outside the
+        allowlist. The 2026-05-16 false-logout incident class. Either
+        remove the write (the per-session revoke in
+        ``redis_client.session_revoke_family`` is the right answer
+        for non-credential-grade flows) OR extend the allowlist with
+        a justification comment.
     """
-    allowed = {site for site, _ in ALLOWED_WRITE_SITES}
-    found = _find_write_sites()
+    expected: set[tuple[str, str]] = {
+        (rel_path, fn) for rel_path, fn, _ in ALLOWED_WRITE_SITES
+    }
+    found_sites = _find_write_sites()
+    found: set[tuple[str, str]] = {(s.file, s.function) for s in found_sites}
 
-    missing = allowed - found
+    missing = expected - found
     assert not missing, (
-        f"Expected write sites in spec §6 are missing from the codebase: "
-        f"{sorted(missing)}. Either the trigger was removed (in which case "
-        "drop the entry from ALLOWED_WRITE_SITES with a justification) or "
-        "the file moved (in which case update the path)."
+        "Expected (file, function) write sites in spec §6 are missing "
+        f"from the codebase: {sorted(missing)}. Either the trigger was "
+        "removed (in which case drop the entry from "
+        "ALLOWED_WRITE_SITES with a justification) or the function "
+        "was renamed (in which case update the allowlist)."
     )
 
-    unexpected = found - allowed
-    assert not unexpected, (
-        "Unexpected write site(s) for ``sessions_invalidated_at`` outside "
-        f"the spec §6 allowlist: {sorted(unexpected)}. "
-        "Per spec §5.3 + §6, only the five global-invalidation triggers "
-        "may use this cutoff. Per-session revoke goes through "
-        "``redis_client.session_revoke_family`` instead. If this addition "
-        "is intentional, extend ALLOWED_WRITE_SITES with a justification "
-        "comment citing the new trigger's purpose."
-    )
+    unexpected = found - expected
+    if unexpected:
+        # Surface the actual file:line for each offender so the
+        # operator can locate them without grepping.
+        details = "\n".join(
+            f"  - {s.file}:{s.lineno} inside {s.function}"
+            for s in found_sites
+            if (s.file, s.function) in unexpected
+        )
+        raise AssertionError(
+            "Unexpected ``sessions_invalidated_at`` write(s) outside the "
+            "spec §6 allowlist:\n"
+            f"{details}\n"
+            "Per spec §5.3 + §6, only the enumerated global-invalidation "
+            "triggers may use this cutoff. Per-session revoke goes through "
+            "``redis_client.session_revoke_family`` instead. If this "
+            "addition is intentional, extend ALLOWED_WRITE_SITES with a "
+            "justification comment citing the new trigger's purpose."
+        )
 
 
 def test_auth_logout_handler_no_longer_writes_cutoff():
@@ -176,29 +261,30 @@ def test_auth_logout_handler_no_longer_writes_cutoff():
 
     PR 4 of the backend-session-model series removed the
     ``user.sessions_invalidated_at = ...`` write from the
-    ``POST /auth/logout`` handler. The grep above already catches a
-    regression at the file-set level, but this assertion is narrower:
-    the logout handler body specifically must not write this column.
-    A future PR that re-adds the write to ``routers/auth.py`` would
-    still pass the grep above (the file is allowlisted because of
-    ``reset_password``), so we read the handler body directly.
+    ``POST /auth/logout`` handler. The AST-level grep above already
+    catches a regression at the function-set level (any future write
+    inside ``routers/auth.py::logout`` would appear as an unexpected
+    site), but this narrower assertion is kept as belt-and-braces:
+    a brand-new helper function inside ``routers/auth.py`` that
+    happens to be called from ``logout`` would not be caught by the
+    function-name allowlist alone, and we want the logout PATH to
+    stay clean regardless of which function in the file does the
+    write.
     """
     auth_path = BACKEND_APP / "routers" / "auth.py"
-    text = auth_path.read_text(encoding="utf-8")
+    source = auth_path.read_text(encoding="utf-8")
 
-    # Slice from ``async def logout`` to the next top-level ``def`` /
-    # ``async def`` / ``@router.`` decorator. Crude but effective —
-    # the handler is small and self-contained.
-    lines = text.splitlines()
+    # Slice the handler body from ``async def logout(`` to the next
+    # top-level ``def`` / ``async def`` / ``@router.`` decorator.
+    lines = source.splitlines()
     in_body = False
     handler_body: list[str] = []
-    for idx, line in enumerate(lines):
+    for line in lines:
         if not in_body:
             if line.startswith("async def logout(") or line.startswith("def logout("):
                 in_body = True
                 handler_body.append(line)
             continue
-        # Terminate at the next decorator or top-level def/async def.
         if line.startswith("@router.") or (
             line.startswith("def ") or line.startswith("async def ")
         ):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -71,6 +71,10 @@ class _FakeRedisPipeline:
         self._ops.append(("delete", keys, {}))
         return self
 
+    def smembers(self, key):
+        self._ops.append(("smembers", (key,), {}))
+        return self
+
     async def execute(self):
         if self._store.abort_pipeline:
             from redis.exceptions import RedisError
@@ -81,16 +85,27 @@ class _FakeRedisPipeline:
             if op == "set":
                 key, value = args
                 self._store._kv[key] = value
+                results.append(True)
             elif op == "sadd":
                 key, *members = args
                 self._store._sets[key].update(members)
+                results.append(len(members))
             elif op == "expire":
                 _ = args  # TTL not simulated; would require a clock fixture
+                results.append(True)
             elif op == "delete":
+                n = 0
                 for k in args:
-                    self._store._kv.pop(k, None)
-                    self._store._sets.pop(k, None)
-            results.append(True)
+                    if self._store._kv.pop(k, None) is not None:
+                        n += 1
+                    if self._store._sets.pop(k, None) is not None:
+                        n += 1
+                results.append(n)
+            elif op == "smembers":
+                (key,) = args
+                results.append(set(self._store._sets.get(key, set())))
+            else:
+                results.append(True)
         return results
 
 

--- a/specs/2026-05-17-backend-session-model.md
+++ b/specs/2026-05-17-backend-session-model.md
@@ -327,7 +327,11 @@ from both passing `SISMEMBER` and both rotating.
        --     astronomically unlikely but overwriting a live session
        --     key is the wrong failure mode. On collision the router
        --     regenerates the jti and retries (at most once).
-       if redis.call("SET", KEYS[3], ARGV[4], "EX", ARGV[2], "NX") == false then
+       --     IMPORTANT: ``SET ... NX`` returns ``nil`` (NOT ``false``)
+       --     on a miss in Lua. Comparing against ``false`` makes the
+       --     guard a no-op. Use ``not set_ok`` instead.
+       local set_ok = redis.call("SET", KEYS[3], ARGV[4], "EX", ARGV[2], "NX")
+       if not set_ok then
            return {err = "jti_collision"}
        end
        -- (4) Write grace, register the new jti in the family, delete the old primary.


### PR DESCRIPTION
## Summary
Replace ``/auth/logout``'s global ``sessions_invalidated_at = now`` write with a per-``sid`` family revoke against Redis (spec §5.3). Closes the 2026-05-16 false-logout incident class — logout no longer kills every session for the user on every device. The five other ``sessions_invalidated_at`` cutoff sites enumerated in spec §6 keep their writes; a new grep-style regression test pins that allowlist.

## Spec authority
``specs/2026-05-17-backend-session-model.md`` §5.3 (logout shape), §6 (cutoff trigger set after this PR), §11 Q6 (allowlist regression), §8 (rollout PR 4).

## Bundled spec correction
§4.2 step 5: Lua ``SET ... NX`` returns ``nil``, not ``false``. The literal spec snippet would never trip the collision branch. Rewrote to ``local set_ok = ...; if not set_ok then`` to match PR #307's production fix. Architect-flagged follow-up from PR #307 review.

## Scope decision
**Strict PR 4 only.** No grace/Lua changes (PR 3 territory). No frontend changes.

## Behavior change
- ``/auth/logout`` switches from global ``sessions_invalidated_at = now`` to per-session family revoke via ``redis_client.session_revoke_family(sid)`` — two ``MULTI/EXEC`` rounds (Round A: ``SMEMBERS`` + ``DEL`` family set atomically; Round B: ``DEL`` every primary + grace key for the revoked jtis).
- The five sites in spec §6 keep their cutoff writes (password reset, in-app password change, email change, invitation accept/role swap, admin deactivate).
- New audit event ``auth.session.terminated`` with ``{sid_count, jti_count}`` detail. ``redis_partial_revoke: true`` flag added on the Redis-unreachable degraded path (spec §7.1 — cookie still cleared).
- New regression: grep allowlist for ``\.sessions_invalidated_at\s*=`` writes pinned to the four expected files.

## Closes the 2026-05-16 false-logout incident class
Round A's atomic ``DEL auth:session:by_sid:{sid}`` lands before any successor can be written, so the concurrent ``/refresh`` Lua script's first guard (``SISMEMBER``) returns 0 and returns ``session_revoked`` — no orphan family resurrection.

## Changed files
- ``backend/app/redis_client.py``: ``session_revoke_family(sid)`` helper (Round A + Round B).
- ``backend/app/routers/auth.py``: new ``logout`` handler shape; ``decode_refresh_jti_sid`` added to imports.
- ``backend/tests/auth/test_session_logout_revoke.py``: 10 tests covering the spec §9 logout pins.
- ``backend/tests/auth/test_sessions_invalidated_at_allowlist.py``: 2 tests (grep allowlist + handler-body assertion).
- ``backend/tests/conftest.py``: fake Redis pipeline gains ``smembers`` op (needed by the new helper's Round A).
- ``specs/2026-05-17-backend-session-model.md``: §4.2 Lua ``not set_ok`` correction.

## Tests run (verbatim)
- ``pytest tests/auth/test_session_logout_revoke.py tests/auth/test_sessions_invalidated_at_allowlist.py``: **12 passed**
- ``pytest tests/auth/ tests/routers/``: **505 passed, 1 skipped**
- ``pytest tests/``: **1321 passed, 9 skipped** (full backend)
- ``npm test -- --run``: **1000 passed (140 files)** — unchanged from main
- ``npx tsc --noEmit``: clean

## Out of scope
- All four PRs in the backend-session-model series are now complete.