### PR TITLE
fix(auth): drop unsupported aiomysql kwargs — prod hotfix

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,22 +28,16 @@ class Settings(BaseSettings):
     # conservative ceiling well under the typical 300 s NAT timeout.
     db_pool_recycle: int = 280
 
-    # connect_timeout / read_timeout / write_timeout are passed
-    # through to ``aiomysql.connect()`` and apply at the socket
-    # layer. Without them the driver blocks until the kernel TCP
-    # RTO, which is the actual mechanism behind the 46 s "(canceled)"
-    # /refresh hang signature.
+    # connect_timeout is passed through to ``aiomysql.connect()`` and
+    # bounds initial handshake. Sized for cold-start under transient
+    # VPC blips — too tight breaks legitimate slow connects without
+    # buying back user-visible latency.
     #
-    # connect_timeout sized for first-connect under cold-start
-    # network conditions where a transient VPC blip can extend the
-    # handshake by a few seconds — too tight breaks legitimate
-    # slow connects without buying back any user-visible latency.
-    # read_timeout / write_timeout apply per-packet, not per-query,
-    # so a legitimately long-running query that streams data is not
-    # affected — only stalls on a dead socket are bounded.
+    # Per-operation read/write timeouts are NOT exposed here:
+    # aiomysql 0.2.0 (pinned in requirements.txt) doesn't accept
+    # them. Stale-socket bounds live at ``db_pool_recycle`` (rotate
+    # before NAT drop) and at the route-local handler timeout.
     db_connect_timeout: int = 10
-    db_read_timeout: int = 30
-    db_write_timeout: int = 30
 
     # Auth
     jwt_secret_key: str = "change-me-generate-a-real-secret"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -17,18 +17,19 @@ def _build_connect_args() -> dict:
     contains a DO-style host (port 25060), enable SSL with server verification
     disabled (DO uses self-signed certs with their own CA).
 
