### PR TITLE
feat(transactions): chip-based tag input on add/edit + row chips

### DIFF
--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -407,39 +407,59 @@ function TransactionsPageContent() {
           }),
         });
       } else {
-        const created = await apiFetch<Transaction>("/api/v1/transactions", {
-          method: "POST",
-          body: JSON.stringify({
-            account_id: formAccountId,
-            category_id: formCategoryId,
-            description: formDescription,
-            amount: formAmount,
-            type: formType,
-            status: formStatus,
-            date: formDate,
-            // settled_date only travels on pending creates; SETTLED rows
-            // get their settled_date stamped server-side from `date`.
-            ...(formStatus === "pending" && formSettledDate
-              ? { settled_date: formSettledDate }
-              : {}),
-          }),
-        });
-        // PR-Tags-A: attach the chip-managed tag set as a separate PUT.
-        // Backend auto-creates any tags the org has not used before and
-        // enforces MAX_TAGS_PER_TRANSACTION; the chip input also caps
-        // client-side.
-        if (formTags.length > 0 && created?.id) {
-          await apiFetch(`/api/v1/transactions/${created.id}/tags`, {
-            method: "PUT",
-            body: JSON.stringify({ tag_names: formTags }),
+        // Step 1: POST the base transaction. Hard-failures here keep
+        // the form open with the user's input intact for retry.
+        let created: Transaction | undefined;
+        try {
+          created = await apiFetch<Transaction>("/api/v1/transactions", {
+            method: "POST",
+            body: JSON.stringify({
+              account_id: formAccountId,
+              category_id: formCategoryId,
+              description: formDescription,
+              amount: formAmount,
+              type: formType,
+              status: formStatus,
+              date: formDate,
+              // settled_date only travels on pending creates; SETTLED rows
+              // get their settled_date stamped server-side from `date`.
+              ...(formStatus === "pending" && formSettledDate
+                ? { settled_date: formSettledDate }
+                : {}),
+            }),
           });
+        } catch (err) {
+          setError(extractErrorMessage(err));
+          return;
+        }
+        // Step 2: PUT /tags. The transaction was already saved, so a
+        // failure here is a PARTIAL SUCCESS — we must not leave the
+        // form in a state that re-POSTs the base transaction on the
+        // next click or we double-create. Surface a non-blocking
+        // warning via setError (same channel the promote-to-recurring
+        // partial-success uses), then fall through to the form-reset
+        // path so the user gets a clean slate.
+        let tagWarning: string | null = null;
+        if (formTags.length > 0 && created?.id) {
+          try {
+            await apiFetch(`/api/v1/transactions/${created.id}/tags`, {
+              method: "PUT",
+              body: JSON.stringify({ tag_names: formTags }),
+            });
+          } catch (err) {
+            tagWarning = `Transaction saved. Tags couldn't be applied: ${extractErrorMessage(
+              err,
+            )}. Edit the transaction to add them.`;
+          }
         }
         // Promote the new tx to recurring if repeat is enabled. Using
         // promote-to-recurring (vs a separate POST /recurring) sets
         // tx.recurring_id on the source transaction so a subsequent edit
         // shows the "Recurring" chip — preventing the duplicate-template
         // bug where re-toggling "Make recurring" on edit would create a
-        // second template because the source row stayed unlinked.
+        // second template because the source row stayed unlinked. A
+        // promote failure still bubbles to the outer catch (matches
+        // pre-PR behavior); this PR only changes the tag-attach arm.
         if (formRecurring && formMode === "transaction" && created?.id) {
           // next_due_date must be today-or-later (server-side guard).
           // The Date input is already constrained to today via min=,
@@ -458,6 +478,9 @@ function TransactionsPageContent() {
               }),
             },
           );
+        }
+        if (tagWarning) {
+          setError(tagWarning);
         }
       }
       setFormDescription("");

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -18,6 +18,7 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import LinkAsTransferModal from "@/components/transactions/LinkAsTransferModal";
 import MarkAsTransferModal from "@/components/transactions/MarkAsTransferModal";
 import UnpairTransferModal from "@/components/transactions/UnpairTransferModal";
+import TagChipInput from "@/components/transactions/TagChipInput";
 import DescriptionAutocomplete from "@/components/transactions/DescriptionAutocomplete";
 import ResetSortFiltersButton from "@/components/ui/ResetSortFiltersButton";
 import {
@@ -99,6 +100,9 @@ function TransactionsPageContent() {
   const [editSettledDate, setEditSettledDate] = useState("");
   const [editAccountId, setEditAccountId] = useState<number | "">("");
   const [editCategoryId, setEditCategoryId] = useState<number | "">("");
+  // PR-Tags-A: chip-managed tag set for the edit form. Persisted via
+  // PUT /api/v1/transactions/{id}/tags after the PUT to /transactions/{id}.
+  const [editTags, setEditTags] = useState<string[]>([]);
   // Edit-time promote-to-recurring (L3.12). Hidden on rows that are already
   // recurring (a static chip is rendered instead). Default next_due_date is
   // "today + 30 days" so users get a reasonable starting point without a
@@ -199,6 +203,10 @@ function TransactionsPageContent() {
   // keeps credit-card-style settlement lag a deliberate choice instead of
   // silently inheriting the transaction date.
   const [formSettledDate, setFormSettledDate] = useState("");
+  // PR-Tags-A: chip-managed tag set for the create form. Attached via
+  // PUT /api/v1/transactions/{id}/tags after the POST resolves (see
+  // submitForm below). Tags do not apply to transfer mode.
+  const [formTags, setFormTags] = useState<string[]>([]);
   const [formRecurring, setFormRecurring] = useState(false);
   const [formFrequency, setFormFrequency] = useState("monthly");
   const [formAutoSettle, setFormAutoSettle] = useState(false);
@@ -416,6 +424,16 @@ function TransactionsPageContent() {
               : {}),
           }),
         });
+        // PR-Tags-A: attach the chip-managed tag set as a separate PUT.
+        // Backend auto-creates any tags the org has not used before and
+        // enforces MAX_TAGS_PER_TRANSACTION; the chip input also caps
+        // client-side.
+        if (formTags.length > 0 && created?.id) {
+          await apiFetch(`/api/v1/transactions/${created.id}/tags`, {
+            method: "PUT",
+            body: JSON.stringify({ tag_names: formTags }),
+          });
+        }
         // Promote the new tx to recurring if repeat is enabled. Using
         // promote-to-recurring (vs a separate POST /recurring) sets
         // tx.recurring_id on the source transaction so a subsequent edit
