### PR TITLE
fix(auth): bound poisoned Redis client retirement

### DIFF
--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -14,6 +14,7 @@ Behavior when `settings.redis_url` is empty:
   Redis and it's missing; see `require_client()` below.
 """
 
+import asyncio
 import functools
 import json
 import logging
@@ -188,7 +189,18 @@ async def _retire_poisoned_client(*, reason: str) -> None:
         extra={"reason": reason},
     )
     try:
-        await poisoned.aclose()
+        await asyncio.wait_for(
+            poisoned.aclose(), timeout=AUTH_REDIS_ACLOSE_TIMEOUT_S
+        )
+    except asyncio.TimeoutError:
+        # Cleanup wedged past the bound. Singleton is already dropped
+        # above; the OS will reclaim the FDs. Surface a distinct event
+        # so operators can tell a wedged retirement apart from a clean
+        # one in production logs.
+        logger.warning(
+            "redis.client.retired.aclose_timeout",
+            extra={"timeout_s": AUTH_REDIS_ACLOSE_TIMEOUT_S},
+        )
     except Exception:  # noqa: BLE001 — best-effort cleanup
         # We've already replaced the singleton; the OS will reclaim the
         # underlying sockets even if aclose() can't tidy up its
@@ -208,6 +220,12 @@ AUTH_REDIS_SOCKET_TIMEOUT_S = 1.0
 AUTH_REDIS_RETRY_BACKOFF_BASE_S = 0.05
 AUTH_REDIS_RETRY_BACKOFF_CAP_S = 0.2
 AUTH_REDIS_RETRY_COUNT = 1
+# Cap for ``_retire_poisoned_client``'s best-effort ``aclose()``.
+# Pool cleanup runs outside the per-command socket-timeout budget,
+# so a wedged close on a stale connection could hold the translated
+# 503 past the frontend's reactive-recovery cap. Bound it at the
+# application layer so retirement always completes promptly.
+AUTH_REDIS_ACLOSE_TIMEOUT_S = 2.0
 
 
 def _build_auth_redis_client(redis_url: str) -> Redis:

--- a/backend/tests/test_redis_transport_normalizer.py
+++ b/backend/tests/test_redis_transport_normalizer.py
@@ -548,3 +548,58 @@ class TestPoisonedClientRetirement:
         with pytest.raises(RedisConnectionError):
             await helper()
         assert rc._client is None
+
+    @pytest.mark.asyncio
+    async def test_retirement_bounds_aclose_when_it_hangs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Pool cleanup runs outside the per-command Redis timeout
+        budget. A wedged ``aclose()`` would hold the translated
+        ``RedisConnectionError`` past the frontend's reactive-recovery
+        cap. Retirement MUST bound ``aclose()`` so the translated
+        exception reaches the caller promptly even when cleanup is
+        stuck."""
+        import asyncio
+        import logging
+        import app.redis_client as rc
+        from unittest.mock import MagicMock
+
+        # Shrink the bound for test speed. The constant is read off
+        # the module at call time, so monkeypatch is sufficient.
+        monkeypatch.setattr(rc, "AUTH_REDIS_ACLOSE_TIMEOUT_S", 0.05)
+        caplog.set_level(logging.WARNING, logger=rc.logger.name)
+
+        async def hang_forever() -> None:
+            # Models a wedged close path — long enough that no plausible
+            # test budget would tolerate it if the bound weren't enforced.
+            await asyncio.sleep(60)
+
+        sentinel_client = MagicMock()
+        sentinel_client.aclose = hang_forever
+        rc._client = sentinel_client
+
+        @_normalize_transport_errors
+        async def helper() -> None:
+            raise RuntimeError("the handler is closed")
+
+        # Outer wait_for makes a regression fail in ~1 s instead of
+        # running the full mocked 60 s sleep. If the inner bound is
+        # missing, this raises asyncio.TimeoutError, not
+        # RedisConnectionError — and the pytest.raises assertion fails
+        # loudly.
+        with pytest.raises(RedisConnectionError):
+            await asyncio.wait_for(helper(), timeout=1.0)
+
+        # Singleton MUST be dropped (core retirement contract).
+        assert rc._client is None
+        # Event contract: the timeout path emits a distinct warning
+        # so operators can tell wedged retirement apart from clean.
+        assert any(
+            record.msg == "redis.client.retired.aclose_timeout"
+            for record in caplog.records
+        ), (
+            "expected redis.client.retired.aclose_timeout log event; "
+            f"captured: {[r.msg for r in caplog.records]}"
+        )


