### PR TITLE
fix(transactions): space commits a tag chip, not just Enter / Tab / comma

### DIFF
--- a/frontend/components/transactions/TagChipInput.tsx
+++ b/frontend/components/transactions/TagChipInput.tsx
@@ -21,14 +21,19 @@ import { input } from "@/lib/styles";
  *
  * Behavior:
  *   - User types -> debounced fetch (200ms). Minimum prefix length 1.
- *   - Enter / Tab / comma / Space commits the typed text as a chip.
- *     Space is the most discoverable trigger for "add another tag" —
- *     users coming from social platforms expect it. Multi-word tags
- *     are no longer typeable from the keyboard once Space commits;
- *     use hyphen ("bike-commute") or click an autocomplete suggestion
- *     that already contains a space. The transactions submit path
- *     posts the chip names to PUT /api/v1/transactions/{id}/tags
- *     which auto-creates any tags the org has not used before.
+ *   - Enter / Tab / comma commits the typed text OR the currently-
+ *     highlighted autocomplete suggestion (whichever is active). The
+ *     transactions submit path posts the chip names to
+ *     PUT /api/v1/transactions/{id}/tags which auto-creates any tags
+ *     the org has not used before.
+ *   - Space ALWAYS commits the typed draft (never the highlighted
+ *     suggestion). Space is the most discoverable "add another tag"
+ *     shortcut for users coming from social platforms; routing it
+ *     past the suggestion list keeps the behavior intuitive — typing
+ *     "bike[space]" commits "bike" even if "biking" is highlighted.
+ *     Multi-word tags from the keyboard are no longer typeable; use
+ *     a hyphen ("bike-commute") or click a suggestion that already
+ *     contains a space.
  *   - Backspace on an empty input removes the last chip.
  *   - Click suggestion commits chip.
  *   - Each chip carries a remove "x" with aria-label="Remove tag <name>".
@@ -261,19 +266,28 @@ export default function TagChipInput({
   }, []);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    const isCommitKey =