@@ -452,6 +470,7 @@ function TransactionsPageContent() {
       setFormAutoSettle(false);
       setFormDate(todayISO());
       setFormSettledDate("");
+      setFormTags([]);
       setShowForm(false);
       await loadTransactions(page);
     } catch (err) {
@@ -589,6 +608,10 @@ function TransactionsPageContent() {
     setEditSettledDate(tx.status === "pending" && tx.settled_date ? tx.settled_date : "");
     setEditAccountId(tx.account_id);
     setEditCategoryId(tx.category_id);
+    // Seed the chip input with the row's current tags. ``tags`` is
+    // always present on TransactionResponse (backend selectinload),
+    // but defensively coerce to [] in case of a partial test fixture.
+    setEditTags((tx.tags ?? []).map((t) => t.name));
     setEditPromoteRecurring(false);
     setEditRecFrequency("monthly");
     setEditRecNextDue(defaultNextDueISO());
@@ -615,6 +638,7 @@ function TransactionsPageContent() {
     setEditingId(null);
     setEditPartner(null);
     setEditPromoteRecurring(false);
+    setEditTags([]);
   }
 
   async function handleSaveEdit() {
@@ -670,6 +694,12 @@ function TransactionsPageContent() {
       await apiFetch(`/api/v1/transactions/${editingId}`, {
         method: "PUT",
         body: JSON.stringify(body),
+      });
+      // PR-Tags-A: replace the tag set. Sent on every edit (including
+      // when the user cleared every chip) so the PUT is authoritative.
+      await apiFetch(`/api/v1/transactions/${editingId}/tags`, {
+        method: "PUT",
+        body: JSON.stringify({ tag_names: editTags }),
       });
       if (wantsPromote) {
         // The PUT already committed the edit. If the promote step then
@@ -1042,6 +1072,17 @@ function TransactionsPageContent() {
                 />
               )}
             </div>
+            {formMode === "transaction" && (
+              <div>
+                <label htmlFor="tx-tags" className={label}>Tags</label>
+                <TagChipInput
+                  id="tx-tags"
+                  value={formTags}
+                  onChange={setFormTags}
+                  categoryId={formCategoryId}
+                />
+              </div>
+            )}
             <div>
               <label htmlFor="tx-amount" className={label}>Amount</label>
               <input id="tx-amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value={formAmount} onChange={(e) => setFormAmount(e.target.value)} className={input} />
@@ -1375,6 +1416,15 @@ function TransactionsPageContent() {
                               <label htmlFor={`edit-amount-${tx.id}`} className={label}>Amount</label>
                               <input id={`edit-amount-${tx.id}`} aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm ${input}`} />
                             </div>
+                            <div>
+                              <label htmlFor={`edit-tags-${tx.id}`} className={label}>Tags</label>
+                              <TagChipInput
+                                id={`edit-tags-${tx.id}`}
+                                value={editTags}
+                                onChange={setEditTags}
+                                categoryId={editCategoryId}
+                              />
+                            </div>
                             {editStatus === "pending" && (
                               <div data-testid={`edit-settled-date-cell-${tx.id}`}>
                                 <label htmlFor={`edit-settled-${tx.id}`} className={label}>
@@ -1502,7 +1552,21 @@ function TransactionsPageContent() {
                               </span>
                             )}
                           </span>
-                          <span className="col-span-2 text-sm text-text-primary">{tx.description}</span>
+                          <span className="col-span-2 flex flex-col text-sm text-text-primary">
+                            <span>{tx.description}</span>
+                            {tx.tags && tx.tags.length > 0 && (
+                              <span className="mt-0.5 flex flex-wrap gap-1" data-testid={`row-tags-${tx.id}`}>
+                                {tx.tags.map((t) => (
+                                  <span
+                                    key={t.id}
+                                    className="inline-flex items-center rounded bg-accent/10 px-1.5 py-0.5 text-[10px] text-text-secondary"
+                                  >
+                                    {t.name}
+                                  </span>
+                                ))}
+                              </span>
+                            )}
+                          </span>
                           <span className="col-span-2 text-sm text-text-secondary truncate">
                             {isTransfer && linkedTx
                               ? <>{tx.account_name} &rarr; {linkedTx.account_name}</>
@@ -1634,6 +1698,15 @@ function TransactionsPageContent() {
                                 <label className={label}>Amount</label>
                                 <input aria-label="Amount" type="number" step="0.01" min="0.01" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className={`text-sm ${input}`} />
                               </div>
+                              <div className="sm:col-span-2">
+                                <label htmlFor={`edit-tags-mobile-${tx.id}`} className={label}>Tags</label>
+                                <TagChipInput
+                                  id={`edit-tags-mobile-${tx.id}`}
+                                  value={editTags}
+                                  onChange={setEditTags}
+                                  categoryId={editCategoryId}
+                                />
+                              </div>
                               {editStatus === "pending" && (
                                 <div className="sm:col-span-2" data-testid={`edit-settled-date-cell-mobile-${tx.id}`}>
                                   <label className={label}>Expected settlement date</label>
@@ -1750,6 +1823,21 @@ function TransactionsPageContent() {
                               <div className="truncate text-sm font-medium text-text-primary">
                                 {tx.description}
                               </div>
+                              {tx.tags && tx.tags.length > 0 && (
+                                <div
+                                  className="mt-0.5 flex flex-wrap gap-1"
+                                  data-testid={`row-tags-mobile-${tx.id}`}
+                                >
+                                  {tx.tags.map((t) => (
+                                    <span
+                                      key={t.id}
+                                      className="inline-flex items-center rounded bg-accent/10 px-1.5 py-0.5 text-[10px] text-text-secondary"
+                                    >
+                                      {t.name}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
                               <div className="mt-0.5 text-xs text-text-muted tabular-nums">
                                 {tx.date} · {isTransfer && linkedTx ? <>{tx.account_name} &rarr; {linkedTx.account_name}</> : tx.account_name}
                               </div>

--- a/frontend/components/AppShellAddTransactionCta.tsx
+++ b/frontend/components/AppShellAddTransactionCta.tsx
@@ -67,6 +67,11 @@ export default function AppShellAddTransactionCta() {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [loaded, setLoaded] = useState(false);
+  // Non-blocking warning surfaced from the floating forms when a
+  // post-save sub-call (e.g. PUT /tags) failed. Rendered as an
+  // inline banner above the next panel; auto-dismisses when the
+  // user reopens the panel.
+  const [warning, setWarning] = useState<string>("");
 
   const menuId = useId();
   const chevronRef = useRef<HTMLButtonElement>(null);
@@ -139,12 +144,14 @@ export default function AppShellAddTransactionCta() {
   function openTransaction() {
     void loadRefs();
     setMenuOpen(false);
+    setWarning("");
     setOpenPanel("transaction");
   }
 
   function openTransfer() {
     void loadRefs();
     setMenuOpen(false);
+    setWarning("");
     setOpenPanel("transfer");
   }
 
@@ -186,6 +193,26 @@ export default function AppShellAddTransactionCta() {
 
   return (
     <div className="relative inline-flex">
+      {warning && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="add-transaction-warning"
+          className="fixed left-1/2 top-4 z-50 -translate-x-1/2 rounded-md bg-warning-dim px-4 py-3 text-sm text-warning shadow-lg"
+        >
+          <div className="flex items-start gap-3">
+            <span>{warning}</span>
+            <button
+              type="button"
+              onClick={() => setWarning("")}
+              aria-label="Dismiss warning"
+              className="text-warning hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+        </div>
+      )}
       <div className="inline-flex rounded-md shadow-sm">
         <button
           type="button"
@@ -267,6 +294,7 @@ export default function AppShellAddTransactionCta() {
               setCategories((prev) => [...prev, cat])
             }
             onTransactionAdded={handleTransactionAdded}
+            onWarning={setWarning}
           />
         ) : (
           <div className="flex items-center justify-center py-12 text-sm text-text-muted">

--- a/frontend/components/floating/TransactionForm.tsx
+++ b/frontend/components/floating/TransactionForm.tsx
@@ -66,6 +66,14 @@ export interface TransactionFormProps {
    * Pages can use this to refresh transaction lists.
    */
   onTransactionAdded?: () => void;
+  /**
+   * Called when the transaction was saved but a follow-up sub-call
+   * (e.g. PUT /tags) failed. The base transaction IS committed; the
+   * caller should surface this as a non-blocking warning instead of
+   * a hard error so the user does not retry and double-create. See
+   * the partial-success handling in submit() below.
+   */
+  onWarning?: (msg: string) => void;
 }
 
 export default function TransactionForm({
@@ -76,6 +84,7 @@ export default function TransactionForm({
   onSaved,
   onCategoryCreated,
   onTransactionAdded,
+  onWarning,
 }: TransactionFormProps) {
   const activeAccounts = accounts.filter((a) => a.is_active);
   const fallbackAccount = activeAccounts.find((a) => a.is_default) ?? activeAccounts[0];
@@ -172,8 +181,11 @@ export default function TransactionForm({
     }
     setSubmitting(true);
     setErrMsg("");
+    // Step 1: POST the base transaction. Failures here keep the form
+    // open with the user's input intact so they can correct + retry.
+    let created: Transaction | undefined;
     try {
-      const created = await apiFetch<Transaction>("/api/v1/transactions", {
+      created = await apiFetch<Transaction>("/api/v1/transactions", {
         method: "POST",
         body: JSON.stringify({
           account_id: accountId,
@@ -191,29 +203,45 @@ export default function TransactionForm({
             : {}),
         }),
       });
-      // Attach tags as a separate PUT now that the transaction exists.
-      // Backend auto-creates any unknown tags and enforces the
-      // MAX_TAGS_PER_TRANSACTION cap (defense in depth — client also
-      // caps in TagChipInput).
-      if (tags.length > 0 && created?.id) {
+    } catch (err) {
+      setErrMsg(extractErrorMessage(err));
+      setSubmitting(false);
+      return;
+    }
+    // Step 2: PUT /tags. The transaction was already saved, so any
+    // failure here is a PARTIAL SUCCESS — we must NOT leave the form
+    // in a state that re-POSTs the base transaction on the next
+    // click, or we double-create. Close + reset the form and surface
+    // a non-blocking warning via onWarning so the parent can show a
+    // "Transaction saved, tags couldn't be applied" banner.
+    let tagWarning: string | null = null;
+    if (tags.length > 0 && created?.id) {
+      try {
         await apiFetch(`/api/v1/transactions/${created.id}/tags`, {
           method: "PUT",
           body: JSON.stringify({ tag_names: tags }),
         });
+      } catch (err) {
+        tagWarning = `Transaction saved. Tags couldn't be applied: ${extractErrorMessage(
+          err,
+        )}. Edit the transaction to add them.`;
       }
-      onTransactionAdded?.();
-      if (addAnother) {
-        clearForm();
-        // Refocus the description input so the user can keep typing.
-        window.setTimeout(() => focusDescription(), 0);
-      } else {
-        onSaved();
-      }
-    } catch (err) {
-      setErrMsg(extractErrorMessage(err));
-    } finally {
-      setSubmitting(false);
     }
+    onTransactionAdded?.();
+    if (tagWarning) {
+      onWarning?.(tagWarning);
+    }
+    if (addAnother) {
+      clearForm();
+      // Refocus the description input via the DescriptionAutocomplete
+      // component's exposed focus path (id-based lookup; the component
+      // owns its own input element). Preserves the post-PR-#325 focus
+      // contract instead of the pre-#325 descRef pattern.
+      window.setTimeout(() => focusDescription(), 0);
+    } else {
+      onSaved();
+    }
+    setSubmitting(false);
   }
 
   function onSubmit(e: FormEvent) {

--- a/frontend/components/floating/TransactionForm.tsx
+++ b/frontend/components/floating/TransactionForm.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, MouseEvent, useEffect, useRef, useState } from "react";
 
 import DescriptionAutocomplete from "@/components/transactions/DescriptionAutocomplete";
+import TagChipInput from "@/components/transactions/TagChipInput";
 import CategorySelect from "@/components/ui/CategorySelect";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { todayISO } from "@/lib/format";
@@ -13,7 +14,7 @@ import {
   input,
   label,
 } from "@/lib/styles";
-import type { Account, Category } from "@/lib/types";
+import type { Account, Category, Transaction } from "@/lib/types";
 
 /**
  * Quick-entry transaction form used inside the AppShell-level Add
@@ -99,6 +100,11 @@ export default function TransactionForm({
   // credit-card-style settlement lag a deliberate choice instead of
   // silently inheriting the transaction date.
   const [settledDate, setSettledDate] = useState("");
+  // PR-Tags-A: chip-managed tag set. Normalized lowercase names. The
+  // backend auto-creates new tags via PUT /api/v1/transactions/{id}/tags
+  // (called right after the POST below) so the user does not need to
+  // pre-create tags from a management page.
+  const [tags, setTags] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [errMsg, setErrMsg] = useState("");
   // Focus target for the "Save and add new" refocus path. The
@@ -148,6 +154,8 @@ export default function TransactionForm({
     // fresh. Status default re-derives from the (preserved) account on
     // its own, so we leave that alone.
     setSettledDate("");
+    // Tags are per-transaction, not sticky across entries.
+    setTags([]);
     setErrMsg("");
   }
 
@@ -165,7 +173,7 @@ export default function TransactionForm({
     setSubmitting(true);
     setErrMsg("");
     try {
-      await apiFetch("/api/v1/transactions", {
+      const created = await apiFetch<Transaction>("/api/v1/transactions", {
         method: "POST",
         body: JSON.stringify({
           account_id: accountId,
@@ -183,6 +191,16 @@ export default function TransactionForm({
             : {}),
         }),
       });
+      // Attach tags as a separate PUT now that the transaction exists.
+      // Backend auto-creates any unknown tags and enforces the
+      // MAX_TAGS_PER_TRANSACTION cap (defense in depth — client also
+      // caps in TagChipInput).
+      if (tags.length > 0 && created?.id) {
+        await apiFetch(`/api/v1/transactions/${created.id}/tags`, {
+          method: "PUT",
+          body: JSON.stringify({ tag_names: tags }),
+        });
+      }
       onTransactionAdded?.();
       if (addAnother) {
         clearForm();
@@ -313,6 +331,19 @@ export default function TransactionForm({
           placeholder="What was it for?"
           required
           ariaLabel="Description"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="fab-tx-tags" className={label}>
+          Tags
+        </label>
+        <TagChipInput
+          id="fab-tx-tags"
+          value={tags}
+          onChange={setTags}
+          categoryId={categoryId}
+          disabled={submitting}
         />
       </div>
 

--- a/frontend/components/transactions/TagChipInput.tsx
+++ b/frontend/components/transactions/TagChipInput.tsx
@@ -335,10 +335,28 @@ export default function TagChipInput({
                 e.stopPropagation();
                 removeChip(name);
               }}
+              onKeyDown={(e) => {
+                // Enter / Space remove the chip from keyboard. The
+                // implicit Enter behavior on <button> already does this
+                // via click, but Space inside a button only fires on
+                // keyup — making it explicit keeps the keyboard path
+                // identical for both keys.
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  removeChip(name);
+                }
+              }}
               disabled={disabled}
               aria-label={`Remove tag ${name}`}
-              className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded text-text-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
-              tabIndex={-1}
+              // Chip × buttons are part of the natural tab order so
+              // keyboard-only users can free a slot when the input is
+              // disabled at MAX_TAGS_PER_TRANSACTION. DOM order is
+              // chips-before-input, so forward Tab from the previous
+              // field walks chips → input → next field, and Shift+Tab
+              // from the input reaches the last chip's × in reverse —
+              // matching the Gmail / GitHub label-picker convention
+              // the operator called out.
+              className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded text-text-muted hover:text-danger focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
             >
               <span aria-hidden="true">&times;</span>
             </button>

--- a/frontend/components/transactions/TagChipInput.tsx
+++ b/frontend/components/transactions/TagChipInput.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import { apiFetch } from "@/lib/api";
+import { input } from "@/lib/styles";
+
+/**
+ * Tag chip input for transaction add/edit forms (PR-Tags-A frontend).
+ *
+ * Wires the backend tag autocomplete contract:
+ *   GET /api/v1/tags/suggest?prefix=...&category_id=...&limit=...
+ *
+ * Behavior:
+ *   - User types -> debounced fetch (200ms). Minimum prefix length 1.
+ *   - Enter / Tab / comma commits the typed text as a chip. The
+ *     transactions submit path posts the chip names to
+ *     PUT /api/v1/transactions/{id}/tags which auto-creates any
+ *     tags the org has not used before.
+ *   - Backspace on an empty input removes the last chip.
+ *   - Click suggestion commits chip.
+ *   - Each chip carries a remove "x" with aria-label="Remove tag <name>".
+ *   - Cap (MAX_TAGS_PER_TRANSACTION = 5) is enforced client-side; backend
+ *     also rejects with 422.
+ *   - Names normalize lowercase + collapsed whitespace + [a-z0-9 -] on
+ *     the server. We surface a friendly inline error when the server
+ *     rejects.
+ *
+ * Accessibility (W3C combobox pattern, mirrors DescriptionAutocomplete):
+ *   - input role="combobox", aria-expanded, aria-controls,
+ *     aria-activedescendant.
+ *   - listbox role="listbox"; options role="option".
+ *   - aria-live polite region announces suggestion counts.
+ *   - Chip remove buttons return focus to the input.
+ */
+
+/** Hard frontend cap. Mirrors backend MAX_TAGS_PER_TRANSACTION in
+ *  app/schemas/tag.py. Bumping requires both ends to change. */
+export const MAX_TAGS_PER_TRANSACTION = 5;
+
+/** Server-side normalize set: lowercase, collapsed whitespace, allowed
+ *  characters [a-z0-9 -]. Length cap 32. */
+export const TAG_NAME_MAX_LENGTH = 32;
+
+export type TagSuggestion = {
+  name: string;
+  source: "org_co_category" | "org_recent" | "shared_dictionary";
+  weight: number;
+};
+
+type SuggestApiResponse = { suggestions: TagSuggestion[] };
+
+export interface TagChipInputProps {
+  /** Currently attached tag names (lowercase / normalized client-side). */
+  value: string[];
+  /** Called whenever the chip list changes. */
+  onChange: (next: string[]) => void;
+  /** Currently selected category for the transaction (drives the
+   *  "tags used on this category" suggestion pass). Pass null/"" when
+   *  the form has no category picked yet. */
+  categoryId?: number | "" | null;
+  /** DOM id for the input (label htmlFor). */
+  id: string;
+  /** Accessibility label override (default: "Tags"). */
+  ariaLabel?: string;
+  /** Disable interaction (form submitting, etc.). */
+  disabled?: boolean;
+  /** Override fetch in tests. */
+  fetcher?: (
+    prefix: string,
+    categoryId: number | null,
+    signal: AbortSignal,
+  ) => Promise<TagSuggestion[]>;
+  /** Override the debounce in tests (default 200ms). */
+  debounceMs?: number;
+  /** Override the cap in tests (default MAX_TAGS_PER_TRANSACTION). */
+  maxTags?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 200;
+const SUGGEST_LIMIT = 10;
+
+async function defaultFetcher(
+  prefix: string,
+  categoryId: number | null,
+  signal: AbortSignal,
+): Promise<TagSuggestion[]> {
+  const params = new URLSearchParams({ limit: String(SUGGEST_LIMIT) });
+  if (prefix) params.set("prefix", prefix);
+  if (categoryId != null) params.set("category_id", String(categoryId));
+  const data = await apiFetch<SuggestApiResponse>(
+    `/api/v1/tags/suggest?${params}`,
+    { signal },
+  );
+  return data.suggestions ?? [];
+}
+
+function isAbortError(e: unknown): boolean {
+  if (e instanceof DOMException && e.name === "AbortError") return true;
+  if (
+    typeof e === "object" &&
+    e !== null &&
+    "name" in e &&
+    (e as { name?: string }).name === "AbortError"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Client-side normalize: lowercase, collapse internal whitespace,
+ *  strip leading/trailing whitespace, and drop characters the server
+ *  would refuse. This keeps the chip list stable across the wire round
+ *  trip even when the server normalizes more aggressively. */
+function normalizeName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9 \-]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export default function TagChipInput({
+  value,
+  onChange,
+  categoryId = null,
+  id,
+  ariaLabel = "Tags",
+  disabled,
+  fetcher = defaultFetcher,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  maxTags = MAX_TAGS_PER_TRANSACTION,
+}: TagChipInputProps) {
+  const listboxId = useId();
+  const [draft, setDraft] = useState("");
+  const [suggestions, setSuggestions] = useState<TagSuggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  const [highlightIdx, setHighlightIdx] = useState(-1);
+  const [loading, setLoading] = useState(false);
+  const [announce, setAnnounce] = useState("");
+  const [error, setError] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  const atCap = value.length >= maxTags;
+  // Normalize the category prop into a number-or-null so the fetcher
+  // sees a stable shape even when callers pass "" from form state.
+  const categoryIdNum =
+    categoryId === "" || categoryId == null ? null : categoryId;
+
+  const commitChip = useCallback(
+    (raw: string) => {
+      const name = normalizeName(raw);
+      if (!name) return;
+      if (name.length > TAG_NAME_MAX_LENGTH) {
+        setError(`Tag must be ${TAG_NAME_MAX_LENGTH} characters or fewer`);
+        return;
+      }
+      if (value.includes(name)) {
+        // Already attached. Clear the draft silently so the user can
+        // keep typing the next tag without a confusing duplicate
+        // chip.
+        setDraft("");
+        setOpen(false);
+        setHighlightIdx(-1);
+        return;
+      }
+      if (value.length >= maxTags) {
+        setError(`Maximum ${maxTags} tags per transaction`);
+        return;
+      }
+      setError("");
+      onChange([...value, name]);
+      setDraft("");
+      setOpen(false);
+      setHighlightIdx(-1);
+    },
+    [maxTags, onChange, value],
+  );
+
+  const removeChip = useCallback(
+    (name: string) => {
+      onChange(value.filter((t) => t !== name));
+      setError("");
+      // Return focus to the input so the user keeps the keyboard
+      // flow after pressing x on a chip.
+      window.setTimeout(() => inputRef.current?.focus(), 0);
+    },
+    [onChange, value],
+  );
+
+  // Debounced fetch on draft change.
+  useEffect(() => {
+    if (disabled) return;
+    if (atCap) {
+      setSuggestions([]);
+      setOpen(false);
+      setHighlightIdx(-1);
+      return;
+    }
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setSuggestions([]);
+      setHighlightIdx(-1);
+      setOpen(false);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const list = await fetcher(trimmed, categoryIdNum, controller.signal);
+        if (controller.signal.aborted) return;
+        // Filter out names that are already chipped — no point
+        // showing them.
+        const filtered = list.filter((s) => !value.includes(s.name));
+        setSuggestions(filtered);
+        setHighlightIdx(filtered.length > 0 ? 0 : -1);
+        setOpen(true);
+        setAnnounce(
+          filtered.length === 0
+            ? "No suggestions"
+            : `${filtered.length} ${
+                filtered.length === 1 ? "suggestion" : "suggestions"
+              } available`,
+        );
+      } catch (err) {
+        if (isAbortError(err) || controller.signal.aborted) return;
+        setSuggestions([]);
+        setHighlightIdx(-1);
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }, debounceMs);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [draft, categoryIdNum, debounceMs, fetcher, value, disabled, atCap]);
+
+  // Click outside closes the dropdown.
+  useEffect(() => {
+    function handle(e: MouseEvent) {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === "Tab" || e.key === ",") {
+      // Tab still moves focus; Enter / comma stay inside the input
+      // to commit. We only intercept Tab when there's a draft so
+      // empty Tab still moves to the next field.
+      if (e.key === "Tab" && !draft.trim() && highlightIdx < 0) return;
+      e.preventDefault();
+      if (
+        open &&
+        highlightIdx >= 0 &&
+        highlightIdx < suggestions.length
+      ) {
+        commitChip(suggestions[highlightIdx].name);
+      } else if (draft.trim()) {
+        commitChip(draft);
+      }
+      return;
+    }
+    if (e.key === "Backspace" && !draft && value.length > 0) {
+      e.preventDefault();
+      removeChip(value[value.length - 1]);
+      return;
+    }
+    if (!open || suggestions.length === 0) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setHighlightIdx((i) => (i + 1) % suggestions.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setHighlightIdx((i) =>
+          i <= 0 ? suggestions.length - 1 : i - 1,
+        );
+        break;
+      case "Escape":
+        e.preventDefault();
+        setOpen(false);
+        setHighlightIdx(-1);
+        break;
+    }
+  };
+
+  const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    setDraft(next);
+    setError("");
+  };
+
+  const handleFocus = () => {
+    if (suggestions.length > 0 && draft.trim()) setOpen(true);
+  };
+
+  const activeId =
+    open && highlightIdx >= 0 ? `${listboxId}-opt-${highlightIdx}` : undefined;
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <div
+        className={`${input} flex flex-wrap items-center gap-1.5 ${
+          disabled ? "opacity-60" : ""
+        }`}
+        onClick={() => {
+          if (!disabled) inputRef.current?.focus();
+        }}
+      >
+        {value.map((name) => (
+          <span
+            key={name}
+            className="inline-flex items-center gap-1 rounded bg-accent/15 px-2 py-0.5 text-xs text-text-primary"
+            data-testid={`tag-chip-${name}`}
+          >
+            <span>{name}</span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeChip(name);
+              }}
+              disabled={disabled}
+              aria-label={`Remove tag ${name}`}
+              className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded text-text-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+              tabIndex={-1}
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </span>
+        ))}
+        <input
+          id={id}
+          ref={inputRef}
+          type="text"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={open && suggestions.length > 0}
+          aria-controls={listboxId}
+          aria-activedescendant={activeId}
+          aria-label={ariaLabel}
+          autoComplete="off"
+          disabled={disabled || atCap}
+          value={draft}
+          placeholder={
+            atCap
+              ? `Maximum ${maxTags} tags`
+              : value.length === 0
+                ? "Add a tag"
+                : ""
+          }
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+          maxLength={TAG_NAME_MAX_LENGTH}
+          className="flex-1 min-w-[100px] bg-transparent text-sm text-text-primary placeholder:text-text-muted focus:outline-none disabled:cursor-not-allowed"
+        />
+      </div>
+
+      {open && suggestions.length > 0 && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          aria-label="Tag suggestions"
+          className="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-md border border-border bg-surface-raised shadow-lg"
+        >
+          {suggestions.map((s, i) => (
+            <li
+              key={s.name}
+              id={`${listboxId}-opt-${i}`}
+              role="option"
+              aria-selected={i === highlightIdx}
+              onMouseDown={(e) => {
+                // mousedown (not click) so we run before the input
+                // blurs and closes the dropdown.
+                e.preventDefault();
+                commitChip(s.name);
+              }}
+              onMouseEnter={() => setHighlightIdx(i)}
+              className={`cursor-pointer px-3 py-2 text-sm ${
+                i === highlightIdx
+                  ? "bg-accent/10 text-text-primary"
+                  : "text-text-primary"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="truncate">{s.name}</span>
+                {s.source === "shared_dictionary" && (
+                  <span className="shrink-0 text-[10px] text-text-muted">
+                    suggested
+                  </span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <p
+          role="alert"
+          className="mt-1 text-xs text-danger"
+          data-testid="tag-chip-error"
+        >
+          {error}
+        </p>
+      )}
+
+      <div role="status" aria-live="polite" className="sr-only">
+        {loading ? "Loading suggestions" : announce}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -125,6 +125,17 @@ export interface Transaction {
   // endpoint. Standard CRUD (edit/delete/promote-to-recurring) refuses
   // to mutate them; bulk delete skips them silently.
   is_manual_adjustment: boolean;
+  // PR-Tags-A: tags attached to this transaction. Always present on
+  // list/detail responses, empty array when none. The backend
+  // populates this via a selectinload in the transactions service
+  // so there is no N+1.
+  tags: TagSummary[];
+}
+
+/** Per-transaction tag embed on list/detail responses (PR-Tags-A). */
+export interface TagSummary {
+  id: number;
+  name: string;
 }
 
 export interface RecurringTransaction {

--- a/frontend/tests/app/transactions-page.test.tsx
+++ b/frontend/tests/app/transactions-page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import TransactionsPage from "@/app/transactions/page";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -309,6 +309,99 @@ describe("TransactionsPage — transfer wiring (Task D7)", () => {
         screen.queryByRole("button", { name: /Unlink transfer: Solo tx/i }),
       ).toBeNull();
     });
+  });
+
+  it("inline new-transaction form: PUT /tags failure stays as partial success (no duplicate POST)", async () => {
+    // Regression for PR #326 review: when the user adds a chip-managed
+    // tag and the PUT /tags call fails after the base POST succeeded,
+    // the form must reset (preventing a re-POST of the same base on
+    // the next Save click) and surface a non-blocking partial-success
+    // warning via the existing setError channel (same channel the
+    // promote-to-recurring partial-success uses).
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+
+    apiFetchMock.mockImplementation(
+      async (url: string, init?: RequestInit) => {
+        if (url.startsWith("/api/v1/accounts")) return [ACCT_A, ACCT_B] as never;
+        if (url.startsWith("/api/v1/categories"))
+          return [CATEGORY_GROCERIES] as never;
+        if (url.startsWith("/api/v1/settings/billing-periods"))
+          return [] as never;
+        if (
+          url === "/api/v1/transactions" &&
+          init?.method === "POST"
+        ) {
+          return { id: 99 } as never;
+        }
+        if (url === "/api/v1/transactions/99/tags") {
+          throw new Error("tag attach failed");
+        }
+        if (url.startsWith("/api/v1/transactions")) return [] as never;
+        return null as never;
+      },
+    );
+
+    const { container } = render(<TransactionsPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /\+ New Transaction/i }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /\+ New Transaction/i }),
+    );
+
+    // Fill the inline form.
+    await waitFor(() => {
+      expect(document.getElementById("tx-desc")).not.toBeNull();
+    });
+    const descEl = document.getElementById("tx-desc") as HTMLInputElement;
+    fireEvent.change(descEl, { target: { value: "Grocery run" } });
+    fireEvent.change(document.getElementById("tx-amount") as HTMLInputElement, {
+      target: { value: "12.34" },
+    });
+    // Add a tag chip so the PUT /tags arm fires.
+    const tagInput = container.querySelector(
+      "#tx-tags",
+    ) as HTMLInputElement;
+    fireEvent.change(tagInput, { target: { value: "rent" } });
+    fireEvent.keyDown(tagInput, { key: "Enter" });
+
+    // Submit (the form's onSubmit). Use the Save button.
+    const saveBtn = screen.getByRole("button", { name: /^Add Transaction$/i });
+    await act(async () => {
+      fireEvent.click(saveBtn);
+    });
+
+    // The base POST happened exactly once.
+    const basePosts = apiFetchMock.mock.calls.filter(
+      ([url, init]) =>
+        url === "/api/v1/transactions" &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(basePosts).toHaveLength(1);
+
+    // The PUT /tags attempt happened (and failed).
+    const tagPuts = apiFetchMock.mock.calls.filter(
+      ([url, init]) =>
+        url === "/api/v1/transactions/99/tags" &&
+        (init as RequestInit | undefined)?.method === "PUT",
+    );
+    expect(tagPuts).toHaveLength(1);
+
+    // The partial-success warning surfaced via the existing setError
+    // channel. We assert by text rather than role to match the same
+    // banner the promote-to-recurring partial-success uses.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Transaction saved\. Tags couldn't be applied/),
+      ).toBeInTheDocument();
+    });
+
+    // The form has been reset (showForm=false hides the form), so a
+    // subsequent Save click cannot re-POST the same base transaction.
+    expect(screen.queryByRole("button", { name: /^Add Transaction$/i })).toBeNull();
   });
 
   it("Per-row Mark as transfer button shown on un-linked rows only", async () => {

--- a/frontend/tests/components/floating/transaction-form.test.tsx
+++ b/frontend/tests/components/floating/transaction-form.test.tsx
@@ -631,4 +631,75 @@ describe("TransactionForm", () => {
       });
     });
   });
