### PR TITLE
fix(model): break Transaction self-FK cycle on transfer-pair delete

### DIFF
--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -139,8 +139,16 @@ class Transaction(Base):
 
     account: Mapped["Account"] = relationship()
     category: Mapped["Category"] = relationship(back_populates="transactions")
+    # post_update=True breaks the topological-sort cycle when both halves of a
+    # transfer pair (A.linked_transaction_id -> B, B.linked_transaction_id -> A)
+    # are queued for delete in the same flush. SQLAlchemy emits an extra UPDATE
+    # to clear the FK before issuing the DELETEs, sidestepping
+    # CircularDependencyError. The DB-level ondelete="SET NULL" still applies
+    # for direct-SQL deletes that bypass the ORM unit of work.
     linked_transaction: Mapped[Optional["Transaction"]] = relationship(
-        foreign_keys=[linked_transaction_id], remote_side="Transaction.id"
+        foreign_keys=[linked_transaction_id],
+        remote_side="Transaction.id",
+        post_update=True,
     )
     # PR-Tags-A: many-to-many to Tag through transaction_tags. Service
     # callers eager-load via selectinload(Transaction.tags) on list /

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -852,14 +852,10 @@ async def bulk_delete_transactions(
         for aid in account_ids_to_lock:
             accounts[aid] = await get_account_for_update(db, aid, org_id)
 
-        # Break linked-transfer FK cycles before deletion so SQLAlchemy can flush
-        # the deletes without hitting a circular dependency error
-        for tx in found:
-            if tx.linked_transaction_id is not None:
-                tx.linked_transaction_id = None
-        await db.flush()
-
-        # Revert balances for settled rows, then delete every row
+        # Revert balances for settled rows, then delete every row.
+        # The Transaction.linked_transaction relationship has post_update=True,
+        # so SQLAlchemy emits the necessary UPDATEs to clear the self-referential
+        # FK before the DELETEs and the flush won't trip on a topological cycle.
         for tx in found:
             if tx.status == TransactionStatus.SETTLED:
                 acct = accounts.get(tx.account_id)

--- a/backend/tests/services/test_transaction_service_delete_linked.py
+++ b/backend/tests/services/test_transaction_service_delete_linked.py
@@ -1,0 +1,119 @@
+"""Regression: deleting a transfer pair must not trip SQLAlchemy's
+topological-sort cycle detection.
+
+Both halves of a transfer carry ``linked_transaction_id`` pointing at
+each other. Without ``post_update=True`` on the
+``Transaction.linked_transaction`` relationship, the ORM unit of work
+cannot pick an order for the two DELETEs and raises
+``CircularDependencyError`` before any SQL is emitted.
+"""
+import pytest_asyncio
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import Base
+from app.models import Account, AccountType, Category, Organization, Transaction
+from app.models.category import CategoryType
+from app.models.transaction import TransactionStatus, TransactionType
+from app.services import transaction_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_pair(session: AsyncSession):
+    """Seed a linked transfer pair: one EXPENSE leg, one INCOME leg, mutual FK."""
+    org = Organization(name="T", billing_cycle_day=1)
+    session.add(org)
+    await session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    session.add(at)
+    await session.flush()
+    src = Account(
+        org_id=org.id, name="Src", account_type_id=at.id,
+        balance=Decimal("400"), currency="EUR",
+    )
+    dst = Account(
+        org_id=org.id, name="Dst", account_type_id=at.id,
+        balance=Decimal("100"), currency="EUR",
+    )
+    session.add_all([src, dst])
+    cat = Category(
+        org_id=org.id, name="Transfer", slug="transfer",
+        type=CategoryType.BOTH, is_system=True,
+    )
+    session.add(cat)
+    await session.flush()
+    expense = Transaction(
+        org_id=org.id, account_id=src.id, category_id=cat.id,
+        description="t", amount=Decimal("100"),
+        type=TransactionType.EXPENSE, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    income = Transaction(
+        org_id=org.id, account_id=dst.id, category_id=cat.id,
+        description="t", amount=Decimal("100"),
+        type=TransactionType.INCOME, status=TransactionStatus.SETTLED,
+        date=date(2026, 5, 1), settled_date=date(2026, 5, 1),
+    )
+    session.add_all([expense, income])
+    await session.flush()
+    expense.linked_transaction_id = income.id
+    income.linked_transaction_id = expense.id
+    await session.commit()
+    return org, src, dst, expense, income
+
+
+async def test_delete_transaction_on_transfer_pair_no_circular_dependency(db_session):
+    """delete_transaction on one half of a transfer pair removes both halves
+    without raising CircularDependencyError."""
+    org, src, dst, expense, income = await _seed_pair(db_session)
+
+    await transaction_service.delete_transaction(db_session, org.id, expense.id)
+
+    remaining = await db_session.scalars(
+        select(Transaction).where(Transaction.id.in_([expense.id, income.id]))
+    )
+    assert remaining.all() == []
+
+
+async def test_bulk_delete_transactions_on_transfer_pair_no_circular_dependency(db_session):
+    """bulk_delete_transactions on both halves of a transfer pair removes
+    both without raising CircularDependencyError, even if the caller's
+    per-row FK null-out were removed."""
+    org, src, dst, expense, income = await _seed_pair(db_session)
+
+    deleted, skipped = await transaction_service.bulk_delete_transactions(
+        db_session, org.id, [expense.id, income.id]
+    )
+
+    assert deleted == 2
+    assert skipped == []
+    remaining = await db_session.scalars(
+        select(Transaction).where(Transaction.id.in_([expense.id, income.id]))
+    )
+    assert remaining.all() == []

--- a/backend/tests/services/test_transaction_service_delete_linked.py
+++ b/backend/tests/services/test_transaction_service_delete_linked.py
@@ -117,3 +117,24 @@ async def test_bulk_delete_transactions_on_transfer_pair_no_circular_dependency(
         select(Transaction).where(Transaction.id.in_([expense.id, income.id]))
     )
     assert remaining.all() == []
+
+
+async def test_delete_transaction_with_asymmetric_link_does_not_orphan(db_session):
+    """Asymmetric FK case: only one half of the pair carries
+    ``linked_transaction_id`` pointing at the other; the back-pointer
+    is ``NULL``. The model allows it, and after a data-migration or
+    partial import it can show up in the wild. Deleting the side
+    that still carries the FK must cascade through the service's
+    ``linked_tx`` lookup, complete without raising, and leave no
+    orphan row."""
+    org, src, dst, expense, income = await _seed_pair(db_session)
+    # Break the back-pointer: income no longer references expense.
+    income.linked_transaction_id = None
+    await db_session.commit()
+
+    await transaction_service.delete_transaction(db_session, org.id, expense.id)
+
+    remaining = await db_session.scalars(
+        select(Transaction).where(Transaction.id.in_([expense.id, income.id]))
+    )
+    assert remaining.all() == []


### PR DESCRIPTION
## Summary

`DELETE /api/v1/transactions/{id}` returned 500 with `sqlalchemy.exc.CircularDependencyError` when the target was one half of a transfer pair. Hit in production 2026-05-20 11:45 UTC. SQLAlchemy's unit of work topologically sorts pending DELETEs and cannot pick an order for two `Transaction` rows whose `linked_transaction_id` columns point at each other.

## Change

- Add `post_update=True` to the `Transaction.linked_transaction` relationship in `backend/app/models/transaction.py`. SQLAlchemy now emits an UPDATE clearing the self-referential FK before issuing the DELETEs, breaking the cycle.
- Drop the manual FK-null-out + flush block from `bulk_delete_transactions` — the model-level fix supersedes it.
- DB-level `ondelete="SET NULL"` is unchanged and still covers direct-SQL deletes that bypass the ORM unit of work.

## Why model-level over service-level

The service-level workaround already existed in `bulk_delete_transactions` (null FKs, flush, then delete) but not in `delete_transaction` — which is exactly where production tripped. A future code path deleting Transactions through the ORM would inherit the same vulnerability. The relationship-level fix is declarative, idiomatic SQLAlchemy, and covers all code paths automatically.

## Regression test

New `backend/tests/services/test_transaction_service_delete_linked.py`:

- `test_delete_transaction_on_transfer_pair_no_circular_dependency` — reproduces the production failure mode.
- `test_bulk_delete_transactions_on_transfer_pair_no_circular_dependency` — guards the bulk path after the manual workaround is removed.

Both fail with `CircularDependencyError` without the model change.