### PR DESCRIPTION
## Summary

Bound `_retire_poisoned_client`'s best-effort `aclose()` with a 2 s `asyncio.wait_for` and emit a distinct `redis.client.retired.aclose_timeout` warning when the bound fires. Singleton is already dropped before `aclose()` is awaited, so the OS reclaims FDs and the next request rebuilds the pool from scratch.

This is **containment for stale-pool retirement latency, not proof of the full mechanism and not the durable orphan-cookie / session-recovery fix.**

## Why now

2026-05-20 production trace captured an idle dashboard's `/auth/refresh` hang signature:

- 4 frontend `(canceled)` entries at exactly 46 s — the reactive-recovery abort timer firing.
- **Zero matching `uvicorn.access` entries** for those 4 attempts. The handler never reached the response stage.
- A 5th attempt eventually completed with a clean 401 in 1.3 s.
- `redis-cli CLIENT LIST` on `pfv-data-01` showed one persistent App Platform → Redis connection at `age=807s / idle=807s / last cmd=get` — consistent with a stale/half-open pool but **not** proof that execution reached `_retire_poisoned_client` (the `redis.client.retired` warning, which would have fired there, is also absent from the window).

The transport normalizer (PR #314) already drops the singleton before raising a transient `RedisConnectionError`, so the retry-on-fresh-pool path is intact. What was missing: the best-effort `aclose()` ran outside the per-command socket-timeout budget, so a wedged cleanup could hold the translated 503 past the frontend's reactive-recovery cap. Bounding it at the application layer makes retirement always complete promptly regardless of what the underlying socket is doing.

## What changed

- `backend/app/redis_client.py`
  - New constant `AUTH_REDIS_ACLOSE_TIMEOUT_S = 2.0`.
  - `_retire_poisoned_client` wraps `poisoned.aclose()` in `asyncio.wait_for(..., timeout=AUTH_REDIS_ACLOSE_TIMEOUT_S)`.
  - On `asyncio.TimeoutError`, emits a structured `redis.client.retired.aclose_timeout` warning so operators can distinguish a wedged retirement from a clean one. Existing `Exception` clause for `aclose()` failures unchanged.
- `backend/tests/test_redis_transport_normalizer.py`
  - New `test_retirement_bounds_aclose_when_it_hangs` in `TestPoisonedClientRetirement` mocks `aclose()` with `asyncio.sleep(60)`, asserts the wrapper still surfaces `RedisConnectionError`, asserts the singleton is dropped, and pins the `redis.client.retired.aclose_timeout` event-name contract via `caplog`.
  - Outer `asyncio.wait_for(helper(), timeout=1.0)` so a regression that removes the bound fails the test in ~1 s instead of after the 60 s mock sleep.

## Tests

- `TestPoisonedClientRetirement`: 6/6 passing (5 pre-existing + 1 new).
- Full backend pytest sweep was green (1405 passed, 9 skipped) prior to this branch's tightening edits, which only changed comment/docstring text and test assertion shape — no production-behavior surface area touched between the sweep and this PR.

## Out of scope

- Route-local `asyncio.wait_for` containment around `/refresh` / `/google/callback` handlers.
- Per-handler breadcrumb logging in `/google/callback`.
- The durable orphan-cookie / catch-up successor-jti mapping (Class 1 from the auth-stability residuals).
- slowapi async storage (Class 2 — confirmed not the cause of today's hang anyway, since `/refresh` isn't slowapi-decorated).