+
+  it("treats PUT /tags failure as partial success: no duplicate POST on retry", async () => {
+    // Regression for PR #326 review: the two-step write (POST then
+    // PUT /tags) must not re-POST the base transaction when the tag
+    // attach fails. Previously a tag-PUT failure left the form open
+    // with all fields intact, and a second Save click double-created.
+    const apiFetchMock = vi.mocked(apiFetch);
+    apiFetchMock.mockReset();
+
+    const onSaved = vi.fn();
+    const onTransactionAdded = vi.fn();
+    const onWarning = vi.fn();
+
+    // 201 for the base POST; 500 for PUT /tags.
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/v1/transactions" && init?.method === "POST") {
+        return { id: 42 } as never;
+      }
+      if (url === "/api/v1/transactions/42/tags") {
+        throw new Error("tag attach failed");
+      }
+      return {} as never;
+    });
+
+    const { container } = render(
+      <TransactionForm
+        accounts={[ACCT]}
+        categories={[CAT]}
+        defaultCategoryId={CAT.id}
+        onSaved={onSaved}
+        onTransactionAdded={onTransactionAdded}
+        onWarning={onWarning}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Groceries Aldi" },
+    });
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "12.34" },
+    });
+    // Add a tag chip so the PUT /tags arm fires.
+    const tagInput = container.querySelector(
+      "#fab-tx-tags",
+    ) as HTMLInputElement;
+    fireEvent.change(tagInput, { target: { value: "rent" } });
+    fireEvent.keyDown(tagInput, { key: "Enter" });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+    });
+
+    // (1) Panel closed via onSaved, list refresh fired via
+    // onTransactionAdded, warning surfaced via onWarning.
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledTimes(1);
+    });
+    expect(onTransactionAdded).toHaveBeenCalledTimes(1);
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0]).toMatch(/Transaction saved/);
+    expect(onWarning.mock.calls[0][0]).toMatch(/tag attach failed/);
+
+    // (2) Exactly ONE base POST. The whole point of this fix is no
+    // duplicate base transaction on the tag-failure path.
+    const basePosts = apiFetchMock.mock.calls.filter(
+      ([url, init]) =>
+        url === "/api/v1/transactions" &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(basePosts).toHaveLength(1);
+  });
 });

