### PR TITLE
feat(scenarios): substrate + analytic engine + trip/purchase + simulator UI (PR1 of Plans train)

### DIFF
--- a/backend/alembic/versions/052_scenarios.py
+++ b/backend/alembic/versions/052_scenarios.py
@@ -1,0 +1,122 @@
+"""Plans simulation sandbox substrate, the ``scenarios`` table.
+
+Revision ID: 052_scenarios
+Revises: 051_reports_v2_substrate
+Create Date: 2026-05-22
+
+Creates the ``scenarios`` table that backs the Plans page (spec
+``specs/2026-05-22-plans-page-simulation-sandbox.md``).
+
+Architect-locked rules baked into this migration:
+
+- Internal name = ``scenarios``. The user-facing label is "Plans";
+  the word "scenario" never appears in the UI but the DB / model /
+  router prefix all use it.
+- Per-user. Plans are private to the creator by default. A future
+  ``visibility`` column would flip per-org sharing on; out of scope
+  here.
+- Org-scoped enforcement at every query (matches the rest of the
+  codebase). Both ``org_id`` and ``user_id`` are NOT NULL.
+- ``params_json`` is a JSON blob validated by a Pydantic
+  discriminated union on ``scenario_type``. Reads are loose; writes
+  validate.
+- ``projection_json`` caches the last computed projection so the
+  list view can render a sparkline / verdict without re-running the
+  engine.
+- ``horizon_months`` defaults to 24. The DB column allows up to 480
+  at the storage layer; the per-``scenario_type`` ceiling (120 for
+  trip/purchase/custom, 480 for retirement) is enforced at the
+  Pydantic validator on the simulate-request payload AND on
+  scenario create / patch.
+- ``is_active`` is the soft-delete flag, matching the rest of the
+  codebase.
+
+No backfill: the table starts empty. The whole substrate is inert
+until a user creates a scenario via ``POST /api/v1/scenarios``.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "052_scenarios"
+down_revision = "051_reports_v2_substrate"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scenarios",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "org_id",
+            sa.Integer(),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column(
+            "scenario_type",
+            sa.Enum(
+                "trip",
+                "purchase",
+                "retirement",
+                "custom",
+                name="scenario_type",
+                values_callable=lambda x: list(x),
+            ),
+            nullable=False,
+        ),
+        sa.Column("params_json", sa.JSON(), nullable=False),
+        sa.Column("projection_json", sa.JSON(), nullable=True),
+        sa.Column("projection_engine", sa.String(length=40), nullable=True),
+        sa.Column("projection_computed_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "horizon_months",
+            sa.Integer(),
+            nullable=False,
+            server_default="24",
+        ),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_scenarios_org_user",
+        "scenarios",
+        ["org_id", "user_id"],
+    )
+    op.create_index(
+        "ix_scenarios_org_active",
+        "scenarios",
+        ["org_id", "is_active"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_scenarios_org_active", table_name="scenarios")
+    op.drop_index("ix_scenarios_org_user", table_name="scenarios")
+    op.drop_table("scenarios")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -425,6 +425,7 @@ app.include_router(announcements.router)
 app.include_router(admin_announcements.router)
 app.include_router(notifications.router)
 app.include_router(reports.router)
+app.include_router(scenarios.router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -39,6 +39,7 @@ from app.models.notification import (  # noqa: F401
     UserNotificationPreferences,
 )
 from app.models.report import Report, ReportVisibility  # noqa: F401
+from app.models.scenario import Scenario, ScenarioType  # noqa: F401
 
 __all__ = [
     "Base",
@@ -92,4 +93,6 @@ __all__ = [
     "UserNotificationPreferences",
     "Report",
     "ReportVisibility",
+    "Scenario",
+    "ScenarioType",
 ]

--- a/backend/app/models/scenario.py
+++ b/backend/app/models/scenario.py
@@ -1,0 +1,103 @@
+"""Plans simulation sandbox model (spec 2026-05-22).
+
+Internal name = ``scenarios``; user-facing label = "Plans" (architect
+lock 2026-05-22). The DB table, SQLAlchemy class, schemas, and router
+prefix all use ``scenarios``. The UI never says "scenario".
+
+Sandboxing contract: this model is the ONLY thing the simulation
+engine writes to. It must not introduce any relationship that would
+let the engine cascade a write into ``accounts``, ``transactions``,
+``budgets``, ``recurring_transactions``, or ``forecast_plans``. The
+guard test in ``tests/services/test_scenario_engine.py`` pins this
+invariant with a row-count delta assertion across all five tables.
+
+``params_json`` is a JSON blob validated by a Pydantic discriminated
+union on ``scenario_type``. ``projection_json`` caches the last
+``simulate`` output so the list view can render without re-running
+the engine.
+
+``horizon_months`` allows 1-480 at the column. The per-type cap
+(120 / 480) is enforced at the request validator, not the column.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ScenarioType(str, enum.Enum):
+    TRIP = "trip"
+    PURCHASE = "purchase"
+    RETIREMENT = "retirement"
+    CUSTOM = "custom"
+
+
+class Scenario(Base):
+    __tablename__ = "scenarios"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    scenario_type: Mapped[ScenarioType] = mapped_column(
+        Enum(
+            ScenarioType,
+            name="scenario_type",
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
+    )
+    params_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    projection_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSON, nullable=True
+    )
+    projection_engine: Mapped[Optional[str]] = mapped_column(
+        String(40), nullable=True
+    )
+    projection_computed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    horizon_months: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=24, server_default="24"
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("ix_scenarios_org_user", "org_id", "user_id"),
+        Index("ix_scenarios_org_active", "org_id", "is_active"),
+    )

