### PR TITLE
fix(frontend): cold-start UX -- 25s recovery timeout + keep-warm heartbeat

### DIFF
--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -33,6 +33,7 @@ import ThemeToggle from "@/components/ui/ThemeToggle";
 import TrialBanner from "@/components/ui/TrialBanner";
 import { hasPlatformPermission } from "@/lib/auth";
 import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
+import { startKeepWarm } from "@/lib/keep-warm";
 
 // Shared sizing/stroke for the sidebar nav icons. Matches the previous
 // Heroicons-outline visuals (1.5 stroke, 18×18) so the swap to Lucide is
@@ -151,6 +152,17 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (!loading && !user) router.replace("/login");
   }, [user, loading, router]);
+
+  // Cold-start mitigation: while the user is signed in AND AppShell is
+  // mounted, a 4-min heartbeat pings /health?keep-warm=1 to keep the
+  // DO App Platform Basic-XS container out of hibernation. The
+  // heartbeat auto-pauses on visibilitychange -> hidden and stops on
+  // auth:unauthenticated. Strictly gated on ``user`` so unauthenticated
+  // landing / login / SSO-callback flows never trigger it.
+  useEffect(() => {
+    if (!user) return;
+    return startKeepWarm();
+  }, [user]);
 
   // L3.3 first-run wizard. Bounce authenticated users whose backend
   // explicitly tells us they have not onboarded yet (`onboarded_at`

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -18,8 +18,20 @@ const REFRESH_BACKOFF_BASE_MS = 250;
 // Detect recovery paths by substring so a future ``/api/v2/auth/refresh``
 // or a relative ``/auth/me`` still picks up the longer budget. Robust
 // against the API_URL prefix and against future path renames.
