### PR TITLE
fix(auth): catch-up Set-Cookie on /refresh grace branches

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -518,6 +518,113 @@ def _clear_legacy_refresh_cookie(response: Response) -> None:
     response.delete_cookie("refresh_token", path=LEGACY_REFRESH_COOKIE_PATH)
 
 
+async def _issue_catchup_refresh_cookie(
+    response: Response,
+    *,
+    user: User,
+    successor_jti: str | None,
+    sid: str,
+    session_start: datetime | None,
+    ttl_seconds: int,
+) -> str:
+    """Emit a Set-Cookie pointing at an EXISTING successor primary key.
+
+    Used by the two ``/refresh`` grace branches that previously returned
+    an access token without touching the refresh cookie — leaving the
+    browser holding a jti that had been rotated past, and locking it
+    out 30s later when the grace key expired. See architect note on PR
+    #314 follow-up (2026-05-19).
+
+    Contract:
+      * ``successor_jti`` is read from ``grace_row["successor_jti"]``,
+        the new primary jti written by the rotation winner inside the
+        Lua transaction. Never derive it from a freshly-minted local
+        ``new_jti`` — that would be the loser's perspective, not the
+        winner's, and the Redis primary key for it does not exist.
+      * Verifies the successor primary key is alive in Redis AND binds
+        back to the same ``(user_id, sid)`` as the request. Mismatch
+        or miss fails closed: logs ``catchup_successor_unavailable``
+        and raises ``401`` — same terminal-401 shape the frontend
+        classifier already handles. We never emit a Set-Cookie for a
+        jti whose Redis row is gone, because that would just re-create
+        the bug class one rotation later.
+      * Mints a fresh JWT for the successor jti using
+        ``create_refresh_token(..., jti=successor_jti)``. No Redis
+        write — the row already exists from the winning rotation.
+      * Preserves the original ``sid`` and ``session_created_at`` so
+        the absolute-lifetime check still measures from the original
+        login, not from the catch-up moment.
+
+    Returns the encoded JWT string (for tests / future logging hooks).
+    """
+    if not successor_jti or not isinstance(successor_jti, str):
+        _log_refresh_rejected(
+            "catchup_successor_unavailable",
+            jti=None,
+            sid=sid,
+            extra={"sub": user.id, "reason_detail": "missing_or_invalid_successor"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has been invalidated",
+        )
+
+    try:
+        successor_row = await redis_client.session_validate(successor_jti)
+    except (RedisRequired, RedisError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+        ) from exc
+
+    if (
+        successor_row is None
+        or successor_row.get("user_id") != user.id
+        or successor_row.get("sid") != sid
+    ):
+        _log_refresh_rejected(
+            "catchup_successor_unavailable",
+            jti=successor_jti,
+            sid=sid,
+            extra={
+                "sub": user.id,
+                "successor_row_missing": successor_row is None,
+                "successor_user_mismatch": (
+                    successor_row is not None
+                    and successor_row.get("user_id") != user.id
+                ),
+                "successor_sid_mismatch": (
+                    successor_row is not None
+                    and successor_row.get("sid") != sid
+                ),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has been invalidated",
+        )
+
+    token, _jti, _sid = create_refresh_token(
+        user.id,
+        ttl_seconds=ttl_seconds,
+        session_created_at=session_start,
+        sid=sid,
+        jti=successor_jti,
+    )
+
+    response.set_cookie(
+        key="refresh_token",
+        value=token,
+        httponly=True,
+        secure=app_settings.cookie_secure,
+        samesite="lax",
+        max_age=ttl_seconds,
+        path="/",
+    )
+    _clear_legacy_refresh_cookie(response)
+    return token
+
+
 def _extract_refresh_cookies(request: Request) -> list[str]:
     """Return ALL ``refresh_token`` cookie values from the request's
     Cookie header, in arrival order.
@@ -548,10 +655,10 @@ def _extract_refresh_cookies(request: Request) -> list[str]:
 async def _validate_single_refresh_token(
     refresh_token: str,
     db: AsyncSession,
-) -> tuple[User, dict, datetime | None, str, int]:
+) -> tuple[User, dict, datetime | None, str, int, dict]:
     """Validate ONE refresh-token JWT value. Returns
-    ``(user, payload, session_start, redis_state, ttl_seconds)`` or
-    raises ``HTTPException(401)``.
+    ``(user, payload, session_start, redis_state, ttl_seconds, session_row)``
+    or raises ``HTTPException(401)``.
 
     ``redis_state`` is ``"primary"`` when the active session key
     ``auth:session:{jti}`` is present, or ``"grace"`` when only the
@@ -560,6 +667,13 @@ async def _validate_single_refresh_token(
     introduces this state so ``/refresh`` and ``/verify`` can absorb
     cross-tab rotation races without forcing a logout — see
     ``specs/2026-05-17-backend-session-model.md`` §5.1 step 4 / §5.2.
+
+    ``session_row`` is the resolved Redis payload — the primary row's
+    ``{user_id, sid}`` on the primary branch, OR the grace row's
+    ``{user_id, sid, successor_jti}`` on the grace branch. ``/refresh``
+    uses ``successor_jti`` to issue a catch-up Set-Cookie that points
+    the browser at the live successor primary key — the 2026-05-19
+    fix for the stale-cookie / locked-out-after-grace-expiry bug.
 
     The validation chain:
       1. JWT decode + ``type == "refresh"``
@@ -785,13 +899,13 @@ async def _validate_single_refresh_token(
                 detail=SESSION_EXPIRED_DETAIL,
             )
 
-    return user, payload, session_start, redis_state, ttl_seconds
+    return user, payload, session_start, redis_state, ttl_seconds, session_row
 
 
 async def _validate_refresh_cookie(
     refresh_tokens: list[str],
     db: AsyncSession,
-) -> tuple[User, dict, datetime | None, str, int]:
+) -> tuple[User, dict, datetime | None, str, int, dict]:
     """Validate the provided refresh-token cookie values and pick one.
 
     Rules:
@@ -830,7 +944,7 @@ async def _validate_refresh_cookie(
             detail="No refresh token",
         )
 
-    successes: list[tuple[User, dict, datetime | None, str, int]] = []
+    successes: list[tuple[User, dict, datetime | None, str, int, dict]] = []
     last_exc: HTTPException | None = None
     transient_exc: HTTPException | None = None
     for token in refresh_tokens:
@@ -911,7 +1025,7 @@ async def refresh(
     """
     refresh_tokens = _extract_refresh_cookies(request)
     try:
-        user, payload, session_start, redis_state, ttl_seconds = await _validate_refresh_cookie(
+        user, payload, session_start, redis_state, ttl_seconds, session_row = await _validate_refresh_cookie(
             refresh_tokens, db
         )
     except HTTPException as exc:
@@ -946,9 +1060,19 @@ async def refresh(
     # ── Grace-path early return (spec §5.1 step 4) ──────────────────────
     # The validator already confirmed the grace key + family set are both
     # alive AND the JWT's sid matches the grace row's sid (the user_id /
-    # sid mismatch check on the row catches forged JWTs). No new refresh
-    # cookie, no rotation oracle.
+    # sid mismatch check on the row catches forged JWTs). Issue a
+    # catch-up Set-Cookie pointing at the live successor primary so the
+    # browser stops sending the stale jti (the 2026-05-19 fix for
+    # post-grace lockout — see ``_issue_catchup_refresh_cookie``).
     if redis_state == "grace":
+        await _issue_catchup_refresh_cookie(
+            response,
+            user=user,
+            successor_jti=session_row.get("successor_jti"),
+            sid=sid,
+            session_start=session_start,
+            ttl_seconds=ttl_seconds,
+        )
         await _record_session_grace_accept(
             session_factory,
             user=user,
@@ -1051,6 +1175,19 @@ async def refresh(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Session has been invalidated",
             )
+        # 2026-05-19 fix: emit a catch-up Set-Cookie pointing at the
+        # winner's successor primary so the browser stops sending the
+        # losing jti. ``grace_row["successor_jti"]`` is the new jti the
+        # winning Lua transaction wrote — NOT the loser's local
+        # ``new_jti`` (which has no Redis row).
+        await _issue_catchup_refresh_cookie(
+            response,
+            user=user,
+            successor_jti=grace_row.get("successor_jti"),
+            sid=sid,
+            session_start=session_start,
+            ttl_seconds=ttl_seconds,
+        )
         await _record_session_grace_accept(
             session_factory,
             user=user,
@@ -1106,7 +1243,12 @@ async def verify(
     Cookie header (PR #211 cookie-shadow guard).
     """
     refresh_tokens = _extract_refresh_cookies(request)
-    user, _payload, _session_start, _redis_state, _ttl_seconds = await _validate_refresh_cookie(
+    # /verify never emits Set-Cookie — even when ``redis_state == "grace"``.
+    # We deliberately discard ``session_row``: catching up the cookie here
+    # would violate the no-Set-Cookie invariant RSC callers rely on. The
+    # /refresh endpoint is the only place that advances the browser's
+    # cookie state. See the 2026-05-19 catch-up fix.
+    user, _payload, _session_start, _redis_state, _ttl_seconds, _session_row = await _validate_refresh_cookie(
         refresh_tokens, db
     )
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -442,7 +442,9 @@ async def _rotate_refresh_session(
     * ``"session_revoked"`` — concurrent logout deleted the family
       set; router returns 401, no audit (terminal — frontend redirects).
     * ``"already_rotated"`` — concurrent ``/refresh`` won the race;
-      router falls into the grace branch, no Set-Cookie, emits
+      router re-probes the grace key, emits a catch-up Set-Cookie for
+      the winner's successor jti via
+      ``_issue_catchup_refresh_cookie`` (2026-05-19 fix), and emits
       ``auth.session.grace_accept {via_already_rotated: true}``.
     * ``"jti_collision"`` — 128-bit RNG collision (cosmic). The router
       regenerates ``jti`` and retries once.
@@ -597,6 +599,38 @@ async def _issue_catchup_refresh_cookie(
                     successor_row is not None
                     and successor_row.get("sid") != sid
                 ),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session has been invalidated",
+        )
+
+    # PR #308 made the family set the authoritative revocation contract:
+    # a jti must be a member of ``auth:session:by_sid:{sid}`` to be
+    # treated as a live session. The primary row + binding match above
+    # are necessary but not sufficient — corrupted/partial Redis state
+    # could leave the row in place after the family was revoked, and
+    # the next primary-path /refresh would reject the catch-up cookie
+    # as ``family_member_missing``. Verify membership here so the
+    # browser never receives a cookie the very next request would 401.
+    try:
+        is_family_member = await redis_client.session_family_member(
+            sid, successor_jti
+        )
+    except (RedisRequired, RedisError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+        ) from exc
+    if not is_family_member:
+        _log_refresh_rejected(
+            "catchup_successor_unavailable",
+            jti=successor_jti,
+            sid=sid,
+            extra={
+                "sub": user.id,
+                "successor_family_member_missing": True,
             },
         )
         raise HTTPException(
@@ -1008,13 +1042,18 @@ async def refresh(
 
     - If the validation chain says ``redis_state == "grace"`` we're on
       the grace branch already (primary key gone, grace key alive,
-      family set alive). Issue an access token only; no Set-Cookie, no
-      rotation. Emit ``auth.session.grace_accept``.
+      family set alive). Issue an access token AND emit a catch-up
+      Set-Cookie pointing at ``grace_row["successor_jti"]`` (the
+      2026-05-19 fix) so the browser converges on the live primary
+      and isn't locked out 30s later when the grace key expires. No
+      Redis writes on this path — the winning rotation already wrote
+      the successor row. Emit ``auth.session.grace_accept``.
     - Otherwise run the Lua rotation script and dispatch on its return:
-      ``ok`` issues a new cookie; ``session_revoked`` returns 401;
-      ``already_rotated`` falls into the grace branch (re-probe + check
-      family set); ``jti_collision`` regenerates and retries once, with
-      a 503 on the second collision.
+      ``ok`` issues a new cookie via the normal rotation flow;
+      ``session_revoked`` returns 401; ``already_rotated`` re-probes
+      grace + family set then emits a catch-up Set-Cookie for the
+      winner's successor jti (same catch-up helper); ``jti_collision``
+      regenerates and retries once, with a 503 on the second collision.
 
     NOTE: FastAPI does NOT merge cookies set on the injected ``response``
     parameter into the JSONResponse it builds from a raised HTTPException
@@ -1132,8 +1171,12 @@ async def refresh(
 
     if lua_result == redis_client.SESSION_ROTATE_ALREADY_ROTATED:
         # Concurrent /refresh won the race. The winner just wrote the
-        # grace key inside their Lua transaction — re-probe it AND
-        # confirm the family set still exists, then issue access-only.
+        # grace key inside their Lua transaction — re-probe it, confirm
+        # the family set still exists, AND emit a catch-up Set-Cookie
+        # pointing at the winner's ``successor_jti`` so the browser
+        # converges on the live primary (2026-05-19 fix — without this,
+        # the loser walks away holding a jti whose Redis row has been
+        # rotated past, and locks out 30s later).
         try:
             grace_row = await redis_client.session_grace(old_jti)
             family_alive = await redis_client.session_family_exists(sid)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -92,6 +92,7 @@ def create_refresh_token(
     ttl_seconds: int | None = None,
     session_created_at: datetime | None = None,
     sid: str | None = None,
+    jti: str | None = None,
 ) -> tuple[str, str, str]:
     """Create a refresh token.
 
@@ -111,9 +112,13 @@ def create_refresh_token(
     survives across the rotation chain — that is what makes per-session
     logout (PR 4) revoke every successor.
 
-    ``jti`` is always freshly minted via ``secrets.token_urlsafe(16)``
+    ``jti`` is normally freshly minted via ``secrets.token_urlsafe(16)``
     (128 bits of entropy). It rotates on every issue and serves as the
-    Redis primary-key suffix.
+    Redis primary-key suffix. Catch-up cookie issuance (the grace-path
+    fix) passes the EXISTING successor jti so the new cookie points at
+    a primary key that is already live in Redis; that path must NOT
+    write Redis again, because the row already exists from the winning
+    rotation. All other callers leave this ``None``.
 
     ``ttl_seconds`` is the session TTL in seconds — drives the JWT
     ``exp`` claim AND must match the cookie ``Max-Age`` AND the Redis
@@ -127,7 +132,7 @@ def create_refresh_token(
     if ttl_seconds is None:
         ttl_seconds = default_session_ttl_seconds()
     expire = now + timedelta(seconds=ttl_seconds)
-    jti = secrets.token_urlsafe(16)
+    jti = jti if jti is not None else secrets.token_urlsafe(16)
     session_id = sid if sid is not None else uuid.uuid4().hex
     payload = {
         "sub": str(subject),

--- a/backend/tests/auth/test_session_grace_lua.py
+++ b/backend/tests/auth/test_session_grace_lua.py
@@ -287,15 +287,28 @@ async def test_concurrent_refresh_one_winner_one_grace(session_factory, fake_red
     cookies_a = _canonical_refresh_cookie(res_a.headers)
     cookies_b = _canonical_refresh_cookie(res_b.headers)
     set_cookies = [c for c in (cookies_a, cookies_b) if c is not None]
-    assert len(set_cookies) == 1, (
-        f"expected exactly one Set-Cookie (winner), got {len(set_cookies)}: "
-        f"A={cookies_a!r} B={cookies_b!r}"
+    # 2026-05-19 catch-up fix: both responses now emit Set-Cookie. The
+    # winner sets it from the normal rotation path; the loser sets it
+    # via ``_issue_catchup_refresh_cookie`` after the
+    # ``already_rotated`` re-probe. Both cookies MUST decode to the
+    # same successor jti so the browser converges on whichever
+    # response lands last.
+    assert len(set_cookies) == 2, (
+        f"expected exactly two Set-Cookies (winner + loser catch-up), "
+        f"got {len(set_cookies)}: A={cookies_a!r} B={cookies_b!r}"
     )
 
-    # Exactly one new jti minted; primary key is in Redis.
-    winner_token = _refresh_token_from_set_cookie(set_cookies[0])
-    winner_jti, winner_sid = decode_refresh_jti_sid(winner_token)
-    assert winner_sid == sid
+    decoded_jtis = []
+    for raw in set_cookies:
+        token = _refresh_token_from_set_cookie(raw)
+        jti, sid_decoded = decode_refresh_jti_sid(token)
+        assert sid_decoded == sid
+        decoded_jtis.append(jti)
+    assert len(set(decoded_jtis)) == 1, (
+        f"winner + loser Set-Cookies must decode to the SAME successor "
+        f"jti; got {decoded_jtis}. Browser convergence depends on this."
+    )
+    winner_jti = decoded_jtis[0]
     assert winner_jti != old_jti
     assert f"auth:session:{winner_jti}" in fake_redis._kv
     # Grace key for old_jti is alive.
@@ -552,15 +565,21 @@ async def test_jti_collision_double_failure_returns_503(
 # ── 10. Direct grace path (the typical cross-tab race after the fact) ───────
 
 
-async def test_refresh_direct_grace_path_no_setcookie_and_audit(
+async def test_refresh_direct_grace_path_emits_catchup_cookie_and_audit(
     session_factory, fake_redis
 ):
     """The "boring" cross-tab race: tab A rotates first, tab B's
     ``/refresh`` arrives later still carrying the old cookie. The
     primary is already gone, the grace key is alive, the family set
-    is alive — the validator hands us ``redis_state == "grace"`` and
-    the router returns access-only without entering Lua. Audit:
-    ``auth.session.grace_accept {via_already_rotated: false}``.
+    is alive — the validator hands us ``redis_state == "grace"``.
+
+    2026-05-19 catch-up fix: the router now emits a catch-up
+    Set-Cookie pointing at the successor jti written by tab A's
+    rotation, so tab B converges to the live primary instead of
+    holding a stale cookie that locks out 30s later. Audit:
+    ``auth.session.grace_accept {via_already_rotated: false}`` (the
+    audit shape is unchanged — the catch-up emits a cookie but is
+    still semantically a grace acceptance, not a rotation).
     """
     await _seed_user(session_factory)
     app = _make_app(session_factory)
@@ -570,6 +589,11 @@ async def test_refresh_direct_grace_path_no_setcookie_and_audit(
 
         r1 = client.post("/api/v1/auth/refresh", cookies={"refresh_token": token})
         assert r1.status_code == 200
+        # Capture the winner's successor jti from r1's Set-Cookie.
+        winner_raw = _canonical_refresh_cookie(r1.headers)
+        assert winner_raw is not None
+        winner_token = _refresh_token_from_set_cookie(winner_raw)
+        winner_jti, _ = decode_refresh_jti_sid(winner_token)
 
         # At this point primary {old_jti} is gone, grace alive, family alive.
         # Tab B replays the old cookie.
@@ -578,8 +602,18 @@ async def test_refresh_direct_grace_path_no_setcookie_and_audit(
         )
 
     assert res.status_code == 200, res.text
-    assert _canonical_refresh_cookie(res.headers) is None, (
-        "grace branch must NOT emit Set-Cookie (no rotation oracle)"
+    catchup_raw = _canonical_refresh_cookie(res.headers)
+    assert catchup_raw is not None, (
+        "grace branch must now emit catch-up Set-Cookie (2026-05-19 fix)"
+    )
+    catchup_token = _refresh_token_from_set_cookie(catchup_raw)
+    catchup_jti, catchup_sid = decode_refresh_jti_sid(catchup_token)
+    assert catchup_sid == sid
+    # Critical: the catch-up cookie points at the WINNER's successor
+    # jti — the live primary in Redis — not a freshly-minted random.
+    assert catchup_jti == winner_jti, (
+        f"catch-up cookie must point at winner's successor; "
+        f"got {catchup_jti!r}, expected {winner_jti!r}"
     )
 
     grace = await _list_audit(session_factory, "auth.session.grace_accept")

--- a/backend/tests/routers/test_refresh_cookie_catchup.py
+++ b/backend/tests/routers/test_refresh_cookie_catchup.py
@@ -1,0 +1,645 @@
+"""Catch-up Set-Cookie on the /refresh grace branches — 2026-05-19.
+
+Production trace at 2026-05-19T10:33–10:50 showed
+``redis_primary_and_grace_missing`` firing repeatedly for the same sid,
+with the browser sending old jtis that had been rotated past in Redis.
+The two grace branches in ``/refresh`` returned ``TokenResponse``
+without emitting ``Set-Cookie``, so when a cross-tab rotation race
+made the browser end up on the grace branch, the cookie was never
+advanced to the live successor primary. After the 30s grace TTL
+expired, the next /refresh hit ``redis_primary_and_grace_missing``
+and forced a logout.
+
+The fix: both grace branches now mint a refresh JWT for the
+``successor_jti`` recorded in the grace row and emit Set-Cookie
+without writing Redis. Browser catches up to the live primary; the
+30s lockout class is eliminated.
+
+These tests pin the seven contracts required by the architect:
+  1. Direct grace branch emits Set-Cookie for successor_jti.
+  2. already_rotated re-probe branch emits Set-Cookie for successor_jti.
+  3. Concurrent race: both responses carry cookies, both decode to the
+     same successor jti and sid.
+  4. The catch-up-issued cookie validates against the primary on the
+     follow-up /refresh.
+  5. No Redis write happens during catch-up issuance.
+  6. Missing/dead successor_jti logs ``catchup_successor_unavailable``
+     and fails closed with no cookie emitted.
+  7. /verify still NEVER emits Set-Cookie, even on the grace path.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+import pytest_asyncio
+import structlog
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_session_factory
+from app.models import Base
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import router as auth_router
+from app.security import create_refresh_token, hash_password
+
+
+PASSWORD = "starting-password-1"
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+def _make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(auth_router)
+    return app
+
+
+async def _seed_user(factory) -> dict[str, Any]:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@example.com",
+            password_hash=hash_password(PASSWORD),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id}
+
+
+def _seed_session_state(
+    user_id: int,
+    *,
+    old_jti: str,
+    successor_jti: str,
+    sid: str,
+    ttl_seconds: int = 30 * 86400,
+) -> None:
+    """Seed the autouse fake Redis so the validator sees:
+    - primary key for ``old_jti`` MISSING (rotated past),
+    - grace key for ``old_jti`` ALIVE with ``successor_jti`` payload,
+    - primary key for ``successor_jti`` ALIVE,
+    - family set for ``sid`` alive and contains both jtis.
+    """
+    from app import redis_client as rc
+
+    client = rc.get_client()
+    assert client is not None, "autouse fake-redis fixture missing"
+
+    # Primary for successor jti (the winner's row).
+    primary_payload = json.dumps(
+        {"user_id": user_id, "sid": sid}, separators=(",", ":")
+    )
+    client._kv[f"auth:session:{successor_jti}"] = primary_payload
+    # Old jti has NO primary (rotation deleted it) — leave unset.
+    # Grace key for the old jti, points at the winning successor jti.
+    grace_payload = json.dumps(
+        {"user_id": user_id, "sid": sid, "successor_jti": successor_jti},
+        separators=(",", ":"),
+    )
+    client._kv[f"auth:session:grace:{old_jti}"] = grace_payload
+    # Family set: both jtis are members (the Lua winner adds the
+    # successor, the loser's jti was added when it was originally
+    # issued).
+    client._sets[f"auth:session:by_sid:{sid}"].add(old_jti)
+    client._sets[f"auth:session:by_sid:{sid}"].add(successor_jti)
+
+
+def _mint_token_for(
+    user_id: int, *, jti: str, sid: str, ttl_seconds: int = 30 * 86400
+) -> str:
+    """Build a refresh JWT with a specific jti/sid (so the validation
+    chain sees the JWT's claims match the seeded Redis state)."""
+    token, _, _ = create_refresh_token(
+        user_id,
+        ttl_seconds=ttl_seconds,
+        sid=sid,
+        jti=jti,
+    )
+    return token
+
+
+# ── 1 + 2. Catch-up Set-Cookie on both grace branches ───────────────────
+
+
+class TestGraceBranchCatchupCookie:
+    @pytest.mark.asyncio
+    async def test_direct_grace_branch_emits_setcookie_for_successor(
+        self, session_factory
+    ) -> None:
+        """When the validator hits ``redis_state == "grace"``,
+        /refresh now issues Set-Cookie with a JWT whose ``jti`` claim
+        is the successor jti from the grace row."""
+        seed = await _seed_user(session_factory)
+        old_jti = "OLD-jti-c5952d8f"
+        successor_jti = "NEW-jti-aa9b0787"
+        sid = "test-sid-943e8eeb"
+        _seed_session_state(
+            seed["user_id"],
+            old_jti=old_jti,
+            successor_jti=successor_jti,
+            sid=sid,
+        )
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+
+        app = _make_app(session_factory)
+        with TestClient(app) as client:
+            res = client.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": token},
+            )
+
+        assert res.status_code == 200, res.json()
+        # Set-Cookie present.
+        set_cookie_headers = [
+            v for k, v in res.headers.items()
+            if k.lower() == "set-cookie" and "refresh_token=" in v
+        ]
+        # Multiple cookies may be set (one canonical Path=/, one
+        # legacy-clearing delete) — find the one carrying the JWT.
+        new_cookie = next(
+            (h for h in set_cookie_headers if "refresh_token=ey" in h),
+            None,
+        )
+        assert new_cookie is not None, (
+            f"Expected refresh_token Set-Cookie; got {set_cookie_headers}"
+        )
+        # Extract the JWT and decode — its ``jti`` claim MUST be the
+        # successor jti, not the old one and not a freshly-minted random.
+        cookie_value = new_cookie.split("refresh_token=", 1)[1].split(";", 1)[0]
+        decoded = pyjwt.decode(
+            cookie_value,
+            app_settings.jwt_secret_key,
+            algorithms=[app_settings.jwt_algorithm],
+        )
+        assert decoded["jti"] == successor_jti
+        assert decoded["sid"] == sid
+        assert decoded["sub"] == str(seed["user_id"])
+
+    @pytest.mark.asyncio
+    async def test_already_rotated_branch_emits_setcookie_for_successor(
+        self, session_factory, monkeypatch
+    ) -> None:
+        """When the Lua rotation returns ``already_rotated`` and the
+        grace re-probe succeeds, /refresh now issues Set-Cookie with
+        a JWT for the grace row's successor jti."""
+        from app.routers import auth as auth_module
+        from app.redis_client import SESSION_ROTATE_ALREADY_ROTATED
+
+        seed = await _seed_user(session_factory)
+        # In this case the validator hits PRIMARY (not grace), so the
+        # primary key for the cookie's jti must be alive. Then the Lua
+        # rotation returns already_rotated; the handler re-probes the
+        # grace key, which carries the successor written by the winner.
+        winner_old_jti = "winner-old-jti"
+        winner_successor = "winner-successor-aa9b"
+        sid = "shared-sid"
+        from app import redis_client as rc
+        client = rc.get_client()
+        client._kv[f"auth:session:{winner_old_jti}"] = json.dumps(
+            {"user_id": seed["user_id"], "sid": sid},
+            separators=(",", ":"),
+        )
+        client._sets[f"auth:session:by_sid:{sid}"].add(winner_old_jti)
+        # Stub the Lua rotation to return already_rotated (the loser's
+        # perspective) and pre-seed the grace key for ``winner_old_jti``
+        # that the winner would have written.
+        client._kv[f"auth:session:grace:{winner_old_jti}"] = json.dumps(
+            {
+                "user_id": seed["user_id"],
+                "sid": sid,
+                "successor_jti": winner_successor,
+            },
+            separators=(",", ":"),
+        )
+        # Successor primary alive too.
+        client._kv[f"auth:session:{winner_successor}"] = json.dumps(
+            {"user_id": seed["user_id"], "sid": sid},
+            separators=(",", ":"),
+        )
+        client._sets[f"auth:session:by_sid:{sid}"].add(winner_successor)
+
+        async def _stub_rotate(user_id, old_jti, sid_, **kwargs):
+            # Return signature: (new_token, new_jti, sid, lua_result)
+            return ("loser-token", "loser-new-jti", sid_, SESSION_ROTATE_ALREADY_ROTATED)
+
+        monkeypatch.setattr(
+            auth_module, "_rotate_refresh_session", _stub_rotate
+        )
+
+        token = _mint_token_for(
+            seed["user_id"], jti=winner_old_jti, sid=sid
+        )
+        app = _make_app(session_factory)
+        with TestClient(app) as cli:
+            res = cli.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": token},
+            )
+
+        assert res.status_code == 200, res.json()
+        # The Set-Cookie's JWT must decode to ``winner_successor``,
+        # NOT the loser's ``loser-new-jti``. This is the architect's
+        # explicit guard against issuing a cookie for the loser's
+        # phantom jti (which has no Redis row).
+        set_cookie_headers = [
+            v for k, v in res.headers.items()
+            if k.lower() == "set-cookie" and "refresh_token=ey" in v
+        ]
+        assert len(set_cookie_headers) == 1, set_cookie_headers
+        cookie_value = (
+            set_cookie_headers[0]
+            .split("refresh_token=", 1)[1]
+            .split(";", 1)[0]
+        )
+        decoded = pyjwt.decode(
+            cookie_value,
+            app_settings.jwt_secret_key,
+            algorithms=[app_settings.jwt_algorithm],
+        )
+        assert decoded["jti"] == winner_successor, (
+            f"Catch-up cookie pointed at {decoded['jti']!r}, not "
+            f"winner_successor={winner_successor!r}. Bug: the loser's "
+            "newly-minted jti was used instead of grace_row.successor_jti."
+        )
+
+
+# ── 3. Concurrent race — both responses carry SAME successor jti ────────
+
+
+class TestConcurrentRaceConvergence:
+    @pytest.mark.asyncio
+    async def test_two_grace_requests_emit_cookies_for_same_successor(
+        self, session_factory
+    ) -> None:
+        """Two concurrent /refresh calls both hit the grace branch
+        (rotation winner is some third request). Both MUST issue
+        Set-Cookie with JWTs decoding to the SAME successor jti and
+        sid — proves the catch-up logic is deterministic w.r.t. the
+        grace row's successor field, not a per-request fresh mint."""
+        seed = await _seed_user(session_factory)
+        old_jti = "race-old-jti"
+        successor_jti = "race-successor"
+        sid = "race-sid"
+        _seed_session_state(
+            seed["user_id"],
+            old_jti=old_jti,
+            successor_jti=successor_jti,
+            sid=sid,
+        )
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+        app = _make_app(session_factory)
+        decoded_jtis: list[str] = []
+        with TestClient(app) as client:
+            for _ in range(2):
+                res = client.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+                assert res.status_code == 200
+                set_cookie = next(
+                    v for k, v in res.headers.items()
+                    if k.lower() == "set-cookie" and "refresh_token=ey" in v
+                )
+                value = (
+                    set_cookie.split("refresh_token=", 1)[1].split(";", 1)[0]
+                )
+                payload = pyjwt.decode(
+                    value,
+                    app_settings.jwt_secret_key,
+                    algorithms=[app_settings.jwt_algorithm],
+                )
+                decoded_jtis.append(payload["jti"])
+                assert payload["sid"] == sid
+        assert len(set(decoded_jtis)) == 1, (
+            f"Both concurrent grace-path responses must carry the "
+            f"SAME successor jti; got {decoded_jtis}"
+        )
+        assert decoded_jtis[0] == successor_jti
+
+
+# ── 4. Follow-up /refresh using the catch-up cookie hits primary ────────
+
+
+class TestCatchupCookieValidatesAgainstPrimary:
+    @pytest.mark.asyncio
+    async def test_followup_refresh_with_catchup_cookie_hits_primary(
+        self, session_factory
+    ) -> None:
+        """After the grace-path response sets the cookie to the
+        successor jti, the NEXT /refresh sent with that cookie must
+        hit the primary path (NOT the grace path again) and emit a
+        normal rotation. This proves the catch-up actually unsticks
+        the browser."""
+        seed = await _seed_user(session_factory)
+        old_jti = "stuck-old-jti"
+        successor_jti = "stuck-successor"
+        sid = "stuck-sid"
+        _seed_session_state(
+            seed["user_id"],
+            old_jti=old_jti,
+            successor_jti=successor_jti,
+            sid=sid,
+        )
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+
+        app = _make_app(session_factory)
+        with TestClient(app) as client:
+            # Round 1: grace path → catch-up cookie.
+            res1 = client.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": token},
+            )
+            assert res1.status_code == 200
+            set_cookie = next(
+                v for k, v in res1.headers.items()
+                if k.lower() == "set-cookie" and "refresh_token=ey" in v
+            )
+            new_token = (
+                set_cookie.split("refresh_token=", 1)[1].split(";", 1)[0]
+            )
+
+            # Round 2: send the catch-up token. The validator should
+            # find ``successor_jti`` as primary, run the rotation,
+            # and emit a NEW Set-Cookie with a DIFFERENT jti.
+            res2 = client.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": new_token},
+            )
+            assert res2.status_code == 200
+            second_set_cookie = next(
+                v for k, v in res2.headers.items()
+                if k.lower() == "set-cookie" and "refresh_token=ey" in v
+            )
+            second_value = (
+                second_set_cookie
+                .split("refresh_token=", 1)[1]
+                .split(";", 1)[0]
+            )
+            second_decoded = pyjwt.decode(
+                second_value,
+                app_settings.jwt_secret_key,
+                algorithms=[app_settings.jwt_algorithm],
+            )
+            # Different jti = real rotation happened (primary path),
+            # not another catch-up (grace path would echo successor_jti).
+            assert second_decoded["jti"] != successor_jti
+
+
+# ── 5. No Redis write during catch-up issuance ──────────────────────────
+
+
+class TestNoRedisWriteOnCatchup:
+    @pytest.mark.asyncio
+    async def test_catchup_does_not_call_session_issue_or_rotate(
+        self, session_factory, monkeypatch
+    ) -> None:
+        """The catch-up helper must NOT call any Redis-writing helper.
+        The winning rotation already wrote the successor primary; a
+        second write here would either be redundant (best case) or
+        clobber the row's TTL/data (worst case)."""
+        seed = await _seed_user(session_factory)
+        old_jti = "nowrite-old-jti"
+        successor_jti = "nowrite-successor"
+        sid = "nowrite-sid"
+        _seed_session_state(
+            seed["user_id"],
+            old_jti=old_jti,
+            successor_jti=successor_jti,
+            sid=sid,
+        )
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+
+        from app import redis_client as rc
+
+        # Spy on the Redis-writing helpers. The grace path is read-only
+        # so neither must be called.
+        write_calls: list[str] = []
+
+        async def _spy_session_issue(*args, **kwargs):
+            write_calls.append("session_issue")
+            return None
+
+        async def _spy_session_rotate_lua(*args, **kwargs):
+            write_calls.append("session_rotate_lua")
+            return "ok"
+
+        async def _spy_session_revoke_family(*args, **kwargs):
+            write_calls.append("session_revoke_family")
+            return []
+
+        monkeypatch.setattr(rc, "session_issue", _spy_session_issue)
+        monkeypatch.setattr(rc, "session_rotate_lua", _spy_session_rotate_lua)
+        monkeypatch.setattr(
+            rc, "session_revoke_family", _spy_session_revoke_family
+        )
+
+        app = _make_app(session_factory)
+        with TestClient(app) as client:
+            res = client.post(
+                "/api/v1/auth/refresh",
+                cookies={"refresh_token": token},
+            )
+        assert res.status_code == 200
+        assert write_calls == [], (
+            f"Catch-up path must not write Redis; calls observed: "
+            f"{write_calls}"
+        )
+
+
+# ── 6. Missing / dead successor_jti fails closed ────────────────────────
+
+
+class TestMissingSuccessorFailsClosed:
+    @pytest.mark.asyncio
+    async def test_missing_successor_jti_logs_and_401s(
+        self, session_factory
+    ) -> None:
+        """Grace row exists but doesn't carry ``successor_jti`` (data
+        corruption / future migration / handcrafted row). Helper must
+        log ``catchup_successor_unavailable`` and 401 — never emit
+        Set-Cookie for an unbound jti."""
+        seed = await _seed_user(session_factory)
+        old_jti = "no-successor-old"
+        sid = "no-successor-sid"
+        from app import redis_client as rc
+
+        client = rc.get_client()
+        # Grace key WITHOUT successor_jti.
+        client._kv[f"auth:session:grace:{old_jti}"] = json.dumps(
+            {"user_id": seed["user_id"], "sid": sid},
+            separators=(",", ":"),
+        )
+        client._sets[f"auth:session:by_sid:{sid}"].add(old_jti)
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+
+        app = _make_app(session_factory)
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as cli:
+                res = cli.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 401
+        # Reason log emitted.
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+            and ev.get("reason") == "catchup_successor_unavailable"
+        ]
+        assert len(rejection_logs) == 1, (
+            f"Expected one catchup_successor_unavailable; got: {captured}"
+        )
+        # No refresh_token Set-Cookie with a JWT value (the
+        # legacy-cookie delete header is allowed).
+        jwt_cookies = [
+            v for k, v in res.headers.items()
+            if k.lower() == "set-cookie" and "refresh_token=ey" in v
+        ]
+        assert jwt_cookies == [], (
+            f"No JWT cookie may be emitted on fail-closed; got {jwt_cookies}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_successor_primary_missing_logs_and_401s(
+        self, session_factory
+    ) -> None:
+        """Grace row carries ``successor_jti`` but the successor
+        primary row is GONE (the successor was itself rotated past
+        and its 30s grace also expired — pathological chain). Helper
+        must fail closed."""
+        seed = await _seed_user(session_factory)
+        old_jti = "dead-successor-old"
+        successor_jti = "dead-successor"
+        sid = "dead-successor-sid"
+        from app import redis_client as rc
+
+        client = rc.get_client()
+        # Grace row points at successor_jti, but successor's primary
+        # is NOT in the kv map.
+        client._kv[f"auth:session:grace:{old_jti}"] = json.dumps(
+            {
+                "user_id": seed["user_id"],
+                "sid": sid,
+                "successor_jti": successor_jti,
+            },
+            separators=(",", ":"),
+        )
+        client._sets[f"auth:session:by_sid:{sid}"].add(old_jti)
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+
+        app = _make_app(session_factory)
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as cli:
+                res = cli.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 401
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+            and ev.get("reason") == "catchup_successor_unavailable"
+        ]
+        assert len(rejection_logs) == 1, (
+            f"Expected one catchup_successor_unavailable; got: {captured}"
+        )
+        # Diagnostic flag identifies the cause for ops.
+        assert rejection_logs[0]["successor_row_missing"] is True
+
+
+# ── 7. /verify never emits Set-Cookie even on grace path ────────────────
+
+
+class TestVerifyNeverEmitsCookie:
+    @pytest.mark.asyncio
+    async def test_verify_on_grace_path_does_not_setcookie(
+        self, session_factory
+    ) -> None:
+        """RSC invariant: ``/auth/verify`` must NEVER emit Set-Cookie.
+        The catch-up logic lives only in ``/auth/refresh``."""
+        seed = await _seed_user(session_factory)
+        old_jti = "verify-grace-old"
+        successor_jti = "verify-grace-successor"
+        sid = "verify-grace-sid"
+        _seed_session_state(
+            seed["user_id"],
+            old_jti=old_jti,
+            successor_jti=successor_jti,
+            sid=sid,
+        )
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+
+        app = _make_app(session_factory)
+        with TestClient(app) as cli:
+            res = cli.post(
+                "/api/v1/auth/verify",
+                cookies={"refresh_token": token},
+            )
+        assert res.status_code == 200
+        # No Set-Cookie header at all from /verify — neither the
+        # canonical Path=/ nor the legacy delete header. The validator's
+        # grace branch hands back ``session_row`` but the verify handler
+        # deliberately discards it.
+        set_cookies = [
+            v for k, v in res.headers.items() if k.lower() == "set-cookie"
+        ]
+        assert set_cookies == [], (
+            f"/verify must never emit Set-Cookie; got {set_cookies}"
+        )

--- a/backend/tests/routers/test_refresh_cookie_catchup.py
+++ b/backend/tests/routers/test_refresh_cookie_catchup.py
@@ -557,6 +557,69 @@ class TestMissingSuccessorFailsClosed:
         )
 
     @pytest.mark.asyncio
+    async def test_successor_not_in_family_set_logs_and_401s(
+        self, session_factory
+    ) -> None:
+        """P2 architect addition: PR #308 made family-set membership the
+        authoritative revocation contract. Successor primary row alive
+        + (user_id, sid) match but jti NOT in ``auth:session:by_sid:{sid}``
+        (corrupted/partial Redis state) must fail closed — otherwise we
+        emit a cookie the very next /refresh would 401 with
+        ``family_member_missing``."""
+        seed = await _seed_user(session_factory)
+        old_jti = "orphan-old"
+        successor_jti = "orphan-successor"
+        sid = "orphan-sid"
+        from app import redis_client as rc
+
+        client = rc.get_client()
+        # Grace row points at successor_jti.
+        client._kv[f"auth:session:grace:{old_jti}"] = json.dumps(
+            {
+                "user_id": seed["user_id"],
+                "sid": sid,
+                "successor_jti": successor_jti,
+            },
+            separators=(",", ":"),
+        )
+        # Successor primary alive and bound to (user_id, sid)…
+        client._kv[f"auth:session:{successor_jti}"] = json.dumps(
+            {"user_id": seed["user_id"], "sid": sid},
+            separators=(",", ":"),
+        )
+        # …BUT successor_jti is NOT in the family set. Family set
+        # contains only ``old_jti`` (simulating a revocation that
+        # dropped the successor while leaving the primary row alive,
+        # or a Redis replica desync).
+        client._sets[f"auth:session:by_sid:{sid}"].add(old_jti)
+        token = _mint_token_for(seed["user_id"], jti=old_jti, sid=sid)
+
+        app = _make_app(session_factory)
+        with structlog.testing.capture_logs() as captured:
+            with TestClient(app) as cli:
+                res = cli.post(
+                    "/api/v1/auth/refresh",
+                    cookies={"refresh_token": token},
+                )
+        assert res.status_code == 401
+        rejection_logs = [
+            ev for ev in captured
+            if ev.get("event") == "auth.refresh.rejected"
+            and ev.get("reason") == "catchup_successor_unavailable"
+            and ev.get("successor_family_member_missing") is True
+        ]
+        assert len(rejection_logs) == 1, (
+            f"Expected catchup_successor_unavailable with "
+            f"successor_family_member_missing=True; got: {captured}"
+        )
+        # No cookie emitted.
+        jwt_cookies = [
+            v for k, v in res.headers.items()
+            if k.lower() == "set-cookie" and "refresh_token=ey" in v
+        ]
+        assert jwt_cookies == []
+
+    @pytest.mark.asyncio
     async def test_successor_primary_missing_logs_and_401s(
         self, session_factory
     ) -> None:

--- a/specs/2026-05-17-backend-session-model.md
+++ b/specs/2026-05-17-backend-session-model.md
@@ -347,9 +347,21 @@ distinguish "grace key for a session that was just rotated normally"
 just logged out" (should reject). The logout path deletes ALL keys
 for the `sid` atomically (Section 5.3); the resolver also performs a
 defence-in-depth check against the `by_sid` set on every grace-path
-acceptance (Section 5.1 step 4). We deliberately do NOT issue a
-fresh cookie on the grace path (no rotation oracle) — see
-Section 5.1.
+acceptance (Section 5.1 step 4).
+
+> **2026-05-19 update — catch-up Set-Cookie on grace.** The original
+> spec said the grace branch issued access-only with no Set-Cookie
+> ("no rotation oracle"). Production logs from 2026-05-19 showed
+> this leaves the browser holding a jti that has been rotated past;
+> 30s later the grace key expires and the browser is locked out
+> with `redis_primary_and_grace_missing`. The grace branches now
+> emit a **catch-up Set-Cookie** for `grace_row["successor_jti"]`
+> via `_issue_catchup_refresh_cookie` (no Redis writes — the
+> winner already wrote that primary row). `/verify` still emits
+> no Set-Cookie. The "no rotation oracle" guarantee was never
+> load-bearing: the grace row already records the predecessor → successor
+> mapping atomically, so handing that successor jti to the browser is
+> just publishing what Redis already knows. See PR #315.
 
 ### 4.2 Operation patterns
 
@@ -368,7 +380,7 @@ from both passing `SISMEMBER` and both rotating.
     1. Resolve `jti` and `sid` from the JWT.
     2. `GET auth:session:{jti}` first. If hit, normal path: rotate (step 5).
     3. If miss, `GET auth:session:grace:{jti}`. If hit, grace path: step 4.
-    4. **Grace-path defence-in-depth (architect feedback P1.1).** Before accepting the grace ticket, also `EXISTS auth:session:by_sid:{sid}`. If the family set is gone (logout ran since the rotation), reject with 401 even though the grace key itself has not yet expired. Otherwise: issue an access token only. Do NOT rotate (no new refresh cookie — no rotation oracle).
+    4. **Grace-path defence-in-depth (architect feedback P1.1).** Before accepting the grace ticket, also `EXISTS auth:session:by_sid:{sid}`. If the family set is gone (logout ran since the rotation), reject with 401 even though the grace key itself has not yet expired. Otherwise: issue an access token AND emit a catch-up `Set-Cookie` whose JWT carries `grace_row["successor_jti"]` as the `jti` claim (2026-05-19 update — see the note at the end of Section 4.1). No new Redis writes — the catch-up cookie points at the primary row the winning rotation already created.
     5. **Rotate (normal path), one atomic Lua script** (architect feedback PR #301 third-pass — see Section 4.3 for the races this closes). The Lua script is the authority; the earlier app-side `GET` (step 2) is purely an optimisation hint to choose which branch to enter:
        ```lua
        -- KEYS[1] = auth:session:{old_jti}
@@ -415,7 +427,7 @@ from both passing `SISMEMBER` and both rotating.
        Three guards inside the script, each load-bearing:
 
        - **`SISMEMBER` (family revoked check).** A concurrent `/logout` has deleted the family set. Router returns 401 `"Session has been invalidated"` (same string as cutoff; the frontend's terminal-vs-transient classifier needs no change). This closes the logout-vs-rotation race documented in Section 4.3.
-       - **`EXISTS old primary` (already-rotated check).** Two concurrent `/refresh` requests with the same `old_jti` could both pass the earlier app-side `GET auth:session:{old_jti}` HIT and both enter this script. Without this check, both would pass `SISMEMBER` (the family still contains `old_jti` until the winner's `DEL`), and both would mint different successor tokens — the test at Section 9 "Concurrent rotation (no double-issue)" would fail. With the check, the loser sees the winner's `DEL old primary` and returns `already_rotated`. The router maps `already_rotated` to the **grace branch** (Section 5.1 step 4): look up `auth:session:grace:{old_jti}` — which the winner just wrote — verify the family set still exists, issue access-only, no Set-Cookie. The loser's user gets a fresh access token without disturbing the winner's new refresh cookie.
+       - **`EXISTS old primary` (already-rotated check).** Two concurrent `/refresh` requests with the same `old_jti` could both pass the earlier app-side `GET auth:session:{old_jti}` HIT and both enter this script. Without this check, both would pass `SISMEMBER` (the family still contains `old_jti` until the winner's `DEL`), and both would mint different successor tokens — the test at Section 9 "Concurrent rotation (no double-issue)" would fail. With the check, the loser sees the winner's `DEL old primary` and returns `already_rotated`. The router maps `already_rotated` to the **grace branch** (Section 5.1 step 4): look up `auth:session:grace:{old_jti}` — which the winner just wrote — verify the family set still exists, issue access token + a catch-up `Set-Cookie` for `grace_row["successor_jti"]` (the winner's jti, NOT the loser's locally-minted candidate). Loser's user converges on the live primary without disturbing the winner's row. See the 2026-05-19 update at the end of Section 4.1.
        - **`SET ... NX` (jti collision guard).** 128 bits of urlsafe entropy makes collisions cosmically improbable but not impossible; overwriting a live session is the wrong failure mode. On collision the router regenerates `jti` once and re-runs the script. If it collides twice in a row, return 503 — the operator has bigger problems (RNG broken).
 
        Lua executes atomically server-side; partial application is not possible. If the script errors before returning (Redis disconnect mid-script — extremely rare), the pre-rotation state is fully preserved; client gets 503 and retries.
@@ -505,20 +517,20 @@ to avoid copy-paste mistakes.
 3. NEW step: `jti = payload["jti"]` and `sid = payload["sid"]`. If **either** is missing, 401 (no legacy tokens, pre-launch policy). Both claims are mandatory after PR 2 ships.
 4. NEW step: probe Redis:
     - `GET auth:session:{jti}` hit -> normal rotation path (Section 4.2 step 5 — the Lua script checks `sid` membership atomically before writing).
-    - `GET auth:session:grace:{jti}` hit -> read the grace value and confirm its stored `sid` matches the JWT's `sid` (defence against an attacker minting a JWT with someone else's `jti` + their own `sid`). Then `EXISTS auth:session:by_sid:{sid}` — if the family set is gone, 401 (logout ran). Otherwise grace path: issue access token only, return without `Set-Cookie`. The frontend already accepts a bare access token from `/refresh`.
+    - `GET auth:session:grace:{jti}` hit -> read the grace value and confirm its stored `sid` matches the JWT's `sid` (defence against an attacker minting a JWT with someone else's `jti` + their own `sid`). Then `EXISTS auth:session:by_sid:{sid}` — if the family set is gone, 401 (logout ran). Otherwise grace path: issue access token AND emit a catch-up `Set-Cookie` carrying a JWT whose `jti` claim is `grace_row["successor_jti"]` (2026-05-19 update; see Section 4.1 note). The catch-up helper also verifies the successor primary row is alive and that `successor_jti` is a member of `auth:session:by_sid:{sid}` — fails closed with `catchup_successor_unavailable` if either check trips.
     - Both miss -> 401 `"Session has been invalidated"` (same string today's cutoff check uses, so the frontend's terminal-vs-transient classifier needs no change).
 5. Pick the winning token via existing `_validate_refresh_cookie` rules (same user, newest iat). Multi-user -> `AMBIGUOUS_SESSION_DETAIL`.
 6. On rotation: run the Lua script (Section 4.2 step 5) and dispatch on its return value:
     - **`"ok"`**: issue access + refresh tokens. The new refresh JWT carries: same `session_created_at`, **same `sid`**, new `jti`, new `iat`, new `exp`. Write `Set-Cookie: refresh_token=...; Path=/; Max-Age={refresh_idle_ttl_days * 86400}; Secure; HttpOnly; SameSite=Lax`.
     - **`{err = "session_revoked"}`** (concurrent logout): 401 with the same `"Session has been invalidated"` string. Do NOT write a Set-Cookie.
-    - **`{err = "already_rotated"}`** (concurrent `/refresh` won the race): fall through to the grace branch. Re-probe `auth:session:grace:{old_jti}` (the winner just wrote it inside their Lua transaction) AND `EXISTS auth:session:by_sid:{sid}`. On both hits, issue access token only, no Set-Cookie — same shape as the original grace path. On either miss (grace already expired or family revoked since), 401.
+    - **`{err = "already_rotated"}`** (concurrent `/refresh` won the race): fall through to the grace branch. Re-probe `auth:session:grace:{old_jti}` (the winner just wrote it inside their Lua transaction) AND `EXISTS auth:session:by_sid:{sid}`. On both hits, issue access token AND a catch-up `Set-Cookie` for `grace_row["successor_jti"]` (NOT the loser's `new_jti`, which has no Redis row). Same catch-up helper as the direct grace path. On either miss (grace already expired or family revoked since), 401 with reason `already_rotated_grace_revalidation_failed`.
     - **`{err = "jti_collision"}`** (defensive NX guard hit a 128-bit collision): regenerate `jti` and re-run the Lua script once. If the second attempt also collides, return 503 — the operator's RNG is broken and we want a loud failure, not a silent overwrite.
-7. On grace path (entered directly from step 4 OR via `already_rotated` in step 6): issue access token only, no `Set-Cookie`. `sid` is NOT rotated either (no new refresh token is minted at all).
+7. On grace path (entered directly from step 4 OR via `already_rotated` in step 6): issue access token AND a catch-up `Set-Cookie` for `grace_row["successor_jti"]` (2026-05-19 update). The `sid` is NOT rotated — the catch-up JWT preserves the original `sid` and `session_created_at`, only the `jti` claim advances to point at the winning successor primary already in Redis. No Redis writes on this path.
 8. Emit audit event:
     - `auth.session.rotated` on Lua `"ok"`. Detail: `{old_jti, new_jti, sid}`.
     - `auth.session.grace_accept` on grace path (direct OR via `already_rotated`). Detail: `{old_jti, sid, via_already_rotated: bool}` so operators can distinguish "tab race" from "in-flight rotation race".
     - `auth.session.terminated` is logout-only — see Section 5.3.
-9. The rotation-loser's path (Lua returns `already_rotated`) is the single most subtle case for Team I to test. Section 9 "Concurrent rotation (no double-issue)" pins it explicitly: two concurrent `/refresh` with the same `old_jti` must produce exactly one rotation (one new Set-Cookie), one grace acceptance (the loser, access-only), and zero 401s.
+9. The rotation-loser's path (Lua returns `already_rotated`) is the single most subtle case for Team I to test. Section 9 "Concurrent rotation (no double-issue)" pins it explicitly: two concurrent `/refresh` with the same `old_jti` must produce exactly one rotation Lua winner (one new Redis primary row), TWO `Set-Cookie` responses — winner's normal rotation cookie plus the loser's catch-up cookie for `grace_row["successor_jti"]`, both decoding to the SAME jti — one `auth.session.rotated` audit, one `auth.session.grace_accept {via_already_rotated: true}`, and zero 401s.
 
 ### 5.2 `POST /api/v1/auth/verify`
 
@@ -759,7 +771,7 @@ Surface for Team I to implement. Pin each at unit + endpoint level.
 
 - GIVEN tab A's `/refresh` rotates `jti_A` -> `jti_B` at T0
 - AND tab B's `/refresh` arrives at T0+15s carrying `jti_A`
-- THEN tab B receives a 200 with an access token AND no `Set-Cookie`.
+- THEN tab B receives a 200 with an access token AND a catch-up `Set-Cookie` whose JWT `jti` claim equals `jti_B` (2026-05-19 update — tab B converges on the live primary instead of holding `jti_A` until the 30s grace expires).
 
 ### Post-grace rejection
 
@@ -814,7 +826,7 @@ never an optional / try/except-around-None pattern.
 Two concurrent `/refresh` calls carrying the same `jti_A` must produce exactly:
 
 - One winner with HTTP 200 + Set-Cookie carrying a new `jti_B` (Lua returned `"ok"`).
-- One loser with HTTP 200 + NO Set-Cookie, access token only (Lua returned `{err = "already_rotated"}` → router fell into grace branch → grace key for `jti_A` was found → access-only).
+- One loser with HTTP 200 + a catch-up Set-Cookie whose JWT decodes to the SAME `jti_B` (Lua returned `{err = "already_rotated"}` → router fell into grace branch → grace key for `jti_A` was found → catch-up cookie issued for `grace_row["successor_jti"] == jti_B`). Test assertion: both responses' Set-Cookie JWTs MUST decode to identical jti — the catch-up helper must use `grace_row["successor_jti"]`, never the loser's locally-minted candidate.
 - Zero 401s.
 
 Pin with `asyncio.gather` and assert the response shapes. Without the Lua `EXISTS old primary` guard (Section 4.2 check (2)), this test fails: both requests pass the earlier app-side `GET` and both `SISMEMBER` checks, both run the full rotation, and the user receives two different new refresh cookies, one of which immediately becomes orphan when the other lands in the browser cookie jar.


### PR DESCRIPTION
## Summary

Production diagnosis (2026-05-19, ~1h after PR #314 merged) showed `redis_primary_and_grace_missing` firing repeatedly for the same `sid_h=943e8eeb`. Redis state was fully healthy — the live primary jti existed with 60d TTL — but the browser was sending OLD jtis (`c5952d8f`, `b87d113c`) that had been rotated past. Reproducible on **both desktop and mobile**, ruling out browser cookie storage.

## Root cause

Both `/refresh` grace branches returned `TokenResponse(access_token=...)` **without emitting Set-Cookie**:

1. **Direct grace path** (`auth.py:951`) — validator hit grace, returned access token only.
2. **Lua `already_rotated` re-probe** (`auth.py:1054`) — loser of rotation race returned access token only.

The rotation grace TTL is 30s but the session lifetime is 30–60 days. So the browser survives on the grace path for 30s after a cross-tab race, then permanently 401s with `redis_primary_and_grace_missing` once the grace key expires. The browser is never told to advance to the live successor.

## The fix

Both grace branches now call `_issue_catchup_refresh_cookie()` which:
- Reads `successor_jti` from `grace_row` (the winner's jti — never the loser's locally-minted `new_jti`)
- Verifies the successor primary key is alive in Redis and binds back to the same `(user_id, sid)`
- Mints a refresh JWT for the successor jti via `create_refresh_token(..., jti=successor_jti)` — **no Redis writes**, the row already exists
- Emits `Set-Cookie` and clears the legacy `Path=/api/v1/auth/refresh` cookie
- Fails closed with reason `catchup_successor_unavailable` if the successor is missing/dead

Architect P1/P1/P2 contract followed verbatim:
- `successor_jti` always from `grace_row["successor_jti"]`, never the loser's `new_jti`
- No Redis writes on the catch-up path
- Original `sid` and `session_created_at` preserved (absolute lifetime still anchored to original login)
- `_clear_legacy_refresh_cookie(response)` called alongside
- `/verify` invariant explicitly maintained — discards `session_row`, never emits Set-Cookie

## Caveat

This prevents recurrence. **Browsers already stuck** (grace key expired with no surviving rotation chain) still need a clean sign-in; the 30s grace mapping is irrecoverable once gone.

## Changes

- `app/security.py` — `create_refresh_token` accepts optional `jti` for catch-up issuance
- `app/routers/auth.py`:
  - new `_issue_catchup_refresh_cookie` helper (read-only path, no Redis writes)
  - both grace branches wired to call it
  - `_validate_single_refresh_token` / `_validate_refresh_cookie` return the resolved `session_row` as 6th tuple element so `/refresh` can read `successor_jti` without re-fetching
  - `/verify` explicitly discards `session_row` (RSC invariant preserved)
- 8 new tests in `tests/routers/test_refresh_cookie_catchup.py` covering the seven architect contracts
- 2 existing tests in `tests/auth/test_session_grace_lua.py` updated to the new contract (grace branch now emits Set-Cookie)

## Test plan

- `pytest tests/routers/test_refresh_cookie_catchup.py` — 8/8 pass
- `pytest tests/auth/test_session_grace_lua.py` — 10/10 pass
- Full backend suite — **1393 pass, 9 skipped**

## What we'll see in production after deploy

- `redis_primary_and_grace_missing` rate should drop substantially (only fires when the chain breaks past 30s in BOTH branches — rare)
- New `catchup_successor_unavailable` events are the leading indicator if anything else is wrong on the grace key
- `auth.session.grace_accept` audit events keep counting cross-tab races, but with cookies now advancing

## Follow-up (separate PR)

Per the user's request, add an `AUTH_DEBUG_LOGGING` env var to gate the `auth.refresh.rejected` events so they only emit during active incident debugging. The new `catchup_successor_unavailable` reason will be gated under the same flag.