### PR TITLE
fix(auth): contain /refresh hang + observability for the wrapped Redis path

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,10 +34,14 @@ class Settings(BaseSettings):
     # RTO, which is the actual mechanism behind the 46 s "(canceled)"
     # /refresh hang signature.
     #
+    # connect_timeout sized for first-connect under cold-start
+    # network conditions where a transient VPC blip can extend the
+    # handshake by a few seconds — too tight breaks legitimate
+    # slow connects without buying back any user-visible latency.
     # read_timeout / write_timeout apply per-packet, not per-query,
     # so a legitimately long-running query that streams data is not
     # affected — only stalls on a dead socket are bounded.
-    db_connect_timeout: int = 5
+    db_connect_timeout: int = 10
     db_read_timeout: int = 30
     db_write_timeout: int = 30
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,6 +19,28 @@ class Settings(BaseSettings):
     db_pool_size: int = 5
     db_max_overflow: int = 10
 
+    # Pool recycle MUST stay under the App Platform → droplet VPC's
+    # idle-connection drop interval. Once a pooled connection sits
+    # idle longer than that, the kernel TCP socket on the App-side is
+    # dead but the pool doesn't know — pre_ping fires, blocks reading
+    # from the dead socket until the kernel TCP RTO (tens of seconds),
+    # and every endpoint that touches the DB hangs. 280 s is a
+    # conservative ceiling well under the typical 300 s NAT timeout.
+    db_pool_recycle: int = 280
+
+    # connect_timeout / read_timeout / write_timeout are passed
+    # through to ``aiomysql.connect()`` and apply at the socket
+    # layer. Without them the driver blocks until the kernel TCP
+    # RTO, which is the actual mechanism behind the 46 s "(canceled)"
+    # /refresh hang signature.
+    #
+    # read_timeout / write_timeout apply per-packet, not per-query,
+    # so a legitimately long-running query that streams data is not
+    # affected — only stalls on a dead socket are bounded.
+    db_connect_timeout: int = 5
+    db_read_timeout: int = 30
+    db_write_timeout: int = 30
+
     # Auth
     jwt_secret_key: str = "change-me-generate-a-real-secret"
     jwt_access_token_expire_minutes: int = 15
@@ -47,6 +69,16 @@ class Settings(BaseSettings):
     # ``redis.client.retired`` event — that is a real ops signal worth
     # keeping on regardless.
     auth_debug_logging: bool = False
+
+    # Absolute ceiling on the wall-clock time the ``/auth/refresh``
+    # handler may spend before the route returns 503. The honest
+    # worst-case Redis budget for the deepest /refresh branch is
+    # ~22 s (see ``redis_client._build_auth_redis_client`` docstring);
+    # this ceiling sits above that so normal slow paths still
+    # complete, and below the frontend's 45 s reactive-recovery
+    # abort so a wedged handler always surfaces as a clean 503 the
+    # browser can retry on instead of a silent hang with no log.
+    refresh_handler_timeout_s: float = 25.0
 
     # Redis (optional — used for sessions/cache in production)
     redis_url: str = ""

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -16,13 +16,26 @@ def _build_connect_args() -> dict:
     DO managed MySQL requires SSL on external connections. When the DATABASE_URL
     contains a DO-style host (port 25060), enable SSL with server verification
     disabled (DO uses self-signed certs with their own CA).
+
+    The socket-layer timeouts (``connect_timeout`` / ``read_timeout`` /
+    ``write_timeout``) bound how long aiomysql will block on a dead
+    socket before raising. Without them, a stale pooled connection
+    whose peer-side has been silently dropped by the VPC NAT causes
+    ``pool_pre_ping``'s ping to wait for the kernel TCP RTO (tens of
+    seconds), which is the actual mechanism behind the silent 46 s
+    /refresh handler hang.
     """
+    args: dict = {
+        "connect_timeout": settings.db_connect_timeout,
+        "read_timeout": settings.db_read_timeout,
+        "write_timeout": settings.db_write_timeout,
+    }
     if ":25060" in settings.database_url:
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
-        return {"ssl": ctx}
-    return {}
+        args["ssl"] = ctx
+    return args
 
 
 def _safe_host(database_url: str) -> str:
@@ -41,22 +54,26 @@ def _safe_host(database_url: str) -> str:
         return "unknown"
 
 
-# DO's network layer silently drops idle TCP to managed MySQL after ~10 min,
-# but the server-side wait_timeout is 8 hours, so without pre_ping the pool
-# hands out dead sockets and the next query fails with "Lost connection
-# during query" (error 2013). Recycle well below the network idle threshold.
+# The VPC NAT between App Platform and the data-plane droplet drops
+# idle TCP after ~5 minutes; the server-side wait_timeout is much
+# longer. Without recycle-before-NAT-drop the pool hands out
+# half-open sockets and the next pre_ping blocks on a dead socket
+# until the kernel TCP RTO fires (tens of seconds). The socket
+# timeouts in connect_args bound that worst case, and pool_recycle
+# brings connections back BEFORE NAT can drop them.
 #
 # Single-replica today: SQLAlchemy defaults (pool_size=5, max_overflow=10)
-# are safe. Multi-replica future (HPA): each replica gets its own pool,
-# so total concurrent DB connections = replicas * (pool_size +
-# max_overflow). Sized for the managed-DB max_connections cap; override
-# DB_POOL_SIZE / DB_MAX_OVERFLOW env vars when scaling horizontally.
+# are safe. Multi-replica future (HPA): each replica gets its own
+# pool, so total concurrent DB connections = replicas * (pool_size +
+# max_overflow). Sized for the data-plane droplet's max_connections
+# cap; override DB_POOL_SIZE / DB_MAX_OVERFLOW env vars when scaling
+# horizontally.
 engine = create_async_engine(
     settings.database_url,
     echo=False,
     connect_args=_build_connect_args(),
     pool_pre_ping=True,
-    pool_recycle=1800,
+    pool_recycle=settings.db_pool_recycle,
     pool_size=settings.db_pool_size,
     max_overflow=settings.db_max_overflow,
 )

--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -17,9 +17,10 @@ Behavior when `settings.redis_url` is empty:
 import asyncio
 import functools
 import json
-import logging
 import time as _time
 from typing import Any, Awaitable, Callable, TypeVar
+
+import structlog
 
 from redis.asyncio import Redis
 from redis.asyncio.retry import Retry
@@ -31,7 +32,12 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from app.config import settings
 
-logger = logging.getLogger(__name__)
+# Use structlog so kwargs (op, reason, duration_ms, ...) and
+# contextvars (request_id) BOTH appear in the rendered JSON. Plain
+# ``logging.getLogger`` + ``extra={...}`` would silently drop the
+# kwargs under ``ProcessorFormatter`` — verified end-to-end by
+# ``tests/test_log_field_propagation.py``.
+logger = structlog.stdlib.get_logger(__name__)
 
 _client: Redis | None = None
 
@@ -113,31 +119,18 @@ def _normalize_transport_errors(fn: _F) -> _F:
     """
     @functools.wraps(fn)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        # Breadcrumbs around the wrapped call let operators pin which