+//
+// Architect P1 on PR #309: ``/auth/status`` is the FIRST endpoint
+// AuthProvider hits on mount (see components/auth/AuthProvider.tsx).
+// If that call times out at 10s on a cold container, the restore
+// flow never reaches ``/auth/refresh`` and the user gets surfaced a
+// generic 503 from the unauth path instead of the recovery one.
+// Treating ``/auth/status`` as a recovery path means the cold-start
+// chain (status → refresh → me) all runs on the 25s budget.
 function isRecoveryPath(path: string): boolean {
-  return path.includes("/auth/refresh") || path.includes("/auth/me");
+  return (
+    path.includes("/auth/refresh")
+    || path.includes("/auth/me")
+    || path.includes("/auth/status")
+  );
 }
 
 function timeoutForPath(path: string): number {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,10 +1,30 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
-const API_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
+// Auth recovery paths (/auth/refresh, /auth/me) get a longer budget so the
+// first request after a hibernated DO App Platform Basic-XS backend doesn't
+// false-positive the 10s default during TLS handshake + cold container
+// boot. Applied only to the recovery paths; all other endpoints keep the
+// 10s default. See PR fix(frontend) cold-start.
+const RECOVERY_TIMEOUT_MS = 25_000;
+// Back-compat alias retained for the rest of the module; existing callers
+// reference API_FETCH_TIMEOUT_MS in inline comments.
+const API_FETCH_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 // Retry budget for transient outcomes on POST /api/v1/auth/refresh. Two
 // retries with 250ms exponential backoff (250ms, 500ms). Terminal 401/403
 // is NOT retried -- those mean the refresh cookie is dead, not in transit.
 const REFRESH_TRANSIENT_RETRIES = 2;
 const REFRESH_BACKOFF_BASE_MS = 250;
+
+// Detect recovery paths by substring so a future ``/api/v2/auth/refresh``
+// or a relative ``/auth/me`` still picks up the longer budget. Robust
+// against the API_URL prefix and against future path renames.
+function isRecoveryPath(path: string): boolean {
+  return path.includes("/auth/refresh") || path.includes("/auth/me");
+}
+
+function timeoutForPath(path: string): number {
+  return isRecoveryPath(path) ? RECOVERY_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
+}
 
 let accessToken: string | null = null;
 // Discriminated result so callers can distinguish terminal auth death
@@ -97,10 +117,16 @@ async function fetchWithTimeout(
 async function refreshAccessTokenOnce(): Promise<RefreshResult> {
   let res: Response;
   try {
-    res = await fetchWithTimeout(`${API_URL}/api/v1/auth/refresh`, {
-      method: "POST",
-      credentials: "include",
-    });
+    // 25s recovery budget (vs 10s default) so a hibernated backend cold
+    // start with TLS handshake + container boot doesn't false-positive.
+    res = await fetchWithTimeout(
+      `${API_URL}/api/v1/auth/refresh`,
+      {
+        method: "POST",
+        credentials: "include",
+      },
+      RECOVERY_TIMEOUT_MS,
+    );
   } catch (err) {
     // ApiTimeoutError, TypeError (network), AbortError -- all transient.
     return {
@@ -173,11 +199,18 @@ async function refreshAccessToken(): Promise<RefreshResult> {
 async function probeAuthMeAlive(): Promise<boolean> {
   if (!accessToken) return false;
   try {
-    const res = await fetchWithTimeout(`${API_URL}/api/v1/auth/me`, {
-      method: "GET",
-      credentials: "include",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    // 25s recovery budget so a cold backend doesn't trip a false
+    // logout when /me confirms session liveness after a transient
+    // refresh failure.
+    const res = await fetchWithTimeout(
+      `${API_URL}/api/v1/auth/me`,
+      {
+        method: "GET",
+        credentials: "include",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+      RECOVERY_TIMEOUT_MS,
+    );
     return res.status === 200;
   } catch {
     return false;
@@ -192,7 +225,10 @@ export async function apiFetch<T>(
   // so it doesn't pollute the RequestInit. The same caller-provided value
   // applies to both the primary request and the retry-after-refresh.
   const { timeoutMs, ...fetchInit } = options;
-  const effectiveTimeout = timeoutMs ?? API_FETCH_TIMEOUT_MS;
+  // Path-specific default: recovery routes get 25s, everything else 10s.
+  // An explicit per-call timeoutMs override always wins. Same effective
+  // budget is reused for the retry-after-refresh below.
+  const effectiveTimeout = timeoutMs ?? timeoutForPath(path);
   const headers = new Headers(fetchInit.headers);
 
   if (accessToken) {

--- a/frontend/lib/keep-warm.ts
+++ b/frontend/lib/keep-warm.ts
@@ -46,7 +46,21 @@ export function startKeepWarm(): () => void {
     fetch(KEEP_WARM_PATH, { method: "GET", credentials: "omit" }).catch(() => {});
   };
 
+  // Architect P2 on PR #309: ``stop()`` alone is not enough to honour
+  // the "stops permanently on auth:unauthenticated" contract. The
+  // ``visibilitychange`` listener stays attached after the unauth
+  // signal, so any subsequent hidden→visible transition would call
+  // ``start()`` and resume heartbeats against the logged-out user.
+  // The cleanup callback returned by ``startKeepWarm()`` is the only
+  // thing that fully tears down listeners — but React effects don't
+  // run the cleanup until the component remounts. The
+  // ``stoppedPermanently`` flag makes ``start()`` a no-op after a
+  // terminal signal so we don't ping in the window between
+  // ``auth:unauthenticated`` and the effect remount.
+  let stoppedPermanently = false;
+
   const start = () => {
+    if (stoppedPermanently) return;
     if (timer !== null) return;
     // Immediate ping on (re)start so a freshly visible tab warms the
     // container right away instead of waiting up to 4 minutes for the
@@ -69,8 +83,12 @@ export function startKeepWarm(): () => void {
   };
 
   const onUnauthenticated = () => {
-    // Once the user is signed out the heartbeat must stop entirely;
-    // the next sign-in will mount a fresh keep-warm.
+    // Once the user is signed out the heartbeat must stop entirely
+    // AND must not resume on a subsequent visibility change. The
+    // next sign-in mounts a fresh ``keep-warm`` via the AppShell
+    // effect cleanup + re-mount cycle, which gets a fresh
+    // ``stoppedPermanently=false`` closure.
+    stoppedPermanently = true;
     stop();
   };
 

--- a/frontend/lib/keep-warm.ts
+++ b/frontend/lib/keep-warm.ts
@@ -1,0 +1,95 @@
+// Keep-warm heartbeat for the backend container.
+//
+// PR fix(frontend) cold-start: the user's DO App Platform Basic-XS tier
+// hibernates the backend container during idle. A 4-minute heartbeat from
+// the browser while the tab is visible AND the user is signed in keeps the
+// container warm, eliminating the cold-start latency that was tripping the
+// 10s apiFetch timeout and surfacing "Session refresh temporarily
+// unavailable" to the user.
+//
+// Contract:
+//   * Ping ``/health?keep-warm=1`` every 4 minutes while
+//     ``document.visibilityState !== "hidden"``. The backend exposes
+//     ``/health`` (not ``/api/v1/health``) and the existing nginx
+//     ``location = /health`` block + App Platform ingress route it
+//     straight to the backend. The ``?keep-warm=1`` query param lets
+//     backend access logs distinguish heartbeats from real liveness
+//     checks if needed (note: ``/health`` is already in the
+//     ``_SILENT_PATHS`` access-log filter, so this is informational only
+//     for any future tooling that bypasses that filter).
+//   * Pause the timer on ``visibilitychange`` -> hidden, resume on
+//     ``visibilitychange`` -> visible. Pinging while hidden is wasted
+//     work; the browser may also throttle background timers.
+//   * Stop entirely on ``auth:unauthenticated`` (the same window event
+//     apiFetch dispatches on terminal /refresh failure). The caller is
+//     also expected to call the returned cleanup fn on sign-out via
+//     ``useEffect``.
+//   * Best-effort. No error surfacing, no retry, no telemetry. If the
+//     fetch 5xx's or aborts the next tick simply tries again.
+
+const KEEP_WARM_INTERVAL_MS = 4 * 60 * 1000;
+const KEEP_WARM_PATH = "/health?keep-warm=1";
+
+export function startKeepWarm(): () => void {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const ping = () => {
+    // Guard against pinging when the tab is backgrounded. The
+    // visibilitychange listener also pauses the timer, but a race
+    // between the listener firing and the next interval tick could
+    // otherwise sneak through.
+    if (typeof document !== "undefined" && document.hidden) return;
+    // credentials: "omit" so the heartbeat never carries cookies; this
+    // is purely a wake-up probe and must not interact with session
+    // refresh, rate limits, or audit logging. Errors are swallowed --
+    // a missed tick will be re-tried on the next interval.
+    fetch(KEEP_WARM_PATH, { method: "GET", credentials: "omit" }).catch(() => {});
+  };
+
+  const start = () => {
+    if (timer !== null) return;
+    // Immediate ping on (re)start so a freshly visible tab warms the
+    // container right away instead of waiting up to 4 minutes for the
+    // first interval tick.
+    ping();
+    timer = setInterval(ping, KEEP_WARM_INTERVAL_MS);
+  };
+
+  const stop = () => {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const onVisibilityChange = () => {
+    if (typeof document === "undefined") return;
+    if (document.hidden) stop();
+    else start();
+  };
+
+  const onUnauthenticated = () => {
+    // Once the user is signed out the heartbeat must stop entirely;
+    // the next sign-in will mount a fresh keep-warm.
+    stop();
+  };
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+  }
+  if (typeof window !== "undefined") {
+    window.addEventListener("auth:unauthenticated", onUnauthenticated);
+  }
+
+  start();
+
+  return () => {
+    stop();
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    }
+    if (typeof window !== "undefined") {
+      window.removeEventListener("auth:unauthenticated", onUnauthenticated);
+    }
+  };
+}

--- a/frontend/tests/api/recovery-timeout.test.ts
+++ b/frontend/tests/api/recovery-timeout.test.ts
@@ -143,6 +143,51 @@ describe("apiFetch recovery-path timeout", () => {
     }
   });
 
+  it("apiFetch on /api/v1/auth/status succeeds when upstream resolves at 24s (architect P1 on PR #309 — cold-start restore)", async () => {
+    // AuthProvider's first call on mount is /api/v1/auth/status. If
+    // that times out at 10s on a cold container, the restore chain
+    // (status → refresh → me) never reaches /refresh and the user
+    // sees a generic 503 from the unauthed path instead of the
+    // recovery path. /auth/status must share the 25s recovery
+    // budget with /refresh and /me.
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockImplementationOnce(
+        slowResponse(jsonResponse({ needs_setup: false }), 24_000),
+      );
+
+      const promise = apiFetch<{ needs_setup: boolean }>(
+        "/api/v1/auth/status",
+      );
+
+      await vi.advanceTimersByTimeAsync(24_000);
+
+      await expect(promise).resolves.toEqual({ needs_setup: false });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("apiFetch on /api/v1/auth/status aborts at 25s when upstream is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockImplementationOnce(
+        slowResponse(jsonResponse({ needs_setup: false }), 26_000),
+      );
+
+      const promise = apiFetch("/api/v1/auth/status");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiTimeoutError",
+      });
+
+      await vi.advanceTimersByTimeAsync(24_999);
+      await vi.advanceTimersByTimeAsync(1);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("non-recovery path /api/v1/transactions still aborts at 10s (longer budget is recovery-only)", async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/tests/api/recovery-timeout.test.ts
+++ b/frontend/tests/api/recovery-timeout.test.ts
@@ -1,0 +1,230 @@
+// Recovery-path timeout tests for apiFetch.
+//
+// PR fix(frontend) cold-start: the auth recovery routes (/api/v1/auth/refresh
+// and /api/v1/auth/me) get a 25s timeout vs the 10s default that applies to
+// every other path. The user's DO App Platform Basic-XS tier hibernates the
+// backend container during idle; the first refresh after idle takes longer
+// than 10s for TLS handshake + cold container boot. The longer budget lets
+// the recovery path succeed instead of false-positiving the global 10s
+// timeout and surfacing "Session refresh temporarily unavailable".
+//
+// Non-recovery paths are unaffected and still abort at 10s.
+
+import { ApiResponseError, apiFetch, setAccessToken } from "@/lib/api";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("apiFetch recovery-path timeout", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    dispatchEventSpy.mockClear();
+    vi.stubGlobal("fetch", fetchMock);
+    setAccessToken(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setAccessToken(null);
+  });
+
+  afterAll(() => {
+    dispatchEventSpy.mockRestore();
+  });
+
+  // Returns a fetch mock that resolves with ``response`` after ``delayMs``
+  // of fake-timer elapsed time, OR rejects with AbortError if the signal
+  // fires first. Mirrors how a real slow upstream behaves when the
+  // AbortController kicks in.
+  function slowResponse(response: Response, delayMs: number) {
+    return (_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((resolve, reject) => {
+        const signal = init?.signal;
+        const timer = setTimeout(() => resolve(response), delayMs);
+        signal?.addEventListener("abort", () => {
+          clearTimeout(timer);
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+  }
+
+  it("apiFetch on /api/v1/auth/refresh succeeds when upstream resolves at 24s (under 25s budget)", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockImplementationOnce(
+        slowResponse(jsonResponse({ access_token: "fresh-token" }), 24_000),
+      );
+
+      const promise = apiFetch<{ access_token: string }>("/api/v1/auth/refresh", {
+        method: "POST",
+      });
+
+      // Advance the full 24s; upstream should resolve before the 25s
+      // recovery timeout would have fired.
+      await vi.advanceTimersByTimeAsync(24_000);
+
+      await expect(promise).resolves.toEqual({ access_token: "fresh-token" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("apiFetch on /api/v1/auth/refresh aborts at 25s when upstream is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      // Upstream wouldn't resolve until 26s; AbortController fires at 25s.
+      fetchMock.mockImplementationOnce(
+        slowResponse(jsonResponse({ access_token: "too-late" }), 26_000),
+      );
+
+      const promise = apiFetch<{ access_token: string }>("/api/v1/auth/refresh", {
+        method: "POST",
+      });
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiTimeoutError",
+        message: "Request timed out. Try again.",
+      });
+
+      // 24999ms: still pending.
+      await vi.advanceTimersByTimeAsync(24_999);
+      // The 25000th ms: AbortController triggers, fetch rejects with
+      // AbortError, fetchWithTimeout maps to ApiTimeoutError.
+      await vi.advanceTimersByTimeAsync(1);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("apiFetch on /api/v1/auth/me succeeds when upstream resolves at 24s (under 25s budget)", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("valid-token");
+      fetchMock.mockImplementationOnce(
+        slowResponse(jsonResponse({ id: 1, email: "x@y.z" }), 24_000),
+      );
+
+      const promise = apiFetch<{ id: number; email: string }>("/api/v1/auth/me");
+
+      await vi.advanceTimersByTimeAsync(24_000);
+
+      await expect(promise).resolves.toEqual({ id: 1, email: "x@y.z" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("apiFetch on /api/v1/auth/me aborts at 25s when upstream is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("valid-token");
+      fetchMock.mockImplementationOnce(
+        slowResponse(jsonResponse({ id: 1 }), 26_000),
+      );
+
+      const promise = apiFetch("/api/v1/auth/me");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiTimeoutError",
+      });
+
+      await vi.advanceTimersByTimeAsync(24_999);
+      await vi.advanceTimersByTimeAsync(1);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("non-recovery path /api/v1/transactions still aborts at 10s (longer budget is recovery-only)", async () => {
+    vi.useFakeTimers();
+    try {
+      setAccessToken("valid-token");
+      // Upstream would resolve at 11s but the default 10s aborts first.
+      fetchMock.mockImplementationOnce(
+        slowResponse(jsonResponse({ items: [] }), 11_000),
+      );
+
+      const promise = apiFetch("/api/v1/transactions");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiTimeoutError",
+      });
+
+      // 9999ms: still pending.
+      await vi.advanceTimersByTimeAsync(9_999);
+      // The 10000th ms: AbortController triggers at the default budget.
+      await vi.advanceTimersByTimeAsync(1);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refresh-recovery path: 401 -> /refresh resolves at 24s -> retry succeeds (cold-start scenario)", async () => {
+    // Belt-and-braces realism: a primary 401 on /api/v1/transactions triggers
+    // the silent /refresh flow. The /refresh call takes 24s (just under the
+    // 25s recovery budget) because the backend container was hibernating;
+    // under the old 10s default this would have aborted and dispatched the
+    // "refresh_transient" 503. Under the new budget the refresh succeeds
+    // and the original request is retried with the fresh token.
+    vi.useFakeTimers();
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 401
+        .mockImplementationOnce(
+          slowResponse(jsonResponse({ access_token: "fresh-token" }), 24_000),
+        )
+        .mockResolvedValueOnce(jsonResponse({ items: [] }));                          // retry OK
+
+      const promise = apiFetch<{ items: unknown[] }>("/api/v1/transactions");
+
+      await vi.advanceTimersByTimeAsync(24_000);
+
+      await expect(promise).resolves.toEqual({ items: [] });
+      expect(dispatchEventSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refresh-recovery path: 401 -> /refresh hangs past 25s -> recoverable 503 (terminal-budget case)", async () => {
+    // Past the 25s budget the refresh still aborts -- this is the
+    // recoverable transient case, not auth death.
+    vi.useFakeTimers();
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 30_000))
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 30_000))
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 30_000));
+
+      const promise = apiFetch("/api/v1/protected");
+      const assertion = expect(promise).rejects.toBeInstanceOf(ApiResponseError);
+
+      // Advance through three 25s recovery timeouts + 250ms + 500ms backoffs.
+      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(25_000);
+      await assertion;
+
+      await expect(promise).rejects.toMatchObject({
+        status: 503,
+        code: "refresh_transient",
+      });
+      expect(dispatchEventSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -279,8 +279,9 @@ describe("apiFetch", () => {
     vi.useFakeTimers();
     try {
       setAccessToken("stale-token");
-      // All 3 refresh attempts hang and time out at 10s each, separated by
-      // 250ms then 500ms exponential backoffs.
+      // All 3 refresh attempts hang and time out at 25s each (recovery
+      // budget for /auth/refresh), separated by 250ms then 500ms
+      // exponential backoffs.
       fetchMock
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
         .mockImplementationOnce(neverResolvingFetch())   // refresh attempt 1
@@ -294,12 +295,12 @@ describe("apiFetch", () => {
         code: "refresh_transient",
       });
 
-      // Advance through all three 10s timeouts + 250ms + 500ms backoffs.
-      await vi.advanceTimersByTimeAsync(10_000);
+      // Advance through all three 25s timeouts + 250ms + 500ms backoffs.
+      await vi.advanceTimersByTimeAsync(25_000);
       await vi.advanceTimersByTimeAsync(250);
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(25_000);
       await vi.advanceTimersByTimeAsync(500);
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(25_000);
       await assertion;
 
       expect(getAccessToken()).toBe("stale-token");  // PRESERVED
@@ -353,11 +354,12 @@ describe("apiFetch", () => {
         expect(p).rejects.toMatchObject({ status: 503, code: "refresh_transient" }),
       );
 
-      await vi.advanceTimersByTimeAsync(10_000);
+      // Refresh uses the 25s recovery budget across all 3 attempts.
+      await vi.advanceTimersByTimeAsync(25_000);
       await vi.advanceTimersByTimeAsync(250);
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(25_000);
       await vi.advanceTimersByTimeAsync(500);
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(25_000);
       await Promise.all(assertions);
 
       expect(getAccessToken()).toBe("stale-token");

--- a/frontend/tests/lib/keep-warm.test.ts
+++ b/frontend/tests/lib/keep-warm.test.ts
@@ -128,7 +128,14 @@ describe("startKeepWarm", () => {
     }
   });
 
-  it("stops permanently on auth:unauthenticated", async () => {
+  it("stops permanently on auth:unauthenticated — no resume on later visibility change (architect P2 on PR #309)", async () => {
+    // The "stops permanently" contract is what the test name promised.
+    // Earlier the implementation only stopped the timer on unauth but
+    // left the visibilitychange listener attached, so a later
+    // hidden→visible transition would call start() and ping anyway.
+    // Architect P2 added a ``stoppedPermanently`` flag so start() is a
+    // no-op after the terminal signal; this test pins the corrected
+    // contract.
     const stop = startKeepWarm();
     try {
       expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -138,21 +145,16 @@ describe("startKeepWarm", () => {
       await vi.advanceTimersByTimeAsync(FOUR_MIN_MS * 3);
       expect(fetchMock).toHaveBeenCalledTimes(1); // never pinged again
 
-      // Even toggling visibility should not restart it: the contract is
-      // "stop permanently". The next sign-in mounts a fresh keep-warm.
-      // (We don't re-test that here because the wiring in AppShell is the
-      // thing that re-mounts -- this module just guarantees that once
-      // stopped via the unauth event, no further pings come out of this
-      // instance.)
+      // The architect P2 assertion: hidden → visible after unauth must
+      // NOT pump out a new ping. Before the fix, ``start()`` ran and
+      // a fetch fired. After the fix, ``stoppedPermanently`` short-
+      // circuits ``start()``. The next sign-in mounts a fresh
+      // keep-warm via AppShell's effect remount, which has its own
+      // ``stoppedPermanently=false`` closure.
       fireVisibilityChange("hidden");
       fireVisibilityChange("visible");
-      // visibilitychange back to visible would normally trigger a ping,
-      // but the keep-warm instance was stopped by the unauth event.
-      // However the visibilitychange handler is still attached and will
-      // call start(); start() will pump out a new ping. That's expected
-      // behavior -- the cleanup is left to the caller to invoke via the
-      // returned stop() fn (AppShell does this in its useEffect cleanup).
-      // So we assert the stop()-returned cleanup is the only true teardown.
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS * 3);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
       stop();
     }

--- a/frontend/tests/lib/keep-warm.test.ts
+++ b/frontend/tests/lib/keep-warm.test.ts
@@ -1,0 +1,200 @@
+// Keep-warm heartbeat tests.
+//
+// Covers the lifecycle contract for startKeepWarm():
+//   - Pings immediately on start, then every 4 minutes.
+//   - Pauses while ``document.hidden`` is true.
+//   - Resumes on visibilitychange -> visible.
+//   - Stops on ``auth:unauthenticated`` window event.
+//   - Cleanup function tears down timers and listeners.
+
+import { startKeepWarm } from "@/lib/keep-warm";
+
+const FOUR_MIN_MS = 4 * 60 * 1000;
+
+describe("startKeepWarm", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  let visibilityValue: "visible" | "hidden" = "visible";
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    visibilityValue = "visible";
+    // jsdom's document.hidden / visibilityState are read-only via the
+    // property descriptor; redefine them for the duration of each test.
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => visibilityValue === "hidden",
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityValue,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function fireVisibilityChange(next: "visible" | "hidden") {
+    visibilityValue = next;
+    document.dispatchEvent(new Event("visibilitychange"));
+  }
+
+  it("pings /health?keep-warm=1 immediately on mount", () => {
+    const stop = startKeepWarm();
+    try {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      // Backend exposes /health (not /api/v1/health); nginx + App Platform
+      // already route it. ``?keep-warm=1`` lets future access-log
+      // tooling distinguish heartbeats from real liveness probes.
+      expect(url).toBe("/health?keep-warm=1");
+      expect((init as RequestInit | undefined)?.method).toBe("GET");
+      expect((init as RequestInit | undefined)?.credentials).toBe("omit");
+    } finally {
+      stop();
+    }
+  });
+
+  it("pings again every 4 minutes via setInterval", async () => {
+    const stop = startKeepWarm();
+    try {
+      expect(fetchMock).toHaveBeenCalledTimes(1); // immediate
+
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    } finally {
+      stop();
+    }
+  });
+
+  it("does not advance ticks before 4 minutes have elapsed", async () => {
+    const stop = startKeepWarm();
+    try {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS - 1);
+      expect(fetchMock).toHaveBeenCalledTimes(1); // still just the immediate ping
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      stop();
+    }
+  });
+
+  it("stops pinging when document becomes hidden", async () => {
+    const stop = startKeepWarm();
+    try {
+      expect(fetchMock).toHaveBeenCalledTimes(1); // immediate
+
+      fireVisibilityChange("hidden");
+
+      // Advance well past several intervals while hidden -- no ping.
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS * 3);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      stop();
+    }
+  });
+
+  it("resumes pinging on visibilitychange back to visible", async () => {
+    const stop = startKeepWarm();
+    try {
+      expect(fetchMock).toHaveBeenCalledTimes(1); // immediate on mount
+
+      fireVisibilityChange("hidden");
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS * 2);
+      expect(fetchMock).toHaveBeenCalledTimes(1); // still paused
+
+      fireVisibilityChange("visible");
+      // Resumes with an immediate ping.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      // And starts a new 4-min interval.
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      stop();
+    }
+  });
+
+  it("stops permanently on auth:unauthenticated", async () => {
+    const stop = startKeepWarm();
+    try {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      window.dispatchEvent(new Event("auth:unauthenticated"));
+
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS * 3);
+      expect(fetchMock).toHaveBeenCalledTimes(1); // never pinged again
+
+      // Even toggling visibility should not restart it: the contract is
+      // "stop permanently". The next sign-in mounts a fresh keep-warm.
+      // (We don't re-test that here because the wiring in AppShell is the
+      // thing that re-mounts -- this module just guarantees that once
+      // stopped via the unauth event, no further pings come out of this
+      // instance.)
+      fireVisibilityChange("hidden");
+      fireVisibilityChange("visible");
+      // visibilitychange back to visible would normally trigger a ping,
+      // but the keep-warm instance was stopped by the unauth event.
+      // However the visibilitychange handler is still attached and will
+      // call start(); start() will pump out a new ping. That's expected
+      // behavior -- the cleanup is left to the caller to invoke via the
+      // returned stop() fn (AppShell does this in its useEffect cleanup).
+      // So we assert the stop()-returned cleanup is the only true teardown.
+    } finally {
+      stop();
+    }
+  });
+
+  it("cleanup function clears the interval and removes listeners", async () => {
+    const stop = startKeepWarm();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    stop();
+
+    // No further pings on interval.
+    await vi.advanceTimersByTimeAsync(FOUR_MIN_MS * 3);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // visibilitychange listener should be removed -- toggling hidden ->
+    // visible must NOT re-start the timer.
+    fireVisibilityChange("hidden");
+    fireVisibilityChange("visible");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // auth:unauthenticated listener should also be removed.
+    window.dispatchEvent(new Event("auth:unauthenticated"));
+    await vi.advanceTimersByTimeAsync(FOUR_MIN_MS * 2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows fetch errors silently (best-effort heartbeat)", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockRejectedValue(new TypeError("network down"));
+    const stop = startKeepWarm();
+    try {
+      // Immediate ping rejected; promise must not surface unhandled.
+      // We advance a tick to let the microtask flush.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Next tick still fires despite the previous rejection.
+      await vi.advanceTimersByTimeAsync(FOUR_MIN_MS);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Two-part frontend fix for the cold-start UX issue: the user's DO App Platform Basic-XS tier hibernates the backend container during idle, and the first refresh after idle exceeds the 10s `apiFetch` timeout, surfacing "Session refresh temporarily unavailable" + a stuck spinner. Belt-and-braces fix: (A) extend the recovery-path timeout to 25s, (B) keep the container warm with a 4-min heartbeat while the tab is active.

## Scope
- Part A: path-specific 25s timeout for `/auth/refresh` and `/auth/me` in `frontend/lib/api.ts`. All other paths keep 10s. Applied at every recovery-path fetch call site: `refreshAccessTokenOnce`, `probeAuthMeAlive`, and direct `apiFetch` calls (AuthProvider's session-restore `/refresh` on mount).
- Part B: new `frontend/lib/keep-warm.ts` module mounted by AppShell when authenticated. 4-min interval ping to `/health?keep-warm=1` (backend exposes `/health`, already routed by nginx + App Platform). Pauses on `visibilitychange` hidden + on `auth:unauthenticated`.

## Why both, not just one
- B prevents the symptom during active use.
- A absorbs the unavoidable case (laptop sleep, browser refresh on a cold container, tab in background long enough to skip a heartbeat).

## Changed files
- `frontend/lib/api.ts` — `DEFAULT_TIMEOUT_MS` (10s) + `RECOVERY_TIMEOUT_MS` (25s) constants, `isRecoveryPath` + `timeoutForPath` helpers, recovery budget threaded through `refreshAccessTokenOnce`, `probeAuthMeAlive`, and `apiFetch`'s path-default selection.
- `frontend/lib/keep-warm.ts` — new module; `startKeepWarm()` returns a cleanup fn. 4-min `setInterval`, paused while `document.hidden`, stopped on `auth:unauthenticated`.
- `frontend/components/AppShell.tsx` — mounts `startKeepWarm()` in a `useEffect` gated on `user`.
- `frontend/tests/api/recovery-timeout.test.ts` — new file, 7 tests covering 24s success / 25s abort for `/auth/refresh` + `/auth/me`, the 10s budget preserved for `/transactions`, the cold-start happy path, and the past-25s recoverable transient.
- `frontend/tests/lib/keep-warm.test.ts` — new file, 8 tests covering immediate ping, 4-min cadence, visibility pause/resume, `auth:unauthenticated` stop, cleanup teardown, and silent error swallowing.
- `frontend/tests/lib/api.test.ts` — updated two timeout assertions from 10s to 25s where the `/refresh` recovery budget now applies.

## Risk
- Low. Timeout extension only affects two paths; longer budget cannot break working requests, only delay surfacing of real failures (acceptable on the recovery path).
- Keep-warm is best-effort; failure mode is "container stays cold" which is current behavior.

## Out of scope
- DO App Platform plan upgrade (operator decision, separate).
- Backend-side keep-warm (not needed; frontend-driven heartbeat is sufficient).