### PR TITLE
feat(auth): proactive refresh — preflight + timer + visibility/focus

### DIFF
--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -195,10 +195,20 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       // no /refresh until we actually need one.
       void ensureFreshAccessToken();
     };
-    document.addEventListener("visibilitychange", checkAndRefresh);
+    const onVisibilityChange = () => {
+      // visibilitychange fires on BOTH visible → hidden AND hidden →
+      // visible transitions. We only care about the latter — when
+      // the user returns to a backgrounded tab, the token may have
+      // ticked into its lead window while setTimeout was throttled,
+      // and a burst of mount fetchers is about to fire. Hidden
+      // transitions don't need a refresh.
+      if (document.visibilityState !== "visible") return;
+      checkAndRefresh();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
     window.addEventListener("focus", checkAndRefresh);
     return () => {
-      document.removeEventListener("visibilitychange", checkAndRefresh);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("focus", checkAndRefresh);
     };
   }, [user]);

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -35,6 +35,9 @@ import { hasPlatformPermission } from "@/lib/auth";
 import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { startKeepWarm } from "@/lib/keep-warm";
 import { logger } from "@/lib/logger";
+import {
+  ensureFreshAccessToken,
+} from "@/lib/api";
 import type {
   RefreshAttemptDetail,
   RetryAfterRefreshDetail,
@@ -167,6 +170,37 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (!user) return;
     return startKeepWarm();
+  }, [user]);
+
+  // 2026-05-18 proactive refresh — visibility / focus side. The
+  // module-level setTimeout in @/lib/api fires the timer-driven
+  // proactive refresh when the tab is active, but a tab that's been
+  // backgrounded for a while may have its setTimeout throttled by
+  // the browser, then the user returns and a burst of mount
+  // fetchers races the timer. Subscribing here means: as soon as
+  // the user looks at the tab again (visibilitychange→visible) or
+  // focuses the window, we ask apiFetch to ensure the token is
+  // fresh. Idempotent + singleflight in apiFetch — at most one
+  // /refresh fires across timer, this handler, and the apiFetch
+  // preflight on any concurrent fetcher.
+  //
+  // Gated on user so unauthenticated flows don't subscribe. The
+  // 401-driven reactive path remains the safety net.
+  useEffect(() => {
+    if (!user) return;
+    const checkAndRefresh = () => {
+      // ensureFreshAccessToken is a no-op when the token isn't near
+      // expiry, so the worst case on every focus/visibility tick is
+      // a function call + an isAccessTokenNearExpiry comparison —
+      // no /refresh until we actually need one.
+      void ensureFreshAccessToken();
+    };
+    document.addEventListener("visibilitychange", checkAndRefresh);
+    window.addEventListener("focus", checkAndRefresh);
+    return () => {
+      document.removeEventListener("visibilitychange", checkAndRefresh);
+      window.removeEventListener("focus", checkAndRefresh);
+    };
   }, [user]);
 
   // 2026-05-18 idle-recovery observability. apiFetch dispatches

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -36,7 +36,7 @@ const REFRESH_BACKOFF_BASE_MS = 250;
 // flow never reaches ``/auth/refresh`` and the user gets surfaced a
 // generic 503 from the unauth path instead of the recovery one.
 // Treating ``/auth/status`` as a recovery path means the cold-start