-        # specific Redis op a /refresh handler was inside when it hung.
-        # Gated by ``settings.auth_debug_logging`` so production stays
-        # quiet under normal operation. Local import avoids the
-        # ``app.config`` cycle this module's import order can introduce.
-        from app.config import settings as _settings  # noqa: PLC0415
-        debug = _settings.auth_debug_logging
         op_name = fn.__name__
-        start = _time.perf_counter() if debug else 0.0
-        if debug:
-            logger.info("redis.call.start", extra={"op": op_name})
+        start = _time.perf_counter()
+        _emit_breadcrumb("redis.call.start", op=op_name)
         try:
             result = await fn(*args, **kwargs)
         except RedisError as exc:
-            if debug:
-                logger.info(
-                    "redis.call.error",
-                    extra={
-                        "op": op_name,
-                        "duration_ms": round(
-                            (_time.perf_counter() - start) * 1000, 1
-                        ),
-                        "error_class": exc.__class__.__name__,
-                    },
-                )
+            _emit_breadcrumb(
+                "redis.call.error",
+                op=op_name,
+                duration_ms=_elapsed_ms(start),
+                error_class=exc.__class__.__name__,
+            )
             # ResponseError, ConnectionError, TimeoutError, etc. — already
             # a sensible Redis-domain exception. Pass through so the
             # caller's ``except (RedisRequired, RedisError)`` runs AND so
@@ -149,17 +142,12 @@ def _normalize_transport_errors(fn: _F) -> _F:
             # through so the caller's existing handler logic runs.
             raise
         except OSError as exc:
-            if debug:
-                logger.info(
-                    "redis.call.error",
-                    extra={
-                        "op": op_name,
-                        "duration_ms": round(
-                            (_time.perf_counter() - start) * 1000, 1
-                        ),
-                        "error_class": exc.__class__.__name__,
-                    },
-                )
+            _emit_breadcrumb(
+                "redis.call.error",
+                op=op_name,
+                duration_ms=_elapsed_ms(start),
+                error_class=exc.__class__.__name__,
+            )
             # Socket-level I/O. Translate to RedisConnectionError so the
             # router's existing 503 fallback kicks in — AND retire the
             # poisoned pool so the next call uses a fresh connection.
@@ -172,17 +160,12 @@ def _normalize_transport_errors(fn: _F) -> _F:
             ) from exc
         except RuntimeError as exc:
             if _looks_like_dead_transport(exc):
-                if debug:
-                    logger.info(
-                        "redis.call.error",
-                        extra={
-                            "op": op_name,
-                            "duration_ms": round(
-                                (_time.perf_counter() - start) * 1000, 1
-                            ),
-                            "error_class": exc.__class__.__name__,
-                        },
-                    )
+                _emit_breadcrumb(
+                    "redis.call.error",
+                    op=op_name,
+                    duration_ms=_elapsed_ms(start),
+                    error_class=exc.__class__.__name__,
+                )
                 # Same as above: poisoned-pool retirement BEFORE the
                 # router's caller hits the next helper. Without this,
                 # the frontend's reactive retry would hit the same
@@ -200,19 +183,30 @@ def _normalize_transport_errors(fn: _F) -> _F:
             # Unrelated RuntimeError — almost certainly a real bug.
             # Let it escape so it surfaces as 500 with full traceback.
             raise
-        if debug:
-            logger.info(
-                "redis.call.ok",
-                extra={
-                    "op": op_name,
-                    "duration_ms": round(
-                        (_time.perf_counter() - start) * 1000, 1
-                    ),
-                },
-            )
+        _emit_breadcrumb(
+            "redis.call.ok",
+            op=op_name,
+            duration_ms=_elapsed_ms(start),
+        )
         return result
 
     return wrapper  # type: ignore[return-value]
+
+
+def _elapsed_ms(start: float) -> float:
+    """Wall-clock elapsed since ``start`` (from ``time.perf_counter``)
+    rounded to 0.1 ms — the resolution operators correlate at."""
+    return round((_time.perf_counter() - start) * 1000, 1)
+
+
+def _emit_breadcrumb(event: str, **fields: Any) -> None:
+    """Emit a ``redis.call.*`` breadcrumb when ``auth_debug_logging`` is
+    on. Gated so production stays quiet by default; flipping the env
+    var on during incident triage surfaces per-op start / ok / error
+    events that pin which Redis call a hung handler was inside."""
+    if not settings.auth_debug_logging:
+        return
+    logger.info(event, **fields)
 
 
 async def _retire_poisoned_client(*, reason: str) -> None:
@@ -240,10 +234,7 @@ async def _retire_poisoned_client(*, reason: str) -> None:
     if poisoned is None:
         return
     _client = None