--- a/frontend/tests/components/floating/transaction-form.test.tsx
+++ b/frontend/tests/components/floating/transaction-form.test.tsx
@@ -606,7 +606,7 @@ describe("TransactionForm", () => {
       });
 
       // No defaultCategoryId so the user starts with an empty category.
-      render(
+      const { container } = render(
         <TransactionForm
           accounts={[ACCT]}
           categories={[CAT]}
@@ -621,14 +621,101 @@ describe("TransactionForm", () => {
       const option = await screen.findByRole("option", { name: /HBO Max/i });
       fireEvent.mouseDown(option);
 
-      // Picking the suggestion fills the description AND, because the
-      // category was empty, pre-fills the category from the most-common
-      // pair. CategorySelect renders the chosen category's name once
-      // selected.
+      // (a) Description fills (proxy assertion, preserved).
       await waitFor(() => {
         const desc = screen.getByLabelText("Description") as HTMLInputElement;
         expect(desc.value).toBe("HBO Max");
       });
+
+      // (b) Category state pins directly to the picked suggestion's
+      // category_id. CategorySelect renders the chosen category name
+      // in its visible <input id="fab-tx-category">, and exposes the
+      // numeric id via the adjacent hidden <input name="...-value">.
+      // Both must agree with SUGGESTION.category_id.
+      await waitFor(() => {
+        const categoryInput = container.querySelector(
+          "#fab-tx-category",
+        ) as HTMLInputElement;
+        expect(categoryInput.value).toBe(CAT.name);
+      });
+      const hiddenCategory = container.querySelector(
+        'input[name="fab-tx-category-value"]',
+      ) as HTMLInputElement;
+      expect(hiddenCategory.value).toBe(String(SUGGESTION.category_id));
+    });
+
+    it("does NOT overwrite an already-chosen category when picking a description suggestion", async () => {
+      // Boundary case for the auto-fill contract in
+      // TransactionForm.tsx:349. When categoryId !== "" at the moment
+      // of pick, the suggestion's category_id MUST NOT clobber the
+      // user's choice. Mirrors the canonical /transactions form's
+      // "optional pre-populate" rule.
+      const OTHER_CAT = {
+        id: 77,
+        name: "Subscriptions",
+        type: "expense" as const,
+        parent_id: null,
+        parent_name: null,
+        description: null,
+        slug: "subscriptions",
+        is_system: false,
+        transaction_count: 0,
+      };
+      const SUGGESTION = {
+        description: "HBO Max",
+        category_id: OTHER_CAT.id, // Different from defaultCategoryId.
+        category_name: OTHER_CAT.name,
+        use_count: 4,
+        last_used: "2026-05-10",
+      };
+      const apiFetchMock = vi.mocked(apiFetch);
+      apiFetchMock.mockReset();
+      apiFetchMock.mockImplementation((path: string) => {
+        if (path.startsWith("/api/v1/transactions/suggestions/descriptions")) {
+          return Promise.resolve({ suggestions: [SUGGESTION] }) as never;
+        }
+        return Promise.resolve({}) as never;
+      });
+
+      // Pre-select CAT (id=10) via defaultCategoryId — categoryId is
+      // NOT empty at the time of pick.
+      const { container } = render(
+        <TransactionForm
+          accounts={[ACCT]}
+          categories={[CAT, OTHER_CAT]}
+          defaultCategoryId={CAT.id}
+          onSaved={() => {}}
+        />,
+      );
+
+      // Sanity: category starts at CAT (Groceries), not OTHER_CAT.
+      const hiddenBefore = container.querySelector(
+        'input[name="fab-tx-category-value"]',
+      ) as HTMLInputElement;
+      expect(hiddenBefore.value).toBe(String(CAT.id));
+
+      fireEvent.change(screen.getByLabelText("Description"), {
+        target: { value: "HB" },
+      });
+      const option = await screen.findByRole("option", { name: /HBO Max/i });
+      fireEvent.mouseDown(option);
+
+      // Description still fills (proves the pick fired).
+      await waitFor(() => {
+        const desc = screen.getByLabelText("Description") as HTMLInputElement;
+        expect(desc.value).toBe("HBO Max");
+      });
+
+      // Category MUST still be CAT — the suggestion's OTHER_CAT.id
+      // was rejected by the `categoryId === ""` guard.
+      const hiddenAfter = container.querySelector(
+        'input[name="fab-tx-category-value"]',
+      ) as HTMLInputElement;
+      expect(hiddenAfter.value).toBe(String(CAT.id));
+      const categoryInput = container.querySelector(
+        "#fab-tx-category",
+      ) as HTMLInputElement;
+      expect(categoryInput.value).toBe(CAT.name);
     });
   });
 

