### PR TITLE
fix(auth): Redis transport-normalizer + structured /refresh rejection logging

### DIFF
--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -126,13 +126,28 @@ def _normalize_transport_errors(fn: _F) -> _F:
             raise
         except OSError as exc:
             # Socket-level I/O. Translate to RedisConnectionError so the
-            # router's existing 503 fallback kicks in.
+            # router's existing 503 fallback kicks in — AND retire the
+            # poisoned pool so the next call uses a fresh connection.
+            await _retire_poisoned_client(
+                reason=f"OSError: {exc.__class__.__name__}: {exc}",
+            )
             raise RedisConnectionError(
                 f"Redis transport I/O failure: "
                 f"{exc.__class__.__name__}: {exc}"
             ) from exc
         except RuntimeError as exc:
             if _looks_like_dead_transport(exc):
+                # Same as above: poisoned-pool retirement BEFORE the
+                # router's caller hits the next helper. Without this,
+                # the frontend's reactive retry would hit the same
+                # dead pool again. ``RuntimeError`` is deliberately
+                # NOT in ``retry_on_error`` (would also retry real
+                # bugs), so redis-py's own disconnect path doesn't
+                # run for this class — we must drop the singleton
+                # ourselves.
+                await _retire_poisoned_client(
+                    reason=f"closed transport: {exc}",
+                )
                 raise RedisConnectionError(
                     f"Redis transport closed: {exc}"
                 ) from exc
@@ -141,6 +156,44 @@ def _normalize_transport_errors(fn: _F) -> _F:
             raise
 
     return wrapper  # type: ignore[return-value]
+
+
+async def _retire_poisoned_client(*, reason: str) -> None:
+    """Drop the module-level Redis singleton so the next ``get_client()``
+    creates a fresh client (and fresh underlying connection pool).
+
+    Called by ``_normalize_transport_errors`` after it detects a known
+    dead-socket / closed-transport state and BEFORE it raises the
+    translated ``RedisConnectionError``. Without this, the frontend's
+    reactive 503 retry would loop back to the same poisoned pool and
+    the user would see another 503 instead of recovering.
+
+    ``RuntimeError`` is deliberately excluded from
+    ``retry_on_error`` (see ``get_client`` rationale), so redis-py's
+    own disconnect-on-retry path does NOT run for the uvloop closed-
+    transport class; the application has to drop the client itself.
+
+    Best-effort: any failure inside ``aclose()`` is swallowed so we
+    don't replace one ConnectionError with another. The next call to
+    ``get_client()`` will rebuild the singleton from
+    ``settings.redis_url`` regardless.
+    """
+    global _client
+    poisoned = _client
+    if poisoned is None:
+        return
+    _client = None
+    logger.warning(
+        "redis.client.retired",
+        extra={"reason": reason},
+    )
+    try:
+        await poisoned.aclose()
+    except Exception:  # noqa: BLE001 — best-effort cleanup
+        # We've already replaced the singleton; the OS will reclaim the
+        # underlying sockets even if aclose() can't tidy up its
+        # bookkeeping. Don't propagate.
+        pass
 
 
 def get_client() -> Redis | None:

--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -14,13 +14,16 @@ Behavior when `settings.redis_url` is empty:
   Redis and it's missing; see `require_client()` below.
 """
 
+import functools
 import json
 import logging
+from typing import Any, Awaitable, Callable, TypeVar
 
 from redis.asyncio import Redis
 from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
 from redis.exceptions import ResponseError as RedisResponseError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
@@ -29,6 +32,115 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 _client: Redis | None = None
+
+
+# 2026-05-19 transport-normalizer. Production hit a class of failures
+# where redis-py's ``health_check_interval`` ping fired against a
+# pool-idle connection whose underlying TCP socket had been silently
+# dropped by some network device (App Platform NAT, VPC router, droplet
+# firewall). uvloop raises ``RuntimeError("unable to perform operation
+# on <TCPTransport closed=True ...>; the handler is closed")`` in that
+# state. ``RuntimeError`` is NOT a ``RedisError`` subclass, so it
+# escaped every router-level ``except (RedisRequired, RedisError)``
+# handler and FastAPI returned a 500. See ``_normalize_transport_errors``
+# below for the narrow translation contract.
+_TRANSPORT_DEAD_MARKERS: tuple[str, ...] = (
+    # uvloop: "unable to perform operation on <TCPTransport closed=True
+    # reading=False ...>; the handler is closed"
+    "tcptransport closed",
+    "handler is closed",
+    # generic asyncio transport already in closed state
+    "transport closed",
+    "transport is closed",
+    "closed transport",
+    # socket-level errors that sometimes surface as RuntimeError on uvloop
+    # instead of bubbling up as OSError
+    "broken pipe",
+    "connection reset",
+    "connection closed",
+    "closed socket",
+)
+
+
+def _looks_like_dead_transport(exc: BaseException) -> bool:
+    """True iff the exception's message matches a known closed-transport
+    state we want to translate into a transient 503 instead of a 500.
+
+    DELIBERATELY narrow: substring match on a small fixed list. Bare
+    ``RuntimeError("programmer bug")`` and ``RedisRequired`` (also a
+    ``RuntimeError`` subclass) must still propagate — we want loud
+    failures on real code bugs and config gaps, not silent
+    re-classification as "Redis hiccup".
+    """
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _TRANSPORT_DEAD_MARKERS)
+
+
+_F = TypeVar("_F", bound=Callable[..., Awaitable[Any]])
+
+
+def _normalize_transport_errors(fn: _F) -> _F:
+    """Decorator. Wrap an async Redis helper so closed-transport /
+    broken-pipe errors raised from inside redis-py/uvloop surface as
+    :class:`redis.exceptions.ConnectionError` (a ``RedisError`` subclass).
+
+    Routers already catch ``(RedisRequired, RedisError)`` and return 503
+    on those, which the frontend treats as transient and retries on a
+    fresh connection. Without this wrapper, the bare ``RuntimeError`` from
+    uvloop bypasses the handler and FastAPI returns 500 — see the
+    production trace at ``2026-05-19T07:10:52`` for the canonical
+    instance this decorator exists to prevent.
+
+    EXPLICITLY preserved unchanged (no re-classification):
+      * ``RedisError`` and subclasses — including ``ResponseError`` from
+        Lua EVAL. ``session_rotate_lua`` parses ``ResponseError`` messages
+        for the Lua-return-token contract (``session_revoked`` /
+        ``already_rotated`` / ``jti_collision``); papering over those
+        with a generic ``ConnectionError`` would break rotation logic.
+      * ``RedisRequired`` — programmer / config signal that ``REDIS_URL``
+        is not set. Pass through so production fails loud until fixed.
+      * Bare ``RuntimeError`` whose message doesn't match the narrow
+        transport-marker list. Almost certainly a real bug; re-raise so
+        it surfaces as a 500 with a complete traceback in logs.
+
+    Translated:
+      * ``OSError`` subclasses (``ConnectionResetError``,
+        ``BrokenPipeError``, ``ConnectionAbortedError``, etc.) — socket
+        I/O failures during a Redis op.
+      * ``RuntimeError`` whose message matches a transport-death marker.
+    """
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await fn(*args, **kwargs)
+        except RedisError:
+            # ResponseError, ConnectionError, TimeoutError, etc. — already
+            # a sensible Redis-domain exception. Pass through so the
+            # caller's ``except (RedisRequired, RedisError)`` runs AND so
+            # ``session_rotate_lua``'s Lua-return-token parser still sees
+            # the raw ResponseError it expects.
+            raise
+        except RedisRequired:
+            # Programmer / config signal. Not a transport problem; pass
+            # through so the caller's existing handler logic runs.
+            raise
+        except OSError as exc:
+            # Socket-level I/O. Translate to RedisConnectionError so the
+            # router's existing 503 fallback kicks in.
+            raise RedisConnectionError(
+                f"Redis transport I/O failure: "
+                f"{exc.__class__.__name__}: {exc}"
+            ) from exc
+        except RuntimeError as exc:
+            if _looks_like_dead_transport(exc):
+                raise RedisConnectionError(
+                    f"Redis transport closed: {exc}"
+                ) from exc
+            # Unrelated RuntimeError — almost certainly a real bug.
+            # Let it escape so it surfaces as 500 with full traceback.
+            raise
+
+    return wrapper  # type: ignore[return-value]
 
 
 def get_client() -> Redis | None:
@@ -49,7 +161,15 @@ def get_client() -> Redis | None:
       timeout errors. This makes the dashboard probe and the MFA nonce
       path tolerate a Valkey blip (e.g. an Ansible re-converge that
       bounces the service) instead of surfacing a hard failure on the
-      very first stale-pool socket.
+      very first stale-pool socket. ``OSError`` (covers
+      ``ConnectionResetError`` and ``BrokenPipeError``) is in the retry
+      list because production observed those classes on idle-dropped
+      sockets — the 2026-05-19T07:10 trace. We deliberately do NOT add
+      bare ``RuntimeError`` here because redis-py's retry contract is
+      "drop connection + reconnect on listed error"; widening to all
+      ``RuntimeError`` would also retry genuine programmer bugs. The
+      transport-runtime case is handled instead by the
+      ``_normalize_transport_errors`` wrapper at the helper layer.
     """
     global _client
     if _client is None and settings.redis_url:
