### PR TITLE
fix(frontend): expose description in category edit form

### DIFF
--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -408,7 +408,12 @@ async def update_category(
             cat.type = new_type
             type_changed = True
 
-    if body.description is not None:
+    # Distinguish "description omitted from body" vs "description explicitly
+    # set to null". Pydantic v2's `model_fields_set` is True for fields the
+    # caller actually supplied (including explicit null), False for fields
+    # left out. Without this, an explicit null is silently dropped — clearing
+    # an existing description never persists.
+    if "description" in body.model_fields_set:
         cat.description = body.description
 
     # Audit rows staged before commit (one per logical change). Only

--- a/backend/tests/routers/test_categories_update_description.py
+++ b/backend/tests/routers/test_categories_update_description.py
@@ -1,0 +1,186 @@
+"""Router-level tests for PUT /api/v1/categories/{id} description handling.
+
+Regression: PR #324 surfaced that the route used
+``if body.description is not None: cat.description = body.description``,
+which silently dropped an explicit ``null`` payload. Clearing an existing
+description never persisted. The fix uses Pydantic v2
+``model_fields_set`` to distinguish "field omitted from the body" from
+"field explicitly set to null".
+
+These tests pin both halves of that distinction:
+    * PUT {"description": null} on a row whose description is non-null
+      MUST clear the DB column to NULL.
+    * PUT without ``description`` in the body MUST leave the existing
+      description unchanged.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.user import Role, User
+from app.routers.categories import router as categories_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    select(User).where(User.is_superadmin.is_(True))
+                )
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(categories_router)
+    return app
+
+
+async def _seed_with_description(factory, description: str | None) -> dict:
+    """Seed an org with the C0 floor satisfied plus one row to mutate."""
+    async with factory() as db:
+        org = Organization(name="T", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id, username="root", email="r@x.com",
+            password_hash=hash_password("pw-1234567"), role=Role.OWNER,
+            is_superadmin=True, is_active=True, email_verified=True,
+        )
+        # Floor: >= 1 income master + 1 expense master + 1 sub per type.
+        income_master = Category(
+            org_id=org.id, name="Income", slug="income_m",
+            type=CategoryType.INCOME,
+        )
+        expense_master = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE,
+        )
+        # The row under test — a top-level expense master with the seeded
+        # description. We mutate this one's description across the tests.
+        target = Category(
+            org_id=org.id, name="Lifestyle", slug="lifestyle",
+            type=CategoryType.EXPENSE, description=description,
+        )
+        db.add_all([user, income_master, expense_master, target])
+        await db.flush()
+        # Subs to satisfy the floor for both types.
+        db.add_all([
+            Category(
+                org_id=org.id, name="Salary", parent_id=income_master.id,
+                type=CategoryType.INCOME,
+            ),
+            Category(
+                org_id=org.id, name="Food", parent_id=expense_master.id,
+                type=CategoryType.EXPENSE,
+            ),
+        ])
+        await db.commit()
+        return {"org_id": org.id, "target_id": target.id}
+
+
+async def _fetch_description(factory, category_id: int) -> str | None:
+    async with factory() as db:
+        return await db.scalar(
+            select(Category.description).where(Category.id == category_id)
+        )
+
+
+@pytest.mark.asyncio
+async def test_put_explicit_null_clears_existing_description(session_factory):
+    """PUT {"description": null} MUST persist NULL to the DB column."""
+    seed = await _seed_with_description(session_factory, "old value")
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['target_id']}",
+            json={"name": "Lifestyle", "description": None},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["description"] is None
+    stored = await _fetch_description(session_factory, seed["target_id"])
+    assert stored is None, (
+        "explicit-null payload must clear description to NULL, "
+        f"got {stored!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_put_omitting_description_preserves_existing_value(session_factory):
+    """PUT without the ``description`` key MUST leave the column untouched."""
+    seed = await _seed_with_description(session_factory, "keep me")
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['target_id']}",
+            json={"name": "Renamed Only"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["description"] == "keep me"
+    stored = await _fetch_description(session_factory, seed["target_id"])
+    assert stored == "keep me", (
+        "omitted-description payload must leave existing description "
+        f"intact, got {stored!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_put_new_description_value_persists(session_factory):
+    """Sanity: setting a non-null description still works."""
+    seed = await _seed_with_description(session_factory, None)
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.put(
+            f"/api/v1/categories/{seed['target_id']}",
+            json={"description": "fresh value"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["description"] == "fresh value"
+    stored = await _fetch_description(session_factory, seed["target_id"])
+    assert stored == "fresh value"

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -85,6 +85,7 @@ export default function CategoriesPage() {
   // Edit
   const [editingCatId, setEditingCatId] = useState<number | null>(null);
   const [editCatName, setEditCatName] = useState("");
+  const [editCatDesc, setEditCatDesc] = useState("");
 
   // Add subcategory form
   const [addingToMaster, setAddingToMaster] = useState<number | null>(null);
@@ -267,7 +268,10 @@ export default function CategoriesPage() {
     try {
       await apiFetch(`/api/v1/categories/${id}`, {
         method: "PUT",
-        body: JSON.stringify({ name: editCatName }),
+        body: JSON.stringify({
+          name: editCatName,
+          description: editCatDesc.trim() ? editCatDesc.trim() : null,
+        }),
       });
       setEditingCatId(null);
       await reload();
@@ -553,8 +557,10 @@ export default function CategoriesPage() {
                   <div className="flex min-w-0 w-full items-center gap-2.5 sm:w-auto sm:flex-1">
                     <Icon className="h-4 w-4 flex-shrink-0 text-text-muted" />
                     {editingCatId === master.id ? (
-                      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                      <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
                         <input type="text" value={editCatName} onChange={(e) => setEditCatName(e.target.value)} className={`min-w-0 flex-1 text-sm ${input}`} autoFocus
+                          onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(master.id); if (e.key === "Escape") setEditingCatId(null); }} />
+                        <input type="text" placeholder="Hint / description" value={editCatDesc} onChange={(e) => setEditCatDesc(e.target.value)} className={`min-w-0 flex-1 text-sm ${input}`}
                           onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(master.id); if (e.key === "Escape") setEditingCatId(null); }} />
                         <button onClick={() => handleEditCat(master.id)} className="inline-flex min-h-[44px] items-center px-1 text-xs text-accent md:min-h-0">Save</button>
                         <button onClick={() => setEditingCatId(null)} className="inline-flex min-h-[44px] items-center px-1 text-xs text-text-muted md:min-h-0">Cancel</button>
@@ -574,7 +580,7 @@ export default function CategoriesPage() {
                     >
                       {addingToMaster === master.id ? "Cancel" : "+ Add Sub"}
                     </button>
-                    <button onClick={() => { setEditingCatId(master.id); setEditCatName(master.name); }} className="inline-flex min-h-[44px] items-center px-2 text-xs text-text-muted hover:text-accent md:min-h-0 md:px-0">Edit</button>
+                    <button onClick={() => { setEditingCatId(master.id); setEditCatName(master.name); setEditCatDesc(master.description ?? ""); }} className="inline-flex min-h-[44px] items-center px-2 text-xs text-text-muted hover:text-accent md:min-h-0 md:px-0">Edit</button>
                     <button onClick={() => setConfirmDeleteId(master.id)} aria-label={`Delete ${master.name}`} className="inline-flex min-h-[44px] items-center px-2 text-xs text-text-muted hover:text-danger md:min-h-0 md:px-0">Delete</button>
                   </div>
                 </div>
@@ -621,8 +627,10 @@ export default function CategoriesPage() {
                             />
                           )}
                           {editingCatId === sub.id ? (
-                            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                            <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
                               <input type="text" value={editCatName} onChange={(e) => setEditCatName(e.target.value)} className={`min-w-0 flex-1 text-sm ${input}`} autoFocus
+                                onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(sub.id); if (e.key === "Escape") setEditingCatId(null); }} />
+                              <input type="text" placeholder="Hint / description" value={editCatDesc} onChange={(e) => setEditCatDesc(e.target.value)} className={`min-w-0 flex-1 text-sm ${input}`}
                                 onKeyDown={(e) => { if (e.key === "Enter") handleEditCat(sub.id); if (e.key === "Escape") setEditingCatId(null); }} />
                               <button onClick={() => handleEditCat(sub.id)} className="inline-flex min-h-[44px] items-center px-2 text-xs text-accent md:min-h-0 md:px-0">Save</button>
                               <button onClick={() => setEditingCatId(null)} className="inline-flex min-h-[44px] items-center px-2 text-xs text-text-muted md:min-h-0 md:px-0">Cancel</button>
@@ -635,7 +643,7 @@ export default function CategoriesPage() {
                                 <span className="ml-2 text-xs text-text-muted" title={`${sub.transaction_count} transaction(s)`}>{sub.transaction_count}</span>
                               </div>
                               <div data-testid={`sub-actions-${sub.id}`} className="flex flex-wrap gap-1 sm:gap-2">
-                                <button onClick={() => { setEditingCatId(sub.id); setEditCatName(sub.name); }} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 text-xs text-text-muted hover:text-accent md:min-h-0 md:min-w-0 md:px-0">Edit</button>
+                                <button onClick={() => { setEditingCatId(sub.id); setEditCatName(sub.name); setEditCatDesc(sub.description ?? ""); }} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 text-xs text-text-muted hover:text-accent md:min-h-0 md:min-w-0 md:px-0">Edit</button>
                                 <button onClick={() => setConfirmDeleteId(sub.id)} aria-label={`Delete ${sub.name}`} className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center px-2 text-xs text-text-muted hover:text-danger md:min-h-0 md:min-w-0 md:px-0">Delete</button>
                               </div>
                             </>

--- a/frontend/tests/app/categories-c2-edit-mode.test.tsx
+++ b/frontend/tests/app/categories-c2-edit-mode.test.tsx
@@ -611,23 +611,44 @@ describe("CategoriesPage -C2 batch delete", () => {
     });
   });
 
-  it("editing with empty description sends description: null", async () => {
+  it("editing with empty description sends description: null AND the cleared value renders post-save", async () => {
+    // The empty-desc -> null contract has two halves:
+    //   1. PUT body must carry `description: null` (so the backend's
+    //      Pydantic v2 `model_fields_set` clears the column).
+    //   2. After the post-save reload, the UI must reflect the cleared
+    //      value, not the pre-save stale string.
+    // Both halves matter — only asserting (1) lets the regression
+    // re-emerge if the reconciliation path ever drops the new row.
     const putCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
-    setupApi({
-      "/api/v1/categories/101": (init) => {
-        if (init?.method === "PUT") {
-          putCalls.push({
-            url: "/api/v1/categories/101",
-            body: JSON.parse((init.body as string) ?? "{}"),
-          });
-          return {};
+    let descriptionCleared = false;
+    const seededCategories = CATEGORIES.map((c) =>
+      c.id === 101 ? { ...c, description: "Eating out" } : c,
+    );
+    vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+      if (url === "/api/v1/categories" && (!init || init.method === undefined)) {
+        if (descriptionCleared) {
+          return Promise.resolve(
+            seededCategories.map((c) =>
+              c.id === 101 ? { ...c, description: null } : c,
+            ),
+          );
         }
-        return {};
-      },
-    });
+        return Promise.resolve(seededCategories);
+      }
+      if (url === "/api/v1/categories/101" && init?.method === "PUT") {
+        const body = JSON.parse((init.body as string) ?? "{}");
+        putCalls.push({ url, body });
+        if (body.description === null) {
+          descriptionCleared = true;
+        }
+        return Promise.resolve({});
+      }
+      return Promise.resolve({});
+    }) as never);
 
     render(<CategoriesPage />);
-    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+    // Pre-save: the stale description is visible on the row.
+    expect(await screen.findByText("Eating out")).toBeInTheDocument();
 
     const subActions = screen.getByTestId("sub-actions-101");
     const editBtn = Array.from(subActions.querySelectorAll("button")).find(
@@ -635,18 +656,31 @@ describe("CategoriesPage -C2 batch delete", () => {
     );
     fireEvent.click(editBtn!);
 
-    // Leave description blank.
+    // Description input opens pre-populated with the existing value, then
+    // gets cleared by the user.
     const descInput = await screen.findByPlaceholderText("Hint / description");
+    expect((descInput as HTMLInputElement).value).toBe("Eating out");
+    fireEvent.change(descInput, { target: { value: "" } });
+
     const editingContainer = descInput.parentElement!;
     const saveBtn = Array.from(editingContainer.querySelectorAll("button")).find(
       (b) => b.textContent === "Save",
     );
     fireEvent.click(saveBtn!);
 
+    // Half 1: PUT carried the explicit null.
     await waitFor(() => expect(putCalls.length).toBe(1));
     expect(putCalls[0].body).toEqual({
       name: "Restaurants",
       description: null,
     });
+
+    // Half 2: post-reload UI renders the cleared value — the stale string
+    // is gone from the DOM.
+    await waitFor(() => {
+      expect(screen.queryByText("Eating out")).not.toBeInTheDocument();
+    });
+    // The sub-category row itself is still present.
+    expect(screen.getByText("Restaurants")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/app/categories-c2-edit-mode.test.tsx
+++ b/frontend/tests/app/categories-c2-edit-mode.test.tsx
@@ -524,4 +524,129 @@ describe("CategoriesPage -C2 batch delete", () => {
     expect(banner.textContent).toMatch(/reload failed/i);
     expect(screen.getByTestId("batch-delete-modal")).toBeInTheDocument();
   });
+
+  it("sub-category edit form exposes a description field and PUTs it", async () => {
+    const putCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    setupApi({
+      "/api/v1/categories/101": (init) => {
+        if (init?.method === "PUT") {
+          putCalls.push({
+            url: "/api/v1/categories/101",
+            body: JSON.parse((init.body as string) ?? "{}"),
+          });
+          return {};
+        }
+        return {};
+      },
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    const subActions = screen.getByTestId("sub-actions-101");
+    const editBtn = Array.from(subActions.querySelectorAll("button")).find(
+      (b) => b.textContent === "Edit",
+    );
+    expect(editBtn).toBeTruthy();
+    fireEvent.click(editBtn!);
+
+    // Description input must appear alongside the name input.
+    const descInput = await screen.findByPlaceholderText("Hint / description");
+    expect(descInput).toBeInTheDocument();
+    fireEvent.change(descInput, { target: { value: "Eating out" } });
+
+    // Click Save (button next to the now-visible inputs).
+    const editingContainer = descInput.parentElement!;
+    const saveBtn = Array.from(editingContainer.querySelectorAll("button")).find(
+      (b) => b.textContent === "Save",
+    );
+    expect(saveBtn).toBeTruthy();
+    fireEvent.click(saveBtn!);
+
+    await waitFor(() => expect(putCalls.length).toBe(1));
+    expect(putCalls[0].body).toEqual({
+      name: "Restaurants",
+      description: "Eating out",
+    });
+  });
+
+  it("editing a top-level category PUTs description (parity with sub-category)", async () => {
+    const putCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    setupApi({
+      "/api/v1/categories/100": (init) => {
+        if (init?.method === "PUT") {
+          putCalls.push({
+            url: "/api/v1/categories/100",
+            body: JSON.parse((init.body as string) ?? "{}"),
+          });
+          return {};
+        }
+        return {};
+      },
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Food")).toBeInTheDocument());
+
+    const masterActions = screen.getByTestId("master-actions-100");
+    const editBtn = Array.from(masterActions.querySelectorAll("button")).find(
+      (b) => b.textContent === "Edit",
+    );
+    expect(editBtn).toBeTruthy();
+    fireEvent.click(editBtn!);
+
+    const descInput = await screen.findByPlaceholderText("Hint / description");
+    fireEvent.change(descInput, { target: { value: "All food spending" } });
+
+    const editingContainer = descInput.parentElement!;
+    const saveBtn = Array.from(editingContainer.querySelectorAll("button")).find(
+      (b) => b.textContent === "Save",
+    );
+    fireEvent.click(saveBtn!);
+
+    await waitFor(() => expect(putCalls.length).toBe(1));
+    expect(putCalls[0].body).toEqual({
+      name: "Food",
+      description: "All food spending",
+    });
+  });
+
+  it("editing with empty description sends description: null", async () => {
+    const putCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    setupApi({
+      "/api/v1/categories/101": (init) => {
+        if (init?.method === "PUT") {
+          putCalls.push({
+            url: "/api/v1/categories/101",
+            body: JSON.parse((init.body as string) ?? "{}"),
+          });
+          return {};
+        }
+        return {};
+      },
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    const subActions = screen.getByTestId("sub-actions-101");
+    const editBtn = Array.from(subActions.querySelectorAll("button")).find(
+      (b) => b.textContent === "Edit",
+    );
+    fireEvent.click(editBtn!);
+
+    // Leave description blank.
+    const descInput = await screen.findByPlaceholderText("Hint / description");
+    const editingContainer = descInput.parentElement!;
+    const saveBtn = Array.from(editingContainer.querySelectorAll("button")).find(
+      (b) => b.textContent === "Save",
+    );
+    fireEvent.click(saveBtn!);
+
+    await waitFor(() => expect(putCalls.length).toBe(1));
+    expect(putCalls[0].body).toEqual({
+      name: "Restaurants",
+      description: null,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The inline category edit form on `/categories` only exposed the name input and only PUT `{ name }` to `/api/v1/categories/{id}`, while the create form (`AddCategoryModal` + the inline Add Sub form) accepts both `name` and `description`. The edit form state and handler are shared between top-level and sub-categories, so adding the description input to both render sites and including it in the PUT body (empty -> `null`, matching create-side behavior) fixes parity in one place. Touches `frontend/app/categories/page.tsx` plus three new tests in `frontend/tests/app/categories-c2-edit-mode.test.tsx`. Verified locally: `tsc --noEmit` clean, all 55 category-page tests pass.