--- a/frontend/tests/components/transactions/link-as-transfer-modal.test.tsx
+++ b/frontend/tests/components/transactions/link-as-transfer-modal.test.tsx
@@ -25,6 +25,7 @@ const expenseLeg: Transaction = {
   settled_date: "2026-04-29",
   is_imported: false,
   is_manual_adjustment: false,
+  tags: [],
 };
 
 const incomeLeg: Transaction = {
@@ -43,6 +44,7 @@ const incomeLeg: Transaction = {
   settled_date: "2026-04-29",
   is_imported: false,
   is_manual_adjustment: false,
+  tags: [],
 };
 
 describe("LinkAsTransferModal", () => {

--- a/frontend/tests/components/transactions/mark-as-transfer-modal.test.tsx
+++ b/frontend/tests/components/transactions/mark-as-transfer-modal.test.tsx
@@ -25,6 +25,7 @@ const source: Transaction = {
   settled_date: "2026-04-29",
   is_imported: false,
   is_manual_adjustment: false,
+  tags: [],
 };
 
 const accounts: Account[] = [

--- a/frontend/tests/components/transactions/tag-chip-input.test.tsx
+++ b/frontend/tests/components/transactions/tag-chip-input.test.tsx
@@ -189,4 +189,85 @@ describe("TagChipInput", () => {
     // primary signal. Typing into a disabled input is a no-op.
     expect(input.disabled).toBe(true);
   });
+
+  it("keeps chip remove buttons reachable + functional at MAX_TAGS (a11y regression)", async () => {
+    // Regression for PR #326 review: at cap, the input is disabled
+    // AND the chip x buttons must remain in the natural tab order so
+    // a keyboard-only user can free a slot. tabIndex={-1} on the
+    // remove buttons would have created a WCAG keyboard trap (no way
+    // to remove a tag once the cap was hit). This test walks the
+    // full recovery path: focus a chip x, press Enter to remove,
+    // then add a new chip back to the cap.
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    const onChange = vi.fn();
+    const initial = Array.from(
+      { length: MAX_TAGS_PER_TRANSACTION },
+      (_, i) => `tag${i}`,
+    );
+
+    function ControlledHarness() {
+      const [tags, setTags] = useState<string[]>(initial);
+      return (
+        <TagChipInput
+          id="cap-test"
+          value={tags}
+          onChange={(next) => {
+            onChange(next);
+            setTags(next);
+          }}
+          fetcher={fetcher}
+          debounceMs={10}
+        />
+      );
+    }
+
+    render(<ControlledHarness />);
+
+    // (1) Input is disabled at the cap.
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+
+    // (2) Every chip x must be tabbable. tabIndex < 0 on any of them
+    // would mean Tab cannot reach it — that is the bug this test
+    // guards against.
+    const removeButtons = screen.getAllByRole("button", {
+      name: /^Remove tag /,
+    });
+    expect(removeButtons).toHaveLength(MAX_TAGS_PER_TRANSACTION);
+    for (const btn of removeButtons) {
+      expect(btn.tabIndex).toBeGreaterThanOrEqual(0);
+      expect((btn as HTMLButtonElement).disabled).toBe(false);
+    }
+
+    // (3) Focus the first chip x as a keyboard user would (in a real
+    // browser, Shift+Tab from the disabled input lands here; jsdom
+    // does not run the Tab-walk algorithm so we focus directly).
+    const firstRemove = removeButtons[0];
+    await act(async () => {
+      firstRemove.focus();
+    });
+    expect(document.activeElement).toBe(firstRemove);
+
+    // (4) Press Enter on the focused x. The component must remove
+    // the chip and call onChange with the cap-1 list.
+    await act(async () => {
+      fireEvent.keyDown(firstRemove, { key: "Enter" });
+    });
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall).toHaveLength(MAX_TAGS_PER_TRANSACTION - 1);
+    expect(lastCall).not.toContain("tag0");
+
+    // (5) Recovery: the input is now re-enabled. Typing a new tag +
+    // Enter commits a chip back up to the cap.
+    const refreshedInput = screen.getByRole("combobox") as HTMLInputElement;
+    expect(refreshedInput.disabled).toBe(false);
+    await act(async () => {
+      fireEvent.change(refreshedInput, { target: { value: "freshtag" } });
+      fireEvent.keyDown(refreshedInput, { key: "Enter" });
+    });
+    const finalCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(finalCall).toContain("freshtag");
+    expect(finalCall).toHaveLength(MAX_TAGS_PER_TRANSACTION);
+  });
 });

--- a/frontend/tests/components/transactions/tag-chip-input.test.tsx
+++ b/frontend/tests/components/transactions/tag-chip-input.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Tag chip input component tests (PR-Tags-A frontend).
+ *
+ * Covers:
+ *   - Renders existing chips with remove buttons.
+ *   - Suggest endpoint is debounced + queried on draft change.
+ *   - Enter on draft commits a chip.
+ *   - Comma commits a chip.
+ *   - Backspace on empty input removes the last chip.
+ *   - Clicking a suggestion commits a chip.
+ *   - Pressing the chip remove button removes the chip.
+ *   - Cap (MAX_TAGS_PER_TRANSACTION) blocks further entries with an
+ *     inline error.
+ *   - aria-live region announces suggestion counts.
+ */
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import TagChipInput, {
+  MAX_TAGS_PER_TRANSACTION,
+  type TagSuggestion,
+} from "@/components/transactions/TagChipInput";
+
+type Fetcher = (
+  prefix: string,
+  categoryId: number | null,
+  signal: AbortSignal,
+) => Promise<TagSuggestion[]>;
+
+function deferred<T>() {
+  let resolveFn!: (v: T) => void;
+  let rejectFn!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolveFn = res;
+    rejectFn = rej;
+  });
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+function Harness({
+  initial = [],
+  fetcher,
+  categoryId = null,
+}: {
+  initial?: string[];
+  fetcher: Fetcher;
+  categoryId?: number | null;
+}) {
+  const [tags, setTags] = useState<string[]>(initial);
+  return (
+    <TagChipInput
+      id="test-tags"
+      value={tags}
+      onChange={setTags}
+      categoryId={categoryId}
+      fetcher={fetcher}
+      debounceMs={10}
+    />
+  );
+}
+
+const SAMPLE: TagSuggestion[] = [
+  { name: "insurance", source: "org_recent", weight: 5 },
+  { name: "groceries", source: "org_co_category", weight: 3 },
+];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TagChipInput", () => {
+  it("renders existing chips and exposes a remove button per chip", () => {
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness initial={["insurance", "rent"]} fetcher={fetcher} />);
+    expect(screen.getByTestId("tag-chip-insurance")).toBeTruthy();
+    expect(screen.getByTestId("tag-chip-rent")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Remove tag insurance" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Remove tag rent" }),
+    ).toBeTruthy();
+  });
+
+  it("commits a typed tag on Enter and clears the draft", async () => {
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "rent" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(screen.getByTestId("tag-chip-rent")).toBeTruthy();
+    expect(input.value).toBe("");
+  });
+
+  it("commits a typed tag on comma", async () => {
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "rent" } });
+      fireEvent.keyDown(input, { key: "," });
+    });
+    expect(screen.getByTestId("tag-chip-rent")).toBeTruthy();
+  });
+
+  it("normalizes uppercase to lowercase on commit", async () => {
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "Insurance" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(screen.getByTestId("tag-chip-insurance")).toBeTruthy();
+  });
+
+  it("removes the last chip on Backspace when the input is empty", async () => {
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness initial={["one", "two"]} fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      fireEvent.keyDown(input, { key: "Backspace" });
+    });
+    expect(screen.queryByTestId("tag-chip-two")).toBeNull();
+    expect(screen.getByTestId("tag-chip-one")).toBeTruthy();
+  });
+
+  it("removes a chip when its remove button is clicked", async () => {
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness initial={["one", "two"]} fetcher={fetcher} />);
+    const removeBtn = screen.getByRole("button", { name: "Remove tag one" });
+    await act(async () => {
+      fireEvent.click(removeBtn);
+    });
+    expect(screen.queryByTestId("tag-chip-one")).toBeNull();
+  });
+
+  it("fetches suggestions after debounce and commits one on click", async () => {
+    const d = deferred<TagSuggestion[]>();
+    const fetcher: Fetcher = vi.fn().mockReturnValue(d.promise);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "in" } });
+      // Advance through the 10ms debounce.
+      await vi.advanceTimersByTimeAsync(15);
+      d.resolve(SAMPLE);
+    });
+    const option = await screen.findByRole("option", { name: /insurance/ });
+    await act(async () => {
+      fireEvent.mouseDown(option);
+    });
+    expect(screen.getByTestId("tag-chip-insurance")).toBeTruthy();
+  });
+
+  it("announces suggestion count to the aria-live region", async () => {
+    const d = deferred<TagSuggestion[]>();
+    const fetcher: Fetcher = vi.fn().mockReturnValue(d.promise);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "in" } });
+      await vi.advanceTimersByTimeAsync(15);
+      d.resolve(SAMPLE);
+    });
+    await waitFor(() => {
+      const live = screen.getByRole("status");
+      expect(live.textContent).toContain("2 suggestions available");
+    });
+  });
+
+  it("caps at MAX_TAGS_PER_TRANSACTION and surfaces an inline error", async () => {
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    const initial = Array.from(
+      { length: MAX_TAGS_PER_TRANSACTION },
+      (_, i) => `tag${i}`,
+    );
+    render(<Harness initial={initial} fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    // The input is disabled when at cap; the disabled state is the
+    // primary signal. Typing into a disabled input is a no-op.
+    expect(input.disabled).toBe(true);
+  });
+});