@@ -60,7 +180,11 @@ def get_client() -> Redis | None:
             socket_timeout=3,
             socket_keepalive=True,
             health_check_interval=30,
-            retry_on_error=[RedisConnectionError, RedisTimeoutError],
+            retry_on_error=[
+                RedisConnectionError,
+                RedisTimeoutError,
+                OSError,
+            ],
             retry=Retry(ExponentialBackoff(cap=1.0, base=0.1), retries=2),
         )
     return _client
@@ -138,6 +262,7 @@ def _family_key(sid: str) -> str:
     return f"auth:session:by_sid:{sid}"
 
 
+@_normalize_transport_errors
 async def session_issue(jti: str, sid: str, user_id: int, ttl_seconds: int) -> None:
     """Write the refresh-session primary key + family-set entry atomically.
 
@@ -160,6 +285,7 @@ async def session_issue(jti: str, sid: str, user_id: int, ttl_seconds: int) -> N
     await pipe.execute()
 
 
+@_normalize_transport_errors
 async def session_validate(jti: str) -> dict | None:
     """Return the JSON payload at ``auth:session:{jti}`` or None on miss.
 
@@ -180,6 +306,7 @@ async def session_validate(jti: str) -> dict | None:
         return None
 
 
+@_normalize_transport_errors
 async def session_grace(jti: str) -> dict | None:
     """Return the JSON payload at ``auth:session:grace:{jti}`` or None on miss.
 
@@ -202,6 +329,7 @@ async def session_grace(jti: str) -> dict | None:
         return None
 
 
+@_normalize_transport_errors
 async def session_family_exists(sid: str) -> bool:
     """Return True iff ``auth:session:by_sid:{sid}`` exists.
 
@@ -214,6 +342,7 @@ async def session_family_exists(sid: str) -> bool:
     return bool(await client.exists(_family_key(sid)))
 
 
+@_normalize_transport_errors
 async def session_family_member(sid: str, jti: str) -> bool:
     """Return True iff ``jti`` is still a member of ``auth:session:by_sid:{sid}``.
 
@@ -301,6 +430,7 @@ return "ok"
 """
 
 