--- a/backend/app/routers/scenarios.py
+++ b/backend/app/routers/scenarios.py
@@ -1,0 +1,250 @@
+"""Plans simulation sandbox router (spec 2026-05-22).
+
+Mounted at ``/api/v1/scenarios``. Architect-locked:
+
+- Internal name = ``scenarios``; user-facing label = "Plans". The
+  router prefix uses the internal name. The UI never says
+  "scenario".
+- Per-user. Plans are private to the creator. Every query filters
+  by ``org_id`` AND ``user_id``. A second user in the same org
+  cannot read another member's scenarios.
+- Horizon caps (120 for trip/purchase/custom, 480 for retirement)
+  are enforced via ``schemas/scenario.py::validate_horizon`` on
+  create, patch, and simulate paths.
+- Sandboxing: ``simulate`` runs a no-DB engine over a frozen
+  ``WorldState`` snapshot. It writes the projection blob back onto
+  the ``Scenario`` row and commits — nothing else.
+- ``compare`` endpoint is PR3 (out of scope for PR1).
+- ``ai_enhanced`` engine raises NotImplementedError (PR4 stub).
+"""
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app._time import utcnow_naive
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.scenario import Scenario, ScenarioType
+from app.models.user import User
+from app.schemas.scenario import (
+    ScenarioCreate,
+    ScenarioResponse,
+    ScenarioUpdate,
+    SimulateRequest,
+    validate_horizon,
+)
+from app.services.scenario_engine import (
+    SimulationRequest,
+    build_world_state,
+    get_engine,
+)
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/scenarios", tags=["scenarios"])
+
+
+def _validate_horizon_or_422(scenario_type: str, horizon_months: int) -> None:
+    """Wrap ``validate_horizon`` so router paths surface 422 (not 500).
+
+    The schema-level ``model_validator`` already converts ValueError
+    to 422 automatically. Router-level cap re-checks (on PATCH and on
+    POST /simulate) bypass that path, so we wrap with an explicit
+    HTTPException so the architect-locked cap surfaces uniformly as a
+    422 across every entry point.
+    """
+    try:
+        validate_horizon(scenario_type, horizon_months)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+
+async def _get_owned_scenario(
+    db: AsyncSession, *, user: User, scenario_id: int
+) -> Scenario:
+    """Fetch a scenario AND assert the current user owns it.
+
+    Architect-locked privacy: per-user scoping. Even a member of the
+    same org cannot read another user's scenarios. We return 404 on
+    cross-user attempts (NOT 403) so a probing client cannot enumerate
+    existence by ownership boundary.
+    """
+    row = await db.get(Scenario, scenario_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Scenario not found")
+    if row.user_id != user.id or row.org_id != user.org_id:
+        raise HTTPException(status_code=404, detail="Scenario not found")
+    return row
+
+
+@router.get("", response_model=list[ScenarioResponse])
+async def list_scenarios(
+    include_archived: bool = Query(default=False),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the current user's scenarios.
+
+    By default, archived (is_active=false) rows are hidden. Pass
+    ``include_archived=true`` to include them.
+    """
+    stmt = select(Scenario).where(
+        Scenario.org_id == current_user.org_id,
+        Scenario.user_id == current_user.id,
+    )
+    if not include_archived:
+        stmt = stmt.where(Scenario.is_active.is_(True))
+    stmt = stmt.order_by(Scenario.created_at.desc())
+    rows = (await db.execute(stmt)).scalars().all()
+    return list(rows)
+
+
+@router.post("", response_model=ScenarioResponse, status_code=201)
+async def create_scenario(
+    body: ScenarioCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new scenario (Plan in UI terms) for the current user."""
+    _validate_horizon_or_422(body.scenario_type.value, body.horizon_months)
+
+    row = Scenario(
+        org_id=current_user.org_id,
+        user_id=current_user.id,
+        name=body.name,
+        scenario_type=body.scenario_type,
+        params_json=body.params.model_dump(mode="json"),
+        horizon_months=body.horizon_months,
+        is_active=True,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+@router.get("/{scenario_id}", response_model=ScenarioResponse)
+async def get_scenario(
+    scenario_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await _get_owned_scenario(db, user=current_user, scenario_id=scenario_id)
+
+
+@router.patch("/{scenario_id}", response_model=ScenarioResponse)
+async def update_scenario(
+    scenario_id: int,
+    body: ScenarioUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Partial update: name, params, horizon_months, is_active.
+
+    scenario_type is immutable post-create (the params blob's
+    discriminator pins it).
+    """
+    row = await _get_owned_scenario(db, user=current_user, scenario_id=scenario_id)
+
+    # Re-check horizon cap against the EXISTING row's scenario_type.
+    if body.horizon_months is not None:
+        _validate_horizon_or_422(row.scenario_type.value, body.horizon_months)
+        row.horizon_months = body.horizon_months
+
+    if body.name is not None:
+        row.name = body.name
+
+    if body.params is not None:
+        if body.params.scenario_type != row.scenario_type.value:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "params scenario_type must match the existing "
+                    "scenario_type on the row"
+                ),
+            )
+        row.params_json = body.params.model_dump(mode="json")
+
+    if body.is_active is not None:
+        row.is_active = body.is_active
+
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+@router.delete(
+    "/{scenario_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_scenario(
+    scenario_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Hard delete a scenario row. (Soft-delete is the ``is_active``
+    flag set via PATCH; this endpoint is the hard remove.)
+    """
+    row = await _get_owned_scenario(db, user=current_user, scenario_id=scenario_id)
+    await db.delete(row)
+    await db.commit()
+
+
+@router.post(
+    "/{scenario_id}/simulate",
+    response_model=ScenarioResponse,
+)
+async def simulate_scenario(
+    scenario_id: int,
+    body: SimulateRequest | None = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Run the configured engine and cache the projection on the row.
+
+    Body is optional; an empty body defaults to ``engine="analytic"``
+    with no options and the row's stored horizon.
+
+    The endpoint:
+      1. Loads the scenario (404 on cross-user).
+      2. Validates the request horizon (or the row's stored horizon)
+         against the per-type cap.
+      3. Builds a frozen WorldState snapshot via build_world_state
+         (READ-ONLY).
+      4. Runs the engine (no DB session inside the engine).
+      5. Writes the projection back onto the scenario row and commits.
+
+    Sandboxing: the engine has no path to mutate accounts /
+    transactions / budgets / recurring / forecast_plans. Only
+    Scenario.projection_json is written.
+    """
+    payload = body or SimulateRequest()
+    row = await _get_owned_scenario(db, user=current_user, scenario_id=scenario_id)
+
+    horizon = payload.horizon_months if payload.horizon_months is not None else row.horizon_months
+    _validate_horizon_or_422(row.scenario_type.value, horizon)
+
+    state = await build_world_state(
+        db, org_id=current_user.org_id, user_id=current_user.id
+    )
+
+    engine = get_engine(payload.engine)
+    sim_request = SimulationRequest(
+        scenario=row,
+        state=state,
+        horizon_months=horizon,
+        options=payload.options,
+    )
+
+    result = engine.simulate(sim_request)
+
+    row.projection_json = result
+    row.projection_engine = result.get("engine_name") or engine.name
+    row.projection_computed_at = utcnow_naive()
+    await db.commit()
+    await db.refresh(row)
+    return row

--- a/backend/app/schemas/scenario.py
+++ b/backend/app/schemas/scenario.py
@@ -1,0 +1,311 @@
+"""Pydantic schemas for the Plans simulation sandbox (spec 2026-05-22).
+
+Architect-locked rules baked into this module:
+
+- Discriminated union by ``scenario_type`` on ``params``. Trip +
+  Purchase params are fully specified in PR1; Retirement + Custom
+  ship minimal stubs (full schema lands in PR2).
+- Horizon caps split by ``scenario_type``: 120 months for
+  trip/purchase/custom, 480 months for retirement. The
+  ``validate_horizon`` helper is the single source of truth and
+  is called from both the create / patch path and the simulate
+  request path.
+- Internal name = ``scenarios``. The user-facing label is "Plans";
+  schemas use the internal name throughout.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Annotated, Any, List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.scenario import ScenarioType
+
+
+# Horizon caps per scenario type. Architect-locked 2026-05-22:
+# 120 months (10y) for trip / purchase / custom (interventions
+# the user might fold back into reality within a decade); 480
+# months (40y) for retirement (a working-life projection).
+HORIZON_CAP_BY_TYPE: dict[str, int] = {
+    "trip": 120,
+    "purchase": 120,
+    "custom": 120,
+    "retirement": 480,
+}
+
+# Minimum horizon is 1 month; zero would project nothing.
+HORIZON_MIN_MONTHS = 1
+
+NAME_MIN_LENGTH = 1
+NAME_MAX_LENGTH = 120
+
+
+def validate_horizon(scenario_type: str, horizon_months: int) -> None:
+    """Raise ValueError when ``horizon_months`` exceeds the per-type cap.
+
+    Shared between create / patch / simulate paths so the cap lives
+    in exactly one place. Pre-launch architect lock: the column
+    allows up to 480 at storage; the cap is enforced at the request
+    validator on EVERY mutating path, never at the column.
+    """
+    if horizon_months < HORIZON_MIN_MONTHS:
+        raise ValueError(
+            f"horizon_months must be >= {HORIZON_MIN_MONTHS}"
+        )
+    cap = HORIZON_CAP_BY_TYPE.get(scenario_type)
+    if cap is None:
+        raise ValueError(f"unknown scenario_type: {scenario_type}")
+    if horizon_months > cap:
+        raise ValueError(
+            f"horizon_months exceeds cap for {scenario_type} ({cap})"
+        )
+
+
+# ── Plan-type params ────────────────────────────────────────────────────
+
+
+class _TripExtra(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(min_length=1, max_length=120)
+    amount: Decimal
+    on_date: date
+
+
+class TripParams(BaseModel):
+    """Trip scenario params (spec §Plan templates, ``trip``).
+
+    Engine derivation: lump-sum expense on ``start_date`` for
+    ``transport_cost + accommodation_per_night * duration_days +
+    daily_budget * duration_days + sum(extras)`` against
+    ``source_account_id``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_type: Literal["trip"]
+    destination: str = Field(min_length=1, max_length=200)
+    start_date: date
+    duration_days: int = Field(ge=1, le=365)
+    currency: str = Field(min_length=3, max_length=3)
+    transport_cost: Decimal = Field(ge=0)
+    accommodation_per_night: Decimal = Field(ge=0)
+    daily_budget: Decimal = Field(ge=0)
+    one_off_extras: list[_TripExtra] = Field(default_factory=list)
+    source_account_id: int
+
+
+class _PurchaseFinancing(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    principal: Decimal = Field(ge=0)
+    annual_rate_pct: Decimal = Field(ge=0)
+    term_months: int = Field(ge=1, le=480)
+    first_payment_date: date
+    payment_account_id: int
+
+
+class PurchaseParams(BaseModel):
+    """Purchase scenario params (car / house / big-ticket items).
+
+    Engine derivation: lump-sum expense (``down_payment``) on
+    ``target_date`` against ``down_payment_account_id``. Then, if
+    ``financing`` is set, a monthly amortized expense from
+    ``first_payment_date`` for ``term_months`` months. If
+    ``financing`` is None, the full ``total_price`` is the lump.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_type: Literal["purchase"]
+    subtype: str = Field(min_length=1, max_length=60)
+    label: str = Field(min_length=1, max_length=200)
+    target_date: date
+    currency: str = Field(min_length=3, max_length=3)
+    total_price: Decimal = Field(ge=0)
+    down_payment: Decimal = Field(ge=0)
+    down_payment_account_id: int
+    financing: Optional[_PurchaseFinancing] = None
+
+
+class RetirementParams(BaseModel):
+    """Retirement scenario params — minimal stub for PR1.
+
+    Full retirement UX (contribution curve editor, projected balance
+    visualization) lands in PR2. PR1 accepts the shape so a user can
+    create a retirement plan and stash params; ``simulate`` runs the
+    analytic engine on the existing fields.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_type: Literal["retirement"]
+    target_retirement_date: date
+    currency: str = Field(min_length=3, max_length=3)
+    monthly_contribution: Decimal = Field(ge=0)
+    contribution_account_id: int
+    target_balance: Decimal = Field(ge=0)
+    annual_return_pct: Decimal = Field(ge=0, le=100)
+
+
+class CustomParams(BaseModel):
+    """Custom scenario params — minimal stub for PR1.
+
+    The full ``events`` event-primitives editor is PR2 territory.
+    PR1 ships the shape (label + opaque event list) so users can
+    sketch a custom scenario today; simulate ignores the events
+    (no engine support yet — also PR2).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_type: Literal["custom"]
+    label: str = Field(min_length=1, max_length=200)
+    events: list[dict[str, Any]] = Field(default_factory=list)
+
+
+ScenarioParams = Annotated[
+    Union[TripParams, PurchaseParams, RetirementParams, CustomParams],
+    Field(discriminator="scenario_type"),
+]
+
+
+# ── Top-level Scenario shapes ───────────────────────────────────────────
+
+
+class ScenarioCreate(BaseModel):
+    """Create payload for ``POST /api/v1/scenarios``.
+
+    The discriminated union pins ``params`` to exactly the shape that
+    matches ``scenario_type``. Mismatching the two returns a 422 from
+    Pydantic before the router ever runs.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=NAME_MIN_LENGTH, max_length=NAME_MAX_LENGTH)
+    scenario_type: ScenarioType
+    params: ScenarioParams
+    horizon_months: int = Field(default=24, ge=HORIZON_MIN_MONTHS)
+
+    @model_validator(mode="after")
+    def _check_type_matches_params_and_horizon(self):
+        # Discriminator enforces type<->params shape match, but the
+        # outer scenario_type field is the source of truth on the row.
+        # Pin them so a future schema tweak can't drift them apart.
+        if self.params.scenario_type != self.scenario_type.value:
+            raise ValueError(
+                "scenario_type and params.scenario_type must match"
+            )
+        validate_horizon(self.scenario_type.value, self.horizon_months)
+        return self
+
+
+class ScenarioUpdate(BaseModel):
+    """Partial update payload for ``PATCH /api/v1/scenarios/{id}``.
+
+    Allowed mutations: name, params, horizon_months, is_active. The
+    scenario_type is immutable post-create (changing it would invalidate
+    the params blob's shape).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Optional[str] = Field(
+        default=None, min_length=NAME_MIN_LENGTH, max_length=NAME_MAX_LENGTH
+    )
+    params: Optional[ScenarioParams] = None
+    horizon_months: Optional[int] = Field(
+        default=None, ge=HORIZON_MIN_MONTHS
+    )
+    is_active: Optional[bool] = None
+
+
+class ScenarioResponse(BaseModel):
+    """Read shape returned by every scenarios endpoint."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    org_id: int
+    user_id: int
+    name: str
+    scenario_type: ScenarioType
+    params_json: dict[str, Any]
+    projection_json: Optional[dict[str, Any]] = None
+    projection_engine: Optional[str] = None
+    projection_computed_at: Optional[datetime] = None
+    horizon_months: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class SimulateRequest(BaseModel):
+    """Body for ``POST /api/v1/scenarios/{id}/simulate``.
+
+    The horizon override on the request is OPTIONAL — when None, the
+    engine uses the row's stored ``horizon_months``. When supplied, it
+    is validated against the cap for the row's scenario_type by the
+    router before the engine runs.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    engine: Literal["analytic", "ai_enhanced"] = "analytic"
+    options: dict[str, Any] = Field(default_factory=dict)
+    horizon_months: Optional[int] = Field(default=None, ge=HORIZON_MIN_MONTHS)
+
+
+# ── Projection (engine output) shape ────────────────────────────────────
+#
+# Mirrors the spec's "Output shape" section. Engine returns Decimals
+# converted to strings so JSON transport stays lossless.
+
+
+class ProjectionPoint(BaseModel):
+    month: str
+    projected_balance: str
+
+
+class AccountSeries(BaseModel):
+    account_id: int
+    account_name: str
+    currency: str
+    points: List[ProjectionPoint]
+
+
+class DipAlert(BaseModel):
+    account_id: int
+    month: str
+    projected_balance: str
+    trigger: str
+    severity: Literal["info", "warn", "critical"] = "warn"
+
+
+class AffordabilityVerdict(BaseModel):
+    color: Literal["green", "yellow", "red"]
+    headline: str
+    reason: str
+
+
+class Suggestion(BaseModel):
+    action: str
+    expected_outcome: str
+    # Numeric hint (e.g. days to shift, amount to reduce) is optional
+    # and free-form so suggestions can evolve without schema churn.
+    by_days: Optional[int] = None
+    by_amount: Optional[str] = None
+
+
+class ProjectionResult(BaseModel):
+    engine_name: str
+    computed_at: datetime
+    horizon_months: int
+    currency: str
+    per_account_series: List[AccountSeries]
+    alerts: List[DipAlert]
+    verdict: AffordabilityVerdict
+    suggestions: List[Suggestion]

--- a/backend/app/services/scenario_engine.py
+++ b/backend/app/services/scenario_engine.py
@@ -1,0 +1,664 @@
+"""Plans simulation engine (analytic baseline + AI stub).
+
+Spec: ``specs/2026-05-22-plans-page-simulation-sandbox.md``.
+
+Architect-locked invariants:
+
+- The engine is the ONLY writer of ``Scenario.projection_json``. It
+  has NO ``db.add`` / commit calls that touch ``transactions``,
+  ``accounts``, ``budgets``, ``recurring_transactions``, or
+  ``forecast_plans``. The sandboxing guard test in
+  ``tests/services/test_scenario_engine.py`` pins this with a
+  row-count delta assertion.
+- ``ScenarioEngine`` is the ABC. ``AnalyticEngine`` is the
+  deterministic baseline. ``AIEngine`` is the PR4 stub that raises
+  ``NotImplementedError("PR4")`` on simulate; ``analytic`` is the
+  default everywhere.
+- Output shape is engine-agnostic so the UI doesn't care which engine
+  ran. Mirrors ``schemas/scenario.py::ProjectionResult``.
+- Math reuses ``app/services/date_utils.py::advance_date`` for
+  recurring cadence and reads accounts + recurring through
+  ``build_world_state``; the engine itself never touches the DB.
+"""
+from __future__ import annotations
+
+import datetime
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Optional
+
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app._time import utcnow_naive
+from app.models.account import Account
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.scenario import Scenario, ScenarioType
+from app.services.date_utils import advance_date
+
+
+_TWOPLACES = Decimal("0.01")
+
+
+def _q(value: Decimal) -> str:
+    """Quantize a Decimal to 2 decimal places and return the JSON string."""
+    return str(value.quantize(_TWOPLACES))
+
+
+# ── Engine contract ─────────────────────────────────────────────────────
+
+
+@dataclass
+class AccountSnapshot:
+    """Frozen view of one account at month 0."""
+
+    account_id: int
+    account_name: str
+    currency: str
+    starting_balance: Decimal
+
+
+@dataclass
+class RecurringSnapshot:
+    """Frozen view of one active recurring template."""
+
+    id: int
+    account_id: int
+    amount: Decimal
+    type: str  # "income" | "expense"
+    frequency: Frequency
+    next_due_date: datetime.date
+
+
+@dataclass
+class WorldState:
+    """Snapshot of the user's current finances, frozen at simulation time.
+
+    Built BEFORE the engine runs; the engine never queries the DB itself.
+    This is what makes the sandboxing guarantee structural rather than
+    aspirational: there's no path inside the engine that could mutate
+    real tables, because the engine doesn't have a session.
+    """
+
+    accounts: list[AccountSnapshot]
+    recurring: list[RecurringSnapshot]
+
+
+@dataclass
+class SimulationRequest:
+    scenario: Scenario
+    state: WorldState
+    horizon_months: int
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+# ── Helpers shared by engines ───────────────────────────────────────────
+
+
+def _month_label(d: datetime.date) -> str:
+    """Format a date as "YYYY-MM" for the projection month axis."""
+    return f"{d.year:04d}-{d.month:02d}"
+
+
+def _first_of_next_month(d: datetime.date) -> datetime.date:
+    """Return the first day of the month AFTER ``d``."""
+    return (d.replace(day=1) + relativedelta(months=1))
+
+
+def _start_of_horizon() -> datetime.date:
+    """Month 0 = the calendar month the simulate call is made in.
+
+    Anchored to "today's" first-of-month so every month-by-month
+    projection lines up with calendar months (which is what the UI's
+    Recharts axis expects).
+    """
+    today = utcnow_naive().date()
+    return today.replace(day=1)
+
+
+def _amortized_monthly_payment(
+    principal: Decimal,
+    annual_rate_pct: Decimal,
+    term_months: int,
+) -> Decimal:
+    """Standard fixed-rate mortgage formula: P * r / (1 - (1+r)^-n).
+
+    Returns 0 when principal is 0; returns ``principal / term_months``
+    when the annual rate is 0 (interest-free amortization).
+    """
+    if principal == 0 or term_months == 0:
+        return Decimal("0")
+    if annual_rate_pct == 0:
+        return (principal / Decimal(term_months)).quantize(_TWOPLACES)
+    r = (annual_rate_pct / Decimal("100")) / Decimal("12")
+    factor = (Decimal("1") + r) ** term_months
+    if factor == 0:
+        return Decimal("0")
+    payment = (principal * r * factor) / (factor - Decimal("1"))
+    return payment.quantize(_TWOPLACES)
+
+
+# ── Engine base class ───────────────────────────────────────────────────
+
+
+class ScenarioEngine(ABC):
+    """Engine contract. Sync; no DB session.
+
+    The sandboxing guarantee is structural: this class is the only
+    type the router instantiates, and its concrete subclasses NEVER
+    accept a ``db`` argument. The world state passed in via
+    ``SimulationRequest`` is the engine's entire view of reality.
+    """
+
+    name: str
+
+    @abstractmethod
+    def simulate(self, req: SimulationRequest) -> dict[str, Any]:
+        """Run the simulation. Return a JSON-serializable dict matching
+        ``schemas/scenario.py::ProjectionResult``.
+        """
+        raise NotImplementedError
+
+
+# ── Analytic engine (deterministic baseline) ────────────────────────────
+
+
+class AnalyticEngine(ScenarioEngine):
+    """Deterministic month-by-month projection.
+
+    Algorithm per the spec §"Analytic baseline algorithm":
+
+      For each month m in [1..horizon_months]:
+        1. Seed: each account's current balance.
+        2. Apply real recurring whose next_due_date falls in m,
+           advancing by frequency.
+        3. Apply scenario overlays (trip lump-sum, purchase
+           amortization, retirement contribution+interest, custom
+           events).
+        4. Carry forward.
+        5. Emit a series point per account per month plus alerts
+           on dip-below-zero events.
+    """
+
+    name = "analytic_v1"
+
+    def simulate(self, req: SimulationRequest) -> dict[str, Any]:
+        scenario = req.scenario
+        horizon = req.horizon_months
+        state = req.state
+
+        currency = _resolve_report_currency(state, scenario)
+
+        balances: dict[int, Decimal] = {
+            a.account_id: Decimal(a.starting_balance) for a in state.accounts
+        }
+        recurring_queue: list[tuple[RecurringSnapshot, datetime.date]] = [
+            (r, r.next_due_date) for r in state.recurring
+        ]
+
+        overlays = _build_overlay_events(scenario)
+
+        series_by_account: dict[int, list[dict[str, str]]] = {
+            a.account_id: [] for a in state.accounts
+        }
+        alerts: list[dict[str, Any]] = []
+
+        month_start = _start_of_horizon()
+        for m_index in range(horizon):
+            month_date = month_start + relativedelta(months=m_index)
+            month_end = _first_of_next_month(month_date) - datetime.timedelta(days=1)
+            month_label = _month_label(month_date)
+
+            # (1) Apply recurring whose next_due_date falls in [month_date, month_end].
+            new_queue: list[tuple[RecurringSnapshot, datetime.date]] = []
+            for snap, due in recurring_queue:
+                next_due = due
+                while next_due <= month_end:
+                    if next_due >= month_date and next_due <= month_end:
+                        delta = Decimal(snap.amount)
+                        if snap.type == "expense":
+                            delta = -delta
+                        if snap.account_id in balances:
+                            balances[snap.account_id] = (
+                                balances[snap.account_id] + delta
+                            )
+                    next_due = advance_date(next_due, snap.frequency)
+                new_queue.append((snap, next_due))
+            recurring_queue = new_queue
+
+            # (2) Apply scenario overlay events for this month.
+            for ev in overlays.get((month_date.year, month_date.month), []):
+                account_id = ev["account_id"]
+                if account_id not in balances:
+                    # Account referenced by the scenario doesn't exist.
+                    # Skip silently; the projection just won't reflect it.
+                    continue
+                delta = Decimal(ev["amount"])
+                if ev["kind"] == "expense":
+                    delta = -delta
+                balances[account_id] = balances[account_id] + delta
+
+                if balances[account_id] < 0:
+                    alerts.append(
+                        {
+                            "account_id": account_id,
+                            "month": month_label,
+                            "projected_balance": _q(balances[account_id]),
+                            "trigger": ev.get("trigger", "scenario_event"),
+                            "severity": "warn",
+                        }
+                    )
+
+            # (3) Emit per-account series points for this month.
+            for account_id, balance in balances.items():
+                series_by_account[account_id].append(
+                    {
+                        "month": month_label,
+                        "projected_balance": _q(balance),
+                    }
+                )
+
+        account_index = {a.account_id: a for a in state.accounts}
+        per_account_series = [
+            {
+                "account_id": account_id,
+                "account_name": account_index[account_id].account_name,
+                "currency": account_index[account_id].currency,
+                "points": points,
+            }
+            for account_id, points in series_by_account.items()
+        ]
+
+        verdict = _compute_verdict(state, balances, alerts)
+        suggestions = _compute_suggestions(scenario, verdict)
+
+        return {
+            "engine_name": self.name,
+            "computed_at": utcnow_naive().isoformat(),
+            "horizon_months": horizon,
+            "currency": currency,
+            "per_account_series": per_account_series,
+            "alerts": alerts,
+            "verdict": verdict,
+            "suggestions": suggestions,
+        }
+
+
+# ── AI engine (stub for PR4) ────────────────────────────────────────────
+
+
+class AIEngine(ScenarioEngine):
+    """AI-enhanced engine — STUB for PR1.
+
+    Real implementation lands in PR4 when Team E's AI Tier SDK is
+    available. Until then, calling ``simulate`` raises
+    ``NotImplementedError("PR4")`` so the engine selector in the
+    router stays honest (a misconfigured request gets a hard error,
+    not a silent analytic fallback).
+
+    The signature is identical to ``AnalyticEngine.simulate`` so the
+    router can swap engines without any other change.
+    """
+
+    name = "ai_enhanced"
+
+    def simulate(self, req: SimulationRequest) -> dict[str, Any]:  # pragma: no cover
+        raise NotImplementedError("PR4")
+
+
+# ── World-state assembler (DB → engine boundary) ────────────────────────
+
+
+async def build_world_state(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    user_id: int,
+) -> WorldState:
+    """Read accounts + active recurring for the given org and return a
+    frozen ``WorldState`` for the engine.
+
+    Pre-launch architect lock: per-user. Plans are private to the
+    creator. World state for engine simulation uses the org's accounts
+    (every member of an org shares the books) but the per-user
+    visibility lives at the router scope, not here.
+
+    No writes; READ ONLY.
+    """
+    account_rows = (
+        await db.execute(
+            select(Account).where(
+                Account.org_id == org_id,
+                Account.is_active.is_(True),
+            )
+        )
+    ).scalars().all()
+    accounts = [
+        AccountSnapshot(
+            account_id=a.id,
+            account_name=a.name,
+            currency=a.currency,
+            starting_balance=Decimal(str(a.balance)),
+        )
+        for a in account_rows
+    ]
+
+    recurring_rows = (
+        await db.execute(
+            select(RecurringTransaction).where(
+                RecurringTransaction.org_id == org_id,
+                RecurringTransaction.is_active.is_(True),
+            )
+        )
+    ).scalars().all()
+    recurring = [
+        RecurringSnapshot(
+            id=r.id,
+            account_id=r.account_id,
+            amount=Decimal(str(r.amount)),
+            type=str(r.type),
+            frequency=r.frequency,
+            next_due_date=r.next_due_date,
+        )
+        for r in recurring_rows
+    ]
+
+    return WorldState(accounts=accounts, recurring=recurring)
+
+
+# ── Internal helpers ────────────────────────────────────────────────────
+
+
+def _resolve_report_currency(state: WorldState, scenario: Scenario) -> str:
+    """Pick the currency to label the projection with.
+
+    Prefers the scenario's source-account currency where the source
+    account exists in the world state; falls back to the first
+    account; finally falls back to the scenario's own ``currency``
+    field (trip / purchase / retirement) or "EUR".
+    """
+    params = scenario.params_json or {}
+    source_account_id = (
+        params.get("source_account_id")
+        or params.get("down_payment_account_id")
+        or params.get("contribution_account_id")
+    )
+    if source_account_id is not None:
+        for acc in state.accounts:
+            if acc.account_id == source_account_id:
+                return acc.currency
+    if state.accounts:
+        return state.accounts[0].currency
+    return str(params.get("currency") or "EUR")
+
+
+def _build_overlay_events(
+    scenario: Scenario,
+) -> dict[tuple[int, int], list[dict[str, Any]]]:
+    """Compile the scenario's params blob into a per-month event map.
+
+    Returned dict shape:
+        { (year, month): [ {kind, amount, account_id, trigger} ] }
+
+    Kinds: "expense" subtracts from the account, "income" adds.
+    Trigger is a human-readable string used in alerts.
+    """
+    params = scenario.params_json or {}
+    out: dict[tuple[int, int], list[dict[str, Any]]] = {}
+
+    def add(year: int, month: int, ev: dict[str, Any]) -> None:
+        out.setdefault((year, month), []).append(ev)
+
+    stype = scenario.scenario_type.value if hasattr(scenario.scenario_type, "value") else str(scenario.scenario_type)
+
+    if stype == ScenarioType.TRIP.value:
+        start_str = params.get("start_date")
+        if not start_str:
+            return out
+        start = _parse_date(start_str)
+        if start is None:
+            return out
+        duration = int(params.get("duration_days", 0) or 0)
+        transport = Decimal(str(params.get("transport_cost", "0") or "0"))
+        accom_per_night = Decimal(str(params.get("accommodation_per_night", "0") or "0"))
+        daily_budget = Decimal(str(params.get("daily_budget", "0") or "0"))
+        extras = params.get("one_off_extras") or []
+        extras_total = sum(
+            (Decimal(str(e.get("amount", "0") or "0")) for e in extras),
+            Decimal("0"),
+        )
+        lump = (
+            transport
+            + accom_per_night * Decimal(duration)
+            + daily_budget * Decimal(duration)
+            + extras_total
+        )
+        source_id = params.get("source_account_id")
+        if source_id is not None and lump > 0:
+            add(start.year, start.month, {
+                "kind": "expense",
+                "amount": lump,
+                "account_id": int(source_id),
+                "trigger": "trip_lump_sum",
+            })
+
+    elif stype == ScenarioType.PURCHASE.value:
+        target_str = params.get("target_date")
+        if not target_str:
+            return out
+        target = _parse_date(target_str)
+        if target is None:
+            return out
+        down_payment = Decimal(str(params.get("down_payment", "0") or "0"))
+        total_price = Decimal(str(params.get("total_price", "0") or "0"))
+        dp_account = params.get("down_payment_account_id")
+        financing = params.get("financing")
+        if financing is None:
+            if dp_account is not None and total_price > 0:
+                add(target.year, target.month, {
+                    "kind": "expense",
+                    "amount": total_price,
+                    "account_id": int(dp_account),
+                    "trigger": "purchase_cash",
+                })
+        else:
+            if dp_account is not None and down_payment > 0:
+                add(target.year, target.month, {
+                    "kind": "expense",
+                    "amount": down_payment,
+                    "account_id": int(dp_account),
+                    "trigger": "purchase_down_payment",
+                })
+            principal = Decimal(str(financing.get("principal", "0") or "0"))
+            rate = Decimal(str(financing.get("annual_rate_pct", "0") or "0"))
+            term = int(financing.get("term_months", 0) or 0)
+            first_str = financing.get("first_payment_date")
+            payment_account = financing.get("payment_account_id")
+            first = _parse_date(first_str) if first_str else None
+            if (
+                first is not None
+                and payment_account is not None
+                and principal > 0
+                and term > 0
+            ):
+                monthly = _amortized_monthly_payment(principal, rate, term)
+                for i in range(term):
+                    when = first + relativedelta(months=i)
+                    add(when.year, when.month, {
+                        "kind": "expense",
+                        "amount": monthly,
+                        "account_id": int(payment_account),
+                        "trigger": "purchase_amortized",
+                    })
+
+    elif stype == ScenarioType.RETIREMENT.value:
+        # PR1 minimal: post the monthly contribution into the
+        # contribution account starting "this month" through the
+        # horizon. Full retirement engine (compound interest +
+        # contribution curve) lands in PR2.
+        contribution = Decimal(str(params.get("monthly_contribution", "0") or "0"))
+        contrib_account = params.get("contribution_account_id")
+        target_str = params.get("target_retirement_date")
+        target = _parse_date(target_str) if target_str else None
+        if contrib_account is not None and contribution > 0:
+            start = _start_of_horizon()
+            stop = target if target else (start + relativedelta(years=40))
+            cursor = start
+            while cursor <= stop:
+                add(cursor.year, cursor.month, {
+                    "kind": "income",
+                    "amount": contribution,
+                    "account_id": int(contrib_account),
+                    "trigger": "retirement_contribution",
+                })
+                cursor = cursor + relativedelta(months=1)
+
+    elif stype == ScenarioType.CUSTOM.value:
+        # PR1 minimal: custom events not replayed yet. Full event
+        # replay (income_off, expense_off, recurring_on, etc.) is PR2.
+        pass
+
+    return out
+
+
+def _parse_date(value: Any) -> Optional[datetime.date]:
+    """Parse an ISO date string (or pass through a date) defensively."""
+    if value is None:
+        return None
+    if isinstance(value, datetime.date):
+        return value
+    try:
+        return datetime.date.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def _compute_verdict(
+    state: WorldState,
+    final_balances: dict[int, Decimal],
+    alerts: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Architect-locked verdict thresholds:
+
+    - Green: no account dipped below zero.
+    - Yellow: any account dipped below zero but recoverably.
+    - Red: an account dipped below zero by 10%+ of its starting balance.
+    """
+    if not alerts:
+        return {
+            "color": "green",
+            "headline": "All accounts stay above zero across the horizon.",
+            "reason": "No projected dips below zero.",
+        }
+
+    starting_by_id = {a.account_id: a.starting_balance for a in state.accounts}
+    severe = False
+    for alert in alerts:
+        starting = starting_by_id.get(alert["account_id"], Decimal("0"))
+        if starting <= 0:
+            severe = True
+            break
+        dip = Decimal(alert["projected_balance"])
+        if dip < -(starting / Decimal("10")):
+            severe = True
+            break
+
+    if severe:
+        return {
+            "color": "red",
+            "headline": "Projection dips significantly below zero.",
+            "reason": (
+                "At least one account drops more than 10% of its "
+                "starting balance below zero in this scenario."
+            ),
+        }
+
+    return {
+        "color": "yellow",
+        "headline": "Plan is feasible but cuts close.",
+        "reason": (
+            "At least one account briefly dips below zero before "
+            "recovering. Consider shifting dates or reducing amounts."
+        ),
+    }
+
+
+def _compute_suggestions(
+    scenario: Scenario,
+    verdict: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Tiny suggestion set for PR1.
+
+    Full suggestion engine (model-judged or rule-driven by overlay
+    type) lands in PR2 + PR4. PR1 ships two canned hints for any
+    yellow / red trip or purchase scenario so the UI has something
+    to render under the chart.
+    """
+    if verdict["color"] == "green":
+        return []
+    stype = (
+        scenario.scenario_type.value
+        if hasattr(scenario.scenario_type, "value")
+        else str(scenario.scenario_type)
+    )
+    if stype == ScenarioType.TRIP.value:
+        return [
+            {
+                "action": "shift_start_date",
+                "by_days": 30,
+                "expected_outcome": (
+                    "Move the trip a month later so the lump-sum lands "
+                    "after one more pay cycle."
+                ),
+            },
+            {
+                "action": "reduce_daily_budget",
+                "by_amount": "10.00",
+                "expected_outcome": (
+                    "Trim the daily budget to bring the trip total under "
+                    "the dip threshold."
+                ),
+            },
+        ]
+    if stype == ScenarioType.PURCHASE.value:
+        return [
+            {
+                "action": "increase_down_payment",
+                "by_amount": "1000.00",
+                "expected_outcome": (
+                    "A larger down payment shrinks the financed principal "
+                    "and the monthly payment."
+                ),
+            },
+            {
+                "action": "extend_term_months",
+                "by_amount": "12",
+                "expected_outcome": (
+                    "Longer term lowers the monthly payment at the cost of "
+                    "more total interest."
+                ),
+            },
+        ]
+    return []
+
+
+# ── Engine selector ─────────────────────────────────────────────────────
+
+
+_ENGINE_REGISTRY: dict[str, type[ScenarioEngine]] = {
+    "analytic": AnalyticEngine,
+    "ai_enhanced": AIEngine,
+}
+
+
+def get_engine(engine_name: str) -> ScenarioEngine:
+    """Return a ScenarioEngine instance for the given engine name.
+
+    Raises ``KeyError`` for unknown engine names — the request schema's
+    Literal["analytic", "ai_enhanced"] gate makes that unreachable in
+    practice but the registry remains the source of truth.
+    """
+    cls = _ENGINE_REGISTRY[engine_name]
+    return cls()

--- a/backend/tests/routers/test_scenarios.py
+++ b/backend/tests/routers/test_scenarios.py
@@ -1,0 +1,534 @@
+"""Router tests for the Plans simulation sandbox (spec 2026-05-22).
+
+Architect-locked invariants pinned here:
+
+- CRUD round-trip with Pydantic discriminator validating params per
+  scenario_type (trip + purchase fully wired; retirement + custom
+  ship minimal stubs).
+- Horizon-cap validator:
+    * trip / purchase / custom with horizon_months > 120 → 422
+    * retirement with horizon_months > 480 → 422
+    * retirement with horizon_months = 480 → 201 (allowed)
+    * trip with horizon_months = 121 → 422 (one over the cap)
+- ``POST /simulate`` writes ``projection_json`` and
+  ``projection_computed_at`` and returns a populated projection.
+- Cross-user isolation: user B cannot read / patch / delete /
+  simulate user A's scenarios (404 on every path).
+- Empty body to ``POST /simulate`` defaults to engine=analytic.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.scenario import Scenario, ScenarioType
+from app.models.user import Organization, Role, User
+from app.routers.scenarios import router as scenarios_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(scenarios_router)
+    return app
+
+
+async def _seed_users_and_account(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        u_a = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        u_b = User(
+            org_id=org.id,
+            username="bob",
+            email="bob@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.MEMBER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add_all([u_a, u_b])
+        await db.commit()
+        at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+        db.add(at)
+        await db.commit()
+        acc = Account(
+            org_id=org.id,
+            account_type_id=at.id,
+            name="Main checking",
+            balance=Decimal("5000.00"),
+            currency="EUR",
+            is_active=True,
+            is_default=True,
+            opening_balance=Decimal("5000.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        db.add(acc)
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "alice_id": u_a.id,
+            "bob_id": u_b.id,
+            "account_id": acc.id,
+        }
+
+
+def _resolver_for(email: str):
+    async def resolve(session_factory):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User).where(User.email == email))
+            ).scalar_one()
+    return resolve
+
+
+def _trip_payload(account_id: int, *, name: str = "Lisbon trip", horizon: int = 24) -> dict:
+    return {
+        "name": name,
+        "scenario_type": "trip",
+        "horizon_months": horizon,
+        "params": {
+            "scenario_type": "trip",
+            "destination": "Lisbon, Portugal",
+            "start_date": "2026-09-15",
+            "duration_days": 10,
+            "currency": "EUR",
+            "transport_cost": "450.00",
+            "accommodation_per_night": "85.00",
+            "daily_budget": "70.00",
+            "one_off_extras": [
+                {
+                    "label": "Castelo tickets",
+                    "amount": "15.00",
+                    "on_date": "2026-09-17",
+                },
+            ],
+            "source_account_id": account_id,
+        },
+    }
+
+
+def _purchase_payload(account_id: int, *, name: str = "Used car", horizon: int = 36) -> dict:
+    return {
+        "name": name,
+        "scenario_type": "purchase",
+        "horizon_months": horizon,
+        "params": {
+            "scenario_type": "purchase",
+            "subtype": "car",
+            "label": "Replacement car",
+            "target_date": "2027-03-01",
+            "currency": "EUR",
+            "total_price": "22000.00",
+            "down_payment": "8000.00",
+            "down_payment_account_id": account_id,
+            "financing": {
+                "principal": "14000.00",
+                "annual_rate_pct": "6.5",
+                "term_months": 60,
+                "first_payment_date": "2027-04-01",
+                "payment_account_id": account_id,
+            },
+        },
+    }
+
+
+def _retirement_payload(account_id: int, *, name: str = "At 62", horizon: int = 240) -> dict:
+    return {
+        "name": name,
+        "scenario_type": "retirement",
+        "horizon_months": horizon,
+        "params": {
+            "scenario_type": "retirement",
+            "target_retirement_date": "2048-06-01",
+            "currency": "EUR",
+            "monthly_contribution": "600.00",
+            "contribution_account_id": account_id,
+            "target_balance": "750000.00",
+            "annual_return_pct": "5.0",
+        },
+    }
+
+
+def _custom_payload(*, name: str = "Sabbatical 2028", horizon: int = 36) -> dict:
+    return {
+        "name": name,
+        "scenario_type": "custom",
+        "horizon_months": horizon,
+        "params": {
+            "scenario_type": "custom",
+            "label": "Sabbatical year, no salary 2028",
+            "events": [],
+        },
+    }
+
+
+# ── CRUD happy path per scenario_type ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_trip_round_trip(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_trip_payload(seeds["account_id"]),
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["name"] == "Lisbon trip"
+    assert body["scenario_type"] == "trip"
+    assert body["horizon_months"] == 24
+    assert body["is_active"] is True
+    assert body["user_id"] == seeds["alice_id"]
+    assert body["org_id"] == seeds["org_id"]
+    assert body["params_json"]["destination"] == "Lisbon, Portugal"
+
+
+@pytest.mark.asyncio
+async def test_create_purchase_round_trip(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_purchase_payload(seeds["account_id"]),
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["scenario_type"] == "purchase"
+    assert body["params_json"]["financing"]["term_months"] == 60
+
+
+@pytest.mark.asyncio
+async def test_create_retirement_minimal(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_retirement_payload(seeds["account_id"]),
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["scenario_type"] == "retirement"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_minimal(session_factory):
+    await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload(),
+        )
+    assert res.status_code == 201, res.text
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_type_params_mismatch(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    payload = _trip_payload(seeds["account_id"])
+    payload["scenario_type"] = "purchase"
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/scenarios", json=payload)
+    # Pydantic v2 surfaces this as a 422 either via discriminator or
+    # via the outer model_validator; both are acceptable signals.
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_list_default_hides_archived(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        client.post("/api/v1/scenarios", json=_trip_payload(seeds["account_id"], name="Visible"))
+        created = client.post(
+            "/api/v1/scenarios",
+            json=_trip_payload(seeds["account_id"], name="Archived"),
+        ).json()
+        client.patch(
+            f"/api/v1/scenarios/{created['id']}",
+            json={"is_active": False},
+        )
+        default_list = client.get("/api/v1/scenarios").json()
+        archived_list = client.get(
+            "/api/v1/scenarios", params={"include_archived": "true"}
+        ).json()
+    default_names = {r["name"] for r in default_list}
+    archived_names = {r["name"] for r in archived_list}
+    assert "Visible" in default_names
+    assert "Archived" not in default_names
+    assert "Archived" in archived_names
+
+
+@pytest.mark.asyncio
+async def test_patch_updates_name_and_horizon(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        res = client.patch(
+            f"/api/v1/scenarios/{created['id']}",
+            json={"name": "Lisbon ALT", "horizon_months": 36},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["name"] == "Lisbon ALT"
+    assert body["horizon_months"] == 36
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_cross_type_params(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        # Trip row receiving a purchase params blob: must be rejected.
+        res = client.patch(
+            f"/api/v1/scenarios/{created['id']}",
+            json={"params": _purchase_payload(seeds["account_id"])["params"]},
+        )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_row(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        res = client.delete(f"/api/v1/scenarios/{created['id']}")
+        assert res.status_code == 204
+        fetch = client.get(f"/api/v1/scenarios/{created['id']}")
+    assert fetch.status_code == 404
+
+
+# ── Horizon-cap validator ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_trip_horizon_121_rejected(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    payload = _trip_payload(seeds["account_id"], horizon=121)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/scenarios", json=payload)
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_purchase_horizon_121_rejected(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    payload = _purchase_payload(seeds["account_id"], horizon=121)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/scenarios", json=payload)
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_retirement_horizon_480_allowed(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    payload = _retirement_payload(seeds["account_id"], horizon=480)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/scenarios", json=payload)
+    assert res.status_code == 201, res.text
+
+
+@pytest.mark.asyncio
+async def test_retirement_horizon_481_rejected(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    payload = _retirement_payload(seeds["account_id"], horizon=481)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/scenarios", json=payload)
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_custom_horizon_121_rejected(session_factory):
+    await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    payload = _custom_payload(horizon=121)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/scenarios", json=payload)
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_patch_horizon_over_cap_rejected(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        res = client.patch(
+            f"/api/v1/scenarios/{created['id']}",
+            json={"horizon_months": 121},
+        )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_simulate_horizon_over_cap_rejected(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        res = client.post(
+            f"/api/v1/scenarios/{created['id']}/simulate",
+            json={"engine": "analytic", "horizon_months": 121, "options": {}},
+        )
+    assert res.status_code == 422, res.text
+
+
+# ── Simulate happy path ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_simulate_writes_projection(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        res = client.post(
+            f"/api/v1/scenarios/{created['id']}/simulate",
+            json={"engine": "analytic", "options": {}},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["projection_json"] is not None
+    assert body["projection_engine"] == "analytic_v1"
+    assert body["projection_computed_at"] is not None
+    projection = body["projection_json"]
+    assert projection["engine_name"] == "analytic_v1"
+    assert projection["horizon_months"] == 24
+    assert len(projection["per_account_series"]) == 1
+    series = projection["per_account_series"][0]
+    assert series["account_id"] == seeds["account_id"]
+    assert len(series["points"]) == 24
+    assert projection["verdict"]["color"] in {"green", "yellow", "red"}
+
+
+@pytest.mark.asyncio
+async def test_simulate_empty_body_defaults_to_analytic(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        # No body at all — should still default to analytic.
+        res = client.post(f"/api/v1/scenarios/{created['id']}/simulate")
+    assert res.status_code == 200, res.text
+    assert res.json()["projection_engine"] == "analytic_v1"
+
+
+# ── Cross-user isolation (per-user scoping) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_user_b_cannot_read_user_a_scenario(session_factory):
+    seeds = await _seed_users_and_account(session_factory)
+    app_a = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    app_b = _make_app(session_factory, _resolver_for("bob@acme.io"))
+    with TestClient(app_a) as ca:
+        created = ca.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+    with TestClient(app_b) as cb:
+        # Get one: 404.
+        assert cb.get(f"/api/v1/scenarios/{created['id']}").status_code == 404
+        # List for Bob: empty (Alice owns the only row).
+        assert cb.get("/api/v1/scenarios").json() == []
+        # Patch / delete / simulate also 404 for Bob.
+        assert cb.patch(
+            f"/api/v1/scenarios/{created['id']}",
+            json={"name": "stolen"},
+        ).status_code == 404
+        assert cb.delete(f"/api/v1/scenarios/{created['id']}").status_code == 404
+        assert cb.post(
+            f"/api/v1/scenarios/{created['id']}/simulate"
+        ).status_code == 404

--- a/backend/tests/services/test_scenario_engine.py
+++ b/backend/tests/services/test_scenario_engine.py
@@ -1,0 +1,475 @@
+"""Service tests for the Plans simulation engine (spec 2026-05-22).
+
+Architect-locked invariants pinned here:
+
+- Trip lump-sum lands on ``start_date`` against
+  ``source_account_id`` and shows up in the projected series.
+- Purchase amortization: down-payment lands on ``target_date``,
+  monthly amortized payment matches ``_amortized_monthly_payment``
+  output starting on ``first_payment_date`` for ``term_months``.
+- Verdict thresholds (green / yellow / red) trigger on synthetic
+  input.
+- **SANDBOXING GUARD** — running ``simulate`` produces zero deltas
+  in ``transactions``, ``accounts``, ``budgets``, ``forecast_plans``,
+  and ``recurring_transactions``. Only ``scenarios`` gains the row
+  the test created up-front. This is THE PR1 architect lock.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, func, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.budget import Budget
+from app.models.category import Category, CategoryType
+from app.models.forecast_plan import ForecastPlan
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.scenario import Scenario, ScenarioType
+from app.models.transaction import Transaction
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services.scenario_engine import (
+    AccountSnapshot,
+    AnalyticEngine,
+    AIEngine,
+    RecurringSnapshot,
+    SimulationRequest,
+    WorldState,
+    _amortized_monthly_payment,
+    build_world_state,
+    get_engine,
+)
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_user_with_realistic_data(factory) -> dict:
+    """Seed a realistic user fixture: 1 org, 1 user, 2 accounts, 2
+    recurring templates, 3 transactions, 1 budget, 1 forecast_plan,
+    1 scenario. The sandboxing guard test snapshots row counts
+    BEFORE running simulate and asserts +0 deltas on every table
+    other than ``scenarios`` afterwards.
+    """
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email="alice@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+        db.add(at)
+        await db.commit()
+        acc1 = Account(
+            org_id=org.id,
+            account_type_id=at.id,
+            name="Main checking",
+            balance=Decimal("4500.00"),
+            currency="EUR",
+            is_active=True,
+            is_default=True,
+            opening_balance=Decimal("4500.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        acc2 = Account(
+            org_id=org.id,
+            account_type_id=at.id,
+            name="Savings",
+            balance=Decimal("12000.00"),
+            currency="EUR",
+            is_active=True,
+            is_default=False,
+            opening_balance=Decimal("12000.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        db.add_all([acc1, acc2])
+        await db.commit()
+        cat_in = Category(
+            org_id=org.id,
+            name="Salary",
+            type=CategoryType.INCOME,
+        )
+        cat_ex = Category(
+            org_id=org.id,
+            name="Groceries",
+            type=CategoryType.EXPENSE,
+        )
+        db.add_all([cat_in, cat_ex])
+        await db.commit()
+        rec1 = RecurringTransaction(
+            org_id=org.id,
+            account_id=acc1.id,
+            category_id=cat_in.id,
+            description="Salary",
+            amount=Decimal("3000.00"),
+            type="income",
+            frequency=Frequency.MONTHLY,
+            next_due_date=date.today().replace(day=1) + timedelta(days=14),
+            auto_settle=False,
+            is_active=True,
+        )
+        rec2 = RecurringTransaction(
+            org_id=org.id,
+            account_id=acc1.id,
+            category_id=cat_ex.id,
+            description="Groceries",
+            amount=Decimal("400.00"),
+            type="expense",
+            frequency=Frequency.MONTHLY,
+            next_due_date=date.today().replace(day=1) + timedelta(days=5),
+            auto_settle=False,
+            is_active=True,
+        )
+        db.add_all([rec1, rec2])
+        await db.commit()
+        budget = Budget(
+            org_id=org.id,
+            category_id=cat_ex.id,
+            amount=Decimal("500.00"),
+            period_start=date.today().replace(day=1),
+            period_end=None,
+        )
+        db.add(budget)
+        await db.commit()
+        # Scenario row the simulate call will run against.
+        scen = Scenario(
+            org_id=org.id,
+            user_id=user.id,
+            name="Lisbon trip",
+            scenario_type=ScenarioType.TRIP,
+            params_json={
+                "scenario_type": "trip",
+                "destination": "Lisbon, Portugal",
+                "start_date": (date.today().replace(day=1) + timedelta(days=60)).isoformat(),
+                "duration_days": 10,
+                "currency": "EUR",
+                "transport_cost": "450.00",
+                "accommodation_per_night": "85.00",
+                "daily_budget": "70.00",
+                "one_off_extras": [],
+                "source_account_id": acc1.id,
+            },
+            horizon_months=12,
+            is_active=True,
+        )
+        db.add(scen)
+        await db.commit()
+        return {
+            "org_id": org.id,
+            "user_id": user.id,
+            "acc1_id": acc1.id,
+            "acc2_id": acc2.id,
+            "rec1_id": rec1.id,
+            "rec2_id": rec2.id,
+            "scenario_id": scen.id,
+        }
+
+
+async def _row_counts(factory) -> dict[str, int]:
+    """Snapshot row counts across every table the sandboxing guard
+    asserts +0 deltas on.
+    """
+    async with factory() as db:
+        return {
+            "transactions": (await db.execute(select(func.count()).select_from(Transaction))).scalar_one(),
+            "accounts": (await db.execute(select(func.count()).select_from(Account))).scalar_one(),
+            "budgets": (await db.execute(select(func.count()).select_from(Budget))).scalar_one(),
+            "forecast_plans": (await db.execute(select(func.count()).select_from(ForecastPlan))).scalar_one(),
+            "recurring_transactions": (await db.execute(select(func.count()).select_from(RecurringTransaction))).scalar_one(),
+            "scenarios": (await db.execute(select(func.count()).select_from(Scenario))).scalar_one(),
+        }
+
+
+# ── Sandboxing guard (the architect-lock test) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_simulate_does_not_mutate_any_real_table(session_factory):
+    """ARCHITECT LOCK PR1: running the analytic engine against a
+    realistic fixture must produce ZERO row-count delta on every
+    real table. Only ``scenarios`` may change (and only because the
+    test seeded the row itself; the row count stays the same across
+    the simulate call).
+    """
+    seeds = await _seed_user_with_realistic_data(session_factory)
+    before = await _row_counts(session_factory)
+
+    async with session_factory() as db:
+        state = await build_world_state(
+            db, org_id=seeds["org_id"], user_id=seeds["user_id"]
+        )
+        scen = (
+            await db.execute(
+                select(Scenario).where(Scenario.id == seeds["scenario_id"])
+            )
+        ).scalar_one()
+        # Detach so engine can run on the snapshot without holding
+        # a live session reference.
+        engine = AnalyticEngine()
+        request = SimulationRequest(
+            scenario=scen,
+            state=state,
+            horizon_months=scen.horizon_months,
+            options={},
+        )
+        result = engine.simulate(request)
+        # NOTE: the engine does NOT call db.commit on its own. The
+        # router writes the projection back outside the engine, so
+        # this test exercises the engine path in isolation — the
+        # row-count check below must therefore see ZERO deltas on
+        # EVERY table including ``scenarios``.
+
+    after = await _row_counts(session_factory)
+
+    # The lock: every table count is identical pre/post.
+    assert after["transactions"] == before["transactions"]
+    assert after["accounts"] == before["accounts"]
+    assert after["budgets"] == before["budgets"]
+    assert after["forecast_plans"] == before["forecast_plans"]
+    assert after["recurring_transactions"] == before["recurring_transactions"]
+    assert after["scenarios"] == before["scenarios"]
+
+    # And the projection itself was actually computed (sanity).
+    assert result["engine_name"] == "analytic_v1"
+    assert len(result["per_account_series"]) == 2
+
+
+# ── Trip lump-sum lands on start_date ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_trip_lump_sum_lands_on_start_date(session_factory):
+    """The trip engine derivation must post a lump-sum expense on
+    ``start_date`` for ``transport_cost + accommodation_per_night
+    * duration_days + daily_budget * duration_days + extras`` against
+    ``source_account_id``.
+    """
+    # Construct a trip scenario starting ~2 months from now.
+    start = (date.today().replace(day=1) + timedelta(days=60))
+    scenario = Scenario(
+        org_id=1,
+        user_id=1,
+        name="t",
+        scenario_type=ScenarioType.TRIP,
+        params_json={
+            "scenario_type": "trip",
+            "destination": "Lisbon",
+            "start_date": start.isoformat(),
+            "duration_days": 10,
+            "currency": "EUR",
+            "transport_cost": "450.00",
+            "accommodation_per_night": "85.00",
+            "daily_budget": "70.00",
+            "one_off_extras": [],
+            "source_account_id": 42,
+        },
+        horizon_months=6,
+    )
+    state = WorldState(
+        accounts=[
+            AccountSnapshot(
+                account_id=42,
+                account_name="Main",
+                currency="EUR",
+                starting_balance=Decimal("5000.00"),
+            ),
+        ],
+        recurring=[],
+    )
+    engine = AnalyticEngine()
+    result = engine.simulate(
+        SimulationRequest(
+            scenario=scenario,
+            state=state,
+            horizon_months=6,
+            options={},
+        )
+    )
+    # Expected lump:  450 + 85*10 + 70*10 + 0  = 450 + 850 + 700 = 2000
+    expected_balance_after_dip = Decimal("5000.00") - Decimal("2000.00")
+    # The point for the trip month must reflect the dip.
+    label = f"{start.year:04d}-{start.month:02d}"
+    series = result["per_account_series"][0]["points"]
+    trip_point = next((p for p in series if p["month"] == label), None)
+    assert trip_point is not None, series
+    assert Decimal(trip_point["projected_balance"]) == expected_balance_after_dip
+
+
+# ── Purchase financing amortization ─────────────────────────────────────
+
+
+def test_amortized_payment_matches_hand_computed():
+    """For P=14000, r=6.5% annual / 12, n=60 months:
+        monthly = 14000 * (0.065/12) / (1 - (1 + 0.065/12)^-60)
+              ≈ 273.91 EUR.
+
+    The engine helper should be within a cent of that.
+    """
+    p = _amortized_monthly_payment(
+        Decimal("14000"), Decimal("6.5"), 60
+    )
+    # Hand computed via standard formula.
+    assert Decimal("273.85") <= p <= Decimal("274.05"), p
+
+
+def test_amortized_payment_zero_interest_is_principal_over_n():
+    p = _amortized_monthly_payment(Decimal("1200"), Decimal("0"), 12)
+    assert p == Decimal("100.00"), p
+
+
+# ── Verdict thresholds ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verdict_green_when_no_dip(session_factory):
+    """No dip below zero → verdict color = green."""
+    scenario = Scenario(
+        org_id=1, user_id=1, name="t",
+        scenario_type=ScenarioType.TRIP,
+        params_json={
+            "scenario_type": "trip",
+            "destination": "x",
+            "start_date": (date.today() + timedelta(days=60)).isoformat(),
+            "duration_days": 2,
+            "currency": "EUR",
+            "transport_cost": "10.00",
+            "accommodation_per_night": "10.00",
+            "daily_budget": "10.00",
+            "one_off_extras": [],
+            "source_account_id": 1,
+        },
+        horizon_months=6,
+    )
+    state = WorldState(
+        accounts=[
+            AccountSnapshot(
+                account_id=1, account_name="A",
+                currency="EUR", starting_balance=Decimal("10000.00")
+            )
+        ],
+        recurring=[],
+    )
+    result = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario, state=state, horizon_months=6, options={}
+        )
+    )
+    assert result["verdict"]["color"] == "green"
+    assert result["alerts"] == []
+
+
+@pytest.mark.asyncio
+async def test_verdict_red_when_severe_dip(session_factory):
+    """Dip > 10% of starting balance → verdict color = red."""
+    scenario = Scenario(
+        org_id=1, user_id=1, name="t",
+        scenario_type=ScenarioType.TRIP,
+        params_json={
+            "scenario_type": "trip",
+            "destination": "x",
+            "start_date": (date.today() + timedelta(days=60)).isoformat(),
+            "duration_days": 30,
+            "currency": "EUR",
+            "transport_cost": "5000.00",
+            "accommodation_per_night": "200.00",
+            "daily_budget": "200.00",
+            "one_off_extras": [],
+            "source_account_id": 1,
+        },
+        horizon_months=12,
+    )
+    state = WorldState(
+        accounts=[
+            AccountSnapshot(
+                account_id=1, account_name="A",
+                currency="EUR", starting_balance=Decimal("1000.00")
+            )
+        ],
+        recurring=[],
+    )
+    result = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario, state=state, horizon_months=12, options={}
+        )
+    )
+    assert result["verdict"]["color"] == "red"
+    assert len(result["alerts"]) >= 1
+
+
+# ── AI engine stub ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ai_engine_raises_not_implemented():
+    """PR4 stub: invoking the AIEngine MUST raise NotImplementedError
+    with the message "PR4" so a misconfigured request surfaces a
+    deliberate error, not a silent analytic fallback.
+    """
+    state = WorldState(accounts=[], recurring=[])
+    scenario = Scenario(
+        org_id=1, user_id=1, name="t",
+        scenario_type=ScenarioType.TRIP,
+        params_json={},
+        horizon_months=6,
+    )
+    with pytest.raises(NotImplementedError) as exc_info:
+        AIEngine().simulate(
+            SimulationRequest(
+                scenario=scenario, state=state, horizon_months=6, options={}
+            )
+        )
+    assert "PR4" in str(exc_info.value)
+
+
+def test_get_engine_returns_analytic_by_default():
+    assert isinstance(get_engine("analytic"), AnalyticEngine)
+    assert isinstance(get_engine("ai_enhanced"), AIEngine)
+
+
+def test_get_engine_unknown_raises_keyerror():
+    with pytest.raises(KeyError):
+        get_engine("bogus")

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -1,0 +1,901 @@
+"use client";
+
+/**
+ * Plans page — life-event simulation sandbox (spec 2026-05-22).
+ *
+ * Architect-locked invariants:
+ * - UI says "Plans" everywhere. The word "scenario" never appears
+ *   in user-visible copy (internal code uses ``scenarios``).
+ * - Per-user visibility: this page only shows the current user's
+ *   plans. The backend enforces it; the UI never asks for an org
+ *   list. Sharing is out of scope for v1.
+ * - Re-simulate on params change is debounced ~400ms so a fast
+ *   typist doesn't pummel the backend.
+ * - Trip and Purchase templates are fully wired in PR1.
+ *   Retirement + Custom render a "Available in a later release"
+ *   surface (params stub + simulate still works, but the editor
+ *   is minimal).
+ * - The user-visible "Apply this plan as real transactions" button
+ *   is OUT OF SCOPE for v1 per the architect lock.
+ */
+
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  label as labelCls,
+  pageTitle,
+} from "@/lib/styles";
+
+// Internal type name uses the DB / API word; the UI label is "Plans".
+export type ScenarioType = "trip" | "purchase" | "retirement" | "custom";
+
+export interface Account {
+  id: number;
+  name: string;
+  currency: string;
+  balance: string;
+}
+
+export interface ProjectionPoint {
+  month: string;
+  projected_balance: string;
+}
+
+export interface AccountSeries {
+  account_id: number;
+  account_name: string;
+  currency: string;
+  points: ProjectionPoint[];
+}
+
+export interface DipAlert {
+  account_id: number;
+  month: string;
+  projected_balance: string;
+  trigger: string;
+  severity: "info" | "warn" | "critical";
+}
+
+export interface AffordabilityVerdict {
+  color: "green" | "yellow" | "red";
+  headline: string;
+  reason: string;
+}
+
+export interface Suggestion {
+  action: string;
+  expected_outcome: string;
+  by_days?: number | null;
+  by_amount?: string | null;
+}
+
+export interface ProjectionResult {
+  engine_name: string;
+  computed_at: string;
+  horizon_months: number;
+  currency: string;
+  per_account_series: AccountSeries[];
+  alerts: DipAlert[];
+  verdict: AffordabilityVerdict;
+  suggestions: Suggestion[];
+}
+
+export interface Scenario {
+  id: number;
+  org_id: number;
+  user_id: number;
+  name: string;
+  scenario_type: ScenarioType;
+  params_json: Record<string, unknown>;
+  projection_json: ProjectionResult | null;
+  projection_engine: string | null;
+  projection_computed_at: string | null;
+  horizon_months: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+const TYPE_LABEL: Record<ScenarioType, string> = {
+  trip: "Trip",
+  purchase: "Purchase",
+  retirement: "Retirement",
+  custom: "Custom",
+};
+
+const VERDICT_BADGE: Record<AffordabilityVerdict["color"], string> = {
+  green: "bg-success-dim text-success",
+  yellow: "bg-accent/15 text-accent",
+  red: "bg-danger-dim text-danger",
+};
+
+export default function PlansPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [items, setItems] = useState<Scenario[]>([]);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [active, setActive] = useState<Scenario | null>(null);
+  const [loadErr, setLoadErr] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createType, setCreateType] = useState<ScenarioType>("trip");
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+    }
+  }, [loading, user, router]);
+
+  const loadAll = useCallback(async () => {
+    try {
+      const [rows, accs] = await Promise.all([
+        apiFetch<Scenario[]>("/api/v1/scenarios"),
+        apiFetch<Account[]>("/api/v1/accounts"),
+      ]);
+      setItems(rows);
+      setAccounts(accs);
+    } catch (e) {
+      setLoadErr(extractErrorMessage(e, "Failed to load plans"));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user) void loadAll();
+  }, [user, loadAll]);
+
+  async function deletePlan(id: number) {
+    try {
+      await apiFetch(`/api/v1/scenarios/${id}`, { method: "DELETE" });
+      setItems((rows) => rows.filter((r) => r.id !== id));
+      if (active && active.id === id) setActive(null);
+    } catch (e) {
+      setLoadErr(extractErrorMessage(e, "Delete failed"));
+    }
+  }
+
+  async function simulate(plan: Scenario): Promise<Scenario | null> {
+    try {
+      const next = await apiFetch<Scenario>(
+        `/api/v1/scenarios/${plan.id}/simulate`,
+        { method: "POST", body: JSON.stringify({ engine: "analytic", options: {} }) },
+      );
+      setItems((rows) => rows.map((r) => (r.id === next.id ? next : r)));
+      if (active && active.id === next.id) setActive(next);
+      return next;
+    } catch (e) {
+      setLoadErr(extractErrorMessage(e, "Simulate failed"));
+      return null;
+    }
+  }
+
+  if (loading || !user) {
+    return null;
+  }
+
+  return (
+    <AppShell>
+      <header className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className={`${pageTitle} mb-0`}>Plans</h1>
+          <p className="mt-1 text-sm text-text-muted">
+            Plan one-off life events. Nothing here touches your real transactions.
+          </p>
+        </div>
+        <button
+          type="button"
+          className={`${btnPrimary} sm:min-h-0`}
+          onClick={() => setCreateOpen(true)}
+          data-testid="plans-new"
+        >
+          + New plan
+        </button>
+      </header>
+
+      {loadErr && <p className={`mb-3 ${errorCls}`}>{loadErr}</p>}
+
+      {active ? (
+        <PlanEditor
+          plan={active}
+          accounts={accounts}
+          onBack={() => setActive(null)}
+          onSimulate={simulate}
+          onUpdated={(updated) => {
+            setItems((rows) => rows.map((r) => (r.id === updated.id ? updated : r)));
+            setActive(updated);
+          }}
+        />
+      ) : (
+        <PlansList
+          items={items}
+          onOpen={setActive}
+          onDelete={deletePlan}
+          onSimulate={simulate}
+        />
+      )}
+
+      {createOpen && (
+        <NewPlanModal
+          type={createType}
+          accounts={accounts}
+          onTypeChange={setCreateType}
+          onClose={() => setCreateOpen(false)}
+          onCreated={(plan) => {
+            setItems((rows) => [plan, ...rows]);
+            setActive(plan);
+            setCreateOpen(false);
+          }}
+        />
+      )}
+    </AppShell>
+  );
+}
+
+
+// ── List view ───────────────────────────────────────────────────────────
+
+
+function PlansList({
+  items,
+  onOpen,
+  onDelete,
+  onSimulate,
+}: {
+  items: Scenario[];
+  onOpen: (plan: Scenario) => void;
+  onDelete: (id: number) => void;
+  onSimulate: (plan: Scenario) => Promise<Scenario | null>;
+}) {
+  if (items.length === 0) {
+    return (
+      <section className={`${card} p-6`} data-testid="plans-empty">
+        <p className="text-sm text-text-muted">
+          No plans yet. Use the New plan button to sketch a trip, purchase, or
+          life event and see how it plays out month by month.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={`${card} p-0`} data-testid="plans-list">
+      <ul className="divide-y divide-border">
+        {items.map((plan) => (
+          <li
+            key={plan.id}
+            className="flex items-center justify-between gap-4 px-5 py-3"
+          >
+            <button
+              type="button"
+              className="flex-1 text-left"
+              onClick={() => onOpen(plan)}
+              data-testid={`plan-row-${plan.id}`}
+            >
+              <p className="text-sm font-medium text-text-primary">{plan.name}</p>
+              <p className="text-xs text-text-muted">
+                {TYPE_LABEL[plan.scenario_type]} · Horizon {plan.horizon_months}mo
+              </p>
+            </button>
+            {plan.projection_json && (
+              <span
+                className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                  VERDICT_BADGE[plan.projection_json.verdict.color]
+                }`}
+              >
+                {plan.projection_json.verdict.color.toUpperCase()}
+              </span>
+            )}
+            <button
+              type="button"
+              className={`${btnSecondary} sm:min-h-0`}
+              onClick={() => void onSimulate(plan)}
+              data-testid={`plan-simulate-${plan.id}`}
+            >
+              Simulate
+            </button>
+            <button
+              type="button"
+              className="text-xs text-danger underline-offset-2 hover:underline"
+              onClick={() => onDelete(plan.id)}
+              data-testid={`plan-delete-${plan.id}`}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+
+// ── Editor (params left + projection right) ─────────────────────────────
+
+
+function PlanEditor({
+  plan,
+  accounts,
+  onBack,
+  onSimulate,
+  onUpdated,
+}: {
+  plan: Scenario;
+  accounts: Account[];
+  onBack: () => void;
+  onSimulate: (plan: Scenario) => Promise<Scenario | null>;
+  onUpdated: (plan: Scenario) => void;
+}) {
+  const [params, setParams] = useState<Record<string, unknown>>(plan.params_json);
+  const [name, setName] = useState(plan.name);
+  const [horizon, setHorizon] = useState<number>(plan.horizon_months);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset state when switching plans.
+  useEffect(() => {
+    setParams(plan.params_json);
+    setName(plan.name);
+    setHorizon(plan.horizon_months);
+  }, [plan.id, plan.params_json, plan.name, plan.horizon_months]);
+
+  // Debounced re-simulate when the editor's local params drift from the
+  // server-side plan. Architect-locked 400ms.
+  useEffect(() => {
+    if (
+      JSON.stringify(params) === JSON.stringify(plan.params_json)
+      && name === plan.name
+      && horizon === plan.horizon_months
+    ) {
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void persist();
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // We deliberately do NOT include persist in deps — useCallback
+    // makes it stable but ESLint can't see that here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params, name, horizon, plan]);
+
+  async function persist() {
+    setBusy(true);
+    setErr("");
+    try {
+      const updated = await apiFetch<Scenario>(
+        `/api/v1/scenarios/${plan.id}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            name,
+            horizon_months: horizon,
+            params: {
+              scenario_type: plan.scenario_type,
+              ...params,
+            },
+          }),
+        },
+      );
+      onUpdated(updated);
+      // Re-simulate immediately after a successful PATCH so the chart
+      // reflects the new params.
+      await onSimulate(updated);
+    } catch (e) {
+      setErr(extractErrorMessage(e, "Update failed"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function manualSimulate() {
+    setBusy(true);
+    setErr("");
+    try {
+      await onSimulate(plan);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const projection = plan.projection_json;
+
+  return (
+    <section data-testid="plan-editor">
+      <button
+        type="button"
+        className="mb-3 text-xs text-text-muted underline-offset-2 hover:underline"
+        onClick={onBack}
+      >
+        ← Back to plans
+      </button>
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+        <div className={`${card} p-5`}>
+          <header className={`mb-3 ${cardHeader}`}>
+            <h2 className={cardTitle}>Params</h2>
+          </header>
+          {err && <p className={`mb-2 ${errorCls}`}>{err}</p>}
+          <div className="space-y-3">
+            <div>
+              <label className={labelCls} htmlFor="plan-name">Name</label>
+              <input
+                id="plan-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className={input}
+                data-testid="plan-name-input"
+              />
+            </div>
+            <div>
+              <label className={labelCls} htmlFor="plan-horizon">Horizon (months)</label>
+              <input
+                id="plan-horizon"
+                type="number"
+                min={1}
+                max={plan.scenario_type === "retirement" ? 480 : 120}
+                value={horizon}
+                onChange={(e) => setHorizon(Number(e.target.value || 0))}
+                className={input}
+              />
+            </div>
+            {plan.scenario_type === "trip" && (
+              <TripParamsEditor params={params} setParams={setParams} accounts={accounts} />
+            )}
+            {plan.scenario_type === "purchase" && (
+              <PurchaseParamsEditor params={params} setParams={setParams} accounts={accounts} />
+            )}
+            {(plan.scenario_type === "retirement" || plan.scenario_type === "custom") && (
+              <p className="text-xs text-text-muted">
+                The {TYPE_LABEL[plan.scenario_type].toLowerCase()} template editor is
+                available in a later release.
+              </p>
+            )}
+            <button
+              type="button"
+              className={`${btnPrimary} sm:min-h-0`}
+              onClick={manualSimulate}
+              disabled={busy}
+              data-testid="plan-simulate-now"
+            >
+              Re-simulate
+            </button>
+          </div>
+        </div>
+        <div className={`${card} p-5`}>
+          <header className={`mb-3 ${cardHeader}`}>
+            <h2 className={cardTitle}>Projection</h2>
+          </header>
+          {projection ? (
+            <ProjectionView projection={projection} />
+          ) : (
+            <p className="text-sm text-text-muted">
+              No projection yet. Click Re-simulate to compute one.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+
+function ProjectionView({ projection }: { projection: ProjectionResult }) {
+  return (
+    <div data-testid="projection-view">
+      <div className={`mb-3 flex items-center gap-2`}>
+        <span
+          className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${VERDICT_BADGE[projection.verdict.color]}`}
+          data-testid="verdict-badge"
+        >
+          {projection.verdict.color.toUpperCase()}
+        </span>
+        <span className="text-sm text-text-primary">{projection.verdict.headline}</span>
+      </div>
+      <p className="mb-4 text-xs text-text-muted">{projection.verdict.reason}</p>
+      <ul className="mb-4 space-y-1">
+        {projection.per_account_series.map((s) => {
+          const last = s.points[s.points.length - 1];
+          return (
+            <li key={s.account_id} className="text-sm text-text-primary">
+              <span className="font-medium">{s.account_name}</span>{" "}
+              <span className="text-text-muted">
+                ends at {last?.projected_balance ?? "?"} {s.currency}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      {projection.alerts.length > 0 && (
+        <div className="mb-4">
+          <p className={`mb-1 text-xs uppercase tracking-wide text-text-muted`}>Alerts</p>
+          <ul className="space-y-1">
+            {projection.alerts.map((a, idx) => (
+              <li key={`${a.account_id}-${a.month}-${idx}`} className={`text-xs ${errorCls}`}>
+                {a.month}: dip to {a.projected_balance} ({a.trigger})
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {projection.suggestions.length > 0 && (
+        <div>
+          <p className={`mb-1 text-xs uppercase tracking-wide text-text-muted`}>Suggestions</p>
+          <ul className="space-y-1">
+            {projection.suggestions.map((s, idx) => (
+              <li key={idx} className="text-xs text-text-primary">
+                {s.expected_outcome}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+function TripParamsEditor({
+  params,
+  setParams,
+  accounts,
+}: {
+  params: Record<string, unknown>;
+  setParams: (next: Record<string, unknown>) => void;
+  accounts: Account[];
+}) {
+  function set(key: string, value: unknown) {
+    setParams({ ...params, [key]: value });
+  }
+  return (
+    <>
+      <div>
+        <label className={labelCls} htmlFor="trip-destination">Destination</label>
+        <input
+          id="trip-destination"
+          value={(params.destination as string) ?? ""}
+          onChange={(e) => set("destination", e.target.value)}
+          className={input}
+          data-testid="trip-destination-input"
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="trip-start">Start date</label>
+        <input
+          id="trip-start"
+          type="date"
+          value={(params.start_date as string) ?? ""}
+          onChange={(e) => set("start_date", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="trip-duration">Duration (days)</label>
+        <input
+          id="trip-duration"
+          type="number"
+          min={1}
+          max={365}
+          value={(params.duration_days as number) ?? 1}
+          onChange={(e) => set("duration_days", Number(e.target.value || 0))}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="trip-transport">Transport cost</label>
+        <input
+          id="trip-transport"
+          type="number"
+          step="0.01"
+          min="0"
+          value={(params.transport_cost as string) ?? "0"}
+          onChange={(e) => set("transport_cost", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="trip-accom">Accommodation per night</label>
+        <input
+          id="trip-accom"
+          type="number"
+          step="0.01"
+          min="0"
+          value={(params.accommodation_per_night as string) ?? "0"}
+          onChange={(e) => set("accommodation_per_night", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="trip-daily">Daily budget</label>
+        <input
+          id="trip-daily"
+          type="number"
+          step="0.01"
+          min="0"
+          value={(params.daily_budget as string) ?? "0"}
+          onChange={(e) => set("daily_budget", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="trip-account">Source account</label>
+        <select
+          id="trip-account"
+          value={(params.source_account_id as number) ?? ""}
+          onChange={(e) => set("source_account_id", Number(e.target.value))}
+          className={input}
+        >
+          {accounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name} ({a.currency})
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}
+
+
+function PurchaseParamsEditor({
+  params,
+  setParams,
+  accounts,
+}: {
+  params: Record<string, unknown>;
+  setParams: (next: Record<string, unknown>) => void;
+  accounts: Account[];
+}) {
+  function set(key: string, value: unknown) {
+    setParams({ ...params, [key]: value });
+  }
+  return (
+    <>
+      <div>
+        <label className={labelCls} htmlFor="p-subtype">Subtype</label>
+        <input
+          id="p-subtype"
+          value={(params.subtype as string) ?? "car"}
+          onChange={(e) => set("subtype", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="p-label">Label</label>
+        <input
+          id="p-label"
+          value={(params.label as string) ?? ""}
+          onChange={(e) => set("label", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="p-target">Target date</label>
+        <input
+          id="p-target"
+          type="date"
+          value={(params.target_date as string) ?? ""}
+          onChange={(e) => set("target_date", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="p-price">Total price</label>
+        <input
+          id="p-price"
+          type="number"
+          step="0.01"
+          min="0"
+          value={(params.total_price as string) ?? "0"}
+          onChange={(e) => set("total_price", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="p-down">Down payment</label>
+        <input
+          id="p-down"
+          type="number"
+          step="0.01"
+          min="0"
+          value={(params.down_payment as string) ?? "0"}
+          onChange={(e) => set("down_payment", e.target.value)}
+          className={input}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor="p-account">Down-payment account</label>
+        <select
+          id="p-account"
+          value={(params.down_payment_account_id as number) ?? ""}
+          onChange={(e) => set("down_payment_account_id", Number(e.target.value))}
+          className={input}
+        >
+          {accounts.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name} ({a.currency})
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}
+
+
+// ── New plan modal ──────────────────────────────────────────────────────
+
+
+function NewPlanModal({
+  type,
+  accounts,
+  onTypeChange,
+  onClose,
+  onCreated,
+}: {
+  type: ScenarioType;
+  accounts: Account[];
+  onTypeChange: (t: ScenarioType) => void;
+  onClose: () => void;
+  onCreated: (plan: Scenario) => void;
+}) {
+  const [name, setName] = useState("New plan");
+  const [destination, setDestination] = useState("Lisbon, Portugal");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  async function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setBusy(true);
+    setErr("");
+    try {
+      const firstAccount = accounts[0]?.id;
+      if (!firstAccount) {
+        throw new Error(
+          "Create at least one account before creating a plan."
+        );
+      }
+      const baseParams: Record<string, unknown> = {
+        scenario_type: type,
+      };
+      if (type === "trip") {
+        Object.assign(baseParams, {
+          destination,
+          start_date: new Date().toISOString().slice(0, 10),
+          duration_days: 7,
+          currency: accounts[0]?.currency ?? "EUR",
+          transport_cost: "0",
+          accommodation_per_night: "0",
+          daily_budget: "0",
+          one_off_extras: [],
+          source_account_id: firstAccount,
+        });
+      } else if (type === "purchase") {
+        Object.assign(baseParams, {
+          subtype: "car",
+          label: name,
+          target_date: new Date().toISOString().slice(0, 10),
+          currency: accounts[0]?.currency ?? "EUR",
+          total_price: "0",
+          down_payment: "0",
+          down_payment_account_id: firstAccount,
+          financing: null,
+        });
+      } else if (type === "retirement") {
+        Object.assign(baseParams, {
+          target_retirement_date: new Date().toISOString().slice(0, 10),
+          currency: accounts[0]?.currency ?? "EUR",
+          monthly_contribution: "0",
+          contribution_account_id: firstAccount,
+          target_balance: "0",
+          annual_return_pct: "5.0",
+        });
+      } else {
+        Object.assign(baseParams, {
+          label: name,
+          events: [],
+        });
+      }
+      const plan = await apiFetch<Scenario>("/api/v1/scenarios", {
+        method: "POST",
+        body: JSON.stringify({
+          name,
+          scenario_type: type,
+          horizon_months: type === "retirement" ? 240 : 24,
+          params: baseParams,
+        }),
+      });
+      onCreated(plan);
+    } catch (e) {
+      setErr(extractErrorMessage(e, "Create failed"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="New plan"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/70 p-4"
+      data-testid="new-plan-modal"
+    >
+      <form
+        onSubmit={submit}
+        className={`${card} w-full max-w-md p-5`}
+      >
+        <header className={`mb-3 ${cardHeader}`}>
+          <h2 className={cardTitle}>New plan</h2>
+        </header>
+        {err && <p className={`mb-2 ${errorCls}`}>{err}</p>}
+        <div className="mb-3">
+          <label className={labelCls} htmlFor="np-template">Template</label>
+          <select
+            id="np-template"
+            value={type}
+            onChange={(e) => onTypeChange(e.target.value as ScenarioType)}
+            className={input}
+            data-testid="new-plan-template"
+          >
+            <option value="trip">Trip</option>
+            <option value="purchase">Purchase</option>
+            <option value="retirement">Retirement</option>
+            <option value="custom">Custom</option>
+          </select>
+        </div>
+        <div className="mb-3">
+          <label className={labelCls} htmlFor="np-name">Name</label>
+          <input
+            id="np-name"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className={input}
+            data-testid="new-plan-name"
+          />
+        </div>
+        {type === "trip" && (
+          <div className="mb-3">
+            <label className={labelCls} htmlFor="np-dest">Destination</label>
+            <input
+              id="np-dest"
+              required
+              value={destination}
+              onChange={(e) => setDestination(e.target.value)}
+              className={input}
+              data-testid="new-plan-destination"
+            />
+          </div>
+        )}
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            className={`${btnSecondary} sm:min-h-0`}
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className={`${btnPrimary} sm:min-h-0`}
+            disabled={busy}
+            data-testid="new-plan-submit"
+          >
+            Create
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -349,29 +349,7 @@ function PlanEditor({
     setHorizon(plan.horizon_months);
   }, [plan.id, plan.params_json, plan.name, plan.horizon_months]);
 
-  // Debounced re-simulate when the editor's local params drift from the
-  // server-side plan. Architect-locked 400ms.
-  useEffect(() => {
-    if (
-      JSON.stringify(params) === JSON.stringify(plan.params_json)
-      && name === plan.name
-      && horizon === plan.horizon_months
-    ) {
-      return;
-    }
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      void persist();
-    }, 400);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-    // We deliberately do NOT include persist in deps — useCallback
-    // makes it stable but ESLint can't see that here.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params, name, horizon, plan]);
-
-  async function persist() {
+  const persist = useCallback(async () => {
     setBusy(true);
     setErr("");
     try {
@@ -398,7 +376,26 @@ function PlanEditor({
     } finally {
       setBusy(false);
     }
-  }
+  }, [plan.id, plan.scenario_type, name, horizon, params, onUpdated, onSimulate]);
+
+  // Debounced re-simulate when the editor's local params drift from the
+  // server-side plan. Architect-locked 400ms.
+  useEffect(() => {
+    if (
+      JSON.stringify(params) === JSON.stringify(plan.params_json)
+      && name === plan.name
+      && horizon === plan.horizon_months
+    ) {
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void persist();
+    }, 400);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [params, name, horizon, plan, persist]);
 
   async function manualSimulate() {
     setBusy(true);

--- a/frontend/app/system/page.tsx
+++ b/frontend/app/system/page.tsx
@@ -22,7 +22,7 @@ type SystemSection = {
 const SECTIONS: readonly SystemSection[] = [
   {
     href: "/system/plans",
-    title: "Plans",
+    title: "Plan Catalog",
     description:
       "Manage subscription plans (free, premium, custom) and per-plan feature flags. Duplicate a plan to build a custom variant for sales-negotiated deals.",
     permission: "plans.manage",

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeftRight,
   BarChart3,
   Building2,
+  CalendarClock,
   ChevronUp,
   CreditCard,
   FileText,
@@ -84,6 +85,11 @@ const navItems = [
     href: "/forecast-plans",
     label: "Forecast Plans",
     icon: <BarChart3 {...NAV_ICON_PROPS} />,
+  },
+  {
+    href: "/plans",
+    label: "Plans",
+    icon: <CalendarClock {...NAV_ICON_PROPS} />,
   },
   {
     href: "/categories",

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -149,7 +149,7 @@ const systemItems: readonly SystemNavItem[] = [
   },
   {
     href: "/system/plans",
-    label: "Plans",
+    label: "Plan Catalog",
     permission: "plans.manage",
     icon: <CreditCard {...NAV_ICON_PROPS} />,
   },

--- a/frontend/tests/app/plans-page.test.tsx
+++ b/frontend/tests/app/plans-page.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * Tests for the Plans page (spec 2026-05-22).
+ *
+ * Architect-locked checks:
+ * - Empty state copy renders when there are zero plans yet.
+ * - List view renders one row per plan returned by the API.
+ * - "New plan" with template = Trip opens the modal with the
+ *   destination field; submit POSTs to /api/v1/scenarios with the
+ *   right body shape.
+ * - "Re-simulate" button calls POST /api/v1/scenarios/{id}/simulate.
+ * - Verdict badge color matches the API verdict.
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import PlansPage from "@/app/plans/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/plans",
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@acme.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner" as const,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const TRIP_PLAN = {
+  id: 7,
+  org_id: 1,
+  user_id: 1,
+  name: "Lisbon trip",
+  scenario_type: "trip" as const,
+  params_json: {
+    scenario_type: "trip",
+    destination: "Lisbon, Portugal",
+    start_date: "2026-09-15",
+    duration_days: 10,
+    currency: "EUR",
+    transport_cost: "450.00",
+    accommodation_per_night: "85.00",
+    daily_budget: "70.00",
+    one_off_extras: [],
+    source_account_id: 12,
+  },
+  projection_json: {
+    engine_name: "analytic_v1",
+    computed_at: "2026-05-22T09:15:00",
+    horizon_months: 24,
+    currency: "EUR",
+    per_account_series: [
+      {
+        account_id: 12,
+        account_name: "Main checking",
+        currency: "EUR",
+        points: [{ month: "2026-06", projected_balance: "4200.00" }],
+      },
+    ],
+    alerts: [],
+    verdict: {
+      color: "yellow" as const,
+      headline: "Plan is feasible but cuts close",
+      reason: "x",
+    },
+    suggestions: [],
+  },
+  projection_engine: "analytic_v1",
+  projection_computed_at: "2026-05-22T09:15:00",
+  horizon_months: 24,
+  is_active: true,
+  created_at: "2026-05-22T00:00:00",
+  updated_at: "2026-05-22T00:00:00",
+};
+
+const SAMPLE_ACCOUNT = {
+  id: 12,
+  name: "Main checking",
+  currency: "EUR",
+  balance: "5000.00",
+};
+
+describe("/plans page", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  function setUser() {
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+  }
+
+  it("redirects an unauthenticated visitor to /login", async () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+    render(<PlansPage />);
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("renders the empty state when the user has no plans", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve([]);
+      if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByTestId("plans-empty");
+    expect(screen.getByTestId("plans-empty")).toHaveTextContent(/No plans yet/i);
+  });
+
+  it("renders a row per plan and shows the verdict badge", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve([TRIP_PLAN]);
+      if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    expect(screen.getByText(/Trip.*Horizon 24mo/i)).toBeInTheDocument();
+    expect(screen.getByText("YELLOW")).toBeInTheDocument();
+  });
+
+  it("opens the New plan modal with the destination field for Trip template", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve([]);
+      if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByTestId("plans-empty");
+    fireEvent.click(screen.getByTestId("plans-new"));
+    await screen.findByTestId("new-plan-modal");
+    expect(screen.getByTestId("new-plan-destination")).toBeInTheDocument();
+    // The template selector defaults to trip.
+    const select = screen.getByTestId("new-plan-template") as HTMLSelectElement;
+    expect(select.value).toBe("trip");
+  });
+
+  it("POSTs to /api/v1/scenarios when the Create button is clicked", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (url === "/api/v1/scenarios" && options?.method === "POST") {
+        return Promise.resolve({ ...TRIP_PLAN, id: 9, name: "Sample trip" });
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByTestId("plans-empty");
+    fireEvent.click(screen.getByTestId("plans-new"));
+    await screen.findByTestId("new-plan-modal");
+    fireEvent.change(screen.getByTestId("new-plan-name"), {
+      target: { value: "Sample trip" },
+    });
+    fireEvent.click(screen.getByTestId("new-plan-submit"));
+    await waitFor(() => {
+      const postCall = apiFetchMock.mock.calls.find(
+        ([url, opts]) =>
+          url === "/api/v1/scenarios" && (opts as RequestInit | undefined)?.method === "POST",
+      );
+      expect(postCall).toBeDefined();
+      const body = JSON.parse((postCall![1] as RequestInit).body as string);
+      expect(body.name).toBe("Sample trip");
+      expect(body.scenario_type).toBe("trip");
+      expect(body.horizon_months).toBe(24);
+      expect(body.params.scenario_type).toBe("trip");
+      expect(body.params.source_account_id).toBe(SAMPLE_ACCOUNT.id);
+    });
+  });
+
+  it("Simulate button on a row POSTs to /api/v1/scenarios/{id}/simulate", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`
+        && options?.method === "POST"
+      ) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-simulate-${TRIP_PLAN.id}`));
+    await waitFor(() => {
+      const simulateCall = apiFetchMock.mock.calls.find(
+        ([url, opts]) =>
+          url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`
+          && (opts as RequestInit | undefined)?.method === "POST",
+      );
+      expect(simulateCall).toBeDefined();
+      const body = JSON.parse((simulateCall![1] as RequestInit).body as string);
+      expect(body.engine).toBe("analytic");
+    });
+  });
+});

--- a/frontend/tests/app/system-hub-page.test.tsx
+++ b/frontend/tests/app/system-hub-page.test.tsx
@@ -62,8 +62,12 @@ describe("SystemHubPage (L5.8)", () => {
     const allLinks = screen.getAllByRole("link");
     const plansLink = allLinks.find((a) => a.getAttribute("href") === "/system/plans");
     expect(plansLink).toBeDefined();
-    // Card-level heading ("Plans") is reachable inside the link element.
-    expect(plansLink!.textContent).toMatch(/plans/i);
+    // Card-level heading ("Plan Catalog") is reachable inside the link
+    // element. Match the substring case-insensitively so the assertion
+    // still passes if the hub card title changes shape (e.g. "Plan
+    // Catalog" vs "Subscription Plan Catalog") as long as it keeps the
+    // word "plan".
+    expect(plansLink!.textContent).toMatch(/plan/i);
     expect(replaceMock).not.toHaveBeenCalled();
   });
 

--- a/frontend/tests/components/app-shell.test.tsx
+++ b/frontend/tests/components/app-shell.test.tsx
@@ -145,7 +145,10 @@ describe("AppShell — system nav gating", () => {
     // admin.view alone does NOT grant the more specific destinations.
     expect(screen.queryByText("Organizations")).toBeNull();
     expect(screen.queryByText("Audit log")).toBeNull();
-    expect(screen.queryByText("Plans")).toBeNull();
+    // System Plan Catalog link gated on plans.manage. Customer "Plans"
+    // link in the main nav is always visible — disambiguate by exact
+    // accessible name on the system-side label.
+    expect(screen.queryByRole("link", { name: "Plan Catalog" })).toBeNull();
   });
 
   it("shows only the Audit log link for a non-superadmin with audit.view alone", async () => {
@@ -165,7 +168,7 @@ describe("AppShell — system nav gating", () => {
     expect(screen.getByText("Audit log")).toBeInTheDocument();
     expect(screen.queryByText("Admin")).toBeNull();
     expect(screen.queryByText("Organizations")).toBeNull();
-    expect(screen.queryByText("Plans")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Plan Catalog" })).toBeNull();
   });
 
   it("shows only the Organizations link for a non-superadmin with orgs.view alone", async () => {
@@ -185,10 +188,10 @@ describe("AppShell — system nav gating", () => {
     expect(screen.getByText("Organizations")).toBeInTheDocument();
     expect(screen.queryByText("Admin")).toBeNull();
     expect(screen.queryByText("Audit log")).toBeNull();
-    expect(screen.queryByText("Plans")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Plan Catalog" })).toBeNull();
   });
 
-  it("shows only the Plans link for a non-superadmin with plans.manage alone", async () => {
+  it("shows only the Plan Catalog link for a non-superadmin with plans.manage alone", async () => {
     useAuthMock.mockReturnValue({
       user: { ...BASE_USER, permissions: ["plans.manage"] } as never,
       loading: false,
@@ -202,7 +205,13 @@ describe("AppShell — system nav gating", () => {
     await renderShell();
 
     expect(screen.getByText(/^System$/)).toBeInTheDocument();
-    expect(screen.getByText("Plans")).toBeInTheDocument();
+    // System-side subscription-tier catalog renders as "Plan Catalog"
+    // to disambiguate from the customer-facing "/plans" scenarios link
+    // in the main nav (both would otherwise share the accessible name
+    // "Plans" and break ambiguous-selector queries).
+    expect(
+      screen.getByRole("link", { name: "Plan Catalog" }),
+    ).toBeInTheDocument();
     expect(screen.queryByText("Admin")).toBeNull();
     expect(screen.queryByText("Organizations")).toBeNull();
     expect(screen.queryByText("Audit log")).toBeNull();


### PR DESCRIPTION
## Summary

PR1 of the Plans train. Substrate for the Plans page (life-event simulation sandbox).

Spec: [`specs/2026-05-22-plans-page-simulation-sandbox.md`](specs/2026-05-22-plans-page-simulation-sandbox.md)

- New ``scenarios`` table, model, Pydantic discriminated-union schemas (trip + purchase fully specified; retirement + custom shipped with minimal stubs).
- ``backend/app/services/scenario_engine.py`` — analytic baseline engine (sync, no DB session, frozen ``WorldState`` snapshot). ``AIEngine`` is a PR4 stub that raises ``NotImplementedError("PR4")``.
- CRUD + simulate router at ``/api/v1/scenarios``. Per-user visibility, 404 (not 403) on cross-user access. Horizon caps enforced via ``schemas/scenario.py::validate_horizon`` (120 months for trip / purchase / custom, 480 for retirement).
- Sandboxing guard test (architect lock) asserts +0 deltas on ``transactions`` / ``accounts`` / ``budgets`` / ``forecast_plans`` / ``recurring_transactions`` after simulate.
- ``/plans`` page with list, editor (params on the left, projection on the right), debounced re-simulate (400ms). New top-level nav item "Plans".

Architect-locked naming: internal code says "scenarios"; UI says "Plans" everywhere, the word "scenario" never appears user-side.

Out of scope (PR2+): retirement / custom rich editors, comparison view (max 3 side-by-side), AI engine wiring, SSE streaming, "apply this plan as real transactions" button.