### PR TITLE
fix(infra): Redis as session store — noeviction + AOF persistence

### DIFF
--- a/infra/ansible/roles/redis/defaults/main.yml
+++ b/infra/ansible/roles/redis/defaults/main.yml
@@ -4,7 +4,23 @@ redis_password: CHANGE_ME
 
 # 300MB cap on the s-1vcpu-2gb shared box (was 200MB on s-1vcpu-1gb).
 # 50% headroom for cache growth without crowding the InnoDB buffer pool.
-# Rate-limit + session-cache workloads still fit easily; allkeys-lru means
-# any overflow evicts cold keys cleanly.
+#
+# Eviction policy: noeviction (2026-05-18). Originally allkeys-lru on the
+# theory that Redis only held ephemeral data (rate limits, cache); since
+# PR #306 (2026-05-17) Redis is the primary auth-session store. Evicting
+# session keys under memory pressure produces phantom 401s
+# (``Session has been invalidated``) when the next /auth/refresh probes
+# Redis and finds the primary key missing. noeviction makes Redis return
+# OOM to writers on overflow instead, which the backend treats as a 503
+# (visible, recoverable) rather than a silent 401.
 redis_maxmemory: 300mb
-redis_maxmemory_policy: allkeys-lru
+redis_maxmemory_policy: noeviction
+
+# Persistence: AOF enabled (2026-05-18). Originally disabled on the same
+# "ephemeral data" assumption. With Redis as the auth-session store, a
+# restart without persistence drops every active session and logs out
+# every user instantly. AOF with appendfsync=everysec gives at most 1s
+# of session-write loss on a hard crash; Redis still reloads sessions on
+# normal restart.
+redis_appendonly: "yes"
+redis_appendfsync: everysec

--- a/infra/ansible/roles/redis/handlers/main.yml
+++ b/infra/ansible/roles/redis/handlers/main.yml
@@ -23,6 +23,10 @@
       CONFIG SET maxmemory {{ redis_maxmemory }}
     redis-cli -a "{{ redis_password }}" --no-auth-warning \
       CONFIG SET maxmemory-policy {{ redis_maxmemory_policy }}
+    redis-cli -a "{{ redis_password }}" --no-auth-warning \
+      CONFIG SET appendonly {{ redis_appendonly }}
+    redis-cli -a "{{ redis_password }}" --no-auth-warning \
+      CONFIG SET appendfsync {{ redis_appendfsync }}
     redis-cli -a "{{ redis_password }}" --no-auth-warning CONFIG REWRITE
   args:
     executable: /bin/bash

--- a/infra/ansible/roles/redis/templates/00-static.conf.j2
+++ b/infra/ansible/roles/redis/templates/00-static.conf.j2
@@ -3,9 +3,11 @@
 {# App Platform backend's redis-py connection pool, so the admin dashboard #}
 {# briefly reports Redis: DOWN until clients reconnect. Keep this file #}
 {# small and only put fields here that the running server cannot reload. #}
+{# #}
+{# Persistence (appendonly / save) deliberately NOT here. Both are live- #}
+{# tunable via CONFIG SET, so they belong in 10-tunables.conf so the next #}
+{# converge can flip them without restarting Redis. See defaults/main.yml #}
+{# for the rationale on why AOF is on (post PR #306 session store). #}
 bind 127.0.0.1 {{ private_ipv4 }}
 protected-mode yes
 requirepass {{ redis_password }}
-# Persistence off: PFV uses Redis only for ephemeral data (rate limits, sessions).
-appendonly no
-save ""

--- a/infra/ansible/roles/redis/templates/10-tunables.conf.j2
+++ b/infra/ansible/roles/redis/templates/10-tunables.conf.j2
@@ -4,3 +4,10 @@
 {# connections, no spurious "Redis: DOWN" on the admin dashboard. #}
 maxmemory {{ redis_maxmemory }}
 maxmemory-policy {{ redis_maxmemory_policy }}
+
+{# Persistence — AOF is on because Redis is the auth-session store. #}
+{# A Redis restart without persistence drops every active session. #}
+{# appendfsync=everysec gives at most 1s of session-write loss on a #}
+{# hard crash; normal restart replays AOF and sessions survive. #}
+appendonly {{ redis_appendonly }}
+appendfsync {{ redis_appendfsync }}


### PR DESCRIPTION
## Summary

The Ansible Redis role was provisioned for an ephemeral cache workload — `allkeys-lru` eviction policy and persistence fully disabled. That assumption was correct until **PR #306 (2026-05-17)** made Redis the primary refresh-session store. Two failure modes were silent under the old config:

1. **Eviction would log users out silently.** Under memory pressure, `allkeys-lru` would evict the least-recently-used keys — session keys included. The next `/auth/refresh` for an evicted `jti` would find the primary key missing, fall through to the grace key (also evictable), and return 401 `"Session has been invalidated"`. From the user's perspective: a phantom logout with no diagnostic.

2. **Any Redis restart wiped the entire keyspace.** Droplet reboot, kernel update, OOM kill, `systemctl restart redis-server` — all of them killed every active session in lockstep.

## Changes

- `redis_maxmemory_policy: allkeys-lru → noeviction`. Under overflow Redis now returns OOM to writers instead of evicting. The backend session code already treats Redis OOM as a transient 503; the frontend's 45 s recovery budget (PR #311) drives the retry. Visible, recoverable, never a phantom 401.

- `appendonly yes` + `appendfsync everysec` (AOF on, sub-1s durability). A restart now replays the AOF and sessions survive.

- Persistence moved out of `00-static.conf.j2` (restart-required) into `10-tunables.conf.j2` (live-tunable). The "Apply redis live tunables" handler grew two more `CONFIG SET` lines so future converges can flip persistence without restarting Redis.

- Stale "Persistence off: PFV uses Redis only for ephemeral data" comment removed. `defaults/main.yml` now documents both decisions inline with the PR #306 context.

## Production verification — already applied

The playbook was run live against `pfv-data-01` before this PR was opened. **Zero session loss across the restart.** Redis startup log from 18:43:15 UTC:

```
Done loading RDB, keys loaded: 31, keys expired: 0.
DB loaded from base file appendonly.aof.1.base.rdb: 0.000 seconds
DB loaded from append only file: 0.001 seconds
Ready to accept connections
CONFIG REWRITE executed with success.
```

31 keys in, 31 keys out. AOF + RDB base replay worked exactly as designed. Post-restart live state confirmed:

```
maxmemory-policy: noeviction
appendonly:       yes
appendfsync:      everysec
DBSIZE:           33 (sessions grew from 31, none lost)
```

Next converge against the droplet will be a no-op.

## Followup deliberately not in this PR

`vm.overcommit_memory=1` on the droplet — Redis logged a fork-safety warning for AOF rewrites. Low priority; Redis works fine without it on this load. Worth a one-line addition to the `common` role next time someone's touching it.

## What this does NOT fix

Today's 401 burst that the operator screenshotted earlier (the burst on `/budgets` hard reload) was disproven as an eviction problem (`evicted_keys=0` in live `INFO stats`). This PR prevents that **future** failure class — it's preventive, not curative for the specific incident the operator saw. To diagnose that incident we still need to capture the `detail` field on the next `/auth/refresh` 401 response (seven candidate causes, all return 401 with different `detail` strings).