### PR TITLE
ci(test): drop 10-minute job timeout on backend + frontend checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
   backend:
     name: Backend Checks
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,8 +45,6 @@ jobs:
   frontend:
     name: Frontend Checks
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Removes `timeout-minutes: 10` from both backend and frontend test jobs in `.github/workflows/test.yml`.
- The suite is brushing the 10-minute ceiling after the recent PR1 wave landed (notifications, reports, scenarios, ai-tier). Backend got canceled mid-suite on #344's first CI run with **all visible tests green** — the cancel was the runner enforcing the timeout, not a real failure.
- Falls back to GitHub Actions' default 6-hour job timeout so the suite always reaches the end.

## Files

- `.github/workflows/test.yml` — 4 lines removed (2 × `timeout-minutes: 10` + 2 blank lines).