### PR TITLE
feat(audit): close 5 sensitive-op audit gaps (PR2 of notification train)

### DIFF
--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -141,6 +141,33 @@ async def update_org_subscription(
         outcome="success",
         detail={"before": before, "after": after},
     )
+
+    # Plan-change-specific audit row (audit-gap closure PR2 of the
+    # notification train). The generic `admin.org.subscription.override`
+    # event above covers any field change on the subscription — plan,
+    # status, trial_end, current_period_end — but PR3 of the
+    # notification train needs a clean trigger source that fires
+    # ONLY when the plan_id actually changes (status flips don't notify
+    # org members about a plan change). Emitting both rows lets the
+    # generic compliance log keep its coverage AND the future
+    # notification dispatcher key off the specific event_type without
+    # parsing detail.before/detail.after.
+    if "plan_id" in before:
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="admin.org.plan.changed",
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=org_id,
+            target_org_name=detail["name"],
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail={
+                "old_plan_id": before["plan_id"],
+                "new_plan_id": after["plan_id"],
+            },
+        )
     return {"before": before, "after": after}
 
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -2052,8 +2052,10 @@ async def mfa_setup(
 @router.post("/mfa/enable", response_model=MfaEnableResponse)
 async def mfa_enable(
     body: MfaEnableRequest,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     """Confirm MFA setup with a TOTP code, activate MFA, return recovery codes."""
     if current_user.mfa_enabled:
@@ -2073,14 +2075,31 @@ async def mfa_enable(
     current_user.recovery_codes = ",".join(hash_recovery_code(c) for c in codes)
     await db.commit()
 
+    # Audit AFTER the business commit succeeds. PR3 of the notification
+    # train uses this row as the trigger source for user.mfa.enabled.
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="user.mfa.enabled",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=current_user.org_id,
+        target_org_name=None,
+        request_id=structlog.contextvars.get_contextvars().get("request_id"),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail=None,
+    )
+
     return MfaEnableResponse(recovery_codes=codes)
 
 
 @router.post("/mfa/disable")
 async def mfa_disable(
     body: MfaDisableRequest,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     """Disable MFA. Requires password confirmation."""
     if not current_user.mfa_enabled:
@@ -2092,6 +2111,22 @@ async def mfa_disable(
     current_user.totp_secret = None
     current_user.recovery_codes = None
     await db.commit()
+
+    # Audit AFTER the business commit succeeds. PR3 of the notification
+    # train uses this row as the trigger source for user.mfa.disabled —
+    # a security-critical signal (the user can react if it wasn't them).
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="user.mfa.disabled",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=current_user.org_id,
+        target_org_name=None,
+        request_id=structlog.contextvars.get_contextvars().get("request_id"),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail=None,
+    )
 
     return {"detail": "MFA disabled"}
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -2,14 +2,15 @@ import re
 import secrets
 from datetime import datetime, timezone
 
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models.user import User
-from app.rate_limit import limiter
+from app.rate_limit import get_client_ip, limiter
 from app.schemas.auth import (
     USERNAME_MAX_LENGTH,
     USERNAME_MIN_LENGTH,
@@ -18,7 +19,13 @@ from app.schemas.auth import (
 )
 from app.schemas.user import PasswordChange, ProfileUpdate
 from app.security import create_email_verification_token, hash_password, verify_password
+from app.services import audit_service
 from app.services.email_service import send_verification_email
+
+
+def _request_id() -> str | None:
+    """Pull the per-request id bound by RequestContextMiddleware (L4.9)."""
+    return structlog.contextvars.get_contextvars().get("request_id")
 
 _USERNAME_RE = re.compile(USERNAME_PATTERN)
 
@@ -66,6 +73,7 @@ async def update_profile(
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     if body.username is not None and body.username != current_user.username:
         # Enforce the stricter /register rules only on actual changes so
@@ -97,6 +105,12 @@ async def update_profile(
     email_changing = (
         body.email is not None and body.email != current_user.email
     )
+    # Snapshot the old email BEFORE the mutation so the post-commit
+    # audit row carries the OLD address. The new address goes into
+    # detail.new_email — there's no `target_user_email` column on
+    # audit_events today, so the user-target identity is carried via
+    # actor_email (self) + detail.
+    old_email_for_audit = current_user.email
     if email_changing:
         # Closes S-P1-2: without re-auth, a session-only compromise could
         # swap the recovery channel to an attacker-controlled inbox and
@@ -182,6 +196,32 @@ async def update_profile(
     await db.commit()
     await db.refresh(current_user, ["organization"])
 
+    if email_changing:
+        # Audit AFTER the business commit succeeds. Independent-session
+        # write — a failure here does not roll back the email change.
+        # PR3 of the notification train uses this row as the trigger
+        # source for the user.email.changed in-app + email notification.
+        # No target_user_id column on audit_events today; the actor
+        # (self) carries the user identity, and the OLD email goes in
+        # actor_email so a future "who was this" lookup after a malicious
+        # email swap can recover the original address. New email lives
+        # in detail.new_email.
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="user.email.changed",
+            actor_user_id=current_user.id,
+            actor_email=old_email_for_audit,
+            target_org_id=current_user.org_id,
+            target_org_name=current_user.organization.name,
+            request_id=_request_id(),
+            ip_address=get_client_ip(request),
+            outcome="success",
+            detail={
+                "old_email": old_email_for_audit,
+                "new_email": current_user.email,
+            },
+        )
+
     return _user_response(current_user)
 
 
@@ -192,6 +232,7 @@ async def change_password(
     body: PasswordChange,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
 ):
     # Two paths through this handler:
     #   - `password_set=True` (default for every classic register flow):
@@ -205,6 +246,10 @@ async def change_password(
     #     (Finding 1 from PR #138.) After the write `password_set`
     #     flips True permanently so subsequent rotations land in the
     #     standard branch above.
+    # Snapshot whether this is a first-time password set (SSO user) or
+    # a rotation (classic register flow) BEFORE the mutation flips the
+    # flag — the audit row needs the pre-mutation value.
+    was_initial_password_set = not current_user.password_set
     if current_user.password_set:
         if not body.current_password or not verify_password(
             body.current_password, current_user.password_hash
@@ -240,3 +285,22 @@ async def change_password(
     current_user.password_changed_at = now
     current_user.sessions_invalidated_at = now
     await db.commit()
+
+    # Audit AFTER the business commit succeeds. PR3 of the notification
+    # train uses this row as the trigger source for the
+    # user.password.changed security notification (always-on email).
+    # Failure paths above raise HTTPException before reaching this
+    # point — failure-path auditing is intentionally not added in this
+    # PR (separate scope per the audit-gap-closures task).
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="user.password.changed",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=current_user.org_id,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={"password_set_initial": was_initial_password_set},
+    )

--- a/backend/tests/routers/test_audit_wiring.py
+++ b/backend/tests/routers/test_audit_wiring.py
@@ -163,6 +163,98 @@ async def test_subscription_override_writes_audit(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_subscription_override_with_plan_change_writes_plan_changed_audit(
+    session_factory,
+):
+    """Audit gap closure PR2 (notification train).
+
+    The generic ``admin.org.subscription.override`` row already covered
+    any field change; PR3's notification dispatcher needs a clean
+    ``admin.org.plan.changed`` trigger that fires ONLY when the plan
+    actually changes (status flips, trial-end nudges shouldn't fan a
+    "your plan changed" notification to every org member).
+
+    This pins both rows on a plan-change PUT and only the generic row
+    on a status-only PUT.
+    """
+    # Seed with an extra plan so we can switch to it.
+    seed = await _seed(session_factory)
+    async with session_factory() as db:
+        pro = Plan(slug="pro", name="Pro")
+        db.add(pro)
+        await db.commit()
+        pro_plan_id = pro.id
+
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/subscription",
+            json={"plan_id": pro_plan_id},
+        )
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        override_rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.subscription.override"
+                )
+            )
+        ).scalars().all()
+        plan_rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.plan.changed"
+                )
+            )
+        ).scalars().all()
+    # Generic compliance row still emitted.
+    assert len(override_rows) == 1
+    # AND the plan-specific row landed.
+    assert len(plan_rows) == 1
+    plan_row = plan_rows[0]
+    assert plan_row.outcome == AuditOutcome.SUCCESS
+    assert plan_row.actor_user_id == seed["admin_user_id"]
+    assert plan_row.actor_email == "root@platform.io"
+    assert plan_row.target_org_id == seed["target_id"]
+    assert plan_row.target_org_name == seed["target_name"]
+    assert plan_row.detail is not None
+    # Old plan id is whatever the seed used (the free plan), new is `pro`.
+    assert plan_row.detail["new_plan_id"] == pro_plan_id
+    assert plan_row.detail["old_plan_id"] != pro_plan_id
+
+
+@pytest.mark.asyncio
+async def test_subscription_override_status_only_skips_plan_changed_audit(
+    session_factory,
+):
+    """Status-only PUT must NOT emit ``admin.org.plan.changed`` —
+    otherwise PR3's notification dispatcher would send a misleading
+    "your plan changed" notification on every trial-status flip."""
+    seed = await _seed(session_factory)
+    app = make_app(session_factory, _superadmin_resolver())
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/admin/orgs/{seed['target_id']}/subscription",
+            json={"status": "active"},
+        )
+    assert res.status_code == 200
+
+    async with session_factory() as db:
+        plan_rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.org.plan.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(plan_rows) == 0, (
+        "admin.org.plan.changed leaked on a status-only override — "
+        "the conditional gate on 'plan_id' in before is broken"
+    )
+
+
+@pytest.mark.asyncio
 async def test_delete_success_persists_audit_with_snapshot(session_factory):
     """PR-C / PR #139 #1: the org-delete success audit row must be
     durably persisted to ``audit_events`` (it used to be lost because

--- a/backend/tests/routers/test_audit_wiring_user_ops.py
+++ b/backend/tests/routers/test_audit_wiring_user_ops.py
@@ -1,0 +1,421 @@
+"""End-to-end audit wiring for the user-facing sensitive operations.
+
+PR2 of the notification train: five sensitive routes that wrote
+business state but no `audit_events` row. This file pins the four
+user-facing ones; the fifth (admin plan change) lives in
+`test_audit_wiring.py` next to the other admin-org audit pins.
+
+Each route is exercised via a real `TestClient`, the business state
+mutation is confirmed (so we don't silently break the route), and the
+audit row is asserted with the expected `event_type`, `outcome` and
+actor identity.
+
+The audit write uses the independent-session pattern (opens its own
+session through the engine-wide factory). Tests override
+`get_session_factory` onto the same in-memory SQLite factory the
+business session uses so the row is visible to the test.
+
+NO `dispatch_notification` is called from any of these routes — that
+wiring is PR3 of the notification train. These tests are guardrails
+against PR3 (or any later refactor) silently dropping the trigger
+source that the notification dispatcher will subscribe to.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+
+import pyotp
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+from fastapi import Depends as _Depends
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.user import Organization, Role, User
+from app.rate_limit import limiter
+from app.routers.auth import router as auth_router
+from app.routers.users import router as users_router
+from app.security import hash_password
+from app.services.mfa_service import encrypt_secret, generate_totp_secret
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    """SlowAPI ``Limiter`` is a module-level singleton; without a reset
+    a 5/hour counter from one test bleeds into the next."""
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+@pytest.fixture(autouse=True)
+def _mfa_key(monkeypatch):
+    """Pin a Fernet key for the MFA encryption helper. Empty by default
+    in test settings (matches dev .env), but every mfa_service call
+    raises MfaConfigError without one. Used by both the test setup
+    (encrypt the seeded TOTP secret) and the route under test (decrypt
+    it during /mfa/enable verification)."""
+    key = Fernet.generate_key().decode()
+    monkeypatch.setattr(app_settings, "mfa_encryption_key", key)
+
+
+def _make_app(session_factory, user_id: int, *, router):
+    """Wire a FastAPI app with all three audit-relevant overrides:
+
+    - ``get_db`` → in-memory SQLite session
+    - ``get_current_user`` → user loaded from THE SAME session (so
+      handler mutations persist on commit; bug magnet)
+    - ``get_session_factory`` → the same factory, so the
+      independent-session audit write lands in the test DB
+    """
+    app = FastAPI()
+    # SlowAPI handler chain — both /users/me and /users/me/password are
+    # @limiter.limit decorated.
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    # Depends on the same `get_db` so FastAPI's per-request dependency
+    # cache hands the same session to override AND to the route.
+    async def override_current_user(
+        db: AsyncSession = _Depends(get_db),
+    ) -> User:
+        user = await db.get(User, user_id)
+        assert user is not None
+        await db.refresh(user, ["organization"])
+        return user
+
+    def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(router)
+    return app
+
+
+async def _seed_user(
+    session_factory,
+    *,
+    email: str = "alice@acme.io",
+    password: str = "starting-password-1",
+    mfa_enabled: bool = False,
+    totp_secret: str | None = None,
+) -> dict:
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username="alice",
+            email=email,
+            password_hash=hash_password(password),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+            password_set=True,
+            mfa_enabled=mfa_enabled,
+            totp_secret=totp_secret,
+        )
+        db.add(user)
+        await db.commit()
+        return {"user_id": user.id, "org_id": org.id, "email": email}
+
+
+# ── password change ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_password_change_writes_audit(session_factory):
+    """POST /users/me/password (success) writes a
+    ``user.password.changed`` audit row that PR3 will use as the
+    trigger for the security notification."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory, seed["user_id"], router=users_router)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/users/me/password",
+            json={
+                "current_password": "starting-password-1",
+                "new_password": "brand-new-passw0rd",
+            },
+        )
+    assert res.status_code == 204, res.text
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "user.password.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == AuditOutcome.SUCCESS
+    assert row.actor_user_id == seed["user_id"]
+    assert row.actor_email == seed["email"]
+    assert row.target_org_id == seed["org_id"]
+    # Target is self — there is no target_user_id column on
+    # audit_events. The actor identity carries the user-target signal,
+    # and PR3's dispatcher keys off (actor_user_id, event_type).
+    assert row.detail is not None
+    # Rotation (not initial set) — password_set was True.
+    assert row.detail.get("password_set_initial") is False
+
+
+@pytest.mark.asyncio
+async def test_password_change_failure_writes_no_audit(session_factory):
+    """Wrong current_password is rejected with 400 BEFORE the audit
+    write — failure-path auditing is intentionally not added in this
+    PR (separate scope per the audit-gap-closures task). Pin that no
+    spurious row is emitted so this gap closure doesn't sneak failure
+    auditing in.
+    """
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory, seed["user_id"], router=users_router)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/users/me/password",
+            json={
+                "current_password": "wrong-password",
+                "new_password": "brand-new-passw0rd",
+            },
+        )
+    assert res.status_code == 400, res.text
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "user.password.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 0
+
+
+# ── email change ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_email_change_writes_audit_with_old_email(session_factory):
+    """PUT /users/me email change captures the OLD email in actor_email
+    (the user's identity at event time) and the NEW email in
+    detail.new_email. Self-target — no target_user_id column."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory, seed["user_id"], router=users_router)
+    with TestClient(app) as client:
+        res = client.put(
+            "/api/v1/users/me",
+            json={
+                "email": "new-address@acme.io",
+                "current_password": "starting-password-1",
+            },
+        )
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "user.email.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == AuditOutcome.SUCCESS
+    assert row.actor_user_id == seed["user_id"]
+    # actor_email carries the OLD identity — the value the audit row
+    # attests to at the time of the event. After the swap, the user's
+    # current email is the new one, but the audit row must point at
+    # who lost the address.
+    assert row.actor_email == "alice@acme.io"
+    assert row.target_org_id == seed["org_id"]
+    assert row.detail is not None
+    assert row.detail["old_email"] == "alice@acme.io"
+    assert row.detail["new_email"] == "new-address@acme.io"
+
+
+@pytest.mark.asyncio
+async def test_email_change_no_change_writes_no_audit(session_factory):
+    """PUT /users/me without an email field (or with the same email)
+    must NOT emit ``user.email.changed`` — otherwise an unrelated
+    profile edit would spam the security notification channel."""
+    seed = await _seed_user(session_factory)
+    app = _make_app(session_factory, seed["user_id"], router=users_router)
+    with TestClient(app) as client:
+        res = client.put(
+            "/api/v1/users/me",
+            json={"first_name": "Alicia"},
+        )
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "user.email.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 0
+
+
+# ── MFA enable + disable ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mfa_enable_writes_audit(session_factory):
+    """POST /auth/mfa/enable success writes ``user.mfa.enabled``.
+
+    Setup: pre-stash an encrypted TOTP secret on the user (the route
+    expects it from a prior /mfa/setup call), then post a TOTP code
+    that verifies against the secret.
+    """
+    secret = generate_totp_secret()
+    seed = await _seed_user(
+        session_factory,
+        totp_secret=encrypt_secret(secret),
+        mfa_enabled=False,
+    )
+    code = pyotp.TOTP(secret).now()
+
+    app = _make_app(session_factory, seed["user_id"], router=auth_router)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/mfa/enable",
+            json={"code": code},
+        )
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "user.mfa.enabled"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == AuditOutcome.SUCCESS
+    assert row.actor_user_id == seed["user_id"]
+    assert row.actor_email == seed["email"]
+    assert row.target_org_id == seed["org_id"]
+
+
+@pytest.mark.asyncio
+async def test_mfa_disable_writes_audit(session_factory):
+    """POST /auth/mfa/disable success writes ``user.mfa.disabled`` —
+    the security-critical signal (a real user can react if it wasn't
+    them)."""
+    secret = generate_totp_secret()
+    seed = await _seed_user(
+        session_factory,
+        totp_secret=encrypt_secret(secret),
+        mfa_enabled=True,
+    )
+    app = _make_app(session_factory, seed["user_id"], router=auth_router)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/mfa/disable",
+            json={"password": "starting-password-1"},
+        )
+    assert res.status_code == 200, res.text
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "user.mfa.disabled"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.outcome == AuditOutcome.SUCCESS
+    assert row.actor_user_id == seed["user_id"]
+    assert row.actor_email == seed["email"]
+    assert row.target_org_id == seed["org_id"]
+
+
+@pytest.mark.asyncio
+async def test_mfa_disable_wrong_password_writes_no_audit(session_factory):
+    """Wrong password → 403, MFA stays enabled, no audit row written
+    (failure-path auditing is out of scope for this PR)."""
+    secret = generate_totp_secret()
+    seed = await _seed_user(
+        session_factory,
+        totp_secret=encrypt_secret(secret),
+        mfa_enabled=True,
+    )
+    app = _make_app(session_factory, seed["user_id"], router=auth_router)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/auth/mfa/disable",
+            json={"password": "wrong-password"},
+        )
+    assert res.status_code == 403, res.text
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "user.mfa.disabled"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 0
+
+    # And MFA is still enabled — the business state didn't change.
+    async with session_factory() as db:
+        user = await db.get(User, seed["user_id"])
+        assert user is not None
+        assert user.mfa_enabled is True


### PR DESCRIPTION
## Summary

Adds audit_events writes to 5 sensitive operations that wrote business state but no audit row. PR3 of the notification train will key off these event types to dispatch in-app + email notifications.

New event types:
- `user.password.changed` (POST /users/me/password)
- `user.email.changed` (PUT /users/me when email field changes)
- `user.mfa.enabled` (POST /auth/mfa/enable)
- `user.mfa.disabled` (POST /auth/mfa/disable)
- `admin.org.plan.changed` (PUT /admin/orgs/{id}/subscription when plan_id changes)

The admin subscription override route already wrote `admin.org.subscription.override`; `admin.org.plan.changed` is emitted as an additional row only when `plan_id` actually changes, so PR3 has a clean trigger without parsing detail.before/after.

All audit writes are post-commit, independent-session (existing pattern). Failure-path auditing intentionally not added (separate scope). Zero `dispatch_notification` calls anywhere; that lands in PR3.

Spec: `specs/2026-05-21-notification-system-sensitive-ops.md`