### PR TITLE
chore(captcha): Turnstile appearance=always — visible widget on /register

### DIFF
--- a/frontend/components/auth/RegisterPageBody.tsx
+++ b/frontend/components/auth/RegisterPageBody.tsx
@@ -266,7 +266,7 @@ export default function RegisterPageBody({ cspNonce }: RegisterPageBodyProps) {
               <Turnstile
                 ref={turnstileRef}
                 siteKey={captchaSiteKey}
-                options={{ action: "register", appearance: "interaction-only" }}
+                options={{ action: "register", appearance: "always" }}
                 scriptOptions={{ nonce: cspNonce }}
                 onSuccess={(token) => setCaptchaToken(token)}
                 onExpire={() => setCaptchaToken("")}


### PR DESCRIPTION
## Summary

- Flips the Turnstile widget appearance from \`interaction-only\` (invisibly resolves for low-risk browsers) to \`always\` (Cloudflare badge always visible).
- Same gate, same backend verify, no behavioral change for the security boundary — just a legible UX signal that the form is protected.

## After merge

Trigger the deploy workflow manually (\`gh workflow run deploy.yml --ref main\` or via UI). Frontend rebuild required — the appearance option lives in the client bundle.

The \`appearance\` literal is not an \`NEXT_PUBLIC_*\` env so this is a pure code change; rebuild is needed only because Next inlines the component code at build.