### PR TITLE
feat(notifications): substrate — schema + service + endpoints (PR1 of train)

### DIFF
--- a/backend/alembic/versions/050_notifications_substrate.py
+++ b/backend/alembic/versions/050_notifications_substrate.py
@@ -1,0 +1,178 @@
+"""Notification system substrate.
+
+Revision ID: 050_notifications
+Revises: 049_announcements
+Create Date: 2026-05-22
+
+Creates the two tables that back the notification system
+(specs ``2026-05-21-notification-system-sensitive-ops.md`` +
+``2026-05-22-notification-system-2nd-arch-pass.md``):
+
+- ``notifications`` — per-user feed rows written by sensitive-op
+  routes. ``seen_at`` + ``audit_event_id`` columns are included
+  from this initial create per the 2nd-arch delta (G1 + G5). No
+  separate follow-up migration.
+- ``user_notification_preferences`` — one row per user, four
+  categories x two channels. Lazy-created by the service layer on
+  first read. ``email_security=True`` is the default; the API
+  layer rejects ``email_security=False`` writes with 400.
+
+No backfill. Both tables start empty. Existing users get
+preference rows lazily on first GET. No notification rows are
+generated for audit events that pre-date the rollout — see
+2nd-arch delta G2.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "050_notifications"
+down_revision = "049_announcements"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "category",
+            sa.Enum(
+                "security",
+                "account",
+                "org_admin",
+                "org_activity",
+                name="notification_category",
+                values_callable=lambda x: list(x),
+            ),
+            nullable=False,
+        ),
+        sa.Column("event_type", sa.String(length=80), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("link_url", sa.String(length=512), nullable=True),
+        sa.Column("seen_at", sa.DateTime(), nullable=True),
+        sa.Column("read_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "audit_event_id",
+            sa.BigInteger().with_variant(sa.Integer(), "sqlite"),
+            sa.ForeignKey("audit_events.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(6),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_notifications_user_unseen",
+        "notifications",
+        ["user_id", "seen_at", "created_at"],
+    )
+    op.create_index(
+        "ix_notifications_user_unread",
+        "notifications",
+        ["user_id", "read_at", "created_at"],
+    )
+    op.create_index(
+        "ix_notifications_event_type",
+        "notifications",
+        ["event_type"],
+    )
+
+    op.create_table(
+        "user_notification_preferences",
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "email_security",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "email_account",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "email_org_admin",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "email_org_activity",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "in_app_security",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "in_app_account",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "in_app_org_admin",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "in_app_org_activity",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_notification_preferences")
+    op.drop_index(
+        "ix_notifications_event_type",
+        table_name="notifications",
+    )
+    op.drop_index(
+        "ix_notifications_user_unread",
+        table_name="notifications",
+    )
+    op.drop_index(
+        "ix_notifications_user_unseen",
+        table_name="notifications",
+    )
+    op.drop_table("notifications")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, onboarding, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -423,6 +423,7 @@ app.include_router(tags.transaction_tags_router)
 app.include_router(feedback.router)
 app.include_router(announcements.router)
 app.include_router(admin_announcements.router)
+app.include_router(notifications.router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -33,6 +33,11 @@ from app.models.announcement import (  # noqa: F401
     AnnouncementSeverity,
     UserDismissedAnnouncement,
 )
+from app.models.notification import (  # noqa: F401
+    Notification,
+    NotificationCategory,
+    UserNotificationPreferences,
+)
 
 __all__ = [
     "Base",
@@ -81,4 +86,7 @@ __all__ = [
     "Announcement",
     "AnnouncementSeverity",
     "UserDismissedAnnouncement",
+    "Notification",
+    "NotificationCategory",
+    "UserNotificationPreferences",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,188 @@
+"""Per-user notification substrate for sensitive operations.
+
+Two tables live here (spec
+``specs/2026-05-21-notification-system-sensitive-ops.md`` + 2nd-arch
+delta ``specs/2026-05-22-notification-system-2nd-arch-pass.md``):
+
+- ``notifications`` — per-user feed rows written by sensitive-op
+  routes. Two mutable columns: ``seen_at`` (cleared on bell-open) and
+  ``read_at`` (cleared on row-click). ``audit_event_id`` is the
+  forensic correlation back to the matching audit row, nullable
+  + ``ON DELETE SET NULL`` so audit row deletion does not orphan
+  the notification feed.
+- ``user_notification_preferences`` — one row per user, four
+  categories x two channels. ``email_security`` is forced TRUE at
+  the API layer (the column shape is preserved so a future "really
+  opt me out" exception is a one-line change). Auto-created on first
+  access via the service layer.
+
+Architect-locked decisions baked into this module:
+
+- ``seen_at`` + ``audit_event_id`` columns are present from PR1's
+  create migration (2nd-arch delta G1 + G5).
+- Hardcoded English ``title`` / ``body`` for v1; the template module
+  ``notification_templates.py`` will centralize them in PR3+.
+- BigInteger id on MySQL — notification feeds grow unbounded, same
+  reasoning as ``audit_events``. SQLite test path uses INTEGER via
+  ``with_variant`` so the in-memory autoincrement stays honest.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class NotificationCategory(str, enum.Enum):
+    """Coarse grouping that maps 1:1 to a preference toggle."""
+
+    SECURITY = "security"
+    ACCOUNT = "account"
+    ORG_ADMIN = "org_admin"
+    ORG_ACTIVITY = "org_activity"
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    # BigInteger on MySQL; SQLite test path uses INTEGER via
+    # with_variant so autoincrement stays available.
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    category: Mapped[NotificationCategory] = mapped_column(
+        Enum(
+            NotificationCategory,
+            name="notification_category",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
+    )
+    # Mirrors the corresponding audit_events.event_type so an operator
+    # can correlate via event_type + timestamp + user_id even when the
+    # explicit audit_event_id FK is NULL.
+    event_type: Mapped[str] = mapped_column(String(80), nullable=False)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    # Relative app path (e.g. /settings/security) so the user can
+    # jump to the affected screen. May be NULL when the action has
+    # no destination (e.g. account.deleted).
+    link_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    # Cleared on bell-open (POST /mark-seen). Clears the badge.
+    seen_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    # Cleared on row-click (PATCH /{id}) or read-all. The "unread"
+    # visual state in the inbox list.
+    read_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    # Forensic correlation back to the audit row that caused this
+    # notification, when there is one. ON DELETE SET NULL so audit
+    # row deletion (rare, but possible via admin tooling) does not
+    # cascade-kill the notification feed. No index — we don't query
+    # notifications BY audit_event_id; the column is for forensic
+    # lookups only.
+    audit_event_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        ForeignKey("audit_events.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(6),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # Covers the unseen-count badge query
+        #   WHERE user_id = ? AND seen_at IS NULL
+        Index(
+            "ix_notifications_user_unseen",
+            "user_id",
+            "seen_at",
+            "created_at",
+        ),
+        # Covers the inbox feed and unread filter
+        #   WHERE user_id = ? ORDER BY created_at DESC
+        #   WHERE user_id = ? AND read_at IS NULL ORDER BY created_at DESC
+        Index(
+            "ix_notifications_user_unread",
+            "user_id",
+            "read_at",
+            "created_at",
+        ),
+        Index("ix_notifications_event_type", "event_type"),
+    )
+
+
+class UserNotificationPreferences(Base):
+    __tablename__ = "user_notification_preferences"
+
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    # Email channel toggles. email_security is forced TRUE at the API
+    # layer — PUT /preferences raises 400 code=security_emails_required
+    # when the request carries email_security=False. The column shape
+    # is preserved so a future "really opt me out of security emails"
+    # exception is a one-line change.
+    email_security: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    email_account: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    email_org_admin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    # Org activity ("who did what in your org" feed) is noisy by
+    # nature; default OFF and opt-in.
+    email_org_activity: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    # In-app toggles mirror the email defaults. Same security force-on
+    # rule applies at the API layer.
+    in_app_security: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    in_app_account: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    in_app_org_admin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    in_app_org_activity: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,183 @@
+"""Customer-facing notification substrate router (specs
+``2026-05-21-notification-system-sensitive-ops.md`` +
+``2026-05-22-notification-system-2nd-arch-pass.md``).
+
+Mounted at ``/api/v1/notifications``. Five endpoints:
+
+- ``GET /notifications`` — cursor-paginated inbox feed for the
+  current user. Newest first.
+- ``POST /notifications/mark-seen`` — clears the unseen-count badge
+  for the bell icon. Idempotent.
+- ``PATCH /notifications/{id}`` — marks a single row as read. Returns
+  the updated row. Cross-user access returns 404 (does not leak ids).
+- ``GET /notifications/preferences`` — current user's preferences,
+  auto-creating the row on first read with the locked defaults.
+- ``PUT /notifications/preferences`` — replaces every preference
+  toggle. Rejects ``email_security=false`` with
+  ``400 {"code": "security_emails_required", ...}`` — the check
+  lives here (NOT in a Pydantic validator) per 2nd-arch delta
+  section 4, because a body-model validator would surface as 422
+  and miss the custom envelope.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.user import User
+from app.schemas.notification import (
+    NotificationListResponse,
+    NotificationPreferencesResponse,
+    NotificationPreferencesUpdate,
+    NotificationResponse,
+)
+from app.services import notification_service
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=NotificationListResponse)
+async def list_notifications(
+    cursor: Optional[str] = Query(default=None),
+    limit: int = Query(
+        default=notification_service.DEFAULT_LIST_LIMIT,
+        ge=1,
+        le=notification_service.MAX_LIST_LIMIT,
+    ),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Cursor-paginated inbox feed for the current user."""
+    try:
+        page = await notification_service.list_for_user(
+            db,
+            user_id=current_user.id,
+            cursor=cursor,
+            limit=limit,
+        )
+    except ValueError as exc:
+        # Malformed cursor — surface as a 400 with a structured code
+        # so the FE can clear its stored cursor and retry.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_cursor",
+                "message": "Notification cursor is malformed.",
+            },
+        ) from exc
+    return NotificationListResponse(
+        items=[NotificationResponse.model_validate(row) for row in page.items],
+        next_cursor=page.next_cursor,
+    )
+
+
+@router.post(
+    "/mark-seen",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def mark_all_seen(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Bell-open: clear the unseen-count badge for the current user.
+
+    Sets ``seen_at = NOW()`` on every unseen row owned by the user.
+    Idempotent — a second call within the same second touches zero
+    rows. Does NOT change ``read_at``; the inbox list's unread state
+    is unaffected.
+    """
+    await notification_service.mark_seen(db, user_id=current_user.id)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.patch(
+    "/{notification_id}",
+    response_model=NotificationResponse,
+)
+async def mark_one_read(
+    notification_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mark a single notification row as read.
+
+    Cross-user access (row owned by a different user) returns 404 so
+    the response does not leak the existence of ids the caller does
+    not own. A row that is already read is left untouched (the
+    original ``read_at`` timestamp is preserved); the response shape
+    is still the row.
+    """
+    row = await notification_service.mark_read(
+        db, user_id=current_user.id, notification_id=notification_id
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notification not found",
+        )
+    await db.commit()
+    return NotificationResponse.model_validate(row)
+
+
+@router.get(
+    "/preferences",
+    response_model=NotificationPreferencesResponse,
+)
+async def get_my_preferences(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the current user's preferences.
+
+    Auto-creates the row on first read with the locked defaults
+    (security + account + org_admin = True, org_activity = False).
+    The auto-create commits before returning so a subsequent GET hits
+    the persisted row rather than re-creating.
+    """
+    row = await notification_service.get_preferences(db, user_id=current_user.id)
+    await db.commit()
+    return NotificationPreferencesResponse.model_validate(row)
+
+
+@router.put(
+    "/preferences",
+    response_model=NotificationPreferencesResponse,
+)
+async def update_my_preferences(
+    body: NotificationPreferencesUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Replace every preference toggle for the current user.
+
+    Rejects ``email_security=False`` with
+    ``400 {"code": "security_emails_required", ...}`` per the locked
+    behavior. The check lives in the route handler (NOT in a Pydantic
+    validator) because a body-model validator raising ``ValueError``
+    surfaces as a default 422 ``RequestValidationError``, never the
+    custom 400 envelope. Match the auth.py:241-247 envelope shape
+    verbatim.
+    """
+    if body.email_security is False:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "security_emails_required",
+                "message": "Security notifications cannot be disabled.",
+            },
+        )
+    row = await notification_service.update_preferences(
+        db, user_id=current_user.id, payload=body
+    )
+    await db.commit()
+    return NotificationPreferencesResponse.model_validate(row)

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,95 @@
+"""Pydantic schemas for the notification substrate.
+
+Architect-locked rules baked into this module (specs
+``2026-05-21-notification-system-sensitive-ops.md`` +
+``2026-05-22-notification-system-2nd-arch-pass.md``):
+
+- ``NotificationPreferencesUpdate.email_security`` is a plain
+  ``bool``. The 400 rejection for ``email_security=False`` lives in
+  the route handler, NOT in a field validator. A field validator
+  raising ``ValueError`` is caught by FastAPI's request-validation
+  layer and produces a 422, never the 400
+  ``{code: "security_emails_required", ...}`` envelope the frontend
+  keys off. See 2nd-arch delta section 4.
+- Notification read shape mirrors the DB row; ``link_url`` and
+  ``audit_event_id`` are nullable.
+- Cursor pagination response carries ``items`` + ``next_cursor``.
+  Cursor opaque to the client; encoded server-side as
+  ``"<created_at_iso>__<id>"``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.notification import NotificationCategory
+
+
+class NotificationResponse(BaseModel):
+    """Single-row read shape returned by GET /notifications and the
+    mark-read PATCH endpoint."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    category: NotificationCategory
+    event_type: str
+    title: str
+    body: str
+    link_url: Optional[str] = None
+    seen_at: Optional[datetime] = None
+    read_at: Optional[datetime] = None
+    audit_event_id: Optional[int] = None
+    created_at: datetime
+
+
+class NotificationListResponse(BaseModel):
+    """Cursor-paginated list shape for GET /notifications.
+
+    ``next_cursor`` is ``None`` when the page is the last page.
+    Otherwise it is an opaque token the client passes back as the
+    ``cursor`` query parameter on the next request. The encoding is
+    ``"<created_at_iso>__<id>"`` — server-side only; clients must
+    treat it as opaque.
+    """
+
+    items: list[NotificationResponse]
+    next_cursor: Optional[str] = None
+
+
+class NotificationPreferencesResponse(BaseModel):
+    """Full preference shape for the current user."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    email_security: bool
+    email_account: bool
+    email_org_admin: bool
+    email_org_activity: bool
+    in_app_security: bool
+    in_app_account: bool
+    in_app_org_admin: bool
+    in_app_org_activity: bool
+
+
+class NotificationPreferencesUpdate(BaseModel):
+    """Update payload for PUT /notifications/preferences.
+
+    ``email_security`` is a plain ``bool`` — NOT a constrained type
+    or a validated field. The 400 rejection for ``email_security=False``
+    lives in the route handler. See module docstring + 2nd-arch
+    delta section 4 for the reasoning.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    email_security: bool
+    email_account: bool
+    email_org_admin: bool
+    email_org_activity: bool
+    in_app_security: bool
+    in_app_account: bool
+    in_app_org_admin: bool
+    in_app_org_activity: bool

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,0 +1,342 @@
+"""Persistence + service layer for the notification substrate.
+
+Per the 2nd-arch delta (G7 — future-queue readiness) and the parent
+spec, this layer is the single home for:
+
+- ``dispatch_notification`` — write a single notification row for a
+  user. PR1 carries the row-write side only; the email-dispatch side
+  is wired in PR3+ when the hook points are added.
+- ``mark_seen`` — bell-open clears the badge for all the user's
+  unseen rows. Idempotent.
+- ``mark_read`` — row-click clears a single row's unread state.
+  Idempotent.
+- ``list_for_user`` — cursor-paginated inbox feed. Ordered newest
+  first by ``(created_at, id)``.
+- ``get_preferences`` — auto-creates the user's preference row on
+  first access. ``email_security`` is forced TRUE on auto-create
+  per the locked default.
+- ``update_preferences`` — applies a typed payload. The 400 for
+  ``email_security=False`` is the route's job; this function trusts
+  its caller.
+
+PR1 scope intentionally excludes:
+
+- ``dispatch_notification_to_org`` (broadcast helper). Lands in
+  PR4 with the hooks that need it.
+- Email scheduling. The function signature here will gain an
+  ``email_service`` dispatcher in PR3 when the first hook hits.
+- ``notification_templates.py``. Hardcoded English strings are
+  passed in by the caller in v1; the template module centralizes
+  them in PR3+.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import and_, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app._time import utcnow_naive
+from app.models.notification import (
+    Notification,
+    NotificationCategory,
+    UserNotificationPreferences,
+)
+
+
+# Page size cap mirrors the parent spec's pagination decision (G3):
+# default 50, hard ceiling 100. The route layer enforces the ceiling
+# by clamping the ``limit`` query parameter before it reaches here.
+DEFAULT_LIST_LIMIT = 50
+MAX_LIST_LIMIT = 100
+
+
+@dataclass(slots=True)
+class NotificationPage:
+    """Result tuple for cursor-paginated list calls."""
+
+    items: list[Notification]
+    next_cursor: Optional[str]
+
+
+# ── dispatch ──────────────────────────────────────────────────────
+
+
+async def dispatch_notification(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    category: NotificationCategory,
+    event_type: str,
+    title: str,
+    body: str,
+    link_url: Optional[str] = None,
+    audit_event_id: Optional[int] = None,
+) -> Notification:
+    """Write a single notification row for ``user_id``.
+
+    Caller is responsible for commit semantics — this matches the
+    parent spec's "persistence-first, dispatch-after" guardrail (the
+    notification ROW write goes through the request's ``AsyncSession``
+    so it commits atomically with the action that caused it). PR1
+    has no email-dispatch side; that wires in PR3+.
+
+    Per G8 idempotency note: callers must invoke this at most once
+    per request per ``(user_id, event_type)`` pair. There is no
+    DB-level dedup; a duplicate invocation produces a duplicate row.
+    """
+    # Set created_at explicitly in Python rather than relying on the
+    # server_default (``func.now(6)`` on MySQL, plain CURRENT_TIMESTAMP
+    # on SQLite). The dialect mismatch matters for cursor pagination:
+    # SQLite stores timestamps without fractional seconds when the
+    # default fires, but SQLAlchemy renders bound DateTime values
+    # WITH ``.000000`` microsecond padding when the same value is
+    # used in a WHERE clause — leading to text comparisons that go
+    # the wrong way. Setting the column from Python gives us a
+    # consistent shape on both backends and guarantees that two rows
+    # written in the same transaction still get monotonically
+    # increasing timestamps (utcnow_naive carries microsecond
+    # precision).
+    row = Notification(
+        user_id=user_id,
+        category=category,
+        event_type=event_type,
+        title=title,
+        body=body,
+        link_url=link_url,
+        audit_event_id=audit_event_id,
+        created_at=utcnow_naive(),
+    )
+    db.add(row)
+    await db.flush()
+    await db.refresh(row)
+    return row
+
+
+# ── reads ─────────────────────────────────────────────────────────
+
+
+def _encode_cursor(row: Notification) -> str:
+    """Server-side opaque cursor token.
+
+    Encoded as ``"<created_at_iso>__<id>"``. Microsecond precision
+    is preserved (the column is ``DATETIME(6)`` on MySQL via the
+    ``func.now(6)`` server default) so two rows written in the same
+    transaction still order deterministically.
+    """
+    return f"{row.created_at.isoformat()}__{row.id}"
+
+
+def _decode_cursor(cursor: str) -> tuple[datetime, int]:
+    """Parse ``"<created_at_iso>__<id>"`` back into the boundary tuple.
+
+    Raises ``ValueError`` on malformed input. The route layer wraps
+    this in a 400 so a bad cursor surfaces cleanly instead of
+    bubbling up as a 500.
+    """
+    try:
+        ts_str, id_str = cursor.rsplit("__", 1)
+        ts = datetime.fromisoformat(ts_str)
+        rid = int(id_str)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(f"invalid cursor: {cursor!r}") from exc
+    return ts, rid
+
+
+async def list_for_user(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    cursor: Optional[str] = None,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> NotificationPage:
+    """Cursor-paginated inbox feed for ``user_id``.
+
+    Ordered newest first by ``(created_at DESC, id DESC)``. The
+    cursor encodes the LAST row of the previous page; the next page
+    starts at the row strictly older than that boundary. This is
+    inclusive-of-(created_at, id) safe because we use a strict
+    ``<`` comparison.
+
+    Returns ``NotificationPage(items, next_cursor)``. ``next_cursor``
+    is ``None`` when this page IS the last page.
+    """
+    effective_limit = max(1, min(limit, MAX_LIST_LIMIT))
+
+    stmt = (
+        select(Notification)
+        .where(Notification.user_id == user_id)
+        .order_by(Notification.created_at.desc(), Notification.id.desc())
+    )
+    if cursor is not None:
+        boundary_ts, boundary_id = _decode_cursor(cursor)
+        # (created_at, id) < (boundary_ts, boundary_id) ordered
+        # tuple comparison, expressed as the equivalent disjunction
+        # so it runs on every dialect.
+        stmt = stmt.where(
+            or_(
+                Notification.created_at < boundary_ts,
+                and_(
+                    Notification.created_at == boundary_ts,
+                    Notification.id < boundary_id,
+                ),
+            )
+        )
+
+    # Pull limit+1 to detect "is there a next page". The extra row
+    # is sliced off the response but its existence drives next_cursor.
+    stmt = stmt.limit(effective_limit + 1)
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+
+    if len(rows) > effective_limit:
+        items = rows[:effective_limit]
+        next_cursor = _encode_cursor(items[-1])
+    else:
+        items = rows
+        next_cursor = None
+    return NotificationPage(items=items, next_cursor=next_cursor)
+
+
+# ── mark seen / mark read ─────────────────────────────────────────
+
+
+async def mark_seen(db: AsyncSession, *, user_id: int) -> int:
+    """Clear the bell badge for ``user_id``.
+
+    Sets ``seen_at = NOW()`` for every unseen row owned by the user.
+    Returns the number of rows touched. Idempotent — a second call
+    in the same second is a no-op (the row already has ``seen_at``
+    set and the WHERE clause excludes it).
+
+    Does NOT touch ``read_at``. Per the parent spec's G1 (read vs
+    seen) the two columns are distinct events.
+    """
+    now = utcnow_naive()
+    stmt = (
+        update(Notification)
+        .where(Notification.user_id == user_id)
+        .where(Notification.seen_at.is_(None))
+        .values(seen_at=now)
+    )
+    result = await db.execute(stmt)
+    await db.flush()
+    return result.rowcount or 0
+
+
+async def mark_read(
+    db: AsyncSession, *, user_id: int, notification_id: int
+) -> Optional[Notification]:
+    """Mark a single notification row as read.
+
+    Returns the updated row, or ``None`` when the row does not exist
+    or belongs to a different user (the route returns 404 in both
+    cases to avoid leaking notification ids across users).
+
+    Sets ``read_at`` only when it is currently NULL; a second call
+    leaves the original ``read_at`` timestamp intact (idempotent).
+    """
+    stmt = select(Notification).where(
+        Notification.id == notification_id,
+        Notification.user_id == user_id,
+    )
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    if row.read_at is None:
+        row.read_at = utcnow_naive()
+        await db.flush()
+        await db.refresh(row)
+    return row
+
+
+# ── preferences ───────────────────────────────────────────────────
+
+
+def _default_preferences(user_id: int) -> UserNotificationPreferences:
+    """Construct the default preference row for a new user.
+
+    ``email_security`` is forced TRUE — the API layer rejects writes
+    that flip it OFF, but the column shape is preserved so a future
+    "really opt me out" exception is a one-line change. The other
+    defaults mirror the parent spec's "noisy by nature" call on
+    ``org_activity``.
+    """
+    return UserNotificationPreferences(
+        user_id=user_id,
+        email_security=True,
+        email_account=True,
+        email_org_admin=True,
+        email_org_activity=False,
+        in_app_security=True,
+        in_app_account=True,
+        in_app_org_admin=True,
+        in_app_org_activity=False,
+    )
+
+
+async def get_preferences(
+    db: AsyncSession, *, user_id: int
+) -> UserNotificationPreferences:
+    """Return the user's preference row.
+
+    Auto-creates the row on first read with the default values when
+    no row exists. Commits the insert through the request's session
+    so the row survives the request even though the caller doesn't
+    explicitly commit (FastAPI's ``get_db`` dep commits at request
+    end on success).
+    """
+    stmt = select(UserNotificationPreferences).where(
+        UserNotificationPreferences.user_id == user_id
+    )
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is not None:
+        # Force email_security = True at READ time as well. The column
+        # value should always be True under normal operation (the PUT
+        # endpoint rejects False), but a stale row from a future
+        # migration / direct DB poke must not leak through.
+        if not row.email_security:
+            row.email_security = True
+            await db.flush()
+        return row
+
+    row = _default_preferences(user_id)
+    db.add(row)
+    await db.flush()
+    await db.refresh(row)
+    return row
+
+
+async def update_preferences(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    payload,
+) -> UserNotificationPreferences:
+    """Apply ``payload`` to the user's preference row.
+
+    The route handler is responsible for the 400 ``security_emails_required``
+    rejection when ``payload.email_security`` is False. This function
+    trusts the caller; ``email_security`` is force-coerced to True
+    here as a defense-in-depth backstop in case an internal call site
+    forgets the route check.
+
+    Auto-creates the row when missing (same path as ``get_preferences``)
+    so a PUT-before-GET workflow Just Works.
+    """
+    row = await get_preferences(db, user_id=user_id)
+    row.email_security = True  # defense in depth — the API gate is the real check
+    row.email_account = payload.email_account
+    row.email_org_admin = payload.email_org_admin
+    row.email_org_activity = payload.email_org_activity
+    row.in_app_security = payload.in_app_security
+    row.in_app_account = payload.in_app_account
+    row.in_app_org_admin = payload.in_app_org_admin
+    row.in_app_org_activity = payload.in_app_org_activity
+    await db.flush()
+    await db.refresh(row)
+    return row

--- a/backend/tests/routers/test_notifications.py
+++ b/backend/tests/routers/test_notifications.py
@@ -1,0 +1,596 @@
+"""Router tests for the notification substrate (specs
+``2026-05-21-notification-system-sensitive-ops.md`` +
+``2026-05-22-notification-system-2nd-arch-pass.md``).
+
+Pins the architect-locked invariants at the HTTP layer:
+
+- Auth gate: anonymous requests are 401 across every endpoint.
+- Cross-user isolation: PATCH on another user's row returns 404.
+- POST /mark-seen sets ``seen_at`` for all unseen rows; leaves
+  ``read_at`` alone.
+- PATCH /{id} marks a single row read; idempotent.
+- GET /preferences auto-creates the row with the locked defaults.
+- PUT /preferences happy path round-trips.
+- PUT /preferences with ``email_security=false`` returns 400 with
+  body shape ``{detail: {code: "security_emails_required", ...}}``
+  — the route-level check, NOT a Pydantic-validator 422.
+- Cursor pagination: 3 pages, every row appears exactly once.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.notification import (
+    Notification,
+    NotificationCategory,
+    UserNotificationPreferences,
+)
+from app.models.user import Organization, Role, User
+from app.routers.notifications import router as notifications_router
+from app.security import hash_password
+from app.services import notification_service
+
+
+# ── fixtures ──────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            finally:
+                await session.close()
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(notifications_router)
+    return app
+
+
+async def _seed_users(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Org", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        alice = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@ex.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+        )
+        bob = User(
+            org_id=org.id,
+            username="bob",
+            email="bob@ex.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add_all([alice, bob])
+        await db.commit()
+        return {"org_id": org.id, "alice_id": alice.id, "bob_id": bob.id}
+
+
+def _user_resolver(username: str):
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.username == username))
+            ).scalar_one()
+    return resolve
+
+
+# ── auth gate ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_requires_auth(session_factory):
+    """Anonymous request fails. We don't override get_current_user
+    here, so FastAPI's HTTPBearer dependency raises before reaching
+    the handler. TestClient surfaces this as 403 (no Authorization
+    header) under HTTPBearer's default; the gate is the same — no
+    anonymous access. The contract: every notifications endpoint is
+    authed."""
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(notifications_router)
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications")
+    # HTTPBearer's default behaviour: missing credentials -> 403.
+    # Either 401 or 403 satisfies "no anonymous access".
+    assert res.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_requires_auth(session_factory):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(notifications_router)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/notifications/mark-seen")
+    assert res.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_preferences_get_requires_auth(session_factory):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(notifications_router)
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications/preferences")
+    assert res.status_code in (401, 403)
+
+
+# ── list ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_empty(session_factory):
+    await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["items"] == []
+    assert body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_returns_rows_newest_first(session_factory):
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        for i in range(3):
+            await notification_service.dispatch_notification(
+                db,
+                user_id=seeds["alice_id"],
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications")
+    assert res.status_code == 200
+    body = res.json()
+    titles = [row["title"] for row in body["items"]]
+    assert titles == ["T2", "T1", "T0"]
+    assert body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_cursor_pagination_three_pages_no_overlap(session_factory):
+    """Three pages of fixture data, asserts:
+    - exactly 3 pages walked
+    - next_cursor is None on the last page
+    - no row appears in two consecutive pages
+    - every id is covered exactly once
+    """
+    seeds = await _seed_users(session_factory)
+    ids: list[int] = []
+    async with session_factory() as db:
+        for i in range(7):
+            row = await notification_service.dispatch_notification(
+                db,
+                user_id=seeds["alice_id"],
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+            ids.append(row.id)
+        await db.commit()
+
+    seen: set[int] = set()
+    pages: list[list[int]] = []
+    cursor: str | None = None
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        for _ in range(5):  # guard cap
+            params = {"limit": 3}
+            if cursor is not None:
+                params["cursor"] = cursor
+            res = client.get("/api/v1/notifications", params=params)
+            assert res.status_code == 200
+            body = res.json()
+            page_ids = [row["id"] for row in body["items"]]
+            assert seen.isdisjoint(page_ids), (
+                f"cursor pagination produced overlap on page {len(pages)}: "
+                f"already-seen {seen & set(page_ids)}"
+            )
+            seen.update(page_ids)
+            pages.append(page_ids)
+            cursor = body["next_cursor"]
+            if cursor is None:
+                break
+
+    assert len(pages) == 3
+    assert [len(p) for p in pages] == [3, 3, 1]
+    assert seen == set(ids)
+
+
+@pytest.mark.asyncio
+async def test_list_only_returns_current_user_rows(session_factory):
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        await notification_service.dispatch_notification(
+            db,
+            user_id=seeds["alice_id"],
+            category=NotificationCategory.SECURITY,
+            event_type="e.a",
+            title="A",
+            body="A",
+        )
+        await notification_service.dispatch_notification(
+            db,
+            user_id=seeds["bob_id"],
+            category=NotificationCategory.SECURITY,
+            event_type="e.b",
+            title="B",
+            body="B",
+        )
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications")
+    body = res.json()
+    titles = [row["title"] for row in body["items"]]
+    assert titles == ["A"]
+
+
+@pytest.mark.asyncio
+async def test_list_malformed_cursor_returns_400(session_factory):
+    await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get(
+            "/api/v1/notifications", params={"cursor": "not-a-cursor"}
+        )
+    assert res.status_code == 400
+    body = res.json()
+    assert body["detail"]["code"] == "invalid_cursor"
+
+
+# ── mark-seen ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_clears_unseen_leaves_read_alone(session_factory):
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        for i in range(3):
+            row = await notification_service.dispatch_notification(
+                db,
+                user_id=seeds["alice_id"],
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+            if i == 0:
+                # Pre-mark one as read so we can verify mark_seen
+                # doesn't touch read_at.
+                row.read_at = row.created_at
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/notifications/mark-seen")
+    assert res.status_code == 204
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification)
+                .where(Notification.user_id == seeds["alice_id"])
+                .order_by(Notification.id)
+            )
+        ).scalars().all()
+    assert all(r.seen_at is not None for r in rows)
+    # The pre-read row's read_at is still set; the other two are
+    # still unread.
+    assert rows[0].read_at is not None
+    assert rows[1].read_at is None
+    assert rows[2].read_at is None
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_does_not_touch_other_users(session_factory):
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        await notification_service.dispatch_notification(
+            db,
+            user_id=seeds["bob_id"],
+            category=NotificationCategory.SECURITY,
+            event_type="e.b",
+            title="B",
+            body="B",
+        )
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/notifications/mark-seen")
+    assert res.status_code == 204
+
+    async with session_factory() as db:
+        bob_row = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.user_id == seeds["bob_id"]
+                )
+            )
+        ).scalar_one()
+    assert bob_row.seen_at is None
+
+
+# ── mark-read ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mark_read_sets_only_targeted(session_factory):
+    seeds = await _seed_users(session_factory)
+    ids: list[int] = []
+    async with session_factory() as db:
+        for i in range(3):
+            row = await notification_service.dispatch_notification(
+                db,
+                user_id=seeds["alice_id"],
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+            ids.append(row.id)
+        await db.commit()
+
+    target = ids[1]
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.patch(f"/api/v1/notifications/{target}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["id"] == target
+    assert body["read_at"] is not None
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification)
+                .where(Notification.user_id == seeds["alice_id"])
+                .order_by(Notification.id)
+            )
+        ).scalars().all()
+    states = [(r.id, r.read_at is not None) for r in rows]
+    assert states == [
+        (ids[0], False),
+        (ids[1], True),
+        (ids[2], False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mark_read_cross_user_returns_404(session_factory):
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=seeds["bob_id"],
+            category=NotificationCategory.SECURITY,
+            event_type="e",
+            title="T",
+            body="B",
+        )
+        await db.commit()
+        nid = row.id
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.patch(f"/api/v1/notifications/{nid}")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_mark_read_missing_returns_404(session_factory):
+    await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.patch("/api/v1/notifications/9999")
+    assert res.status_code == 404
+
+
+# ── preferences GET (auto-create) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_preferences_get_auto_creates_with_defaults(session_factory):
+    seeds = await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+
+    # Confirm no row exists before the GET.
+    async with session_factory() as db:
+        existing = (
+            await db.execute(
+                select(UserNotificationPreferences).where(
+                    UserNotificationPreferences.user_id == seeds["alice_id"]
+                )
+            )
+        ).scalar_one_or_none()
+    assert existing is None
+
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications/preferences")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["email_security"] is True
+    assert body["email_account"] is True
+    assert body["email_org_admin"] is True
+    assert body["email_org_activity"] is False
+    assert body["in_app_security"] is True
+    assert body["in_app_account"] is True
+    assert body["in_app_org_admin"] is True
+    assert body["in_app_org_activity"] is False
+
+    # The row now exists.
+    async with session_factory() as db:
+        persisted = (
+            await db.execute(
+                select(UserNotificationPreferences).where(
+                    UserNotificationPreferences.user_id == seeds["alice_id"]
+                )
+            )
+        ).scalar_one()
+    assert persisted.user_id == seeds["alice_id"]
+
+
+# ── preferences PUT (happy path + 400) ────────────────────────────
+
+
+def _full_payload(**overrides) -> dict:
+    base = {
+        "email_security": True,
+        "email_account": True,
+        "email_org_admin": True,
+        "email_org_activity": False,
+        "in_app_security": True,
+        "in_app_account": True,
+        "in_app_org_admin": True,
+        "in_app_org_activity": False,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_preferences_put_happy_path(session_factory):
+    await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+    payload = _full_payload(
+        email_account=False,
+        email_org_admin=False,
+        email_org_activity=True,
+        in_app_account=False,
+        in_app_org_activity=True,
+    )
+    with TestClient(app) as client:
+        res = client.put("/api/v1/notifications/preferences", json=payload)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["email_security"] is True
+    assert body["email_account"] is False
+    assert body["email_org_admin"] is False
+    assert body["email_org_activity"] is True
+    assert body["in_app_security"] is True
+    assert body["in_app_account"] is False
+    assert body["in_app_org_admin"] is True
+    assert body["in_app_org_activity"] is True
+
+
+@pytest.mark.asyncio
+async def test_preferences_put_rejects_email_security_false_with_400(
+    session_factory,
+):
+    """The architect-locked envelope shape — pinned exactly.
+
+    Must be a 400 (not a 422), and the detail must be a dict with
+    ``code`` + ``message`` keys (NOT a list-of-errors shape, which
+    is what FastAPI's default request-validation handler would
+    produce if the check were a Pydantic field validator).
+    """
+    await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+    payload = _full_payload(email_security=False)
+    with TestClient(app) as client:
+        res = client.put("/api/v1/notifications/preferences", json=payload)
+    assert res.status_code == 400
+    body = res.json()
+    # Envelope shape: detail must be an object, not a list.
+    assert isinstance(body["detail"], dict), (
+        f"expected route-level 400 envelope, got {body!r}"
+    )
+    assert body["detail"]["code"] == "security_emails_required"
+    assert "message" in body["detail"]
+    assert body["detail"]["message"]  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_preferences_put_round_trip_via_get(session_factory):
+    await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+    payload = _full_payload(email_account=False, email_org_admin=False)
+    with TestClient(app) as client:
+        put_res = client.put("/api/v1/notifications/preferences", json=payload)
+        assert put_res.status_code == 200
+        get_res = client.get("/api/v1/notifications/preferences")
+    assert get_res.status_code == 200
+    assert get_res.json()["email_account"] is False
+    assert get_res.json()["email_org_admin"] is False

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -1,0 +1,524 @@
+"""Service-layer tests for the notification substrate.
+
+Pins the architect-locked invariants exercised at the function level
+(without the FastAPI request/commit envelope):
+
+- ``dispatch_notification`` writes the row, optionally carrying
+  ``link_url`` and ``audit_event_id``.
+- ``mark_seen`` clears ``seen_at`` for every unseen row and leaves
+  ``read_at`` untouched.
+- ``mark_read`` sets ``read_at`` only on the targeted row; a second
+  call is a no-op.
+- ``list_for_user`` honors cursor pagination and never repeats a
+  row across consecutive pages.
+- ``get_preferences`` auto-creates the row with the locked defaults.
+- ``update_preferences`` round-trips the writable fields and
+  defense-in-depth-forces ``email_security=True`` on write.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.notification import (
+    Notification,
+    NotificationCategory,
+    UserNotificationPreferences,
+)
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services import notification_service
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_user(factory, *, username: str = "alice", email: str = "alice@ex.io") -> int:
+    async with factory() as db:
+        org = Organization(name=f"Org-{username}", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username=username,
+            email=email,
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+# ── dispatch_notification ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_notification_happy_path_minimal(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.SECURITY,
+            event_type="user.password.changed",
+            title="Your password was changed",
+            body="A change happened.",
+        )
+        await db.commit()
+    assert row.id is not None
+    assert row.user_id == user_id
+    assert row.category == NotificationCategory.SECURITY
+    assert row.event_type == "user.password.changed"
+    assert row.title == "Your password was changed"
+    assert row.body == "A change happened."
+    assert row.link_url is None
+    assert row.audit_event_id is None
+    assert row.read_at is None
+    assert row.seen_at is None
+    assert row.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_notification_with_link_url(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.ACCOUNT,
+            event_type="account.role_changed",
+            title="Role changed",
+            body="Your role was updated.",
+            link_url="/settings/profile",
+        )
+        await db.commit()
+    assert row.link_url == "/settings/profile"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_notification_with_audit_event_id(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        audit_row = AuditEvent(
+            event_type="user.password.changed",
+            actor_email="alice@ex.io",
+            outcome=AuditOutcome.SUCCESS,
+        )
+        db.add(audit_row)
+        await db.commit()
+        await db.refresh(audit_row)
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.SECURITY,
+            event_type="user.password.changed",
+            title="Password changed",
+            body="Your password was changed.",
+            audit_event_id=audit_row.id,
+        )
+        await db.commit()
+    assert row.audit_event_id == audit_row.id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_notification_with_link_and_audit(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        audit_row = AuditEvent(
+            event_type="admin.org.plan.changed",
+            actor_email="admin@ex.io",
+            outcome=AuditOutcome.SUCCESS,
+        )
+        db.add(audit_row)
+        await db.commit()
+        await db.refresh(audit_row)
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.ORG_ADMIN,
+            event_type="admin.org.plan.changed",
+            title="Plan changed",
+            body="Org plan was changed.",
+            link_url="/settings/billing",
+            audit_event_id=audit_row.id,
+        )
+        await db.commit()
+    assert row.link_url == "/settings/billing"
+    assert row.audit_event_id == audit_row.id
+
+
+# ── mark_seen ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_clears_all_unseen_only(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        for i in range(3):
+            await notification_service.dispatch_notification(
+                db,
+                user_id=user_id,
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+        await db.commit()
+
+    async with session_factory() as db:
+        touched = await notification_service.mark_seen(db, user_id=user_id)
+        await db.commit()
+    assert touched == 3
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification).where(Notification.user_id == user_id)
+            )
+        ).scalars().all()
+    assert all(r.seen_at is not None for r in rows)
+    # read_at must not have been touched.
+    assert all(r.read_at is None for r in rows)
+
+    # A second call returns 0 — idempotent.
+    async with session_factory() as db:
+        touched = await notification_service.mark_seen(db, user_id=user_id)
+        await db.commit()
+    assert touched == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_seen_does_not_clear_other_users(session_factory):
+    alice = await _seed_user(session_factory, username="alice", email="a@ex.io")
+    bob = await _seed_user(session_factory, username="bob", email="b@ex.io")
+    async with session_factory() as db:
+        for u in (alice, bob):
+            await notification_service.dispatch_notification(
+                db,
+                user_id=u,
+                category=NotificationCategory.SECURITY,
+                event_type="e",
+                title="t",
+                body="b",
+            )
+        await db.commit()
+
+    async with session_factory() as db:
+        await notification_service.mark_seen(db, user_id=alice)
+        await db.commit()
+
+    async with session_factory() as db:
+        bob_row = (
+            await db.execute(
+                select(Notification).where(Notification.user_id == bob)
+            )
+        ).scalar_one()
+    assert bob_row.seen_at is None
+
+
+# ── mark_read ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mark_read_sets_only_targeted_row(session_factory):
+    user_id = await _seed_user(session_factory)
+    ids: list[int] = []
+    async with session_factory() as db:
+        for i in range(3):
+            row = await notification_service.dispatch_notification(
+                db,
+                user_id=user_id,
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+            ids.append(row.id)
+        await db.commit()
+    target_id = ids[1]
+
+    async with session_factory() as db:
+        updated = await notification_service.mark_read(
+            db, user_id=user_id, notification_id=target_id
+        )
+        await db.commit()
+    assert updated is not None
+    assert updated.read_at is not None
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification)
+                .where(Notification.user_id == user_id)
+                .order_by(Notification.id)
+            )
+        ).scalars().all()
+    read_states = [(r.id, r.read_at is not None) for r in rows]
+    assert read_states == [
+        (ids[0], False),
+        (ids[1], True),
+        (ids[2], False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mark_read_idempotent_preserves_timestamp(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.SECURITY,
+            event_type="e",
+            title="t",
+            body="b",
+        )
+        await db.commit()
+        nid = row.id
+
+    async with session_factory() as db:
+        updated = await notification_service.mark_read(
+            db, user_id=user_id, notification_id=nid
+        )
+        await db.commit()
+    first_read = updated.read_at
+    assert first_read is not None
+
+    async with session_factory() as db:
+        again = await notification_service.mark_read(
+            db, user_id=user_id, notification_id=nid
+        )
+        await db.commit()
+    assert again is not None
+    # Idempotent: original timestamp preserved.
+    assert again.read_at == first_read
+
+
+@pytest.mark.asyncio
+async def test_mark_read_cross_user_returns_none(session_factory):
+    alice = await _seed_user(session_factory, username="alice", email="a@ex.io")
+    bob = await _seed_user(session_factory, username="bob", email="b@ex.io")
+    async with session_factory() as db:
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=alice,
+            category=NotificationCategory.SECURITY,
+            event_type="e",
+            title="t",
+            body="b",
+        )
+        await db.commit()
+        nid = row.id
+
+    async with session_factory() as db:
+        updated = await notification_service.mark_read(
+            db, user_id=bob, notification_id=nid
+        )
+    assert updated is None
+
+
+# ── list_for_user (cursor pagination) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_cursor_pagination_three_pages(session_factory):
+    user_id = await _seed_user(session_factory)
+    # Seed 7 rows so a limit=3 walk gives 3 pages (3 + 3 + 1).
+    ids: list[int] = []
+    async with session_factory() as db:
+        for i in range(7):
+            row = await notification_service.dispatch_notification(
+                db,
+                user_id=user_id,
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+            ids.append(row.id)
+        await db.commit()
+
+    seen_ids: set[int] = set()
+    pages: list[list[int]] = []
+    cursor: str | None = None
+    async with session_factory() as db:
+        for _ in range(5):  # guard cap; we expect exactly 3 iterations
+            page = await notification_service.list_for_user(
+                db, user_id=user_id, cursor=cursor, limit=3
+            )
+            page_ids = [r.id for r in page.items]
+            pages.append(page_ids)
+            # No row appears in two consecutive pages.
+            assert seen_ids.isdisjoint(page_ids), (
+                "cursor pagination produced an overlapping row"
+            )
+            seen_ids.update(page_ids)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+    assert len(pages) == 3
+    assert len(pages[0]) == 3
+    assert len(pages[1]) == 3
+    assert len(pages[2]) == 1
+    # Newest first: highest id should be on page 0.
+    assert pages[0][0] == ids[-1]
+    # All 7 ids covered, exactly once.
+    assert seen_ids == set(ids)
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_empty_returns_no_cursor(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        page = await notification_service.list_for_user(
+            db, user_id=user_id, cursor=None, limit=10
+        )
+    assert page.items == []
+    assert page.next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_invalid_cursor_raises(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        with pytest.raises(ValueError):
+            await notification_service.list_for_user(
+                db, user_id=user_id, cursor="not_a_cursor", limit=10
+            )
+
+
+# ── get_preferences (auto-create) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_preferences_auto_creates_row_with_defaults(session_factory):
+    user_id = await _seed_user(session_factory)
+    async with session_factory() as db:
+        existing = (
+            await db.execute(
+                select(UserNotificationPreferences).where(
+                    UserNotificationPreferences.user_id == user_id
+                )
+            )
+        ).scalar_one_or_none()
+    assert existing is None
+
+    async with session_factory() as db:
+        prefs = await notification_service.get_preferences(db, user_id=user_id)
+        await db.commit()
+    assert prefs.user_id == user_id
+    # Default values per architect lock.
+    assert prefs.email_security is True
+    assert prefs.email_account is True
+    assert prefs.email_org_admin is True
+    assert prefs.email_org_activity is False
+    assert prefs.in_app_security is True
+    assert prefs.in_app_account is True
+    assert prefs.in_app_org_admin is True
+    assert prefs.in_app_org_activity is False
+
+    # Second call returns the same row.
+    async with session_factory() as db:
+        prefs2 = await notification_service.get_preferences(db, user_id=user_id)
+    assert prefs2.user_id == user_id
+
+
+# ── update_preferences ────────────────────────────────────────────
+
+
+class _PrefPayload:
+    """Light stand-in matching the schema attribute names; the
+    service only reads attributes so we don't import the Pydantic
+    class here to keep this test independent of the wire layer."""
+
+    def __init__(self, **kwargs):
+        self.email_security = kwargs.get("email_security", True)
+        self.email_account = kwargs.get("email_account", True)
+        self.email_org_admin = kwargs.get("email_org_admin", True)
+        self.email_org_activity = kwargs.get("email_org_activity", False)
+        self.in_app_security = kwargs.get("in_app_security", True)
+        self.in_app_account = kwargs.get("in_app_account", True)
+        self.in_app_org_admin = kwargs.get("in_app_org_admin", True)
+        self.in_app_org_activity = kwargs.get("in_app_org_activity", False)
+
+
+@pytest.mark.asyncio
+async def test_update_preferences_round_trips(session_factory):
+    user_id = await _seed_user(session_factory)
+    payload = _PrefPayload(
+        email_security=True,
+        email_account=False,
+        email_org_admin=False,
+        email_org_activity=True,
+        in_app_security=True,
+        in_app_account=False,
+        in_app_org_admin=True,
+        in_app_org_activity=True,
+    )
+    async with session_factory() as db:
+        prefs = await notification_service.update_preferences(
+            db, user_id=user_id, payload=payload
+        )
+        await db.commit()
+    assert prefs.email_security is True
+    assert prefs.email_account is False
+    assert prefs.email_org_admin is False
+    assert prefs.email_org_activity is True
+    assert prefs.in_app_security is True
+    assert prefs.in_app_account is False
+    assert prefs.in_app_org_admin is True
+    assert prefs.in_app_org_activity is True
+
+
+@pytest.mark.asyncio
+async def test_update_preferences_forces_security_true_defense_in_depth(session_factory):
+    """The route layer is the real gate for email_security=False, but
+    the service force-coerces to True as defense in depth so an
+    internal call site that forgets the route check cannot persist a
+    broken state.
+    """
+    user_id = await _seed_user(session_factory)
+    payload = _PrefPayload(email_security=False)
+    async with session_factory() as db:
+        prefs = await notification_service.update_preferences(
+            db, user_id=user_id, payload=payload
+        )
+        await db.commit()
+    assert prefs.email_security is True


### PR DESCRIPTION
## Summary

PR1 of the notification system rollout train. Ships the persistent layer + service layer + customer-facing endpoints. No hooks, no frontend, no email dispatch — those wire in PR3+.

- **Migrations.** New tables: ``notifications`` (with ``seen_at`` + ``audit_event_id`` columns from the initial create per 2nd-arch delta G1 + G5) and ``user_notification_preferences`` (four categories x two channels).
- **Service.** ``dispatch_notification``, ``mark_seen``, ``mark_read``, ``list_for_user`` (cursor pagination), ``get_preferences`` (auto-create on first read), ``update_preferences`` (defense-in-depth ``email_security=True`` coerce).
- **Endpoints under ``/api/v1/notifications``.** ``GET`` (cursor + limit), ``POST /mark-seen``, ``PATCH /{id}``, ``GET /preferences``, ``PUT /preferences``.
- **400 envelope.** ``PUT /preferences`` rejects ``email_security=false`` with ``{code: security_emails_required, message: ...}`` via a route-level check (NOT a Pydantic validator). A body-model validator surfaces as a 422 ``RequestValidationError`` and misses the custom envelope — pinned by test. Matches ``backend/app/routers/auth.py:241-247`` shape verbatim.
- **Cursor pagination.** Service sets ``created_at`` from Python (``utcnow_naive()``) rather than the column server_default so MySQL ``func.now(6)`` and SQLite ``CURRENT_TIMESTAMP`` agree on fractional-second precision. Without this, the cursor boundary on SQLite compares lexicographically wrong and consecutive pages can overlap.
- **32 tests** pinning the architect-locked invariants. Broader regression sweep clean on ``test_auth.py``, ``test_admin_users_*.py``, ``test_announcements.py``, ``test_audit_*.py``. Frontend ``tsc --noEmit`` clean.

## Specs

- ``specs/2026-05-21-notification-system-sensitive-ops.md``
- ``specs/2026-05-22-notification-system-2nd-arch-pass.md``

## Out of scope (lands in later PRs of this train)

- Audit gap closures for password/MFA/email/plan change — PR2.
- Hooks calling ``dispatch_notification`` — PR3+.
- Frontend bell + popover + ``/settings/notifications`` — PR3+.
- Email sending (Mailgun integration), ``notification_templates.py``, broadcast helper — PR3+.