### PR TITLE
fix(deps): pin PyMySQL to restore SQLAlchemy ping() detection

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,15 @@ pydantic[email]==2.11.3
 pydantic-settings==2.9.1
 sqlalchemy==2.0.41
 aiomysql==0.2.0
+# PyMySQL is a transitive dep of aiomysql; pin explicitly because
+# SQLAlchemy's mysql dialect inspects PyMySQL's ``connect.__doc__`` to
+# decide whether to call ``ping()`` with or without an argument. A
+# newer PyMySQL whose docstring no longer contains the marker flips
+# that detection and causes ``AsyncAdapt_aiomysql_connection.ping()``
+# to be invoked with no args, which raises a TypeError because the
+# adapter's ping signature still requires ``reconnect``. 1.1.3 is
+# known good against sqlalchemy==2.0.41 + aiomysql==0.2.0.
+PyMySQL==1.1.3
 alembic==1.15.2
 PyJWT[crypto]==2.10.1
 bcrypt==4.3.0

--- a/backend/tests/test_requirements_pins.py
+++ b/backend/tests/test_requirements_pins.py
@@ -1,0 +1,43 @@
+"""Pin-contract regression tests for dependencies whose unpinned drift
+has previously broken the application at runtime."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REQUIREMENTS_PATH = (
+    Path(__file__).resolve().parent.parent / "requirements.txt"
+)
+
+
+def _parse_requirements() -> dict[str, str]:
+    """Return ``{name_lower: version}`` for every ``==`` / ``~=`` pin in
+    ``backend/requirements.txt``. Skips blank lines and ``#`` comments;
+    strips extras (``pydantic[email]`` → ``pydantic``)."""
+    pins: dict[str, str] = {}
+    for raw in REQUIREMENTS_PATH.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        for sep in ("==", "~="):
+            if sep in line:
+                name, _, ver = line.partition(sep)
+                pins[name.split("[", 1)[0].strip().lower()] = ver.strip()
+                break
+    return pins
+
+
+def test_pymysql_is_pinned() -> None:
+    """PyMySQL is a transitive dependency of aiomysql. SQLAlchemy's
+    mysql dialect decides whether to invoke ``ping()`` with or without
+    an argument by inspecting ``PyMySQL.connect.__doc__`` at engine
+    init. Drift to a PyMySQL whose docstring no longer matches that
+    detection breaks every DB pool checkout, because the async adapter's
+    ``ping(self, reconnect)`` still requires the positional arg.
+    Pinning PyMySQL is therefore part of the contract — not optional."""
+    assert "pymysql" in _parse_requirements(), (
+        "PyMySQL must be pinned in requirements.txt. aiomysql does "
+        "not pin it, so a fresh `pip install` will resolve whatever "
+        "PyMySQL is current on PyPI — and that has caused production "
+        "outages when SQLAlchemy's dialect detection silently flipped."
+    )


### PR DESCRIPTION
## Summary

Pin `PyMySQL==1.1.3` in `backend/requirements.txt` and add a small regression test that asserts the pin exists. Restores production after deploy `d3906938` started 500ing every DB-touching request, including the backend readiness probe.

## What happened

After PR #318 merged, the rebuilt production container's `pip install` resolved a newer PyMySQL than the local container has (transitive dep of `aiomysql==0.2.0`, never pinned). On first DB pool checkout the new instance crashed with:

```
TypeError: AsyncAdapt_aiomysql_connection.ping() missing 1 required positional argument: 'reconnect'
```

This blew up `/auth/login`, the readiness probe at `app.main`, and any other DB-touching endpoint.

## Why it happened

SQLAlchemy's mysql dialect chooses between calling `dbapi_connection.ping(False)` and `dbapi_connection.ping()` based on a memoized property `_send_false_to_ping`, which inspects `PyMySQL.connect.__doc__` for the substring `reconnect=False`. The newer PyMySQL's docstring no longer contains that marker, so the property resolves False and the dialect calls `ping()` with no args. SQLAlchemy's `AsyncAdapt_aiomysql_connection.ping(self, reconnect)` still requires the positional `reconnect`, so it raises `TypeError` on every checkout.

The local working container has PyMySQL 1.1.3 (where the docstring detection still works correctly against `sqlalchemy==2.0.41` + `aiomysql==0.2.0`). Pinning to that version restores production parity.

## What changed

- `backend/requirements.txt`: pin `PyMySQL==1.1.3` directly under `aiomysql==0.2.0`, with a comment explaining the contract so the next person who tries to relax it understands what they'd be breaking.
- `backend/tests/test_requirements_pins.py`: new file. `test_pymysql_is_pinned` parses `requirements.txt` and asserts `pymysql` has a pin. Catches an accidental future removal at CI time, since the install-side failure mode is silent and only surfaces on first DB pool checkout.

## Why pin-existence (not pin-version) in the regression test

The strict alternative — asserting `PyMySQL == 1.1.3` specifically — would force every future routine bump to update the test. The looser alternative — asserting that *some* pin exists — protects against the immediate failure mode (unpinned drift) without that maintenance tax. Per architect: "at least assert the explicit PyMySQL pin exists."

## Out of scope

- Pinning every transitive dependency project-wide. Doing it broadly belongs in a separate hygiene PR with lockfile-style tooling, not in an incident hotfix.
- Re-verifying PR #318 (bounded poisoned-client retirement). Authenticated traffic is currently confounded by this DB-checkout failure, so refresh behavior cannot validate #318 until this lands.