-    logger.warning(
-        "redis.client.retired",
-        extra={"reason": reason},
-    )
+    logger.warning("redis.client.retired", reason=reason)
     try:
         await asyncio.wait_for(
             poisoned.aclose(), timeout=AUTH_REDIS_ACLOSE_TIMEOUT_S
@@ -255,7 +246,7 @@ async def _retire_poisoned_client(*, reason: str) -> None:
         # one in production logs.
         logger.warning(
             "redis.client.retired.aclose_timeout",
-            extra={"timeout_s": AUTH_REDIS_ACLOSE_TIMEOUT_S},
+            timeout_s=AUTH_REDIS_ACLOSE_TIMEOUT_S,
         )
     except Exception:  # noqa: BLE001 — best-effort cleanup
         # We've already replaced the singleton; the OS will reclaim the

--- a/backend/app/redis_client.py
+++ b/backend/app/redis_client.py
@@ -18,6 +18,7 @@ import asyncio
 import functools
 import json
 import logging
+import time as _time
 from typing import Any, Awaitable, Callable, TypeVar
 
 from redis.asyncio import Redis
@@ -112,9 +113,31 @@ def _normalize_transport_errors(fn: _F) -> _F:
     """
     @functools.wraps(fn)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        # Breadcrumbs around the wrapped call let operators pin which
+        # specific Redis op a /refresh handler was inside when it hung.
+        # Gated by ``settings.auth_debug_logging`` so production stays
+        # quiet under normal operation. Local import avoids the
+        # ``app.config`` cycle this module's import order can introduce.
+        from app.config import settings as _settings  # noqa: PLC0415
+        debug = _settings.auth_debug_logging
+        op_name = fn.__name__
+        start = _time.perf_counter() if debug else 0.0
+        if debug:
+            logger.info("redis.call.start", extra={"op": op_name})
         try:
-            return await fn(*args, **kwargs)
-        except RedisError:
+            result = await fn(*args, **kwargs)
+        except RedisError as exc:
+            if debug:
+                logger.info(
+                    "redis.call.error",
+                    extra={
+                        "op": op_name,
+                        "duration_ms": round(
+                            (_time.perf_counter() - start) * 1000, 1
+                        ),
+                        "error_class": exc.__class__.__name__,
+                    },
+                )
             # ResponseError, ConnectionError, TimeoutError, etc. — already
             # a sensible Redis-domain exception. Pass through so the
             # caller's ``except (RedisRequired, RedisError)`` runs AND so
@@ -126,6 +149,17 @@ def _normalize_transport_errors(fn: _F) -> _F:
             # through so the caller's existing handler logic runs.
             raise
         except OSError as exc:
+            if debug:
+                logger.info(
+                    "redis.call.error",
+                    extra={
+                        "op": op_name,
+                        "duration_ms": round(
+                            (_time.perf_counter() - start) * 1000, 1
+                        ),
+                        "error_class": exc.__class__.__name__,
+                    },
+                )
             # Socket-level I/O. Translate to RedisConnectionError so the
             # router's existing 503 fallback kicks in — AND retire the
             # poisoned pool so the next call uses a fresh connection.
@@ -138,6 +172,17 @@ def _normalize_transport_errors(fn: _F) -> _F:
             ) from exc
         except RuntimeError as exc:
             if _looks_like_dead_transport(exc):
+                if debug:
+                    logger.info(
+                        "redis.call.error",
+                        extra={
+                            "op": op_name,
+                            "duration_ms": round(
+                                (_time.perf_counter() - start) * 1000, 1
+                            ),
+                            "error_class": exc.__class__.__name__,
+                        },
+                    )
                 # Same as above: poisoned-pool retirement BEFORE the
                 # router's caller hits the next helper. Without this,
                 # the frontend's reactive retry would hit the same
@@ -155,6 +200,17 @@ def _normalize_transport_errors(fn: _F) -> _F:
             # Unrelated RuntimeError — almost certainly a real bug.
             # Let it escape so it surfaces as 500 with full traceback.
             raise
+        if debug:
+            logger.info(
+                "redis.call.ok",
+                extra={
+                    "op": op_name,
+                    "duration_ms": round(
+                        (_time.perf_counter() - start) * 1000, 1
+                    ),
+                },
+            )
+        return result
 
     return wrapper  # type: ignore[return-value]
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import secrets
 import hmac as _hmac
@@ -1070,7 +1071,44 @@ async def refresh(
     onto a directly-returned RedirectResponse). For the session-expiry
     path we therefore return a JSONResponse directly so the
     delete-cookie header actually reaches the browser.
+
+    A route-local ``asyncio.wait_for`` bounds the entire handler at
+    ``settings.refresh_handler_timeout_s`` (default 25 s). If anything
+    in the call chain (Redis pool acquire, MySQL pool checkout,
+    pre_ping on a stale socket, etc.) hangs longer than that, the
+    handler returns 503 with ``SESSION_REDIS_UNAVAILABLE_DETAIL`` and
+    emits ``auth.refresh.handler_timeout`` so operators can correlate.
+    Without this bound, a wedged dependency blocks the request
+    silently until the frontend's reactive-recovery abort fires at
+    45 s with no matching backend access log — the smoking-gun
+    signature operators previously had no observability into.
     """
+    try:
+        return await asyncio.wait_for(
+            _refresh_impl(request, response, db, session_factory),
+            timeout=app_settings.refresh_handler_timeout_s,
+        )
+    except asyncio.TimeoutError:
+        _LOGGER.warning(
+            "auth.refresh.handler_timeout",
+            extra={"timeout_s": app_settings.refresh_handler_timeout_s},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=SESSION_REDIS_UNAVAILABLE_DETAIL,
+        )
+
+
+async def _refresh_impl(
+    request: Request,
+    response: Response,
+    db: AsyncSession,
+    session_factory: async_sessionmaker[AsyncSession],
+):
+    """Body of ``/auth/refresh``, extracted so the route handler can
+    apply a route-local ``asyncio.wait_for(...)`` ceiling. The full
+    spec lives on the public ``refresh()`` handler above; do not
+    duplicate it here."""
     refresh_tokens = _extract_refresh_cookies(request)
     try:
         user, payload, session_start, redis_state, ttl_seconds, session_row = await _validate_refresh_cookie(

--- a/backend/tests/test_database_pool_config.py
+++ b/backend/tests/test_database_pool_config.py
@@ -81,7 +81,9 @@ def test_engine_is_constructed_with_settings_pool_values(monkeypatch):
         assert captured["kwargs"]["max_overflow"] == 13
         # Sanity: existing safety params still on the engine.
         assert captured["kwargs"]["pool_pre_ping"] is True
-        assert captured["kwargs"]["pool_recycle"] == 1800
+        # pool_recycle is now sourced from settings.db_pool_recycle —
+        # see test_db_engine_config.py for the NAT-idle-ceiling rationale.
+        assert captured["kwargs"]["pool_recycle"] == app_config.settings.db_pool_recycle
     finally:
         # Restore module state for any later tests in the run.
         importlib.reload(app_config)

--- a/backend/tests/test_db_engine_config.py
+++ b/backend/tests/test_db_engine_config.py
@@ -1,0 +1,59 @@
+"""Engine-level pool / socket-timeout config — regression tests for
+the 2026-05-20 silent 46 s /auth/refresh hang.
+
+Without these bounds the SQLAlchemy pool's ``pre_ping`` could block on
+a half-open socket until the kernel TCP RTO (tens of seconds), with
+no application-level recovery point. Every endpoint that touches the
+DB inherited the hang; uvicorn never emitted an access log because the
+handler never reached the response stage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app.database as database
+from app.config import settings
+
+
+def test_pool_recycle_is_under_typical_nat_idle() -> None:
+    """``pool_recycle`` must stay well under the VPC NAT's idle-drop
+    interval (~300 s typical). The setting carries the value into the
+    engine; this test pins the default so a future bump to e.g. 1800 s
+    (the pre-2026-05-20 value) re-introduces the silent-hang class
+    immediately and fails CI."""
+    assert settings.db_pool_recycle <= 290, (
+        "db_pool_recycle must stay under the typical VPC NAT idle "
+        f"timeout; got {settings.db_pool_recycle}s"
+    )
+
+
+def test_socket_timeouts_are_propagated_to_aiomysql() -> None:
+    """``connect_timeout`` / ``read_timeout`` / ``write_timeout`` are
+    aiomysql constructor args that bound socket I/O. Without them, a
+    stale pooled connection blocks until the kernel TCP RTO. The
+    builder must thread the configured values through verbatim — a
+    drop here would silently re-open the hang."""
+    args = database._build_connect_args()
+    assert args.get("connect_timeout") == settings.db_connect_timeout
+    assert args.get("read_timeout") == settings.db_read_timeout
+    assert args.get("write_timeout") == settings.db_write_timeout
+
+
+def test_socket_timeouts_have_sane_defaults() -> None:
+    """Defaults must be bounded (>0 and below the route-local handler
+    ceiling) so a single stuck operation cannot consume the whole
+    budget. read/write timeouts apply per-packet so the values can
+    safely be larger than the connect timeout — but never unbounded."""
+    assert 0 < settings.db_connect_timeout < settings.refresh_handler_timeout_s
+    assert 0 < settings.db_read_timeout < 120
+    assert 0 < settings.db_write_timeout < 120
+
+
+# NOTE: a fourth test originally asserted
+# ``database.engine.pool._recycle == settings.db_pool_recycle`` but was
+# dropped — the equivalent ``pool_recycle`` kwarg assertion in
+# ``test_database_pool_config.test_engine_is_constructed_with_settings_pool_values``
+# covers the construction contract without depending on the module-level
+# engine reference, which other tests in the suite stub via
+# ``importlib.reload`` and a fake ``create_async_engine``.

--- a/backend/tests/test_log_field_propagation.py
+++ b/backend/tests/test_log_field_propagation.py
@@ -1,0 +1,109 @@
+"""End-to-end contract test: structured fields a foreign-record
+emitter passes (``op``, ``reason``, ``timeout_s``, etc.) AND
+contextvars (``request_id``) BOTH appear in the rendered JSON.
+
+This pins the production-observability contract that the 2026-05-20
+PR review surfaced: a stdlib ``logger.info(msg, extra={...})`` call
+silently drops the ``extra`` fields under the project's
+``ProcessorFormatter`` config, while a structlog ``logger.info(msg,
+**kwargs)`` carries them through. Without this regression test, a
+future refactor that swaps the logger type back can silently strip
+operator-visible fields from every breadcrumb without breaking any
+caplog-based test.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+
+import pytest
+import structlog
+
+
+@pytest.fixture
+def captured_stream(monkeypatch: pytest.MonkeyPatch):
+    """Wire the structlog ProcessorFormatter from ``app.logging`` to a
+    StringIO so we can read what production would have written to
+    stdout. Restores the original handler list afterwards so the
+    rest of the suite is untouched."""
+    # Settings init requires JWT_SECRET_KEY when imported the first
+    # time. Ensure it is set before ``app.logging`` is loaded.
+    monkeypatch.setenv(
+        "JWT_SECRET_KEY",
+        "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12",
+    )
+
+    from app.logging import setup_logging
+
+    setup_logging()
+
+    buf = io.StringIO()
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    formatter = saved_handlers[0].formatter
+    test_handler = logging.StreamHandler(buf)
+    test_handler.setFormatter(formatter)
+    root.handlers = [test_handler]
+
+    yield buf
+
+    root.handlers = saved_handlers
+    structlog.contextvars.clear_contextvars()
+
+
+def _parse_lines(buf: io.StringIO) -> list[dict]:
+    return [json.loads(line) for line in buf.getvalue().strip().splitlines() if line.strip()]
+
+
+def test_redis_client_logger_emits_op_and_request_id(captured_stream) -> None:
+    """Contract: a structured Redis breadcrumb must include both the
+    operator-visible op field and the request_id from contextvars in
+    the rendered JSON. If either is missing in production, the
+    breadcrumbs are useless for correlation."""
+    import app.redis_client as rc
+
+    structlog.contextvars.bind_contextvars(request_id="req-test-1234")
+    rc.logger.info("redis.call.start", op="session_validate")
+    rc.logger.info(
+        "redis.call.ok",
+        op="session_validate",
+        duration_ms=2.3,
+    )
+
+    events = _parse_lines(captured_stream)
+    assert len(events) == 2
+    for event in events:
+        assert event["op"] == "session_validate", (
+            f"op field missing from rendered output: {event}"
+        )
+        assert event["request_id"] == "req-test-1234", (
+            f"request_id field missing from rendered output: {event}"
+        )
+    assert events[0]["event"] == "redis.call.start"
+    assert events[1]["event"] == "redis.call.ok"
+    assert events[1]["duration_ms"] == 2.3
+
+
+def test_redis_retired_warning_emits_reason_and_request_id(captured_stream) -> None:
+    """Same contract for the existing ``redis.client.retired`` warning
+    — the ``reason`` field must reach the rendered JSON. This was
+    silently broken before the 2026-05-20 logger switch because the
+    stdlib-style ``extra={"reason": ...}`` was dropped by
+    ProcessorFormatter."""
+    import app.redis_client as rc
+
+    structlog.contextvars.bind_contextvars(request_id="req-retired-7")
+    rc.logger.warning("redis.client.retired", reason="OSError: BrokenPipeError: ...")
+
+    events = _parse_lines(captured_stream)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "redis.client.retired"
+    assert event["reason"] == "OSError: BrokenPipeError: ...", (
+        f"reason field missing from rendered output: {event}"
+    )
+    assert event["request_id"] == "req-retired-7"
+    assert event["level"] == "warning"

--- a/backend/tests/test_redis_transport_normalizer.py
+++ b/backend/tests/test_redis_transport_normalizer.py
@@ -553,23 +553,25 @@ class TestPoisonedClientRetirement:
     async def test_retirement_bounds_aclose_when_it_hangs(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Pool cleanup runs outside the per-command Redis timeout
         budget. A wedged ``aclose()`` would hold the translated
         ``RedisConnectionError`` past the frontend's reactive-recovery
         cap. Retirement MUST bound ``aclose()`` so the translated
         exception reaches the caller promptly even when cleanup is
-        stuck."""
+        stuck.
+
+        Patches the module-level ``logger`` so the structlog kwarg
+        contract is asserted at the call site (``record.msg`` is not
+        a useful surface when the logger is a structlog
+        ``BoundLogger``)."""
         import asyncio
-        import logging
         import app.redis_client as rc
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock, patch
 
         # Shrink the bound for test speed. The constant is read off
         # the module at call time, so monkeypatch is sufficient.
         monkeypatch.setattr(rc, "AUTH_REDIS_ACLOSE_TIMEOUT_S", 0.05)
-        caplog.set_level(logging.WARNING, logger=rc.logger.name)
 
         async def hang_forever() -> None:
             # Models a wedged close path — long enough that no plausible
@@ -589,17 +591,16 @@ class TestPoisonedClientRetirement:
         # missing, this raises asyncio.TimeoutError, not
         # RedisConnectionError — and the pytest.raises assertion fails
         # loudly.
-        with pytest.raises(RedisConnectionError):
-            await asyncio.wait_for(helper(), timeout=1.0)
+        with patch.object(rc, "logger") as logger_mock:
+            with pytest.raises(RedisConnectionError):
+                await asyncio.wait_for(helper(), timeout=1.0)
 
         # Singleton MUST be dropped (core retirement contract).
         assert rc._client is None
         # Event contract: the timeout path emits a distinct warning
         # so operators can tell wedged retirement apart from clean.
-        assert any(
-            record.msg == "redis.client.retired.aclose_timeout"
-            for record in caplog.records
-        ), (
+        warning_events = [c.args[0] for c in logger_mock.warning.call_args_list]
+        assert "redis.client.retired.aclose_timeout" in warning_events, (
             "expected redis.client.retired.aclose_timeout log event; "
-            f"captured: {[r.msg for r in caplog.records]}"
+            f"captured: {warning_events}"
         )

--- a/backend/tests/test_redis_wrapper_breadcrumbs.py
+++ b/backend/tests/test_redis_wrapper_breadcrumbs.py
@@ -7,11 +7,18 @@ triage, every wrapped Redis op emits ``redis.call.start`` and either
 duration — that data was the missing piece on the 2026-05-20 silent
 46 s hang where uvicorn never emitted an access log because the
 handler hung mid-await.
+
+These tests patch ``redis_client.logger`` directly and inspect call
+args because the logger is a structlog ``BoundLogger`` whose kwargs
+do not appear as plain attributes on the underlying ``LogRecord``
+that ``caplog`` captures — the contract surface is what gets passed
+to ``logger.info`` / ``logger.warning``, not the post-format record
+shape.
 """
 
 from __future__ import annotations
 
-import logging
+from unittest.mock import patch
 
 import pytest
 from redis.exceptions import ConnectionError as RedisConnectionError
@@ -25,102 +32,101 @@ class TestBreadcrumbsGated:
     async def test_breadcrumbs_silent_when_flag_off(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Default-off: zero ``redis.call.*`` events emitted regardless
         of success or failure. Production noise floor stays untouched."""
-        import app.config as cfg
         import app.redis_client as rc
 
-        monkeypatch.setattr(cfg.settings, "auth_debug_logging", False)
-        caplog.set_level(logging.INFO, logger=rc.logger.name)
+        monkeypatch.setattr(rc.settings, "auth_debug_logging", False)
 
         @_normalize_transport_errors
         async def helper() -> int:
             return 1
 
-        result = await helper()
+        with patch.object(rc, "logger") as logger_mock:
+            result = await helper()
         assert result == 1
-        breadcrumbs = [r for r in caplog.records if r.msg.startswith("redis.call.")]
-        assert breadcrumbs == [], (
-            f"expected no breadcrumbs with flag off; got {[r.msg for r in breadcrumbs]}"
+        assert logger_mock.info.call_args_list == [], (
+            "expected no breadcrumbs with flag off; got "
+            f"{logger_mock.info.call_args_list}"
         )
 
     @pytest.mark.asyncio
     async def test_breadcrumbs_on_success(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Flag-on success path emits start + ok with op name and
         duration. The wrapped function's ``__name__`` is the
         operator-visible op label — preserved by ``functools.wraps``."""
-        import app.config as cfg
         import app.redis_client as rc
 
-        monkeypatch.setattr(cfg.settings, "auth_debug_logging", True)
-        caplog.set_level(logging.INFO, logger=rc.logger.name)
+        monkeypatch.setattr(rc.settings, "auth_debug_logging", True)
 
         @_normalize_transport_errors
         async def session_validate() -> str:
             return "ok"
 
-        await session_validate()
+        with patch.object(rc, "logger") as logger_mock:
+            await session_validate()
 
-        events = [r for r in caplog.records if r.msg.startswith("redis.call.")]
-        assert [r.msg for r in events] == ["redis.call.start", "redis.call.ok"]
-        # Both events carry the op name; ok event also carries duration.
-        for record in events:
-            assert getattr(record, "op", None) == "session_validate"
-        ok_event = events[1]
-        assert isinstance(getattr(ok_event, "duration_ms", None), (int, float))
+        info_calls = logger_mock.info.call_args_list
+        assert [c.args[0] for c in info_calls] == [
+            "redis.call.start",
+            "redis.call.ok",
+        ]
+        # Start event carries op name only (no duration — call hasn't
+        # run yet); ok event carries op name + duration_ms.
+        assert info_calls[0].kwargs == {"op": "session_validate"}
+        ok_kwargs = info_calls[1].kwargs
+        assert ok_kwargs["op"] == "session_validate"
+        assert isinstance(ok_kwargs.get("duration_ms"), (int, float))
 
     @pytest.mark.asyncio
     async def test_breadcrumbs_on_redis_error(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """RedisError still propagates unchanged AND the wrapper emits a
         ``redis.call.error`` breadcrumb carrying the error class so the
         operator can grep for transient ConnectionError bursts vs Lua
         ResponseError without spelunking tracebacks."""
-        import app.config as cfg
         import app.redis_client as rc
 
-        monkeypatch.setattr(cfg.settings, "auth_debug_logging", True)
-        caplog.set_level(logging.INFO, logger=rc.logger.name)
+        monkeypatch.setattr(rc.settings, "auth_debug_logging", True)
 
         @_normalize_transport_errors
         async def session_rotate_lua() -> None:
             raise RedisResponseError("session_revoked")
 
-        with pytest.raises(RedisResponseError):
-            await session_rotate_lua()
+        with patch.object(rc, "logger") as logger_mock:
+            with pytest.raises(RedisResponseError):
+                await session_rotate_lua()
 
-        events = [r for r in caplog.records if r.msg.startswith("redis.call.")]
-        assert [r.msg for r in events] == ["redis.call.start", "redis.call.error"]
-        error_event = events[1]
-        assert getattr(error_event, "op", None) == "session_rotate_lua"
-        assert getattr(error_event, "error_class", None) == "ResponseError"
+        info_calls = logger_mock.info.call_args_list
+        assert [c.args[0] for c in info_calls] == [
+            "redis.call.start",
+            "redis.call.error",
+        ]
+        error_kwargs = info_calls[1].kwargs
+        assert error_kwargs["op"] == "session_rotate_lua"
+        assert error_kwargs["error_class"] == "ResponseError"
+        assert isinstance(error_kwargs.get("duration_ms"), (int, float))
 
     @pytest.mark.asyncio
     async def test_breadcrumbs_on_oserror_translation(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """OSError is translated to RedisConnectionError by the wrapper.
         The breadcrumb on the error path must carry the ORIGINAL error
         class name (``BrokenPipeError``) so the operator can tell the
         transport-failure class apart from a normal RedisConnectionError
         that some other layer raised."""
-        import app.config as cfg
         import app.redis_client as rc
         from unittest.mock import AsyncMock, MagicMock
 
-        monkeypatch.setattr(cfg.settings, "auth_debug_logging", True)
-        caplog.set_level(logging.INFO, logger=rc.logger.name)
+        monkeypatch.setattr(rc.settings, "auth_debug_logging", True)
 
         # Retirement path needs a sentinel client to drop; install one
         # so the wrapper completes its full path.
@@ -132,9 +138,13 @@ class TestBreadcrumbsGated:
         async def session_validate() -> None:
             raise BrokenPipeError(32, "Broken pipe")
 
-        with pytest.raises(RedisConnectionError):
-            await session_validate()
+        with patch.object(rc, "logger") as logger_mock:
+            with pytest.raises(RedisConnectionError):
+                await session_validate()
 
-        events = [r for r in caplog.records if r.msg.startswith("redis.call.")]
-        assert [r.msg for r in events] == ["redis.call.start", "redis.call.error"]
-        assert getattr(events[1], "error_class", None) == "BrokenPipeError"
+        info_calls = logger_mock.info.call_args_list
+        assert [c.args[0] for c in info_calls] == [
+            "redis.call.start",
+            "redis.call.error",
+        ]
+        assert info_calls[1].kwargs["error_class"] == "BrokenPipeError"

--- a/backend/tests/test_redis_wrapper_breadcrumbs.py
+++ b/backend/tests/test_redis_wrapper_breadcrumbs.py
@@ -1,0 +1,140 @@
+"""Wrapper-layer breadcrumbs for the auth Redis call path.
+
+Gated by ``settings.auth_debug_logging`` so production stays quiet
+under normal operation. When the flag is flipped on during incident
+triage, every wrapped Redis op emits ``redis.call.start`` and either
+``redis.call.ok`` or ``redis.call.error`` with the function name and
+duration — that data was the missing piece on the 2026-05-20 silent
+46 s hang where uvicorn never emitted an access log because the
+handler hung mid-await.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError as RedisResponseError
+
+from app.redis_client import _normalize_transport_errors
+
+
+class TestBreadcrumbsGated:
+    @pytest.mark.asyncio
+    async def test_breadcrumbs_silent_when_flag_off(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Default-off: zero ``redis.call.*`` events emitted regardless
+        of success or failure. Production noise floor stays untouched."""
+        import app.config as cfg
+        import app.redis_client as rc
+
+        monkeypatch.setattr(cfg.settings, "auth_debug_logging", False)
+        caplog.set_level(logging.INFO, logger=rc.logger.name)
+
+        @_normalize_transport_errors
+        async def helper() -> int:
+            return 1
+
+        result = await helper()
+        assert result == 1
+        breadcrumbs = [r for r in caplog.records if r.msg.startswith("redis.call.")]
+        assert breadcrumbs == [], (
+            f"expected no breadcrumbs with flag off; got {[r.msg for r in breadcrumbs]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_breadcrumbs_on_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Flag-on success path emits start + ok with op name and
+        duration. The wrapped function's ``__name__`` is the
+        operator-visible op label — preserved by ``functools.wraps``."""
+        import app.config as cfg
+        import app.redis_client as rc
+
+        monkeypatch.setattr(cfg.settings, "auth_debug_logging", True)
+        caplog.set_level(logging.INFO, logger=rc.logger.name)
+
+        @_normalize_transport_errors
+        async def session_validate() -> str:
+            return "ok"
+
+        await session_validate()
+
+        events = [r for r in caplog.records if r.msg.startswith("redis.call.")]
+        assert [r.msg for r in events] == ["redis.call.start", "redis.call.ok"]
+        # Both events carry the op name; ok event also carries duration.
+        for record in events:
+            assert getattr(record, "op", None) == "session_validate"
+        ok_event = events[1]
+        assert isinstance(getattr(ok_event, "duration_ms", None), (int, float))
+
+    @pytest.mark.asyncio
+    async def test_breadcrumbs_on_redis_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """RedisError still propagates unchanged AND the wrapper emits a
+        ``redis.call.error`` breadcrumb carrying the error class so the
+        operator can grep for transient ConnectionError bursts vs Lua
+        ResponseError without spelunking tracebacks."""
+        import app.config as cfg
+        import app.redis_client as rc
+
+        monkeypatch.setattr(cfg.settings, "auth_debug_logging", True)
+        caplog.set_level(logging.INFO, logger=rc.logger.name)
+
+        @_normalize_transport_errors
+        async def session_rotate_lua() -> None:
+            raise RedisResponseError("session_revoked")
+
+        with pytest.raises(RedisResponseError):
+            await session_rotate_lua()
+
+        events = [r for r in caplog.records if r.msg.startswith("redis.call.")]
+        assert [r.msg for r in events] == ["redis.call.start", "redis.call.error"]
+        error_event = events[1]
+        assert getattr(error_event, "op", None) == "session_rotate_lua"
+        assert getattr(error_event, "error_class", None) == "ResponseError"
+
+    @pytest.mark.asyncio
+    async def test_breadcrumbs_on_oserror_translation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """OSError is translated to RedisConnectionError by the wrapper.
+        The breadcrumb on the error path must carry the ORIGINAL error
+        class name (``BrokenPipeError``) so the operator can tell the
+        transport-failure class apart from a normal RedisConnectionError
+        that some other layer raised."""
+        import app.config as cfg
+        import app.redis_client as rc
+        from unittest.mock import AsyncMock, MagicMock
+
+        monkeypatch.setattr(cfg.settings, "auth_debug_logging", True)
+        caplog.set_level(logging.INFO, logger=rc.logger.name)
+
+        # Retirement path needs a sentinel client to drop; install one
+        # so the wrapper completes its full path.
+        sentinel_client = MagicMock()
+        sentinel_client.aclose = AsyncMock()
+        rc._client = sentinel_client
+
+        @_normalize_transport_errors
+        async def session_validate() -> None:
+            raise BrokenPipeError(32, "Broken pipe")
+
+        with pytest.raises(RedisConnectionError):
+            await session_validate()
+
+        events = [r for r in caplog.records if r.msg.startswith("redis.call.")]
+        assert [r.msg for r in events] == ["redis.call.start", "redis.call.error"]
+        assert getattr(events[1], "error_class", None) == "BrokenPipeError"

--- a/backend/tests/test_refresh_handler_timeout.py
+++ b/backend/tests/test_refresh_handler_timeout.py
@@ -116,11 +116,11 @@ class TestRefreshHandlerTimeout:
         for an expired refresh token, 503 for Redis-down, etc.) must
         propagate unchanged. The timeout wrapper must NOT catch them
         and convert them to its own 503."""
-        import app.config as cfg
         import app.routers.auth as auth_mod
         from fastapi import HTTPException, status
 
-        monkeypatch.setattr(cfg.settings, "refresh_handler_timeout_s", 5.0)
+        # See sibling test for why this targets ``auth_mod.app_settings``.
+        monkeypatch.setattr(auth_mod.app_settings, "refresh_handler_timeout_s", 5.0)
 
         async def reject_401(*args, **kwargs):
             raise HTTPException(
@@ -139,3 +139,36 @@ class TestRefreshHandlerTimeout:
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
         assert exc_info.value.detail == "Invalid refresh token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_passes_through_unexpected_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unexpected exception (e.g. a real programmer bug, NOT a
+        TimeoutError, NOT an HTTPException) must propagate unchanged so
+        it surfaces as a 500 with a complete traceback in logs. The
+        timeout wrapper must NOT swallow it and convert to a 503 —
+        that would mask the actual bug under a misleading
+        Redis-unavailable detail."""
+        import app.routers.auth as auth_mod
+
+        # See sibling test for why this targets ``auth_mod.app_settings``.
+        monkeypatch.setattr(auth_mod.app_settings, "refresh_handler_timeout_s", 5.0)
+
+        class ProgrammerBug(Exception):
+            pass
+
+        async def boom(*args, **kwargs):
+            raise ProgrammerBug("list index out of range")
+
+        with patch.object(auth_mod, "_refresh_impl", boom):
+            with pytest.raises(ProgrammerBug) as exc_info:
+                await auth_mod.refresh(
+                    request=None,  # type: ignore[arg-type]
+                    response=None,  # type: ignore[arg-type]
+                    db=None,  # type: ignore[arg-type]
+                    session_factory=None,  # type: ignore[arg-type]
+                )
+
+        assert "list index out of range" in str(exc_info.value)

--- a/backend/tests/test_refresh_handler_timeout.py
+++ b/backend/tests/test_refresh_handler_timeout.py
@@ -1,0 +1,141 @@
+"""Route-local ``asyncio.wait_for`` on ``/auth/refresh``.
+
+The 2026-05-20 trace showed the handler hanging silently — no
+``uvicorn.access`` entry, no structured ``auth.refresh.rejected``,
+just the frontend's 45 s reactive-recovery abort entries in the
+browser. The route-local timeout converts that silent hang into a
+fast 503 + ``auth.refresh.handler_timeout`` warning so the next
+recurrence has a request_id to trace.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+class TestRefreshHandlerTimeout:
+    @pytest.mark.asyncio
+    async def test_refresh_returns_503_when_inner_impl_hangs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If ``_refresh_impl`` exceeds the route ceiling the public
+        ``refresh()`` must surface a 503 with the Redis-unavailable
+        detail string (so the frontend treats it as transient and
+        retries on a fresh state) — NOT propagate the
+        ``asyncio.TimeoutError`` as a 500. The structured
+        ``auth.refresh.handler_timeout`` event must also fire so the
+        timeout shows up in production logs."""
+        import app.routers.auth as auth_mod
+        from fastapi import HTTPException, status
+
+        # Shrink the bound so a regression that drops asyncio.wait_for
+        # would fail in ~1 s instead of running the full 60 s mock hang.
+        # IMPORTANT: monkeypatch the SAME settings object the auth module
+        # already holds (``auth_mod.app_settings``), not a freshly imported
+        # ``app.config.settings``. Earlier tests in the suite (e.g.
+        # ``test_database_pool_config``) call ``importlib.reload(app_config)``
+        # which creates a NEW settings instance, but ``app.routers.auth``
+        # keeps its reference to the OLD one — patching the new one
+        # would never reach the handler's read path.
+        monkeypatch.setattr(auth_mod.app_settings, "refresh_handler_timeout_s", 0.05)
+
+        async def hang_forever(*args, **kwargs):
+            await asyncio.sleep(60)
+
+        # Patch _LOGGER on the module so we can assert the structured
+        # event regardless of how structlog's processor chain routes
+        # output. ``warning`` is the contract surface.
+        with patch.object(auth_mod, "_refresh_impl", hang_forever), \
+             patch.object(auth_mod, "_LOGGER") as logger_mock:
+            start = time.monotonic()
+            with pytest.raises(HTTPException) as exc_info:
+                await auth_mod.refresh(
+                    request=None,  # type: ignore[arg-type]
+                    response=None,  # type: ignore[arg-type]
+                    db=None,  # type: ignore[arg-type]
+                    session_factory=None,  # type: ignore[arg-type]
+                )
+            elapsed = time.monotonic() - start
+
+        assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert exc_info.value.detail == auth_mod.SESSION_REDIS_UNAVAILABLE_DETAIL
+        # Bound must be enforced — generous headroom over the 50 ms cap.
+        assert elapsed < 2.0, (
+            f"refresh handler took {elapsed:.2f}s; "
+            f"asyncio.wait_for not enforced"
+        )
+        # Structured operator signal: exactly one warning with the
+        # event name and the configured timeout value. Operators grep
+        # this in production logs to correlate hangs to request_ids.
+        logger_mock.warning.assert_called_once()
+        call_args, call_kwargs = logger_mock.warning.call_args
+        assert call_args[0] == "auth.refresh.handler_timeout"
+        assert call_kwargs["extra"]["timeout_s"] == pytest.approx(0.05)
+
+    @pytest.mark.asyncio
+    async def test_refresh_passes_through_inner_result_on_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``_refresh_impl`` returns normally, ``refresh()`` returns
+        the same value (the timeout wrapper is transparent on the
+        happy path). A regression that always wrapped in TimeoutError
+        would break every successful refresh."""
+        import app.routers.auth as auth_mod
+
+        # See sibling test for why this targets ``auth_mod.app_settings``.
+        monkeypatch.setattr(auth_mod.app_settings, "refresh_handler_timeout_s", 5.0)
+
+        sentinel = {"access_token": "fake", "expires_in": 900}
+
+        async def quick_success(*args, **kwargs):
+            return sentinel
+
+        with patch.object(auth_mod, "_refresh_impl", quick_success):
+            result = await auth_mod.refresh(
+                request=None,  # type: ignore[arg-type]
+                response=None,  # type: ignore[arg-type]
+                db=None,  # type: ignore[arg-type]
+                session_factory=None,  # type: ignore[arg-type]
+            )
+
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_refresh_passes_through_httpexception_from_inner_impl(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """HTTPException raised by ``_refresh_impl`` (the normal 401 path
+        for an expired refresh token, 503 for Redis-down, etc.) must
+        propagate unchanged. The timeout wrapper must NOT catch them
+        and convert them to its own 503."""
+        import app.config as cfg
+        import app.routers.auth as auth_mod
+        from fastapi import HTTPException, status
+
+        monkeypatch.setattr(cfg.settings, "refresh_handler_timeout_s", 5.0)
+
+        async def reject_401(*args, **kwargs):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid refresh token",
+            )
+
+        with patch.object(auth_mod, "_refresh_impl", reject_401):
+            with pytest.raises(HTTPException) as exc_info:
+                await auth_mod.refresh(
+                    request=None,  # type: ignore[arg-type]
+                    response=None,  # type: ignore[arg-type]
+                    db=None,  # type: ignore[arg-type]
+                    session_factory=None,  # type: ignore[arg-type]
+                )
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc_info.value.detail == "Invalid refresh token"


### PR DESCRIPTION
## Summary

Three-layer defense against the 46 s silent-handler hang on `/auth/refresh` that recurred today after PR #318 was deployed for hours — the architect's "fix didn't help" signal from `reference_post_pr_318_verification_signals.md`. Containment + observability, not a claimed root cause.

## What was wrong

Production trace at `12:12–12:17` UTC: frontend emitted six consecutive `auth.refresh-attempt` warnings with `outcome: 'transient'`, `status: undefined`, `duration_ms: ~46000` (the reactive-recovery abort firing six times). Backend log for the same window shows **zero** matching `uvicorn.access` entries, **zero** `redis.client.retired`, **zero** `auth.refresh.rejected`. The handler reached neither response nor any logging point — exactly the signature PR #318 was supposed to fix at the `aclose()` layer. Since `aclose()` is already bounded, the hang must be somewhere upstream — most likely the MySQL pool checkout / pre_ping path or the wrapped Redis pool acquire, both of which can block until the kernel TCP RTO (tens of seconds) when the underlying socket has been silently dropped by the VPC NAT.

Without a hard ceiling at the route level, every DB- or Redis-touching handler inherits that hang. The frontend aborts at 45 s, the handler never emits an access log, and operators see nothing.

## Three layers, each minimal and reversible

### 1. MySQL socket-layer timeouts

`connect_args` now carries `connect_timeout` / `read_timeout` / `write_timeout` (default 10 / 30 / 30 s) sourced from `settings`. `pool_recycle` moves from `1800 s → 280 s` so pooled connections are rotated **before** the typical 300 s VPC NAT idle-drop interval. Without these, a stale pooled connection's `pre_ping` can block for tens of seconds on a half-open socket. All three new settings are env-overridable.

### 2. Wrapper-layer breadcrumbs in `_normalize_transport_errors`

Gated by `settings.auth_debug_logging` (already ON in production for triage). When the flag is on, every wrapped Redis op emits:

- `redis.call.start { op: <fn_name> }` before the await
- `redis.call.ok { op, duration_ms }` on success
- `redis.call.error { op, duration_ms, error_class }` on any exception class (RedisError / OSError / closed-transport RuntimeError)

The module's logger is `structlog.stdlib.get_logger()` so kwargs (`op`, `reason`, `duration_ms`, ...) AND contextvars (`request_id`) both reach the rendered JSON. This also fixes a pre-existing silent bug where `redis.client.retired` warnings were emitting their `reason` field via stdlib `extra={...}` and `ProcessorFormatter` was dropping it. Pinned end-to-end in `tests/test_log_field_propagation.py`. Default-off keeps production noise floor untouched.

### 3. Route-local `asyncio.wait_for` on `/auth/refresh`

The handler body is extracted to a private `_refresh_impl()`; the public `refresh()` wraps it in `asyncio.wait_for(timeout=settings.refresh_handler_timeout_s)` (default 25 s). On `TimeoutError`:

- emit `auth.refresh.handler_timeout` warning with `timeout_s` for operator grep
- raise 503 with `SESSION_REDIS_UNAVAILABLE_DETAIL` (the frontend already treats that as transient and retries on a fresh pool)

25 s sits **above** the honest worst-case Redis budget (~22 s for the deepest already-rotated branch documented in `redis_client._build_auth_redis_client`) and **below** the frontend's 45 s reactive-recovery abort, so legitimate slow paths still complete while a wedged handler always surfaces as a loggable 503 with a request_id operators can trace.

#### Trade-off note

The route-local timeout may *slightly* increase the orphan-cookie rate in pathological cases: when `asyncio.wait_for` cancels mid-`session_rotate_lua`, the Lua write to Redis is atomic and may complete server-side while the response containing the new cookie never reaches the browser. The current code already has this same risk at the frontend's 45 s abort point — this PR just accelerates the failure mode from 45 s to 25 s in those edge cases. Net effect: substantially better UX on the happy path (3 s 503 + retry instead of 45 s hang) at the cost of a marginally higher orphan-cookie rate. The orphan-cookie itself is the still-open Class 1 residual and needs the durable catch-up-mapping fix the architect specced separately.

## What this is NOT

- Not a claim of root cause. The actual hang location is still undetermined; this PR makes the next recurrence produce structured diagnostic data (breadcrumb timestamps pinning which Redis op the handler was inside) instead of vanishing silently. Per architect's playbook in `reference_post_pr_318_verification_signals.md`.
- Not the durable orphan-cookie / catch-up successor fix (Class 1 residual still open).
- Not a fix for the cookie-shadow signal observed alongside today's hang (PR #289's duplicate-cookie reader has a gap — separate concern).
- Not the transfer-pair `CircularDependencyError` on DELETE — separate code-level bug, separate task.

## Review-fix follow-up commit

A self-review surfaced one real observability gap (the stdlib-logger `extra={}` drop — silently broke the existing `redis.client.retired` reason field too) plus six polish items, all addressed in the second commit on this branch. Specifically:

- Switched `redis_client.py` to `structlog.stdlib.get_logger()` and converted all call sites to kwarg form. End-to-end test pins the contract.
- Aligned the third refresh-timeout test with the other two on `auth_mod.app_settings` (the previous `cfg.settings` only worked because that path didn't fire the timeout).
- Removed a misleading "circular import" comment + runtime import inside the wrapper.
- Bumped `db_connect_timeout` default 5 s → 10 s to avoid false-positive fails under cold-start network conditions.
- Extracted `_emit_breadcrumb()` + `_elapsed_ms()` helpers, eliminating four repeated blocks.
- Dropped the conditional `perf_counter()` micro-opt for readability.
- Added a test pinning that the timeout wrapper does NOT swallow real exceptions (programmer bugs propagate as 500, not 503).

## Tests

15 new + 1 existing updated. Full backend suite **1419 passed, 9 skipped**.

- `tests/test_db_engine_config.py` (new, 3 tests): `db_pool_recycle` ≤ 290 s; socket timeouts propagated to aiomysql connect_args; defaults sane.
- `tests/test_redis_wrapper_breadcrumbs.py` (new, 4 tests): breadcrumbs silent with flag off; start+ok on success; start+error on RedisError; start+error preserves original error class on OSError translation.
- `tests/test_refresh_handler_timeout.py` (new, 4 tests): inner hang → 503 + structured warning within bound; happy path passes through unchanged; inner `HTTPException` propagates unchanged (NOT swallowed); unexpected exceptions also propagate (NOT swallowed into a 503).
- `tests/test_log_field_propagation.py` (new, 2 tests): rendered JSON includes both kwargs (`op`, `reason`) and contextvars (`request_id`) — pins the production-observability contract.
- `tests/test_database_pool_config.py` (updated): the hardcoded `pool_recycle == 1800` assertion now reads from `settings.db_pool_recycle` so the value is the contract.