### PR TITLE
feat(auth): idle-recovery — 45s timeout + observability events

### DIFF
--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -174,10 +174,16 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   // outcome ok/terminal/transient + durationMs) and
   // ``auth:retry-after-refresh`` after the original 401'd request is
   // retried with the new bearer (with the retry's path + status).
-  // AppShell pipes both into the structured JSON logger so production
-  // can confirm the silent-refresh chain is recovering AND so the
-  // 28s tail (or whatever the current tail is) is visible per-event
-  // without instrumenting every page's fetcher individually.
+  //
+  // Today this subscription pipes both into ``@/lib/logger``, which
+  // in the browser writes to ``console.*`` only — App Platform's log
+  // shipper captures backend stdout/stderr, NOT browser console, so
+  // these events DO NOT reach production logs yet. The subscription
+  // is kept as the hook point so a follow-up can wire a real
+  // client-telemetry sink (POST to a backend collector, batched +
+  // rate-limited) without touching apiFetch or every consumer. For
+  // local development the browser console emission already makes
+  // the chain visible in DevTools.
   useEffect(() => {
     const onRefreshAttempt = (e: Event) => {
       const detail = (e as CustomEvent<RefreshAttemptDetail>).detail;

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -34,6 +34,11 @@ import TrialBanner from "@/components/ui/TrialBanner";
 import { hasPlatformPermission } from "@/lib/auth";
 import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { startKeepWarm } from "@/lib/keep-warm";
+import { logger } from "@/lib/logger";
+import type {
+  RefreshAttemptDetail,
+  RetryAfterRefreshDetail,
+} from "@/lib/api";
 
 // Shared sizing/stroke for the sidebar nav icons. Matches the previous
 // Heroicons-outline visuals (1.5 stroke, 18×18) so the swap to Lucide is
@@ -163,6 +168,48 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     if (!user) return;
     return startKeepWarm();
   }, [user]);
+
+  // 2026-05-18 idle-recovery observability. apiFetch dispatches
+  // ``auth:refresh-attempt`` per refresh attempt (with attempt index +
+  // outcome ok/terminal/transient + durationMs) and
+  // ``auth:retry-after-refresh`` after the original 401'd request is
+  // retried with the new bearer (with the retry's path + status).
+  // AppShell pipes both into the structured JSON logger so production
+  // can confirm the silent-refresh chain is recovering AND so the
+  // 28s tail (or whatever the current tail is) is visible per-event
+  // without instrumenting every page's fetcher individually.
+  useEffect(() => {
+    const onRefreshAttempt = (e: Event) => {
+      const detail = (e as CustomEvent<RefreshAttemptDetail>).detail;
+      const level =
+        detail.outcome === "ok"
+          ? "info"
+          : detail.outcome === "terminal"
+            ? "warn"
+            : "warn"; // transient counts as warn too — repeated transients deserve attention
+      logger[level]("auth.refresh-attempt", {
+        attempt: detail.attempt,
+        outcome: detail.outcome,
+        status: detail.status,
+        duration_ms: Math.round(detail.durationMs),
+      });
+    };
+    const onRetryAfterRefresh = (e: Event) => {
+      const detail = (e as CustomEvent<RetryAfterRefreshDetail>).detail;
+      logger[detail.ok ? "info" : "warn"]("auth.retry-after-refresh", {
+        path: detail.path,
+        status: detail.status,
+        ok: detail.ok,
+        duration_ms: Math.round(detail.durationMs),
+      });
+    };
+    window.addEventListener("auth:refresh-attempt", onRefreshAttempt);
+    window.addEventListener("auth:retry-after-refresh", onRetryAfterRefresh);
+    return () => {
+      window.removeEventListener("auth:refresh-attempt", onRefreshAttempt);
+      window.removeEventListener("auth:retry-after-refresh", onRetryAfterRefresh);
+    };
+  }, []);
 
   // L3.3 first-run wizard. Bounce authenticated users whose backend
   // explicitly tells us they have not onboarded yet (`onboarded_at`

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -57,12 +57,27 @@ type RefreshResult =
   | { ok: false; kind: "terminal"; status: number }
   | { ok: false; kind: "transient"; error: Error; status?: number };
 
-// 2026-05-18 idle-recovery observability: every refresh attempt AND
-// every retry-after-refresh fires a CustomEvent on window so prod
-// can wire up logging AND tests can assert no swallowed failures.
-// Lightweight — no React, no Suspense, no third-party metrics SDK.
-// Gated on ``typeof window !== "undefined"`` so SSR / vitest jsdom
-// without window doesn't NPE.
+// 2026-05-18 idle-recovery observability hooks. apiFetch fires
+// CustomEvents on window for every refresh attempt and every
+// retry-after-refresh. Lightweight — no React, no Suspense, no
+// third-party metrics SDK. Gated on ``typeof window !== "undefined"``
+// so SSR / vitest jsdom without window doesn't NPE.
+//
+// Subscribers today:
+//   - tests/api/recovery-timeout.test.ts (regression tests pin the
+//     end-to-end contract: 28s tail → /refresh ok → original replays)
+//   - tests/lib/api.test.ts (singleflight + retry budget pins)
+//   - components/AppShell.tsx pipes them into the structured JSON
+//     logger, which today emits to the BROWSER console only. App
+//     Platform's log shipper captures backend stdout/stderr, NOT
+//     browser console output, so these events do not yet reach
+//     production logs. A follow-up will wire a real client-telemetry
+//     sink (POST to a backend collector, batched, rate-limited,
+//     PII-redacted at source per the redaction notes below).
+//
+// PII contract: the ``path`` field on RetryAfterRefreshDetail is
+// stripped of query string + fragment BEFORE dispatch (see the
+// retry-after-refresh dispatch site for the rationale).
 export interface RefreshAttemptDetail {
   attempt: number;          // 1-indexed: 1 = initial, 2 = 1st retry, 3 = 2nd retry
   outcome: "ok" | "terminal" | "transient";
@@ -71,7 +86,13 @@ export interface RefreshAttemptDetail {
 }
 
 export interface RetryAfterRefreshDetail {
-  path: string;             // The original 401-ing path (relative to API_URL)
+  /**
+   * Pathname of the original 401-ing request. Query string and
+   * fragment are stripped at dispatch time so the event detail
+   * never carries user-entered values (e.g. transaction search
+   * terms). Subscribers receive the route signature only.
+   */
+  path: string;
   status: number;           // Final response status after the retry
   ok: boolean;              // Convenience: status in [200, 300)
   durationMs: number;       // Wall-clock elapsed for the retry fetch
@@ -355,15 +376,26 @@ export async function apiFetch<T>(
         },
         effectiveTimeout,
       );
-      // 2026-05-18 idle-recovery observability: every retry-after-
-      // refresh fires a CustomEvent so prod can confirm the
-      // singleflight handed the new bearer to the original 401'd
-      // request AND the retry actually completed. Without this, a
-      // page-level silent .catch(() => {}) on the original fetcher
-      // would mask retry failures entirely.
+      // 2026-05-18 idle-recovery observability hook. Subscribers
+      // (today: AppShell's browser-console logger; tomorrow: a real
+      // client-telemetry sink) can confirm the singleflight handed
+      // the new bearer to the original 401'd request AND the retry
+      // actually completed. Without this, a page-level silent
+      // ``.catch(() => {})`` on the original fetcher would mask
+      // retry failures entirely.
+      //
+      // PII redaction: ``path`` as passed in by callers can include
+      // user-entered values in the query string (e.g.
+      // ``/api/v1/transactions?q=mortgage`` carries a search term
+      // entered into the transactions filter). Strip the query
+      // string (and any fragment) BEFORE dispatching so the event
+      // detail never exposes user input to telemetry consumers.
+      // Pathname alone is the route signature — enough for ops
+      // triage, none of the PII surface.
+      const safePath = path.split("?")[0].split("#")[0];
       const retryDurationMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - retryStartedAt;
       dispatchAuthEvent<RetryAfterRefreshDetail>("auth:retry-after-refresh", {
-        path,
+        path: safePath,
         status: res.status,
         ok: res.ok,
         durationMs: retryDurationMs,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,11 +1,22 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 const DEFAULT_TIMEOUT_MS = 10_000;
-// Auth recovery paths (/auth/refresh, /auth/me) get a longer budget so the
-// first request after a hibernated DO App Platform Basic-XS backend doesn't
-// false-positive the 10s default during TLS handshake + cold container
-// boot. Applied only to the recovery paths; all other endpoints keep the
-// 10s default. See PR fix(frontend) cold-start.
-const RECOVERY_TIMEOUT_MS = 25_000;
+// Auth recovery paths (/auth/refresh, /auth/me, /auth/status) get a
+// longer budget so the first request after a hibernated DO App Platform
+// basic-xxs backend doesn't false-positive during TLS handshake + cold
+// container boot. Applied only to the recovery paths; all other
+// endpoints keep the 10s default.
+//
+// 2026-05-18 idle-recovery: bumped 25s → 45s after the production log
+// (deployment 7506c8ff at 10:32:55) showed /auth/refresh resolving at
+// 28s in the cold-start tail — the previous 25s budget aborted the
+// fetch right when the backend was about to send the response,
+// producing an orphaned 200 in the access log AND a frontend
+// "refresh_transient" 503 whose retry budget then had to recover.
+// The dashboard's silent .catch(() => {}) mount-loaders meant the
+// retry succeeded silently but the original /accounts and /categories
+// requests were never replayed visibly to the user. 45s gives the
+// observed tail enough headroom that a single attempt succeeds.
+const RECOVERY_TIMEOUT_MS = 45_000;
 // Back-compat alias retained for the rest of the module; existing callers
 // reference API_FETCH_TIMEOUT_MS in inline comments.
 const API_FETCH_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
@@ -45,6 +56,31 @@ type RefreshResult =
   | { ok: true; accessToken: string }
   | { ok: false; kind: "terminal"; status: number }
   | { ok: false; kind: "transient"; error: Error; status?: number };
+
+// 2026-05-18 idle-recovery observability: every refresh attempt AND
+// every retry-after-refresh fires a CustomEvent on window so prod
+// can wire up logging AND tests can assert no swallowed failures.
+// Lightweight — no React, no Suspense, no third-party metrics SDK.
+// Gated on ``typeof window !== "undefined"`` so SSR / vitest jsdom
+// without window doesn't NPE.
+export interface RefreshAttemptDetail {
+  attempt: number;          // 1-indexed: 1 = initial, 2 = 1st retry, 3 = 2nd retry
+  outcome: "ok" | "terminal" | "transient";
+  status?: number;          // HTTP status when known (terminal always; transient sometimes)
+  durationMs: number;       // Wall-clock elapsed for THIS attempt
+}
+
+export interface RetryAfterRefreshDetail {
+  path: string;             // The original 401-ing path (relative to API_URL)
+  status: number;           // Final response status after the retry
+  ok: boolean;              // Convenience: status in [200, 300)
+  durationMs: number;       // Wall-clock elapsed for the retry fetch
+}
+
+function dispatchAuthEvent<T>(name: string, detail: T): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(name, { detail }));
+}
 
 let refreshPromise: Promise<RefreshResult> | null = null;
 // Count of awaiters currently holding the in-flight refreshPromise. Used
@@ -126,11 +162,24 @@ async function fetchWithTimeout(
   }
 }
 
-async function refreshAccessTokenOnce(): Promise<RefreshResult> {
+async function refreshAccessTokenOnce(attempt: number): Promise<RefreshResult> {
+  const startedAt = (typeof performance !== "undefined" ? performance.now() : Date.now());
+  const emit = (result: RefreshResult): RefreshResult => {
+    const durationMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - startedAt;
+    const detail: RefreshAttemptDetail = result.ok
+      ? { attempt, outcome: "ok", durationMs }
+      : result.kind === "terminal"
+        ? { attempt, outcome: "terminal", status: result.status, durationMs }
+        : { attempt, outcome: "transient", status: result.status, durationMs };
+    dispatchAuthEvent<RefreshAttemptDetail>("auth:refresh-attempt", detail);
+    return result;
+  };
+
   let res: Response;
   try {
-    // 25s recovery budget (vs 10s default) so a hibernated backend cold
-    // start with TLS handshake + container boot doesn't false-positive.
+    // 45s recovery budget so a hibernated backend cold start with TLS
+    // handshake + container boot doesn't false-positive at the
+    // observed 28s tail. See RECOVERY_TIMEOUT_MS comment.
     res = await fetchWithTimeout(
       `${API_URL}/api/v1/auth/refresh`,
       {
@@ -141,48 +190,48 @@ async function refreshAccessTokenOnce(): Promise<RefreshResult> {
     );
   } catch (err) {
     // ApiTimeoutError, TypeError (network), AbortError -- all transient.
-    return {
+    return emit({
       ok: false,
       kind: "transient",
       error: err instanceof Error ? err : new Error(String(err)),
-    };
+    });
   }
 
   if (res.status === 401 || res.status === 403) {
-    return { ok: false, kind: "terminal", status: res.status };
+    return emit({ ok: false, kind: "terminal", status: res.status });
   }
 
   if (!res.ok) {
-    return {
+    return emit({
       ok: false,
       kind: "transient",
       error: new Error(`refresh returned ${res.status}`),
       status: res.status,
-    };
+    });
   }
 
   let data: { access_token?: string };
   try {
     data = await res.json();
   } catch (err) {
-    return {
+    return emit({
       ok: false,
       kind: "transient",
       error: err instanceof Error ? err : new Error("invalid JSON"),
-    };
+    });
   }
 
   if (!data.access_token) {
     // 200 OK but no access_token: protocol failure, not auth death.
-    return {
+    return emit({
       ok: false,
       kind: "transient",
       error: new Error("refresh succeeded without access_token"),
-    };
+    });
   }
 
   accessToken = data.access_token;
-  return { ok: true, accessToken: data.access_token };
+  return emit({ ok: true, accessToken: data.access_token });
 }
 
 // Retry budget wrapper. Re-runs refreshAccessTokenOnce up to
@@ -190,13 +239,13 @@ async function refreshAccessTokenOnce(): Promise<RefreshResult> {
 // (network/timeout/5xx/JSON parse/protocol). Terminal 401/403 short-
 // circuits immediately -- those mean the refresh cookie is dead.
 async function refreshAccessToken(): Promise<RefreshResult> {
-  let last: RefreshResult = await refreshAccessTokenOnce();
+  let last: RefreshResult = await refreshAccessTokenOnce(1);
   for (let attempt = 1; attempt <= REFRESH_TRANSIENT_RETRIES; attempt++) {
     if (last.ok || last.kind === "terminal") return last;
     // Exponential backoff: 250ms, 500ms.
     const delay = REFRESH_BACKOFF_BASE_MS * 2 ** (attempt - 1);
     await new Promise<void>((resolve) => setTimeout(resolve, delay));
-    last = await refreshAccessTokenOnce();
+    last = await refreshAccessTokenOnce(attempt + 1);
   }
   return last;
 }
@@ -296,6 +345,7 @@ export async function apiFetch<T>(
 
     if (refreshResult.ok) {
       headers.set("Authorization", `Bearer ${refreshResult.accessToken}`);
+      const retryStartedAt = (typeof performance !== "undefined" ? performance.now() : Date.now());
       res = await fetchWithTimeout(
         `${API_URL}${path}`,
         {
@@ -305,6 +355,19 @@ export async function apiFetch<T>(
         },
         effectiveTimeout,
       );
+      // 2026-05-18 idle-recovery observability: every retry-after-
+      // refresh fires a CustomEvent so prod can confirm the
+      // singleflight handed the new bearer to the original 401'd
+      // request AND the retry actually completed. Without this, a
+      // page-level silent .catch(() => {}) on the original fetcher
+      // would mask retry failures entirely.
+      const retryDurationMs = (typeof performance !== "undefined" ? performance.now() : Date.now()) - retryStartedAt;
+      dispatchAuthEvent<RetryAfterRefreshDetail>("auth:retry-after-refresh", {
+        path,
+        status: res.status,
+        ok: res.ok,
+        durationMs: retryDurationMs,
+      });
       // Retry attempted; fall through to normal !res.ok handling below.
     } else if (refreshResult.kind === "terminal") {
       // Ambiguous-401 defense: before dispatching auth:unauthenticated,

--- a/frontend/tests/api/recovery-timeout.test.ts
+++ b/frontend/tests/api/recovery-timeout.test.ts
@@ -429,8 +429,10 @@ describe("apiFetch recovery-path timeout", () => {
 
   it("retry-after-refresh event carries the original path AND the retry status", async () => {
     // Even when the retry comes back non-2xx (rare but possible —
-    // e.g. backend authz changed mid-refresh), the event should
-    // surface that so prod can spot it.
+    // e.g. backend authz changed mid-refresh), the event detail
+    // must surface that status so any subscriber can react. (Today:
+    // tests + the browser-console logger in AppShell; tomorrow: a
+    // real client-telemetry sink — see RetryAfterRefreshDetail.)
     vi.useFakeTimers();
     const events: Array<{ type: string; detail: unknown }> = [];
     const recorder = (e: Event) => {

--- a/frontend/tests/api/recovery-timeout.test.ts
+++ b/frontend/tests/api/recovery-timeout.test.ts
@@ -464,4 +464,80 @@ describe("apiFetch recovery-path timeout", () => {
       vi.useRealTimers();
     }
   });
+
+  // ── 2026-05-18 idle-recovery P2 review fix: PII redaction ────────────────
+  //
+  // Authenticated paths may include user-entered values in the query
+  // string (e.g. /api/v1/transactions?q=<search term> carries the
+  // transactions filter the user typed; /api/v1/categories?name=<...>
+  // carries a category name; etc.). The retry-after-refresh event
+  // MUST strip the query string + fragment before dispatch so the
+  // detail never carries user input to telemetry consumers. The
+  // route signature (pathname) is enough for ops triage.
+
+  it("retry-after-refresh strips query string from path (PII redaction)", async () => {
+    vi.useFakeTimers();
+    const events: Array<{ path: string }> = [];
+    const recorder = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { path: string };
+      events.push({ path: detail.path });
+    };
+    window.addEventListener("auth:retry-after-refresh", recorder);
+
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+        .mockResolvedValueOnce(jsonResponse({ access_token: "fresh-token" }))
+        .mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      // Path carries a search term that should NEVER reach telemetry.
+      const promise = apiFetch(
+        "/api/v1/transactions?q=mortgage-payment&date_from=2026-01-01",
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(promise).resolves.toEqual({ items: [] });
+
+      expect(events).toHaveLength(1);
+      // Pathname only — no query string, no fragment.
+      expect(events[0].path).toBe("/api/v1/transactions");
+      expect(events[0].path).not.toContain("?");
+      expect(events[0].path).not.toContain("mortgage-payment");
+      expect(events[0].path).not.toContain("date_from");
+    } finally {
+      window.removeEventListener("auth:retry-after-refresh", recorder);
+      vi.useRealTimers();
+    }
+  });
+
+  it("retry-after-refresh strips URL fragment too", async () => {
+    // Fragments don't reach the server, but a caller could plausibly
+    // pass one (e.g. a deep-link route). Defence-in-depth: strip it.
+    vi.useFakeTimers();
+    const events: Array<{ path: string }> = [];
+    const recorder = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { path: string };
+      events.push({ path: detail.path });
+    };
+    window.addEventListener("auth:retry-after-refresh", recorder);
+
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+        .mockResolvedValueOnce(jsonResponse({ access_token: "fresh-token" }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const promise = apiFetch("/api/v1/categories#sensitive-anchor");
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      expect(events).toHaveLength(1);
+      expect(events[0].path).toBe("/api/v1/categories");
+      expect(events[0].path).not.toContain("#");
+    } finally {
+      window.removeEventListener("auth:retry-after-refresh", recorder);
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/tests/api/recovery-timeout.test.ts
+++ b/frontend/tests/api/recovery-timeout.test.ts
@@ -56,11 +56,11 @@ describe("apiFetch recovery-path timeout", () => {
       });
   }
 
-  it("apiFetch on /api/v1/auth/refresh succeeds when upstream resolves at 24s (under 25s budget)", async () => {
+  it("apiFetch on /api/v1/auth/refresh succeeds when upstream resolves at 24s (under 45s budget)", async () => {
     vi.useFakeTimers();
     try {
       fetchMock.mockImplementationOnce(
-        slowResponse(jsonResponse({ access_token: "fresh-token" }), 24_000),
+        slowResponse(jsonResponse({ access_token: "fresh-token" }), 44_000),
       );
 
       const promise = apiFetch<{ access_token: string }>("/api/v1/auth/refresh", {
@@ -69,7 +69,7 @@ describe("apiFetch recovery-path timeout", () => {
 
       // Advance the full 24s; upstream should resolve before the 25s
       // recovery timeout would have fired.
-      await vi.advanceTimersByTimeAsync(24_000);
+      await vi.advanceTimersByTimeAsync(44_000);
 
       await expect(promise).resolves.toEqual({ access_token: "fresh-token" });
     } finally {
@@ -77,12 +77,12 @@ describe("apiFetch recovery-path timeout", () => {
     }
   });
 
-  it("apiFetch on /api/v1/auth/refresh aborts at 25s when upstream is still pending", async () => {
+  it("apiFetch on /api/v1/auth/refresh aborts at 45s when upstream is still pending", async () => {
     vi.useFakeTimers();
     try {
       // Upstream wouldn't resolve until 26s; AbortController fires at 25s.
       fetchMock.mockImplementationOnce(
-        slowResponse(jsonResponse({ access_token: "too-late" }), 26_000),
+        slowResponse(jsonResponse({ access_token: "too-late" }), 46_000),
       );
 
       const promise = apiFetch<{ access_token: string }>("/api/v1/auth/refresh", {
@@ -94,7 +94,7 @@ describe("apiFetch recovery-path timeout", () => {
       });
 
       // 24999ms: still pending.
-      await vi.advanceTimersByTimeAsync(24_999);
+      await vi.advanceTimersByTimeAsync(44_999);
       // The 25000th ms: AbortController triggers, fetch rejects with
       // AbortError, fetchWithTimeout maps to ApiTimeoutError.
       await vi.advanceTimersByTimeAsync(1);
@@ -104,17 +104,17 @@ describe("apiFetch recovery-path timeout", () => {
     }
   });
 
-  it("apiFetch on /api/v1/auth/me succeeds when upstream resolves at 24s (under 25s budget)", async () => {
+  it("apiFetch on /api/v1/auth/me succeeds when upstream resolves at 24s (under 45s budget)", async () => {
     vi.useFakeTimers();
     try {
       setAccessToken("valid-token");
       fetchMock.mockImplementationOnce(
-        slowResponse(jsonResponse({ id: 1, email: "x@y.z" }), 24_000),
+        slowResponse(jsonResponse({ id: 1, email: "x@y.z" }), 44_000),
       );
 
       const promise = apiFetch<{ id: number; email: string }>("/api/v1/auth/me");
 
-      await vi.advanceTimersByTimeAsync(24_000);
+      await vi.advanceTimersByTimeAsync(44_000);
 
       await expect(promise).resolves.toEqual({ id: 1, email: "x@y.z" });
     } finally {
@@ -122,12 +122,12 @@ describe("apiFetch recovery-path timeout", () => {
     }
   });
 
-  it("apiFetch on /api/v1/auth/me aborts at 25s when upstream is still pending", async () => {
+  it("apiFetch on /api/v1/auth/me aborts at 45s when upstream is still pending", async () => {
     vi.useFakeTimers();
     try {
       setAccessToken("valid-token");
       fetchMock.mockImplementationOnce(
-        slowResponse(jsonResponse({ id: 1 }), 26_000),
+        slowResponse(jsonResponse({ id: 1 }), 46_000),
       );
 
       const promise = apiFetch("/api/v1/auth/me");
@@ -135,7 +135,7 @@ describe("apiFetch recovery-path timeout", () => {
         name: "ApiTimeoutError",
       });
 
-      await vi.advanceTimersByTimeAsync(24_999);
+      await vi.advanceTimersByTimeAsync(44_999);
       await vi.advanceTimersByTimeAsync(1);
       await assertion;
     } finally {
@@ -148,19 +148,19 @@ describe("apiFetch recovery-path timeout", () => {
     // that times out at 10s on a cold container, the restore chain
     // (status → refresh → me) never reaches /refresh and the user
     // sees a generic 503 from the unauthed path instead of the
-    // recovery path. /auth/status must share the 25s recovery
+    // recovery path. /auth/status must share the 45s recovery
     // budget with /refresh and /me.
     vi.useFakeTimers();
     try {
       fetchMock.mockImplementationOnce(
-        slowResponse(jsonResponse({ needs_setup: false }), 24_000),
+        slowResponse(jsonResponse({ needs_setup: false }), 44_000),
       );
 
       const promise = apiFetch<{ needs_setup: boolean }>(
         "/api/v1/auth/status",
       );
 
-      await vi.advanceTimersByTimeAsync(24_000);
+      await vi.advanceTimersByTimeAsync(44_000);
 
       await expect(promise).resolves.toEqual({ needs_setup: false });
     } finally {
@@ -168,11 +168,11 @@ describe("apiFetch recovery-path timeout", () => {
     }
   });
 
-  it("apiFetch on /api/v1/auth/status aborts at 25s when upstream is still pending", async () => {
+  it("apiFetch on /api/v1/auth/status aborts at 45s when upstream is still pending", async () => {
     vi.useFakeTimers();
     try {
       fetchMock.mockImplementationOnce(
-        slowResponse(jsonResponse({ needs_setup: false }), 26_000),
+        slowResponse(jsonResponse({ needs_setup: false }), 46_000),
       );
 
       const promise = apiFetch("/api/v1/auth/status");
@@ -180,7 +180,7 @@ describe("apiFetch recovery-path timeout", () => {
         name: "ApiTimeoutError",
       });
 
-      await vi.advanceTimersByTimeAsync(24_999);
+      await vi.advanceTimersByTimeAsync(44_999);
       await vi.advanceTimersByTimeAsync(1);
       await assertion;
     } finally {
@@ -215,7 +215,7 @@ describe("apiFetch recovery-path timeout", () => {
   it("refresh-recovery path: 401 -> /refresh resolves at 24s -> retry succeeds (cold-start scenario)", async () => {
     // Belt-and-braces realism: a primary 401 on /api/v1/transactions triggers
     // the silent /refresh flow. The /refresh call takes 24s (just under the
-    // 25s recovery budget) because the backend container was hibernating;
+    // 45s recovery budget) because the backend container was hibernating;
     // under the old 10s default this would have aborted and dispatched the
     // "refresh_transient" 503. Under the new budget the refresh succeeds
     // and the original request is retried with the fresh token.
@@ -225,50 +225,242 @@ describe("apiFetch recovery-path timeout", () => {
       fetchMock
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary 401
         .mockImplementationOnce(
-          slowResponse(jsonResponse({ access_token: "fresh-token" }), 24_000),
+          slowResponse(jsonResponse({ access_token: "fresh-token" }), 44_000),
         )
         .mockResolvedValueOnce(jsonResponse({ items: [] }));                          // retry OK
 
       const promise = apiFetch<{ items: unknown[] }>("/api/v1/transactions");
 
-      await vi.advanceTimersByTimeAsync(24_000);
+      await vi.advanceTimersByTimeAsync(44_000);
 
       await expect(promise).resolves.toEqual({ items: [] });
-      expect(dispatchEventSpy).not.toHaveBeenCalled();
+      // 2026-05-18: the new auth:refresh-attempt + auth:retry-after-
+      // refresh events DO fire (logging observability), but the
+      // pre-existing intent of this assertion was "no
+      // auth:unauthenticated escapes when the session is alive."
+      // Narrow accordingly.
+      expect(
+        dispatchEventSpy.mock.calls.some(
+          ([e]) => (e as Event).type === "auth:unauthenticated",
+        ),
+      ).toBe(false);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("refresh-recovery path: 401 -> /refresh hangs past 25s -> recoverable 503 (terminal-budget case)", async () => {
-    // Past the 25s budget the refresh still aborts -- this is the
+  it("refresh-recovery path: 401 -> /refresh hangs past 45s -> recoverable 503 (terminal-budget case)", async () => {
+    // Past the 45s budget the refresh still aborts -- this is the
     // recoverable transient case, not auth death.
     vi.useFakeTimers();
     try {
       setAccessToken("stale-token");
       fetchMock
         .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 })) // primary
-        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 30_000))
-        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 30_000))
-        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 30_000));
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 50_000))
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 50_000))
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 50_000));
 
       const promise = apiFetch("/api/v1/protected");
       const assertion = expect(promise).rejects.toBeInstanceOf(ApiResponseError);
 
-      // Advance through three 25s recovery timeouts + 250ms + 500ms backoffs.
-      await vi.advanceTimersByTimeAsync(25_000);
+      // Advance through three 45s recovery timeouts + 250ms + 500ms backoffs.
+      await vi.advanceTimersByTimeAsync(45_000);
       await vi.advanceTimersByTimeAsync(250);
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await vi.advanceTimersByTimeAsync(500);
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await assertion;
 
       await expect(promise).rejects.toMatchObject({
         status: 503,
         code: "refresh_transient",
       });
-      expect(dispatchEventSpy).not.toHaveBeenCalled();
+      // Transient refresh exhaustion must NOT escalate to logout.
+      // The new auth:refresh-attempt events fire as observability;
+      // we only care that auth:unauthenticated did not.
+      expect(
+        dispatchEventSpy.mock.calls.some(
+          ([e]) => (e as Event).type === "auth:unauthenticated",
+        ),
+      ).toBe(false);
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ── 2026-05-18 idle-recovery: 28s tail replay regression ─────────────────
+  //
+  // Production log (deployment 7506c8ff at 10:32:55 GMT, basic-xxs
+  // backend, ~30 min user idle) showed:
+  //
+  //   10:32:55.226  GET  /api/v1/accounts     401  (access token expired)
+  //   10:32:55.332  GET  /api/v1/categories   401
+  //   10:32:55.446  GET  /api/v1/categories   401
+  //   10:33:23.785  POST /api/v1/auth/refresh 200  (28s after the 401s)
+  //
+  // Under the previous 25s recovery budget the browser aborted the
+  // refresh fetch BEFORE the 28s backend response arrived; the
+  // backend logged 200 (orphaned) and the frontend logged a transient
+  // 503. apiFetch's retry-after-refresh path never fired because
+  // refreshResult.ok was never true on the first attempt — the
+  // singleflight saw a transient, and the original 401'd /accounts
+  // and /categories requests surfaced 503s into page-level silent
+  // .catch(() => {}) handlers.
+  //
+  // Under the new 45s budget, a 28s upstream resolves within budget,
+  // refreshAccessTokenOnce returns ok, the original request retries
+  // with the fresh bearer, AND the auth:retry-after-refresh event
+  // fires with the retry's 200 status. This test pins that contract
+  // end-to-end so a future regression of the timeout knob is caught.
+
+  it("28s observed tail: 401 -> /refresh resolves at 28s -> original request replays with new bearer", async () => {
+    vi.useFakeTimers();
+    const events: Array<{ type: string; detail: unknown }> = [];
+    const recorder = (e: Event) => {
+      if (
+        e.type === "auth:refresh-attempt"
+        || e.type === "auth:retry-after-refresh"
+      ) {
+        events.push({ type: e.type, detail: (e as CustomEvent).detail });
+      }
+    };
+    window.addEventListener("auth:refresh-attempt", recorder);
+    window.addEventListener("auth:retry-after-refresh", recorder);
+
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        // 1) Original /api/v1/accounts → 401 (access token expired
+        //    after ~15 min idle on basic-xxs).
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+        // 2) Silent /refresh → resolves at 28s, just under the new
+        //    45s recovery budget but well past the old 25s.
+        .mockImplementationOnce(
+          slowResponse(jsonResponse({ access_token: "fresh-token" }), 28_000),
+        )
+        // 3) Retry of /accounts with new bearer → 200.
+        .mockResolvedValueOnce(jsonResponse({ accounts: [{ id: 1, name: "Checking" }] }));
+
+      const promise = apiFetch<{ accounts: Array<{ id: number; name: string }> }>(
+        "/api/v1/accounts",
+      );
+
+      await vi.advanceTimersByTimeAsync(28_000);
+
+      await expect(promise).resolves.toEqual({
+        accounts: [{ id: 1, name: "Checking" }],
+      });
+
+      // The retry MUST have actually hit the network with the new
+      // bearer. Three fetch calls total: original, refresh, retry.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const retryHeaders = fetchMock.mock.calls[2]?.[1]?.headers as Headers;
+      expect(retryHeaders.get("Authorization")).toBe("Bearer fresh-token");
+
+      // Observability: exactly one auth:refresh-attempt with outcome
+      // "ok" (the single attempt succeeded — no retries), and exactly
+      // one auth:retry-after-refresh with status 200.
+      const refreshEvents = events.filter((e) => e.type === "auth:refresh-attempt");
+      expect(refreshEvents).toHaveLength(1);
+      expect(refreshEvents[0].detail).toMatchObject({
+        attempt: 1,
+        outcome: "ok",
+      });
+      const retryEvents = events.filter((e) => e.type === "auth:retry-after-refresh");
+      expect(retryEvents).toHaveLength(1);
+      expect(retryEvents[0].detail).toMatchObject({
+        path: "/api/v1/accounts",
+        status: 200,
+        ok: true,
+      });
+    } finally {
+      window.removeEventListener("auth:refresh-attempt", recorder);
+      window.removeEventListener("auth:retry-after-refresh", recorder);
+      vi.useRealTimers();
+    }
+  });
+
+  it("refresh outcome events: each attempt dispatches auth:refresh-attempt with attempt index", async () => {
+    // Three transient outcomes (timeout, timeout, success) must
+    // dispatch three auth:refresh-attempt events with attempts
+    // 1, 2, 3 respectively.
+    vi.useFakeTimers();
+    const refreshEvents: Array<{ attempt: number; outcome: string }> = [];
+    const recorder = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { attempt: number; outcome: string };
+      refreshEvents.push({ attempt: detail.attempt, outcome: detail.outcome });
+    };
+    window.addEventListener("auth:refresh-attempt", recorder);
+
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+        // Attempt 1: aborts at 45s timeout.
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 50_000))
+        // Attempt 2: aborts at 45s timeout.
+        .mockImplementationOnce(slowResponse(jsonResponse({ access_token: "x" }), 50_000))
+        // Attempt 3: succeeds.
+        .mockResolvedValueOnce(jsonResponse({ access_token: "fresh" }))
+        // Retry of /protected with fresh bearer.
+        .mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const promise = apiFetch("/api/v1/protected");
+
+      await vi.advanceTimersByTimeAsync(45_000);  // attempt 1 abort
+      await vi.advanceTimersByTimeAsync(250);     // backoff
+      await vi.advanceTimersByTimeAsync(45_000);  // attempt 2 abort
+      await vi.advanceTimersByTimeAsync(500);     // backoff
+      // attempt 3 resolves synchronously (mockResolvedValueOnce).
+
+      await expect(promise).resolves.toEqual({ items: [] });
+
+      expect(refreshEvents).toEqual([
+        { attempt: 1, outcome: "transient" },
+        { attempt: 2, outcome: "transient" },
+        { attempt: 3, outcome: "ok" },
+      ]);
+    } finally {
+      window.removeEventListener("auth:refresh-attempt", recorder);
+      vi.useRealTimers();
+    }
+  });
+
+  it("retry-after-refresh event carries the original path AND the retry status", async () => {
+    // Even when the retry comes back non-2xx (rare but possible —
+    // e.g. backend authz changed mid-refresh), the event should
+    // surface that so prod can spot it.
+    vi.useFakeTimers();
+    const events: Array<{ type: string; detail: unknown }> = [];
+    const recorder = (e: Event) => {
+      events.push({ type: e.type, detail: (e as CustomEvent).detail });
+    };
+    window.addEventListener("auth:retry-after-refresh", recorder);
+
+    try {
+      setAccessToken("stale-token");
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, { status: 401 }))
+        .mockResolvedValueOnce(jsonResponse({ access_token: "fresh-token" }))
+        .mockResolvedValueOnce(jsonResponse({ detail: "forbidden" }, { status: 403 }));
+
+      const promise = apiFetch("/api/v1/admin/orgs");
+      const assertion = expect(promise).rejects.toMatchObject({
+        name: "ApiResponseError",
+        status: 403,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await assertion;
+
+      expect(events).toHaveLength(1);
+      expect(events[0].detail).toMatchObject({
+        path: "/api/v1/admin/orgs",
+        status: 403,
+        ok: false,
+      });
+    } finally {
+      window.removeEventListener("auth:retry-after-refresh", recorder);
       vi.useRealTimers();
     }
   });

--- a/frontend/tests/components/app-shell.test.tsx
+++ b/frontend/tests/components/app-shell.test.tsx
@@ -205,10 +205,14 @@ describe("AppShell — system nav gating", () => {
 //
 // apiFetch dispatches ``auth:refresh-attempt`` and
 // ``auth:retry-after-refresh`` CustomEvents on every silent-refresh
-// outcome. AppShell subscribes and pipes them into the structured
-// JSON logger so production can confirm the recovery chain works
-// AND so the 28s cold-start tail is visible per-event without
-// instrumenting every page's fetcher individually.
+// outcome. AppShell subscribes and pipes them into ``@/lib/logger``,
+// which in the browser writes to ``console.*`` only — App Platform's
+// log shipper captures backend stdout/stderr, NOT browser console,
+// so these events DO NOT reach production logs yet. The subscription
+// is kept as the hook point for a follow-up client-telemetry sink.
+// These tests pin the subscription's contract (info on ok / 2xx,
+// warn on transient/terminal/non-2xx) so the wiring is ready when
+// the sink lands.
 
 describe("AppShell — auth refresh observability", () => {
   const useAuthMock = vi.mocked(useAuth);

--- a/frontend/tests/components/app-shell.test.tsx
+++ b/frontend/tests/components/app-shell.test.tsx
@@ -2,6 +2,16 @@ import { act, render, screen } from "@testing-library/react";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { logger } from "@/lib/logger";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
 vi.mock("@/components/auth/AuthProvider", async () => {
   const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
@@ -188,5 +198,140 @@ describe("AppShell — system nav gating", () => {
     expect(screen.queryByText("Admin")).toBeNull();
     expect(screen.queryByText("Organizations")).toBeNull();
     expect(screen.queryByText("Audit log")).toBeNull();
+  });
+});
+
+// ── 2026-05-18 idle-recovery observability ──────────────────────────────
+//
+// apiFetch dispatches ``auth:refresh-attempt`` and
+// ``auth:retry-after-refresh`` CustomEvents on every silent-refresh
+// outcome. AppShell subscribes and pipes them into the structured
+// JSON logger so production can confirm the recovery chain works
+// AND so the 28s cold-start tail is visible per-event without
+// instrumenting every page's fetcher individually.
+
+describe("AppShell — auth refresh observability", () => {
+  const useAuthMock = vi.mocked(useAuth);
+  const loggerInfo = vi.mocked(logger.info);
+  const loggerWarn = vi.mocked(logger.warn);
+
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    loggerInfo.mockReset();
+    loggerWarn.mockReset();
+    useAuthMock.mockReturnValue({
+      user: BASE_USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("logs auth:refresh-attempt with attempt + outcome + duration", async () => {
+    await renderShell();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("auth:refresh-attempt", {
+          detail: { attempt: 1, outcome: "ok", durationMs: 28_412 },
+        }),
+      );
+    });
+
+    expect(loggerInfo).toHaveBeenCalledWith("auth.refresh-attempt", {
+      attempt: 1,
+      outcome: "ok",
+      status: undefined,
+      duration_ms: 28_412,
+    });
+  });
+
+  it("logs auth:refresh-attempt as warn when outcome is transient", async () => {
+    await renderShell();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("auth:refresh-attempt", {
+          detail: { attempt: 1, outcome: "transient", durationMs: 45_001 },
+        }),
+      );
+    });
+
+    expect(loggerWarn).toHaveBeenCalledWith("auth.refresh-attempt", {
+      attempt: 1,
+      outcome: "transient",
+      status: undefined,
+      duration_ms: 45_001,
+    });
+  });
+
+  it("logs auth:refresh-attempt as warn when outcome is terminal (401/403)", async () => {
+    await renderShell();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("auth:refresh-attempt", {
+          detail: { attempt: 1, outcome: "terminal", status: 401, durationMs: 120 },
+        }),
+      );
+    });
+
+    expect(loggerWarn).toHaveBeenCalledWith("auth.refresh-attempt", {
+      attempt: 1,
+      outcome: "terminal",
+      status: 401,
+      duration_ms: 120,
+    });
+  });
+
+  it("logs auth:retry-after-refresh with path + status + ok", async () => {
+    await renderShell();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("auth:retry-after-refresh", {
+          detail: {
+            path: "/api/v1/accounts",
+            status: 200,
+            ok: true,
+            durationMs: 87,
+          },
+        }),
+      );
+    });
+
+    expect(loggerInfo).toHaveBeenCalledWith("auth.retry-after-refresh", {
+      path: "/api/v1/accounts",
+      status: 200,
+      ok: true,
+      duration_ms: 87,
+    });
+  });
+
+  it("logs auth:retry-after-refresh as warn when retry was non-2xx", async () => {
+    await renderShell();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("auth:retry-after-refresh", {
+          detail: {
+            path: "/api/v1/admin/orgs",
+            status: 403,
+            ok: false,
+            durationMs: 95,
+          },
+        }),
+      );
+    });
+
+    expect(loggerWarn).toHaveBeenCalledWith("auth.retry-after-refresh", {
+      path: "/api/v1/admin/orgs",
+      status: 403,
+      ok: false,
+      duration_ms: 95,
+    });
   });
 });

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -16,6 +16,20 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 }
 
 
+// 2026-05-18 idle-recovery: apiFetch now emits auth:refresh-attempt and
+// auth:retry-after-refresh events on the silent-refresh path as
+// observability hooks. The pre-existing assertions used
+// `dispatchEventSpy).not.toHaveBeenCalled()` to mean "no spurious
+// auth:unauthenticated escapes". Narrow accordingly so the new
+// observability dispatches don't false-positive the assertion.
+function noAuthUnauthenticatedDispatched(
+  spy: { mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> } },
+): boolean {
+  return !spy.mock.calls.some(
+    (call) => (call[0] as Event).type === "auth:unauthenticated",
+  );
+}
+
 describe("apiFetch", () => {
   const fetchMock = vi.fn<typeof fetch>();
   const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
@@ -121,7 +135,7 @@ describe("apiFetch", () => {
       // but the session is intact, so the user can simply retry the same
       // call without being kicked back to /login.
       expect(getAccessToken()).toBe("fresh-token");
-      expect(dispatchEventSpy).not.toHaveBeenCalled();
+      expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);
       expect(fetchMock).toHaveBeenCalledTimes(3);  // primary + refresh + retry
     } finally {
       vi.useRealTimers();
@@ -200,7 +214,7 @@ describe("apiFetch", () => {
     });
 
     expect(getAccessToken()).toBe("fresh-token");
-    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);
   });
 
   // Architect-locked 2026-05-15: refreshAccessToken() now returns a
@@ -250,7 +264,7 @@ describe("apiFetch", () => {
     });
 
     expect(getAccessToken()).toBe("still-valid-token"); // PRESERVED
-    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);
   });
 
   it("refresh transient (TypeError, AbortError, then OK) retries within budget without logout", async () => {
@@ -270,7 +284,7 @@ describe("apiFetch", () => {
 
     expect(data).toEqual({ ok: true });
     expect(getAccessToken()).toBe("fresh-token");
-    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);
     // 1 primary + 3 refresh attempts + 1 retry = 5
     expect(fetchMock).toHaveBeenCalledTimes(5);
   });
@@ -296,15 +310,15 @@ describe("apiFetch", () => {
       });
 
       // Advance through all three 25s timeouts + 250ms + 500ms backoffs.
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await vi.advanceTimersByTimeAsync(250);
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await vi.advanceTimersByTimeAsync(500);
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await assertion;
 
       expect(getAccessToken()).toBe("stale-token");  // PRESERVED
-      expect(dispatchEventSpy).not.toHaveBeenCalled();  // NO event
+      expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);  // NO event
     } finally {
       vi.useRealTimers();
     }
@@ -325,7 +339,7 @@ describe("apiFetch", () => {
     });
 
     expect(getAccessToken()).toBe("stale-token");
-    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);
   });
 
   it("parallel 401 herd with transient refresh fires exactly one /refresh (and its retries) across all callers", async () => {
@@ -355,15 +369,15 @@ describe("apiFetch", () => {
       );
 
       // Refresh uses the 25s recovery budget across all 3 attempts.
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await vi.advanceTimersByTimeAsync(250);
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await vi.advanceTimersByTimeAsync(500);
-      await vi.advanceTimersByTimeAsync(25_000);
+      await vi.advanceTimersByTimeAsync(45_000);
       await Promise.all(assertions);
 
       expect(getAccessToken()).toBe("stale-token");
-      expect(dispatchEventSpy).not.toHaveBeenCalled();
+      expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);
       // 4 primaries + 3 refresh attempts (single-flight: shared across
       // all 4 callers) = 7 fetch calls total. The 4 callers do NOT each
       // fire their own /refresh.
@@ -436,7 +450,7 @@ describe("apiFetch", () => {
       message: "bad creds",
     });
 
-    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    expect(noAuthUnauthenticatedDispatched(dispatchEventSpy)).toBe(true);
   });
 
   it("flattens FastAPI 422 validation payloads into a readable message", async () => {


### PR DESCRIPTION
## Summary

Closes the 15-minute access-token recovery path that PR #310 left untouched. Production log from deployment `7506c8ff` showed the exact failure mode this PR fixes:

```
10:32:55.226  /api/v1/accounts     401  (access token expired after ~30 min idle)
10:32:55.332  /api/v1/categories   401
10:32:55.446  /api/v1/categories   401
10:33:23.785  /api/v1/auth/refresh 200  ← 28s after the 401s
```

Under the previous 25s `RECOVERY_TIMEOUT_MS` the browser aborted the refresh fetch BEFORE the 28s backend response arrived — the backend's 200 was an orphaned response. The singleflight saw a transient outcome, the retry-after-refresh path never fired, and the original 401'd requests surfaced 503s into the page-level silent `.catch(() => {})` handlers on the dashboard. From the user's perspective: stale data, no diagnostic, until they reloaded.

## Changes

1. **`RECOVERY_TIMEOUT_MS` 25_000 → 45_000** in `frontend/lib/api.ts`. The observed 28s tail now resolves within budget on the first attempt; the singleflight retries the original request with the fresh bearer; the page renders cleanly. **This is the deterministic recovery fix.**

2. **New CustomEvents emitted from `apiFetch`** as future-telemetry hook points:
   - `auth:refresh-attempt` — per attempt with `{ attempt, outcome, status?, durationMs }`
   - `auth:retry-after-refresh` — after the retry with `{ path, status, ok, durationMs }`

   PII guarantee on `path`: query string and fragment are stripped at dispatch time so the event detail never carries user-entered values (e.g. transaction search terms).

3. **AppShell subscribes** and pipes both into `@/lib/logger`. **Scope note:** the logger's browser branch writes to `console.*` only — App Platform's log shipper captures backend stdout/stderr, NOT browser console, so these events DO NOT reach production logs yet. The subscription is kept as the **hook point** so a follow-up PR can wire a real client-telemetry sink (POST to a backend collector, batched + rate-limited) without touching `apiFetch` or any consumer. For local development the browser console emission makes the chain visible in DevTools, and the events power the regression tests in this PR.

4. **Canonical 28s replay regression test**:
   > _28s observed tail: 401 → `/refresh` resolves at 28s → original request replays with new bearer_

   Pins the production failure mode end-to-end: 3 fetch calls (original 401, slow `/refresh`, retry 200), the retry header carries the fresh bearer, and the observability events fire with the correct shape.

5. **Existing tests updated** to the new budget (`24_000` → `44_000`, `25_000` → `45_000`, `30_000` → `50_000`). The two `dispatchEventSpy.not.toHaveBeenCalled()` assertions narrowed to "no `auth:unauthenticated` escaped" (the pre-existing intent — the new observability events don't count) via a shared `noAuthUnauthenticatedDispatched` helper.

6. **7 new tests** pin the new contracts:
   - **AppShell observability** (5): logger subscription routes ok / 2xx to `info`, transient / terminal / non-2xx to `warn`
   - **PII redaction** (2): query string and fragment are stripped from the dispatched path before any subscriber sees it

## Audit (out of scope for this PR)

No production code selectively swallows `refresh_transient`. The silent-failure class is wider: **12+ page-level fetcher `.catch(() => {})` handlers** that swallow ALL errors on mount loaders — `/accounts`, `/categories`, `/budgets`, `/recurring`, `/transactions`, settings pages, admin pages. With the 45s budget `refresh_transient` becomes very rare. A follow-up PR will replace the silent `.catch` sites with visible error UX, scoped page-by-page. Once a real client-telemetry sink lands (see Changes #3), ops will also be able to detect any remaining occurrence from logs via the existing `auth.refresh-attempt outcome=transient` events.

## Deliberately parked

**Proactive refresh** (timer + visibilitychange/focus, using JWT `exp`) is parked for a second stacked PR per review feedback — get the reactive recovery path correct first with instrumentation, then let prod telemetry decide whether proactive refresh is still required.

**Real client-telemetry sink** (POSTing the observability events to a backend collector) is parked. AppShell's subscription is the hook point; today the events stay in the browser. Once a sink lands the PII redaction already in place protects against query-string leakage.

## Tests

- Frontend Vitest: **1040 pass** (+12 new across this PR)
- `tsc --noEmit`: clean