-// chain (status → refresh → me) all runs on the 25s budget.
+// chain (status → refresh → me) all runs on the 45s budget.
 function isRecoveryPath(path: string): boolean {
   return (
     path.includes("/auth/refresh")
@@ -439,7 +439,7 @@ async function refreshAccessToken(): Promise<RefreshResult> {
 async function probeAuthMeAlive(): Promise<boolean> {
   if (!accessToken) return false;
   try {
-    // 25s recovery budget so a cold backend doesn't trip a false
+    // 45s recovery budget so a cold backend doesn't trip a false
     // logout when /me confirms session liveness after a transient
     // refresh failure.
     const res = await fetchWithTimeout(
@@ -465,7 +465,7 @@ export async function apiFetch<T>(
   // so it doesn't pollute the RequestInit. The same caller-provided value
   // applies to both the primary request and the retry-after-refresh.
   const { timeoutMs, ...fetchInit } = options;
-  // Path-specific default: recovery routes get 25s, everything else 10s.
+  // Path-specific default: recovery routes get 45s, everything else 10s.
   // An explicit per-call timeoutMs override always wins. Same effective
   // budget is reused for the retry-after-refresh below.
   const effectiveTimeout = timeoutMs ?? timeoutForPath(path);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -50,6 +50,26 @@ function timeoutForPath(path: string): number {
 }
 
 let accessToken: string | null = null;
+// 2026-05-18 proactive refresh: track the access-token exp claim
+// alongside the token so the preflight + timer + visibility/focus
+// handlers can decide whether to refresh BEFORE the bearer expires.
+// Stored as the raw exp value (unix seconds, as encoded in the JWT)
+// — no clock-skew adjustment here; the consumers apply their own.
+let accessTokenExp: number | null = null;
+// Module-level timer driven by setAccessToken. Cleared on every
+// token update so a fresh token's exp drives the next scheduled
+// refresh.
+let proactiveRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+// "Near expiry" window: refresh when `exp - now <= 65s` (60s lead
+// + 5s clock-skew tolerance). The 60s lead is large enough to
+// absorb the silent-refresh path's 45s RECOVERY_TIMEOUT_MS + small
+// network jitter on basic-xxs cold start. The 5s skew tolerance
+// keeps the window honest under a few seconds of clock disagreement
+// between the user's browser, the App Platform pod, and the JWT
+// issuer (all should be NTP-synced but defence-in-depth).
+const PROACTIVE_REFRESH_LEAD_SECONDS = 60;
+const CLOCK_SKEW_TOLERANCE_SECONDS = 5;
+
 // Discriminated result so callers can distinguish terminal auth death
 // from transient refresh failure. Architect-locked 2026-05-15.
 type RefreshResult =
@@ -119,10 +139,145 @@ let mePromise: Promise<boolean> | null = null;
 
 export function setAccessToken(token: string | null) {
   accessToken = token;
+  accessTokenExp = token ? decodeJwtExp(token) : null;
+  scheduleProactiveRefresh();
 }
 
 export function getAccessToken(): string | null {
   return accessToken;
+}
+
+/**
+ * Decode the ``exp`` claim from a JWT WITHOUT verifying the
+ * signature (verification is the backend's job). Returns the exp
+ * as unix seconds, or ``null`` if the token isn't a parseable JWT
+ * or has no numeric ``exp`` claim. The "no exp" fallback is
+ * critical for the proactive-refresh design: a token whose exp is
+ * unknown drives the reactive 401 path as today, not a silent
+ * forever-stale session.
+ */
+function decodeJwtExp(token: string): number | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    // JWT payload is base64url-encoded. Normalize to standard base64
+    // then pad to a length divisible by 4 so ``atob`` accepts it.
+    let payloadB64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    while (payloadB64.length % 4 !== 0) payloadB64 += "=";
+    const payload = JSON.parse(atob(payloadB64)) as { exp?: unknown };
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the current access token is within the lead window of
+ * its declared exp. ``false`` when there is no token OR the token
+ * has no/invalid exp — the latter is the deliberate fallback that
+ * keeps the reactive 401 path as the recovery for legacy / non-JWT
+ * tokens. Exported so AppShell's visibility/focus handler can
+ * gate the refresh trigger without calling apiFetch.
+ */
+export function isAccessTokenNearExpiry(): boolean {
+  if (accessTokenExp === null) return false;
+  const nowSec = Math.floor(Date.now() / 1000);
+  return (
+    accessTokenExp - nowSec
+    <= PROACTIVE_REFRESH_LEAD_SECONDS + CLOCK_SKEW_TOLERANCE_SECONDS
+  );
+}
+
+/**
+ * Auth endpoints MUST skip the proactive preflight to avoid loops:
+ *   - ``/auth/refresh`` IS the refresh — preflighting it would
+ *     recurse into itself.
+ *   - ``/auth/login``, ``/auth/register`` carry no bearer and
+ *     don't need it.
+ *   - ``/auth/me``, ``/auth/status``, ``/auth/logout`` are part
+ *     of the auth-lifecycle path; their own flow handles failures.
+ *   - MFA, SSO step-up, password-reset, email-verify, etc. follow
+ *     the same convention.
+ *
+ * Definition is conservative: any path under ``/api/v1/auth/`` is
+ * exempt. The non-API ``/auth/*`` pages don't go through apiFetch.
+ */
+function isAuthEndpoint(path: string): boolean {
+  return path.startsWith("/api/v1/auth/");
+}
+
+/**
+ * Schedule the next proactive refresh based on the current token's
+ * exp. No-op if there's no token, no decoded exp, or the lead
+ * window has already passed (preflight will handle that case).
+ * Idempotent: clears any pending timer first so a fresh token's
+ * exp always drives the schedule.
+ */
+function scheduleProactiveRefresh(): void {
+  if (proactiveRefreshTimer !== null) {
+    clearTimeout(proactiveRefreshTimer);
+    proactiveRefreshTimer = null;
+  }
+  if (typeof window === "undefined") return;
+  if (accessTokenExp === null) return;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const refreshAtSec = accessTokenExp - PROACTIVE_REFRESH_LEAD_SECONDS;
+  const delayMs = (refreshAtSec - nowSec) * 1000;
+  if (delayMs <= 0) {
+    // Already inside the lead window; let the apiFetch preflight or
+    // visibility/focus handler fire on the next user interaction.
+    // Avoid a tight setTimeout(0) loop here.
+    return;
+  }
+  proactiveRefreshTimer = setTimeout(() => {
+    proactiveRefreshTimer = null;
+    // Fire and forget. Failures are non-destructive (see
+    // ensureFreshAccessToken): transient leaves state intact;
+    // terminal lets the reactive 401 path handle logout via the
+    // already-established /me probe.
+    void ensureFreshAccessToken();
+  }, delayMs);
+}
+
+/**
+ * Single entry point for proactive refresh: timer, visibility/focus
+ * handler, AND apiFetch preflight all converge here. Idempotent
+ * (no-op when the token isn't near expiry) so callers don't need
+ * to gate themselves. Uses the SAME refreshPromise singleflight as
+ * the reactive 401 handler so a 401-driven refresh in flight and a
+ * proactive one never run in parallel.
+ *
+ * Failure semantics — DELIBERATELY non-destructive:
+ *   - ok: ``accessToken`` is updated by ``refreshAccessTokenOnce``,
+ *     ``setAccessToken`` re-schedules the next timer.
+ *   - terminal (401/403): silent return. The next normal apiFetch
+ *     will 401, drive the reactive path, and that path's /me
+ *     probe + auth:unauthenticated dispatch handles logout. No
+ *     destructive side effects from the proactive path.
+ *   - transient (timeout/5xx/network): silent return. State is
+ *     preserved; the reactive 401 path recovers on next failure.
+ *
+ * This way "should clear auth only through the already established
+ * terminal path" holds — proactive refresh is purely additive.
+ */
+export async function ensureFreshAccessToken(): Promise<void> {
+  if (!accessToken || !isAccessTokenNearExpiry()) return;
+  if (!refreshPromise) {
+    refreshPromise = refreshAccessToken();
+  }
+  const sharedPromise = refreshPromise;
+  refreshAwaiters++;
+  try {
+    await sharedPromise;
+    // We deliberately ignore the outcome: ok writes accessToken via
+    // refreshAccessTokenOnce (and the test pinning ensures it),
+    // terminal/transient fall through to the reactive path.
+  } finally {
+    refreshAwaiters--;
+    if (refreshAwaiters === 0 && refreshPromise === sharedPromise) {
+      refreshPromise = null;
+    }
+  }
 }
 
 export class ApiTimeoutError extends Error {
@@ -251,7 +406,10 @@ async function refreshAccessTokenOnce(attempt: number): Promise<RefreshResult> {
     });
   }
 
-  accessToken = data.access_token;
+  // Route through setAccessToken so the exp decode + next-refresh
+  // timer reschedule fire — without this the proactive timer would
+  // keep firing off the OLD token's exp after a successful refresh.
+  setAccessToken(data.access_token);
   return emit({ ok: true, accessToken: data.access_token });
 }
 
@@ -311,6 +469,28 @@ export async function apiFetch<T>(
   // An explicit per-call timeoutMs override always wins. Same effective
   // budget is reused for the retry-after-refresh below.
   const effectiveTimeout = timeoutMs ?? timeoutForPath(path);
+
+  // 2026-05-18 proactive refresh preflight. Before sending any
+  // non-auth request, if the access token is within the
+  // refresh-lead window of its exp, await the same singleflight
+  // refresh as the reactive 401 path. This closes the focus /
+  // visibility race where a backgrounded tab returns with an
+  // about-to-expire token, fires a burst of page-mount fetchers,
+  // and each one ships the expired bearer to the backend before
+  // the timer-driven refresh has completed.
+  //
+  // Skipped for /api/v1/auth/* to avoid loops (auth/refresh
+  // calling preflight calling auth/refresh) and because those
+  // endpoints' own flows handle their auth-lifecycle failures.
+  //
+  // Failure of the proactive refresh is silent (see
+  // ``ensureFreshAccessToken``): if it fails we still send the
+  // request, get a 401, and the existing reactive recovery +
+  // /me probe + terminal logout path handles it as today.
+  if (!isAuthEndpoint(path)) {
+    await ensureFreshAccessToken();
+  }
+
   const headers = new Headers(fetchInit.headers);
 
   if (accessToken) {
@@ -425,7 +605,9 @@ export async function apiFetch<T>(
         // awaiter clears the token first wins; subsequent awaiters
         // observe accessToken === null and skip the duplicate event.
         if (accessToken !== null) {
-          accessToken = null;
+          // setAccessToken(null) clears the proactive-refresh timer
+          // and resets accessTokenExp alongside the token itself.
+          setAccessToken(null);
           if (typeof window !== "undefined") {
             window.dispatchEvent(new Event("auth:unauthenticated"));
           }

--- a/frontend/tests/api/proactive-refresh.test.ts
+++ b/frontend/tests/api/proactive-refresh.test.ts
@@ -1,0 +1,339 @@
+// Proactive refresh tests — 2026-05-18.
+//
+// Reactive 401-driven refresh (PR #311) eliminates session DEATH but
+// leaves a visible 401 burst in DevTools every time the access token
+// expires mid-session: every concurrent fetcher ships the expired
+// bearer, the backend returns 401, apiFetch's silent refresh fires,
+// the original request retries with the new bearer. The user sees
+// the data, but the Console shows red errors.
+//
+// Proactive refresh closes that gap. Before sending any non-auth
+// request, apiFetch checks whether the access token is within the
+// refresh-lead window of its exp; if so, it awaits the same
+// singleflight refresh as the reactive path. No expired bearer ever
+// leaves the browser. AppShell adds a visibility/focus handler so
+// the same path fires when a backgrounded tab returns to foreground
+// (where setTimeout throttling would otherwise have stalled the
+// timer-driven refresh).
+//
+// These tests pin the six contracts the user spec'd:
+//   1. token expiring soon → apiFetch("/accounts") refreshes first,
+//      then sends /accounts ONCE with fresh bearer
+//   2. focus/visibility with near-expiry token triggers refresh
+//   3. concurrent requests near expiry share one refresh
+//   4. transient proactive refresh failure preserves token and
+//      original request still follows existing behavior
+//   5. auth endpoints do not preflight-refresh
+//   6. token with no/invalid exp falls back cleanly
+//
+// Helpers:
+//   - jwtWithExp(secondsFromNow) builds a minimal three-part JWT
+//     with a numeric `exp` claim. The signature is junk (the
+//     frontend never verifies it; the backend does).
+import {
+  apiFetch,
+  ensureFreshAccessToken,
+  isAccessTokenNearExpiry,
+  setAccessToken,
+} from "@/lib/api";
+
+function base64UrlEncode(s: string): string {
+  return btoa(s).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/**
+ * Build a minimal JWT with an ``exp`` claim ``secondsFromNow`` from
+ * the current wall clock. The header + signature are placeholders;
+ * decodeJwtExp only reads the payload's exp.
+ */
+function jwtWithExp(secondsFromNow: number): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = base64UrlEncode(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + secondsFromNow }),
+  );
+  return `${header}.${payload}.fake-signature`;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("apiFetch proactive refresh", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    setAccessToken(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setAccessToken(null);
+  });
+
+  // ── Spec #1: near-expiry token preflights before sending ─────────────────
+
+  it("near-expiry token: apiFetch(/accounts) refreshes first, then sends /accounts ONCE with the fresh bearer", async () => {
+    // Token expires in 30s — well inside the 65s refresh-lead window
+    // (60s lead + 5s clock-skew tolerance).
+    const expiringToken = jwtWithExp(30);
+    setAccessToken(expiringToken);
+    expect(isAccessTokenNearExpiry()).toBe(true);
+
+    fetchMock
+      // 1st call: /api/v1/auth/refresh fires from the preflight.
+      .mockResolvedValueOnce(jsonResponse({ access_token: jwtWithExp(900) }))
+      // 2nd call: /api/v1/accounts with the fresh bearer.
+      .mockResolvedValueOnce(jsonResponse({ accounts: [] }));
+
+    const result = await apiFetch<{ accounts: unknown[] }>("/api/v1/accounts");
+    expect(result).toEqual({ accounts: [] });
+
+    // Exactly 2 fetch calls: preflight /refresh, then /accounts once.
+    // No 401 burst, no retry-after-refresh.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/refresh");
+    expect(String(fetchMock.mock.calls[1][0])).toContain("/api/v1/accounts");
+
+    // /accounts went out with the FRESH bearer, not the expiring one.
+    const accountsHeaders = fetchMock.mock.calls[1][1]?.headers as Headers;
+    const bearerHeader = accountsHeaders.get("Authorization");
+    expect(bearerHeader).not.toBe(`Bearer ${expiringToken}`);
+    expect(bearerHeader).toMatch(/^Bearer /);
+  });
+
+  // ── Spec #2: focus/visibility triggers refresh ───────────────────────────
+
+  it("focus event with near-expiry token: ensureFreshAccessToken issues a /refresh", async () => {
+    setAccessToken(jwtWithExp(20));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ access_token: jwtWithExp(900) }),
+    );
+
+    await ensureFreshAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/refresh");
+  });
+
+  it("ensureFreshAccessToken is a no-op when token is NOT near expiry", async () => {
+    // Token expires in 15 min — well outside the 65s lead window.
+    setAccessToken(jwtWithExp(900));
+    expect(isAccessTokenNearExpiry()).toBe(false);
+
+    await ensureFreshAccessToken();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // ── Spec #3: concurrent near-expiry requests share one refresh ───────────
+
+  it("concurrent near-expiry requests share one /refresh via the singleflight", async () => {
+    setAccessToken(jwtWithExp(20));
+
+    // Slow /refresh so the second/third callers definitely race the first
+    // through the preflight singleflight.
+    let resolveRefresh!: (r: Response) => void;
+    const refreshPending = new Promise<Response>((r) => { resolveRefresh = r; });
+    fetchMock
+      .mockReturnValueOnce(refreshPending)        // preflight /refresh (shared)
+      .mockResolvedValueOnce(jsonResponse({ a: 1 }))  // /accounts
+      .mockResolvedValueOnce(jsonResponse({ c: 1 }))  // /categories
+      .mockResolvedValueOnce(jsonResponse({ b: 1 })); // /budgets
+
+    // Fire three concurrent fetchers — all near-expiry preflight should
+    // converge on the SAME pending refresh promise.
+    const p1 = apiFetch<{ a: number }>("/api/v1/accounts");
+    const p2 = apiFetch<{ c: number }>("/api/v1/categories");
+    const p3 = apiFetch<{ b: number }>("/api/v1/budgets");
+
+    // Let the microtasks resolve so each apiFetch enters the preflight.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // At this point only the /refresh has been issued — none of the
+    // downstream endpoint calls fire until /refresh resolves.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/refresh");
+
+    // Resolve the shared refresh; all three apiFetch awaiters unblock.
+    resolveRefresh(jsonResponse({ access_token: jwtWithExp(900) }));
+
+    await expect(p1).resolves.toEqual({ a: 1 });
+    await expect(p2).resolves.toEqual({ c: 1 });
+    await expect(p3).resolves.toEqual({ b: 1 });
+
+    // Exactly 4 fetch calls: 1 refresh + 3 endpoint calls.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const refreshCalls = fetchMock.mock.calls.filter((call) =>
+      String(call[0]).includes("/api/v1/auth/refresh"),
+    );
+    expect(refreshCalls).toHaveLength(1);
+  });
+
+  // ── Spec #4: transient proactive failure preserves state ─────────────────
+
+  it("transient proactive refresh failure preserves the token and lets reactive recovery handle the 401", async () => {
+    const expiringToken = jwtWithExp(20);
+    setAccessToken(expiringToken);
+
+    fetchMock
+      // Preflight /refresh: all 3 attempts time out / 5xx. The retry
+      // budget exhausts to transient; ensureFreshAccessToken returns
+      // silently (no clear).
+      .mockResolvedValueOnce(jsonResponse({ detail: "x" }, { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "x" }, { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "x" }, { status: 500 }))
+      // Original /accounts goes out with the still-near-expiry token
+      // (backend WILL accept it because it isn't actually expired yet
+      // — we're inside the lead window but the JWT exp hasn't passed).
+      .mockResolvedValueOnce(jsonResponse({ accounts: [{ id: 1 }] }));
+
+    const result = await apiFetch<{ accounts: Array<{ id: number }> }>(
+      "/api/v1/accounts",
+    );
+    expect(result).toEqual({ accounts: [{ id: 1 }] });
+
+    // Token preserved (transient = non-destructive).
+    expect(typeof window === "undefined" ? null : null).toBeNull(); // no-op guard
+    // Most importantly: the original /accounts request DID go out
+    // (reactive recovery still works) and we never spuriously
+    // cleared the token.
+    const accountsCall = fetchMock.mock.calls[3];
+    const accountsHeaders = accountsCall[1]?.headers as Headers;
+    expect(accountsHeaders.get("Authorization")).toBe(`Bearer ${expiringToken}`);
+  });
+
+  // ── Spec #5: auth endpoints skip the preflight ───────────────────────────
+
+  it("/api/v1/auth/refresh does NOT preflight-refresh itself (no loop)", async () => {
+    setAccessToken(jwtWithExp(20));  // near expiry
+    fetchMock.mockResolvedValueOnce(jsonResponse({ access_token: "new" }));
+
+    await apiFetch("/api/v1/auth/refresh", { method: "POST" });
+
+    // Exactly 1 fetch — the explicit /refresh. No preflight.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/refresh");
+  });
+
+  it("/api/v1/auth/me does NOT preflight-refresh", async () => {
+    setAccessToken(jwtWithExp(20));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1, email: "x@y.z" }));
+
+    await apiFetch("/api/v1/auth/me");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/me");
+  });
+
+  it("/api/v1/auth/status does NOT preflight-refresh", async () => {
+    setAccessToken(jwtWithExp(20));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ needs_setup: false }));
+
+    await apiFetch("/api/v1/auth/status");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/status");
+  });
+
+  it("/api/v1/auth/login does NOT preflight-refresh (credential check)", async () => {
+    // Even if a stale token is in memory, /login carries credentials,
+    // not a bearer — it must not trigger an upstream refresh.
+    setAccessToken(jwtWithExp(20));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ access_token: "x" }));
+
+    await apiFetch("/api/v1/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ login: "a", password: "b" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/login");
+  });
+
+  it("/api/v1/auth/mfa/verify does NOT preflight-refresh", async () => {
+    setAccessToken(jwtWithExp(20));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ access_token: "x" }));
+
+    await apiFetch("/api/v1/auth/mfa/verify", {
+      method: "POST",
+      body: JSON.stringify({ mfa_token: "x", code: "123456" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/auth/mfa/verify");
+  });
+
+  // ── Spec #6: token with no/invalid exp falls back cleanly ────────────────
+
+  it("token with no exp claim: no preflight, falls back to reactive 401 path", async () => {
+    // Hand-crafted JWT with a payload that lacks `exp`. decodeJwtExp
+    // returns null; isAccessTokenNearExpiry returns false; no preflight.
+    const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const payload = base64UrlEncode(JSON.stringify({ sub: "1" }));  // no exp
+    const noExpToken = `${header}.${payload}.fake`;
+    setAccessToken(noExpToken);
+    expect(isAccessTokenNearExpiry()).toBe(false);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [] }));
+
+    await apiFetch("/api/v1/accounts");
+
+    // Exactly 1 call — straight to /accounts, no preflight.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/accounts");
+  });
+
+  it("non-JWT token: no preflight, falls back to reactive 401 path", async () => {
+    // Bare string — not a three-part JWT. Pre-PR #310 the production
+    // app actually issued bearer tokens like this for legacy paths,
+    // so the fallback is load-bearing.
+    setAccessToken("not-a-jwt-just-a-bearer-string");
+    expect(isAccessTokenNearExpiry()).toBe(false);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [] }));
+    await apiFetch("/api/v1/accounts");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/accounts");
+  });
+
+  it("malformed JWT (broken base64): no preflight, falls back cleanly", async () => {
+    setAccessToken("aaa.@@@-not-base64-@@@.bbb");
+    expect(isAccessTokenNearExpiry()).toBe(false);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [] }));
+    await apiFetch("/api/v1/accounts");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("JWT with non-numeric exp: no preflight, falls back cleanly", async () => {
+    const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const payload = base64UrlEncode(JSON.stringify({ exp: "not-a-number" }));
+    setAccessToken(`${header}.${payload}.fake`);
+    expect(isAccessTokenNearExpiry()).toBe(false);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [] }));
+    await apiFetch("/api/v1/accounts");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Bonus: null token has no preflight effect ────────────────────────────
+
+  it("null access token: apiFetch sends without bearer, no preflight", async () => {
+    setAccessToken(null);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [] }));
+    await apiFetch("/api/v1/accounts");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const headers = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get("Authorization")).toBeNull();
+  });
+});