+@_normalize_transport_errors
 async def session_rotate_lua(
     old_jti: str,
     new_jti: str,
@@ -369,6 +499,7 @@ async def session_rotate_lua(
     return result
 
 
+@_normalize_transport_errors
 async def session_revoke_family(sid: str) -> list[str]:
     """Atomically revoke an entire session family (spec §5.3 / §4.2 logout).
 
@@ -414,3 +545,57 @@ async def session_revoke_family(sid: str) -> list[str]:
         pipe_b.delete(_grace_key(jti))
     await pipe_b.execute()
     return jtis
+
+
+# ── MFA single-use nonces ───────────────────────────────────────────────
+#
+# The /mfa/email-verify path proves an emailed 6-digit code was not
+# replayed. The jti embedded in the email JWT is recorded in Redis at
+# issue time AND deleted on first successful verify. 0 == not found ==
+# replay attempt → 401.
+#
+# These helpers exist (vs. inline ``get_client().set(...)`` in auth.py)
+# so the ``_normalize_transport_errors`` wrapper covers the MFA path
+# too — without this layer, a closed-transport RuntimeError during
+# /mfa/email-verify produces a 500 instead of a recoverable 503.
+#
+# Both helpers return ``None`` when Redis isn't configured (dev mode);
+# production callers MUST check for that and fail closed with 503.
+# 2026-05-19: added by the Redis transport-normalizer PR.
+
+
+_MFA_EMAIL_JTI_KEY = "mfa_email_jti:{jti}"
+
+
+@_normalize_transport_errors
+async def mfa_email_nonce_set(jti: str, user_id: int, ttl_seconds: int) -> bool:
+    """Store the MFA single-use nonce. Returns True if Redis is
+    configured and the write landed, False if Redis is not configured
+    (dev mode with empty ``REDIS_URL``). Production callers should
+    refuse to issue the email token when this returns False.
+    """
+    client = get_client()
+    if client is None:
+        return False
+    await client.set(
+        _MFA_EMAIL_JTI_KEY.format(jti=jti),
+        str(user_id),
+        ex=ttl_seconds,
+    )
+    return True
+
+
+@_normalize_transport_errors
+async def mfa_email_nonce_consume(jti: str) -> int | None:
+    """Atomically consume the MFA single-use nonce. Returns:
+      * ``None`` — Redis not configured (dev mode); caller is
+        responsible for failing closed if production.
+      * ``0`` — nonce was not in Redis (replay attempt or expired); the
+        caller should 401.
+      * ``1`` — nonce existed and was deleted in this call; verify
+        proceeds.
+    """
+    client = get_client()
+    if client is None:
+        return None
+    return await client.delete(_MFA_EMAIL_JTI_KEY.format(jti=jti))

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -819,6 +819,12 @@ async def _validate_refresh_cookie(
     the parser surfaces.
     """
     if not refresh_tokens:
+        # 2026-05-19: log the no-cookie case explicitly. The overnight
+        # logout symptom (the 2026-05-19T07:10 incident) had the
+        # browser stop sending the refresh cookie at some point; this
+        # reason code is what lets ops distinguish "cookie missing"
+        # from "cookie present but invalid".
+        _log_refresh_rejected("no_refresh_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="No refresh token",
@@ -826,15 +832,31 @@ async def _validate_refresh_cookie(
 
     successes: list[tuple[User, dict, datetime | None, str, int]] = []
     last_exc: HTTPException | None = None
+    transient_exc: HTTPException | None = None
     for token in refresh_tokens:
         try:
             successes.append(await _validate_single_refresh_token(token, db))
         except HTTPException as exc:
             last_exc = exc
+            # 2026-05-19: remember the FIRST 5xx (transport / Redis
+            # unavailable) we saw across the cookie list. When a
+            # legacy + current cookie pair is present, a Redis
+            # transport failure on the valid cookie followed by an
+            # invalid-token rejection on the stale one would otherwise
+            # let the 401 win as the final ``last_exc`` — terminal
+            # logout instead of recoverable retry. Prefer the 5xx.
+            if exc.status_code >= 500 and transient_exc is None:
+                transient_exc = exc
 
     if not successes:
-        assert last_exc is not None  # loop ran at least once
-        raise last_exc
+        # Prefer the 5xx (transient / Redis unavailable) over any 4xx
+        # (terminal-auth) seen across the cookie list. The frontend's
+        # classifier treats 5xx as transient and retries on a fresh
+        # connection; treating it as a 401 would force a real logout
+        # for what is actually a recoverable infra blip.
+        chosen = transient_exc or last_exc
+        assert chosen is not None  # loop ran at least once
+        raise chosen
 
     distinct_user_ids = {tup[0].id for tup in successes}
     if len(distinct_user_ids) > 1:
@@ -973,6 +995,12 @@ async def refresh(
     if lua_result == redis_client.SESSION_ROTATE_REVOKED:
         # Concurrent /logout deleted the family set. Terminal 401 — the
         # frontend's classifier already handles this string.
+        _log_refresh_rejected(
+            "lua_session_revoked",
+            jti=old_jti,
+            sid=sid,
+            extra={"sub": user.id},
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Session has been invalidated",
@@ -996,6 +1024,29 @@ async def refresh(
             or grace_row.get("sid") != sid
             or grace_row.get("user_id") != user.id
         ):
+            # Lua said "already_rotated" so the winner SHOULD have left
+            # a grace key behind, but by the time we re-probe it's
+            # gone (TTL expired, concurrent logout, etc.). Log which
+            # part failed so ops can tell normal-grace-expiry apart
+            # from "family revoked between rotation and re-probe".
+            _log_refresh_rejected(
+                "already_rotated_grace_revalidation_failed",
+                jti=old_jti,
+                sid=sid,
+                extra={
+                    "sub": user.id,
+                    "grace_row_missing": grace_row is None,
+                    "family_alive": family_alive,
+                    "grace_sid_mismatch": (
+                        grace_row is not None
+                        and grace_row.get("sid") != sid
+                    ),
+                    "grace_user_mismatch": (
+                        grace_row is not None
+                        and grace_row.get("user_id") != user.id
+                    ),
+                },
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Session has been invalidated",

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -319,6 +319,53 @@ async def login(
     return TokenResponse(access_token=access_token)
 
 
+# 2026-05-19: structured logging for every terminal refresh rejection.
+# Ops needs to know WHICH of the seven 401 paths fired without seeing
+# raw tokens — the screenshot from 2026-05-19T07:10 produced 401s with
+# no distinguishing signal in the uvicorn access log.
+#
+# ``reason`` is a stable enum string; ``jti_h`` / ``sid_h`` are 8-char
+# SHA-256 prefixes (sufficient for correlation, useless for replay).
+# Never log raw jti/sid/cookie values — telemetry retention varies and
+# raw refresh-token claims are a session-takeover vector.
+_LOGGER = structlog.stdlib.get_logger()
+
+
+def _hash_for_log(value: str | None) -> str | None:
+    """8-char SHA-256 prefix of a refresh-token claim, safe to log.
+
+    Returns None for None input. 8 hex chars (32 bits) is enough for
+    ops to correlate the same jti across log lines on a single tab
+    over a few minutes; not enough to reverse to the original jti
+    even with the source code in hand.
+    """
+    if not value:
+        return None
+    import hashlib
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+
+
+def _log_refresh_rejected(
+    reason: str,
+    *,
+    jti: str | None = None,
+    sid: str | None = None,
+    extra: dict | None = None,
+) -> None:
+    """One structlog event per terminal refresh-cookie rejection with a
+    stable ``reason`` enum. Ops correlates by ``request_id`` (already
+    bound by ``RequestContextMiddleware``) + ``jti_h``/``sid_h`` to
+    distinguish the user's seven distinct 401 paths."""
+    detail = {
+        "reason": reason,
+        "jti_h": _hash_for_log(jti),
+        "sid_h": _hash_for_log(sid),
+    }
+    if extra:
+        detail.update(extra)
+    _LOGGER.info("auth.refresh.rejected", **detail)
+
+
 SESSION_EXPIRED_DETAIL = "Session expired — please sign in again"
 
 # Standard 503 response detail returned from any issue / rotation site
@@ -530,15 +577,24 @@ async def _validate_single_refresh_token(
     """
     payload = decode_token(refresh_token)
     if payload is None or payload.get("type") != "refresh":
+        _log_refresh_rejected("invalid_token_decode")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
         )
 
     user_id = int(payload["sub"])
+    jti = payload.get("jti")
+    sid = payload.get("sid")
     result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if user is None or not user.is_active:
+        _log_refresh_rejected(
+            "user_not_found_or_inactive",
+            jti=jti,
+            sid=sid,
+            extra={"sub": user_id},
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found or inactive",
@@ -550,6 +606,16 @@ async def _validate_single_refresh_token(
     if iat is not None:
         token_issued_at = datetime.fromtimestamp(iat, tz=timezone.utc)
         if token_issued_at < token_cutoff(user):
+            _log_refresh_rejected(
+                "iat_before_cutoff",
+                jti=jti,
+                sid=sid,
+                extra={
+                    "sub": user_id,
+                    "iat": iat,
+                    "cutoff": int(token_cutoff(user).timestamp()),
+                },
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Session has been invalidated",
@@ -562,9 +628,13 @@ async def _validate_single_refresh_token(
     # frontend's terminal-vs-transient classifier needs no change. The
     # planned reauth break is operator-decision Q7 — see
     # infra/PR2_REAUTH_BREAK.md.
-    jti = payload.get("jti")
-    sid = payload.get("sid")
     if not jti or not sid:
+        _log_refresh_rejected(
+            "missing_jti_or_sid",
+            jti=jti,
+            sid=sid,
+            extra={"sub": user_id},
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Session has been invalidated",
@@ -596,6 +666,12 @@ async def _validate_single_refresh_token(
             detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
         ) from exc
     if session_row is None:
+        _log_refresh_rejected(
+            "redis_primary_and_grace_missing",
+            jti=jti,
+            sid=sid,
+            extra={"sub": user.id},
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Session has been invalidated",
@@ -622,6 +698,17 @@ async def _validate_single_refresh_token(
     row_user_id = session_row.get("user_id")
     row_sid = session_row.get("sid")
     if row_user_id != user.id or row_sid != sid:
+        _log_refresh_rejected(
+            "row_binding_mismatch",
+            jti=jti,
+            sid=sid,
+            extra={
+                "sub": user.id,
+                "row_user_id": row_user_id,
+                "row_sid_h": _hash_for_log(row_sid) if isinstance(row_sid, str) else None,
+                "redis_state": redis_state,
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Session has been invalidated",
@@ -657,6 +744,12 @@ async def _validate_single_refresh_token(
                 detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
             ) from exc
         if not in_family:
+            _log_refresh_rejected(
+                "family_member_missing",
+                jti=jti,
+                sid=sid,
+                extra={"sub": user.id},
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Session has been invalidated",
@@ -675,6 +768,18 @@ async def _validate_single_refresh_token(
     if session_created_at:
         session_start = datetime.fromtimestamp(session_created_at, tz=timezone.utc)
         if datetime.now(timezone.utc) - session_start > timedelta(seconds=ttl_seconds):
+            _log_refresh_rejected(
+                "absolute_lifetime_expired",
+                jti=jti,
+                sid=sid,
+                extra={
+                    "sub": user.id,
+                    "ttl_seconds": ttl_seconds,
+                    "age_seconds": int(
+                        (datetime.now(timezone.utc) - session_start).total_seconds()
+                    ),
+                },
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail=SESSION_EXPIRED_DETAIL,
@@ -733,6 +838,10 @@ async def _validate_refresh_cookie(
 
     distinct_user_ids = {tup[0].id for tup in successes}
     if len(distinct_user_ids) > 1:
+        _log_refresh_rejected(
+            "ambiguous_session_multiple_users",
+            extra={"distinct_user_count": len(distinct_user_ids)},
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=AMBIGUOUS_SESSION_DETAIL,
@@ -1745,14 +1854,23 @@ async def mfa_email_code(
     # Redis so /mfa/email-verify can enforce single-use (pentest L1).
     email_token, jti = create_mfa_email_token(user.id, code)
 
-    redis = redis_client.get_client()
-    if redis is not None:
-        await redis.set(
-            f"mfa_email_jti:{jti}", str(user.id), ex=MFA_EMAIL_TOKEN_TTL_SECONDS
+    # 2026-05-19: route through the redis_client helper so the
+    # transport-normalizer wrapper covers this path. Without the
+    # wrapper, a closed-transport RuntimeError from uvloop here would
+    # produce a 500 instead of a recoverable 503. The helper returns
+    # False when REDIS_URL is unset (dev mode); production must fail
+    # closed.
+    try:
+        stored = await redis_client.mfa_email_nonce_set(
+            jti, user.id, MFA_EMAIL_TOKEN_TTL_SECONDS
         )
-    elif app_settings.app_env == "production":
-        # In prod we must have Redis; empty REDIS_URL means the single-use
-        # guarantee is disabled — refuse to issue a token.
+    except (RedisRequired, RedisError) as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="MFA email flow temporarily unavailable",
+        ) from exc
+    if not stored and app_settings.app_env == "production":
+        # Empty REDIS_URL in prod = single-use guarantee disabled. Refuse.
         raise HTTPException(
             status_code=503,
             detail="MFA email flow temporarily unavailable",
@@ -1788,13 +1906,13 @@ async def mfa_email_verify(
     # Legacy tokens (pre-jti) are rejected so users re-request under the
     # new single-use flow.
     jti = email_payload.get("jti")
-    redis = redis_client.get_client()
-    if redis is None and app_settings.app_env == "production":
+    redis_configured = redis_client.get_client() is not None
+    if not redis_configured and app_settings.app_env == "production":
         raise HTTPException(
             status_code=503,
             detail="MFA email flow temporarily unavailable",
         )
-    if redis is not None and jti is None:
+    if redis_configured and jti is None:
         raise HTTPException(status_code=401, detail="Invalid or expired email code")
 
     # Verify the code matches using HMAC (keyed hash, not brute-forceable).
@@ -1809,8 +1927,17 @@ async def mfa_email_verify(
     # Only consume the jti after the code is proven valid. Atomic DEL:
     # if it returns 0 the token was already used (replay attempt) → 401.
     # Rate limit (10/min) backs this up against concurrent racing.
-    if redis is not None:
-        consumed = await redis.delete(f"mfa_email_jti:{jti}")
+    #
+    # 2026-05-19: route through the redis_client helper so the
+    # transport-normalizer wrapper covers this path too.
+    if redis_configured:
+        try:
+            consumed = await redis_client.mfa_email_nonce_consume(jti)
+        except (RedisRequired, RedisError) as exc:
+            raise HTTPException(
+                status_code=503,
+                detail="MFA email flow temporarily unavailable",
+            ) from exc
         if not consumed:
             raise HTTPException(status_code=401, detail="Invalid or expired email code")
 

--- a/backend/tests/routers/test_refresh_redis_transport_integration.py
+++ b/backend/tests/routers/test_refresh_redis_transport_integration.py
@@ -353,3 +353,260 @@ class TestRefreshRejectedLogging:
         # Hash is 8 hex chars.
         assert len(rejection_logs[0]["jti_h"]) == 8
         assert len(rejection_logs[0]["sid_h"]) == 8
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_token_logs_reason(
+        self, session_factory
+    ) -> None:
+        """Empty cookie header → ``no_refresh_token`` log event. This
+        is the diagnostic the 2026-05-19 overnight incident needs:
+        when the browser stops sending the refresh cookie, ops can
+        distinguish "cookie missing" from "cookie present but
+        invalid"."""
+        app = _make_app(session_factory)
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as client:
+                res = client.post("/api/v1/auth/refresh")
+        assert res.status_code == 401
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+            and ev.get("reason") == "no_refresh_token"
+        ]
+        assert len(rejection_logs) == 1, (
+            f"Expected exactly one no_refresh_token event; got: {captured}"
+        )
+
+
+# ── 503 wins over a later 401 across the cookie list ────────────────────
+
+
+class TestRefreshPrefersTransientOverTerminal:
+    """When the browser sends BOTH a legacy and a current
+    ``refresh_token`` cookie, the validator walks them in arrival
+    order. If the FIRST one hits a Redis transport failure (503) and
+    the SECOND one is invalid (401), the response MUST be 503, not
+    401 — otherwise a transient infra blip on the live cookie would
+    force a real logout because the stale cookie's 401 overwrote the
+    503 as the final ``last_exc``.
+
+    This is the architect's P1 fix on PR #314: terminal-auth (401)
+    must never silently overwrite a transient (5xx) seen earlier
+    across the cookie list.
+    """
+
+    def _patch_client_get(self, side_effect):
+        """Same client-level patch trick as the parent file: patch
+        the inner Redis client's ``.get`` so the wrapper actually
+        runs. ``side_effect`` may be a callable for per-call values."""
+        import app.redis_client as rc
+
+        client = rc.get_client()
+        if client is None:
+            pytest.skip(
+                "Autouse fake-Redis fixture didn't install a client"
+            )
+        return patch.object(client, "get", side_effect=side_effect)
+
+    @pytest.mark.asyncio
+    async def test_first_cookie_503_beats_second_cookie_401(
+        self, session_factory
+    ) -> None:
+        """Two refresh_token cookies in the header. The first hits a
+        closed-transport RuntimeError → 503; the second is a
+        malformed JWT → 401 before it ever touches Redis. Final
+        status MUST be 503."""
+        seed = await _seed_user(session_factory)
+        good_token = issue_test_refresh_token(seed["user_id"])
+        app = _make_app(session_factory)
+
+        # Closed-transport RuntimeError only on the first .get call;
+        # the second cookie ("not.a.jwt") fails JWT decode before
+        # any Redis call, so .get is never called for it.
+        with self._patch_client_get(
+            side_effect=RuntimeError(
+                "unable to perform operation on <TCPTransport closed=True "
+                "reading=False 0x0>; the handler is closed"
+            ),
+        ):
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    headers={
+                        # Two cookies, same name, in arrival order: the
+                        # valid JWT first (will hit Redis → 503), the
+                        # malformed one second (would 401 on decode).
+                        "cookie": (
+                            f"refresh_token={good_token}; "
+                            f"refresh_token=not.a.jwt"
+                        ),
+                    },
+                )
+
+        # The contract: 503 wins. A 401 here would be the regression.
+        assert res.status_code == 503, (
+            f"Expected 503 (transient), got {res.status_code}: "
+            f"{res.json()}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_invalid_cookie_still_401(
+        self, session_factory
+    ) -> None:
+        """Sanity guard: the transient-preferral logic must NOT
+        upgrade a single-cookie 401 to a 503. When only one cookie is
+        present and it fails terminally, the response is still 401 —
+        no transient ever seen."""
+        app = _make_app(session_factory)
+        with TestClient(app) as client:
+            res = client.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": "not.a.jwt"},
+            )
+        assert res.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_503_first_then_503_returns_503(
+        self, session_factory
+    ) -> None:
+        """Belt-and-braces: two cookies, both produce 503. Result is
+        still 503 (transient_exc captured from the first; last_exc
+        also 5xx)."""
+        seed = await _seed_user(session_factory)
+        a = issue_test_refresh_token(seed["user_id"])
+        b = issue_test_refresh_token(seed["user_id"])
+        app = _make_app(session_factory)
+        with self._patch_client_get(
+            side_effect=RuntimeError("the handler is closed"),
+        ):
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    headers={
+                        "cookie": f"refresh_token={a}; refresh_token={b}"
+                    },
+                )
+        assert res.status_code == 503
+
+
+# ── Lua rotation rejection paths emit reason logs ───────────────────────
+
+
+class TestRefreshLuaRotationLogging:
+    """The two rotation-layer terminal 401 paths must emit
+    ``auth.refresh.rejected`` events with a stable ``reason`` so ops
+    can distinguish them from the earlier validation-chain 401s.
+
+    Architect P2 on PR #314: 'all terminal 401 paths are logged' is the
+    contract these tests pin. Tests stub ``_rotate_refresh_session`` at
+    the auth-module level so the validation chain succeeds and we land
+    inside the rotation outcome branches without spinning up a real
+    Lua-capable Redis."""
+
+    @pytest.mark.asyncio
+    async def test_lua_session_revoked_logs_reason(
+        self, session_factory, monkeypatch
+    ) -> None:
+        """When the Lua script returns ``session_revoked`` (concurrent
+        /logout deleted the family set), the rotation handler emits
+        ``lua_session_revoked`` and raises 401."""
+        from app.routers import auth as auth_module
+        from app.redis_client import SESSION_ROTATE_REVOKED
+
+        seed = await _seed_user(session_factory)
+        token = issue_test_refresh_token(seed["user_id"])
+        app = _make_app(session_factory)
+
+        async def _stub_rotate(
+            user_id, old_jti, sid, *, ttl_seconds, session_created_at,
+        ):
+            # Return signature: (new_token, new_jti, sid, lua_result)
+            return ("unused", "new-jti", sid, SESSION_ROTATE_REVOKED)
+
+        monkeypatch.setattr(
+            auth_module, "_rotate_refresh_session", _stub_rotate
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 401
+        assert "invalidated" in res.json()["detail"].lower()
+
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+            and ev.get("reason") == "lua_session_revoked"
+        ]
+        assert len(rejection_logs) == 1, (
+            f"Expected exactly one lua_session_revoked event; got: "
+            f"{captured}"
+        )
+        # PII guard: only hash prefixes, no raw jti/sid.
+        assert rejection_logs[0]["sub"] == seed["user_id"]
+        assert len(rejection_logs[0]["jti_h"]) == 8
+        assert len(rejection_logs[0]["sid_h"]) == 8
+
+    @pytest.mark.asyncio
+    async def test_already_rotated_grace_revalidation_failed_logs_reason(
+        self, session_factory, monkeypatch
+    ) -> None:
+        """When the Lua script returns ``already_rotated`` but the
+        winner's grace key is gone by the time we re-probe (TTL expired
+        or concurrent logout), emit
+        ``already_rotated_grace_revalidation_failed`` and 401."""
+        from app.routers import auth as auth_module
+        from app.redis_client import SESSION_ROTATE_ALREADY_ROTATED
+
+        seed = await _seed_user(session_factory)
+        token = issue_test_refresh_token(seed["user_id"])
+        app = _make_app(session_factory)
+
+        async def _stub_rotate(
+            user_id, old_jti, sid, *, ttl_seconds, session_created_at,
+        ):
+            return ("unused", "new-jti", sid, SESSION_ROTATE_ALREADY_ROTATED)
+
+        async def _stub_grace_missing(jti):
+            return None  # Winner's grace key is gone.
+
+        async def _stub_family_alive(sid):
+            return True
+
+        monkeypatch.setattr(
+            auth_module, "_rotate_refresh_session", _stub_rotate
+        )
+        monkeypatch.setattr(
+            auth_module.redis_client, "session_grace", _stub_grace_missing
+        )
+        monkeypatch.setattr(
+            auth_module.redis_client,
+            "session_family_exists",
+            _stub_family_alive,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 401
+
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+            and ev.get("reason") == "already_rotated_grace_revalidation_failed"
+        ]
+        assert len(rejection_logs) == 1, (
+            f"Expected exactly one already_rotated_grace_revalidation_failed "
+            f"event; got: {captured}"
+        )
+        # The diagnostic fields let ops triage which check failed.
+        ev = rejection_logs[0]
+        assert ev["grace_row_missing"] is True
+        assert ev["family_alive"] is True
+        assert ev["sub"] == seed["user_id"]

--- a/backend/tests/routers/test_refresh_redis_transport_integration.py
+++ b/backend/tests/routers/test_refresh_redis_transport_integration.py
@@ -1,0 +1,355 @@
+"""End-to-end coverage for the Redis transport-normalizer fix.
+
+Tests in ``test_redis_transport_normalizer.py`` pin the decorator's
+contract in isolation. These tests pin the integrated behaviour: when
+``redis_client.session_validate`` raises the closed-transport
+``RuntimeError`` from inside FastAPI's request-handling stack, the
+router returns **503**, not **500** — the canonical fix for the
+2026-05-19T07:10:52 production trace.
+
+Also covered: the structured ``auth.refresh.rejected`` log event fires
+on every terminal 401 path with the correct ``reason`` enum.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+import structlog
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import router as auth_router
+from app.security import hash_password
+from tests.conftest import issue_test_refresh_token
+
+
+PASSWORD = "starting-password-1"
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(factory) -> dict[str, Any]:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@example.com",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id}
+
+
+# ── The canonical 2026-05-19T07:10 production trace, end-to-end ─────────
+
+
+class TestRefreshReturns503OnClosedTransport:
+    """When the underlying Redis client raises a closed-transport
+    ``RuntimeError``, the ``_normalize_transport_errors`` wrapper
+    translates it to ``RedisConnectionError`` so the router's existing
+    ``except (RedisRequired, RedisError)`` handler catches it and
+    returns **503** — not 500.
+
+    The MOCK strategy: patch the inner Redis client's ``get`` method
+    so the wrapped ``session_validate`` function actually runs (and
+    the decorator's try/except fires). Patching ``session_validate``
+    directly would bypass the wrapper entirely — the test would tell
+    us nothing about the integrated behaviour.
+    """
+
+    def _patch_client_get(self, side_effect):
+        """Context manager: patch the inner Redis client's ``.get``
+        method on the autouse fake-Redis instance that's already
+        installed by tests/conftest.py. Returns the patch object."""
+        # The fake Redis client lives in app.redis_client._client after
+        # the autouse fixture runs. Patch its .get to raise the desired
+        # exception when called.
+        import app.redis_client as rc
+
+        # Force the fake client to materialize if it hasn't.
+        client = rc.get_client()
+        if client is None:
+            pytest.skip(
+                "Autouse fake-Redis fixture didn't install a client"
+            )
+        return patch.object(client, "get", side_effect=side_effect)
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_503_on_closed_transport_runtime_error(
+        self, session_factory
+    ) -> None:
+        seed = await _seed_user(session_factory)
+        token = issue_test_refresh_token(seed["user_id"])
+        app = _make_app(session_factory)
+
+        # The exact production trace from 2026-05-19T07:10:52.
+        closed_transport_error = RuntimeError(
+            "unable to perform operation on <TCPTransport closed=True "
+            "reading=False 0x55a57d2583e0>; the handler is closed"
+        )
+
+        with self._patch_client_get(side_effect=closed_transport_error):
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+
+        # The contract: 503, not 500. The frontend reactive-recovery
+        # path then treats this as transient and retries.
+        assert res.status_code == 503, (
+            f"Expected 503, got {res.status_code}: {res.json()}"
+        )
+        body = res.json()
+        # User-facing constant, not the raw transport message.
+        assert "temporarily unavailable" in body["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_503_on_broken_pipe(
+        self, session_factory
+    ) -> None:
+        """Same property for the OSError class. ``BrokenPipeError``
+        derives from ``OSError``; the wrapper catches the whole
+        family."""
+        seed = await _seed_user(session_factory)
+        token = issue_test_refresh_token(seed["user_id"])
+        app = _make_app(session_factory)
+
+        with self._patch_client_get(
+            side_effect=BrokenPipeError(32, "Broken pipe")
+        ):
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_refresh_returns_500_on_genuine_programmer_bug(
+        self, session_factory
+    ) -> None:
+        """CRITICAL safety property of the narrow filter: a bare
+        ``RuntimeError`` whose message doesn't match a transport
+        marker MUST still propagate as 500. If this test ever passes
+        with status 503, the filter has been widened too far and
+        real programmer bugs would be silently swallowed as
+        "Service Unavailable" in production."""
+        seed = await _seed_user(session_factory)
+        token = issue_test_refresh_token(seed["user_id"])
+        app = _make_app(session_factory)
+
+        with self._patch_client_get(
+            side_effect=RuntimeError("programmer bug: list index out of range")
+        ):
+            # raise_server_exceptions=False so TestClient returns the
+            # 500 response instead of re-raising the inner exception —
+            # we want to assert on the response, not catch the bug.
+            with TestClient(app, raise_server_exceptions=False) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 500, (
+            f"Genuine RuntimeError must stay a 500; got {res.status_code}"
+        )
+
+
+# ── Structured rejection logging ────────────────────────────────────────
+
+
+class TestRefreshRejectedLogging:
+    """Every terminal 401 path emits one ``auth.refresh.rejected``
+    structlog event with a stable ``reason`` enum. Ops uses this to
+    distinguish the seven 401 paths without seeing raw refresh tokens.
+    ``jti_h`` / ``sid_h`` are 8-char SHA-256 prefixes; raw ``jti``/
+    ``sid`` are NEVER logged.
+
+    Uses ``structlog.testing.capture_logs()`` (NOT pytest ``caplog``)
+    because the app's structlog setup uses native structlog renderers
+    rather than the stdlib bridge, so ``caplog.records`` doesn't see
+    our events.
+    """
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_logs_reason(
+        self, session_factory
+    ) -> None:
+        app = _make_app(session_factory)
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": "not.a.jwt"},
+                )
+        assert res.status_code == 401
+        rejection_logs = [
+            ev for ev in captured if ev.get("event") == "auth.refresh.rejected"
+        ]
+        assert len(rejection_logs) >= 1, (
+            f"Expected auth.refresh.rejected event; got: {captured}"
+        )
+        assert rejection_logs[0]["reason"] == "invalid_token_decode"
+
+    @pytest.mark.asyncio
+    async def test_missing_jti_sid_logs_reason(
+        self, session_factory
+    ) -> None:
+        """A refresh JWT without ``jti``/``sid`` (legacy from before
+        PR #306) logs ``missing_jti_or_sid``."""
+        from app.security import create_refresh_token
+
+        seed = await _seed_user(session_factory)
+        # Build a refresh JWT that LACKS jti/sid — simulate a legacy
+        # pre-PR-306 token by stripping those claims after issue.
+        import jwt as _jwt
+        token = create_refresh_token(seed["user_id"], ttl_seconds=3600)[0]
+        payload = _jwt.decode(
+            token, app_settings.jwt_secret_key,
+            algorithms=[app_settings.jwt_algorithm],
+        )
+        payload.pop("jti", None)
+        payload.pop("sid", None)
+        legacy_token = _jwt.encode(
+            payload, app_settings.jwt_secret_key,
+            algorithm=app_settings.jwt_algorithm,
+        )
+
+        app = _make_app(session_factory)
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": legacy_token},
+                )
+        assert res.status_code == 401
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+            and ev.get("reason") == "missing_jti_or_sid"
+        ]
+        assert len(rejection_logs) >= 1, (
+            f"Expected missing_jti_or_sid event; got: {captured}"
+        )
+        # Confirm the user id field is populated for ops correlation.
+        assert rejection_logs[0]["sub"] == seed["user_id"]
+
+    @pytest.mark.asyncio
+    async def test_log_event_never_contains_raw_jti_or_sid(
+        self, session_factory
+    ) -> None:
+        """PII guard: raw jti and sid values must NEVER appear in any
+        captured log event. Only the 8-char hash prefix is allowed."""
+        from app.security import create_refresh_token
+
+        seed = await _seed_user(session_factory)
+        # Hand-mint a token with known jti/sid we can grep for.
+        # ``create_refresh_token`` returns ``(token, jti, sid)`` but does
+        # NOT insert the primary key into Redis — so the validation
+        # chain hits the "redis_primary_and_grace_missing" path.
+        token, jti, sid = create_refresh_token(
+            seed["user_id"], ttl_seconds=3600
+        )
+
+        app = _make_app(session_factory)
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as client:
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 401
+
+        # Confirm we hit a redacted-log path.
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+        ]
+        assert rejection_logs, f"No rejection log captured: {captured}"
+
+        # Flatten every captured event to a string and assert that NO
+        # field contains the raw jti or sid. Only the hash prefix is
+        # acceptable.
+        for ev in captured:
+            for key, value in ev.items():
+                if not isinstance(value, str):
+                    continue
+                assert value != jti, (
+                    f"Raw jti leaked in event field {key!r}: {value!r}"
+                )
+                assert value != sid, (
+                    f"Raw sid leaked in event field {key!r}: {value!r}"
+                )
+
+        # The rejection log MUST carry the hash prefix instead.
+        assert rejection_logs[0]["jti_h"] is not None
+        assert rejection_logs[0]["sid_h"] is not None
+        # Hash is 8 hex chars.
+        assert len(rejection_logs[0]["jti_h"]) == 8
+        assert len(rejection_logs[0]["sid_h"]) == 8

--- a/backend/tests/test_redis_transport_normalizer.py
+++ b/backend/tests/test_redis_transport_normalizer.py
@@ -411,3 +411,140 @@ class TestLuaResponseErrorParserStillWorks:
         # Original ResponseError preserved — NOT wrapped as
         # RedisConnectionError.
         assert "WRONGTYPE" in str(exc_info.value)
+
+
+# ── Poisoned-pool retirement ────────────────────────────────────────────
+
+
+class TestPoisonedClientRetirement:
+    """When the wrapper translates a closed-transport ``RuntimeError``
+    or socket-level ``OSError`` into ``RedisConnectionError``, it MUST
+    also drop the module-level Redis singleton so the next call to
+    ``get_client()`` rebuilds the underlying connection pool.
+
+    Without this, the frontend's reactive 503 retry would loop back to
+    the same poisoned pool (``RuntimeError`` is deliberately excluded
+    from ``retry_on_error``, so redis-py's own disconnect-on-retry
+    path doesn't run for the uvloop closed-transport class). The
+    operator-visible symptom would be: one closed-transport event
+    triggers a permanent burst of 503s until the worker restarts.
+    """
+
+    @pytest.mark.asyncio
+    async def test_closed_transport_retires_singleton(self) -> None:
+        import app.redis_client as rc
+
+        # Install a sentinel client so retirement has something to drop.
+        # AsyncMock-style aclose so the best-effort cleanup succeeds.
+        from unittest.mock import AsyncMock, MagicMock
+        sentinel_client = MagicMock()
+        sentinel_client.aclose = AsyncMock()
+        rc._client = sentinel_client
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RuntimeError(
+                "unable to perform operation on <TCPTransport closed=True "
+                "reading=False 0x55a57d2583e0>; the handler is closed"
+            )
+
+        with pytest.raises(RedisConnectionError):
+            await helper()
+
+        # The singleton MUST have been dropped — that is the core
+        # contract of the fix. The next ``get_client()`` will rebuild.
+        assert rc._client is None
+        # Best-effort cleanup ran on the poisoned client.
+        sentinel_client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_broken_pipe_retires_singleton(self) -> None:
+        """OSError branch must also retire — broken pipe / connection
+        reset class follows the same code path."""
+        import app.redis_client as rc
+        from unittest.mock import AsyncMock, MagicMock
+
+        sentinel_client = MagicMock()
+        sentinel_client.aclose = AsyncMock()
+        rc._client = sentinel_client
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise BrokenPipeError(32, "Broken pipe")
+
+        with pytest.raises(RedisConnectionError):
+            await helper()
+        assert rc._client is None
+
+    @pytest.mark.asyncio
+    async def test_unrelated_runtime_error_does_not_retire_singleton(
+        self,
+    ) -> None:
+        """Critical safety property: a real programmer bug must NOT
+        retire the pool. Dropping the singleton on every random
+        RuntimeError would mask bugs AND thrash the connection pool."""
+        import app.redis_client as rc
+        from unittest.mock import AsyncMock, MagicMock
+
+        sentinel_client = MagicMock()
+        sentinel_client.aclose = AsyncMock()
+        rc._client = sentinel_client
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RuntimeError("programmer bug: list index out of range")
+
+        with pytest.raises(RuntimeError):
+            await helper()
+        # Singleton still in place — NOT retired.
+        assert rc._client is sentinel_client
+        sentinel_client.aclose.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_redis_response_error_does_not_retire_singleton(
+        self,
+    ) -> None:
+        """ResponseError carries Lua return tokens; the connection is
+        still healthy. Retiring on this class would force every
+        ``session_revoked`` rotation to rebuild the pool — pointless
+        churn."""
+        import app.redis_client as rc
+        from unittest.mock import AsyncMock, MagicMock
+
+        sentinel_client = MagicMock()
+        sentinel_client.aclose = AsyncMock()
+        rc._client = sentinel_client
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RedisResponseError("session_revoked")
+
+        with pytest.raises(RedisResponseError):
+            await helper()
+        assert rc._client is sentinel_client
+        sentinel_client.aclose.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retirement_survives_aclose_failure(self) -> None:
+        """``aclose()`` is best-effort: if the underlying socket is
+        already dead, ``aclose`` itself may raise. The singleton must
+        still be dropped — we don't want to replace one
+        ConnectionError with another."""
+        import app.redis_client as rc
+        from unittest.mock import AsyncMock, MagicMock
+
+        sentinel_client = MagicMock()
+        sentinel_client.aclose = AsyncMock(
+            side_effect=RuntimeError("aclose can't reach dead socket")
+        )
+        rc._client = sentinel_client
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RuntimeError("the handler is closed")
+
+        # The translated ConnectionError still surfaces — aclose's
+        # failure is swallowed.
+        with pytest.raises(RedisConnectionError):
+            await helper()
+        assert rc._client is None

--- a/backend/tests/test_redis_transport_normalizer.py
+++ b/backend/tests/test_redis_transport_normalizer.py
@@ -1,0 +1,413 @@
+"""Redis transport-error normalizer — 2026-05-19.
+
+Production trace at 2026-05-19T07:10:52 showed an uncaught
+``RuntimeError: unable to perform operation on <TCPTransport closed=True
+reading=False ...>; the handler is closed`` escaping from
+``redis-py``'s ``health_check`` during ``/api/v1/auth/refresh``. The
+router's existing ``except (RedisRequired, RedisError)`` handler did
+not catch it (``RuntimeError`` is not a ``RedisError`` subclass), so
+FastAPI returned 500 instead of the recoverable 503-fallback the
+frontend already knows how to handle.
+
+``redis_client._normalize_transport_errors`` is the narrow translation
+layer that converts the known closed-transport ``RuntimeError`` (and
+socket-level ``OSError`` family) into ``redis.exceptions.ConnectionError``.
+These tests pin the contract:
+
+  1. Closed-transport ``RuntimeError`` → ``RedisConnectionError``
+  2. Unrelated ``RuntimeError("programmer bug")`` propagates unchanged
+  3. ``OSError`` / ``BrokenPipeError`` / ``ConnectionResetError`` →
+     ``RedisConnectionError``
+  4. ``RedisRequired`` (also a ``RuntimeError`` subclass) propagates
+     unchanged — programmer/config signal, not transport
+  5. ``RedisError`` subclasses (including ``ResponseError`` from Lua)
+     pass through unchanged — ``session_rotate_lua``'s Lua-return-token
+     parser depends on the raw ``ResponseError`` message
+  6. Application-level success values pass through unchanged
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
+from redis.exceptions import ResponseError as RedisResponseError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from app.redis_client import (
+    RedisRequired,
+    _looks_like_dead_transport,
+    _normalize_transport_errors,
+)
+
+
+# ── Marker detection ────────────────────────────────────────────────────
+
+
+class TestLooksLikeDeadTransport:
+    """The closed-transport detector must be narrow: real bug
+    ``RuntimeError`` must NOT match. Production uvloop / asyncio
+    transport-death messages MUST match.
+    """
+
+    def test_uvloop_tcptransport_closed_matches(self) -> None:
+        # Verbatim message from the 2026-05-19T07:10:52 production trace.
+        exc = RuntimeError(
+            "unable to perform operation on <TCPTransport closed=True "
+            "reading=False 0x55a57d2583e0>; the handler is closed"
+        )
+        assert _looks_like_dead_transport(exc) is True
+
+    def test_handler_is_closed_alone_matches(self) -> None:
+        exc = RuntimeError("the handler is closed")
+        assert _looks_like_dead_transport(exc) is True
+
+    def test_broken_pipe_message_matches(self) -> None:
+        exc = RuntimeError("broken pipe during write")
+        assert _looks_like_dead_transport(exc) is True
+
+    def test_connection_reset_message_matches(self) -> None:
+        exc = RuntimeError("Connection reset by peer")
+        assert _looks_like_dead_transport(exc) is True
+
+    def test_transport_closed_generic_matches(self) -> None:
+        exc = RuntimeError("transport is closed")
+        assert _looks_like_dead_transport(exc) is True
+
+    def test_case_insensitive(self) -> None:
+        # Real messages may be mixed case; the matcher normalises.
+        exc = RuntimeError("TCPTRANSPORT CLOSED")
+        assert _looks_like_dead_transport(exc) is True
+
+    def test_unrelated_runtime_error_does_not_match(self) -> None:
+        """The critical guard: programmer bugs MUST NOT match."""
+        exc = RuntimeError("programmer bug: list index out of range")
+        assert _looks_like_dead_transport(exc) is False
+
+    def test_empty_message_does_not_match(self) -> None:
+        exc = RuntimeError()
+        assert _looks_like_dead_transport(exc) is False
+
+    def test_value_error_with_transport_words_does_not_match(self) -> None:
+        # Pedantic: the matcher only runs inside the wrapper's RuntimeError
+        # branch, but the predicate itself should also not falsely match
+        # if accidentally called on a non-RuntimeError.
+        exc = ValueError("tcptransport closed but this is not a transport error")
+        # The matcher is a substring scan; it WILL match on the string.
+        # That's by design — the wrapper only routes to this matcher
+        # for RuntimeError, so a stray ValueError can't reach it in
+        # practice. Documenting the design here.
+        assert _looks_like_dead_transport(exc) is True
+
+
+# ── Decorator wrapping behaviour ────────────────────────────────────────
+
+
+class TestNormalizeTransportErrors:
+    """Six core contracts the wrapper must enforce."""
+
+    @pytest.mark.asyncio
+    async def test_success_passes_through(self) -> None:
+        @_normalize_transport_errors
+        async def helper() -> str:
+            return "ok"
+
+        assert await helper() == "ok"
+
+    @pytest.mark.asyncio
+    async def test_closed_transport_runtime_error_becomes_redis_connection_error(
+        self,
+    ) -> None:
+        """Spec #1 — the canonical production failure."""
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RuntimeError(
+                "unable to perform operation on <TCPTransport closed=True "
+                "reading=False 0x55a57d2583e0>; the handler is closed"
+            )
+
+        with pytest.raises(RedisConnectionError) as exc_info:
+            await helper()
+        # The original RuntimeError is preserved as the cause so a future
+        # traceback still shows where the closed-transport surfaced.
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert "the handler is closed" in str(exc_info.value.__cause__)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_runtime_error_propagates_unchanged(self) -> None:
+        """Spec #2 — real programmer bugs MUST still fail loudly as 500.
+        This is the critical safety property of the narrow filter."""
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RuntimeError("programmer bug: divide by zero")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await helper()
+        # The original RuntimeError is the raised exception, NOT a
+        # RedisConnectionError. The except clause must let it through.
+        assert not isinstance(exc_info.value, RedisConnectionError)
+        assert "programmer bug" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_broken_pipe_oserror_becomes_redis_connection_error(self) -> None:
+        """Spec #3a — socket-level I/O failure during a Redis op."""
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise BrokenPipeError(32, "Broken pipe")
+
+        with pytest.raises(RedisConnectionError) as exc_info:
+            await helper()
+        assert isinstance(exc_info.value.__cause__, BrokenPipeError)
+
+    @pytest.mark.asyncio
+    async def test_connection_reset_oserror_becomes_redis_connection_error(
+        self,
+    ) -> None:
+        """Spec #3b — NAT idle-drop class."""
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise ConnectionResetError(104, "Connection reset by peer")
+
+        with pytest.raises(RedisConnectionError) as exc_info:
+            await helper()
+        assert isinstance(exc_info.value.__cause__, ConnectionResetError)
+
+    @pytest.mark.asyncio
+    async def test_generic_oserror_becomes_redis_connection_error(self) -> None:
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise OSError(101, "Network unreachable")
+
+        with pytest.raises(RedisConnectionError):
+            await helper()
+
+    @pytest.mark.asyncio
+    async def test_redis_required_propagates_unchanged(self) -> None:
+        """Spec #4 — RedisRequired (a RuntimeError subclass) is a
+        programmer / config signal, not a transport issue. It must
+        pass through so the operator sees the original error."""
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RedisRequired("REDIS_URL must be set")
+
+        with pytest.raises(RedisRequired) as exc_info:
+            await helper()
+        assert not isinstance(exc_info.value, RedisConnectionError)
+        assert "REDIS_URL must be set" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_redis_response_error_passes_through_for_lua_token_parsing(
+        self,
+    ) -> None:
+        """Spec #5 — ResponseError carries Lua ``{err = "..."}`` return
+        tokens that ``session_rotate_lua`` parses for the rotation
+        result. Re-classifying as RedisConnectionError would break that
+        parser and turn ``session_revoked`` into a generic 503 instead
+        of a terminal 401."""
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RedisResponseError("session_revoked")
+
+        with pytest.raises(RedisResponseError) as exc_info:
+            await helper()
+        # Original ResponseError preserved verbatim — message intact.
+        assert str(exc_info.value) == "session_revoked"
+
+    @pytest.mark.asyncio
+    async def test_redis_connection_error_passes_through(self) -> None:
+        """Already a sensible Redis-domain exception. No need to
+        re-wrap; routers' existing handler matches on RedisError."""
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RedisConnectionError("Error 111 connecting to host:6379")
+
+        with pytest.raises(RedisConnectionError) as exc_info:
+            await helper()
+        assert "Error 111" in str(exc_info.value)
+        # And it's the literal class — no wrapping / re-raise added.
+        assert exc_info.value.__cause__ is None
+
+    @pytest.mark.asyncio
+    async def test_redis_timeout_error_passes_through(self) -> None:
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RedisTimeoutError("Timeout reading from socket")
+
+        with pytest.raises(RedisTimeoutError):
+            await helper()
+
+    @pytest.mark.asyncio
+    async def test_generic_redis_error_passes_through(self) -> None:
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RedisError("some other Redis-domain error")
+
+        with pytest.raises(RedisError) as exc_info:
+            await helper()
+        assert not isinstance(exc_info.value, RedisConnectionError)
+
+
+# ── End-to-end coverage of every wrapped helper ─────────────────────────
+
+
+class TestSessionHelpersWrapped:
+    """Every public session_* helper in redis_client must wrap. This
+    catches the case where someone adds a new helper and forgets the
+    decorator — a closed transport in the new helper would bypass
+    the wrapper and produce a 500."""
+
+    def test_session_validate_is_wrapped(self) -> None:
+        from app.redis_client import session_validate
+
+        assert hasattr(session_validate, "__wrapped__"), (
+            "session_validate is missing @_normalize_transport_errors"
+        )
+
+    def test_session_grace_is_wrapped(self) -> None:
+        from app.redis_client import session_grace
+
+        assert hasattr(session_grace, "__wrapped__")
+
+    def test_session_family_exists_is_wrapped(self) -> None:
+        from app.redis_client import session_family_exists
+
+        assert hasattr(session_family_exists, "__wrapped__")
+
+    def test_session_family_member_is_wrapped(self) -> None:
+        from app.redis_client import session_family_member
+
+        assert hasattr(session_family_member, "__wrapped__")
+
+    def test_session_issue_is_wrapped(self) -> None:
+        """Spec #6a — pipeline ops (issue, rotation, revoke) MUST also
+        wrap. A broken-pipe error during ``MULTI/EXEC`` would otherwise
+        escape as 500."""
+        from app.redis_client import session_issue
+
+        assert hasattr(session_issue, "__wrapped__")
+
+    def test_session_rotate_lua_is_wrapped(self) -> None:
+        """Spec #6b — rotation pipeline ops wrapped."""
+        from app.redis_client import session_rotate_lua
+
+        assert hasattr(session_rotate_lua, "__wrapped__")
+
+    def test_session_revoke_family_is_wrapped(self) -> None:
+        """Spec #6c — revoke pipeline ops wrapped."""
+        from app.redis_client import session_revoke_family
+
+        assert hasattr(session_revoke_family, "__wrapped__")
+
+    def test_mfa_email_nonce_set_is_wrapped(self) -> None:
+        """Direct-get_client() MFA path must also be covered, per
+        review feedback — wrapping only session helpers leaves the
+        MFA single-use nonce path exposed."""
+        from app.redis_client import mfa_email_nonce_set
+
+        assert hasattr(mfa_email_nonce_set, "__wrapped__")
+
+    def test_mfa_email_nonce_consume_is_wrapped(self) -> None:
+        from app.redis_client import mfa_email_nonce_consume
+
+        assert hasattr(mfa_email_nonce_consume, "__wrapped__")
+
+
+# ── Integration: session_rotate_lua's ResponseError parser still works ──
+
+
+class TestLuaResponseErrorParserStillWorks:
+    """Spec #5 verified at the integration level: when the Lua script
+    returns ``{err = "session_revoked"}`` (or one of the other
+    rotation tokens), the wrapper does NOT swallow it — the inner
+    ``except RedisResponseError`` in ``session_rotate_lua`` runs and
+    returns the token string. This is the hottest path that breaks
+    if we accidentally over-wrap."""
+
+    @pytest.mark.asyncio
+    async def test_lua_session_revoked_returns_token_not_503(self) -> None:
+        from app.redis_client import (
+            SESSION_ROTATE_REVOKED,
+            session_rotate_lua,
+        )
+
+        # Mock the client.eval to raise ResponseError("session_revoked").
+        # The wrapper must let it propagate to session_rotate_lua's own
+        # except clause, which maps it to the bare string token.
+        with patch("app.redis_client.require_client") as mock_require:
+            mock_client = mock_require.return_value
+            mock_client.eval.side_effect = RedisResponseError(
+                "session_revoked"
+            )
+            result = await session_rotate_lua(
+                old_jti="old", new_jti="new", sid="s", user_id=1,
+                idle_ttl_seconds=60,
+            )
+        # The function returns the bare token string, NOT raise.
+        assert result == SESSION_ROTATE_REVOKED
+
+    @pytest.mark.asyncio
+    async def test_lua_already_rotated_returns_token(self) -> None:
+        from app.redis_client import (
+            SESSION_ROTATE_ALREADY_ROTATED,
+            session_rotate_lua,
+        )
+
+        with patch("app.redis_client.require_client") as mock_require:
+            mock_client = mock_require.return_value
+            mock_client.eval.side_effect = RedisResponseError(
+                "already_rotated"
+            )
+            result = await session_rotate_lua(
+                old_jti="o", new_jti="n", sid="s", user_id=1,
+                idle_ttl_seconds=60,
+            )
+        assert result == SESSION_ROTATE_ALREADY_ROTATED
+
+    @pytest.mark.asyncio
+    async def test_lua_jti_collision_returns_token(self) -> None:
+        from app.redis_client import (
+            SESSION_ROTATE_JTI_COLLISION,
+            session_rotate_lua,
+        )
+
+        with patch("app.redis_client.require_client") as mock_require:
+            mock_client = mock_require.return_value
+            mock_client.eval.side_effect = RedisResponseError(
+                "jti_collision"
+            )
+            result = await session_rotate_lua(
+                old_jti="o", new_jti="n", sid="s", user_id=1,
+                idle_ttl_seconds=60,
+            )
+        assert result == SESSION_ROTATE_JTI_COLLISION
+
+    @pytest.mark.asyncio
+    async def test_lua_unknown_response_error_propagates(self) -> None:
+        """An unknown ResponseError (Lua script bug, syntax error,
+        replica desync) is NOT one of the known tokens — it must
+        propagate as RedisResponseError so the router can return
+        503 fail-closed."""
+        from app.redis_client import session_rotate_lua
+
+        with patch("app.redis_client.require_client") as mock_require:
+            mock_client = mock_require.return_value
+            mock_client.eval.side_effect = RedisResponseError(
+                "WRONGTYPE Operation against a key holding the wrong "
+                "kind of value"
+            )
+            with pytest.raises(RedisResponseError) as exc_info:
+                await session_rotate_lua(
+                    old_jti="o", new_jti="n", sid="s", user_id=1,
+                    idle_ttl_seconds=60,
+                )
+        # Original ResponseError preserved — NOT wrapped as
+        # RedisConnectionError.
+        assert "WRONGTYPE" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Production trace at **2026-05-19T07:10:52** showed an uncaught `RuntimeError: unable to perform operation on <TCPTransport closed=True ...>; the handler is closed` escaping from redis-py's health-check during `/api/v1/auth/refresh` — uvloop's signal that the underlying TCP socket had been silently dropped between App Platform and the Redis droplet. The router's existing `except (RedisRequired, RedisError)` did not catch it (`RuntimeError` isn't a `RedisError`), so FastAPI returned **500** instead of the recoverable **503** the frontend's reactive recovery already handles.

User-visible symptom (the screenshot upstream of this PR):

```
Phase 1 — 3× client-side 46s timeouts as redis-py retried against a dead socket
Phase 2 — POST /auth/refresh 500 (this uncaught RuntimeError)
Phase 3 — POST /auth/refresh 401 (next request on a fresh pool connection)
Cascade — frontend dispatched auth:unauthenticated → AppShell → /login
```

This PR fixes the **500-uncaught-exception** class. Phase 3 (session keys missing post-overnight) is a separate investigation; this PR also adds **structured rejection logging** so the next time it happens, we can pin which of the ten 401 paths fired without seeing raw refresh tokens.

## Changes

### `_normalize_transport_errors` decorator (`redis_client.py`)

Narrow filter applied to every async Redis helper. Translates:
- `OSError` family (`BrokenPipeError`, `ConnectionResetError`, generic `OSError`) — socket-level I/O failures during a Redis op.
- `RuntimeError` whose message matches a small fixed list: `tcptransport closed`, `handler is closed`, `transport closed`, `broken pipe`, `connection reset`, `closed socket`.

Both become `redis.exceptions.ConnectionError` so the router's existing 503 fallback fires.

**Deliberately preserved (NOT re-classified):**
- `RedisError` subclasses — including `ResponseError` from Lua EVAL. `session_rotate_lua` parses ResponseError for the rotation-token contract (`session_revoked` / `already_rotated` / `jti_collision`); papering over that would break rotation logic. Tests pin this.
- `RedisRequired` — programmer/config signal. Must still fail loud until `REDIS_URL` is set.
- Bare `RuntimeError` whose message doesn't match the marker list — almost certainly a real bug. Re-raise so it surfaces as 500 with full traceback. The `test_unrelated_runtime_error_propagates_unchanged` test is the canonical safety property of the narrow filter.

Decorator applied to all 7 session helpers (`session_issue`, `session_validate`, `session_grace`, `session_family_exists`, `session_family_member`, `session_rotate_lua`, `session_revoke_family`) + 2 new MFA helpers.

### Poisoned-pool retirement (review follow-up, a2ffdb0)

The wrapper now drops the module-level Redis singleton via `_retire_poisoned_client()` BEFORE raising the translated `ConnectionError`, on both the `OSError` and matching-`RuntimeError` branches. Without this, the frontend's reactive 503 retry would loop straight back to the same poisoned pool (uvloop's closed-transport `RuntimeError` is deliberately excluded from `retry_on_error`, so redis-py's own disconnect-on-retry path doesn't run for this class). `aclose()` is best-effort; the singleton is dropped first so a failure in `aclose` can't keep the poisoned client alive.

### 5xx-over-401 preferral across duplicate cookies (review follow-up, a2ffdb0)

`_validate_refresh_cookie` now tracks the first `>=500` exception across the cookie list and prefers it over the final `last_exc` when nothing validates. A transient Redis-transport failure on the live cookie followed by an invalid-token rejection on a stale legacy cookie no longer silently downgrades to a terminal 401.

### `retry_on_error` narrow widening

Added `OSError` to the redis-py client's `retry_on_error` list (covers `BrokenPipeError`, `ConnectionResetError`). Deliberately did NOT add bare `RuntimeError` — that would retry genuine programmer bugs. The transport-runtime case is handled by the helper-layer wrapper instead.

### MFA path now wrapped too

New `mfa_email_nonce_set` / `mfa_email_nonce_consume` helpers in `redis_client.py`, both decorated. Replaces the two direct `get_client()` call sites in auth.py's `/mfa/email-*` paths that would otherwise stay exposed to the raw RuntimeError class. Audited per architect feedback: "wrapping only session helpers may leave another path exposed."

### Structured `/refresh` rejection logging (`auth.py`)

New `_log_refresh_rejected` helper emits an `auth.refresh.rejected` structlog event at every terminal 401 raise site:

- `no_refresh_token` — empty Cookie header (distinguishes "browser stopped sending the cookie" from "cookie present but invalid")
- `invalid_token_decode` — JWT decode failed
- `user_not_found_or_inactive` — user row gone or deactivated
- `iat_before_cutoff` — token issued before user's session-cutoff (logout/password change)
- `missing_jti_or_sid` — legacy token from before PR #306
- `redis_primary_and_grace_missing` — Redis lost the session row
- `row_binding_mismatch` — Redis row's `user_id` or `sid` doesn't match the JWT
- `family_member_missing` — jti not in `auth:session:by_sid:{sid}` set (logout race)
- `absolute_lifetime_expired` — `session_lifetime_days` cap hit
- `ambiguous_session_multiple_users` — request carried valid cookies for >1 user
- `lua_session_revoked` — concurrent /logout deleted the family set
- `already_rotated_grace_revalidation_failed` — Lua said `already_rotated` but the winner's grace key was gone by the time we re-probed (diagnostic fields: `grace_row_missing` / `family_alive` / sid + user mismatch flags)

**PII guarantee:** `jti` and `sid` only ever leave the process as 8-char SHA-256 hash prefixes. Raw token claims are NEVER logged. Tests pin this.

## Tests (50 new)

`backend/tests/test_redis_transport_normalizer.py` (38 tests):
- 9 marker-detection cases (uvloop trace verbatim, broken-pipe, reset, generic transport-closed, case-insensitive, **unrelated-RuntimeError-must-not-match**)
- 11 decorator-contract cases (each preservation rule one test)
- 9 "every helper is wrapped" guards (catches future authors who add a helper and forget the decorator)
- 4 Lua-ResponseError integration tests (each rotation token still parses correctly post-wrapper)
- **5 poisoned-pool retirement** (closed-transport retires, broken-pipe retires, programmer-bug does NOT retire, `ResponseError` does NOT retire, `aclose` failure swallowed but singleton still dropped)

`backend/tests/routers/test_refresh_redis_transport_integration.py` (12 tests):
- **503** on uvloop closed-transport `RuntimeError` (verbatim trace from prod)
- **503** on `BrokenPipeError`
- **500** on genuine programmer-bug `RuntimeError` (safety property of the narrow filter)
- `auth.refresh.rejected` event fires with `reason=invalid_token_decode`
- `reason=missing_jti_or_sid` fires with correct `sub` field
- **PII guard:** raw jti and sid never appear in any captured log event field; only the 8-char hash prefix
- `reason=no_refresh_token` fires when Cookie header is empty
- **3 cookie-list 503 preferral** (two-cookie 503-then-401 returns 503, single-cookie 401 stays 401, two-cookie 503-then-503 returns 503)
- `reason=lua_session_revoked` fires on concurrent-logout race
- `reason=already_rotated_grace_revalidation_failed` fires when winner's grace key is gone by re-probe time

**Full suite: backend 1385 pass / 9 skipped.**

## Scope note

This PR fixes the **500-uncaught-exception** class only. Phase 3 (terminal 401s after the connection recovered) means the user's session keys were no longer in Redis for reasons we haven't pinned. The new structured rejection log will tell us **which** 401 path fires next time it happens — that diagnosis goes in a follow-up PR. The architect was explicit: "Do not let them claim this fully fixes the overnight logout yet."