-      e.key === "Enter" ||
-      e.key === "Tab" ||
-      e.key === "," ||
-      e.key === " ";
-    if (isCommitKey) {
-      // Tab still moves focus when there's nothing to commit; Enter /
-      // comma / Space stay inside the input. Space at an empty draft
-      // is a no-op (passes through so the user can type a leading
-      // space if they really want one — the normalize step strips it
-      // later anyway).
+    // Space is the "commit my typed draft now" shortcut. Routed
+    // separately from Enter / Tab / comma so it NEVER accepts the
+    // currently-highlighted suggestion — pressing space conceptually
+    // ends the word the user is typing, not the word autocomplete is
+    // offering. Architect call 2026-05-21 after the PR #334 review.
+    //
+    // Always preventDefault so a real browser doesn't insert a literal
+    // space character into the input (which the test harness can't
+    // observe via fireEvent.keyDown).
+    if (e.key === " ") {
+      e.preventDefault();
+      if (draft.trim()) {
+        commitChip(draft);
+      }
+      return;
+    }
+
+    if (e.key === "Enter" || e.key === "Tab" || e.key === ",") {
+      // Tab still moves focus; Enter / comma stay inside the input
+      // to commit. We only intercept Tab when there's a draft so
+      // empty Tab still moves to the next field.
       if (e.key === "Tab" && !draft.trim() && highlightIdx < 0) return;
-      if (e.key === " " && !draft.trim()) return;
       e.preventDefault();
       if (
         open &&

--- a/frontend/components/transactions/TagChipInput.tsx
+++ b/frontend/components/transactions/TagChipInput.tsx
@@ -21,10 +21,14 @@ import { input } from "@/lib/styles";
  *
  * Behavior:
  *   - User types -> debounced fetch (200ms). Minimum prefix length 1.
- *   - Enter / Tab / comma commits the typed text as a chip. The
- *     transactions submit path posts the chip names to
- *     PUT /api/v1/transactions/{id}/tags which auto-creates any
- *     tags the org has not used before.
+ *   - Enter / Tab / comma / Space commits the typed text as a chip.
+ *     Space is the most discoverable trigger for "add another tag" —
+ *     users coming from social platforms expect it. Multi-word tags
+ *     are no longer typeable from the keyboard once Space commits;
+ *     use hyphen ("bike-commute") or click an autocomplete suggestion
+ *     that already contains a space. The transactions submit path
+ *     posts the chip names to PUT /api/v1/transactions/{id}/tags
+ *     which auto-creates any tags the org has not used before.
  *   - Backspace on an empty input removes the last chip.
  *   - Click suggestion commits chip.
  *   - Each chip carries a remove "x" with aria-label="Remove tag <name>".
@@ -257,11 +261,19 @@ export default function TagChipInput({
   }, []);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" || e.key === "Tab" || e.key === ",") {
-      // Tab still moves focus; Enter / comma stay inside the input
-      // to commit. We only intercept Tab when there's a draft so
-      // empty Tab still moves to the next field.
+    const isCommitKey =
+      e.key === "Enter" ||
+      e.key === "Tab" ||
+      e.key === "," ||
+      e.key === " ";
+    if (isCommitKey) {
+      // Tab still moves focus when there's nothing to commit; Enter /
+      // comma / Space stay inside the input. Space at an empty draft
+      // is a no-op (passes through so the user can type a leading
+      // space if they really want one — the normalize step strips it
+      // later anyway).
       if (e.key === "Tab" && !draft.trim() && highlightIdx < 0) return;
+      if (e.key === " " && !draft.trim()) return;
       e.preventDefault();
       if (
         open &&

--- a/frontend/tests/components/transactions/tag-chip-input.test.tsx
+++ b/frontend/tests/components/transactions/tag-chip-input.test.tsx
@@ -110,6 +110,37 @@ describe("TagChipInput", () => {
     expect(screen.getByTestId("tag-chip-rent")).toBeTruthy();
   });
 
+  it("commits a typed tag on Space and clears the draft", async () => {
+    // Space is the most discoverable "add another tag" trigger for
+    // users coming from social platforms. The previous version of the
+    // input only committed on Enter / Tab / comma — fjorge feedback
+    // 2026-05-21: nobody figures out Enter on first try.
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "bike" } });
+      fireEvent.keyDown(input, { key: " " });
+    });
+    expect(screen.getByTestId("tag-chip-bike")).toBeTruthy();
+    expect(input.value).toBe("");
+  });
+
+  it("Space at an empty draft is a no-op (does NOT commit an empty chip)", async () => {
+    // Avoids the surprise where pressing space on focus creates a
+    // mysterious empty chip. The keyboard handler explicitly returns
+    // early when draft is empty.
+    const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      input.focus();
+      fireEvent.keyDown(input, { key: " " });
+    });
+    // No chip created.
+    expect(input.parentElement?.querySelectorAll("[data-testid^='tag-chip-']").length).toBe(0);
+  });
+
   it("normalizes uppercase to lowercase on commit", async () => {
     const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
     render(<Harness fetcher={fetcher} />);

--- a/frontend/tests/components/transactions/tag-chip-input.test.tsx
+++ b/frontend/tests/components/transactions/tag-chip-input.test.tsx
@@ -141,6 +141,36 @@ describe("TagChipInput", () => {
     expect(input.parentElement?.querySelectorAll("[data-testid^='tag-chip-']").length).toBe(0);
   });
 
+  it("Space commits the TYPED draft even when a suggestion is highlighted (not the suggestion)", async () => {
+    // Architect-flagged contract pin (PR #334 review 2026-05-21):
+    // Space and Enter take DIFFERENT paths. Enter on an open suggestion
+    // list accepts the highlighted suggestion; Space always commits
+    // the word the user is typing. Regression covers the case where
+    // the user types "in" (suggestions "insurance" / "groceries" open
+    // with "insurance" highlighted) and presses Space — the chip MUST
+    // be "in", not "insurance".
+    const d = deferred<TagSuggestion[]>();
+    const fetcher: Fetcher = vi.fn().mockReturnValue(d.promise);
+    render(<Harness fetcher={fetcher} />);
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "in" } });
+      await vi.advanceTimersByTimeAsync(15);
+      d.resolve(SAMPLE);
+    });
+    // Confirm the suggestion list rendered before we press Space —
+    // otherwise this test is vacuous.
+    await screen.findByRole("option", { name: /insurance/ });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: " " });
+    });
+    // The typed draft "in" should be the chip; "insurance" must NOT
+    // have been committed.
+    expect(screen.getByTestId("tag-chip-in")).toBeTruthy();
+    expect(screen.queryByTestId("tag-chip-insurance")).toBeNull();
+    expect(input.value).toBe("");
+  });
+
   it("normalizes uppercase to lowercase on commit", async () => {
     const fetcher: Fetcher = vi.fn().mockResolvedValue([]);
     render(<Harness fetcher={fetcher} />);


### PR DESCRIPTION
## Summary

- Operator feedback 2026-05-21: nobody figures out Enter as the chip-commit trigger on first try. Space is the discoverable shortcut (Twitter / Discord / Slack conventions).
- **Space + non-empty draft** → commits the typed value as a chip and clears the input.
- **Space + empty draft** → no-op (avoids the mysterious empty-chip surprise on first focus).
- Enter / Tab / comma still work as before. No regression on existing commit triggers.

## Trade-off (noted in JSDoc)

Multi-word tags from the keyboard are no longer typeable (a space ends the current draft). Workarounds:
- type with a hyphen: \`bike-commute\`
- click an autocomplete suggestion that already contains a space

Backend normalization accepts both shapes; only the keyboard authoring path changes.

## Tests

Two new Vitest cases (\`tests/components/transactions/tag-chip-input.test.tsx\`):
- \"commits a typed tag on Space and clears the draft\"
- \"Space at an empty draft is a no-op (does NOT commit an empty chip)\"

12 / 12 tests pass. Lint + tsc clean.