--- a/frontend/tests/components/app-shell.test.tsx
+++ b/frontend/tests/components/app-shell.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen } from "@testing-library/react";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { ensureFreshAccessToken } from "@/lib/api";
 import { logger } from "@/lib/logger";
 
 vi.mock("@/lib/logger", () => ({
@@ -32,11 +33,18 @@ vi.mock("next/navigation", () => ({
 // AppShellAddTransactionCta loads accounts/categories on mount; stub the
 // fetch so these system-nav-focused tests don't trip the act() warning
 // when the CTA's loadRefs settles after assertions complete.
+//
+// Also stub ensureFreshAccessToken so the proactive-refresh focus /
+// visibility tests can spy on the call without exercising the real
+// JWT-decode + singleflight machinery (that path is covered by
+// tests/api/proactive-refresh.test.ts). The keep-real-types pattern
+// preserves the named-export shape so AppShell's import succeeds.
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
   return {
     ...actual,
     apiFetch: vi.fn(async () => [] as never),
+    ensureFreshAccessToken: vi.fn(async () => undefined),
   };
 });
 
@@ -337,5 +345,175 @@ describe("AppShell — auth refresh observability", () => {
       ok: false,
       duration_ms: 95,
     });
+  });
+});
+
+// ── 2026-05-18 proactive refresh: AppShell focus/visibility wiring ──────
+//
+// The api.ts proactive-refresh module exposes ensureFreshAccessToken;
+// AppShell subscribes to focus + visibilitychange so a backgrounded
+// tab returning to the foreground catches up if its setTimeout was
+// throttled. These tests pin the AppShell side of that contract:
+//
+//   - user-gated focus triggers ensureFreshAccessToken
+//   - user-gated visibilitychange → visible triggers it
+//   - visibilitychange → hidden does NOT trigger (matches the
+//     comment "visibilitychange→visible"; without this guard the
+//     handler would fire on every transition, doubling traffic
+//     and surprising future readers)
+//   - no user → no subscription (anonymous landing / login pages
+//     never fire proactive refresh)
+//   - unmount removes the listeners (no leak across navigations)
+describe("AppShell — proactive refresh focus/visibility", () => {
+  const useAuthMock = vi.mocked(useAuth);
+  const ensureFreshAccessTokenMock = vi.mocked(ensureFreshAccessToken);
+
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    ensureFreshAccessTokenMock.mockReset();
+    ensureFreshAccessTokenMock.mockResolvedValue(undefined);
+  });
+
+  function mockSignedInUser() {
+    useAuthMock.mockReturnValue({
+      user: BASE_USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  }
+
+  it("focus event fires ensureFreshAccessToken when user is signed in", async () => {
+    mockSignedInUser();
+    await renderShell();
+    ensureFreshAccessTokenMock.mockClear();
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(ensureFreshAccessTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("visibilitychange → visible fires ensureFreshAccessToken", async () => {
+    mockSignedInUser();
+    await renderShell();
+    ensureFreshAccessTokenMock.mockClear();
+
+    // jsdom doesn't update document.visibilityState on its own;
+    // override the getter for this test so the AppShell guard
+    // (visibilityState === "visible") evaluates true.
+    const visibilityStateSpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("visible");
+    try {
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      expect(ensureFreshAccessTokenMock).toHaveBeenCalledTimes(1);
+    } finally {
+      visibilityStateSpy.mockRestore();
+    }
+  });
+
+  it("visibilitychange → hidden does NOT fire ensureFreshAccessToken", async () => {
+    mockSignedInUser();
+    await renderShell();
+    ensureFreshAccessTokenMock.mockClear();
+
+    const visibilityStateSpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("hidden");
+    try {
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      // Hidden transitions are no-ops — comment intent enforced.
+      expect(ensureFreshAccessTokenMock).not.toHaveBeenCalled();
+    } finally {
+      visibilityStateSpy.mockRestore();
+    }
+  });
+
+  it("no user: no subscription, focus is a no-op", async () => {
+    // user=null + loading=false would trip AppShell's redirect-to-
+    // /login useEffect, so set loading=true to keep AppShell
+    // rendering the spinner branch without redirect side effects.
+    // Either way the proactive-refresh useEffect is gated on `user`
+    // and must NOT subscribe when user is falsy.
+    useAuthMock.mockReturnValue({
+      user: null,
+      loading: true,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+    await renderShell();
+    ensureFreshAccessTokenMock.mockClear();
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    const visibilityStateSpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("visible");
+    try {
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+    } finally {
+      visibilityStateSpy.mockRestore();
+    }
+
+    expect(ensureFreshAccessTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("unmount removes focus + visibilitychange listeners", async () => {
+    mockSignedInUser();
+    // Render via act() so we get back the unmount function returned
+    // by RTL's render. renderShell() doesn't expose it, so we
+    // inline the render here.
+    const { render, act: rtlAct } = await import("@testing-library/react");
+    let unmount: () => void = () => {};
+    await rtlAct(async () => {
+      const result = render(
+        <AppShell>
+          <p>page body</p>
+        </AppShell>,
+      );
+      unmount = result.unmount;
+    });
+
+    // Sanity: while mounted, focus fires the spy.
+    ensureFreshAccessTokenMock.mockClear();
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(ensureFreshAccessTokenMock).toHaveBeenCalledTimes(1);
+
+    // After unmount: events fire nothing.
+    ensureFreshAccessTokenMock.mockClear();
+    act(() => {
+      unmount();
+    });
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    const visibilityStateSpy = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("visible");
+    try {
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+    } finally {
+      visibilityStateSpy.mockRestore();
+    }
+    expect(ensureFreshAccessTokenMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Eliminates the visible 401 burst when an access token expires mid-session. PR #311 fixed session DEATH (reactive recovery now succeeds in ~3.5s end-to-end); this PR fixes session NOISE by never letting an expired bearer leave the browser in the first place.

Production log from the post-#311 deployment showed the reactive chain working exactly as designed:

```
15:17:09.352-574  10 concurrent 401s on dashboard endpoints
15:17:12.687     /auth/refresh 200 (3.3s later)
15:17:12.75-13.29 13 successful retries, dashboard rendered
```

Functional but ugly: every 15-min boundary produced a red 401 storm in DevTools. After this PR no expired bearer is sent in the first place — the 401s simply do not happen.

## Design

Spec'd by architect feedback; built to match exactly:

1. **`apiFetch` preflight.** Before sending any non-`/api/v1/auth/*` request, if the access token is within the refresh-lead window of its `exp`, await the **same singleflight refresh** as the reactive 401 path. Closes the focus/visibility race where a backgrounded tab returns and fires a burst of page-mount fetchers before the timer-driven refresh has completed.

2. **JWT `exp` stored alongside the token.** `setAccessToken` decodes the JWT payload's `exp` WITHOUT signature verification (backend's job) and stashes it at module scope. Refresh window: `exp - now <= 60s + 5s` clock-skew tolerance. Tokens with no/invalid/non-numeric `exp` fall back cleanly to the existing reactive 401 path.

3. **Single singleflight.** Timer, `AppShell` visibility/focus handler, AND the `apiFetch` preflight all converge on `ensureFreshAccessToken`, which reuses the existing `refreshPromise` + `refreshAwaiters` counter. AT MOST one `/api/v1/auth/refresh` is in flight per tab across all three triggers.

4. **Auth endpoints skip the preflight.** `isAuthEndpoint` matches anything under `/api/v1/auth/`. `/auth/refresh` would otherwise recurse into itself; `/auth/me`, `/auth/status`, `/auth/login`, `/auth/mfa/*`, etc. follow the same convention.

5. **Non-destructive failure.** Proactive refresh that returns terminal (401/403) or transient (timeout/5xx/network) silently returns; the caller proceeds, hits the existing reactive path, and the `/me` probe + `auth:unauthenticated` dispatch handle terminal logout exactly as before. Proactive refresh is purely additive — terminal semantics stay centralized in the reactive path.

6. **AppShell visibility/focus handler.** Backgrounded tabs throttle `setTimeout`, so the module-level timer can stall. On `visibilitychange→visible` OR `focus`, `ensureFreshAccessToken` fires (no-op when token isn't near expiry, so the cost is one comparison per event). Gated on `user` so unauthenticated flows don't subscribe.

## Tests

`frontend/tests/api/proactive-refresh.test.ts` (15 new tests). Pins all six spec cases plus edge fallbacks:

- **Near-expiry token**: `/accounts` refreshes first, then sends ONCE with the fresh bearer (the canonical "no expired bearer leaves the browser" assertion).
- **Focus/visibility** triggers refresh via `ensureFreshAccessToken`.
- **Concurrent near-expiry requests** share ONE `/refresh` (3 parallel `apiFetch` + 1 slow refresh = exactly 4 fetch calls).
- **Transient proactive failure** preserves the token; original request still goes out with the existing bearer (reactive recovery still works).
- `/auth/refresh`, `/auth/me`, `/auth/status`, `/auth/login`, `/auth/mfa/verify` all **skip the preflight** (no loop, no spurious refresh).
- Tokens with **no `exp`**, **non-JWT strings**, **malformed JWTs**, and **non-numeric `exp`** all fall back to the reactive path.
- Null access token: no preflight, no bearer header.
- Non-near-expiry token: `ensureFreshAccessToken` is a no-op.

**Full suite: frontend 1055 pass (+15 new), tsc clean.**

## Deliberately parked

- **Real client-telemetry sink** (AppShell still has the hook point from PR #311).
- **BroadcastChannel cross-tab logout** — only needed if we ever lengthen access TTL. This PR does NOT lengthen TTL; the existing 15-min stale-token window is unchanged.