-    The socket-layer timeouts (``connect_timeout`` / ``read_timeout`` /
-    ``write_timeout``) bound how long aiomysql will block on a dead
-    socket before raising. Without them, a stale pooled connection
-    whose peer-side has been silently dropped by the VPC NAT causes
-    ``pool_pre_ping``'s ping to wait for the kernel TCP RTO (tens of
-    seconds), which is the actual mechanism behind the silent 46 s
-    /refresh handler hang.
+    ``connect_timeout`` bounds how long aiomysql will block while
+    establishing a new connection — important for cold-start and
+    pool-grow paths where a network blip would otherwise hang the
+    handler. Per-operation read/write timeouts are NOT set here:
+    aiomysql 0.2.0 (the version pinned in requirements.txt) does
+    not accept ``read_timeout`` / ``write_timeout`` kwargs — those
+    were added in 0.2.1+. The stale-socket-hang class is therefore
+    bounded at two other layers: ``pool_recycle`` (rotates pooled
+    connections before the VPC NAT can drop them) and the
+    route-local ``asyncio.wait_for`` on ``/auth/refresh``.
     """
     args: dict = {
         "connect_timeout": settings.db_connect_timeout,
-        "read_timeout": settings.db_read_timeout,
-        "write_timeout": settings.db_write_timeout,
     }
     if ":25060" in settings.database_url:
         ctx = ssl.create_default_context()

--- a/backend/tests/test_db_engine_config.py
+++ b/backend/tests/test_db_engine_config.py
@@ -10,6 +10,9 @@ handler never reached the response stage.
 
 from __future__ import annotations
 
+import inspect
+
+import aiomysql
 import pytest
 
 import app.database as database
@@ -53,19 +56,13 @@ def test_connect_timeout_has_sane_default() -> None:
 
 
 def test_connect_args_only_uses_aiomysql_supported_kwargs() -> None:
-    """Hard guard against the 2026-05-20 14:22 UTC production incident:
-    PR #321's first commit added ``read_timeout`` and ``write_timeout``
-    to ``connect_args``, but aiomysql 0.2.0 (the version pinned in
-    requirements.txt) does NOT accept them — every DB-touching
-    request 500'd with ``TypeError: connect() got an unexpected
-    keyword argument 'read_timeout'``. CI tests passed because the
-    args dict construction was tested in isolation; aiomysql was
-    never asked to accept it. This test closes that gap by
-    introspecting aiomysql's real ``connect()`` signature and
-    asserting every key we pass is in it."""
-    import inspect
-    import aiomysql
-
+    """Every key in ``connect_args`` must be an accepted kwarg of the
+    installed ``aiomysql.connect()``. Without this guard, a typo or a
+    speculatively-added timeout kwarg passes CI (the dict construction
+    is tested in isolation) but blows up on first DB request in
+    production with ``TypeError: connect() got an unexpected keyword
+    argument '...'``. Introspecting the real signature catches the
+    mismatch at CI time."""
     supported = set(inspect.signature(aiomysql.connect).parameters)
     args = database._build_connect_args()
     unsupported = set(args) - supported

--- a/backend/tests/test_db_engine_config.py
+++ b/backend/tests/test_db_engine_config.py
@@ -28,26 +28,52 @@ def test_pool_recycle_is_under_typical_nat_idle() -> None:
     )
 
 
-def test_socket_timeouts_are_propagated_to_aiomysql() -> None:
-    """``connect_timeout`` / ``read_timeout`` / ``write_timeout`` are
-    aiomysql constructor args that bound socket I/O. Without them, a
-    stale pooled connection blocks until the kernel TCP RTO. The
-    builder must thread the configured values through verbatim — a
-    drop here would silently re-open the hang."""
+def test_connect_timeout_is_propagated_to_aiomysql() -> None:
+    """``connect_timeout`` is the only socket-level timeout aiomysql
+    0.2.0 accepts. The builder must thread the configured value
+    through verbatim — a drop here would re-introduce the unbounded
+    cold-start connect class. (``read_timeout`` / ``write_timeout``
+    are deliberately NOT passed because aiomysql 0.2.0 raises
+    ``TypeError`` on them; the stale-socket class is bounded at
+    ``pool_recycle`` + the route-local handler timeout instead.)"""
     args = database._build_connect_args()
     assert args.get("connect_timeout") == settings.db_connect_timeout
-    assert args.get("read_timeout") == settings.db_read_timeout
-    assert args.get("write_timeout") == settings.db_write_timeout
+    # Pin the negative contract too: a future bump to aiomysql 0.2.1+
+    # might add support for these, but until requirements.txt moves,
+    # passing them through here is a hard production failure.
+    assert "read_timeout" not in args
+    assert "write_timeout" not in args
 
 
-def test_socket_timeouts_have_sane_defaults() -> None:
-    """Defaults must be bounded (>0 and below the route-local handler
-    ceiling) so a single stuck operation cannot consume the whole
-    budget. read/write timeouts apply per-packet so the values can
-    safely be larger than the connect timeout — but never unbounded."""
+def test_connect_timeout_has_sane_default() -> None:
+    """Default must be bounded (>0 and below the route-local handler
+    ceiling) so a stuck initial connect cannot consume the whole
+    budget."""
     assert 0 < settings.db_connect_timeout < settings.refresh_handler_timeout_s
-    assert 0 < settings.db_read_timeout < 120
-    assert 0 < settings.db_write_timeout < 120
+
+
+def test_connect_args_only_uses_aiomysql_supported_kwargs() -> None:
+    """Hard guard against the 2026-05-20 14:22 UTC production incident:
+    PR #321's first commit added ``read_timeout`` and ``write_timeout``
+    to ``connect_args``, but aiomysql 0.2.0 (the version pinned in
+    requirements.txt) does NOT accept them — every DB-touching
+    request 500'd with ``TypeError: connect() got an unexpected
+    keyword argument 'read_timeout'``. CI tests passed because the
+    args dict construction was tested in isolation; aiomysql was
+    never asked to accept it. This test closes that gap by
+    introspecting aiomysql's real ``connect()`` signature and
+    asserting every key we pass is in it."""
+    import inspect
+    import aiomysql
+
+    supported = set(inspect.signature(aiomysql.connect).parameters)
+    args = database._build_connect_args()
+    unsupported = set(args) - supported
+    assert unsupported == set(), (
+        f"connect_args contains kwargs not accepted by aiomysql.connect() "
+        f"in the pinned version: {unsupported}. Either drop them or bump "
+        f"aiomysql in requirements.txt."
+    )
 
 
 # NOTE: a fourth test originally asserted


### PR DESCRIPTION
## URGENT — production hotfix for PR #321 regression

PR #321's deploy at **`2026-05-20T14:22 UTC`** started 500ing every DB-touching request with:

```
TypeError: connect() got an unexpected keyword argument 'read_timeout'
```

`aiomysql 0.2.0` (pinned in `requirements.txt` since PR #320) does **not** accept `read_timeout` / `write_timeout` constructor kwargs — those were added in 0.2.1+. PR #321's `_build_connect_args()` started passing them and every connection now fails at `aiomysql.connect()`. CI tests passed because they exercised the args-dict construction in isolation and never asked aiomysql to actually validate it.

## Fix

- Drop `read_timeout` / `write_timeout` from `connect_args` in `database.py`.
- Drop matching `db_read_timeout` / `db_write_timeout` settings.
- Update inline docs to note the stale-socket class is bounded by `db_pool_recycle` (rotate before NAT drop) + the route-local `asyncio.wait_for` on `/refresh`.
- **Add `test_connect_args_only_uses_aiomysql_supported_kwargs`** that introspects `aiomysql.connect()`'s real signature and asserts every kwarg we pass is in it. Closes the exact CI gap that let this incident through — the test would have failed loudly on the first commit of #321.

`connect_timeout` IS supported by aiomysql 0.2.0 and stays — bounds cold-start handshake.

## Tests

57/57 in the touched-test sweep. Full backend suite green.