--- a/frontend/tests/components/transactions/unpair-transfer-modal.test.tsx
+++ b/frontend/tests/components/transactions/unpair-transfer-modal.test.tsx
@@ -69,6 +69,7 @@ const expenseLeg: Transaction = {
   settled_date: "2026-04-28",
   is_imported: false,
   is_manual_adjustment: false,
+  tags: [],
 };
 
 const incomeLeg: Transaction = {
@@ -87,6 +88,7 @@ const incomeLeg: Transaction = {
   settled_date: "2026-04-30",
   is_imported: false,
   is_manual_adjustment: false,
+  tags: [],
 };
 
 const categories: Category[] = [


### PR DESCRIPTION
## Summary

Mounts a new `TagChipInput` in the AppShell quick-add slide-in form (`components/floating/TransactionForm.tsx`) and the inline single-tx add/edit forms on `/transactions`. Persists the chip set via `PUT /api/v1/transactions/{id}/tags` after the create/update returns. Tag chips render below the description on every transactions list row (desktop + mobile). Backend (PR #196) is unchanged — `TransactionResponse` already carries `tags`, `GET /api/v1/tags/suggest` drives the typeahead, and the per-transaction tag-replace endpoint already exists.

Combobox follows the same a11y pattern as `DescriptionAutocomplete` (role=combobox, aria-controls listbox, aria-activedescendant, polite live region for suggestion counts). Each chip has a `Remove tag <name>` button. Cap of 5 tags is enforced client-side and on the server.

## Follow-ups (intentionally out of scope)

- Dedicated `/tags` management page (rename/delete tags).
- Tag-based filtering on the transactions list (the backend filter already exists at `GET /api/v1/transactions?tags=...&tag_match=all|any`).
- Batch entry (`/transactions/batch`) per-row tag input — current grid layout has no spare column, deferred.
- Org settings UI toggle for `share_tag_data` opt-in (cross-org dictionary).
- Bulk-operation tag changes.