### PR TITLE
chore(specs): migrate design docs from local memory to repo

### DIFF
--- a/specs/accounts-side-by-side-layout.md
+++ b/specs/accounts-side-by-side-layout.md
@@ -2,7 +2,6 @@
 name: Accounts Page Side-by-Side Layout (follow-up to PR #199)
 description: User suggestion 2026-05-10 to put Account Types and Accounts cards side-by-side again, but with reduced "Account" column widths so both cards fit cleanly without the cramping that made PR #199 necessary.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Captured 2026-05-10.** PR #199 stacked the two cards vertically because the side-by-side layout cramped the Accounts list at lg+ viewports. User confirmed the stack works ("it's fixed"), but suggested an alternative shape:
 

--- a/specs/accounts-side-by-side-layout.md
+++ b/specs/accounts-side-by-side-layout.md
@@ -1,0 +1,32 @@
+---
+name: Accounts Page Side-by-Side Layout (follow-up to PR #199)
+description: User suggestion 2026-05-10 to put Account Types and Accounts cards side-by-side again, but with reduced "Account" column widths so both cards fit cleanly without the cramping that made PR #199 necessary.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Captured 2026-05-10.** PR #199 stacked the two cards vertically because the side-by-side layout cramped the Accounts list at lg+ viewports. User confirmed the stack works ("it's fixed"), but suggested an alternative shape:
+
+> "We could definitely put the cards side by side using the same format you have now, but just reducing the 'Account' column width for both cards."
+
+## Concept
+
+Today's stacked layout (post-#199) uses each card's full content width. The Accounts list shows: Account name + type + close-day · Balance · Edit · Adjust balance · Set default · Deactivate · Delete. That's a lot of horizontal real estate per row.
+
+The friend's suggestion: put Account Types and Accounts back side-by-side at lg+, but tighten the "Account" column on both so the action cluster fits.
+
+## Open design questions
+
+1. **What's the minimum Account column width** that doesn't truncate "ING Mastercard" + "Credit Card" + "closes day 5" on one line? Probably ~22ch with truncation.
+2. **Action cluster width** — 5 actions at ~80px each is ~400px. Can compress to icon-only buttons with tooltips? Or hide-on-hover overflow-menu pattern?
+3. **Account Types card sizing** — small (5 system rows in fresh installs). Side-by-side at 1:1 wastes left half. Maybe asymmetric grid: `grid-cols-[20rem_1fr]` so Types is ~320px and Accounts gets the remaining width.
+4. **Tablet (768-1023)** — current PR #199 keeps it stacked. The side-by-side variant might still want to stack at md and only split at lg+ given remaining width.
+
+## Why park it
+
+PR #199 solved the immediate visual regression. The side-by-side variant is polish, not a bug fix. Sized S-M depending on whether action cluster collapse is needed. Not a launch blocker.
+
+## Cross-references
+
+- PR #199 (current stacked layout)
+- PR #188 (Accounts list headers + fixed action column — still in effect post-#199)
+- R1 responsive audit findings doc (mobile/tablet/desktop parity is the broader workstream)

--- a/specs/apex-orphaned-static-cleanup.md
+++ b/specs/apex-orphaned-static-cleanup.md
@@ -1,0 +1,68 @@
+---
+name: Apex S3 — clean up orphaned _next/static chunks
+description: PR #267 stopped using --delete on the immutable hashed-asset sync to avoid 404ing browser-cached HTML, leaving orphaned chunks accumulating. Needs a periodic cleanup.
+type: project
+originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
+---
+# Orphaned hashed-asset cleanup for apex S3
+
+## Background
+
+PR #267 (apex deploy workflow) changed the sync strategy after owner review caught a race:
+- Old behavior: `aws s3 sync out-apex/_next/static/ s3://bucket/_next/static/ --delete` could delete chunks still referenced by browser-cached HTML (5-min TTL), producing 404s for users mid-deploy.
+- New behavior: hashed-asset sync uploads first WITHOUT --delete. Mutable sync runs second WITH --delete and `--exclude "_next/static/*"`. Safe deploy order; chunks always exist before HTML references them; old chunks survive the deploy window.
+
+Trade-off: hashed chunks orphaned by a rename (Next.js content-hashes filenames on every change) are never pruned by the deploy. They accumulate forever.
+
+## What PR #240's lifecycle rule does NOT cover
+
+The S3 bucket has `aws_s3_bucket_lifecycle_configuration.apex` expiring noncurrent versions after 90 days. That rule handles objects where the SAME KEY gets overwritten and the old version becomes noncurrent. It does NOT handle hashed chunks whose key changes entirely (e.g., `app-abc123.js` → `app-def456.js` is a new key, the old one remains current forever from S3's POV).
+
+## Why it's low-priority
+
+- Each hashed chunk is small (KB to low MB). Even with daily deploys, annual storage growth is at most a few hundred MB.
+- S3 Standard is ~$0.023/GB/mo. Years of accumulation costs cents.
+- No correctness or performance issue, purely housekeeping.
+
+## Two implementation options
+
+### Option A: S3 lifecycle rule (IaC, preferred)
+
+Add a lifecycle rule to `infra/terraform/apex/main.tf`'s `aws_s3_bucket_lifecycle_configuration.apex`:
+
+```hcl
+rule {
+  id     = "expire-orphaned-next-static"
+  status = "Enabled"
+  filter {
+    prefix = "_next/static/"
+  }
+  expiration {
+    days = 30
+  }
+}
+```
+
+**Risk:** this expires the CURRENT version after 30 days, NOT just orphans. Any chunk that was uploaded 31 days ago and is still referenced by current HTML would 404. The deploy workflow re-uploads chunks on every deploy so any in-use chunk gets its mtime refreshed, but only if it's part of the new build output. A chunk that hasn't changed across deploys (rare for Next.js but possible for content-stable utility chunks) could age out while still in use.
+
+Mitigation: bump to 90 days, or run apex deploy on a regular cadence (cron) so all current chunks stay refreshed.
+
+### Option B: Scheduled cleanup workflow (GH Actions, more precise)
+
+Add a weekly GH Actions workflow that:
+1. Fetches the current bucket's `_next/static/` object list.
+2. Downloads the current `index.html` and crawls referenced `/_next/static/...` URLs (or downloads `_meta.json` to confirm which build SHA is current).
+3. Computes the diff: objects in bucket not referenced by current HTML.
+4. Deletes orphans older than N days.
+
+More precise but more code, more failure modes. Probably overkill for a landing site.
+
+## Recommended path
+
+Option A with `days = 90`, scoped to `_next/static/` prefix. The 90-day window matches the existing noncurrent-version expiry, gives a generous safety margin, and is IaC-managed (no scheduled job to maintain).
+
+Effort: XS. One Terraform PR, single resource block addition.
+
+## When to do this
+
+Post-launch. Storage cost is irrelevant for the first ~6 months even if we deploy 10x/day.

--- a/specs/apex-orphaned-static-cleanup.md
+++ b/specs/apex-orphaned-static-cleanup.md
@@ -2,7 +2,6 @@
 name: Apex S3 — clean up orphaned _next/static chunks
 description: PR #267 stopped using --delete on the immutable hashed-asset sync to avoid 404ing browser-cached HTML, leaving orphaned chunks accumulating. Needs a periodic cleanup.
 type: project
-originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
 ---
 # Orphaned hashed-asset cleanup for apex S3
 

--- a/specs/apex-s3-cloudfront-l5-2a.md
+++ b/specs/apex-s3-cloudfront-l5-2a.md
@@ -2,7 +2,6 @@
 name: Apex landing on AWS S3 + CloudFront (L5.2a)
 description: Strategic shift 2026-05-12 — drop Cloudflare from the apex landing plan; host the apex marketing site on AWS S3 (private) + CloudFront (OAC + ACM) instead. Standard SaaS pattern. Brainstorm + open decisions captured here pending owner decisions.
 type: project
-originSessionId: 8c696f02-828f-45cb-8352-6fc04e4fb413
 ---
 # Apex landing on AWS S3 + CloudFront
 

--- a/specs/apex-s3-cloudfront-l5-2a.md
+++ b/specs/apex-s3-cloudfront-l5-2a.md
@@ -1,0 +1,126 @@
+---
+name: Apex landing on AWS S3 + CloudFront (L5.2a)
+description: Strategic shift 2026-05-12 — drop Cloudflare from the apex landing plan; host the apex marketing site on AWS S3 (private) + CloudFront (OAC + ACM) instead. Standard SaaS pattern. Brainstorm + open decisions captured here pending owner decisions.
+type: project
+originSessionId: 8c696f02-828f-45cb-8352-6fc04e4fb413
+---
+# Apex landing on AWS S3 + CloudFront
+
+**Locked direction (2026-05-12):** apex `thebetterdecision.com` will be served from AWS S3 + CloudFront. `app.thebetterdecision.com` stays on DigitalOcean App Platform. Cloudflare is dropped from the apex plan.
+
+**Status:** brainstorm, open decisions surfaced below. No dispatch until decisions are locked.
+
+## Recommended architecture (one canonical stack)
+
+```
+Route 53 zone (thebetterdecision.com, existing)
+├── thebetterdecision.com           A     → ALIAS → CloudFront distribution
+├── www.thebetterdecision.com       A     → ALIAS → CloudFront distribution (same)
+└── app.thebetterdecision.com       CNAME → ondigitalocean.app (unchanged)
+
+CloudFront distribution
+├── Default origin: S3 bucket (private, OAC, region eu-west-1 or us-east-1)
+├── TLS: ACM cert in us-east-1 (CloudFront requirement) for apex + www
+├── Response-headers policy: HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy
+├── Cache policy: long TTL on hashed assets, short TTL on /index.html
+└── Behaviors: redirect HTTP -> HTTPS, optionally www -> apex via Lambda@Edge or CloudFront Function
+
+S3 bucket
+├── Block all public access (bucket private, OAC is the only reader)
+├── Versioning ON (rollback)
+└── Server-side encryption (SSE-S3)
+
+IAM
+├── GitHub Actions OIDC role: s3:PutObject + s3:DeleteObject + cloudfront:CreateInvalidation
+└── TFC OIDC role: full infra provisioning (s3, cloudfront, route53, acm, iam)
+
+Build + deploy
+├── GitHub Actions on push to main touching landing/* or matching path filter
+├── Builds Next.js static export of the landing surface only
+├── Aws s3 sync to bucket
+└── CloudFront invalidation for /index.html and /
+```
+
+## Open owner decisions
+
+### D1 — Cloudflare scope
+
+The 2026-05-12 instruction was "remove Cloudflare from the game for now" with explicit reference to the apex landing. Two interpretations:
+
+- **D1.A (default reading):** Cloudflare is out of the apex landing only. `app.` may still adopt Cloudflare later as a CDN/WAF if desired (currently `app.` is directly on DO App Platform).
+- **D1.B (broader reading):** Cloudflare is out of the entire product stack. `app.` stays on DO without any external CDN/WAF in front of it.
+
+**Coordinator recommendation:** D1.A. `app.` stays as-is for now; Cloudflare/CloudFront/etc. in front of `app.` is a separate later decision.
+
+### D2 — AWS account
+
+The roadmap and infra-followups memory don't reference an existing AWS account for this project. To proceed:
+
+- **D2.A:** Existing personal AWS account holds the bucket + DNS. Quickest path. Owner is also account admin.
+- **D2.B:** New AWS Organization with a dedicated `pfv-prod` account, owner is the org root. More boundary-clean, more setup.
+- **D2.C:** Same Linode/DO budget umbrella, with AWS only used for the marketing surface. Pragmatic middle ground if a personal AWS already exists.
+
+**Coordinator recommendation:** D2.A (existing personal AWS) for v1. Move to dedicated account if AWS surface grows past landing. Owner names which account ID + region; everything else falls out.
+
+### D3 — Build pipeline shape
+
+Two viable shapes for the Next.js landing static export:
+
+- **D3.A (single repo, single Next.js app, two outputs):** Add `output: 'export'` to a SECOND build target inside the existing `frontend/` Next.js project, scoped to landing routes only. One source of truth for components; landing inherits the `<Logo />`, `lib/brand.ts`, design tokens. Single PR sequence.
+- **D3.B (extract `apex/` subdirectory):** Move landing to a fresh top-level `apex/` Next.js or Astro project. Independent lifecycle, cleaner boundaries. Bigger refactor; landing components duplicate or get shared via a workspace package.
+- **D3.C (hand-rolled static HTML):** Generate landing from current Next.js components into a small set of HTML files. Smallest blast radius, but the maintenance story degrades fast once we want any dynamism.
+
+**Coordinator recommendation:** D3.A. Reuses the already-shipped landing from PR #230 (TopNav / Hero / FeatureTiles / SecondCta / LandingFooter), keeps brand assets in one place. Caveat: the existing `LandingAuthRedirect` client island calls `useAuth` — on apex it'll be a no-op (no app cookies cross domain boundaries) but it will ship as inert JS. Either keep it and accept ~5 KB inert, or stub it out at build time. Easy follow-up.
+
+### D4 — Credential mechanism
+
+Two real options for TFC + GH Actions ↔ AWS:
+
+- **D4.A (static IAM access keys):** Generate two IAM users (one for TFC, one for GH Actions), store keys as TFC env variables and GH repo secrets. Quick to set up; rotation is manual.
+- **D4.B (OIDC federation):** TFC and GH Actions assume IAM roles via OIDC — no long-lived secrets stored anywhere. Setup is a one-time IAM trust-policy + Terraform `aws_iam_role`. The locked policy `feedback_terraform_vcs_only` is happy here because TFC's OIDC integration runs through TFC's existing VCS-driven flow.
+
+**Coordinator recommendation:** D4.B. No long-lived AWS credentials, audit-friendlier, matches the trajectory of the rest of the infra. Initial setup is ~30 minutes of TFC + AWS IAM console work plus a Terraform module.
+
+### D5 — Cutover phasing
+
+Five-phase plan, where only phase 5 is irreversible:
+
+1. **Phase 1 — Terraform provisions (no DNS changes yet).** S3 bucket, CloudFront distribution, ACM cert (DNS-validated via Route 53, no record yet for the apex itself), IAM OIDC roles. CloudFront distribution gets a `dXXX.cloudfront.net` URL. Reversible.
+2. **Phase 2 — Build + deploy pipeline.** GH Actions workflow with OIDC assume-role; pushes static export to S3; invalidates CloudFront. Verify by hitting the cloudfront.net URL directly. Reversible.
+3. **Phase 3 — Soft validation.** Owner reviews the cloudfront.net URL end-to-end: layout, fonts, OG image, links to `app.thebetterdecision.com/register` + `/login`. Reversible.
+4. **Phase 4 — TTL drop.** Terraform lowers Route 53 apex record TTL to 60s ahead of cutover. Reversible.
+5. **Phase 5 — DNS cutover.** Terraform swaps the apex `A` ALIAS from current target to the CloudFront distribution. Rollback = revert Terraform PR. ~5-minute propagation at the dropped TTL.
+
+**Coordinator recommendation:** adopt this phasing as-is. Each phase is its own small Terraform PR.
+
+## Dispatch sequence (not yet fired)
+
+Pending D1–D5 lock:
+
+1. **PR-A — Terraform: S3 + CloudFront + ACM + OIDC roles (no DNS).** Provisions infrastructure; doesn't change Route 53 yet beyond ACM DNS validation records.
+2. **PR-B — GH Actions: build + deploy workflow.** Workflow file + path filters + OIDC role ARN + invalidation step. Test against the cloudfront.net URL.
+3. **PR-C — Next.js: landing static-export build target.** `next.config` second target, build script, output sanity test.
+4. **PR-D — Terraform: Route 53 cutover.** Drop TTL first commit, swap apex record second commit. Owner approves apply in TFC.
+
+Each PR is small, reversible, and dispatchable to a separate team. PR-A and PR-C can run in parallel (different files, different domains). PR-B depends on PR-A's OIDC role ARN. PR-D depends on PR-A, PR-B, PR-C all being merged.
+
+## Estimated cost
+
+S3: cents/month. CloudFront: ~$1/month for landing traffic. ACM: free. Route 53: $0.50/month (existing). IAM OIDC: free. Total **<$3/month** new spend.
+
+## Risk inventory
+
+- **DNS cutover** is the only irreversible-without-impact step. TTL drop + Terraform-managed change makes rollback fast.
+- **www → apex redirect:** the spec doesn't lock this. Sane default: redirect www to apex via CloudFront Function (negligible cost; supports the canonical-URL story from L5.2).
+- **OIDC trust setup error:** common failure mode. Test by running a no-op Terraform plan through TFC and a no-op `aws s3 ls` from GH Actions before any real apply.
+- **ACM cert is in us-east-1 by CloudFront requirement** even if the bucket is eu-west-1. This is fine; just call it out in the Terraform module.
+- **Locale / latency:** CloudFront is a global edge network; serves EU traffic from EU PoPs. No SLA concern.
+
+## Touch points (post-decision)
+
+- New: `infra/terraform/apex/*.tf` (S3, CloudFront, ACM, IAM OIDC, Route 53 record).
+- New: `.github/workflows/deploy-apex.yml`.
+- New: `frontend/next.config.apex.ts` (or equivalent flag inside the existing `next.config`).
+- New: `frontend/scripts/build-apex.sh` orchestrating the static export.
+- Update: `infra/terraform/README.md` to document the AWS workspace + OIDC trust.
+- Update: this memo + `project_roadmap.md` once cutover lands.

--- a/specs/appshell-header-balance.md
+++ b/specs/appshell-header-balance.md
@@ -1,0 +1,69 @@
+---
+name: AppShell Header Layout Balance
+description: Rebalance AppShell header. Today's left-only cluster (trial banner + New Transaction CTA + docs + theme toggle) leaves the right side empty and looks lopsided. Use /impeccable critique when picking this up.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Captured 2026-05-10.** Backlog item, sized S. Pure layout polish on AppShell header.
+
+## Symptom
+
+Today's AppShell header (post-#200) has all interactive elements clustered on the LEFT:
+- Trial banner ("Trial ending today Upgrade")
+- `+ New Transaction` brass CTA
+- Docs help icon
+- Theme toggle (sun/moon)
+
+The RIGHT side is empty. The visual weight is lopsided. Users coming from other SaaS apps expect primary actions and secondary chrome to split between left (brand/nav) and right (user/account/actions).
+
+Reference screenshot at `~/.claude/image-cache/0bf77f16-13ef-4926-8a64-7a5ddd96efc6/43.png`.
+
+## What's blocking a quick fix
+
+This isn't a "just move the button" decision. The header has competing tenants:
+- The `+ New Transaction` CTA is the primary action (brass, frequent use, AppShell-mounted from #200).
+- The trial banner is conditional and time-sensitive.
+- The docs/help link is meta-navigation.
+- The theme toggle is preference.
+- A future feedback widget (per `project_inapp_feedback_widget.md`) will likely also live in this region.
+
+Splitting these between left and right requires deciding the convention: what goes left, what goes right, what's the tab/keyboard order, what stays consistent across mobile/tablet/desktop, what becomes a dropdown menu.
+
+## Recommended approach when picking up
+
+Use `/impeccable critique` on the AppShell header layout. The impeccable plugin (loaded in this project at `/Users/fjorge/.claude/plugins/cache/impeccable/impeccable/3.0.7`) will:
+- Run the cognitive load + Nielsen heuristics scoring.
+- Surface the AppShell-specific anti-patterns (left-clustered actions, empty right side, ambiguous primary-action placement).
+- Recommend a redesign that respects DESIGN.md's tokenized colors and PRODUCT.md's editorial-confident voice (one brass moment per screen).
+
+Avoid invoking impeccable cold without context. The setup gates need PRODUCT.md + DESIGN.md context loaded; both are already in place (`load-context.mjs` runs).
+
+## Likely answer (preview, do not commit)
+
+Conventional split for a financial-planning product:
+- **Left:** brand mark, primary nav (already there).
+- **Right:** trial banner (when present), help icon, theme toggle, future feedback widget, future user menu / org switcher.
+- **Primary CTA `+ New Transaction`:** could live either left-anchored (next to brand, "always-available add") or right-anchored (next to user actions, "this is your action"). The impeccable critique should pick.
+
+Don't pre-commit to a layout — let the critique drive it.
+
+## Acceptance criteria
+
+- Run `/impeccable critique` on the AppShell header.
+- Pick a layout that resolves the right-side emptiness.
+- Apply changes via a focused PR. Single file (AppShell.tsx) ideally.
+- Tests: existing AppShell tests still pass; a11y test confirms tab order is sensible.
+- Mobile collapse behavior preserved (CTA still icon-only on narrow widths per #200's spec).
+- Trial banner placement remains conditional (only shown during trial period).
+- Brass focus rings preserved on all pressable elements (per DESIGN.md Pressable-Surfaces Rule).
+
+## Why park
+
+Visual polish, not a functional bug. Users can still access every action; they're just clustered. The impeccable critique should run when there's bandwidth to apply the recommendation properly, not as a rushed move.
+
+## Cross-references
+
+- PR #200 — AppShell CTA mounted with route-gated visibility
+- `project_inapp_feedback_widget.md` — future feedback widget that will share this header region
+- DESIGN.md — One Brass Rule, Tonal Depth Rule, Pressable-Surfaces Rule
+- PRODUCT.md — editorial-confident voice; users open the app to make decisions

--- a/specs/appshell-header-balance.md
+++ b/specs/appshell-header-balance.md
@@ -2,7 +2,6 @@
 name: AppShell Header Layout Balance
 description: Rebalance AppShell header. Today's left-only cluster (trial banner + New Transaction CTA + docs + theme toggle) leaves the right side empty and looks lopsided. Use /impeccable critique when picking this up.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Captured 2026-05-10.** Backlog item, sized S. Pure layout polish on AppShell header.
 
@@ -16,7 +15,7 @@ Today's AppShell header (post-#200) has all interactive elements clustered on th
 
 The RIGHT side is empty. The visual weight is lopsided. Users coming from other SaaS apps expect primary actions and secondary chrome to split between left (brand/nav) and right (user/account/actions).
 
-Reference screenshot at `~/.claude/image-cache/0bf77f16-13ef-4926-8a64-7a5ddd96efc6/43.png`.
+Reference screenshot captured in operator's local notes (not in repo).
 
 ## What's blocking a quick fix
 
@@ -31,7 +30,7 @@ Splitting these between left and right requires deciding the convention: what go
 
 ## Recommended approach when picking up
 
-Use `/impeccable critique` on the AppShell header layout. The impeccable plugin (loaded in this project at `/Users/fjorge/.claude/plugins/cache/impeccable/impeccable/3.0.7`) will:
+Use `/impeccable critique` on the AppShell header layout. The impeccable plugin will:
 - Run the cognitive load + Nielsen heuristics scoring.
 - Surface the AppShell-specific anti-patterns (left-clustered actions, empty right side, ambiguous primary-action placement).
 - Recommend a redesign that respects DESIGN.md's tokenized colors and PRODUCT.md's editorial-confident voice (one brass moment per screen).

--- a/specs/architect-review-2026-05-02.md
+++ b/specs/architect-review-2026-05-02.md
@@ -2,7 +2,6 @@
 name: System Architect Review 2026-05-02
 description: External architect review of PFV — captures roadmap-level recommendations to apply post-L3.10. Also records what the team explicitly disagreed on and why.
 type: project
-originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
 ---
 ## Context
 

--- a/specs/architect-review-2026-05-02.md
+++ b/specs/architect-review-2026-05-02.md
@@ -1,0 +1,75 @@
+---
+name: System Architect Review 2026-05-02
+description: External architect review of PFV — captures roadmap-level recommendations to apply post-L3.10. Also records what the team explicitly disagreed on and why.
+type: project
+originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
+---
+## Context
+
+External system architect reviewed the PFV codebase, status, roadmap, smart-rules spec, billing-flow notes, and test backlog on **2026-05-02** (during L3.10 implementation). Net assessment: PFV is no longer a prototype — it has a "fairly serious SaaS skeleton." The biggest 1.0 risk is **product completeness around import, onboarding, trust, and operations**, not core code structure.
+
+**Why:** Sanity check before scope balloons further. Architect was specifically asked to flag risks where the team has been engineering-strong and product-thin.
+
+**How to apply:** Treat this as the next-backlog list once L3.10 ships. NONE of these are in scope for the current `feat/smart-rules-categorization` branch.
+
+---
+
+## In-flight (applied during L3.10)
+
+| Item | Decision | Action taken |
+|---|---|---|
+| Tougher normalization tests + restore spec's "longest letter-run" tokenization | **Applied** | Plan Task 2 expanded with ~13 messy real-world descriptors (IBAN tails, double terminal IDs, double dates, accent folding, URL-ish merchants) and the implementation now does explicit token-walking, not just regex chains. |
+| Conservative learning ("don't overwrite high-match rules on a single edit") | **Deferred** | Stay with most-recent-wins per locked spec. Fjorge's stance: user picks are commands, not AI suggestions; the opposite failure mode ("I keep editing this and it won't stick") is worse. Architect agreed: "Do not change learning semantics yet. Adds policy before evidence." Revisit after metrics show whether sticky bad rules are real. |
+| Smart-rules metrics from day one | **Applied (with architect's refinement)** | Plan Tasks 6/7 now emit `smart_rules.preview_built` (one aggregate per preview) and `smart_rules.import_executed` (one aggregate per import). `smart_rules.miss` fires per UNIQUE normalized token within an import, NOT per row — keeps "top missed tokens" answerable later without log spam. Privacy: `org_id` and `normalized_token` only; raw description never logged. |
+
+---
+
+## Post-L3.10 backlog (the architect's pull-forward list)
+
+Order is rough priority. Sequencing details belong in `project_roadmap.md` once L3.10 ships and we re-plan Week 7+.
+
+### Trust + product completeness (cheap, launch-relevant)
+
+1. **Uncategorized Inbox** — focused view for transactions with no category. Pairs with smart rules. Daily workflow: "clean up what the importer couldn't classify." High user value, ~2 day build.
+2. **Import Quality Dashboard** — after each import, show: imported count, skipped duplicates, transfers detected, uncategorized count, suggestions accepted. Turns import from black box into transparent step. Reuses the metrics scaffold from L3.10. ~1-2 day build.
+3. **Data Export** (GDPR portability) — currently in P1; pull forward. Simple ZIP with CSV/JSON. ~1 day. Trust-relevant for finance.
+4. **Account Closure / Delete My Data** — even if v1 is "request deletion" via email + admin tool. ~1 day. Trust-relevant.
+5. **Opening Balance UX** — already on pentest follow-ups. Either reject non-zero balance at create OR auto-create opening-balance transaction atomically. Architect prefers the latter (better UX). Decide before opening the PR.
+6. **Global error / empty / loading states** (L5.7) — pull forward. Public products feel fragile when framework defaults leak. Add empty states for transactions, budgets, forecasts, imports.
+7. **First-Run Setup Wizard** (L3.3) — short flow: create accounts, choose/import categories, set period dates, optionally seed demo data, then import. More important for conversion than several advanced analytics features.
+
+### Sequencing the architect explicitly called out
+
+8. **L4.7 Audit log before more admin power.** L4.3 already introduced destructive admin ops with structlog events. Persist them before adding impersonation, user management actions, feature overrides, manual verification, or payment adjustments. Treat L4.7 as a near-term platform primitive, not a later admin nice-to-have.
+9. **L4.11 Plan features & org overrides BEFORE any LAI work.** Already locked in roadmap (Week 8). Architect is just confirming the sequencing — don't ship Pro positioning, AI plan columns, or per-org comps until L4.11 lands.
+10. **LAI.1 ONLY after smart-rules coverage is measured**, then **LAI.5 usage caps before any broader AI surface**. Don't rush the LLM tier just because the column exists.
+
+### Operational observability for support (paid-launch gate, not public-beta)
+
+11. Request correlation, auth context, user/org drilldown, persisted admin events. L4.7 + L4.9 are the backbone. Without them, support keeps requiring raw DB / log spelunking. Acceptable gap for the friend-tester phase; not acceptable once paid.
+
+### Help / support surface
+
+12. **Help/Manual focused on workflows**, not generic docs. Topics: "import bank CSV", "fix uncategorized transactions", "set billing cycle", "understand forecast vs plan", "reset demo data".
+13. **User-Visible Security Activity** — login history, active sessions, MFA changes, password changes. Post-launch nice-to-have; reinforces trust + helps support.
+14. **Admin Support Timeline** — per-org timeline of imports, subscription changes, admin actions, member invites, resets, exports. Backed by L4.7 audit events. Builds on item 8.
+
+### The architectural slow-burn (most important and most underweighted)
+
+15. **Billing period model is at risk of becoming a UX trap.** Schema supports explicit period dates, but if the UI stays cycle-day-driven, users with salary-anchored periods, multi-card cycles, or provider spillover will fight the app. Budget vs Forecast 1.0 (PR #100) started fixing this. The next time we touch a period-aware screen, drop the "current period = calendar month" assumption end-to-end. Doesn't ship a feature; changes how every screen thinks. The most subtle and most important point in the review.
+
+---
+
+## Architect's launch-gate framing (advisory, not adopted as ceremony)
+
+The architect proposed three explicit gates: Public Beta / Paid Launch / Pro Differentiation.
+
+**Decision:** **don't formalize gate names.** PFV is one person's side project being tested by EU friends. Naming gates implies process. Track sequencing in the roadmap and project_status; that's enough. The implicit version of the architect's framing is already in place: friends now (L3.10 + L1.4-L1.6 security finish + this backlog), charge when L2 + L4.11 + L4.7 + closure flow are all done, AI tier last.
+
+**What to take from the framing anyway:** the prioritization signal — security-finish (L1.4/L1.5/L1.6) and import-hardening should rank higher than they currently do, because they're cheap and trust-visible.
+
+---
+
+## Changelog
+
+- **2026-05-02** — Initial capture during L3.10 implementation. A + C applied in plan; B deferred; D (this file) recorded as next-backlog reference.

--- a/specs/archive/shipped-bot-signup-captcha.md
+++ b/specs/archive/shipped-bot-signup-captcha.md
@@ -1,0 +1,58 @@
+---
+name: bot-signup-wave-captcha-gate-tomorrow-first-thing
+description: "2026-05-20 EOD — bot wave hitting /register with garbage usernames (e.g. \"XzYtsQPnOBeMfkdTQYV\"), never verifying. 403/445 emails bouncing (~90% bounce rate). Op manually deleting orgs. First-thing-tomorrow: add CAPTCHA to registration."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 07e4bc03-eeac-434d-b0e3-5566db6bbda8
+---
+
+# Bot signup wave — CAPTCHA gate (P0 for 2026-05-21)
+
+## Symptom (as of 2026-05-20 EOD)
+
+- Started ~3 days ago (2026-05-17 ish — confirm with `audit_events` / `users.created_at` timestamps when investigating).
+- New users registering with garbage random-string usernames: `"XzYtsQPnOBeMfkdTQYV"` is the operator's example. Pattern: ~20-char alnum, no human structure.
+- Email verification step never completed by these accounts → orphan unverified users + orgs.
+- Provider bounce rate: **403 bounced / 445 sent ≈ 90.6%** in the affected window. Most "users" supplied fake emails too.
+- Operator has been manually deleting these orgs as they appear. Not sustainable.
+
+## Working hypothesis
+
+Botnet probing the public `/api/v1/auth/register` endpoint. Pre-launch app, low real signup volume, so the spike is conspicuous against the baseline. Possible motives: building a list of valid-looking accounts for later abuse, recon for a credential-stuffing pivot, or generic spam-relay testing. Operator's read: "likely attempts to invade the system."
+
+## Required defense (build first thing 2026-05-21)
+
+**Add a CAPTCHA to the registration flow.** No further design discussion needed before tomorrow — this is the gate. Candidate primitives (operator picks at brainstorm time):
+
+- **hCaptcha** — privacy-leaning, free tier sufficient, easy to wire to FastAPI as a server-side verify call against `https://api.hcaptcha.com/siteverify`. Frontend renders the widget.
+- **Cloudflare Turnstile** — invisible-by-default, lower UX friction, requires Cloudflare account but no domain on CF needed for the widget itself. Server-side verify against `https://challenges.cloudflare.com/turnstile/v0/siteverify`.
+- **Google reCAPTCHA v3** — invisible/score-based, but operator has been steering away from Google deps in this app. Likely not the pick.
+
+Operator's preference TBD at brainstorm. Default recommendation: Turnstile for the invisible UX, with a server-side verify in `auth.py` register handler.
+
+## Implementation sketch (do not start until operator confirms direction)
+
+1. Add `CAPTCHA_PROVIDER`, `CAPTCHA_SITE_KEY`, `CAPTCHA_SECRET` env vars (frontend + backend respectively).
+2. Frontend `/register` form renders the widget; on submit, POST the token along with the registration payload.
+3. Backend `register` handler verifies the token server-side BEFORE creating the user / sending the verification email. Reject with 400 + structured error code `captcha_failed` if verify returns false.
+4. Stage rollout: enable in production first (where the bots live), keep dev/staging unaffected or use a test site-key. Operator already prefers env-var gating; this fits.
+5. Audit-event emission on failed CAPTCHA so the bounce signature has a downstream trail.
+
+## Out of scope for the CAPTCHA PR
+
+- Rate limiting beyond what slowapi already provides on `/register`.
+- Email-provider reputation work (the 90% bounce rate WILL hurt deliverability with the email provider — separate cleanup needed: bulk-delete the orphan users + orgs to bring bounce rate down).
+- WAF/Cloudflare-level blocking.
+
+## Companion cleanup (also tomorrow, after CAPTCHA lands)
+
+- Script or admin action to bulk-delete unverified users + orgs older than N hours (operator was doing this manually).
+- Decide on the N: 24h is conservative, 1h is aggressive. 24h is probably right because real users sometimes verify slowly.
+- The bounce-rate damage to the email provider domain is the second-biggest concern after the bot wave itself. Bulk cleanup helps but may not be sufficient if the provider has already throttled.
+
+## Cross-references
+
+- [[reference_bot_signup_signature]] — diagnostic pattern (username shape + bounce rate + time window) for matching new instances.
+- [[feedback_no_em_dashes]] — applies to any user-facing CAPTCHA error copy.
+- The slowapi sync-Redis event-loop block concern in [[project_auth_stability_residuals]] is separately latent; CAPTCHA doesn't fix it but slowapi WILL be one of the layers the CAPTCHA verify lives behind.

--- a/specs/archive/shipped-bot-signup-captcha.md
+++ b/specs/archive/shipped-bot-signup-captcha.md
@@ -1,10 +1,6 @@
 ---
 name: bot-signup-wave-captcha-gate-tomorrow-first-thing
 description: "2026-05-20 EOD — bot wave hitting /register with garbage usernames (e.g. \"XzYtsQPnOBeMfkdTQYV\"), never verifying. 403/445 emails bouncing (~90% bounce rate). Op manually deleting orgs. First-thing-tomorrow: add CAPTCHA to registration."
-metadata: 
-  node_type: memory
-  type: project
-  originSessionId: 07e4bc03-eeac-434d-b0e3-5566db6bbda8
 ---
 
 # Bot signup wave — CAPTCHA gate (P0 for 2026-05-21)

--- a/specs/archive/shipped-dashboard-recent-tx-columns.md
+++ b/specs/archive/shipped-dashboard-recent-tx-columns.md
@@ -1,0 +1,19 @@
+---
+name: Dashboard Recent Transactions Column Order + Status Column — SHIPPED #256
+description: SHIPPED via PR #256 on 2026-05-13. Dashboard Recent Transactions now matches /transactions column order (Date → Description → Status → Amount) with sortable Status pill and right-aligned tabular-nums Amount.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Status:** SHIPPED via PR #256, commit `44b8bf3`, merged 2026-05-13.
+
+## What landed
+- `frontend/app/dashboard/page.tsx` (~L1115-1232) renders Recent Transactions columns in canonical order: **Date → Description → Status → Amount** — a subset of `/transactions`' order (Date → Description → Account → Category → Status → Amount at `frontend/app/transactions/page.tsx` ~L1260-1265).
+- Status is a sortable column using standardized pill tokens (`bg-success-dim text-success` for settled, `bg-warning-dim text-warning` for pending).
+- Amount is right-aligned, tabular-nums, rightmost cell.
+- Regression coverage at `frontend/tests/app/dashboard-recent-tx-columns.test.tsx` asserts the document order Date → Description → Status → Amount.
+
+## Original concept (kept for context)
+Dashboard's Recent Transactions list and the `/transactions` page had different column orderings, breaking consistency for users moving between the two. The fix brought Dashboard into alignment with `/transactions`. Captured 2026-05-10, sized XS-S, shipped 3 days later.
+
+## Why this memory is kept
+To prevent re-picking the shipped task off the roadmap. The roadmap entry [Dashboard Recent Tx Columns] in `MEMORY.md` under "Open backlog items" needs to move to archive — done by the same session that finds this memory.

--- a/specs/archive/shipped-dashboard-recent-tx-columns.md
+++ b/specs/archive/shipped-dashboard-recent-tx-columns.md
@@ -2,7 +2,6 @@
 name: Dashboard Recent Transactions Column Order + Status Column — SHIPPED #256
 description: SHIPPED via PR #256 on 2026-05-13. Dashboard Recent Transactions now matches /transactions column order (Date → Description → Status → Amount) with sortable Status pill and right-aligned tabular-nums Amount.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Status:** SHIPPED via PR #256, commit `44b8bf3`, merged 2026-05-13.
 

--- a/specs/archive/shipped-pfv-dev-dep-drift-guard.md
+++ b/specs/archive/shipped-pfv-dev-dep-drift-guard.md
@@ -1,0 +1,26 @@
+---
+name: ./pfv start dev-dependency-drift guard (XS) — SHIPPED #249
+description: SHIPPED via PR #249 on 2026-05-13. Frontend lock-file drift between host and container now warns on ./pfv start/restart/status/logs frontend/shell frontend. Optional backend stretch goal not done.
+type: project
+originSessionId: 17ea612e-f064-4be7-b422-256d0da7b876
+---
+# `./pfv start` dev-dependency-drift guard — SHIPPED
+
+**Status:** SHIPPED via PR #249, commit `9c9e2d6`, merged 2026-05-13.
+
+## What landed
+- `pfv` lines 32-92: `check_frontend_dep_drift()` — compares host `frontend/package-lock.json` sha256 vs container's `/app/package-lock.json`. Warns to stderr on mismatch with hints to `./pfv rebuild` or `docker compose exec frontend npm ci`. Skips silently when frontend container isn't running, when docker isn't available, or when neither `sha256sum` nor `shasum` is on PATH. Exit code unchanged.
+- Hooks: `cmd_start`, `cmd_restart`, `cmd_status`, `cmd_logs frontend`, `cmd_shell frontend`.
+- Test seam env vars: `PFV_DEPDRIFT_HOST_HASH`, `PFV_DEPDRIFT_CONTAINER_HASH`, `PFV_DEPDRIFT_SKIP`.
+
+## Background (kept for context)
+
+The dev frontend image bakes `node_modules` in at build time. Dev compose bind-mounts source but NOT `frontend/node_modules`, so a host `npm install` changes `package-lock.json` without that change reaching the running container. Silent failure mode until the new dep is actually imported (twice in May 2026: #203 stale CSS, #212 `server-only` MODULE_NOT_FOUND).
+
+## Open stretch goal (not shipped, low priority)
+
+Same drift check for `backend/requirements.txt` and `backend/requirements-dev.txt`. Backend has fewer dep changes per PR and Python imports are eager (container exits noisily on dep miss), so payoff is small. Pick up only if a backend dep drift incident actually bites.
+
+## Why this memory is kept
+
+To prevent re-picking the shipped task off the roadmap. The roadmap entry [./pfv dev-dep-drift guard] in `MEMORY.md` under "Open backlog items" needs to move to archive — done by the same session that finds this memory.

--- a/specs/archive/shipped-pfv-dev-dep-drift-guard.md
+++ b/specs/archive/shipped-pfv-dev-dep-drift-guard.md
@@ -2,7 +2,6 @@
 name: ./pfv start dev-dependency-drift guard (XS) — SHIPPED #249
 description: SHIPPED via PR #249 on 2026-05-13. Frontend lock-file drift between host and container now warns on ./pfv start/restart/status/logs frontend/shell frontend. Optional backend stretch goal not done.
 type: project
-originSessionId: 17ea612e-f064-4be7-b422-256d0da7b876
 ---
 # `./pfv start` dev-dependency-drift guard — SHIPPED
 

--- a/specs/archive/shipped-subcategory-edit-form-parity.md
+++ b/specs/archive/shipped-subcategory-edit-form-parity.md
@@ -2,7 +2,6 @@
 name: Sub-category edit form — missing description field — SHIPPED #324
 description: SHIPPED via PR #324 on 2026-05-20. Top-level + sub-category edit forms now expose description input. Backend gained Pydantic v2 model_fields_set check at categories.py:411 so explicit-null clears (was conflated with "field omitted" before).
 type: project
-originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
 ---
 **Status:** SHIPPED via PR #324, merged 2026-05-20. Two commits: initial fix + review-feedback follow-up (`efa8c50`).
 

--- a/specs/archive/shipped-subcategory-edit-form-parity.md
+++ b/specs/archive/shipped-subcategory-edit-form-parity.md
@@ -1,0 +1,24 @@
+---
+name: Sub-category edit form — missing description field — SHIPPED #324
+description: SHIPPED via PR #324 on 2026-05-20. Top-level + sub-category edit forms now expose description input. Backend gained Pydantic v2 model_fields_set check at categories.py:411 so explicit-null clears (was conflated with "field omitted" before).
+type: project
+originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
+---
+**Status:** SHIPPED via PR #324, merged 2026-05-20. Two commits: initial fix + review-feedback follow-up (`efa8c50`).
+
+## What landed
+- `frontend/app/categories/page.tsx` — `editCatDesc` state + description `<input>` in both the master and sub-category inline edit forms (one shared handler, two render sites). PUT body includes `description` (trimmed; empty → `null`).
+- `backend/app/routers/categories.py:411` — `if "description" in body.model_fields_set:` (was `if body.description is not None:`). Pydantic v2 PATCH semantics: explicit null now clears the column, field omission still preserves the existing value.
+- `CategoryUpdate.description: Optional[str] = None` schema was already correct — no schema change required.
+- New tests:
+  - `backend/tests/routers/test_categories_update_description.py` — 3 cases (explicit-null clears, omitted preserves, new value persists).
+  - `frontend/tests/app/categories-c2-edit-mode.test.tsx` — 3 new cases (sub-edit, top-level parity, empty-desc → null with after-save UI reconciliation).
+
+## Why the review-cycle was needed
+The first PR pass only asserted the outbound PUT body. It didn't catch the silent-no-op on the backend (`is not None` dropping explicit nulls). Architect caught it; second commit added `model_fields_set` + the persistence test that exercises the full clear-then-reload reconciliation path.
+
+## Lesson for future Optional-field fixes
+"Test the outbound request body" ≠ "test persistence." Always exercise the after-save reconciliation path on partial updates. The pattern locks into [[reference_ci_driver_contract_testing]] family of "contract verified against the OTHER side, not against our own assumption."
+
+## Why this memory is kept
+To prevent re-picking the shipped task off the roadmap. The roadmap entry [Sub-category edit form missing description] in `MEMORY.md` needs to move to archive — done by the same session that finds this memory.

--- a/specs/billing-cycle-design.md
+++ b/specs/billing-cycle-design.md
@@ -1,0 +1,39 @@
+---
+name: Billing Cycle and Transaction Status Design
+description: Design decisions for billing cycles, transaction status, recurring transactions, and dashboard improvements
+type: project
+---
+
+## Billing Cycle
+- Org-level setting for month close date (e.g., 15th instead of 1st)
+- All monthly views (dashboard, forecasts) respect this cycle
+- Per-account reporting is a future nice-to-have but not the primary view
+
+## Transaction Status
+- Two states: `settled` and `pending`
+- Settled transactions affect actual account balance
+- Pending transactions only count toward monthly forecast
+- Status is always editable by the user
+
+## Recurring Transactions
+- Templates with frequency (weekly, monthly, etc.)
+- Auto-generate `pending` transactions ahead of time
+- Can be settled manually by the user or auto-settled on the due date
+- Editable — user can change status, amount, date after generation
+
+## Dashboard Improvements
+- Quick-add transaction form on dashboard
+- Last 10 transactions with color-coded amounts
+- Pagination scoped to current billing cycle (month)
+- Link to full transactions page for broader views
+
+## Transactions Page Filters
+- By type (income/expense)
+- By status (settled/pending)
+- By account
+- By category
+- By date range
+
+**Why:** User manages credit cards with different settlement dates. All bills paid from same income, so org-level cycle makes sense. Pending transactions give visibility into upcoming obligations without corrupting actual balances.
+
+**How to apply:** Build in phases — status + dashboard first, then recurring, then billing cycle. All within the transactions domain while we're still building it out.

--- a/specs/billing-settled-date-design.md
+++ b/specs/billing-settled-date-design.md
@@ -1,0 +1,17 @@
+---
+name: Billing Period Settlement Design
+description: settled_date field determines which billing period a transaction counts against — critical for CC late settlements
+type: project
+originSessionId: abad3c60-c398-4e0e-851e-811d6900a085
+---
+**Design decision (2026-04-13):** Transactions have both `date` (purchase date) and `settled_date` (when settled).
+
+**Why:** CC transactions that settle after a billing period closes should count against the NEXT period, not the period they were purchased in. This matches real-world CC billing behavior.
+
+**How to apply:**
+- `Budget spend` queries filter by `settled_date` (not `date`)
+- `Forecast executed` queries filter by `settled_date`
+- `Forecast pending` queries still use `date` (for visibility in the period the purchase happened)
+- `settled_date` is set to `date` when created as settled, `today()` when toggling pending→settled, cleared when toggling settled→pending
+- ALL Transaction() creation paths must set `settled_date` when status is SETTLED (transaction_service, recurring_service)
+- Index: `ix_transactions_org_settled_date` on (org_id, status, settled_date)

--- a/specs/billing-settled-date-design.md
+++ b/specs/billing-settled-date-design.md
@@ -2,7 +2,6 @@
 name: Billing Period Settlement Design
 description: settled_date field determines which billing period a transaction counts against — critical for CC late settlements
 type: project
-originSessionId: abad3c60-c398-4e0e-851e-811d6900a085
 ---
 **Design decision (2026-04-13):** Transactions have both `date` (purchase date) and `settled_date` (when settled).
 

--- a/specs/brand-consolidation.md
+++ b/specs/brand-consolidation.md
@@ -1,0 +1,108 @@
+---
+name: Brand consolidation (pre-1.0 launch) — PARTIAL
+description: Standardize naming on "The Better Decision" + product logo. Customer-facing surfaces mostly shipped (#125, #224, #228, #229, #230, #231). Internal/operational rename (repo, working dir, CLI script, compose services, DB name, env vars, memory slug) still open; product-logo asset set may also have residual scope beyond #224's foundation pass. Architect decision pending on internal rename scope.
+type: project
+originSessionId: 497b4e5b-526f-4ed1-bca0-0ee0c5bbc716
+---
+**STATUS: 🟡 PARTIAL.** Customer-facing brand work shipped through multiple PRs:
+- **PR #125** (L5.7): brand-consistent error / 404 / loading fallbacks.
+- **PR #224** (L5.10): brand foundation assets, tokens, voice guide.
+- **PR #228**: localStorage key rename `pfv2-theme` → `tbd-theme`.
+- **PR #229** (L5.9): brand-compliant Google SSO button.
+- **PR #230** (L5.1): landing brand integration.
+- **PR #231** (L5.6): brand-aligned email templates.
+
+**Still open:** internal/operational rename scope (repo `flamarion/pfv`, working dir `/Users/fjorge/src/pfv`, `./pfv` CLI → `./tbd`, compose service names, DB name `pfv2`, env var prefixes, Claude memory slug). Architect to decide full-rename vs grandfather, then scope and dispatch.
+
+Original 2026-05-08 capture below preserved for context.
+
+## Why
+Today the name splits: "The Better Decision (TBD)" in customer-facing surfaces (README, in-app copy, public `/docs` route); "Personal Finances V2" / "pfv" / "pfv2" in repo name, working directory, container names, DB, CLI script, env var prefixes, internal docs. Mixed naming creates friction at launch (onboarding / legal copy / support channels) and in agent prompts (which name is canonical?). Decision: **The Better Decision** is the canonical product name. **TBD** acceptable as short form in internal/casual contexts.
+
+## Two parts
+
+### 1. Naming standardization
+
+**User-facing surfaces (non-negotiable):**
+- In-app copy: page titles, header, footer, error messages, empty-state copy
+- Email templates (Mailgun)
+- Legal pages (`/privacy`, `/terms`)
+- Public `/docs` route content (added in PR #159)
+- README.md, CONTRIBUTING.md (already use "The Better Decision" — double-check no stragglers reference pfv as a product name vs. as a repo/dir name)
+- Marketing surface (if any) — domain, landing page, OG image, social share
+
+**Internal/operational surfaces (decision needed: full rename vs. grandfather):**
+- GitHub repo: `flamarion/pfv` → e.g. `flamarion/the-better-decision` or `flamarion/tbd` (renames preserve issue/PR history; GitHub auto-sets up redirects)
+- Local working dir: `/Users/fjorge/src/pfv` → match
+- CLI script: `./pfv start|stop|...` → `./tbd` (or a wrapper aliasing the old name during transition)
+- Docker compose service names: `pfv-backend`, `pfv-frontend`, `pfv-mysql`, `pfv-redis`, `pfv-nginx`
+- DB name: `pfv2` → decide
+- Env var prefixes (if any `PFV_*` exist) → decide
+- Claude memory dir slug: `~/.claude/projects/-Users-fjorge-src-pfv/` is derived from the working directory. Renaming the dir creates a new slug; old memory becomes orphaned. Plan a one-time copy.
+
+### 2. Logo design
+
+**Asset set required:**
+- SVG primary logo / wordmark (app header + marketing)
+- Favicon (16, 32, 48, 180 px PNG + .ico fallback)
+- OG image (1200×630 — social share)
+- App icon (512×512 + maskable variant if PWA-installable later)
+- Email header image (Mailgun templates)
+
+**Direction TBD:**
+- Type-only wordmark vs. wordmark + symbol vs. symbol-only
+- Color palette: pick 2-3 brand colors that survive light/dark mode (Tailwind-driven theme today)
+- DIY (system-stack wordmark + one geometric mark) likely sufficient for 1.0; commissioning is upside, not a launch dependency
+
+## Constraints
+
+- **Repo rename** triggers: GitHub redirects (auto), DO App Platform `spec.git_source.repository` update (manual), GitHub Actions workflow secrets / OIDC trust if any, working-tree remote URLs, README badges.
+- **DB rename**: per `feedback_pre_launch_state.md`, no production data exists yet. A fresh DB on the next deploy is acceptable; no migration tool needed.
+- **Mailgun sender identity / DKIM** may reference current naming — verify what changes if anything.
+- **Claude memory slug rename** is a one-time chore (copy old → new slug, then delete old).
+
+## Suggested PR shape (architect to confirm)
+
+If full rename is chosen:
+- **PR 1** in-codebase rename: CLI script, compose service names, env var prefixes, DB name in compose, README/CONTRIBUTING housekeeping, customer copy sweep.
+- **PR 2** repo rename: GitHub UI action + Actions workflow updates + DO `spec.git_source` update + working-tree remote re-setup.
+- **PR 3** logo assets + frontend wiring (favicons, OG image, header logo, email template).
+
+If internal `pfv` is grandfathered:
+- **Single PR** customer copy sweep — mechanical, fast.
+- Logo PR is unchanged.
+
+## Open questions
+
+- **Domain** for the launched product (e.g. `thebetterdecision.app` / `.com`) — drives marketing surface and email sender choice.
+- **Trademark availability** on "The Better Decision" — quick search before committing.
+- **Internal `pfv` rename**: full sweep or grandfathered? Architect to weigh cost (operational churn, broken bookmarks, redirect debt) against long-term clarity.
+- **Logo direction**: dispatched to a creative agent? DIY by you? External commission?
+
+## Status update 2026-05-14
+
+Both brand parts have landed:
+
+**Domain locked.** `thebetterdecision.com` is live as the apex (AWS S3 + CloudFront, L5.2a, PRs #240/#241/#267/#270/#271). `app.thebetterdecision.com` continues to host the authed app (DO App Platform). Email sender is `hello@thebetterdecision.com` (constant in `frontend/lib/brand.ts`).
+
+**Internal `pfv` is grandfathered.** No repo / DB / CLI / compose-service rename has been performed. The brief Brand-team dispatch (2026-05-14, this memo's Section C Team 1) explicitly held that scope: "DO NOT rename repo/DB/internal pfv unless explicitly approved." Locked.
+
+**Logo direction locked: DIY type-only-plus-mark.** The decision was made in PR #224 (`feat(brand): foundation assets, tokens, voice guide (L5.10)`). The mark is two stacked chevrons reading as a decision arrow (the lower a muted slate echo, the upper brass) — "no best, only better." Implemented in `frontend/components/brand/Logo.tsx` as `<Mark />` / `<Wordmark />` / `<Logo />`. Brand surface palette in `frontend/lib/brand.ts`. Full kit documented in `BRAND.md` at repo root.
+
+**Asset surface shipped:**
+- `frontend/app/icon.svg` — 32px favicon (live).
+- `frontend/app/apple-icon.tsx` — 180×180 generated PNG for iOS (live).
+- `frontend/app/opengraph-image.tsx` — 1200×630 generated PNG for social share (live).
+- Email header: inline chevron mark in `backend/app/services/email_service.py`, copied verbatim from `icon.svg` so the email surface stays in lockstep (live, PR #231).
+- AppShell + LandingFooter + TopNav use the canonical `<Logo />` component.
+
+**Voice policy:** customer-copy em-dash sweep landed today (PR #273 from `feat/brand/voice-sweep`), plus regression-guard test at `frontend/tests/voice/no-em-dash-in-customer-copy.test.ts`.
+
+**Landing iteration (L5.1):** added `HowItWorks` 3-step section + Hero trust line (PR #279 from `feat/brand/landing-iteration`). Apex static export verified.
+
+**Still open:**
+- `favicon.ico` binary file (only `icon.svg` exists today). Build-apex allowlist already accepts it. Low priority — every modern browser honors the SVG favicon.
+- 512×512 maskable PWA icon variant. Only needed when the app becomes PWA-installable (post-launch).
+- Email-header PNG asset. Not needed today because every brand email renders the chevron inline; the inline SVG is the spec.
+
+Logo / favicon / OG / email / landing iteration are all DONE at the code level. The remaining brand-consolidation backlog is post-launch polish, not blocking 1.0.

--- a/specs/brand-consolidation.md
+++ b/specs/brand-consolidation.md
@@ -2,7 +2,6 @@
 name: Brand consolidation (pre-1.0 launch) — PARTIAL
 description: Standardize naming on "The Better Decision" + product logo. Customer-facing surfaces mostly shipped (#125, #224, #228, #229, #230, #231). Internal/operational rename (repo, working dir, CLI script, compose services, DB name, env vars, memory slug) still open; product-logo asset set may also have residual scope beyond #224's foundation pass. Architect decision pending on internal rename scope.
 type: project
-originSessionId: 497b4e5b-526f-4ed1-bca0-0ee0c5bbc716
 ---
 **STATUS: 🟡 PARTIAL.** Customer-facing brand work shipped through multiple PRs:
 - **PR #125** (L5.7): brand-consistent error / 404 / loading fallbacks.
@@ -12,7 +11,7 @@ originSessionId: 497b4e5b-526f-4ed1-bca0-0ee0c5bbc716
 - **PR #230** (L5.1): landing brand integration.
 - **PR #231** (L5.6): brand-aligned email templates.
 
-**Still open:** internal/operational rename scope (repo `flamarion/pfv`, working dir `/Users/fjorge/src/pfv`, `./pfv` CLI → `./tbd`, compose service names, DB name `pfv2`, env var prefixes, Claude memory slug). Architect to decide full-rename vs grandfather, then scope and dispatch.
+**Still open:** internal/operational rename scope (repo `flamarion/pfv`, the local working dir under the operator's home, `./pfv` CLI → `./tbd`, compose service names, DB name `pfv2`, env var prefixes, Claude memory dir slug). Architect to decide full-rename vs grandfather, then scope and dispatch.
 
 Original 2026-05-08 capture below preserved for context.
 
@@ -33,12 +32,12 @@ Today the name splits: "The Better Decision (TBD)" in customer-facing surfaces (
 
 **Internal/operational surfaces (decision needed: full rename vs. grandfather):**
 - GitHub repo: `flamarion/pfv` → e.g. `flamarion/the-better-decision` or `flamarion/tbd` (renames preserve issue/PR history; GitHub auto-sets up redirects)
-- Local working dir: `/Users/fjorge/src/pfv` → match
+- Local working directory under the operator's home → match the chosen new name
 - CLI script: `./pfv start|stop|...` → `./tbd` (or a wrapper aliasing the old name during transition)
 - Docker compose service names: `pfv-backend`, `pfv-frontend`, `pfv-mysql`, `pfv-redis`, `pfv-nginx`
 - DB name: `pfv2` → decide
 - Env var prefixes (if any `PFV_*` exist) → decide
-- Claude memory dir slug: `~/.claude/projects/-Users-fjorge-src-pfv/` is derived from the working directory. Renaming the dir creates a new slug; old memory becomes orphaned. Plan a one-time copy.
+- Claude memory dir slug: derived from the local working directory path. Renaming the working dir creates a new slug; old memory becomes orphaned. Plan a one-time copy.
 
 ### 2. Logo design
 

--- a/specs/category-fallback-design.md
+++ b/specs/category-fallback-design.md
@@ -2,7 +2,6 @@
 name: Category Fallback Design (post-L3.10) — PARTIAL
 description: Architect-approved 4-layer design. Layer A SHIPPED via PR #108 (empty-state UX on import). Layers B (type-specific category requirement at preview time + structured 400) and C (Restore recommended categories action) still PENDING. Layer D (slug aliasing) deferred to P-IL post-launch.
 type: project
-originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
 ---
 **STATUS: 🟡 PARTIAL.**
 - **Layer A** — empty-state UX on import. ✅ SHIPPED via PR #108 (`feat/import-empty-categories-state`, 2026-05-02).

--- a/specs/category-fallback-design.md
+++ b/specs/category-fallback-design.md
@@ -1,0 +1,73 @@
+---
+name: Category Fallback Design (post-L3.10) — PARTIAL
+description: Architect-approved 4-layer design. Layer A SHIPPED via PR #108 (empty-state UX on import). Layers B (type-specific category requirement at preview time + structured 400) and C (Restore recommended categories action) still PENDING. Layer D (slug aliasing) deferred to P-IL post-launch.
+type: project
+originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
+---
+**STATUS: 🟡 PARTIAL.**
+- **Layer A** — empty-state UX on import. ✅ SHIPPED via PR #108 (`feat/import-empty-categories-state`, 2026-05-02).
+- **Layer B** — type-specific category requirement at preview time + structured 400 contract. 🔵 PENDING. Needs backend change in `import_service.build_preview` + structured error + frontend handling.
+- **Layer C** — "Restore recommended categories" button (re-runs `SYSTEM_CATEGORIES` seed for current org, idempotent). 🔵 PENDING. Service + UI + tests.
+- **Layer D** — Category slug aliasing for shared-dictionary lookups. ⏳ DEFERRED to post-launch P-IL track.
+
+## Problem
+
+L3.10 import preview silently dead-ends if the user has zero categories. The UI's "Confirm Import" button stays disabled (because `default_category_id` is required and the dropdown is empty), with no error message. Same dead-end can hit transaction-create flows. Discovered when the user removed all pre-seed system categories from their prod account on 2026-05-02.
+
+## Architect's recommended shape (2026-05-02)
+
+Four-layer design, increasing scope:
+
+### A. Empty-state UX when zero categories — SHIP NOW
+
+If `categories.length === 0` on the import page, render a clear empty state with a CTA button/link to `/categories` for category creation. Replaces the silent dead-end with an actionable message. Frontend-only, ~15 min.
+
+**Status:** PR #108 opened 2026-05-02 (`feat/import-empty-categories-state`). Empty state shown when SWR has loaded an empty array; upload + preview steps gated off so the user can't reach the disabled confirm. Loading state unchanged. Backend / smart-rule suggestions / `default_category_id` contract untouched. 53/53 frontend tests pass.
+
+### B. Type-specific category requirement at preview time — REFINED, NOT YET SHIPPED
+
+I originally proposed "require at least one income + one expense category before allowing import." Architect pushed back: that's too broad. **An expense-only CSV shouldn't be blocked because the user has no income category.**
+
+**Refined design:** at preview time, the backend has already parsed the rows and knows which `type` values are present. Inspect the parsed row set and require at least one compatible category for each type actually present:
+
+- if any rows have `type == "expense"` → require `count(categories WHERE type IN ("expense", "both")) >= 1`
+- if any rows have `type == "income"` → require `count(categories WHERE type IN ("income", "both")) >= 1`
+
+If a required category type is missing, return a 400 with a structured `detail` payload the frontend can surface as a targeted message ("This CSV has expense rows but you have no expense category. Add one to continue.").
+
+This belongs in `import_service.build_preview` or a new pre-flight check. **Not Saturday-sized:** needs a backend change + structured error contract + frontend handling. Capture as a follow-up.
+
+### C. "Restore recommended categories" button — LONG-TERM RECOVERY PATH
+
+A button on `/categories` (or `/settings/organization`) that re-runs the `SYSTEM_CATEGORIES` seed for the current org. Idempotent: skip slugs that already exist. Two reasons users want this:
+
+1. They deleted system categories by accident or to clean up, then realized they want them back.
+2. They started with the "skip pre-seed" option in onboarding (when L3.3 ships) and later decide to opt in.
+
+Pairs naturally with L3.3 onboarding. Treats pre-seed as a deliberate choice (which fits the user's "optional pre-seed + tour" vision). **Not Saturday-sized:** ~1 day for service + UI + tests.
+
+### D. Category slug aliasing — ARCHITECTURAL, BELONGS IN P-IL
+
+L3.10's shared `merchant_dictionary` resolves slugs against `categories.slug` AND `categories.is_system=True`. A user with only custom categories ("Food" instead of "Groceries") gets ZERO shared-dictionary suggestions.
+
+**The fix:** add an `alias_slug` field on Category so a user-created "Food" can claim slug `groceries` and pick up shared-dictionary suggestions. Lookup chain becomes:
+
+```
+WHERE org_id=? AND (
+    (slug=? AND is_system=True) OR
+    (alias_slug=?)
+)
+```
+
+This is real architectural work tied to the P-IL (Localized Import Intelligence) thread and overlaps with P-IL.2 (per-locale `merchant_dictionary` extension). Captured in `project_localized_import_intelligence.md` as part of P-IL.
+
+## Why this came up now
+
+The user removed all pre-seed system categories from their prod account before testing the L3.10 ING NL CSV import. The preview returned zero suggestions (Tier-2 dictionary lookup needs system-categories with matching slugs) AND the confirm dropdown was empty (no categories to pick as default). They hit the silent dead-end.
+
+## Sequence
+
+1. **Saturday 2026-05-02:** Ship A. Open small PR: empty state on `/import` when `categories.length === 0`.
+2. **Next-iteration backlog:** B-refined as a small backend + frontend pair. Roughly half-day.
+3. **L3.3 onboarding:** ship C as the "I want pre-seed back" recovery button.
+4. **P-IL thread:** D as part of the locale-aware dictionary work.

--- a/specs/category-hierarchy-design.md
+++ b/specs/category-hierarchy-design.md
@@ -1,0 +1,44 @@
+---
+name: Category Hierarchy Design
+description: Hierarchical categories — master categories for budgets, subcategories as transaction tags
+type: project
+---
+
+## Structure
+- **Master categories** = top-level (no parent_id) — used for budgeting and report grouping
+- **Subcategories** = child categories (parent_id set) — used as tags on transactions
+- Transactions reference subcategories; master category derived via parent relationship
+
+## Schema additions to categories table
+- `parent_id` — nullable, self-referencing FK
+- `description` — hint text to help users understand the category
+- `is_system` + `slug` — seeded on registration, protected from deletion
+
+## System-seeded categories (12 master + ~50 subcategories)
+
+| Master | Subcategories |
+|--------|--------------|
+| Income | Paycheck/Salary, Side Hustles, Bonuses, Interest/Dividends, Tax Refunds |
+| Housing | Rent/Mortgage, Property Taxes, Home Insurance, HOA Fees, Repairs/Maintenance |
+| Utilities | Electricity, Water, Gas, Internet, Phone, Trash/Recycling |
+| Food & Dining | Groceries, Restaurants, Coffee Shops, Fast Food/Takeout |
+| Transportation | Fuel/Gas, Car Payments, Auto Insurance, Public Transit, Maintenance/Repairs, Parking/Tolls |
+| Health & Wellness | Health Insurance, Doctor Visits/Copays, Pharmacy/Meds, Gym Membership, Dental/Vision |
+| Personal Care | Haircuts, Toiletries, Clothing, Shoes, Laundry/Dry Cleaning |
+| Lifestyle & Fun | Streaming Services, Movies/Concerts, Hobbies, Travel/Vacation, Books/Media |
+| Financial Goals | Emergency Fund, Retirement (401k/IRA), General Savings, Brokerage Investments |
+| Debt Repayment | Credit Cards, Student Loans, Personal Loans |
+| Giving & Gifts | Charitable Donations, Birthday/Holiday Gifts |
+| Miscellaneous | Bank Fees, Taxes (Non-Property), Uncategorized/Unexpected |
+
+## Type mapping
+- Income master → type=income, all its subcategories → type=income
+- All other masters → type=expense, subcategories → type=expense
+- Custom categories can be type=both
+
+## Future use
+- Budgets allocate at master category level
+- Reports can drill down from master → subcategory
+- Charts group by master, filter by subcategory
+
+**Why:** Rich categorization enables meaningful budgets, reports, and charts. Master/sub split gives flexibility without forcing users into too-granular or too-broad categories.

--- a/specs/ci-test-sharding.md
+++ b/specs/ci-test-sharding.md
@@ -1,10 +1,6 @@
 ---
 name: ci-test-sharding-followup
 description: "Architect-aligned plan to shard backend pytest in GitHub Actions after a timing audit; target <3 min backend check, preserve full-suite semantics"
-metadata: 
-  node_type: memory
-  type: project
-  originSessionId: 61ba1946-1626-4e59-9b33-07b26d7a04eb
 ---
 
 # CI test sharding — near-term follow-up (2026-05-17)

--- a/specs/ci-test-sharding.md
+++ b/specs/ci-test-sharding.md
@@ -1,0 +1,55 @@
+---
+name: ci-test-sharding-followup
+description: "Architect-aligned plan to shard backend pytest in GitHub Actions after a timing audit; target <3 min backend check, preserve full-suite semantics"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 61ba1946-1626-4e59-9b33-07b26d7a04eb
+---
+
+# CI test sharding — near-term follow-up (2026-05-17)
+
+## Trigger
+
+Backend pytest runtime has grown materially during the parallel-team wave:
+
+- After PR #305 (Team I PR 1): ~270s
+- After PR #306 (Team I PR 2): ~275s
+- After PR #307 (Team I PR 3): ~308s
+- After PR #308 (Team I PR 4 + architect patches): ~298s
+- After PR #309 (cold-start UX) + others: backend remains in the 4:30–5:00 minute band.
+
+GitHub Actions backend check is the slowest gate on every PR. The wave shipped fine, but the trend is non-trivial as we add more session-model concurrency tests, integration coverage, etc.
+
+## Architect-aligned approach (do NOT skip the audit)
+
+1. **Measure first** — timing audit per test file. `pytest --durations=50` against current `main` to see where the runtime is actually concentrated. Likely candidates: integration tests, Redis-heavy auth tests, full-suite migration boots.
+2. **Target backend pytest only** — it is the obvious first target. Frontend Vitest is currently ~11s for 1017 tests; not material.
+3. **Start with 4 shards, not 10** — the article cited went to 10; architect recommends 4 first. Less efficiency loss per shard, easier to debug contention.
+4. **Deterministic ordering** — either `pytest-split` (uses a recorded duration file checked into the repo) or `pytest-xdist` with `--dist=loadgroup` to keep related tests together. NO random ordering unless tests are proven fully isolated.
+5. **Preserve full-suite semantics** — fixtures, autouse, conftest, allowlist regressions etc. must still see the same view of the codebase. Allowlist tests like `test_sessions_invalidated_at_allowlist.py` scan files; they must run in exactly one shard or be replicated to all (one shard is cheaper).
+6. **DB / container contention is the hidden trap** — each shard needs its own MySQL + Redis. Either spin a stack per shard in GH Actions, or move all integration tests into a single shard while sharding pure-unit tests across the others.
+
+## Target
+
+- **Backend check wall-clock < 3 minutes.**
+- No flaky tests masked by parallelism (would manifest as intermittent failures that pass on rerun — keep an eye out during the first few weeks).
+- No new CI minutes blow-up — running 4 shards in parallel costs ~4× the minutes for the same wall-clock, so the total minute cost is similar (within 10-20% overhead).
+
+## Implementation order (when picked up)
+
+1. Run `pytest --durations=50` on current main → produce a ranked list. Save the report somewhere referenceable.
+2. Decide between `pytest-split` (deterministic, recorded times) vs `pytest-xdist` (work-stealing). Start with `pytest-split` — it has better debug ergonomics.
+3. Add a new GH Actions matrix step. 4 shards. Each shard spins its own MySQL + Redis via `docker compose -p team-shard-N` (same pattern as the agent-isolation rule already in CLAUDE.md).
+4. Replicate the allowlist-scan test to all shards OR pin it to shard 0. Either works; replication is simpler.
+5. After two weeks of clean runs, optionally bump to 6 or 8 shards if the wall-clock is still over 3 minutes.
+
+## Out of scope
+
+- Frontend Vitest sharding (not material at current runtime).
+- Test parallelism within a single pytest process via `pytest-xdist -n auto` (different concept; can stack on top of GH-Actions sharding later if useful).
+- Rewriting tests to be faster (would help but is a much bigger initiative).
+
+## Relates to
+
+[[project_status]] — wave 2026-05-17 is complete; this is the natural next CI improvement.

--- a/specs/configurable-dashboard-widgets.md
+++ b/specs/configurable-dashboard-widgets.md
@@ -1,0 +1,82 @@
+---
+name: Configurable Dashboard / Widget System
+description: Let users add, remove, and reorder cards on Dashboard (and later other pages) like widgets. Friend feedback 2026-05-09.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Captured 2026-05-10.** Friend feedback echoed by the user. Not a launch blocker. Sized L-XL depending on scope. Parks for post-launch.
+
+## Concept
+
+Today's Dashboard is a fixed layout (On Track, Forecast, Spending by Category, Budget Progress, Forecast by Category, Recent Transactions). Users want:
+- Add or remove cards.
+- Reorder cards (drag and drop or up/down arrows).
+- Eventually: add cards from a catalog (e.g. the new low-balance-day warning, custom category breakdowns, savings goals).
+- Eventually: same widget system on other pages (Accounts, Transactions, etc.).
+
+## Phases
+
+### Phase 0 — Per-account-type consolidation tiles (pre-widget; 2026-05-15 addition)
+
+Owner confirmed 2026-05-15: short-term, ship static consolidated tiles per account type without committing to the widget framework yet. Goal: validate the consolidation is what the user actually wants to see before paying for the configurability infra.
+
+**Tiles to add to Dashboard:**
+- Checking subtotal
+- Savings subtotal
+- Credit-card subtotal (sum of current balances, NOT credit limits)
+- Loan subtotal (if loan account type ships — see `project_loan_account_type.md`)
+- Investments subtotal (if/when an investment account type lands)
+
+Each tile: total balance + count of accounts of that type + small comparison sparkline if cheap.
+
+**Source data:** `lib/api.ts` already paginates `GET /api/v1/accounts`; group by `account_type.slug` client-side. No new endpoint required.
+
+**Scope discipline:** static cards, no drag/resize, no per-user layout state. If users like the consolidation, the value of widgetizing increases; if they don't use it, we saved ourselves Phase 1's infra cost.
+
+**Cross-cut:** the user's idea is that this concept (consolidation cards / contextual subtotals / configurable widgets) eventually extends beyond Dashboard to other pages (Accounts, Transactions, etc.). Honor in framing: Phase 0 ships only Dashboard tiles; later phases reuse the same idea on other pages once the widget framework exists.
+
+**Effort:** XS-S. Single PR.
+
+### Phase 1 — Dashboard reorder + visibility toggles
+
+- Persist per-user a list of `{widget_id, visible, order}` tuples.
+- "Edit dashboard" mode: toggle visibility on each card, reorder via drag-and-drop or up/down buttons.
+- Reset-to-default affordance.
+- Storage: backend `user_preferences` JSON column or a dedicated `dashboard_layouts` table. Probably JSON column on `users` for v1 simplicity.
+
+### Phase 2 — Widget catalog
+
+- Define a registry of available widgets (existing cards become the seed list).
+- Add-widget flow: user picks from catalog, widget appears on dashboard.
+- Widget instances may have config (e.g. "Spending by Category — current period" vs "Spending by Category — last 3 months").
+- This unlocks the low-balance-day warning as an opt-in widget.
+
+### Phase 3 — Cross-page widgets
+
+- Same primitives applied to Accounts, Transactions, etc.
+- Shared widget primitives (header, body, edit-mode chrome).
+- Per-page layout persisted independently.
+
+## Open questions
+
+1. **Reorder UX**: drag-and-drop is expected but breaks down on touch. Up/down buttons are cheap and accessible. Probably ship both.
+2. **Per-org vs per-user**: per-user is the obvious answer; org-shared dashboards are post-launch.
+3. **Mobile**: responsive parity has to be designed in from the start. Widgets at narrow viewports stack 1-up regardless of layout config.
+4. **Backend shape**: JSON-on-users is fastest; dedicated table is cleaner if widget configs grow.
+5. **Default layout**: every new user gets the current canonical layout. "Reset to defaults" reverts to that.
+6. **A11y**: drag-and-drop is notoriously hard for keyboard users. Up/down arrows are the keyboard-friendly answer.
+
+## Cross-references
+
+- `project_low_balance_day_warning.md` (a candidate widget for Phase 2)
+- DESIGN.md card system (existing cards become widget instances; no new visual primitives required for Phase 1)
+
+## Why park Phases 1-3
+
+Pre-launch, the canonical layout is opinionated and serves the seed user (finance-savvy spreadsheet operator who wants Plan vs Forecast vs Actual front and center). Configurability is post-launch polish that becomes valuable once enough users want different views to justify the engineering cost. Likely Phase 1 lands as a small post-launch P1 if user demand exists.
+
+**Phase 0 (per-type tiles) is the exception** — owner confirmed 2026-05-15 it's worth shipping pre-launch as a small static-UI step that doesn't require the widget framework.
+
+## 2026-05-15 owner addition — widget motion vocabulary
+
+Owner reinforced the long-term vision: users should be able to **move, resize, and reposition** widgets, not just toggle visibility / reorder. Phase 1 as originally scoped (reorder + visibility) is a subset of what the owner ultimately wants. When Phase 1 lands, the data model should leave room for `width` / `height` per-widget so Phase 2 can add resize without a second migration. Reorder UI in Phase 1 should use a primitive (e.g., `react-grid-layout`) that also supports resize so we don't throw away the implementation when Phase 2 lights up.

--- a/specs/configurable-dashboard-widgets.md
+++ b/specs/configurable-dashboard-widgets.md
@@ -2,7 +2,6 @@
 name: Configurable Dashboard / Widget System
 description: Let users add, remove, and reorder cards on Dashboard (and later other pages) like widgets. Friend feedback 2026-05-09.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Captured 2026-05-10.** Friend feedback echoed by the user. Not a launch blocker. Sized L-XL depending on scope. Parks for post-launch.
 

--- a/specs/credit-card-model-upgrade.md
+++ b/specs/credit-card-model-upgrade.md
@@ -1,0 +1,152 @@
+---
+name: Credit Card Account Model Upgrade
+description: 2026-05-15 owner backlog. Critical assessment of a suggested CC model upgrade — keeps the useful pieces (credit limit, statement closing/due day, payment source linkage) and rejects the bank-replication pieces (cron-based statement reset, interest accrual, computed min payment).
+type: project
+originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
+---
+# Credit Card Account Model Upgrade
+
+**Captured 2026-05-15.** Discussion-grade spec; pre-implementation. Owner-locked principle: **PFV is a personal-decision planning tool, not a bank/billing system.** Most "compute everything" suggestions trip that wire.
+
+## Owner-stated motivation
+
+Today the credit-card account treats cards roughly like checking accounts with a single "due date" field. The user wants:
+- Visibility into credit health (utilization, available credit)
+- Better forecasting — when the statement closes, what's going out of the source account, on what day
+- Reasonable upgrade from "one date" to a richer cycle model
+
+## What the suggested design proposed
+
+The suggestion (verbatim user message) included these elements:
+- New fields: Credit Limit, Statement Closing Date, APR, Grace Period
+- Computed metrics: Utilization Rate, Statement Balance, Minimum Monthly Payment, Interest Accrual
+- UI: limit + APR + closing day + due day on creation
+- A cron job on Statement Closing Day to "calculate the new Statement Balance, clear the previous month's history, and set the next Due Date"
+
+## Critical assessment
+
+### What's right (keep)
+
+1. **Credit Limit** is a real attribute. Without it, the dashboard cannot show "available credit" or "utilization %", both of which are real personal-finance signals.
+2. **Statement closing day + payment due day** are real per-card attributes. Replacing the single "due date" field is the right shape.
+3. **Statement balance** as a *displayed* concept (sum of settled transactions in the closed cycle, currently visible vs frozen) is useful.
+4. **Utilization metric** (balance / limit) is trivial to compute on-demand from existing data once `credit_limit` exists.
+
+### What's overengineered or wrong-by-construction (reject)
+
+1. **Cron-based statement reset.** No. PFV does not need a cron job mutating financial data. Statement closing is a *bank* event we observe; we don't reproduce it. The closed-cycle view we want is a computed *read* (sum of settled transactions in the cycle), not a mutated snapshot. Cron mutations of financial state are an incident magnet and we have none in production right now. Keep it that way.
+2. **Computed interest accrual.** PFV cannot accurately compute interest. Banks use daily-average-balance math, issuer-specific grace-period rules, posting-date vs transaction-date distinctions. We don't have those signals from a CSV/OFX import. Trying to "compute interest" produces wrong numbers the user will rely on. The user's bank statement IS the source of truth for interest; PFV's job is to surface what the user owes when, not invent the math.
+3. **Computed minimum payment.** Same class of error. Min payment is on the user's statement; we should READ it (if the user enters it), not COMPUTE it. The proposed `max($25, interest + 1% of balance)` is one issuer's formula, not universal.
+4. **Grace Period as a stored field.** It's derivable from `closing_day → due_day` distance. No separate field needed.
+5. **APR as a *required* field.** Optional metadata is fine for the user's own tracking, but PFV doesn't use it for any computed output. Don't force the user to enter it.
+
+### What's missing from the suggested design (add)
+
+1. **Payment source account linkage** (cross-cutting with Loan spec — see `project_loan_account_type.md`). The bill gets paid from somewhere. If the user can declare "Citi Mastercard's statement balance gets paid from BBVA Checking", the forecast can correctly drop BBVA Checking's projected balance on the due day. This is the single most valuable visibility upgrade — and the user explicitly asked for it.
+2. **Payment strategy.** Some users pay full balance every cycle (and never pay interest), some pay the minimum + carry balance, some pay a custom fixed amount. The strategy affects how much leaves the source account on the due date. Model:
+   - `payment_strategy: enum('full_balance' | 'minimum_only' | 'fixed_amount' | 'custom_per_period')`
+   - For `fixed_amount`: a `fixed_payment_amount Decimal`
+   - For `custom_per_period`: the user enters the amount per cycle as they go
+3. **Cycle anchoring decision.** Today PFV groups all transactions by `Organization.billing_cycle_day` (per-org monthly anchor). Credit cards have per-card closing days that may differ. Open product question: do we (a) keep grouping CC transactions by the org's anchor (simpler, less honest about real cycles), or (b) group CC transactions by the CC's own closing day (more honest, requires per-account period bucketing)? **Lean (a) for V1**, surface (b) as a future enhancement if users complain.
+
+## Recommended V1 scope
+
+### Schema additions (`accounts` table)
+
+| Field | Type | Notes |
+|---|---|---|
+| `credit_limit` | DECIMAL(12,2) NULL | NULL on non-credit accounts |
+| `statement_closing_day` | TINYINT NULL | 1-31 (handle months with fewer days; 31 → last day of month) |
+| `payment_due_day` | TINYINT NULL | 1-31, same handling |
+| `payment_strategy` | ENUM NULL | `full_balance` (default for CC) / `minimum_only` / `fixed_amount` / `custom_per_period` |
+| `fixed_payment_amount` | DECIMAL(12,2) NULL | Required if `payment_strategy='fixed_amount'` |
+| `payment_source_account_id` | INT NULL FK | FK to `accounts.id` SET NULL; same-org constraint; only allowed for credit/loan account types |
+| `apr` | DECIMAL(5,2) NULL | Optional metadata, no computed use V1 |
+
+Migration shape: one alembic file, ~30 lines, single ALTER TABLE.
+
+### Validation rules
+
+- `credit_limit`, `statement_closing_day`, `payment_due_day` are required for accounts whose `account_type.slug === 'credit_card'`. Not required for other account types.
+- `payment_source_account_id` constraints:
+  - Must be same org
+  - Source account's `account_type.slug` must be in `('checking', 'savings')` — not another credit card, not a loan
+  - Cannot equal `self.id` (no self-pay)
+- `statement_closing_day` and `payment_due_day`: 1-31, integer. Day-31 wraps to last day of month (we ALREADY handle this for `billing_cycle_day`; reuse `lib/date_utils.py`'s end-of-month logic).
+
+### UI changes
+
+**Account create/edit form (`/accounts`):**
+- When `account_type.slug === 'credit_card'`:
+  - Replace single "due date" field (if present today) with: credit limit (number), statement closing day (1-31 dropdown), payment due day (1-31 dropdown), payment source account (account picker, owner+admin scope), payment strategy (radio), fixed payment amount (conditional), APR (optional number)
+  - The picker for source account excludes the current CC + other CCs + loan accounts
+
+**Account detail view:**
+- Show credit limit + current balance + computed utilization (visible only on credit cards)
+- Show "Paid from: <source account name>" line
+- Show next statement period at-a-glance (computed from closing day): "Cycle closes Oct 5, due Oct 26"
+
+### Forecast service changes
+
+When the forecast service computes a credit-card account's projected outflow:
+- If `payment_source_account_id` is set:
+  - Determine projected statement balance for the cycle ending on the next `statement_closing_day` (sum of settled tx in cycle)
+  - Apply `payment_strategy` to determine outflow amount (full | minimum | fixed | custom)
+  - On `payment_due_day`, debit the source account by that amount in the forecast view
+  - The credit card account itself shows "Paid: $X" on the due day, balance returns to current outstanding minus payment
+- If `payment_source_account_id` is NULL: current behavior (user manually models payment as a recurring transaction)
+
+### Out of scope V1
+
+- Interest accrual computation. User enters interest manually as a transaction if they want it tracked.
+- Min payment computation. User enters min payment manually IF their `payment_strategy === 'minimum_only'`. (Or: prompt them at statement-cycle close to enter it as the next month's outflow.)
+- Frozen statement balance snapshot. Statement balance is a computed view, not a stored field.
+- Per-CC cycle bucketing. Transactions still group by org billing-cycle-day in V1.
+- Cron jobs of any kind.
+
+## Recurring expense suggestion (user's secondary note)
+
+User suggested CC bills should appear in the recurring list. **Partially agree.** Two ways:
+
+1. **Auto-create a recurring transaction** when the user sets up a CC with a `payment_source_account_id` and a `payment_strategy !== 'custom_per_period'`. The recurring is created on the source account, monthly, amount = expected payment, category = "Debt Payment". Pros: visible in the recurring list, drives existing forecast logic. Cons: amount drifts each cycle for `full_balance` strategy; needs auto-update.
+
+2. **Treat payment as a derived forecast item** (not a recurring transaction). The forecast service synthesizes the outflow each cycle from the CC's settings + cycle balance. Pros: amount is always correct. Cons: doesn't appear in the recurring list.
+
+**Recommendation: (2).** The recurring list is for user-defined recurring expenses. CC payments are *bills derived from current usage*, not fixed recurring expenses. They belong in the forecast as a synthesized item with provenance `source=credit_card_payment`. The user can SEE them in forecast detail; they don't clutter the recurring list with auto-generated rows whose amounts they didn't choose.
+
+## Open product questions (for discussion)
+
+1. **Cycle anchoring**: org-level billing cycle OR per-card closing day for transaction grouping?
+2. **Statement balance handling**: pure computed view, OR snapshot at close for historical audit?
+3. **Min payment**: never tracked, OR optional user-entered field for `minimum_only` strategy?
+4. **APR**: drop entirely from V1, OR keep as optional metadata for users who want to see "you have a high-APR card"?
+5. **Multiple payment sources**: V1 single source per CC OR allow splits ("pay 50% from checking, 50% from savings")?
+6. **Linked-asset accounting on payment**: when the user records a payment from checking → CC, do we automatically create a *transfer pair* (existing PFV primitive) between the two accounts? Or keep them as two separate transactions? Lean: transfer pair, since PFV already has `linked_transaction_id` + transfer detection.
+
+## Effort estimate
+
+- Schema (CC-specific columns only — `payment_source_account_id` ships in the foundation slice) + validation + form changes + forecast integration: **M (2-4 days)**
+- Doc updates + audit-event coverage on the new fields: **XS-S**
+- Total: **M**, single-PR feasible if scope is held tight to V1.
+
+## Priority + sequencing (architect-locked 2026-05-15)
+
+**P2 pre-launch**, second in the financial-primitives stack:
+
+1. Foundation: `payment_source_account_id` plumbing — see `project_payment_source_account_foundation.md`
+2. **THIS SLICE: Credit Card model V1**
+3. Dashboard Phase 0 per-type tiles — independent of foundation
+4. Loan V1 — deferred unless central to target-user first impression
+5. Configurable dashboard widget framework — post-launch
+
+**Updated bundling recommendation (supersedes earlier "consider bundling with Loan"):** do NOT bundle CC and Loan UX in one PR. Ship the foundation first; then CC UX as its own PR; then Loan UX as its own PR. Architect rationale: keeps each review small, lets either liability UX ship without blocking the other, and decouples liability models in case one is reworked.
+
+**Schema placement of the shared field**: deferred to the foundation slice's decision memo (`accounts.payment_source_account_id` directly vs new `liability_terms` child table). This CC spec assumes the architect-approved placement; do not re-decide here.
+
+## Cross-references
+
+- `project_payment_source_account_foundation.md` — prerequisite slice; consumes nothing from here
+- `project_loan_account_type.md` — companion liability spec; same dependency on foundation
+- `project_billing_cycle.md` — existing billing-cycle-day work; cycle-anchoring decision here may depend on what's there
+- `project_user_billing_flow.md` — user's salary-anchored period thinking; CC cycles may want to honor that
+- L3 roadmap section (financial primitives) — natural fit for an L3.x row if this gets approved

--- a/specs/credit-card-model-upgrade.md
+++ b/specs/credit-card-model-upgrade.md
@@ -2,7 +2,6 @@
 name: Credit Card Account Model Upgrade
 description: 2026-05-15 owner backlog. Critical assessment of a suggested CC model upgrade — keeps the useful pieces (credit limit, statement closing/due day, payment source linkage) and rejects the bank-replication pieces (cron-based statement reset, interest accrual, computed min payment).
 type: project
-originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
 ---
 # Credit Card Account Model Upgrade
 

--- a/specs/csp-console-warning-audit.md
+++ b/specs/csp-console-warning-audit.md
@@ -2,7 +2,6 @@
 name: CSP Console Warning Audit
 description: Investigate browser CSP warning (script-src blocked eval/string evaluation). DO NOT add 'unsafe-eval' to production CSP. Investigate first; the warning is most likely dev-only or third-party.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Captured 2026-05-10.** Backlog item, P2 priority. Raise to P1 only if reproduced in deployed production AND breaks functionality.
 

--- a/specs/csp-console-warning-audit.md
+++ b/specs/csp-console-warning-audit.md
@@ -1,0 +1,63 @@
+---
+name: CSP Console Warning Audit
+description: Investigate browser CSP warning (script-src blocked eval/string evaluation). DO NOT add 'unsafe-eval' to production CSP. Investigate first; the warning is most likely dev-only or third-party.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Captured 2026-05-10.** Backlog item, P2 priority. Raise to P1 only if reproduced in deployed production AND breaks functionality.
+
+## Background — what's already correct
+
+`frontend/next.config.ts:20` already does the right broad thing:
+- **Dev:** allows `'unsafe-eval'` (Next.js / React debugging needs this).
+- **Production:** does NOT allow `'unsafe-eval'`.
+
+Repo scan found NO first-party usage of `eval`, `new Function`, string-form `setTimeout`, or string-form `setInterval`. Next.js docs explicitly note `unsafe-eval` may be needed in development for React debugging but should not be in production by default.
+
+## What NOT to do
+
+**Do not add `'unsafe-eval'` to production CSP.** That's the wrong fix. Loosening the policy because of a console warning, without first identifying the source, weakens defense-in-depth. Any decision to relax production CSP requires explicit security review that accepts the specific risk.
+
+## Investigation steps (the right fix)
+
+1. **Reproduce against deployed production.** `https://app.thebetterdecision.com`, not local dev. Local dev has `'unsafe-eval'` so the warning won't fire there.
+2. **Capture full DevTools details:**
+   - Blocked URI
+   - Source file, line/column
+   - Route where it fires
+   - Browser + version
+   - Does anything actually BREAK, or is it pure console noise?
+3. **Confirm production CSP still omits `'unsafe-eval'`.** Re-read `frontend/next.config.ts:20` and the deployed response headers (`curl -I https://app.thebetterdecision.com` and check `Content-Security-Policy`).
+4. **Confirm first-party code has no offenders:**
+   - `git grep -nE "\\beval\\s*\\(|new\\s+Function\\s*\\(" frontend/`
+   - `git grep -nE "setTimeout\\s*\\(\\s*['\"]|setInterval\\s*\\(\\s*['\"]" frontend/`
+5. **Identify the source bucket:**
+   - **Browser extension?** Test in Incognito with extensions disabled. If the warning vanishes, it's a user-environment issue, not a product bug. Close as not-a-bug.
+   - **Third-party script (analytics, embeds, GSI button)?** Identify the script source and decide: remove, replace with a CSP-clean alternative, or isolate via iframe / nonce-allowed inline.
+   - **First-party bundle issue?** Webpack/Next.js sometimes injects `Function()` for code-splitting helpers; validate via the source file name in the warning.
+6. **Optional hardening (independent of root-cause fix):** add CSP `report-uri` / `report-to` in report-only mode so violations are collected centrally instead of manually discovered. This is a small, separate PR worth shipping regardless.
+
+## Acceptance criteria
+
+- Warning reproduced (or not) against deployed production, not local dev.
+- DevTools capture filed with all five fields above.
+- Production CSP confirmed to still omit `'unsafe-eval'`.
+- First-party code grep confirmed clean.
+- If third-party: removed, replaced, or isolated. NOT papered over with CSP relaxation.
+- Closing the item documents which path (browser extension / third-party / first-party / Next.js internal) was the cause.
+
+## Priority
+
+- P2 by default.
+- P1 if reproduced in deployed production AND a real functional break is observed (not just a console warning).
+- If the warning is dev-only or extension-only: close as not-a-bug.
+
+## Short brief for the dev who picks this up
+
+Investigate and document the CSP violation. Do not add `'unsafe-eval'` to production. The current config (`unsafe-eval` allowed in dev only) is correct; if the warning fires in prod, find the source and fix it there, not in the CSP.
+
+## Cross-references
+
+- `frontend/next.config.ts` — the CSP construction (line 20 area for the dev/prod split)
+- Pentest history (per `code_sweep_*.md` memories) — CSP hardening was an explicit goal
+- DESIGN.md — no specific CSP rule, but the broader "production stays strict" posture is consistent with the project's locked rules

--- a/specs/flaky-transactions-page-test.md
+++ b/specs/flaky-transactions-page-test.md
@@ -2,7 +2,6 @@
 name: Flaky frontend test — transactions-page Task D7 transfer-wiring action column
 description: Frontend test tests/app/transactions-page.test.tsx > "TransactionsPage — transfer wiring (Task D7) > Per-row action column renders all actions on a single un-linked row (responsive layout)" intermittently fails in CI on getByRole('button', { name: /Mark as transfer: Solo tx/i }). Backend-only PRs (no frontend diff) have hit it. Likely a timing/visibility race with the responsive-layout DOM tree.
 type: project
-originSessionId: 8c696f02-828f-45cb-8352-6fc04e4fb413
 ---
 # Flaky test: transactions-page Task D7 action column
 

--- a/specs/flaky-transactions-page-test.md
+++ b/specs/flaky-transactions-page-test.md
@@ -1,0 +1,53 @@
+---
+name: Flaky frontend test — transactions-page Task D7 transfer-wiring action column
+description: Frontend test tests/app/transactions-page.test.tsx > "TransactionsPage — transfer wiring (Task D7) > Per-row action column renders all actions on a single un-linked row (responsive layout)" intermittently fails in CI on getByRole('button', { name: /Mark as transfer: Solo tx/i }). Backend-only PRs (no frontend diff) have hit it. Likely a timing/visibility race with the responsive-layout DOM tree.
+type: project
+originSessionId: 8c696f02-828f-45cb-8352-6fc04e4fb413
+---
+# Flaky test: transactions-page Task D7 action column
+
+**First spotted:** 2026-05-12 during the Wave 2A/B parallel sweep. **Recurring on at least:** PR #244, #246, #248, #261 (all unrelated scopes; backend-only PRs trigger it too).
+
+## Symptom
+
+```
+TestingLibraryElementError: Unable to find an accessible element
+  with the role "button" and name /Mark as transfer: Solo tx/i
+```
+
+Test file/name: `frontend/tests/app/transactions-page.test.tsx > TransactionsPage — transfer wiring (Task D7) > Per-row action column renders all actions on a single un-linked row (responsive layout)`.
+
+Always fails on the FIRST assertion that searches for the "Mark as transfer: Solo tx" button. Passes 4-5/5 times locally and on CI rerun.
+
+## Why it's a flake (not a real regression)
+
+- Backend-only PRs (zero frontend files modified) trigger the same failure.
+- The test passes on rerun every observed time so far.
+- The accessibility-tree dump in the failure shows the form-control surface but the button row is absent from the snapshot, suggesting a render-timing issue in the responsive-layout DOM that the test queries before it stabilizes.
+
+## Likely root cause hypotheses
+
+1. **Responsive layout double-render race.** The test runs in jsdom which doesn't honor CSS media queries the same way a real browser does. The component may render both the mobile + desktop branches and the action button is in the branch the test's query path doesn't reach on cold cache.
+2. **Async state not awaited.** A `useEffect` in TransactionsPage may set state after first paint, and the test queries `getByRole` before the second render lands. A `findByRole` + explicit wait would make it pass reliably.
+3. **Fixture pre-seeding race.** Setup helpers may create accounts/categories asynchronously and the test reads before mount completes.
+
+## Suggested fix shape (S effort, file-wide pass)
+
+Don't fix one test — fix the file's pattern. Sweep `frontend/tests/app/transactions-page.test.tsx` and replace EVERY `getByRole(/.../i)` that runs after a `render()` of `TransactionsPage` with `await findByRole(...)`. Or factor a helper at the top of the file that waits for the action column to be visible before any test assertions touch it (e.g., `await screen.findByRole('button', { name: /Edit:/i })` once after render, then sync `getByRole` calls for the rest of that test).
+
+Run the entire file 30+ times in a row locally to gain confidence (`for i in {1..30}; do npx vitest run frontend/tests/app/transactions-page.test.tsx --reporter=json | grep numFailingTests; done`). Don't ship until you observe 0 flakes in that loop.
+
+Don't change the production code — the responsive layout is correct in real browsers. Just fix the test file's brittleness, comprehensively.
+
+## Touch points
+
+- `frontend/tests/app/transactions-page.test.tsx` — file-wide audit + targeted async-wait conversions. Likely a shared setup helper at top of the file (renders TransactionsPage, returns a refs object) — that helper should `await` the first render-complete affordance before returning.
+- Possibly `frontend/tests/setup.ts` if a shared mock has a deferred resolution pattern that's contributing.
+
+## Impact
+
+Every flaky failure costs a CI rerun (~7 min wall clock) and breaks the "merge as soon as green" flow. Has surfaced as PR-blocker friction on at least 4 PRs to date.
+
+## Effort
+
+XS-S. ~10-30 LoC fix, plus running the test 20-50 times locally to gain confidence in stability before pushing.

--- a/specs/forecast-budget-enable-disable.md
+++ b/specs/forecast-budget-enable-disable.md
@@ -2,7 +2,6 @@
 name: Forecast + Budget enable/disable at org level (post-critical-work)
 description: Owner idea captured 2026-05-13. Move the per-page "Hide details" switch on Forecast plans (and a similar future affordance on Budget) up to Org configuration as an "Enable/Disable Forecasts" + "Enable/Disable Budgets" toggle. Not a current-batch dispatch; revisit when critical work is done.
 type: project
-originSessionId: 8c696f02-828f-45cb-8352-6fc04e4fb413
 ---
 # Forecast + Budget enable/disable at org level
 

--- a/specs/forecast-budget-enable-disable.md
+++ b/specs/forecast-budget-enable-disable.md
@@ -1,0 +1,50 @@
+---
+name: Forecast + Budget enable/disable at org level (post-critical-work)
+description: Owner idea captured 2026-05-13. Move the per-page "Hide details" switch on Forecast plans (and a similar future affordance on Budget) up to Org configuration as an "Enable/Disable Forecasts" + "Enable/Disable Budgets" toggle. Not a current-batch dispatch; revisit when critical work is done.
+type: project
+originSessionId: 8c696f02-828f-45cb-8352-6fc04e4fb413
+---
+# Forecast + Budget enable/disable at org level
+
+**Captured:** 2026-05-13. Idea, not for current-batch dispatch.
+
+## Context
+
+Today the `/forecast-plans` page has a "Hide details" switch (client-side preference). Owner observation: this is really an org-level capability toggle in disguise — "I don't want this feature at all" rather than "I want it but collapsed today." Same shape applies to Budget.
+
+Proposal: move both into the Org configuration surface (`/settings/organization` or a new dedicated `/settings/organization/features` tab) as proper enable/disable toggles:
+- **Enable forecasts** (default ON) — when OFF, hide forecast UI entry points across the app (sidebar nav, dashboard tiles, etc.) and skip the underlying queries
+- **Enable budgets** (default ON) — same shape
+
+## Why this matters
+
+1. UX: a user who never wants forecasts shouldn't see them surfaced repeatedly. A persisted org toggle is a more honest contract than a per-page collapse.
+2. Performance: when forecasts are disabled, the dashboard skips the forecast-aggregator query path. Same for budgets.
+3. Adoption signal: lets us measure "what percentage of orgs disable each surface" as a product signal once telemetry is in (L6.2).
+
+## Open questions to settle before dispatch
+
+- **L4.11 feature-overrides integration:** the existing `plans.features` JSON + `org_feature_overrides` table from PR #109 is the right substrate. Add keys `feature.forecasts` (default true) and `feature.budgets` (default true) to the catalog. Owner-controllable via `/system/plans` and per-org via `/admin/orgs/[id]` overrides AND via the org's own settings surface (different scope from admin override — needs threat model).
+- **Migration path:** existing orgs default to ON, no migration needed for existing data. New orgs default to ON unless plan says otherwise.
+- **UI removal coverage:** every entry point needs `has_feature(org_id, "feature.forecasts")` gating. Sidebar, dashboard tiles, settings tabs, navigation deep links.
+- **Data preservation:** when disabled, the org's existing forecast plans / budget data MUST persist (not deleted). Re-enabling restores access.
+- **"Hide details" switch fate:** keep as a per-user UI preference even after the org toggle ships? Or retire it entirely? Owner to decide.
+
+## Dependencies / sequencing
+
+- Best done after L4.11 plan-features infrastructure is fully wired (already shipped in PR #109). Implementation is mostly UI gating + the two new feature keys.
+- Should NOT block on AWS apex / launch infrastructure work.
+- Owner explicitly deferred this to "when we finish the critical work" — revisit after the current Wave (cross-org user search, rate limit overrides, reconciliation UI, apex track) settles.
+
+## Estimated effort
+
+S-M. ~300-500 LoC across the two feature gates, settings UI, and the entry-point audit. No new tables; no migration.
+
+## Touch points (when dispatched)
+
+- `backend/app/auth/feature_catalog.py` — add `feature.forecasts` + `feature.budgets`
+- `backend/app/services/feature_service.py` — `has_feature` already exists
+- `frontend/app/settings/organization/page.tsx` — new feature-toggle section
+- `frontend/components/AppShell.tsx` — sidebar entry point gating
+- `frontend/app/dashboard/page.tsx` — tile gating
+- All forecast/budget routes — feature-gate or 404 when disabled

--- a/specs/functional-tests-backlog.md
+++ b/specs/functional-tests-backlog.md
@@ -2,7 +2,6 @@
 name: Functional/E2E Tests Backlog
 description: Pre-launch nice-to-have — add functional/E2E tests so UX edge cases get caught by automation, not by manual exploration
 type: project
-originSessionId: 1d48e329-4340-4f5d-a67c-182b3d3f7479
 ---
 **Pre-launch backlog (good-to-have, not blocking):** Add functional/E2E tests on top of the unit suite.
 

--- a/specs/functional-tests-backlog.md
+++ b/specs/functional-tests-backlog.md
@@ -1,0 +1,22 @@
+---
+name: Functional/E2E Tests Backlog
+description: Pre-launch nice-to-have — add functional/E2E tests so UX edge cases get caught by automation, not by manual exploration
+type: project
+originSessionId: 1d48e329-4340-4f5d-a67c-182b3d3f7479
+---
+**Pre-launch backlog (good-to-have, not blocking):** Add functional/E2E tests on top of the unit suite.
+
+**Why:** Several UX bugs only surfaced through hands-on usage by fjorge — the close_period stub-collision (PR #93), the org-billing-cycle-day input behavior (number input clobber, stale value on revisit, missing projected end date) (PR for fix/org-billing-cycle-ux). These are exactly the cases unit tests miss because they're cross-layer (frontend state + backend response + UX flow).
+
+**How to apply when picked up:**
+- Stack candidates: Playwright (already used by Claude Code MCP) or Cypress, run against the local docker-compose stack.
+- Seed a clean test user/org via the existing `./pfv seed` flow or a dedicated test fixture.
+- Cover the high-value flows first:
+  1. Sign up → first user becomes superadmin → land on dashboard.
+  2. Set billing cycle day → revisit settings → value persists.
+  3. Close period → dashboard reflects new period → re-close (idempotent UI behavior).
+  4. Add transaction → appears in current period → close period → transaction stays where it belongs.
+  5. SSO login flow (the one that has bitten us twice).
+- Wire into CI as an optional/separate job (don't gate every PR on a 5-minute browser run; gate `main` merges instead).
+
+Captured 2026-04-26 after fjorge's manual QA caught the org-billing-cycle UX bugs that unit tests didn't.

--- a/specs/google-callback-observability-2026-05-20.md
+++ b/specs/google-callback-observability-2026-05-20.md
@@ -1,0 +1,62 @@
+---
+name: project-google-callback-observability-2026-05-20
+description: "Tomorrow-me's PR plan for the Google SSO callback hang surfaced 2026-05-19. Architect-locked constraints, framing, and scope fence."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 03afad38-c810-4af2-92cd-e1e586905784
+---
+
+# Google callback observability PR — 2026-05-20
+
+## Why this PR exists
+
+2026-05-19 18:51-18:54 production: user signs in via Google, hits Google's "Choose an account" page, picks account, ends up stuck. Backend logs show `POST oauth2/token` and `GET userinfo` both 200 OK — but **no uvicorn.access entry for the callback request's response**. The handler hung between userinfo and the redirect. Second attempt 2 min later worked (classic stale-pool retirement signature — see [[reference_first_attempt_stuck_pattern]]).
+
+We can't tell which `await` is hanging because none of the steps between userinfo and the redirect emit a log line. Uvicorn's access log only fires at response time.
+
+## Architect-locked constraints (do not negotiate without operator approval)
+
+1. **Breadcrumb logs at each Google callback phase, with durations + request_id.** Specific event names the architect listed verbatim:
+   - `userinfo_ok`
+   - `db_user_lookup_ok`
+   - `user_prepare_ok`
+   - `ttl_resolved`
+   - `session_issue_ok`
+   - `db_commit_ok`
+   - `redirect_built`
+   - `audit_ok`
+
+   **PII guard:** no raw Google tokens, no raw email unless hashed or already accepted audit style. The email field passes through `audit_events` for the new-user branch already — use that style.
+
+2. **Add a timeout around `_retire_poisoned_client.aclose()`.** Current implementation in `backend/app/redis_client.py` sets `_client = None` first (good), then `await poisoned.aclose()` **unbounded**. If aclose itself hangs on a dead socket, the retirement path becomes its own hang. Bound it with `asyncio.wait_for(..., timeout=2.0)` or similar; swallow the timeout exception (best-effort cleanup).
+
+3. **Be careful with request-level timeout middleware.** Architect: "broad cancellation can leave DB transactions and audit writes in awkward states if not tested well." Direction:
+   - **For tomorrow's PR:** route-local containment for the Google callback / post-userinfo section ONLY. `asyncio.wait_for` around the post-userinfo block, or per-step inside it.
+   - **NOT in this PR:** global middleware. Add later, with explicit cancellation tests (DB transaction rollback, audit fire-and-forget semantics, slowapi cleanup).
+
+4. **Do not present this as "the fix."** Framing is **containment + observability**. The durable orphan-cookie / catch-up mapping is still the real remaining session-design fix (see [[project_auth_stability_residuals]] Class 1). Do not let the PR title or body imply otherwise.
+
+## Scope fence
+
+**In scope:**
+- Breadcrumb logs at the 8 named phases.
+- `_retire_poisoned_client.aclose()` bounded timeout.
+- Route-local timeout on `/api/v1/auth/google/callback` post-userinfo section.
+- Tests: assert breadcrumbs fire; assert aclose timeout doesn't surface as RedisError; assert callback returns 503 on timeout (not hang).
+
+**Out of scope:**
+- Global request-timeout middleware.
+- Orphan-cookie durable catch-up (Class 1).
+- slowapi async storage (Class 2).
+- Any other auth refactor.
+
+## Approach hint
+
+The `_record_google_callback_failure` audit-write helper is already in `routers/auth.py` and used on each error branch. Add a parallel `_log_callback_breadcrumb(phase, duration_ms, request_id=...)` helper using structlog with a stable event name like `auth.google.callback.phase`. That keeps the operator-visible event family naming consistent with `auth.refresh.rejected`.
+
+**Gate the breadcrumbs behind `AUTH_DEBUG_LOGGING`** (the env var #316 introduced — see [[reference_auth_debug_logging]])? Architect didn't specify. Default position: **yes, gate them**, so production stays quiet under normal operation. Flip the flag during incident triage to capture phase durations.
+
+## Caveat for next-session-me
+
+The user was tired and frustrated when this was scoped. Honor the "small, focused" framing. Don't bundle anything else into this PR. Don't promise the orphan-cookie class will be fixed by this. When the user asks "will this fix it" — tell them: it makes the callback either succeed or surface a clear 503 with breadcrumbs that pin which await hangs next time. Not a fix for the class itself.

--- a/specs/google-callback-observability-2026-05-20.md
+++ b/specs/google-callback-observability-2026-05-20.md
@@ -1,10 +1,6 @@
 ---
 name: project-google-callback-observability-2026-05-20
 description: "Tomorrow-me's PR plan for the Google SSO callback hang surfaced 2026-05-19. Architect-locked constraints, framing, and scope fence."
-metadata: 
-  node_type: memory
-  type: project
-  originSessionId: 03afad38-c810-4af2-92cd-e1e586905784
 ---
 
 # Google callback observability PR — 2026-05-20

--- a/specs/i18n-l10n-goals.md
+++ b/specs/i18n-l10n-goals.md
@@ -2,7 +2,6 @@
 name: i18n and l10n Goals
 description: User locale preferences — country drives date/number/timezone defaults. Number format is per-user, NOT per-currency.
 type: project
-originSessionId: 132c537e-108e-499c-8f92-fb20140f80f3
 ---
 User wants to add internationalization/localization features:
 

--- a/specs/i18n-l10n-goals.md
+++ b/specs/i18n-l10n-goals.md
@@ -1,0 +1,20 @@
+---
+name: i18n and l10n Goals
+description: User locale preferences — country drives date/number/timezone defaults. Number format is per-user, NOT per-currency.
+type: project
+originSessionId: 132c537e-108e-499c-8f92-fb20140f80f3
+---
+User wants to add internationalization/localization features:
+
+1. **Country preference** — user selects country, which suggests defaults for everything below
+2. **Timezone support** — store/display dates in user's timezone, suggested from country but overridable
+3. **Date format** — country-driven (DD/MM/YYYY, MM/DD/YYYY, etc.)
+4. **Number format** — country-driven (1.000,00 vs 1,000.00 etc.)
+5. **Language support** — multi-language UI (i18n)
+6. **Multi-currency** — already partially supported (accounts have currency field), but needs proper currency conversion/display
+
+**Key design decision:** Number format is a **single user-level preference**, NOT per-currency. Even though accounts can have different currencies, all amounts display in the same number format. Mixing formats (e.g., € 1.000,00 alongside $ 1,000.00) would make transaction lists inconsistent and confusing.
+
+**Why:** Personal use across different contexts; the app should feel native regardless of locale.
+
+**How to apply:** When building new features involving dates, amounts, or user-facing text, design with i18n/l10n in mind (e.g., use UTC internally, format dates/numbers at the display layer, keep UI strings extractable). All formatting happens client-side based on user preferences, not server-side.

--- a/specs/infra-followups-post-cutover.md
+++ b/specs/infra-followups-post-cutover.md
@@ -2,7 +2,6 @@
 name: Infra Follow-ups (post-cutover) — PARTIAL
 description: App Platform droplet upgrade to 2GB SHIPPED via PR #143. Ansible CI + DO dynamic inventory and Terraform-generated data-plane passwords still PENDING. Both also tracked in the project_roadmap.md Tech Debt section to avoid double-counting.
 type: project
-originSessionId: 2a9f7d60-8bf7-49a0-873b-232cfcd5e16a
 ---
 After PR #116 (self-hosted MySQL + Redis droplet) ships and the managed → droplet cutover completes, three follow-up PRs are queued in this order. Architect-endorsed sequencing 2026-05-04.
 

--- a/specs/infra-followups-post-cutover.md
+++ b/specs/infra-followups-post-cutover.md
@@ -1,0 +1,80 @@
+---
+name: Infra Follow-ups (post-cutover) — PARTIAL
+description: App Platform droplet upgrade to 2GB SHIPPED via PR #143. Ansible CI + DO dynamic inventory and Terraform-generated data-plane passwords still PENDING. Both also tracked in the project_roadmap.md Tech Debt section to avoid double-counting.
+type: project
+originSessionId: 2a9f7d60-8bf7-49a0-873b-232cfcd5e16a
+---
+After PR #116 (self-hosted MySQL + Redis droplet) ships and the managed → droplet cutover completes, three follow-up PRs are queued in this order. Architect-endorsed sequencing 2026-05-04.
+
+**Why:** The cutover window is the worst possible time to introduce new secret-management or CI mechanisms. Land on the known-good `EV[...]`-via-`doctl` + manual Ansible flow first; iterate after.
+
+**How to apply:** Don't bundle these into PR #116 or its cutover. Open them as separate PRs after the droplet is in production and stable for a few days.
+
+---
+
+## Follow-up A: Ansible CI + DO dynamic inventory
+
+Replace the manual `ansible-playbook` step and the static `inventory.yml` with:
+
+- **Dynamic inventory plugin: `digitalocean.cloud.droplets`** (DO's official collection — NOT `community.digitalocean.digitalocean`, which is the older community fork). Filter by Terraform tag `data` via `api_filters.tag_name`; use `compose` to set `ansible_host` from `networks.v4` private IP.
+- `.github/workflows/ansible-config.yml` triggers on `infra/ansible/**` push to `main`, runs `ansible-playbook -i inventory/do.yml playbooks/site.yml`.
+- Vault-encrypt `mysql_app_password`, `mysql_backup_password`, `redis_password`; move from inventory vars to `group_vars/all/vault.yml`.
+- New GH Secrets: `DO_API_TOKEN_READ` (read-only droplets scope, separate from the TFC token), `ANSIBLE_VAULT_PASSWORD`, `ANSIBLE_SSH_KEY` (private key matching `fjorge-home` or a dedicated CI key).
+- Delete `inventory.yml.example`; update `infra/README.md` Step 2 to reflect dynamic inventory.
+
+Auto-committing a generated inventory is the wrong default — creates CI loops and noisy history. Dynamic inventory removes the drift problem entirely.
+
+## Follow-up B: Terraform-generated data-plane passwords
+
+`random_password` for MySQL app user, MySQL backup user, and Redis. Outputs marked `sensitive = true`. Ansible (running in CI from follow-up A) reads them via `terraform output -raw` and configures MySQL/Redis accordingly.
+
+**Scope strictly limited to the data plane.** Do NOT touch App Platform env vars in this PR.
+
+**Caveat (architect-flagged):** This is *not* secretless. Terraform docs are explicit: sensitive values still live in state, and `terraform output -raw` prints sensitive outputs. TFC state is encrypted at rest and access is RBAC-gated, but workspace permissions matter. Discipline: every output `sensitive = true`, no read-only collaborators on the workspace who shouldn't see the passwords.
+
+**Bootstrap order**: Terraform creates the droplet + `random_password` resources first; Ansible CI runs second and pulls passwords from TFC outputs.
+
+## Follow-up C: App Platform → single droplet migration (Option A)
+
+After follow-ups A and B settle, migrate App Platform (backend + frontend services + migrate PRE_DEPLOY job) onto a single droplet alongside MySQL + Redis. Architect-endorsed 2026-05-04, with explicit preference for **Option A (one 2GB droplet for everything)** over Option B (separate app + data droplets).
+
+**Why Option A over B for this project's size:**
+- Simpler than two 1GB droplets; avoids private networking between app and data boxes.
+- Gives MySQL more breathing room (1GB is tight, 2GB has headroom).
+- $12/mo for one `s-1vcpu-2gb` vs $13.20/mo for two `s-1vcpu-1gb` — within rounding error.
+- If the box runs hot, vertical scale to `s-2vcpu-4gb` ($24/mo) is still cheaper than App Platform.
+- If separation later becomes necessary, split data back out then.
+
+**Why this triggered (cost math, 2026-05-04):**
+- Current: $30/mo managed DB+Redis + ~$10-15/mo App Platform = **~$40-45/mo**
+- After PR #116 only: $7.20 data droplet + ~$10-15 App Platform = **~$17-22/mo** (saves ~$23/mo)
+- After Follow-up C (Option A): one $12/mo droplet for everything = **~$12/mo** (saves ~$28/mo total, $336/yr)
+
+**What this PR has to build (operational surface that App Platform was giving for free):**
+- TLS termination + cert auto-renewal (Caddy, or nginx + certbot)
+- Reverse proxy / routing (`/api` → backend, `/` → frontend)
+- Process supervision (systemd units, or Docker Compose with `restart: always`)
+- GH Actions workflow that builds backend + frontend container images, pushes to GHCR, SSHes to droplet, `docker compose pull && docker compose up -d`
+- Secret delivery: GH Secrets → SSH → `.env` file on droplet, OR continue using DO Secrets / external store. NOT `EV[...]` since App Platform is gone.
+- Health checks (existing `/api/v1/health` + `/api/v1/ready` endpoints work; just need the proxy to use them)
+- Backup story: nightly mysqldump (already done via Ansible), plus app-side log rotation
+- Rollback: keep last N image tags in GHCR, `docker compose up` with previous tag
+
+**Trigger conditions before starting:**
+- PR #116 cutover stable for 3-4 days
+- Data droplet CPU/RAM/disk metrics observed; confirms 2GB is enough headroom for MySQL + Redis + app
+- No outstanding incidents from the data cutover
+
+If the data droplet is already at >70% RAM with just MySQL+Redis, abort Option A and reconsider Option B (separate droplets) instead.
+
+## Follow-up D (CONDITIONAL, only if Follow-up C is NOT taken): App Platform spec ownership
+
+Only relevant if we decide to *stay* on App Platform long-term. Would replace the current `.do/app.yaml` + `doctl apps update --spec` flow with `digitalocean_app` resource end-to-end. Architect's framing: don't half-own it.
+
+If Follow-up C ships (move off App Platform), this whole question is moot — `.do/app.yaml`, the deploy GH Action, and the `EV[...]` re-encryption dance all go away.
+
+---
+
+## What stays out of scope even with all four follow-ups
+
+External-issued secrets — `MAILGUN_API_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` — are issued by their respective platforms. Terraform can't generate them. They'll always need an external source (DO Secrets, 1Password CLI, GH Secrets, manual `EV[...]` blobs while still on App Platform). Pattern stays: Terraform-generated for things it can mint; external for everything else.

--- a/specs/loan-account-type.md
+++ b/specs/loan-account-type.md
@@ -2,7 +2,6 @@
 name: Loan Account Type
 description: 2026-05-15 owner backlog. Critical assessment of a suggested Loan account type. Keeps principal/rate/term/origination + amortization formula + payment source linkage. Defers per-payment interest/principal split + full amortization UI to V2.
 type: project
-originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
 ---
 # Loan Account Type
 

--- a/specs/loan-account-type.md
+++ b/specs/loan-account-type.md
@@ -1,0 +1,158 @@
+---
+name: Loan Account Type
+description: 2026-05-15 owner backlog. Critical assessment of a suggested Loan account type. Keeps principal/rate/term/origination + amortization formula + payment source linkage. Defers per-payment interest/principal split + full amortization UI to V2.
+type: project
+originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
+---
+# Loan Account Type
+
+**Captured 2026-05-15.** Discussion-grade spec; pre-implementation. Companion to `project_credit_card_model_upgrade.md` — both share the `payment_source_account_id` plumbing.
+
+## Owner-stated motivation
+
+Today PFV has no native loan modeling. Users with a fixed-term loan (car, mortgage, personal) model it as a generic account that goes from negative to zero. They lose: payoff-date projection, principal-vs-interest visibility, amortization-aware forecasting.
+
+The user wants a Loan account type that natively understands a fixed lump sum, fixed monthly payment, and a maturation date.
+
+## What the suggested design proposed
+
+The suggestion (verbatim user message) included:
+- New fields: Principal Amount, Interest Rate, Loan Term (months), Amortization Type, Origination Date
+- Computed: Amortization Schedule (full table), Fixed Monthly Payment via standard PMT formula, Maturation Date
+- UI: total borrowed, interest rate, term length, first payment date
+- Transactions: log initial disbursement to a linked asset account, every payment splits into interest expense + principal reduction
+
+## Critical assessment
+
+### What's right (keep)
+
+1. **Loans really are different from credit cards.** A loan has a fixed schedule (P, r, n → PMT) and a known maturation date. A CC has a revolving balance. Treating them as the same account-type with different copy is dishonest to the data shape.
+2. **Principal, rate, term, origination date** are real attributes with no ambiguity.
+3. **PMT formula** is well-understood and deterministic: `PMT = P × r(1+r)^n / ((1+r)^n − 1)` where r is *monthly* rate. We can compute the expected monthly payment with high confidence.
+4. **Maturation date** is derivable from origination + term. Shown to user as "Payoff date: 2031-04-15" is a real visibility win.
+5. **Disbursement → linked asset account** is correct accounting. Money came from somewhere; the loan liability is offset by that asset's increase.
+
+### What's overengineered for V1
+
+1. **Per-payment interest/principal split.** The standard amortization split (early payments mostly interest, late payments mostly principal) is well-known math, BUT real banks often: charge fees mid-loan, accept extra principal payments that change the schedule, modify the schedule for skip-a-payment programs, adjust for variable rates. V1 should model payments as opaque outflows: balance decreases by the payment amount, no split shown. V2 can add the split as a per-transaction `principal_portion + interest_portion` if users ask.
+2. **Full amortization schedule UI.** Generating a 60- or 360-row schedule is cheap (it's pure math). Rendering it usefully in the UI is its own design task (it's a long table that needs sorting, pagination, "what if I pay extra" overlays). Defer to V2 reports tier. V1 surfaces just the *next* payment + the *payoff date*.
+3. **"Amortization Type" enum.** Suggested as "Standard Simple Interest". 99% of consumer loans are standard amortization. Don't store a field for a value that has only one value in practice. Add the enum only when we encounter a second amortization type that needs different math.
+
+### What's missing from the suggested design (add)
+
+1. **Payment source account linkage** — same plumbing as the CC spec. Loan payments come from a checking/savings account. The forecast service needs to know which, to drop the source account's projected balance on the payment date.
+2. **Variable-rate loans.** The standard PMT formula assumes a fixed rate. Adjustable-rate loans (ARMs) and HELOCs change the rate per period. For V1: only fixed-rate loans are supported; ARM is a flag for "talk to me when we encounter a real user with an ARM."
+3. **Early payoff handling.** What if the user pays an extra $5000 toward principal? The remaining schedule changes. V1 should recompute the schedule whenever a payment exceeds the expected PMT (treats overage as extra principal). V2 can let the user explicitly tag transactions as "extra principal."
+4. **Outstanding-balance projection.** The user's dashboard should be able to show "loan balance projected at end-of-year = $X". This is a forecast-service integration point.
+
+## Recommended V1 scope
+
+### New AccountType row
+
+Seed a system row via migration:
+```
+INSERT INTO account_types (org_id=NULL, name='Loan', slug='loan', is_system=TRUE) -- or per-org idempotent insert per existing seeding pattern
+```
+
+(Per `codebase_shape.md` §2, AccountType is a per-org table with `is_system` flag. Replicate the existing seeding pattern — each org gets a loan AccountType on bootstrap, OR a global is_system=TRUE row visible to all orgs. Decide based on existing `org_bootstrap_service.seed_org_defaults` shape.)
+
+### Schema additions (`accounts` table — same migration as CC upgrade if bundled)
+
+| Field | Type | Notes |
+|---|---|---|
+| `principal_amount` | DECIMAL(12,2) NULL | Required for loan accounts |
+| `interest_rate_apr` | DECIMAL(5,2) NULL | Required for loan accounts; fixed-rate only V1 |
+| `term_months` | SMALLINT NULL | Required for loan accounts |
+| `origination_date` | DATE NULL | Required for loan accounts |
+| `first_payment_date` | DATE NULL | Required for loan accounts |
+| `payment_source_account_id` | INT NULL FK | Shared with CC spec |
+
+(`payment_source_account_id` and the CC fields can share one migration if both designs land together. Bundling avoids two ALTER TABLEs on `accounts` in close succession.)
+
+### Validation rules
+
+- All five loan-specific fields required when `account_type.slug === 'loan'`
+- `principal_amount > 0`, `interest_rate_apr >= 0`, `term_months > 0`, `term_months <= 480` (40 years max — covers mortgages)
+- `first_payment_date >= origination_date`
+- `payment_source_account_id` same constraints as CC spec (same org, source type is checking/savings, not self)
+
+### Computed (no storage)
+
+| Metric | Formula |
+|---|---|
+| Expected monthly payment | `PMT = P × r(1+r)^n / ((1+r)^n − 1)` where r = APR/12/100, n = term_months, P = principal_amount |
+| Maturation date | `first_payment_date + (term_months - 1) months` |
+| Payoff date projected (current) | `first_payment_date + ceil(current_balance / expected_monthly_payment) months` — assumes current pace |
+| Total interest projected | `(expected_monthly_payment × term_months) - principal_amount` |
+
+All computed on-demand in `app/services/loan_service.py` (new file) and exposed via the account detail endpoint.
+
+### UI changes
+
+**Account create form:**
+- When `account_type.slug === 'loan'` is selected, show: principal amount, interest rate (%), term length (months — dropdown 12/24/36/48/60/72/84/120/180/240/360/custom), origination date, first payment date, payment source account picker
+- On submit: optional one-click "create the matching disbursement transaction" — credits the source asset account by `principal_amount`, debits the loan account by `-principal_amount`. Use existing transfer-pair primitive (`linked_transaction_id`) so it's auditable and unlinkable later.
+
+**Account detail view:**
+- Show: principal, current balance, interest rate, expected monthly payment, maturation date, payoff date projected
+- Show: "Paid from: <source account name>" with edit affordance
+- Show: next payment ("$X due on Apr 15, 2026")
+- Auto-create a recurring transaction template on loan creation? **Yes** — leverage existing `recurring` model (per `codebase_shape.md` §2). The recurring template fires monthly from `first_payment_date`, amount = expected monthly payment, source account = `payment_source_account_id`, category = "Debt Payment". User can edit / pause / delete the recurring if their actual payment differs.
+
+**Dashboard tile (optional V1, more likely V2):**
+- "Loans on track" widget — counts loans where projected payoff < maturation, etc.
+
+### Forecast service integration
+
+- When forecasting a future period, look at every loan account
+- Project an outflow of `expected_monthly_payment` from `payment_source_account_id` on every `first_payment_date + n months` falling in the forecast window
+- Project a balance reduction of `expected_monthly_payment` on the loan account on each payment date
+- Source: synthesized forecast item with provenance `source=loan_payment` — same shape as the CC `source=credit_card_payment` proposal
+
+### Out of scope V1
+
+- Per-payment interest/principal split (defer to V2)
+- Full amortization schedule UI (defer to V2 reports/insights tier)
+- Variable-rate / ARM loans (defer until a user has one)
+- Extra-principal-payment overlays / "what if I pay extra" simulator (V2)
+- Refinancing flow (V3)
+- Multiple loan disbursements (lines of credit) — that's a different account type
+- Interest deduction tax tracking (V3+, only relevant in some jurisdictions)
+
+## Cross-references
+
+- `project_payment_source_account_foundation.md` — prerequisite slice for the shared `payment_source_account_id` plumbing
+- `project_credit_card_model_upgrade.md` — companion liability spec; same dependency on foundation
+- `project_billing_cycle.md` — loan payments should honor the org's billing-cycle-day in the forecast view
+- `project_user_billing_flow.md` — salary-anchored period thinking applies
+- L3 roadmap section — natural fit for an L3.x row
+
+## Open product questions
+
+1. **Disbursement auto-transaction**: required, optional with a checkbox, or never auto-create? Lean: optional with the checkbox defaulted ON. User who imported their loan from CSV and already has the disbursement won't want a duplicate; the checkbox lets them opt out.
+2. **Variable-rate flag**: do we add a placeholder `rate_type` field NOW even though V1 is fixed-rate only? Cheap insurance against later migrations. Lean: YES, add `rate_type ENUM('fixed', 'variable') NOT NULL DEFAULT 'fixed'` and only support `'fixed'` in code paths until a real ARM lands.
+3. **Recurring template auto-creation**: cleanest UX if it exists, but what if user changes the source account later? Need to update the recurring template. Add this as a write hook on `accounts.payment_source_account_id` change.
+
+(The earlier "bundle with CC?" question is now resolved: ship separately per architect 2026-05-15 — see Priority section below.)
+
+## Effort estimate
+
+- Schema (Loan-specific columns only — `payment_source_account_id` ships in the foundation slice) + AccountType seed + validation + service + recurring auto-creation + forecast integration: **M-L (3-6 days)**
+
+## Priority + sequencing (architect-locked 2026-05-15)
+
+**P4 pre-launch — DEFERRABLE.** Architect-locked sequencing places this fourth in the financial-primitives stack:
+
+1. Foundation: `payment_source_account_id` plumbing — see `project_payment_source_account_foundation.md`
+2. Credit Card model V1 — see `project_credit_card_model_upgrade.md`
+3. Dashboard Phase 0 per-type tiles — independent of foundation
+4. **THIS SLICE: Loan account V1**
+5. Configurable dashboard widget framework — post-launch
+
+**Defer unless loans are central to target-user first impression.** Architect rationale: loans are a bigger product surface than CC, and most beta users don't have a primary loan to track. CC affects monthly cash-flow ambiguity more heavily and ships sooner. Loan V1 stays specced and ready, but no commit to ship pre-launch unless the product positioning explicitly needs it.
+
+**Do NOT bundle with CC.** Each liability UX ships as its own PR after the foundation lands, so one liability model can't block the other in review and either can be reworked without touching the other.
+
+**Schema placement of the shared field**: deferred to the foundation slice's decision memo (`accounts.payment_source_account_id` directly vs new `liability_terms` child table). This Loan spec assumes the architect-approved placement; do not re-decide here.
+
+Becomes more valuable as a feature differentiator if shipped post-launch (compared to YNAB / Monarch / Copilot — none of them model loans well today).

--- a/specs/localized-import-intelligence.md
+++ b/specs/localized-import-intelligence.md
@@ -1,0 +1,58 @@
+---
+name: Localized Import Intelligence (long-term thread)
+description: Architect direction (2026-05-02) for evolving import categorization beyond the global deterministic L3.10 baseline into a locale-aware system. Captures the lookup order, telemetry shape, and per-locale extensions planned post-L3.10.
+type: project
+originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
+---
+## Direction (architect-locked 2026-05-02)
+
+PFV's import pipeline must eventually handle merchants, dates, numbers, and bank descriptors **per country/locale**, not just globally. L3.10 ships deterministic and global; this thread evolves it. The current `merchant_dictionary` is global token → category slug, which works for English/Iberian merchants but misses entirely on real Dutch banking data (verified 2026-05-02 against 345-row ING NL CSV: 0/345 coverage with the original Iberian/UK seed).
+
+**Lookup order (locked):** `org_rules → locale-aware dictionary → AI fallback → default`. AI is a resolver for ambiguous localized descriptors, NOT the first layer.
+
+## What's true today (post-L3.10)
+
+- **`merchant_dictionary` schema:** global, no locale columns. Single normalized_token column.
+- **Seed scope:** Iberian + UK + a few Dutch additions (KPN, ODIDO, THUISBEZORGD, JUMBO, AYVENS, FRANK ENERGIE) added in L3.10's Path B fix-pass. Coverage on the user's real ING data lifts from 0% → ~3.5% with these additions; further lift requires locale-aware normalization (city/country tail stripping) that's been deferred.
+- **Normalization** (`category_rules_service.normalize_description`): global. Strips bank-noise prefixes, masked card prefixes, IBAN tails, terminal IDs, dates, NFKD-folds accents, strips trailing company-form suffixes (B.V., N.V., S.A., BVBA, GMBH, AG, INC, LLC, LTD).
+- **Metrics scaffold** (`smart_rules.preview_built` and `smart_rules.import_executed` + `smart_rules.miss`): captures `org_id`, `normalized_token`, source-split counts. **Forward-compatible** — structlog kwargs are additive; future locale tags slot in without breaking existing log consumers.
+- **CSV parser:** assumes ISO-ish dates and US decimal. Doesn't auto-detect `YYYYMMDD`, comma-decimal, or semicolon delimiter (real ING NL format).
+- **Account model:** no `country_code`, no `currency`, no `source_bank`. All scoping is by `org_id` only.
+
+## Future work (sequenced — see `project_roadmap.md` P-IL section)
+
+1. **P-IL.1 — Locale hints on accounts + CSV imports.** Country, currency, source-bank fields where derivable. CSV uploader detects format hints (semicolon + comma-decimal + YYYYMMDD ≈ NL/DE export). User can override per import.
+
+2. **P-IL.2 — Per-locale `merchant_dictionary` extension.** Add optional `country_code` and `source_bank_hint` columns; lookup falls back to global match if no locale-specific entry. Migrate the Dutch additions from L3.10 into NL-locale rows.
+
+3. **P-IL.3 — Locale-aware normalization.** Country-specific tail-stripping. The single biggest unlock for Dutch coverage today: strip trailing city/country tokens like `AMERSFOORT NLD`, `LISBOA`, `DUBLIN IRL`. Out of scope for L3.10 (architect approved). Likely a `_TRAILING_LOCATION_TOKENS` set keyed by `country_code`.
+
+4. **P-IL.4 — Miss-token telemetry with locale tags.** Extend `smart_rules.miss` to include `country_code`, `currency`, `source_bank` when known. Lets us measure dictionary gaps per market. **Privacy:** never log raw descriptions, only `normalized_token` + locale metadata.
+
+5. **P-IL.5 — LAI.1 prompt locale-awareness.** When the LLM fallback ships, pass locale as system context so the model resolves "JUMBO ... NLD" without seeing PII.
+
+6. **P-IL.6 — Date/number CSV parser per locale.** Required for L3.2 import hardening on non-EN/US banks. Currently a hard miss for ING NL (semicolon, comma-decimal, YYYYMMDD).
+
+## Privacy invariants (carry forward)
+
+- `org_id` and `normalized_token` are loggable. Raw transaction descriptions are NOT.
+- Cross-org `vote_count` bumps in `merchant_dictionary` only happen when the org has explicitly opted in via `org_settings.share_merchant_data`.
+- Per-locale dictionary extensions follow the same rule: no raw text crosses an org boundary; only canonical normalized tokens + locale metadata.
+- LLM fallback (LAI.1) sends only the description string + locale hint, never amount/account/org context. Already documented in the LAI tier section of the roadmap.
+
+## Why the current architecture is forward-compatible
+
+- The lookup function `infer_category(db, *, org_id, description)` already returns `(cat_id, source)` — the source dimension extends to `"locale_dictionary"` later without API change.
+- `merchant_dictionary` is a single table — adding nullable `country_code`/`source_bank_hint` columns is a non-breaking migration. Existing rows become "global" entries (NULL = match-anything).
+- Metric events take arbitrary kwargs — adding `country_code=...` is non-breaking.
+- The trailing-company-form strip in normalization is opt-in via `_TRAILING_COMPANY_FORMS` constant — locale-specific stops can be added per country without rewriting the function.
+
+## How to act on this thread
+
+When ANY of these signals fire, revisit this thread:
+- Real users in a new market report low suggestion coverage.
+- `smart_rules.miss` aggregate logs show a dominant non-English token cluster.
+- A new bank format is added that the parser doesn't handle.
+- LAI.1 implementation begins (P-IL.5 dependency lights up).
+
+Don't preemptively build P-IL.1 through P-IL.6. The architect's framing: ship L3.10, measure, iterate.

--- a/specs/localized-import-intelligence.md
+++ b/specs/localized-import-intelligence.md
@@ -2,7 +2,6 @@
 name: Localized Import Intelligence (long-term thread)
 description: Architect direction (2026-05-02) for evolving import categorization beyond the global deterministic L3.10 baseline into a locale-aware system. Captures the lookup order, telemetry shape, and per-locale extensions planned post-L3.10.
 type: project
-originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
 ---
 ## Direction (architect-locked 2026-05-02)
 

--- a/specs/localstorage-scope-persisted-filters.md
+++ b/specs/localstorage-scope-persisted-filters.md
@@ -2,7 +2,6 @@
 name: localStorage Scope for Persisted Sort/Filter Keys (post-#195)
 description: PR #195 introduced sort + filter persistence keys keyed by surface only (`pfv:sort:transactions`, etc). Reviewer flagged as non-blocking residual: scope by org/user when shared-browser org switching becomes common.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Captured 2026-05-10.** Non-blocking residual flagged by external reviewer when approving PR #195. Park for post-launch.
 

--- a/specs/localstorage-scope-persisted-filters.md
+++ b/specs/localstorage-scope-persisted-filters.md
@@ -1,0 +1,43 @@
+---
+name: localStorage Scope for Persisted Sort/Filter Keys (post-#195)
+description: PR #195 introduced sort + filter persistence keys keyed by surface only (`pfv:sort:transactions`, etc). Reviewer flagged as non-blocking residual: scope by org/user when shared-browser org switching becomes common.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Captured 2026-05-10.** Non-blocking residual flagged by external reviewer when approving PR #195. Park for post-launch.
+
+## Current state (post-#195)
+
+`frontend/lib/hooks/persisted-keys.ts` defines flat keys:
+- `pfv:sort:transactions`
+- `pfv:sort:accounts`
+- `pfv:sort:dashboard-spending`
+- `pfv:sort:dashboard-transactions`
+- `pfv:filters:transactions`
+
+These are NOT scoped by user or org. Two consequences worth noting:
+
+1. **Same-browser, multi-org user.** If a user belongs to multiple orgs and switches between them, they see the same persisted sort and filter state across orgs. That can be a feature (consistent UX) or a bug (filters that made sense for org A don't for org B). Today it's not common; post-launch with multi-org users it might bite.
+
+2. **Same-browser, multiple-user accounts.** A shared device (e.g., couple sharing a laptop) where partner A and partner B each have their own account: today, both inherit each other's persisted sort/filter state. Harmless for sort direction, potentially confusing for filters.
+
+## Suggested fix shape
+
+When this becomes worth doing, scope keys via the current user/org context:
+- `pfv:sort:transactions:org-${orgId}` or `pfv:sort:transactions:user-${userId}`
+- Decide which scope: probably `org-${orgId}:user-${userId}` for full isolation; or just `user-${userId}` if filter context is per-user not per-org
+- Keys become a function rather than a constant: `sortKey(orgId, userId, "transactions")`
+- The `usePersistedSort` and `usePersistedFilters` hook signatures take the dynamic key
+- On user logout / org switch, the keys swap automatically because the hook reads the current context
+
+## Why park
+
+- Pre-launch: friends-testing only, low likelihood of multi-org or shared-browser usage matching the failure mode
+- Single-user solo accounts (the seed user) experience zero impact
+- Easy to retrofit when/if needed; no migration of existing localStorage values required (old keys just become orphaned)
+
+## Cross-references
+
+- PR #195 (`feat/sort-filters-persistence`) — the work that introduced the unscoped keys
+- `frontend/lib/hooks/persisted-keys.ts` — the file to change when scoping is added
+- `frontend/lib/hooks/use-persisted-sort.ts`, `use-persisted-filters.ts` — the hooks that consume the keys

--- a/specs/low-balance-day-warning.md
+++ b/specs/low-balance-day-warning.md
@@ -2,7 +2,6 @@
 name: Low-Balance-Day Warning (cashflow risk forecast)
 description: Surface a warning when the user's expected balance on a specific day of the month dips below upcoming expenses, based on recurring + pending + historical patterns.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Captured 2026-05-10.** Not a launch blocker. Rough idea, sized M-L, parks for future prioritization.
 

--- a/specs/low-balance-day-warning.md
+++ b/specs/low-balance-day-warning.md
@@ -1,0 +1,53 @@
+---
+name: Low-Balance-Day Warning (cashflow risk forecast)
+description: Surface a warning when the user's expected balance on a specific day of the month dips below upcoming expenses, based on recurring + pending + historical patterns.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Captured 2026-05-10.** Not a launch blocker. Rough idea, sized M-L, parks for future prioritization.
+
+## Concept
+
+Warn the user when an upcoming day in the current (or near-future) period is projected to leave them unable to cover expenses falling on that day. Surface as either:
+- A new Dashboard card ("Cashflow risk: 2026-05-22"), OR
+- A signal on the Accounts card / Forecast section, OR
+- An inline highlight on the day in a calendar/timeline view (post-launch).
+
+Final placement TBD; test in user research.
+
+## Inputs
+
+- **Pending transactions** with `settled_date` (PR #157 + #163 work). Already a first-class field.
+- **Recurring transactions** generation (templates that materialize on `next_due_date`).
+- **Historical patterns** (optional v2): if the user typically pays X on day 25 even without a recurring template, flag it.
+- **Current account balance(s)** at compute time.
+- **Per-account or aggregate** — open question (probably aggregate per currency to start).
+
+## Algorithm sketch
+
+```
+For each day D between today and end-of-period:
+    expected_balance(D) = current_balance
+                        + sum(pending_inflows where settled_date <= D)
+                        - sum(pending_outflows where settled_date <= D)
+                        + sum(recurring_inflows where next_due_date <= D and within period)
+                        - sum(recurring_outflows where next_due_date <= D and within period)
+    if expected_balance(D) < 0 OR expected_balance(D) < threshold:
+        flag D as risk day, with the obligations falling on/by D
+```
+
+Threshold can be 0 (overdraft) or a user-set buffer (e.g., "warn if I drop below 200 EUR").
+
+## Open questions
+
+1. **Per-account vs aggregate.** Per-account is more accurate (a credit card doesn't bail out a checking account at the bank level). Aggregate is simpler. Probably do per-account once the data model supports it cleanly.
+2. **Currencies.** Multi-currency is post-launch (P3); v1 should be single-currency-aware.
+3. **Historical-pattern detection.** Looks like a small ML or rule-based pass over `transactions` grouped by description/merchant. Out of scope for v1; add to LAI tier if useful.
+4. **UX.** Card vs banner vs calendar overlay vs inline-on-Forecast. Test before committing.
+5. **False-positive cost.** Warning the user about a "risk day" when they have a settlement coming creates anxiety. Rules must be conservative.
+
+## Cross-references
+
+- `project_billing_settled_date.md` (settled_date semantics)
+- `2026-05-08-forecasts-ux-restructure.md` (per-account month-end balance — same data shape, different time slice)
+- Punch list item 13 (settled_date in form, shipped via PR #197)

--- a/specs/payment-source-account-foundation.md
+++ b/specs/payment-source-account-foundation.md
@@ -1,0 +1,164 @@
+---
+name: Payment Source Account Foundation
+description: 2026-05-15 architect-locked sequencing — ship the shared payment_source_account_id plumbing as its own PR before any CC or Loan UX work. Foundation only. No payment automation, no generated transactions, no cron jobs.
+type: project
+originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
+---
+# Payment Source Account Foundation
+
+**Captured 2026-05-15.** Architect-locked sequencing decision: this slice ships FIRST, before any of the financial-primitives liability UX (Credit Card model upgrade, Loan account type). The CC and Loan UX slices both depend on this plumbing; landing it independently lets each liability UX ship without blocking the other in review.
+
+## Architect-locked scope (verbatim)
+
+> Scope:
+> - Add nullable `payment_source_account_id` to account/liability metadata where appropriate.
+> - Validation: same org, source account must be checking/savings/cash-like, source cannot equal target account.
+> - No payment automation, no generated transactions, no cron jobs.
+> - Expose the field in backend schemas and account settings UI only where relevant.
+> - Add tests for validation, org isolation, deletion/deactivation behavior, and forecast read compatibility.
+> - Include a short decision memo on whether this belongs directly on accounts or in a liability-specific metadata table before implementing.
+>
+> Out of scope:
+> - Credit card statement cycles
+> - Loan amortization UI
+> - Minimum payment / interest computation
+> - Configurable dashboard widgets
+> - Auto-created recurring rows
+
+## Open decision (resolve before implementing)
+
+**Schema placement: `accounts.payment_source_account_id` (V1A) vs new `liability_terms` child table (V1B)?**
+
+The foundation PR must produce a short decision memo on this question first. Both options carry the same logical field — the difference is whether liability-specific metadata lives directly on the parent `accounts` row or in a 1:0..1 child table keyed by `account_id`.
+
+### V1A: directly on `accounts`
+
+Pros:
+- Simple, denormalized; fast reads (no join for the common "account detail" page)
+- Matches the existing PFV convention (`billing_cycle_day`, `allow_manual_balance_adjustment`, opening-balance fields all live directly on `accounts` / `organizations`)
+- One ALTER TABLE; small migration surface
+- Easy to query in admin tools without joining
+
+Cons:
+- `accounts` accumulates nullable columns: `payment_source_account_id`, plus eventual CC fields (`credit_limit`, `statement_closing_day`, `payment_due_day`, `apr`, `payment_strategy`, `fixed_payment_amount`), plus eventual Loan fields (`principal_amount`, `interest_rate_apr`, `term_months`, `origination_date`, `first_payment_date`, `rate_type`). For an asset account (checking/savings/cash) none of those apply, leaving most rows with ~10 NULL columns.
+- Schema-level inability to express "these fields are required IFF account is a credit card" — has to live in service/validation layer
+
+### V1B: new `liability_terms` table
+
+Shape sketch:
+
+```sql
+CREATE TABLE liability_terms (
+  account_id INT PRIMARY KEY,
+  payment_source_account_id INT NULL,
+  -- credit card fields (added when CC spec lands)
+  credit_limit DECIMAL(12,2) NULL,
+  statement_closing_day TINYINT NULL,
+  payment_due_day TINYINT NULL,
+  apr DECIMAL(5,2) NULL,
+  payment_strategy ENUM(...) NULL,
+  fixed_payment_amount DECIMAL(12,2) NULL,
+  -- loan fields (added when Loan spec lands)
+  principal_amount DECIMAL(12,2) NULL,
+  interest_rate_apr DECIMAL(5,2) NULL,
+  term_months SMALLINT NULL,
+  origination_date DATE NULL,
+  first_payment_date DATE NULL,
+  rate_type ENUM('fixed','variable') NULL,
+  FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE,
+  FOREIGN KEY (payment_source_account_id) REFERENCES accounts(id) ON DELETE SET NULL
+);
+```
+
+Pros:
+- `accounts` stays clean; the parent row's columns describe what every account has, not what some accounts might have
+- Cascading delete is naturally scoped to the liability metadata
+- A liability-specific service layer has one obvious source of truth
+
+Cons:
+- Every "show me the credit card detail" path needs a join — most callers care about it; usage frequency is high
+- The PFV pattern leans toward fat-account-row (per existing code) — this would be a new pattern that future authors have to know about
+- Two-step writes (insert account + insert liability_terms) need transactional discipline
+
+### Decision-memo deliverable
+
+Foundation PR must produce a 1-page decision memo capturing:
+- The two options laid out above (or any third option the implementer discovers)
+- A recommendation with rationale referencing PFV's existing schema patterns (`codebase_shape.md` §2: list of fields on `accounts` and `organizations` to compare against)
+- Migration sketch for the chosen option
+- Owner sign-off line at the bottom
+
+Default lean if no strong signal emerges: **V1A** (directly on `accounts`), because it matches existing PFV idiom and the asymmetry-tolerance pattern is already established (most accounts won't have `allow_manual_balance_adjustment=TRUE` either, and that's a single column with no complaints). Resolve in the memo.
+
+## Concrete scope of the foundation PR
+
+### Schema (one column, on the chosen home)
+
+- `payment_source_account_id INT NULL` FK to `accounts.id` ON DELETE SET NULL
+- New alembic migration, ~10 lines
+
+### Validation (`accounts_service.py` or equivalent)
+
+When `payment_source_account_id` is set or updated:
+1. Source account must exist in the same `org_id` as the target account
+2. Source account's `account_type.slug` must be in an allowlist: `checking`, `savings`, `cash`. NOT `credit_card`, NOT `loan`. Resolve via join to `account_types`.
+3. Source account cannot equal target (no self-pay): `source_id != target.id`
+4. Source account must be active (`is_active=TRUE`) at write time. After write, if source is later deactivated, the FK SET NULL handles automatic cleanup — call it out in the deletion test.
+
+### Backend schema exposure
+
+- `AccountResponse` Pydantic schema gains optional `payment_source_account_id: int | None`
+- `AccountCreate` and `AccountUpdate` schemas accept it; null clears, omit preserves (use the project's existing `model_fields_set` idiom — see `codebase_shape.md` §3)
+- Routes that already serialize `Account` (currently `GET /api/v1/accounts`, `POST /api/v1/accounts`, `PATCH /api/v1/accounts/{id}`) inherit the field for free
+
+### UI exposure (minimal, V1)
+
+- Account edit form: show a "Paid from" picker on accounts whose `account_type.slug` is `credit_card` OR `loan`. Picker shows other accounts of allowlisted types in the same org. Null option = "(none)".
+- Account detail: show "Paid from: <source name>" line if set.
+- DO NOT add to dashboard yet (forecast integration is the CC/Loan UX slices).
+
+### Tests
+
+Five tests minimum on the service layer:
+
+1. **Same-org validation**: setting `payment_source_account_id` to an account in a different org returns 400/422 (depending on existing error class)
+2. **Org isolation read**: `GET /api/v1/accounts` for org A never surfaces a `payment_source_account_id` pointing at an org B account (currently true by construction since accounts are org-scoped; pin it)
+3. **Type allowlist**: setting source to a credit_card or loan account returns 422
+4. **Self-pay prevention**: setting source to the account itself returns 422
+5. **Deletion/deactivation behavior**: deleting the source account leaves the target with `payment_source_account_id=NULL` (FK SET NULL); deactivating the source account leaves the FK intact but a separate test asserts UI/service surfaces a "source is inactive" warning at read time
+
+Plus one schema-level test: existing forecast reads continue to compile and return the same shape with the new field present.
+
+## Out of scope (architect-locked)
+
+- Credit card statement cycles → `project_credit_card_model_upgrade.md`
+- Loan amortization UI / PMT computation → `project_loan_account_type.md`
+- Minimum payment / interest computation (both rejected per CC spec)
+- Configurable dashboard widgets → `project_configurable_dashboard_widgets.md`
+- Auto-created recurring rows
+- Forecast service integration (this is the CC and Loan UX slices' job to consume the field)
+
+## Effort estimate
+
+- Schema + validation + backend schema exposure + minimal UI + tests + decision memo: **S (1-2 days)**
+
+## Priority
+
+**P2 pre-launch**, per architect 2026-05-15. The foundation by itself improves nothing user-visible; its value is unlocking the CC and Loan UX slices without coupling them.
+
+## Sequencing (architect-locked 2026-05-15)
+
+| Slice | Dependency | Status |
+|---|---|---|
+| 1. Foundation (this memo) | — | not started |
+| 2. Credit Card model V1 | depends on foundation | spec frozen; awaiting foundation |
+| 3. Dashboard Phase 0 per-account-type tiles | independent (no foundation dependency) | spec frozen in `project_configurable_dashboard_widgets.md` Phase 0 |
+| 4. Loan account V1 | depends on foundation | spec frozen; deferred unless central to target user impression |
+| 5. Configurable dashboard widget framework | depends on Phase 0 validation | post-launch |
+
+## Cross-references
+
+- `project_credit_card_model_upgrade.md` — consumes `payment_source_account_id` in CC UX
+- `project_loan_account_type.md` — consumes `payment_source_account_id` in Loan UX
+- `project_configurable_dashboard_widgets.md` Phase 0 — independent of this slice
+- `codebase_shape.md` §2 (models / `accounts` field list), §3 (`AccountUpdate` partial-update idiom)

--- a/specs/payment-source-account-foundation.md
+++ b/specs/payment-source-account-foundation.md
@@ -2,7 +2,6 @@
 name: Payment Source Account Foundation
 description: 2026-05-15 architect-locked sequencing — ship the shared payment_source_account_id plumbing as its own PR before any CC or Loan UX work. Foundation only. No payment automation, no generated transactions, no cron jobs.
 type: project
-originSessionId: 31bd894a-67ce-4301-b8b1-880672646504
 ---
 # Payment Source Account Foundation
 

--- a/specs/remove-vs-deactivate-org-member.md
+++ b/specs/remove-vs-deactivate-org-member.md
@@ -2,13 +2,12 @@
 name: Remove vs Deactivate org member — investigate semantics
 description: User-reported 2026-05-14 — clicking "Remove" on org member soft-deactivates instead of removing. Decide intent and align endpoint + UI copy.
 type: project
-originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
 ---
 # Remove vs Deactivate org member
 
-## Observation (2026-05-14, fjorge)
+## Observation (2026-05-14, operator)
 
-Tried to delete user `jorge.flamarion` (email `jorge.flamarion@icloud.com`) from Org id=1 via the admin UI. Result: user was deactivated, not removed. If the UI exposes both "Deactivate" and "Remove" actions, "Remove" should effectively remove the membership.
+Tried to delete a test user from Org id=1 via the admin UI. Result: user was deactivated, not removed. If the UI exposes both "Deactivate" and "Remove" actions, "Remove" should effectively remove the membership.
 
 ## Context
 

--- a/specs/remove-vs-deactivate-org-member.md
+++ b/specs/remove-vs-deactivate-org-member.md
@@ -1,0 +1,42 @@
+---
+name: Remove vs Deactivate org member — investigate semantics
+description: User-reported 2026-05-14 — clicking "Remove" on org member soft-deactivates instead of removing. Decide intent and align endpoint + UI copy.
+type: project
+originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
+---
+# Remove vs Deactivate org member
+
+## Observation (2026-05-14, fjorge)
+
+Tried to delete user `jorge.flamarion` (email `jorge.flamarion@icloud.com`) from Org id=1 via the admin UI. Result: user was deactivated, not removed. If the UI exposes both "Deactivate" and "Remove" actions, "Remove" should effectively remove the membership.
+
+## Context
+
+L4.4 shipped the superadmin org-member management slice in PR #221, exposing `GET/PATCH/DELETE /api/v1/admin/orgs/{org_id}/members` and a frontend Members section under `/admin/orgs/[id]` with per-row Role / deactivate-reactivate / remove (`ConfirmModal`) controls. Guard rule already in place: cannot remove self, superadmin, or last active OWNER.
+
+## What to investigate
+
+1. **What does `DELETE /api/v1/admin/orgs/{org_id}/members/{user_id}` actually do today** — is it soft-deletion (`is_active=False`) on the user row, or does it remove the org-membership association while keeping the user? File: `backend/app/services/admin_org_members_service.py`. The likely culprit: the "Remove" handler maps to the same code path as "Deactivate" by design (preserves user history) rather than detaching from the org.
+2. **What's the correct product semantic** — three options to evaluate:
+   - **(a)** Remove = detach from org (drop org_membership row), preserve user identity for cross-org history. Cleanest if we ever introduce true multi-org membership.
+   - **(b)** Remove = hard-delete user row + cascade to all their org-scoped data (transactions, accounts, etc.). Aggressive; rare in SaaS products.
+   - **(c)** Remove = soft-delete (the current behavior). Then the UI button should be labeled "Deactivate", and "Remove" should not exist as a separate option.
+3. **Audit trail expectations** — whatever semantic we pick, `audit_events` should already capture the action via L4.7's audit hook. Confirm the event_type names match the user-facing semantic.
+
+## Constraints + prior decisions to honor
+
+- `audit_events` has snapshot columns (`actor_email`, `target_org_name`) so audit rows survive user deletion — that's design intent from L4.7. Doesn't dictate the remove semantic; it just means option (b) is feasible without losing audit.
+- Pre-launch state: no backcompat shims (per user rule), so we can change the contract freely.
+- Currently a single user belongs to a single org (no multi-org membership). So option (a) and option (b) differ only in whether the user row survives.
+
+## Effort estimate
+
+S to M. Pure backend service decision + frontend label tweak. No migrations unless we choose option (a) AND a multi-org future requires a separate membership table.
+
+## Priority
+
+P3. Not urgent, not a launch blocker. Pick up after L5.2a apex split fully cuts over.
+
+## How to apply
+
+When picking this up: start by reading `admin_org_members_service.py`'s DELETE path to confirm which option (a)/(b)/(c) we're currently in. Then bring product semantic back to fjorge before touching code.

--- a/specs/reseed-synthetic-data-post-launch.md
+++ b/specs/reseed-synthetic-data-post-launch.md
@@ -1,0 +1,47 @@
+---
+name: In-app reseed with synthetic data
+description: 2026-05-14 fjorge — affordance to load demo / synthetic data from the UI, for users who skip the onboarding opt-in or who wipe their org data and want to see the system populated again.
+type: project
+originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
+---
+# In-app reseed with synthetic data
+
+## Observation
+
+Today there are two ways an org can end up empty:
+1. User registers and skips the L3.3 onboarding opt-in for demo data.
+2. Owner uses the L3.1 Danger Zone reset (`POST /api/v1/orgs/data/reset`) to wipe transactions/accounts/budgets/forecasts/etc.
+
+In both cases the user lands on a clean but empty app and has to either import data, manually create accounts/transactions, or live with the blank state. There's no way to ask the product to fill itself with synthetic data so a user can poke around.
+
+A `./pfv seed` CLI exists for local development and is documented in `CONTRIBUTING.md`'s seeding section. The opt-in inside the onboarding wizard (PR #238) uses the same underlying seed logic. What's missing is an **in-app** trigger usable after the onboarding window has closed.
+
+## Brainstorm topics before scoping
+
+1. **Audience:** every user, or owners only? Probably owners only (writes data into the org). Reuses the L3.1 owner-only Danger Zone guard pattern.
+2. **Append vs replace:** if the org already has data, seeding on top likely produces garbage (duplicate categories, weird date overlaps). Two sane semantics:
+   - **Replace:** wipe first (reuse `wipe_org_data` from L3.1) then seed. Typed-confirm like the Reset action.
+   - **Append only when empty:** check that the org has zero transactions/accounts before allowing the action. Simpler, safer.
+   Pick one. "Append only when empty" is the cleaner default.
+3. **What dataset?** Reuse the existing seed mechanism (`./pfv seed` + `SEED_*` env vars from CONTRIBUTING.md) or carve out a leaner "demo preset" that ships fewer, more illustrative records? Probably reuse to avoid divergence.
+4. **Where it lives in the UI:**
+   - Org owner: Settings → Organization → "Load demo data" affordance (sibling to "Reset org data" Danger Zone).
+   - On the empty dashboard: a one-time banner "Load demo data to explore" with dismiss + load actions.
+   - Maybe both — banner is more discoverable, settings is the canonical location.
+5. **Audit:** like L3.1, emit a `org.data.seeded` audit event. The L4.7 audit table handles this idempotently.
+6. **Backend reuse:** the seed logic lives in a script outside the FastAPI app today. To trigger from a request handler we'd either shell out (yuck), import the seed module from FastAPI (cleaner), or extract the seed body into `app/services/seed_service.py` (cleanest).
+
+## Related code
+
+- `pfv` CLI script — has the `./pfv seed` subcommand and the `SEED_*` env vars.
+- Onboarding seed opt-in: PR #238 — find the backend route it calls; that's the most reusable starting point.
+- L3.1 wipe path: `app/services/org_data_service.py` (the `wipe_org_data` function and the public `POST /api/v1/orgs/data/reset` endpoint).
+- L4.7 audit hook pattern.
+
+## Effort
+
+S to M. The biggest piece is extracting the seed logic into a service that can be called from a request handler. Once that exists the endpoint + UI + audit event are short.
+
+## Priority
+
+P3. Post-launch UX. Pair with the tour-restart work (see `project_restart_tour.md`); both are "I want a fresh demo experience" affordances and could be a single small initiative.

--- a/specs/reseed-synthetic-data-post-launch.md
+++ b/specs/reseed-synthetic-data-post-launch.md
@@ -2,7 +2,6 @@
 name: In-app reseed with synthetic data
 description: 2026-05-14 fjorge — affordance to load demo / synthetic data from the UI, for users who skip the onboarding opt-in or who wipe their org data and want to see the system populated again.
 type: project
-originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
 ---
 # In-app reseed with synthetic data
 

--- a/specs/restart-tour-post-launch.md
+++ b/specs/restart-tour-post-launch.md
@@ -2,7 +2,6 @@
 name: Restart the onboarding tour
 description: 2026-05-14 fjorge — allow users to re-run the onboarding flow after skipping or completing it once. Currently the L3.3 tour fires once on first-run and there's no way back in.
 type: project
-originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
 ---
 # Restart the onboarding tour
 

--- a/specs/restart-tour-post-launch.md
+++ b/specs/restart-tour-post-launch.md
@@ -1,0 +1,38 @@
+---
+name: Restart the onboarding tour
+description: 2026-05-14 fjorge — allow users to re-run the onboarding flow after skipping or completing it once. Currently the L3.3 tour fires once on first-run and there's no way back in.
+type: project
+originSessionId: e75406f8-d01b-42d2-aa05-cdc574be2d1a
+---
+# Restart the onboarding tour
+
+## Observation
+
+The L3.3 first-run onboarding wizard (shipped in PR #238) fires once on first-run and is gated by a "completed/skipped" flag. There's no in-app affordance to re-run it. Users who:
+- Skipped the tour and want to see it later
+- Completed it but want to refresh on a feature
+- Are showing the product to a colleague or partner
+
+...are stuck.
+
+## Brainstorm topics before scoping
+
+1. **Where is the "completed tour" flag stored?** Inspect `frontend/components/tour/TourProvider.tsx` and the corresponding backend field on the User or OrgSettings model. Most likely a user-level boolean. Knowing this drives whether "restart" needs a PATCH on `/users/me` or a frontend-only state reset.
+2. **Resume vs full restart?** Re-run from the beginning is simpler and clearer. Resume is fiddly because the dataset changes between sessions.
+3. **Per-section replay or full sequence?** A help-menu link like "Replay the onboarding tour" probably wants full sequence. A future "Tour: this feature" could pin per-section replay.
+4. **Entry point:** Settings → Preferences (a "Replay onboarding tour" button)? AppShell user-menu dropdown? Footer help link? `/docs` page (the help manual)? Probably Settings + the help drawer feels right.
+5. **Org vs user scope:** if multi-user orgs exist, the tour state is per-user, not per-org. Replay shouldn't affect other org members.
+
+## Related code
+
+- `frontend/components/tour/TourProvider.tsx` — tour engine.
+- Backend likely has a `users.onboarding_completed_at` or similar; check `backend/app/models/user.py`.
+- PR #238 history has the full design and dispatch context.
+
+## Effort
+
+XS to S. Backend: maybe one endpoint or a PATCH-allowed field on `/users/me`. Frontend: a button + the existing tour-start call.
+
+## Priority
+
+P3. Post-launch UX polish. Pair with the synthetic-data reseed work (see `project_reseed_synthetic_data.md`) since they have overlapping UX (both are "I want to start fresh" affordances).

--- a/specs/session-lifetime-60d.md
+++ b/specs/session-lifetime-60d.md
@@ -1,0 +1,96 @@
+---
+name: session-lifetime-60d
+description: "Pending spec — separate refresh-TTL (idle ceiling) from absolute-session-lifetime semantics, allow org override up to 60 days. Surfaced during the 2026-05-16 cookie-shadow incident when fjorge's expected \"60-day session\" turned out not to be configured anywhere."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 61ba1946-1626-4e59-9b33-07b26d7a04eb
+---
+
+# Session-lifetime semantics + 60d org override (pending spec)
+
+## Trigger
+
+2026-05-16 incident investigation surfaced that fjorge's expected
+"60-day session length" is **not configured anywhere** in pfv:
+
+- `backend/app/config.py:25` — `JWT_REFRESH_TOKEN_EXPIRE_DAYS=7` (the
+  hard ceiling — both the refresh JWT `exp` and the cookie `max_age`)
+- `backend/app/config.py:27` — `SESSION_LIFETIME_DAYS=30` (commented
+  in `.env.example`, governs absolute lifetime via
+  `_validate_single_refresh_token`'s `session_created_at` check)
+- four hardcoded `max_age=7*24*60*60` in `backend/app/routers/auth.py`
+  (lines 296, 446, 530 implied, 714, 1363) — drift bait
+
+So the practical ceiling is 7 days idle (or however long the user
+keeps actively refreshing), with a 30-day absolute cap. "60 days" is
+not a knob anyone has turned.
+
+**Why:** The mismatch hides a real policy question: refresh-TTL
+governs idle-out, `session_lifetime_days` governs absolute session
+age. Conflating them in env knobs invites further drift.
+
+**How to apply:** Before bumping any session-related constant, finish
+this spec so the three concepts (refresh-cookie max_age, refresh-JWT
+exp, absolute session lifetime) are explicit and the cookie/JWT/policy
+TTLs can never silently drift apart.
+
+## Out of scope for the 2026-05-16 cookie-shadow hotfix (PR #289)
+
+Per architect direction during the incident, this spec does NOT ride
+along with PR #289. That hotfix is narrowly the legacy-cookie cleanup
++ duplicate-cookie reader. Session lifetime is its own PR with its
+own tests.
+
+## Proposed semantics
+
+1. **Refresh cookie/JWT max_age = idle ceiling.** Caps how long a user
+   can be away before they must re-authenticate. Default 30 days.
+2. **`session_lifetime_days` = absolute session age.** Refresh
+   rotation carries `session_created_at` from original login; once
+   `now - session_created_at > session_lifetime_days` the session
+   ends regardless of recent activity. Default 30 days.
+3. **Org-level override.** `OrgSetting(key="session_lifetime_days")`
+   already exists and is honored in `_validate_single_refresh_token`.
+   Add validation: `1 <= value <= 90`. Optionally allow override of
+   the refresh-cookie max_age separately.
+4. **Single source of truth.** Drop the four hardcoded
+   `7*24*60*60` literals. Use `app_settings.jwt_refresh_token_expire_days
+   * 24 * 60 * 60` everywhere — when the env value changes, every
+   set_cookie picks it up.
+
+## Tests the spec PR must add
+
+- Default org gets 30-day absolute lifetime behavior end-to-end.
+- Org override to 60 is honored on `/refresh` validation.
+- Refresh rotation preserves `session_created_at` across rotations
+  (regression already exists; pin it for this work).
+- Expired absolute lifetime still logs out even if the refresh JWT
+  itself has not expired (current `SESSION_EXPIRED_DETAIL` path).
+- Org `session_lifetime_days` outside `[1, 90]` is rejected at the
+  setting-write site (admin endpoint or whichever writes
+  `OrgSetting`).
+
+## Migration
+
+No data migration. The constants and the validation rule change is
+pure code. Cookie max_age change affects future logins only; existing
+cookies expire by their currently-set max_age. PR can ship
+non-emergent.
+
+## Cross-references
+
+- [[cookie-attribute-migration-trap]] — the related cookie discipline
+- PR #211 — the cookie path widening that exposed the cookie-attribute
+  drift class
+- PR #289 — the legacy cookie cleanup hotfix
+- `backend/app/routers/auth.py:296, 446, 714, 1363` — hardcoded
+  `max_age` sites to consolidate
+- `backend/app/config.py:25-27` — current TTL settings
+- `backend/app/models/settings.py` — `OrgSetting` substrate for the
+  override
+
+## Status
+
+- **2026-05-16**: spec captured, not started. P2 in launch path.
+- **Owner**: TBD.

--- a/specs/session-lifetime-60d.md
+++ b/specs/session-lifetime-60d.md
@@ -1,10 +1,6 @@
 ---
 name: session-lifetime-60d
 description: "Pending spec — separate refresh-TTL (idle ceiling) from absolute-session-lifetime semantics, allow org override up to 60 days. Surfaced during the 2026-05-16 cookie-shadow incident when fjorge's expected \"60-day session\" turned out not to be configured anywhere."
-metadata: 
-  node_type: memory
-  type: project
-  originSessionId: 61ba1946-1626-4e59-9b33-07b26d7a04eb
 ---
 
 # Session-lifetime semantics + 60d org override (pending spec)

--- a/specs/spreadsheet-reference.md
+++ b/specs/spreadsheet-reference.md
@@ -1,0 +1,60 @@
+---
+name: Spreadsheet Reference
+description: User's current spreadsheet workflow — the target experience to replicate and improve upon
+type: project
+---
+
+## User's Current Workflow (Google Sheets)
+
+The user manages finances in a monthly spreadsheet with the following structure:
+
+### Left side: ING Expenses
+Each line item has: Description, Executed amount, Status (Pago/Aberto), Budget Balance, Budget, Budget Forecast.
+Examples: Rent (2,691.15), Car payment (695.59), Health plan (16.66), Groceries (1,200), etc.
+
+### Right side: ING Income
+Each line: Description, Executed, Status (Pago), Forecast.
+Examples: Salary (10,606.61), Karaoke income (93.60), Government aid (770.36), etc.
+
+### Right side: Credit Card (Amex) Expenses
+Separate section for CC: Executed vs Forecast per line.
+Examples: iCloud, Spotify, Disney+, Netflix, Supplements (-169.54), AWS (-18.18), LinkedIn (-39.99), Viagem Baltics (-821.79), etc.
+
+### Summary (far right)
+- Executed: Income 29,021.86 / Expenses -19,090.82 / Balance 9,931.04
+- Forecast: Income 29,021.86 / Expenses -19,090.82 / Balance 9,931.04
+
+### Account Totals (bottom)
+- Amex: -3,178.73
+- ING: -1,227.75
+- Total: -4,406.48
+
+### Savings
+- Balance: 9,931.04 (shown separately)
+- Savings: 6,081.46
+
+## Key Features to Replicate
+
+1. **Line-item budget + forecast** — not just category totals, each expense line has its own budget and forecast
+2. **Executed vs Forecast dual view** — see what happened vs what was planned
+3. **Per-account expense separation** — ING expenses vs Credit Card expenses as distinct sections
+4. **Status per line** — Pago (settled) vs Aberto (pending) — we have this
+5. **Budget balance per line** — remaining from allocated budget per expense
+6. **Summary: executed AND forecast** — the total picture for the month
+7. **Manual monthly process** — user copies sheet each month and adjusts, wants automation
+
+## What PFV2 Already Covers
+- Status (settled/pending) ✓
+- Per-account filtering ✓
+- Category-level budgets ✓
+- Billing periods ✓
+- Recurring transactions ✓
+
+## What's Missing (Phase 3b/3c targets)
+- Line-item forecasting (pending + recurring = forecast)
+- Executed vs Forecast comparison view
+- Per-account expense grouping view
+- Summary tiles: executed totals + forecast totals side by side
+- Savings calculation (income - expenses = available for savings)
+
+**Why:** This spreadsheet is the user's actual workflow. The app needs to match this level of financial visibility while automating the manual parts (monthly copying, status tracking, recurring items).

--- a/specs/tech-debt-create-transaction-no-commit.md
+++ b/specs/tech-debt-create-transaction-no-commit.md
@@ -2,7 +2,6 @@
 name: _create_transaction_no_commit double-lock optimization (deferred)
 description: Pre-lock pattern in convert_and_create_leg + create_transfer_pair causes _create_transaction_no_commit to re-enter the account lock internally. Acceptable today; cleanup opportunity is a no-lock "create with already-locked account" helper.
 type: project
-originSessionId: c08a4469-7a56-42db-a6cd-d380693d40d3
 ---
 **Status:** Deferred follow-up. Non-blocking. Flagged 2026-05-03 by reviewer during PR #118 final pass.
 

--- a/specs/tech-debt-create-transaction-no-commit.md
+++ b/specs/tech-debt-create-transaction-no-commit.md
@@ -1,0 +1,41 @@
+---
+name: _create_transaction_no_commit double-lock optimization (deferred)
+description: Pre-lock pattern in convert_and_create_leg + create_transfer_pair causes _create_transaction_no_commit to re-enter the account lock internally. Acceptable today; cleanup opportunity is a no-lock "create with already-locked account" helper.
+type: project
+originSessionId: c08a4469-7a56-42db-a6cd-d380693d40d3
+---
+**Status:** Deferred follow-up. Non-blocking. Flagged 2026-05-03 by reviewer during PR #118 final pass.
+
+## What's happening
+
+Two service functions sort-pre-lock affected accounts via `get_account_for_update` to prevent deadlocks under concurrent opposite-direction operations:
+
+- `convert_and_create_leg` (transaction_service.py) — pre-locks src + dst accounts before the create.
+- `create_transfer_pair` import branch (import_service.py) — same pattern: pre-locks both accounts before either `_create_transaction_no_commit` call.
+
+After the pre-lock, `_create_transaction_no_commit` is called twice (once per leg in the transfer-pair case). Internally it ALSO calls `get_account_for_update(body.account_id, ...)` for SETTLED rows. Inside the same DB transaction, re-acquiring `SELECT ... FOR UPDATE` on an already-held row is a no-op for correctness — but it's still an extra round trip per leg.
+
+## Cost
+
+For a 1000-row import where 200 rows use `create_transfer_pair`, that's 200 × 2 = 400 redundant FOR UPDATE round trips. Tiny per-call cost; cumulative impact depends on row counts and network latency to MySQL. Probably negligible for solo-user workloads but visible if measured.
+
+## Cleanup options
+
+**Option A (cleanest):** Add a sibling primitive `_create_transaction_no_commit_with_account(db, org_id, body, account, *, is_imported=False)` that takes an already-loaded `Account` object and skips the internal `get_account_for_update`. Used by callers that have pre-locked. Existing `_create_transaction_no_commit` stays as the public-wrapper-friendly variant.
+
+**Option B (overload):** Add an optional `account: Account | None = None` parameter to `_create_transaction_no_commit`; when set, skip the lock acquisition. Slightly muddier contract.
+
+**Option C (no-op):** Leave it. The double-lock is harmless and the redundant round trip is small.
+
+## When to fix
+
+Not a launch blocker. Revisit if:
+- Import performance becomes a real complaint at scale.
+- We add another caller that pre-locks (3+ callers makes the helper extraction worthwhile).
+- Database round-trip latency becomes a measurable cost (e.g., move from local MySQL to a remote managed instance — relevant once `project_infra_cost_reduction.md` ships).
+
+## Cross-refs
+
+- `convert_and_create_leg` — backend/app/services/transaction_service.py (added in PR-B, lock-fix in PR-B review).
+- `create_transfer_pair` import branch — backend/app/services/import_service.py (added in PR #118).
+- `_create_transaction_no_commit` — backend/app/services/transaction_service.py (added in PR-A Task A8).

--- a/specs/tech-debt-frontend-decimal-typing.md
+++ b/specs/tech-debt-frontend-decimal-typing.md
@@ -1,0 +1,33 @@
+---
+name: Frontend Decimal Typing Debt (deferred)
+description: Backend serializes Decimal fields as JSON strings; frontend types them as `number` and coerces at usage sites. Working but not type-honest. Flagged 2026-05-03 during PR-D/PR-E review; explicitly not blocking, deferred to a dedicated cleanup PR.
+type: project
+originSessionId: c08a4469-7a56-42db-a6cd-d380693d40d3
+---
+**Status:** Deferred technical debt. Not blocking any current work. Flagged 2026-05-03 by reviewer during PR-D / PR-E re-review of transfers-between-accounts: "the frontend still follows the existing project convention of typing Decimal-backed amount fields as `number`, even though backend serialization encodes Decimal as strings. Current PR-D/PR-E code coerces safely, so I would not block these PRs on that broader type debt."
+
+## What's wrong
+
+Pydantic v2 with `Decimal` columns serializes to JSON as **strings** (e.g., `"10.50"`, not `10.5`). The pfv frontend types `Transaction.amount`, `TransferCandidate.amount`, `Account.balance`, `Category` budget fields, etc. as `number` for ergonomic arithmetic and rendering.
+
+This works because:
+- `formatAmount(n: number | string): string` accepts both shapes and coerces.
+- `equalsAmount(a: string, b: string): boolean` is string-based and reads from the JSON shape directly.
+- React components coerce via `Number(...)` or `parseFloat` where needed.
+
+But it's not type-honest: at the network boundary, the runtime values are strings, and the static types say number.
+
+## Why it hasn't been fixed
+
+- Solo dev, pre-launch — no incident has surfaced from the mismatch.
+- Touching it requires a sweep across every API-boundary type and every consumer (transactions, accounts, budgets, forecast, dashboard, reports, smart rules — all touch Decimal-backed fields).
+- The `equalsAmount` / `formatAmount` helpers already exist and gracefully handle both shapes, so consumers haven't been forced to converge.
+
+## When to fix
+
+Recommend revisiting after the launch-path is feature-complete (post all L4.x). At that point:
+1. Decide canonical: either match backend (string at the boundary) or convert at the API client (parseFloat in a typed deserializer in `lib/api.ts`).
+2. Sweep all `amount: number` / `balance: number` references and align.
+3. Verify no consumer relies on float arithmetic that would break under string semantics (or update them to use string-decimal helpers consistently).
+
+This is post-launch cleanup, not a launch-blocker.

--- a/specs/tech-debt-frontend-decimal-typing.md
+++ b/specs/tech-debt-frontend-decimal-typing.md
@@ -2,7 +2,6 @@
 name: Frontend Decimal Typing Debt (deferred)
 description: Backend serializes Decimal fields as JSON strings; frontend types them as `number` and coerces at usage sites. Working but not type-honest. Flagged 2026-05-03 during PR-D/PR-E review; explicitly not blocking, deferred to a dedicated cleanup PR.
 type: project
-originSessionId: c08a4469-7a56-42db-a6cd-d380693d40d3
 ---
 **Status:** Deferred technical debt. Not blocking any current work. Flagged 2026-05-03 by reviewer during PR-D / PR-E re-review of transfers-between-accounts: "the frontend still follows the existing project convention of typing Decimal-backed amount fields as `number`, even though backend serialization encodes Decimal as strings. Current PR-D/PR-E code coerces safely, so I would not block these PRs on that broader type debt."
 

--- a/specs/tech-debt-router-test-app-factory.md
+++ b/specs/tech-debt-router-test-app-factory.md
@@ -2,7 +2,6 @@
 name: Centralized router test-app factory
 description: Centralize router test app construction so security middleware and exception handlers are opt-in by default, not manually re-created per file. Small tech-debt follow-up surfaced during PR #164 review.
 type: project
-originSessionId: 497b4e5b-526f-4ed1-bca0-0ee0c5bbc716
 ---
 Captured 2026-05-08. Small tech-debt follow-up, NOT blocking #164.
 

--- a/specs/tech-debt-router-test-app-factory.md
+++ b/specs/tech-debt-router-test-app-factory.md
@@ -1,0 +1,46 @@
+---
+name: Centralized router test-app factory
+description: Centralize router test app construction so security middleware and exception handlers are opt-in by default, not manually re-created per file. Small tech-debt follow-up surfaced during PR #164 review.
+type: project
+originSessionId: 497b4e5b-526f-4ed1-bca0-0ee0c5bbc716
+---
+Captured 2026-05-08. Small tech-debt follow-up, NOT blocking #164.
+
+## Problem
+
+Ad-hoc FastAPI test apps in `backend/tests/` can silently omit middleware and exception handlers like SlowAPI's `app.state.limiter` + `RateLimitExceeded` handler. Tests pass without ever exercising the production wiring. Affects security middleware, exception handlers, auth overrides, session factory overrides, and any other app-state the production app installs.
+
+## Concrete trigger
+
+PR #164 review surfaced that `test_orgs_rename.py` and `test_account_balance_adjustment.py` build their own FastAPI test apps without wiring SlowAPI. The new rate-limit decorators (added in #164) silently no-op in those tests. If someone later writes a 429 regression test in either file, the assertion will spuriously pass because the limiter isn't installed.
+
+PR #164's own new tests wire SlowAPI correctly (mirroring `test_users_password_set.py`), so the immediate gap is covered. The tech-debt is the pattern, not the PR.
+
+## Desired shape
+
+Shared helper, e.g.:
+```python
+def make_test_app(
+    routers: list[APIRouter],
+    *,
+    with_limiter: bool = True,
+    with_exception_handlers: bool = True,
+    db_override: Callable | None = None,
+    auth_override: Callable | None = None,
+) -> FastAPI: ...
+```
+
+- Defaults install the production middleware/handler stack.
+- Opt-out flags exist for tests that intentionally want a stripped app.
+- Centralizes the auth/db override boilerplate that's currently copy-pasted.
+- Single source of truth for what a "router test app" looks like.
+
+## Acceptance
+
+- A new 429 test on a rate-limited endpoint **fails** if the test forgot to call `make_test_app(..., with_limiter=True)` (or, if `with_limiter` defaults true, the limiter wiring just works).
+- Existing endpoint tests can migrate gradually; no big-bang rewrite.
+- New router tests written after this lands use the factory by default; PR review catches deviations.
+
+## Priority
+
+Small tech-debt follow-up. Not blocking any current launch-path work. Slot in alongside the next test-touching item that already has the relevant files open.

--- a/specs/tech-debt-ui-improvements-historical.md
+++ b/specs/tech-debt-ui-improvements-historical.md
@@ -1,0 +1,57 @@
+---
+name: UI/UX Historical Log
+description: Completed-item history only. All forward-looking work migrated to project_roadmap.md (single source of truth) on 2026-04-20.
+type: project
+originSessionId: c173ba6d-e79b-4e8b-afdf-2ed15a799de4
+---
+# UI/UX Historical Log
+
+**All open/active items now live in `project_roadmap.md`.** This file is kept for historical reference — which items shipped in which PR. When adding new UI backlog items, put them in the roadmap under the appropriate phase (L3 Core UX, L4 Polish, or P-series post-launch).
+
+## Completed
+
+1. ✅ Tooltip text colors (Remaining/Spent/Over budget) — PR #55
+2. ✅ Clickable bar charts → filter transactions — PR #55
+4. ✅ Auto-description for transfers — earlier PR
+5. ✅ Transaction descriptions mandatory — earlier PR
+6. ✅ Replace all `window.confirm()` with ConfirmModal (12 callsites) — PR #55
+7. ✅ Responsive / mobile layout (hamburger sidebar) — PR #55
+8. ✅ Show all active accounts on dashboard — PR #55
+10. ✅ Dashboard balances refresh on settle/unsettle — PR #55
+11. ✅ Dashboard Forecast card colors match Forecast page — PR #55
+14. ✅ Dashboard Budget bar chart semantic colors — PR #55
+15. ✅ Dashboard Forecast bar chart colors/legend — PR #55
+22. ✅ Budget transfer form keeps spent/amount visible — PR #55
+24a. ✅ Import page: CategorySelect type-ahead — PR #55
+24b. ✅ Transfer form: optional category picker — PR #55
+29. ✅ Mobile responsive sweep — PR #63 (data tables) + PR #64 (everything else)
+33. ✅ Multi-select + bulk delete transactions — PR #65
+
+## Open — see `project_roadmap.md`
+
+| Previous backlog # | Now lives at |
+|---|---|
+| #3 Transfer exclusion from spending chart | L3.5 |
+| #9 CC pending after payment | L3.4 |
+| #12 Dashboard Forecast explanation | L3.7 |
+| #13 CC pending in forecast investigation | Technical Debt |
+| #16 Donut charts for dashboard | Technical Debt |
+| #17 Composite index for import dedup | P1.5 |
+| #18 pytest infrastructure | Technical Debt |
+| #19 User manual / help | L5.3 |
+| #20 Quick tour / onboarding | L3.3 |
+| #21 Demo seed opt-in | L3.3 |
+| #23 Notification preferences | P1.2 |
+| #24c Inline "Add category" | L3.6 |
+| #25 System Admin Dashboard | **L4.2–L4.8** (promoted to launch blocker) |
+| #26 OpenTelemetry | P7.1 |
+| #27 User locale preferences | P2.* |
+| #28 Header & footer redesign | L5.4 |
+| #30 Privacy policy page | L1.2 |
+| #31 Footer link to privacy policy | L5.4 |
+| #32 Migrate /settings/security to SettingsLayout | Technical Debt |
+| #34 Reset org data | **L3.1** (bumped to first L3 item) |
+| #35 Auth hardening round 2 | L1.1 |
+| #36 Strict CSP nonce middleware | Technical Debt |
+| #37 SEO baseline | L5.1 |
+| #38 Cloudflare HSTS + authenticated ZAP | L1.5 + L1.6 |

--- a/specs/tech-debt-ui-improvements-historical.md
+++ b/specs/tech-debt-ui-improvements-historical.md
@@ -2,7 +2,6 @@
 name: UI/UX Historical Log
 description: Completed-item history only. All forward-looking work migrated to project_roadmap.md (single source of truth) on 2026-04-20.
 type: project
-originSessionId: c173ba6d-e79b-4e8b-afdf-2ed15a799de4
 ---
 # UI/UX Historical Log
 

--- a/specs/tech-debt-uvicorn-logger-name.md
+++ b/specs/tech-debt-uvicorn-logger-name.md
@@ -1,0 +1,37 @@
+---
+name: uvicorn.error logger name (cosmetic)
+description: P3 polish — uvicorn's "uvicorn.error" logger name is misleading because it carries info/warning/error events alike. Cosmetic only; no behavior change.
+type: project
+originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
+---
+## What
+
+Backend JSON logs surface lines like:
+
+```json
+{"event": "Application shutdown complete.", "level": "info", "logger": "uvicorn.error", "timestamp": "..."}
+```
+
+The `logger` field reads `uvicorn.error` even for INFO events. This is correct Python-logging behavior: uvicorn defines exactly two named loggers (`uvicorn.access` for HTTP access logs, `uvicorn.error` for everything else — startup, shutdown, app lifecycle, AND real errors). The `level` field next to it is the actual severity.
+
+**Not a bug.** Just an awkward inherited convention from uvicorn upstream.
+
+## Why it's worth noting
+
+Operators reading logs at a glance might skim `"logger": "uvicorn.error"` and assume something failed. With prod log routing (Datadog, Loki, Grafana), the level is usually the prominent column and `logger` is dim metadata, so most operators tune it out. But for support and debugging, it's a small papercut.
+
+## How to fix (when it's worth doing)
+
+Two options, both ~5-line changes:
+
+1. **Structlog processor** in `backend/app/logging.py` that rewrites `logger == "uvicorn.error"` → `"uvicorn"` (or `"uvicorn.lifecycle"`) in the JSON renderer. Lowest blast radius.
+
+2. **Configure uvicorn's `LOGGING_CONFIG`** to rename the logger at the source. More invasive (touches uvicorn config) but cleaner.
+
+## Priority
+
+P3 — polish, no behavior impact. Surface in any future "operational hygiene" pass; not launch-blocking.
+
+## Captured
+
+2026-05-02 during L3.10 implementation. User flagged the question while I was doing pre-merge fixes; explicitly tagged as low priority. No action taken on this branch.

--- a/specs/tech-debt-uvicorn-logger-name.md
+++ b/specs/tech-debt-uvicorn-logger-name.md
@@ -2,7 +2,6 @@
 name: uvicorn.error logger name (cosmetic)
 description: P3 polish — uvicorn's "uvicorn.error" logger name is misleading because it carries info/warning/error events alike. Cosmetic only; no behavior change.
 type: project
-originSessionId: 672f9f52-7ffa-43a4-9e88-ffc9e47e0229
 ---
 ## What
 

--- a/specs/unused-preloaded-css-warning.md
+++ b/specs/unused-preloaded-css-warning.md
@@ -2,7 +2,6 @@
 name: Audit Unused Preloaded CSS Warning (Next.js Production)
 description: P3 backlog. Chrome reports `_next/static/chunks/...css` was preloaded but not used shortly after load on /dashboard. Most likely Next.js-generated CSS chunking, not first-party. Investigate before changing config.
 type: project
-originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
 ---
 **Captured 2026-05-10.** P3 backlog item. Raise to P2 only if many repeated CSS preload warnings appear OR measurable dashboard performance impact (LCP, FOUC, layout shift, extra transfer size).
 

--- a/specs/unused-preloaded-css-warning.md
+++ b/specs/unused-preloaded-css-warning.md
@@ -1,0 +1,51 @@
+---
+name: Audit Unused Preloaded CSS Warning (Next.js Production)
+description: P3 backlog. Chrome reports `_next/static/chunks/...css` was preloaded but not used shortly after load on /dashboard. Most likely Next.js-generated CSS chunking, not first-party. Investigate before changing config.
+type: project
+originSessionId: 0bf77f16-13ef-4926-8a64-7a5ddd96efc6
+---
+**Captured 2026-05-10.** P3 backlog item. Raise to P2 only if many repeated CSS preload warnings appear OR measurable dashboard performance impact (LCP, FOUC, layout shift, extra transfer size).
+
+## Background — what's already correct
+
+Repo audit confirmed: app only imports `frontend/app/layout.tsx:5` for global CSS. No manual `<link rel="preload">` injection in first-party code. Next.js production builds automatically split CSS into route chunks. The warning is therefore most likely Next-generated, not a bug in our code.
+
+## What NOT to do
+
+**Do not disable CSS chunking or change Next config just to silence the warning.** That trades a console warning for a real performance regression (one big CSS file instead of route-split chunks). Any config change requires evidence of measurable impact.
+
+## Investigation steps
+
+1. **Reproduce in production** after hard refresh (Cmd+Shift+R) in Incognito with extensions disabled. Local dev's HMR-injected CSS won't reproduce this.
+2. **Capture the exact `<link rel="preload">` tag** from page source / DevTools Elements. Confirm it carries `as="style"` (the warning is specific to that combination).
+3. **Identify the owning route/component** via DevTools Network → Initiator OR by inspecting `.next/build-manifest.json` / `.next/static/chunks/` mappings.
+4. **Verify metric impact:**
+   - LCP delta with/without the preloaded chunk
+   - FOUC visible during route transitions
+   - Cumulative Layout Shift (CLS)
+   - Network transfer size (the wasted bytes if the chunk is preloaded but never applied)
+5. **Decide based on findings:**
+   - If the CSS chunk comes from an accidental route-level / global CSS import that's reaching pages that don't need it: reduce import scope (move the CSS to the route that actually uses it).
+   - If the warning is purely Next-generated and no metric or visual issue exists: document as benign and close. Console warnings without functional impact aren't bugs.
+
+## Acceptance criteria
+
+- Reproduced (or not) in production with extensions disabled.
+- DevTools capture: link tag, route, owning chunk, metric deltas.
+- If first-party scope can be reduced: PR opened with the import-scope fix.
+- If benign: closed with a one-paragraph rationale documented in this file.
+
+## Priority
+
+- **P3 by default** — pure console noise without proof of real-world impact.
+- **P2** if multiple repeated CSS preload warnings stack up OR a measurable dashboard performance impact lands in DevTools / synthetic monitoring.
+
+## Cross-references
+
+- `frontend/app/layout.tsx` — the single global CSS import path
+- Next.js build manifests under `frontend/.next/` — for owning-route attribution
+- DESIGN.md — page CSS scope rules (cards / forms / etc. live in tokenized utility classes, not per-route stylesheets)
+
+## Why it lives in backlog rather than active queue
+
+Console warnings are not bugs. The product's seed user opens the app to make decisions, not to inspect console output (per PRODUCT.md). Real-user functional impact has to lead any config change to Next.js's default CSS chunking behavior.

--- a/specs/user-billing-flow.md
+++ b/specs/user-billing-flow.md
@@ -1,0 +1,18 @@
+---
+name: User Billing Flow
+description: fjorge's real-world billing/cycle workflow — informs the org-admin period UI redesign brainstorm
+type: project
+originSessionId: 1d48e329-4340-4f5d-a67c-182b3d3f7479
+---
+How fjorge actually runs his finances (target UX context for the period management redesign):
+
+- **Period anchor = salary day.** The new period starts the day salary lands; the previous period closes the day before. Salary day is known but varies (~23rd–25th).
+- **Forecast spillover.** Some forecasted income/expenses don't settle on the planned day. When that happens, the entry is pushed to the new period and the new period's forecast is bumped to absorb the unexpected slip.
+- **Provider charge dates are not fixed**, which is why spillover happens.
+- **Multiple credit-card cycles.** Card A closes ~25th, card B closes ~5th. After salary lands (e.g., the 25th), card B charges between then and the 5th are added to the previous, already-closed period — because the user treats "the period that owns this card cycle" as the close target, not the calendar period.
+
+**Why:** This is the workflow fjorge wants the app to mirror; it's why the simple "one open period at a time" model is too rigid.
+
+**How to apply:** When designing the period roster UI (12-month list with inline close/edit, December-rolls-to-next-Jan), the design must support: (1) reopening or editing the immediately previous closed period, (2) moving transactions across the close boundary after the fact, (3) adjusting forecast on the new period at close time. Don't assume calendar-month alignment.
+
+**Per-period start AND end dates must both be user-editable.** Today the only knob is org-level `billing_cycle_day`, and `ensure_future_periods` derives both start and end from it (start = cycle day each month, end = day-before-next-start). User wants to set, e.g., a period "Apr 25 → May 24" explicitly per row. The `BillingPeriod` model already has `(start_date, end_date)` as separate nullable columns, so the schema is fine — it's a UI surface gap. Cycle day can remain a seed default for new stubs but should not constrain per-row edits.

--- a/specs/user-billing-flow.md
+++ b/specs/user-billing-flow.md
@@ -2,7 +2,6 @@
 name: User Billing Flow
 description: fjorge's real-world billing/cycle workflow — informs the org-admin period UI redesign brainstorm
 type: project
-originSessionId: 1d48e329-4340-4f5d-a67c-182b3d3f7479
 ---
 How fjorge actually runs his finances (target UX context for the period management redesign):
 


### PR DESCRIPTION
## Summary

Bulk import of design specs, bug specs, backlog items, and tech-debt notes from the operator's local memory directory into the repo's \`specs/\` folder, so they survive the upcoming laptop migration.

## What landed

- **19 active design specs** (apex-s3-cloudfront, billing-cycle, category-fallback, credit-card-model-upgrade, loan-account-type, payment-source-account-foundation, session-lifetime-60d, etc.)
- **13 bug + backlog items** (flaky-transactions-page-test, accounts-side-by-side-layout, restart-tour-post-launch, i18n-l10n-goals, etc.)
- **5 tech-debt notes** (router-test-app-factory, frontend-decimal-typing, uvicorn-logger-name, etc.)
- **4 shipped specs** moved to \`specs/archive/\` (bot-signup-captcha, dashboard-recent-tx-columns, pfv-dev-dep-drift-guard, subcategory-edit-form-parity)

## What stays in memory

- All \`reference_*\` (gotchas + ops knowledge)
- All \`feedback_*\` (user behavior rules)
- \`project_status.md\`, \`project_roadmap*.md\` (live status snapshots)
- Coordination / wave-tracking files
- \`user_profile.md\`, \`MEMORY.md\` itself

These are Claude's per-machine context, not project artifacts.

## Naming convention

Kept descriptive names, dropped the \`project_\` prefix, replaced underscores with hyphens. Date-prefixed specs authored this week (2026-05-17-* and 2026-05-21-*) stay as authored.

## Follow-up (post-merge, separate session)

After merge, the source files in \`~/.claude/projects/-Users-fjorge-src-pfv/memory/\` are deleted to actually reduce backup surface. MEMORY.md gets a section pointing at the new repo locations.