### PR TITLE
feat(ai): usage ledger + cap enforcement (PR2 of AI tier train)

### DIFF
--- a/backend/alembic/versions/058_ai_usage_ledger.py
+++ b/backend/alembic/versions/058_ai_usage_ledger.py
@@ -1,0 +1,129 @@
+"""AI usage ledger (PR2 of AI tier train).
+
+Revision ID: 058_ai_usage_ledger
+Revises: 057_ai_provider_enum_native
+Create Date: 2026-05-22
+
+PR2 of the AI tier rollout wires the dispatch chokepoint
+(``call_llm``) with cap enforcement + the per-call ledger. This
+migration creates the ledger table; the cap tables themselves landed
+in 055.
+
+Indexes mirror the read patterns in spec §7 / the PR2 brief:
+
+- ``(org_id, dispatched_at)`` — feeds the rolling-window org-wide
+  cap query (``SUM(est_cost_cents) WHERE org_id=? AND dispatched_at
+  BETWEEN month_start AND now``).
+- ``(org_id, feature_key, dispatched_at)`` — same shape for the
+  per-feature cap query.
+
+Composite FK ``(org_id, credential_id) → org_ai_credentials
+(org_id, id)`` matches the routing tables — cross-org references
+fail at the DB layer (T14 in the spec's threat model). The column
+is nullable + ON DELETE SET NULL so a credential revoke leaves
+historical ledger rows intact (forensics depends on this).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "058_ai_usage_ledger"
+down_revision = "057_ai_provider_enum_native"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_usage_ledger",
+        sa.Column(
+            "id",
+            sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+            nullable=False,
+            autoincrement=True,
+        ),
+        sa.Column("org_id", sa.Integer(), nullable=False),
+        sa.Column("credential_id", sa.Integer(), nullable=True),
+        sa.Column("feature_key", sa.String(length=120), nullable=False),
+        sa.Column("model", sa.String(length=120), nullable=False),
+        sa.Column(
+            "prompt_tokens",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "completion_tokens",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "total_tokens",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "est_cost_cents",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "dispatched_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "latency_ms",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "success",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("error_class", sa.String(length=120), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="pk_ai_usage_ledger"),
+        sa.ForeignKeyConstraint(
+            ["org_id"],
+            ["organizations.id"],
+            name="fk_ai_usage_ledger_org",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["org_id", "credential_id"],
+            ["org_ai_credentials.org_id", "org_ai_credentials.id"],
+            name="fk_ai_usage_ledger_cred",
+            ondelete="SET NULL",
+        ),
+    )
+    op.create_index(
+        "ix_ai_usage_org_dispatched",
+        "ai_usage_ledger",
+        ["org_id", "dispatched_at"],
+    )
+    op.create_index(
+        "ix_ai_usage_org_feature_dispatched",
+        "ai_usage_ledger",
+        ["org_id", "feature_key", "dispatched_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_ai_usage_org_feature_dispatched",
+        table_name="ai_usage_ledger",
+    )
+    op.drop_index(
+        "ix_ai_usage_org_dispatched",
+        table_name="ai_usage_ledger",
+    )
+    op.drop_table("ai_usage_ledger")

--- a/backend/alembic/versions/058_ai_usage_ledger.py
+++ b/backend/alembic/versions/058_ai_usage_ledger.py
@@ -17,11 +17,17 @@ Indexes mirror the read patterns in spec §7 / the PR2 brief:
 - ``(org_id, feature_key, dispatched_at)`` — same shape for the
   per-feature cap query.
 
-Composite FK ``(org_id, credential_id) → org_ai_credentials
-(org_id, id)`` matches the routing tables — cross-org references
-fail at the DB layer (T14 in the spec's threat model). The column
-is nullable + ON DELETE SET NULL so a credential revoke leaves
-historical ledger rows intact (forensics depends on this).
+FK shape note: the ledger uses a single-column FK on
+``credential_id`` (ON DELETE SET NULL) rather than the composite
+``(org_id, credential_id)`` pattern used by the routing tables.
+Reason: MySQL refuses ON DELETE SET NULL on a composite FK where
+``org_id`` is NOT NULL (errno 1830). Cross-org integrity for the
+ledger is enforced UPSTREAM — every ledger row is written by the
+dispatch chokepoint (``ai_dispatch.call_llm``) using a credential
+the routing FK already pinned to the org, so a cross-org row is
+unreachable through normal code. The column stays nullable + ON
+DELETE SET NULL so a credential revoke leaves the historical row
+intact (T13 forensic source).
 """
 from __future__ import annotations
 
@@ -99,8 +105,8 @@ def upgrade() -> None:
             ondelete="RESTRICT",
         ),
         sa.ForeignKeyConstraint(
-            ["org_id", "credential_id"],
-            ["org_ai_credentials.org_id", "org_ai_credentials.id"],
+            ["credential_id"],
+            ["org_ai_credentials.id"],
             name="fk_ai_usage_ledger_cred",
             ondelete="SET NULL",
         ),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -485,6 +485,7 @@ app.include_router(notifications.router)
 app.include_router(reports.router)
 app.include_router(scenarios.router)
 app.include_router(ai_providers.router)
+app.include_router(admin_ai_usage.router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -54,6 +54,7 @@ from app.models.org_ai_caps import (  # noqa: F401
     OrgAIFeatureCaps,
 )
 from app.models.org_ai_consent import OrgAIConsent  # noqa: F401
+from app.models.ai_usage_ledger import AIUsageLedger  # noqa: F401
 
 __all__ = [
     "Base",
@@ -108,6 +109,7 @@ __all__ = [
     "OrgAIDefaultCaps",
     "OrgAIFeatureCaps",
     "OrgAIConsent",
+    "AIUsageLedger",
     "ROUTABLE_FEATURE_NAMES",
     "UserDismissedAnnouncement",
     "Notification",

--- a/backend/app/models/ai_usage_ledger.py
+++ b/backend/app/models/ai_usage_ledger.py
@@ -1,0 +1,107 @@
+"""Per-call usage ledger row for AI dispatch (PR2 of AI tier train).
+
+Every ``call_llm`` invocation writes exactly one row here on
+completion (success or failure). The ledger is the source of truth
+for cap aggregation, soft-cap warnings, and the superadmin
+``/admin/ai/usage`` debug surface.
+
+Indexes:
+
+- ``(org_id, dispatched_at)`` — feeds the rolling-window cap check
+  for the org-wide cap.
+- ``(org_id, feature_key, dispatched_at)`` — feeds the per-feature
+  cap check.
+
+The ``credential_id`` is the composite-FK reference used by the
+routing tables; it stays nullable so a credential delete doesn't
+cascade-kill historical ledger rows.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AIUsageLedger(Base):
+    __tablename__ = "ai_usage_ledger"
+    __table_args__ = (
+        # Composite FK to (org_id, id) on org_ai_credentials matches
+        # the routing tables — keeps cross-org references structurally
+        # impossible at the DB layer. Nullable so credential deletes
+        # don't cascade-kill historical rows.
+        ForeignKeyConstraint(
+            ["org_id", "credential_id"],
+            ["org_ai_credentials.org_id", "org_ai_credentials.id"],
+            name="fk_ai_usage_ledger_cred",
+            ondelete="SET NULL",
+        ),
+        Index("ix_ai_usage_org_dispatched", "org_id", "dispatched_at"),
+        Index(
+            "ix_ai_usage_org_feature_dispatched",
+            "org_id",
+            "feature_key",
+            "dispatched_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    org_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey(
+            "organizations.id",
+            name="fk_ai_usage_ledger_org",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    # Nullable on the column itself; the composite FK above carries
+    # the ON DELETE SET NULL behavior so a credential delete leaves
+    # the historical row intact.
+    credential_id: Mapped[Optional[int]] = mapped_column(
+        Integer, nullable=True
+    )
+    feature_key: Mapped[str] = mapped_column(String(120), nullable=False)
+    model: Mapped[str] = mapped_column(String(120), nullable=False)
+    prompt_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    completion_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    total_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    est_cost_cents: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    dispatched_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    latency_ms: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    success: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="0"
+    )
+    error_class: Mapped[Optional[str]] = mapped_column(
+        String(120), nullable=True
+    )

--- a/backend/app/models/ai_usage_ledger.py
+++ b/backend/app/models/ai_usage_ledger.py
@@ -26,7 +26,6 @@ from sqlalchemy import (
     Boolean,
     DateTime,
     ForeignKey,
-    ForeignKeyConstraint,
     Index,
     Integer,
     String,
@@ -40,16 +39,17 @@ from app.models.base import Base
 class AIUsageLedger(Base):
     __tablename__ = "ai_usage_ledger"
     __table_args__ = (
-        # Composite FK to (org_id, id) on org_ai_credentials matches
-        # the routing tables — keeps cross-org references structurally
-        # impossible at the DB layer. Nullable so credential deletes
-        # don't cascade-kill historical rows.
-        ForeignKeyConstraint(
-            ["org_id", "credential_id"],
-            ["org_ai_credentials.org_id", "org_ai_credentials.id"],
-            name="fk_ai_usage_ledger_cred",
-            ondelete="SET NULL",
-        ),
+        # The composite (org_id, credential_id) -> org_ai_credentials
+        # cross-org FK can't co-exist with ON DELETE SET NULL on MySQL
+        # because org_id stays NOT NULL. Cross-org integrity for the
+        # ledger is enforced UPSTREAM at the routing-table FK + the
+        # dispatch chokepoint (see ai_dispatch.call_llm): the ledger
+        # is a write-only output of dispatch, so a row can only be
+        # written for a credential the chokepoint already resolved
+        # through the routing FK. Here we keep a single-column FK on
+        # ``credential_id`` so that a credential delete leaves the
+        # historical ledger row intact (forensic source per spec
+        # T13).
         Index("ix_ai_usage_org_dispatched", "org_id", "dispatched_at"),
         Index(
             "ix_ai_usage_org_feature_dispatched",
@@ -73,11 +73,16 @@ class AIUsageLedger(Base):
         ),
         nullable=False,
     )
-    # Nullable on the column itself; the composite FK above carries
-    # the ON DELETE SET NULL behavior so a credential delete leaves
-    # the historical row intact.
+    # Nullable + ON DELETE SET NULL so a credential delete leaves
+    # the historical row intact (T13 forensic source).
     credential_id: Mapped[Optional[int]] = mapped_column(
-        Integer, nullable=True
+        Integer,
+        ForeignKey(
+            "org_ai_credentials.id",
+            name="fk_ai_usage_ledger_cred",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
     )
     feature_key: Mapped[str] = mapped_column(String(120), nullable=False)
     model: Mapped[str] = mapped_column(String(120), nullable=False)

--- a/backend/app/routers/admin_ai_usage.py
+++ b/backend/app/routers/admin_ai_usage.py
@@ -1,0 +1,177 @@
+"""Superadmin debug endpoint for AI usage aggregation (PR2 of AI tier train).
+
+Single endpoint:
+
+- ``GET /api/v1/admin/ai/usage?org_id=...&period=YYYY-MM`` returns
+  aggregated usage for the period. Useful when a soft-cap warning
+  fires and ops wants to see which feature drove the spend before
+  PR3 ships a customer-facing usage page.
+
+Superadmin only — never reachable by a regular admin, even for
+their own org. Cross-org reads are the *point* of this surface; a
+regular admin's audit log already has enough breadcrumbs for their
+own org.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models.ai_usage_ledger import AIUsageLedger
+from app.models.user import User
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(prefix="/api/v1/admin/ai", tags=["admin-ai"])
+
+
+_PERIOD_RE = re.compile(r"^(\d{4})-(\d{2})$")
+
+
+def _parse_period(period: str) -> tuple[datetime, datetime]:
+    """Return ``(start_inclusive, end_exclusive)`` for the ``YYYY-MM`` period.
+
+    Naive datetimes — the ledger column is naive on both backends, so
+    we match the comparison shape directly.
+    """
+    match = _PERIOD_RE.match(period)
+    if not match:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_period_format"},
+        )
+    year = int(match.group(1))
+    month = int(match.group(2))
+    if month < 1 or month > 12:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_period_format"},
+        )
+    start = datetime(year, month, 1)
+    if month == 12:
+        end = datetime(year + 1, 1, 1)
+    else:
+        end = datetime(year, month + 1, 1)
+    return (start, end)
+
+
+async def require_superadmin(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    if not current_user.is_superadmin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )
+    return current_user
+
+
+@router.get("/usage")
+async def get_usage(
+    org_id: int = Query(..., ge=1),
+    period: str = Query(..., description="YYYY-MM"),
+    _current_user: User = Depends(require_superadmin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Aggregate AI usage for an org for the given period.
+
+    Response shape::
+
+        {
+          "org_id": 42,
+          "period": "2026-05",
+          "total_prompt_tokens": 1234,
+          "total_completion_tokens": 567,
+          "total_cost_cents": 89,
+          "by_feature": [
+            {
+              "feature_key": "chat",
+              "prompt_tokens": ...,
+              "completion_tokens": ...,
+              "cost_cents": ...,
+              "calls": 3,
+              "failed_calls": 0
+            },
+            ...
+          ]
+        }
+
+    Failed-call rows (success=false) are included in the call counts
+    but their token/cost contributions are zero per spec.
+    """
+    start, end = _parse_period(period)
+
+    totals_row = (
+        await db.execute(
+            select(
+                func.coalesce(func.sum(AIUsageLedger.prompt_tokens), 0),
+                func.coalesce(func.sum(AIUsageLedger.completion_tokens), 0),
+                func.coalesce(func.sum(AIUsageLedger.est_cost_cents), 0),
+                func.count(),
+            ).where(
+                AIUsageLedger.org_id == org_id,
+                AIUsageLedger.dispatched_at >= start,
+                AIUsageLedger.dispatched_at < end,
+            )
+        )
+    ).one()
+    total_prompt, total_completion, total_cost, total_calls = totals_row
+
+    by_feature_rows = (
+        await db.execute(
+            select(
+                AIUsageLedger.feature_key,
+                func.coalesce(func.sum(AIUsageLedger.prompt_tokens), 0),
+                func.coalesce(func.sum(AIUsageLedger.completion_tokens), 0),
+                func.coalesce(func.sum(AIUsageLedger.est_cost_cents), 0),
+                func.count(),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (AIUsageLedger.success == False, 1),  # noqa: E712
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ),
+            )
+            .where(
+                AIUsageLedger.org_id == org_id,
+                AIUsageLedger.dispatched_at >= start,
+                AIUsageLedger.dispatched_at < end,
+            )
+            .group_by(AIUsageLedger.feature_key)
+            .order_by(AIUsageLedger.feature_key)
+        )
+    ).all()
+
+    by_feature = [
+        {
+            "feature_key": row[0],
+            "prompt_tokens": int(row[1] or 0),
+            "completion_tokens": int(row[2] or 0),
+            "cost_cents": int(row[3] or 0),
+            "calls": int(row[4] or 0),
+            "failed_calls": int(row[5] or 0),
+        }
+        for row in by_feature_rows
+    ]
+
+    return {
+        "org_id": org_id,
+        "period": period,
+        "total_prompt_tokens": int(total_prompt or 0),
+        "total_completion_tokens": int(total_completion or 0),
+        "total_cost_cents": int(total_cost or 0),
+        "total_calls": int(total_calls or 0),
+        "by_feature": by_feature,
+    }

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -20,7 +20,12 @@ Flow (spec §3, PR2 scope):
    for the first time in the period, enqueue a notification via
    ``notification_service.dispatch_notification`` for every owner /
    admin of the org. Idempotent per (org, feature_key, period) via
-   a Redis marker with a 35-day TTL.
+   a Redis marker with a 35-day TTL. The warning fires from two
+   sites: a pre-call check (catches usage that was already at-or-above
+   the cap going in — e.g., marker expired, retroactive ledger rows)
+   and a post-write check (catches the boundary call that takes usage
+   from below to at-or-above the cap for the first time). The Redis
+   marker dedupes across both sites.
 4. Decrypt credentials via ``ai_credential_crypto.decrypt``, build
    the adapter via ``ai_providers.get_adapter``, dispatch.
 5. Time the call. Write a ledger row with token counts, cost,
@@ -623,6 +628,27 @@ async def call_llm(
         success=True,
         error_class=None,
     )
+
+    # 7. Post-write boundary check: catch the very first call that
+    # CROSSES the soft cap. The pre-call check (step 3) only fires when
+    # ``cost_so_far`` is already at-or-above the cap, so the call that
+    # takes us from below to at-or-above the cap was previously missed.
+    # The Redis dedupe marker shared with ``_maybe_warn_soft_cap``
+    # ensures we don't double-fire when both checks would otherwise
+    # match (pre-call already set the marker -> post-write SET NX
+    # returns False -> warning skipped).
+    if (
+        resolved.soft_cap_cents is not None
+        and cost_so_far < resolved.soft_cap_cents <= cost_so_far + cost
+    ):
+        await _maybe_warn_soft_cap(
+            db,
+            org_id=org_id,
+            feature_key=feature_key,
+            resolved=resolved,
+            cost_before_call=cost_so_far + cost,
+            period=_current_period(),
+        )
 
     logger.info(
         "ai.dispatch.success",

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -39,9 +39,16 @@ Soft-cap warning idempotence — design note:
 
 The Redis marker ``ai_soft_cap_warned:{org_id}:{feature_key}:{period}``
 is keyed on ``feature_key="__default__"`` when the soft cap that
-fired was the org-wide default rather than a per-feature override.
-This keeps a default-only soft-cap from re-firing once per feature
-in the same month.
+fired was the org-wide default rather than a per-feature soft-cap
+override. This keeps a default-only soft-cap from re-firing once per
+feature in the same month.
+
+The "did the feature row override this" decision is made on the
+**soft cap alone**. A feature row that supplies only a hard cap (soft
+left null, default soft still winning) MUST NOT scope the marker to
+the feature — that would let the same org-wide soft-cap warning fire
+once per feature in a period. See ``_resolve_caps`` for the source-
+tracking implementation.
 
 Open spec ambiguity resolved here: the brief asks whether a
 rejected-by-hard-cap call writes a ledger row. **We do not write a
@@ -171,9 +178,16 @@ def http_for_dispatch_error(exc: AIDispatchError) -> HTTPException:
 class _ResolvedCaps:
     soft_cap_cents: Optional[int]
     hard_cap_cents: Optional[int]
-    # ``True`` if the resolved row was the per-feature override, which
-    # changes the Redis marker key shape.
-    from_feature_override: bool
+    # ``True`` iff the EFFECTIVE soft cap (the one ``soft_cap_cents``
+    # holds) came from the per-feature override row. This is used to
+    # shape the Redis dedupe marker for soft-cap warnings.
+    #
+    # IMPORTANT: this tracks the source of the SOFT cap only. The hard
+    # cap's source is intentionally not tracked here — it does not
+    # affect warning dedupe, and conflating the two would let a
+    # feature-specific hard cap silently fragment an org-wide soft-cap
+    # warning into one-per-feature.
+    soft_from_feature_override: bool
 
 
 def _tighter_cap(a: Optional[int], b: Optional[int]) -> Optional[int]:
@@ -189,6 +203,34 @@ def _tighter_cap(a: Optional[int], b: Optional[int]) -> Optional[int]:
     return min(a, b)
 
 
+def _soft_cap_from_feature(
+    default_soft: Optional[int], feat_soft: Optional[int]
+) -> bool:
+    """Decide whether the effective soft cap came from the feature row.
+
+    The effective soft cap is ``_tighter_cap(default_soft, feat_soft)``.
+    "From feature" means the feature row supplied a soft cap AND that
+    soft cap is the one that won (i.e. the feature soft cap is tighter
+    than the default, or the default is absent).
+
+    Examples:
+      default=None, feat=None      -> False  (no soft cap at all)
+      default=100,  feat=None      -> False  (default wins)
+      default=None, feat=50        -> True   (feature wins, default absent)
+      default=100,  feat=50        -> True   (feature wins, tighter)
+      default=50,   feat=100       -> False  (default wins, tighter)
+      default=50,   feat=50        -> False  (tie — default wins; the
+                                              dedupe scope is org-wide
+                                              and that's the safer default)
+    """
+    if feat_soft is None:
+        return False
+    if default_soft is None:
+        return True
+    # Strict less-than: ties resolve to the default (org-wide marker).
+    return feat_soft < default_soft
+
+
 async def _resolve_caps(
     db: AsyncSession, *, org_id: int, feature_key: str
 ) -> _ResolvedCaps:
@@ -197,6 +239,15 @@ async def _resolve_caps(
     Both default + feature caps must pass — whichever is tighter
     wins. We return a single (soft, hard) tuple representing the
     composite enforcement.
+
+    Source tracking — only the SOFT cap's source is tracked, via
+    ``soft_from_feature_override``. The hard cap's source is not
+    surfaced because it does not affect any downstream behavior; in
+    particular it must NOT influence the soft-cap warning dedupe
+    marker. Bug guard: a feature row with ``soft_cap_cents=None`` and
+    ``hard_cap_cents=300`` (default soft still wins) must produce
+    ``soft_from_feature_override=False`` so the warning dedupe stays
+    org-wide via the ``__default__`` marker.
     """
     default_row = (
         await db.execute(
@@ -219,16 +270,12 @@ async def _resolve_caps(
 
     soft = _tighter_cap(default_soft, feat_soft)
     hard = _tighter_cap(default_hard, feat_hard)
-    # The marker key distinguishes "feature override caused this" vs
-    # "org default caused this". Whichever cap value actually fired
-    # wins. The choice only matters for soft-cap warning dedup.
-    from_feature_override = feat_row is not None and (
-        feat_soft is not None or feat_hard is not None
-    )
     return _ResolvedCaps(
         soft_cap_cents=soft,
         hard_cap_cents=hard,
-        from_feature_override=from_feature_override,
+        soft_from_feature_override=_soft_cap_from_feature(
+            default_soft, feat_soft
+        ),
     )
 
 
@@ -307,8 +354,13 @@ async def _maybe_warn_soft_cap(
     if cost_before_call < resolved.soft_cap_cents:
         return False
 
+    # The marker is scoped by where the EFFECTIVE soft cap came from.
+    # If the org-default soft cap is the one that fired, the marker is
+    # ``__default__`` so the warning fires ONCE for the org per period
+    # (not once per feature). If a feature row supplied its own tighter
+    # soft cap, that warning is feature-scoped instead.
     marker_feature = (
-        feature_key if resolved.from_feature_override else "__default__"
+        feature_key if resolved.soft_from_feature_override else "__default__"
     )
     marker_key = (
         f"ai_soft_cap_warned:{org_id}:{marker_feature}:{period}"

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -1,0 +1,654 @@
+"""AI dispatch chokepoint — ``call_llm`` (PR2 of AI tier train).
+
+This is the only code path that talks to a real provider. Feature
+surfaces (categorization, chat, smart_forecast — none of which are
+wired in PR2) MUST go through this function. Direct adapter calls
+bypass cap enforcement and the ledger and are a bug.
+
+Flow (spec §3, PR2 scope):
+
+1. Resolve routing via ``ai_routing_service.get_routing_for_feature``.
+   Feature override beats default; no row at all -> 412 with code
+   ``ai_routing_not_configured``.
+2. Pre-check caps: aggregate the rolling-window (calendar month)
+   ``est_cost_cents`` for the org from ``ai_usage_ledger``. Compare
+   against both ``org_ai_default_caps`` AND ``org_ai_feature_caps``
+   for the feature; whichever is tighter wins. Hard cap exceeded ->
+   402 with code ``ai_hard_cap_exceeded`` (no adapter call, no
+   ledger row).
+3. Soft-cap warning: if the current usage crosses ``soft_cap_cents``
+   for the first time in the period, enqueue a notification via
+   ``notification_service.dispatch_notification`` for every owner /
+   admin of the org. Idempotent per (org, feature_key, period) via
+   a Redis marker with a 35-day TTL.
+4. Decrypt credentials via ``ai_credential_crypto.decrypt``, build
+   the adapter via ``ai_providers.get_adapter``, dispatch.
+5. Time the call. Write a ledger row with token counts, cost,
+   latency, success=true.
+6. On adapter failure: write a ledger row with success=false,
+   error_class set, tokens 0, cost 0. Re-raise as ``AIDispatchFailed``
+   (passes through ``NoRoutingConfigured`` and ``AICapExceeded``
+   unchanged because those are caught before the adapter call).
+
+Soft-cap warning idempotence — design note:
+
+The Redis marker ``ai_soft_cap_warned:{org_id}:{feature_key}:{period}``
+is keyed on ``feature_key="__default__"`` when the soft cap that
+fired was the org-wide default rather than a per-feature override.
+This keeps a default-only soft-cap from re-firing once per feature
+in the same month.
+
+Open spec ambiguity resolved here: the brief asks whether a
+rejected-by-hard-cap call writes a ledger row. **We do not write a
+ledger row for hard-cap rejections.** Rationale: rejected calls
+never reach the provider, so there's no cost/latency to record,
+and writing zero-cost rows would inflate the row count without
+adding ops signal. Hard-cap events are surfaced via the structlog
+``ai.dispatch.cap.exceeded`` event and (in PR3+) an audit row.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import redis_client
+from app.models.ai_usage_ledger import AIUsageLedger
+from app.models.notification import NotificationCategory
+from app.models.org_ai_caps import OrgAIDefaultCaps, OrgAIFeatureCaps
+from app.models.org_ai_credential import OrgAICredential
+from app.models.user import Role, User
+from app.services import ai_routing_service, notification_service
+from app.services.ai_credential_crypto import decrypt
+from app.services.ai_pricing import estimate_cost_cents
+from app.services.ai_providers import (
+    AIProviderError,
+    LLMResponse,
+    NativeNotAvailable,
+    get_adapter,
+)
+from app.services.notification_templates import ai_cap_soft_warning
+
+
+logger = structlog.stdlib.get_logger()
+
+
+# 35-day TTL so the marker spans an entire monthly billing window
+# plus a small buffer. The actual key incorporates the period
+# (``YYYY-MM``) so once a new month starts, a stale marker won't fire.
+SOFT_CAP_WARNED_TTL_SECONDS = 35 * 24 * 60 * 60
+
+
+# --- Typed exceptions -------------------------------------------------
+
+
+class AIDispatchError(Exception):
+    """Base for typed dispatch errors. Maps to an HTTPException at the
+    router layer via the route-side helpers below.
+    """
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class NoRoutingConfigured(AIDispatchError):
+    """Neither a per-feature override nor an org default routing row
+    exists. Spec §3 maps this to HTTP 412.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("ai_routing_not_configured")
+
+
+class AICapExceeded(AIDispatchError):
+    """Hard cap was exceeded at the dispatch chokepoint. Spec §3 maps
+    this to HTTP 402.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("ai_hard_cap_exceeded")
+
+
+class AIDispatchFailed(AIDispatchError):
+    """Adapter raised a typed error and we wrote the ledger row before
+    re-raising. The router maps this to HTTP 502.
+    """
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+
+
+# --- HTTPException mappers ------------------------------------------
+
+
+def http_for_dispatch_error(exc: AIDispatchError) -> HTTPException:
+    """Translate a typed dispatch error to an HTTPException for routers.
+
+    Feature surfaces (PR3+) call this in their except handler when
+    they want to surface ``call_llm`` failures with the spec's typed
+    codes. Not used inside ``call_llm`` itself — the dispatcher just
+    raises the typed error and the caller decides whether to surface
+    it as 412/402/502 or recover internally.
+    """
+    if isinstance(exc, NoRoutingConfigured):
+        return HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": exc.code},
+        )
+    if isinstance(exc, AICapExceeded):
+        return HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"code": exc.code},
+        )
+    if isinstance(exc, NativeNotAvailable):
+        return HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "ai_native_not_available"},
+        )
+    return HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail={"code": exc.code},
+    )
+
+
+# --- Cap resolution + check -------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ResolvedCaps:
+    soft_cap_cents: Optional[int]
+    hard_cap_cents: Optional[int]
+    # ``True`` if the resolved row was the per-feature override, which
+    # changes the Redis marker key shape.
+    from_feature_override: bool
+
+
+def _tighter_cap(a: Optional[int], b: Optional[int]) -> Optional[int]:
+    """Return the smaller of two optional cap values.
+
+    ``None`` means "no cap"; a real integer is always tighter than
+    None. Two ``None``s means no cap at all.
+    """
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return min(a, b)
+
+
+async def _resolve_caps(
+    db: AsyncSession, *, org_id: int, feature_key: str
+) -> _ResolvedCaps:
+    """Resolve effective caps for (org_id, feature_key).
+
+    Both default + feature caps must pass — whichever is tighter
+    wins. We return a single (soft, hard) tuple representing the
+    composite enforcement.
+    """
+    default_row = (
+        await db.execute(
+            select(OrgAIDefaultCaps).where(OrgAIDefaultCaps.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+    feat_row = (
+        await db.execute(
+            select(OrgAIFeatureCaps).where(
+                OrgAIFeatureCaps.org_id == org_id,
+                OrgAIFeatureCaps.feature_key == feature_key,
+            )
+        )
+    ).scalar_one_or_none()
+
+    default_soft = default_row.soft_cap_cents if default_row else None
+    default_hard = default_row.hard_cap_cents if default_row else None
+    feat_soft = feat_row.soft_cap_cents if feat_row else None
+    feat_hard = feat_row.hard_cap_cents if feat_row else None
+
+    soft = _tighter_cap(default_soft, feat_soft)
+    hard = _tighter_cap(default_hard, feat_hard)
+    # The marker key distinguishes "feature override caused this" vs
+    # "org default caused this". Whichever cap value actually fired
+    # wins. The choice only matters for soft-cap warning dedup.
+    from_feature_override = feat_row is not None and (
+        feat_soft is not None or feat_hard is not None
+    )
+    return _ResolvedCaps(
+        soft_cap_cents=soft,
+        hard_cap_cents=hard,
+        from_feature_override=from_feature_override,
+    )
+
+
+def _current_period(now: Optional[datetime] = None) -> str:
+    """Return the calendar-month period string used for cap windows.
+
+    Format ``YYYY-MM`` in UTC. Aggregates across all rows whose
+    ``dispatched_at`` falls inside this calendar month for the org.
+    """
+    now = now or datetime.now(timezone.utc)
+    return f"{now.year:04d}-{now.month:02d}"
+
+
+def _month_start(now: Optional[datetime] = None) -> datetime:
+    """First instant of the current calendar month (UTC, naive)."""
+    now = now or datetime.now(timezone.utc)
+    # Naive because the ledger column is naive DateTime on SQLite +
+    # MySQL alike. The server_default for ``dispatched_at`` is also
+    # naive, so this matches the comparison shape.
+    return datetime(now.year, now.month, 1)
+
+
+async def _aggregate_cost_cents(
+    db: AsyncSession, *, org_id: int, since: datetime
+) -> int:
+    """Sum est_cost_cents for the org for the current period."""
+    total = await db.scalar(
+        select(func.coalesce(func.sum(AIUsageLedger.est_cost_cents), 0)).where(
+            AIUsageLedger.org_id == org_id,
+            AIUsageLedger.dispatched_at >= since,
+        )
+    )
+    return int(total or 0)
+
+
+# --- Soft-cap warning -------------------------------------------------
+
+
+async def _list_org_admin_user_ids(
+    db: AsyncSession, *, org_id: int
+) -> list[int]:
+    """Return user_ids for org admins/owners; recipients for the warning.
+
+    PR2 dispatches the warning to every owner+admin of the org. The
+    notification service is per-user, so a single soft-cap event
+    fans out to N rows. Idempotence (per org+feature+period) lives
+    in the Redis marker that wraps this whole branch.
+    """
+    res = await db.execute(
+        select(User.id).where(
+            User.org_id == org_id,
+            User.role.in_([Role.OWNER, Role.ADMIN]),
+        )
+    )
+    return [int(r) for r in res.scalars().all()]
+
+
+async def _maybe_warn_soft_cap(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    resolved: _ResolvedCaps,
+    cost_before_call: int,
+    period: str,
+) -> bool:
+    """Fire the first-time soft-cap warning for this period if needed.
+
+    Returns ``True`` if a warning was dispatched (or attempted), else
+    ``False``. Idempotence is guarded by a Redis marker; if Redis is
+    unavailable the warning still fires (degrades to "warn every call"
+    rather than skipping silently).
+    """
+    if resolved.soft_cap_cents is None:
+        return False
+    if cost_before_call < resolved.soft_cap_cents:
+        return False
+
+    marker_feature = (
+        feature_key if resolved.from_feature_override else "__default__"
+    )
+    marker_key = (
+        f"ai_soft_cap_warned:{org_id}:{marker_feature}:{period}"
+    )
+
+    redis = redis_client.get_client()
+    if redis is not None:
+        try:
+            # SET NX + EX guarantees a single warning per period.
+            set_ok = await redis.set(
+                marker_key,
+                "1",
+                ex=SOFT_CAP_WARNED_TTL_SECONDS,
+                nx=True,
+            )
+            if not set_ok:
+                return False
+        except Exception as exc:  # pragma: no cover - resilience path
+            # Don't let a Redis blip suppress the warning. Worst case
+            # the org sees the warning more than once per period; the
+            # ops signal still surfaces.
+            logger.warning(
+                "ai.dispatch.soft_cap_marker.redis_error",
+                error_class=type(exc).__name__,
+                org_id=org_id,
+                feature_key=feature_key,
+            )
+
+    percent = 0
+    if resolved.soft_cap_cents > 0:
+        percent = min(
+            100, int(round((cost_before_call / resolved.soft_cap_cents) * 100))
+        )
+    title, body, link_url = ai_cap_soft_warning(
+        feature_key=feature_key, period=period, percent=percent
+    )
+
+    recipients = await _list_org_admin_user_ids(db, org_id=org_id)
+    for user_id in recipients:
+        await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.ORG_ADMIN,
+            event_type="ai.cap.soft_warning",
+            title=title,
+            body=body,
+            link_url=link_url,
+        )
+    await db.commit()
+
+    logger.info(
+        "ai.dispatch.soft_cap.warned",
+        org_id=org_id,
+        feature_key=feature_key,
+        period=period,
+        soft_cap_cents=resolved.soft_cap_cents,
+        cost_before_call=cost_before_call,
+        recipients=len(recipients),
+    )
+    return True
+
+
+# --- Ledger write -----------------------------------------------------
+
+
+async def _write_ledger_row(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    credential_id: int,
+    feature_key: str,
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    est_cost_cents_value: int,
+    latency_ms: int,
+    success: bool,
+    error_class: Optional[str],
+) -> AIUsageLedger:
+    row = AIUsageLedger(
+        org_id=org_id,
+        credential_id=credential_id,
+        feature_key=feature_key,
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        est_cost_cents=est_cost_cents_value,
+        latency_ms=latency_ms,
+        success=success,
+        error_class=error_class,
+        dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+# --- Public chokepoint ------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DispatchResult:
+    """Internal-only result type for ``call_llm`` callers.
+
+    Carries the LLMResponse plus the ledger row id so the caller can
+    correlate downstream events (PR3+ may need this for audit).
+    """
+
+    response: LLMResponse
+    ledger_id: int
+
+
+async def call_llm(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    request_payload: dict,
+    capability: str = "chat",
+) -> DispatchResult:
+    """Dispatch a single LLM call through the cap + ledger chokepoint.
+
+    Args:
+        db: per-request AsyncSession.
+        org_id: routing + cap scope.
+        feature_key: maps to a ``ROUTABLE_FEATURE_NAMES`` entry.
+        request_payload: provider-neutral request body. PR2 only
+            wires ``capability="chat"``; the payload must carry
+            ``messages: list[dict]`` and may carry ``max_tokens``.
+        capability: which adapter method to call. PR2 ships ``"chat"``
+            only; other capabilities raise NotImplementedError.
+
+    Returns:
+        DispatchResult with the LLMResponse and the ledger row id.
+
+    Raises:
+        NoRoutingConfigured: no routing row at all -> HTTP 412.
+        AICapExceeded: hard cap reached -> HTTP 402.
+        NativeNotAvailable: native gate still off / not implemented.
+        AIDispatchFailed: any provider failure (network, 4xx, 5xx,
+            timeout, JSON parse). Ledger row written with success=false.
+    """
+    if capability != "chat":
+        # PR2 wires chat only. Spec §3 future-allows embed/function_call/
+        # stream but those land in PR3+.
+        raise NotImplementedError(
+            f"capability={capability!r} not wired in PR2; chat only"
+        )
+
+    # 1. Resolve routing.
+    routing = await ai_routing_service.get_routing_for_feature(
+        db, org_id=org_id, feature_name=feature_key
+    )
+    if routing is None:
+        logger.info(
+            "ai.dispatch.routing.missing",
+            org_id=org_id,
+            feature_key=feature_key,
+        )
+        raise NoRoutingConfigured()
+    credential_id, model = routing
+
+    # Pull the credential row (we need provider, base_url, encrypted
+    # key/bearer). The routing FK structurally pins it to org_id, but
+    # check belt-and-suspenders anyway.
+    cred = (
+        await db.execute(
+            select(OrgAICredential).where(
+                OrgAICredential.id == credential_id,
+                OrgAICredential.org_id == org_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if cred is None:
+        # Defensive: routing FK should make this unreachable.
+        logger.error(
+            "ai.dispatch.routing.dangling",
+            org_id=org_id,
+            feature_key=feature_key,
+            credential_id=credential_id,
+        )
+        raise NoRoutingConfigured()
+
+    # 2. Pre-check caps.
+    resolved = await _resolve_caps(
+        db, org_id=org_id, feature_key=feature_key
+    )
+    cost_so_far = await _aggregate_cost_cents(
+        db, org_id=org_id, since=_month_start()
+    )
+    if (
+        resolved.hard_cap_cents is not None
+        and cost_so_far >= resolved.hard_cap_cents
+    ):
+        logger.info(
+            "ai.dispatch.cap.exceeded",
+            org_id=org_id,
+            feature_key=feature_key,
+            cost_so_far=cost_so_far,
+            hard_cap_cents=resolved.hard_cap_cents,
+        )
+        raise AICapExceeded()
+
+    # 3. Soft-cap warning (first-time-in-period).
+    await _maybe_warn_soft_cap(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        resolved=resolved,
+        cost_before_call=cost_so_far,
+        period=_current_period(),
+    )
+
+    # 4. Build adapter.
+    api_key = decrypt(cred.encrypted_api_key)
+    bearer = (
+        decrypt(cred.encrypted_bearer_token)
+        if cred.encrypted_bearer_token
+        else None
+    )
+    adapter = get_adapter(
+        cred.provider,
+        api_key=api_key,
+        bearer_token=bearer,
+        base_url=cred.base_url,
+    )
+
+    messages = request_payload.get("messages") or []
+    max_tokens = request_payload.get("max_tokens")
+
+    # 5. Time + dispatch.
+    start = time.perf_counter()
+    try:
+        response: LLMResponse = await adapter.chat(  # type: ignore[attr-defined]
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+        )
+    except NativeNotAvailable:
+        # Don't write a ledger row — the call never reached a provider
+        # and "rejected because native is dormant" is the same posture
+        # as "rejected because routing missing" (no spend, no signal
+        # for the ops view).
+        logger.info(
+            "ai.dispatch.native.unavailable",
+            org_id=org_id,
+            feature_key=feature_key,
+        )
+        raise
+    except AIProviderError as exc:
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        await _write_ledger_row(
+            db,
+            org_id=org_id,
+            credential_id=credential_id,
+            feature_key=feature_key,
+            model=model,
+            prompt_tokens=0,
+            completion_tokens=0,
+            est_cost_cents_value=0,
+            latency_ms=latency_ms,
+            success=False,
+            error_class=exc.code,
+        )
+        logger.info(
+            "ai.dispatch.adapter.failed",
+            org_id=org_id,
+            feature_key=feature_key,
+            error_class=exc.code,
+            latency_ms=latency_ms,
+        )
+        raise AIDispatchFailed(exc.code) from None
+    except Exception as exc:  # pragma: no cover - defensive
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        await _write_ledger_row(
+            db,
+            org_id=org_id,
+            credential_id=credential_id,
+            feature_key=feature_key,
+            model=model,
+            prompt_tokens=0,
+            completion_tokens=0,
+            est_cost_cents_value=0,
+            latency_ms=latency_ms,
+            success=False,
+            error_class=type(exc).__name__,
+        )
+        logger.warning(
+            "ai.dispatch.unexpected_error",
+            org_id=org_id,
+            feature_key=feature_key,
+            error_class=type(exc).__name__,
+            latency_ms=latency_ms,
+        )
+        raise AIDispatchFailed(type(exc).__name__) from None
+
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    cost = estimate_cost_cents(
+        model=model,
+        prompt_tokens=response.prompt_tokens,
+        completion_tokens=response.completion_tokens,
+    )
+
+    # 6. Success ledger row.
+    ledger = await _write_ledger_row(
+        db,
+        org_id=org_id,
+        credential_id=credential_id,
+        feature_key=feature_key,
+        model=model,
+        prompt_tokens=response.prompt_tokens,
+        completion_tokens=response.completion_tokens,
+        est_cost_cents_value=cost,
+        latency_ms=latency_ms,
+        success=True,
+        error_class=None,
+    )
+
+    logger.info(
+        "ai.dispatch.success",
+        org_id=org_id,
+        feature_key=feature_key,
+        model=model,
+        prompt_tokens=response.prompt_tokens,
+        completion_tokens=response.completion_tokens,
+        est_cost_cents=cost,
+        latency_ms=latency_ms,
+        ledger_id=ledger.id,
+    )
+
+    # Best-effort last_used_at refresh — same fire-and-forget posture
+    # as the unwrap path in PR1's credential_service.
+    asyncio.create_task(_touch_last_used(cred.id))  # noqa: RUF006
+
+    return DispatchResult(response=response, ledger_id=ledger.id)
+
+
+async def _touch_last_used(credential_id: int) -> None:  # pragma: no cover
+    """Stub for the deferred last_used_at refresh hook.
+
+    PR1's credential_service.unwrap already has the bookkeeping live;
+    this stub is a placeholder so the call site in ``call_llm`` keeps
+    its current shape when the unified hook lands.
+    """
+    _ = credential_id
+    return

--- a/backend/app/services/ai_pricing.py
+++ b/backend/app/services/ai_pricing.py
@@ -1,0 +1,95 @@
+"""Cost-estimate constants for AI provider models (PR2 of AI tier train).
+
+Architect lock #18 / spec §7: cost estimates are **code constants**,
+updated quarterly via manual PR. No nightly crawler, no managed price
+feed. Approximate cost is fine — the cap is a guardrail, not an
+accounting truth.
+
+Updated quarterly via manual PR. No nightly crawler — see architect
+lock #14 in memory and spec §7.
+
+Values are USD cents per 1,000,000 tokens. Source for the v1 table is
+each provider's public pricing page as of 2026-05-22. The ``_default``
+row is a conservative high cost so an unknown model never silently
+under-meters (better to refuse a legitimate call after a polite
+warning than to accidentally let an org rack up unmetered spend).
+
+``estimate_cost_cents`` rounds **up** to the nearest cent — the cap
+is a ceiling, not a budget, and the rounding direction must match.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """Per-1M-token cost in USD cents.
+
+    Both ``prompt_per_1m_cents`` and ``completion_per_1m_cents`` are
+    integers in *cents* (not dollars), to match the rest of the cap /
+    ledger stack which is INT-cents end to end.
+    """
+
+    prompt_per_1m_cents: int
+    completion_per_1m_cents: int
+
+
+# Models pinned for the v1 ledger. Add new ones in a quarterly PR;
+# unknown models fall through to ``_default`` below.
+#
+# Pricing reference (2026-05-22, USD cents per 1M tokens):
+#   gpt-4o            : $2.50 in / $10.00 out   → 250 / 1000
+#   gpt-4o-mini       : $0.15 in / $0.60 out    → 15  / 60
+#   claude-sonnet-4-7 : $3.00 in / $15.00 out   → 300 / 1500
+#   claude-haiku-4-5  : $0.80 in / $4.00 out    → 80  / 400
+MODEL_PRICING: dict[str, ModelPricing] = {
+    "gpt-4o": ModelPricing(prompt_per_1m_cents=250, completion_per_1m_cents=1000),
+    "gpt-4o-mini": ModelPricing(prompt_per_1m_cents=15, completion_per_1m_cents=60),
+    "claude-sonnet-4-7": ModelPricing(
+        prompt_per_1m_cents=300, completion_per_1m_cents=1500
+    ),
+    "claude-haiku-4-5": ModelPricing(
+        prompt_per_1m_cents=80, completion_per_1m_cents=400
+    ),
+    # Conservative fallback — picked to be higher than every known
+    # frontier model. Unknown-model usage gets counted at this rate so
+    # the cap fires sooner rather than later. Refresh during the
+    # quarterly PR if frontier prices climb past this value.
+    "_default": ModelPricing(
+        prompt_per_1m_cents=1500, completion_per_1m_cents=6000
+    ),
+}
+
+
+def get_pricing(model: str) -> ModelPricing:
+    """Return the pricing row for ``model``, or the ``_default`` row."""
+    return MODEL_PRICING.get(model, MODEL_PRICING["_default"])
+
+
+def estimate_cost_cents(
+    *, model: str, prompt_tokens: int, completion_tokens: int
+) -> int:
+    """Compute the integer-cent cost estimate for a single call.
+
+    Cost = (prompt_tokens * prompt_per_1m / 1_000_000)
+         + (completion_tokens * completion_per_1m / 1_000_000)
+
+    Rounded **up** to the nearest cent (math.ceil). The cap is a
+    ceiling, so under-rounding would defeat the guardrail. Zero
+    tokens => zero cents.
+    """
+    if prompt_tokens <= 0 and completion_tokens <= 0:
+        return 0
+    pricing = get_pricing(model)
+    raw = (
+        prompt_tokens * pricing.prompt_per_1m_cents
+        + completion_tokens * pricing.completion_per_1m_cents
+    )
+    # math.ceil on a fraction; integer-only arithmetic so we don't
+    # round through a float.
+    cents, remainder = divmod(raw, 1_000_000)
+    if remainder > 0:
+        cents += 1
+    return cents

--- a/backend/app/services/ai_providers/__init__.py
+++ b/backend/app/services/ai_providers/__init__.py
@@ -1,21 +1,24 @@
-"""Provider adapter package for BYO AI credentials (PR1).
+"""Provider adapter package for BYO AI credentials.
 
-PR1 ships only the ``ValidateCapable`` protocol — adapters reach out to
-each provider's ``/models`` endpoint to confirm the key works and
-discover available models. The other Capable protocols
-(``ChatCapable``, ``EmbedCapable``, ``StructuredOutputCapable``,
-``StreamCapable``, ``FunctionCallCapable``) are declared as empty
-``Protocol`` stubs so type-checking lights up in later PRs without a
-follow-up refactor of this module.
+PR1 shipped the ``ValidateCapable`` protocol. PR2 adds:
+
+- ``ChatCapable.chat`` — implementations on OpenAI, Anthropic,
+  Ollama, and OpenAI-compatible adapters.
+- ``LLMResponse`` — provider-neutral response shape.
+- ``AIProviderError`` — typed wrapper with a sanitized message.
+- ``StructuredOutputCapable.chat_structured`` — protocol signature
+  only (implementations deferred to PR3 per architect lock).
 
 Distinct from the older ``ai_adapters`` package (LAI foundation mock
 adapter) — that one is the call_llm() chokepoint; this one is the
 provider abstraction for BYO credentials.
 """
 from app.services.ai_providers.base import (
+    AIProviderError,
     ChatCapable,
     EmbedCapable,
     FunctionCallCapable,
+    LLMResponse,
     NativeNotAvailable,
     StreamCapable,
     StructuredOutputCapable,
@@ -25,9 +28,11 @@ from app.services.ai_providers.base import (
 )
 
 __all__ = [
+    "AIProviderError",
     "ChatCapable",
     "EmbedCapable",
     "FunctionCallCapable",
+    "LLMResponse",
     "NativeNotAvailable",
     "StreamCapable",
     "StructuredOutputCapable",

--- a/backend/app/services/ai_providers/anthropic.py
+++ b/backend/app/services/ai_providers/anthropic.py
@@ -1,15 +1,25 @@
-"""Anthropic adapter — validates by GET /v1/models."""
+"""Anthropic adapter — validate via GET /v1/models, chat via /v1/messages."""
 from __future__ import annotations
+
+from typing import Optional
 
 import httpx
 
-from app.services.ai_providers.base import ValidateResult
+from app.services.ai_providers.base import (
+    AIProviderError,
+    LLMResponse,
+    ValidateResult,
+)
 
 
 VALIDATE_TIMEOUT_S = 10.0
+CHAT_TIMEOUT_S = 30.0
 DEFAULT_CAPABILITIES = ["chat"]
 MODELS_URL = "https://api.anthropic.com/v1/models"
+MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
+# Anthropic requires max_tokens on every messages call.
+DEFAULT_CHAT_MAX_TOKENS = 1024
 
 
 class AnthropicAdapter:
@@ -52,3 +62,80 @@ class AnthropicAdapter:
             discovered_models=models,
             discovered_capabilities=list(DEFAULT_CAPABILITIES),
         )
+
+    async def chat(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """POST /v1/messages. Maps response.content[*].text -> content.
+
+        Anthropic separates ``system`` from the user/assistant turns.
+        We do the standard remap: any ``role == "system"`` message
+        becomes the top-level ``system`` field; the rest stay in
+        ``messages``.
+        """
+        system_parts: list[str] = []
+        chat_messages: list[dict] = []
+        for m in messages:
+            if m.get("role") == "system":
+                content = m.get("content") or ""
+                if content:
+                    system_parts.append(str(content))
+            else:
+                chat_messages.append(m)
+
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+        }
+        body: dict = {
+            "model": model,
+            "messages": chat_messages,
+            "max_tokens": max_tokens or DEFAULT_CHAT_MAX_TOKENS,
+        }
+        if system_parts:
+            body["system"] = "\n\n".join(system_parts)
+
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(
+                    MESSAGES_URL, headers=headers, json=body
+                )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            blocks = payload.get("content", []) or []
+            content_text = "".join(
+                str(b.get("text", "") or "")
+                for b in blocks
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("input_tokens", 0) or 0)
+            completion_tokens = int(usage.get("output_tokens", 0) or 0)
+        except (KeyError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content_text,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
+        raise NotImplementedError("PR3")

--- a/backend/app/services/ai_providers/base.py
+++ b/backend/app/services/ai_providers/base.py
@@ -1,8 +1,18 @@
-"""Capability protocols + adapter factory for BYO AI providers (PR1).
+"""Capability protocols + adapter factory for BYO AI providers.
 
-Only ``ValidateCapable`` has a real implementation today; the other
-protocols are empty stubs reserved for PR3+ (chat / embed / function
-calling / streaming / structured output).
+PR1 shipped ``ValidateCapable`` only. PR2 adds:
+
+- ``LLMResponse`` — provider-neutral chat response shape consumed by
+  the dispatch chokepoint (``call_llm`` in ``ai_dispatch``).
+- ``AIProviderError`` — typed wrapper raised by every adapter when
+  the provider call fails. The wrapped message is **sanitized** (no
+  provider response body), per the PR1 SSRF / sanitization lock.
+- ``ChatCapable.chat`` — protocol signature for the chat dispatch.
+  OpenAI, Anthropic, Ollama, and OpenAI-compatible adapters implement
+  it as a thin pass-through; Native still raises ``NativeNotAvailable``.
+- ``StructuredOutputCapable.chat_structured`` — protocol signature
+  only. The implementation is deferred to PR3 (architect lock: retry
+  cap).
 """
 from __future__ import annotations
 
@@ -20,6 +30,25 @@ class ValidateResult:
     discovered_capabilities: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class LLMResponse:
+    """Provider-neutral chat response.
+
+    ``content`` is the assistant message text. ``prompt_tokens`` /
+    ``completion_tokens`` feed the cap accounting (``est_cost_cents``
+    is computed downstream by ``ai_pricing.estimate_cost_cents``).
+    ``model`` echoes the model the adapter actually called — useful
+    in the ledger for ops debugging when an adapter falls back to a
+    different model than the routing requested (e.g. Ollama with a
+    missing pinned model).
+    """
+
+    content: str
+    prompt_tokens: int
+    completion_tokens: int
+    model: str
+
+
 class NativeNotAvailable(Exception):
     """Raised by the native adapter while AI_NATIVE_ENABLED is False.
 
@@ -35,20 +64,39 @@ class NativeNotAvailable(Exception):
         self.code = code
 
 
+class AIProviderError(Exception):
+    """Adapter-side failure surface.
+
+    Wraps any network/4xx/5xx/timeout exception from a provider into
+    a typed error with a **sanitized** message. The raw provider
+    response body and the exception's own repr are NEVER carried
+    through — a hostile OAI-compatible endpoint can mirror request
+    headers back, leaking the plaintext API key that just left this
+    process. Same posture as PR1's ``validate`` paths.
+    """
+
+    def __init__(self, *, code: str, status_code: Optional[int] = None) -> None:
+        super().__init__(code)
+        self.code = code
+        self.status_code = status_code
+
+
 @runtime_checkable
 class ValidateCapable(Protocol):
     async def validate(self) -> ValidateResult:
         ...
 
 
-# ---------------------------------------------------------------------
-# Stubs reserved for PR3+. Empty Protocol bodies — implementations land
-# alongside the per-feature surfaces that need them.
-# ---------------------------------------------------------------------
-
 @runtime_checkable
 class ChatCapable(Protocol):
-    ...  # implemented in PR3+
+    async def chat(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        ...
 
 
 @runtime_checkable
@@ -58,7 +106,23 @@ class EmbedCapable(Protocol):
 
 @runtime_checkable
 class StructuredOutputCapable(Protocol):
-    ...  # implemented in PR3+
+    """Protocol signature only — implementation deferred to PR3.
+
+    Architect lock: ``chat_structured`` ships in PR3 with the
+    documented retry cap of 2 on JSON parse / schema-validation
+    failure. Defining the signature here lets PR3 add adapter
+    implementations without re-shaping the protocol layer.
+    """
+
+    async def chat_structured(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        schema: dict,
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        ...
 
 
 @runtime_checkable

--- a/backend/app/services/ai_providers/native.py
+++ b/backend/app/services/ai_providers/native.py
@@ -49,3 +49,13 @@ class NativeAdapter:
         # registry symmetric and lets PR4 plug in real validation
         # without changing the call sites.
         raise NativeNotAvailable("not_yet_available")
+
+    async def chat(self, *, model, messages, max_tokens=None):
+        # PR4 will gate this on ``AI_NATIVE_ENABLED`` once a real native
+        # backend exists. For PR2 the adapter is wired into the
+        # registry so the dispatch layer is symmetric, but the chat
+        # path still refuses immediately.
+        raise NativeNotAvailable("not_yet_available")
+
+    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
+        raise NativeNotAvailable("not_yet_available")

--- a/backend/app/services/ai_providers/ollama.py
+++ b/backend/app/services/ai_providers/ollama.py
@@ -2,6 +2,7 @@
 
 Auth on Ollama is rare in the wild but supported via an optional
 ``Bearer`` token when fronting the server with a reverse proxy.
+PR2 adds the ``chat()`` pass-through against ``/api/chat``.
 """
 from __future__ import annotations
 
@@ -9,10 +10,15 @@ from typing import Optional
 
 import httpx
 
-from app.services.ai_providers.base import ValidateResult
+from app.services.ai_providers.base import (
+    AIProviderError,
+    LLMResponse,
+    ValidateResult,
+)
 
 
 VALIDATE_TIMEOUT_S = 10.0
+CHAT_TIMEOUT_S = 30.0
 DEFAULT_CAPABILITIES = ["chat", "embed"]
 
 
@@ -31,10 +37,14 @@ class OllamaAdapter:
         self.api_key = api_key
         self.bearer_token = bearer_token
 
-    async def validate(self) -> ValidateResult:
+    def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {}
         if self.bearer_token:
             headers["Authorization"] = f"Bearer {self.bearer_token}"
+        return headers
+
+    async def validate(self) -> ValidateResult:
+        headers = self._headers()
         url = f"{self.base_url}/api/tags"
         try:
             async with httpx.AsyncClient(timeout=VALIDATE_TIMEOUT_S) as client:
@@ -67,3 +77,61 @@ class OllamaAdapter:
             discovered_models=models,
             discovered_capabilities=list(DEFAULT_CAPABILITIES),
         )
+
+    async def chat(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """POST {base_url}/api/chat. ``stream=false`` so we get one
+        complete response back, not an NDJSON stream.
+
+        Ollama doesn't return a stable token-count contract — newer
+        builds emit ``prompt_eval_count`` / ``eval_count`` at the top
+        level, older ones don't. We use them when present and fall
+        back to 0 (cost falls back to the ``_default`` pricing row,
+        which is conservatively high — see ``ai_pricing``).
+        """
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        body: dict = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+        }
+        if max_tokens is not None:
+            body["options"] = {"num_predict": max_tokens}
+        url = f"{self.base_url}/api/chat"
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(url, headers=headers, json=body)
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            message = payload.get("message", {}) or {}
+            content = str(message.get("content", "") or "")
+            prompt_tokens = int(payload.get("prompt_eval_count", 0) or 0)
+            completion_tokens = int(payload.get("eval_count", 0) or 0)
+        except (KeyError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
+        raise NotImplementedError("PR3")

--- a/backend/app/services/ai_providers/openai.py
+++ b/backend/app/services/ai_providers/openai.py
@@ -1,14 +1,22 @@
-"""OpenAI adapter — validates by GET /v1/models."""
+"""OpenAI adapter — validate via GET /v1/models, chat via /v1/chat/completions."""
 from __future__ import annotations
+
+from typing import Optional
 
 import httpx
 
-from app.services.ai_providers.base import ValidateResult
+from app.services.ai_providers.base import (
+    AIProviderError,
+    LLMResponse,
+    ValidateResult,
+)
 
 
 VALIDATE_TIMEOUT_S = 10.0
+CHAT_TIMEOUT_S = 30.0
 DEFAULT_CAPABILITIES = ["chat", "embed"]
 MODELS_URL = "https://api.openai.com/v1/models"
+CHAT_URL = "https://api.openai.com/v1/chat/completions"
 
 
 class OpenAIAdapter:
@@ -48,3 +56,57 @@ class OpenAIAdapter:
             discovered_models=models,
             discovered_capabilities=list(DEFAULT_CAPABILITIES),
         )
+
+    async def chat(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """POST /v1/chat/completions. 30s timeout.
+
+        Errors are wrapped in ``AIProviderError`` with a sanitized
+        ``code`` — never the provider's response body, never the raw
+        exception repr (same posture as ``validate``).
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body: dict = {"model": model, "messages": messages}
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(CHAT_URL, headers=headers, json=body)
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            content = payload["choices"][0]["message"]["content"] or ""
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+        except (KeyError, IndexError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
+        # Architect lock: chat_structured is PR3 with retry cap.
+        raise NotImplementedError("PR3")

--- a/backend/app/services/ai_providers/openai_compatible.py
+++ b/backend/app/services/ai_providers/openai_compatible.py
@@ -1,12 +1,19 @@
 """OpenAI-compatible adapter — validates by GET {base_url}/v1/models."""
 from __future__ import annotations
 
+from typing import Optional
+
 import httpx
 
-from app.services.ai_providers.base import ValidateResult
+from app.services.ai_providers.base import (
+    AIProviderError,
+    LLMResponse,
+    ValidateResult,
+)
 
 
 VALIDATE_TIMEOUT_S = 10.0
+CHAT_TIMEOUT_S = 30.0
 DEFAULT_CAPABILITIES = ["chat", "embed"]
 
 
@@ -54,3 +61,57 @@ class OpenAICompatibleAdapter:
             discovered_models=models,
             discovered_capabilities=list(DEFAULT_CAPABILITIES),
         )
+
+    async def chat(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """POST {base_url}/v1/chat/completions.
+
+        Same response shape as the OpenAI adapter — hostile OAI-compatible
+        endpoints can still mirror the request body back, so error
+        wrapping never echoes provider content.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body: dict = {"model": model, "messages": messages}
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        url = f"{self.base_url}/v1/chat/completions"
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(url, headers=headers, json=body)
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            content = payload["choices"][0]["message"]["content"] or ""
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+        except (KeyError, IndexError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
+        raise NotImplementedError("PR3")

--- a/backend/app/services/notification_templates.py
+++ b/backend/app/services/notification_templates.py
@@ -1,0 +1,44 @@
+"""Notification copy templates (PR2 of AI tier train).
+
+This module centralizes notification ``title`` / ``body`` strings for
+events the backend emits. The notification service (`PR1`) deliberately
+left these as caller-passed strings; this module adds the first one
+(``ai.cap.soft_warning``) and keeps the surface minimal so PR3+ can
+grow it without re-shaping the API.
+
+Module shape:
+
+- Each function returns a ``(title, body, link_url)`` tuple. Plain
+  Python strings, no Markdown — the notification feed renders the
+  body verbatim. ``link_url`` is ``None`` for now because PR2 doesn't
+  ship a usage-detail page (admins investigate via the new
+  ``/api/v1/admin/ai/usage`` endpoint).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+def ai_cap_soft_warning(
+    *, feature_key: str, period: str, percent: int
+) -> tuple[str, str, Optional[str]]:
+    """Copy for the first-time soft-cap crossing in a billing period.
+
+    Args:
+        feature_key: e.g. ``"chat"`` or ``"categorize_transactions"``.
+        period: ``YYYY-MM`` string for the calendar month the cap
+            applies to.
+        percent: how much of the soft cap has been consumed at the
+            moment of the warning. Rounded to a whole integer.
+
+    Returns:
+        ``(title, body, link_url)``. ``link_url`` is None — admins
+        investigate via the superadmin ``/admin/ai/usage`` debug
+        endpoint until PR3+ ships a customer-facing usage page.
+    """
+    title = "AI spend approaching cap"
+    body = (
+        f"{feature_key} usage in {period} reached {percent}% "
+        "of the soft cap."
+    )
+    return (title, body, None)

--- a/backend/tests/routers/test_admin_ai_usage.py
+++ b/backend/tests/routers/test_admin_ai_usage.py
@@ -1,0 +1,255 @@
+"""Admin AI usage debug endpoint tests (PR2 of AI tier train).
+
+Pins:
+
+- Superadmin GET returns aggregated usage for the period.
+- Non-superadmin -> 403.
+- Cross-org isolation: superadmin can read any org; regular admin cannot.
+- Period parse rejects bad shapes (400).
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Base
+from app.models.ai_usage_ledger import AIUsageLedger
+from app.models.user import Organization, Role, User
+from app.routers.admin_ai_usage import router as admin_router
+from app.security import hash_password
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _make_app(session_factory, user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await user_resolver(session_factory)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.include_router(admin_router)
+    return app
+
+
+async def _seed(session_factory) -> tuple[int, int, int]:
+    """Insert two orgs + ledger rows for the first one.
+
+    Returns (target_org_id, superadmin_user_id, regular_admin_user_id).
+    """
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        other = Organization(name="Other", billing_cycle_day=1)
+        db.add(other)
+        await db.commit()
+
+        superadmin = User(
+            org_id=org.id,
+            username="super",
+            email="super@admin.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+            is_superadmin=True,
+        )
+        admin = User(
+            org_id=org.id,
+            username="admin",
+            email="admin@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.ADMIN,
+            is_active=True,
+            email_verified=True,
+            is_superadmin=False,
+        )
+        db.add_all([superadmin, admin])
+        await db.commit()
+
+        # Ledger rows for org in May 2026.
+        rows = [
+            AIUsageLedger(
+                org_id=org.id,
+                credential_id=None,
+                feature_key="chat",
+                model="gpt-4o-mini",
+                prompt_tokens=100,
+                completion_tokens=50,
+                total_tokens=150,
+                est_cost_cents=5,
+                latency_ms=42,
+                success=True,
+                error_class=None,
+                dispatched_at=datetime(2026, 5, 10, 12, 0, 0),
+            ),
+            AIUsageLedger(
+                org_id=org.id,
+                credential_id=None,
+                feature_key="chat",
+                model="gpt-4o-mini",
+                prompt_tokens=200,
+                completion_tokens=80,
+                total_tokens=280,
+                est_cost_cents=10,
+                latency_ms=44,
+                success=True,
+                error_class=None,
+                dispatched_at=datetime(2026, 5, 15, 12, 0, 0),
+            ),
+            AIUsageLedger(
+                org_id=org.id,
+                credential_id=None,
+                feature_key="smart_forecast",
+                model="claude-haiku-4-5",
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                est_cost_cents=0,
+                latency_ms=10,
+                success=False,
+                error_class="provider_status_500",
+                dispatched_at=datetime(2026, 5, 20, 12, 0, 0),
+            ),
+            # Out-of-period row (April).
+            AIUsageLedger(
+                org_id=org.id,
+                credential_id=None,
+                feature_key="chat",
+                model="gpt-4o-mini",
+                prompt_tokens=999,
+                completion_tokens=999,
+                total_tokens=1998,
+                est_cost_cents=999,
+                latency_ms=10,
+                success=True,
+                error_class=None,
+                dispatched_at=datetime(2026, 4, 30, 23, 59, 59),
+            ),
+        ]
+        db.add_all(rows)
+        await db.commit()
+        return (org.id, superadmin.id, admin.id)
+
+
+async def _get_user(session_factory, user_id: int) -> User:
+    from sqlalchemy import select
+
+    async with session_factory() as db:
+        return (await db.execute(select(User).where(User.id == user_id))).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_superadmin_can_aggregate_usage(session_factory):
+    org_id, super_id, _ = await _seed(session_factory)
+
+    async def resolver(factory):
+        return await _get_user(factory, super_id)
+
+    client = TestClient(_make_app(session_factory, resolver))
+    resp = client.get(f"/api/v1/admin/ai/usage?org_id={org_id}&period=2026-05")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["org_id"] == org_id
+    assert body["period"] == "2026-05"
+    assert body["total_prompt_tokens"] == 300
+    assert body["total_completion_tokens"] == 130
+    assert body["total_cost_cents"] == 15  # 5 + 10 (+ 0 for failed)
+    assert body["total_calls"] == 3
+    by_feature = {row["feature_key"]: row for row in body["by_feature"]}
+    assert by_feature["chat"]["calls"] == 2
+    assert by_feature["chat"]["failed_calls"] == 0
+    assert by_feature["smart_forecast"]["calls"] == 1
+    assert by_feature["smart_forecast"]["failed_calls"] == 1
+    # April row is NOT counted.
+    assert "999" not in str(body)
+
+
+@pytest.mark.asyncio
+async def test_regular_admin_gets_403(session_factory):
+    org_id, _, admin_id = await _seed(session_factory)
+
+    async def resolver(factory):
+        return await _get_user(factory, admin_id)
+
+    client = TestClient(_make_app(session_factory, resolver))
+    resp = client.get(f"/api/v1/admin/ai/usage?org_id={org_id}&period=2026-05")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_superadmin_can_read_other_orgs(session_factory):
+    """Cross-org reads are the whole point — superadmin debug tool."""
+    org_id, super_id, _ = await _seed(session_factory)
+    # Confirm we can also read org_id+1 (the "Other" org seeded above)
+    # and get an empty aggregation back rather than 403.
+    async def resolver(factory):
+        return await _get_user(factory, super_id)
+
+    client = TestClient(_make_app(session_factory, resolver))
+    resp = client.get(
+        f"/api/v1/admin/ai/usage?org_id={org_id + 1}&period=2026-05"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_calls"] == 0
+    assert body["by_feature"] == []
+
+
+@pytest.mark.asyncio
+async def test_bad_period_returns_400(session_factory):
+    org_id, super_id, _ = await _seed(session_factory)
+
+    async def resolver(factory):
+        return await _get_user(factory, super_id)
+
+    client = TestClient(_make_app(session_factory, resolver))
+    resp = client.get(
+        f"/api/v1/admin/ai/usage?org_id={org_id}&period=2026/05"
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["detail"]["code"] == "invalid_period_format"

--- a/backend/tests/services/test_ai_adapters_chat.py
+++ b/backend/tests/services/test_ai_adapters_chat.py
@@ -1,0 +1,309 @@
+"""Adapter chat() method tests (PR2 of AI tier train).
+
+Each adapter (OpenAI, Anthropic, Ollama, OpenAI-compatible) is mocked
+via ``httpx.MockTransport`` and asserted against:
+
+- Request URL is correct for the provider.
+- Auth header is present and carries the API key (or bearer token).
+- Request body shape is provider-correct.
+- Response is parsed into ``LLMResponse`` with the documented token
+  fields.
+- Errors are wrapped in ``AIProviderError`` and the wrapped message
+  NEVER carries a leaked-secret marker (provider response body is
+  not echoed).
+"""
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import httpx
+import pytest
+
+from app.services.ai_providers.anthropic import AnthropicAdapter
+from app.services.ai_providers.base import AIProviderError
+from app.services.ai_providers.ollama import OllamaAdapter
+from app.services.ai_providers.openai import OpenAIAdapter
+from app.services.ai_providers.openai_compatible import (
+    OpenAICompatibleAdapter,
+)
+
+
+# Sentinel that, if it appears in any wrapped error message, means a
+# hostile provider response body has leaked through the adapter's
+# sanitization. Treat every adapter-level error catch as a test point.
+LEAKED_SECRET_MARKER = "sk-LEAKED-XXX"
+
+
+def _install_transport(monkeypatch, handler) -> list[httpx.Request]:
+    """Install an httpx.MockTransport on AsyncClient and capture
+    requests for later assertion.
+    """
+    captured: list[httpx.Request] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(_wrapped)
+    original = httpx.AsyncClient.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _patched_init)
+    return captured
+
+
+# ---------- OpenAI ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_request_shape_and_response_parsing(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["model"] == "gpt-4o-mini"
+        assert body["messages"] == [{"role": "user", "content": "hi"}]
+        return httpx.Response(
+            200,
+            json={
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {"message": {"role": "assistant", "content": "hello!"}}
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+            },
+        )
+
+    captured = _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    resp = await adapter.chat(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert resp.content == "hello!"
+    assert resp.prompt_tokens == 10
+    assert resp.completion_tokens == 5
+    assert resp.model == "gpt-4o-mini"
+    req = captured[0]
+    assert str(req.url) == "https://api.openai.com/v1/chat/completions"
+    assert req.headers["Authorization"] == "Bearer sk-test"
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_500_is_sanitized(monkeypatch):
+    """A 5xx must surface a sanitized AIProviderError that does NOT
+    carry the provider's response body (which could mirror a leaked
+    secret).
+    """
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # Provider body laced with a fake leaked secret.
+        return httpx.Response(
+            500,
+            text=f"internal err — saw your key {LEAKED_SECRET_MARKER}",
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.chat(model="gpt-4o-mini", messages=[])
+    msg = str(exc_info.value)
+    assert LEAKED_SECRET_MARKER not in msg
+    assert exc_info.value.code == "provider_status_500"
+
+
+# ---------- Anthropic -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_chat_request_shape_and_response_parsing(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        # role=system is remapped to top-level system field.
+        assert body["model"] == "claude-haiku-4-5"
+        assert body["system"] == "You are helpful."
+        assert body["messages"] == [{"role": "user", "content": "ping"}]
+        assert body["max_tokens"] == 1024
+        return httpx.Response(
+            200,
+            json={
+                "model": "claude-haiku-4-5",
+                "content": [
+                    {"type": "text", "text": "pong"},
+                    {"type": "text", "text": "!"},
+                ],
+                "usage": {"input_tokens": 11, "output_tokens": 4},
+            },
+        )
+
+    captured = _install_transport(monkeypatch, handler)
+    adapter = AnthropicAdapter(api_key="sk-ant-test")
+    resp = await adapter.chat(
+        model="claude-haiku-4-5",
+        messages=[
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "ping"},
+        ],
+    )
+    assert resp.content == "pong!"
+    assert resp.prompt_tokens == 11
+    assert resp.completion_tokens == 4
+    assert resp.model == "claude-haiku-4-5"
+    req = captured[0]
+    assert str(req.url) == "https://api.anthropic.com/v1/messages"
+    assert req.headers["x-api-key"] == "sk-ant-test"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_4xx_is_sanitized(monkeypatch):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401, text=f"bad key {LEAKED_SECRET_MARKER}"
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = AnthropicAdapter(api_key="sk-ant-test")
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.chat(
+            model="claude-haiku-4-5",
+            messages=[{"role": "user", "content": "x"}],
+        )
+    assert LEAKED_SECRET_MARKER not in str(exc_info.value)
+    assert exc_info.value.code == "provider_status_401"
+
+
+# ---------- Ollama ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_chat_no_bearer(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["stream"] is False
+        assert body["model"] == "llama3:8b"
+        assert "Authorization" not in request.headers
+        return httpx.Response(
+            200,
+            json={
+                "model": "llama3:8b",
+                "message": {"role": "assistant", "content": "ack"},
+                "prompt_eval_count": 7,
+                "eval_count": 3,
+            },
+        )
+
+    captured = _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    resp = await adapter.chat(
+        model="llama3:8b", messages=[{"role": "user", "content": "yo"}]
+    )
+    assert resp.content == "ack"
+    assert resp.prompt_tokens == 7
+    assert resp.completion_tokens == 3
+    assert str(captured[0].url) == "http://10.0.0.10:11434/api/chat"
+
+
+@pytest.mark.asyncio
+async def test_ollama_chat_with_bearer_token(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer secret-bearer"
+        return httpx.Response(
+            200,
+            json={
+                "model": "llama3:8b",
+                "message": {"role": "assistant", "content": "ok"},
+                "prompt_eval_count": 1,
+                "eval_count": 1,
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434",
+        api_key="x",
+        bearer_token="secret-bearer",
+    )
+    resp = await adapter.chat(
+        model="llama3:8b", messages=[{"role": "user", "content": "x"}]
+    )
+    assert resp.content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ollama_5xx_is_sanitized(monkeypatch):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text=f"down — {LEAKED_SECRET_MARKER}")
+
+    _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.chat(
+            model="llama3:8b",
+            messages=[{"role": "user", "content": "x"}],
+        )
+    assert LEAKED_SECRET_MARKER not in str(exc_info.value)
+
+
+# ---------- OpenAI-compatible ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_chat_shape(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["model"] == "any-model"
+        assert request.headers["Authorization"] == "Bearer sk-compat"
+        return httpx.Response(
+            200,
+            json={
+                "model": "any-model",
+                "choices": [
+                    {"message": {"role": "assistant", "content": "yo"}}
+                ],
+                "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+            },
+        )
+
+    captured = _install_transport(monkeypatch, handler)
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    resp = await adapter.chat(
+        model="any-model", messages=[{"role": "user", "content": "x"}]
+    )
+    assert resp.content == "yo"
+    assert resp.prompt_tokens == 2
+    assert resp.completion_tokens == 1
+    assert (
+        str(captured[0].url)
+        == "https://compat.example.org/v1/chat/completions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_hostile_response_does_not_leak(monkeypatch):
+    """Spec §10 T2-class invariant: a hostile OAI-compatible endpoint
+    mirroring the request back through an error body MUST NOT leak
+    the secret marker into the wrapped exception's message.
+    """
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            418, text=f"echo of request: {LEAKED_SECRET_MARKER}"
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.chat(
+            model="any-model",
+            messages=[{"role": "user", "content": "x"}],
+        )
+    assert LEAKED_SECRET_MARKER not in str(exc_info.value)
+    assert exc_info.value.code == "provider_status_418"

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -1,0 +1,560 @@
+"""Dispatch service tests (PR2 of AI tier train).
+
+Pins the ``call_llm`` chokepoint:
+
+- Happy path writes a ledger row.
+- Missing routing raises ``NoRoutingConfigured``.
+- Hard cap raises ``AICapExceeded``; the adapter is NEVER called and
+  NO ledger row is written for the rejected call.
+- Soft cap crossing first time -> notification dispatched + Redis
+  marker set; second call same period does NOT re-dispatch.
+- Adapter failure -> ledger row with success=false, error_class set,
+  exception re-raised as AIDispatchFailed.
+- Feature cap tighter than default -> feature cap wins.
+- Default cap tighter than feature cap -> default cap wins.
+"""
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.models import Base
+from app.models.ai_usage_ledger import AIUsageLedger
+from app.models.org_ai_caps import OrgAIDefaultCaps, OrgAIFeatureCaps
+from app.models.org_ai_credential import AiProvider, OrgAICredential
+from app.models.org_ai_routing import (
+    OrgAIDefaultRouting,
+    OrgAIFeatureRouting,
+)
+from app.models.user import Organization, Role, User
+from app.services import ai_dispatch
+from app.services.ai_credential_crypto import encrypt
+from app.services.ai_dispatch import (
+    AICapExceeded,
+    AIDispatchFailed,
+    NoRoutingConfigured,
+    call_llm,
+)
+from app.services.ai_providers.base import AIProviderError, LLMResponse
+
+
+# ---------- fixtures --------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture(autouse=True)
+def _set_ai_key(monkeypatch):
+    monkeypatch.setattr(
+        app_settings,
+        "ai_credential_encryption_key",
+        base64.urlsafe_b64encode(os.urandom(32)).decode("ascii"),
+    )
+    monkeypatch.setattr(
+        app_settings, "ai_credential_encryption_key_prev", ""
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_redis(monkeypatch):
+    """Default: Redis disabled so the soft-cap path falls through to
+    "warn every call". Tests that care about marker behavior install
+    their own MagicMock client.
+    """
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client",
+        lambda: None,
+    )
+
+
+@pytest_asyncio.fixture
+async def org(db: AsyncSession) -> Organization:
+    org = Organization(name="Acme", billing_cycle_day=1)
+    db.add(org)
+    await db.commit()
+    return org
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession, org: Organization) -> User:
+    user = User(
+        org_id=org.id,
+        username="admin",
+        email="admin@example.com",
+        password_hash="x" * 64,
+        role=Role.OWNER,
+    )
+    db.add(user)
+    await db.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def credential(db: AsyncSession, org: Organization) -> OrgAICredential:
+    cred = OrgAICredential(
+        org_id=org.id,
+        provider=AiProvider.OPENAI,
+        encrypted_api_key=encrypt("sk-test-12345"),
+        encrypted_bearer_token=None,
+        base_url=None,
+        key_fingerprint="0123456789abcdef",
+        last_four="2345",
+        label="primary",
+    )
+    db.add(cred)
+    await db.commit()
+    return cred
+
+
+@pytest_asyncio.fixture
+async def default_routing(
+    db: AsyncSession, org: Organization, credential: OrgAICredential
+) -> OrgAIDefaultRouting:
+    row = OrgAIDefaultRouting(
+        org_id=org.id, credential_id=credential.id, model="gpt-4o-mini"
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
+def _make_adapter(response: Optional[LLMResponse] = None, raises=None):
+    """Build an adapter mock with an async chat() coroutine."""
+    adapter = MagicMock()
+    if raises is not None:
+        adapter.chat = AsyncMock(side_effect=raises)
+    else:
+        adapter.chat = AsyncMock(
+            return_value=response
+            or LLMResponse(
+                content="hi", prompt_tokens=10, completion_tokens=5, model="gpt-4o-mini"
+            )
+        )
+    return adapter
+
+
+# ---------- happy path ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_writes_ledger_row(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    adapter = _make_adapter(
+        LLMResponse(
+            content="hello", prompt_tokens=42, completion_tokens=8, model="gpt-4o-mini"
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert result.response.content == "hello"
+    adapter.chat.assert_awaited_once()
+    # Ledger row written.
+    rows = (
+        await db.execute(select(AIUsageLedger).where(AIUsageLedger.org_id == org.id))
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].success is True
+    assert rows[0].prompt_tokens == 42
+    assert rows[0].completion_tokens == 8
+    assert rows[0].total_tokens == 50
+    assert rows[0].feature_key == "chat"
+    assert rows[0].model == "gpt-4o-mini"
+    assert rows[0].error_class is None
+    assert rows[0].est_cost_cents >= 1  # nonzero from pricing table
+
+
+# ---------- no routing ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_routing_raises_412(
+    db: AsyncSession, org: Organization, admin_user
+):
+    with pytest.raises(NoRoutingConfigured) as exc_info:
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    assert exc_info.value.code == "ai_routing_not_configured"
+
+
+# ---------- hard cap --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hard_cap_blocks_dispatch_no_adapter_call_no_ledger_row(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    # Default cap: hard=10 cents.
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id, soft_cap_cents=None, hard_cap_cents=10, period="monthly"
+        )
+    )
+    # Pre-existing ledger row brings the total to 12 cents already.
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="chat",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=12,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded) as exc_info:
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={"messages": []},
+            )
+    assert exc_info.value.code == "ai_hard_cap_exceeded"
+    adapter.chat.assert_not_awaited()
+
+    # Still just the one pre-existing ledger row — no row for the
+    # rejected call.
+    rows = (
+        await db.execute(select(AIUsageLedger).where(AIUsageLedger.org_id == org.id))
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].est_cost_cents == 12
+
+
+# ---------- adapter failure ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_adapter_failure_writes_failed_ledger_row_and_reraises(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    adapter = _make_adapter(
+        raises=AIProviderError(code="provider_status_500", status_code=500)
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AIDispatchFailed) as exc_info:
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={"messages": []},
+            )
+    assert exc_info.value.code == "provider_status_500"
+    rows = (
+        await db.execute(select(AIUsageLedger).where(AIUsageLedger.org_id == org.id))
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].success is False
+    assert rows[0].error_class == "provider_status_500"
+    assert rows[0].prompt_tokens == 0
+    assert rows[0].completion_tokens == 0
+    assert rows[0].est_cost_cents == 0
+
+
+# ---------- soft cap notification + Redis dedupe ---------------------
+
+
+@pytest.mark.asyncio
+async def test_soft_cap_dispatches_notification_once_per_period(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing, monkeypatch
+):
+    # Default soft cap = 5 cents; pre-seed 6 cents so the next call
+    # crosses it.
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id, soft_cap_cents=5, hard_cap_cents=None, period="monthly"
+        )
+    )
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="chat",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=6,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    # Fake redis client — SET NX returns True first time, False second.
+    redis_state: dict[str, str] = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in redis_state:
+                return False
+            redis_state[key] = value
+            return True
+
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client", lambda: fake
+    )
+
+    dispatch_mock = AsyncMock(side_effect=lambda *a, **k: None)
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.notification_service.dispatch_notification",
+        dispatch_mock,
+    )
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    # First call dispatched a notification to the org admin.
+    assert dispatch_mock.await_count == 1
+    # Redis marker set.
+    assert any(k.startswith("ai_soft_cap_warned:") for k in redis_state)
+
+    # Second call same period -> no new notification.
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    assert dispatch_mock.await_count == 1
+
+
+# ---------- cap resolution ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_feature_cap_tighter_than_default_wins(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    # Default hard cap = 1000, feature hard cap = 10.
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id, soft_cap_cents=None, hard_cap_cents=1000, period="monthly"
+        )
+    )
+    db.add(
+        OrgAIFeatureCaps(
+            org_id=org.id,
+            feature_key="chat",
+            soft_cap_cents=None,
+            hard_cap_cents=10,
+            period="monthly",
+        )
+    )
+    # Ledger total 15 — over feature cap (10), under default (1000).
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="chat",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=15,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded):
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={"messages": []},
+            )
+    adapter.chat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_default_cap_tighter_than_feature_cap_wins(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    # Default hard = 10, feature hard = 1000.
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id, soft_cap_cents=None, hard_cap_cents=10, period="monthly"
+        )
+    )
+    db.add(
+        OrgAIFeatureCaps(
+            org_id=org.id,
+            feature_key="chat",
+            soft_cap_cents=None,
+            hard_cap_cents=1000,
+            period="monthly",
+        )
+    )
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="chat",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=15,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(AICapExceeded):
+            await call_llm(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                request_payload={"messages": []},
+            )
+    adapter.chat.assert_not_awaited()
+
+
+# ---------- feature routing wins over default ------------------------
+
+
+@pytest.mark.asyncio
+async def test_feature_routing_wins_over_default(
+    db: AsyncSession, org: Organization, admin_user, credential, default_routing
+):
+    # A second credential pinned via a feature routing override.
+    other = OrgAICredential(
+        org_id=org.id,
+        provider=AiProvider.OPENAI,
+        encrypted_api_key=encrypt("sk-other"),
+        encrypted_bearer_token=None,
+        base_url=None,
+        key_fingerprint="abcdef0123456789",
+        last_four="ther",
+        label="override",
+    )
+    db.add(other)
+    await db.commit()
+    db.add(
+        OrgAIFeatureRouting(
+            org_id=org.id,
+            feature_name="chat",
+            credential_id=other.id,
+            model="claude-haiku-4-5",
+        )
+    )
+    await db.commit()
+
+    adapter = _make_adapter()
+    captured = {}
+
+    def _capture_factory(provider, *, api_key, bearer_token=None, base_url=None):
+        captured["api_key"] = api_key
+        return adapter
+
+    with patch(
+        "app.services.ai_dispatch.get_adapter", side_effect=_capture_factory
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    assert captured["api_key"] == "sk-other"
+    # Model from the feature row was passed through.
+    adapter.chat.assert_awaited_once()
+    kwargs = adapter.chat.await_args.kwargs
+    assert kwargs["model"] == "claude-haiku-4-5"

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -824,3 +824,285 @@ async def test_feature_routing_wins_over_default(
     adapter.chat.assert_awaited_once()
     kwargs = adapter.chat.await_args.kwargs
     assert kwargs["model"] == "claude-haiku-4-5"
+
+
+# ---------- soft-cap marker source-tracking ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_soft_warning_marker_is_default_when_only_hard_cap_is_feature_specific(
+    db: AsyncSession,
+    org: Organization,
+    admin_user,
+    credential,
+    default_routing,
+    monkeypatch,
+):
+    """Feature row with ONLY a hard cap must NOT scope the soft-cap
+    marker to the feature.
+
+    Setup:
+      - org_ai_default_caps: soft=100, hard=200
+      - org_ai_feature_caps[categorize_transactions]: soft=None, hard=300
+      - feature row contributes NOTHING to the effective soft cap
+        (300 > 200 default-hard, so default-hard wins for hard; default
+        soft=100 wins for soft).
+
+    The soft cap that fires is the org-wide default (100). The Redis
+    marker MUST be ``__default__`` so the warning is org-wide and a
+    second crossing on a different feature in the same period does
+    NOT re-dispatch.
+    """
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=100,
+            hard_cap_cents=200,
+            period="monthly",
+        )
+    )
+    db.add(
+        OrgAIFeatureCaps(
+            org_id=org.id,
+            feature_key="categorize_transactions",
+            soft_cap_cents=None,
+            hard_cap_cents=300,
+            period="monthly",
+        )
+    )
+    # 90 cents prior usage; one 20-cent call crosses the 100-cent default
+    # soft cap on the post-write check.
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="categorize_transactions",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=90,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+    )
+    await db.commit()
+
+    redis_state: dict[str, str] = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in redis_state:
+                return False
+            redis_state[key] = value
+            return True
+
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client", lambda: fake
+    )
+
+    dispatch_mock = AsyncMock(side_effect=lambda *a, **k: None)
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.notification_service.dispatch_notification",
+        dispatch_mock,
+    )
+
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 20,
+    )
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="categorize_transactions",
+            request_payload={"messages": []},
+        )
+    # Boundary call dispatched the warning exactly once.
+    assert dispatch_mock.await_count == 1
+    # The marker must be org-wide (``__default__``), NOT feature-specific.
+    period = ai_dispatch._current_period()
+    expected_key = f"ai_soft_cap_warned:{org.id}:__default__:{period}"
+    assert expected_key in redis_state, (
+        f"expected org-wide marker, got keys: {sorted(redis_state)}"
+    )
+    feature_specific_key = (
+        f"ai_soft_cap_warned:{org.id}:categorize_transactions:{period}"
+    )
+    assert feature_specific_key not in redis_state, (
+        "feature-specific marker leaked despite feature row contributing "
+        "only a hard cap"
+    )
+
+    # Second call against a DIFFERENT feature in the same period that
+    # also crosses the same default soft cap MUST NOT re-dispatch.
+    # Ledger now totals 110 cents; another 5-cent call keeps it above
+    # the 100-cent default soft cap.
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 5,
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="smart_forecast",
+            request_payload={"messages": []},
+        )
+    # The ``__default__`` marker covers org-wide -> no second dispatch.
+    assert dispatch_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_soft_warning_marker_is_feature_specific_when_feature_has_own_soft_cap(
+    db: AsyncSession,
+    org: Organization,
+    admin_user,
+    credential,
+    default_routing,
+    monkeypatch,
+):
+    """Feature row with its OWN tighter soft cap must scope the marker
+    to that feature.
+
+    Setup:
+      - org_ai_default_caps: soft=100, hard=200
+      - org_ai_feature_caps[categorize_transactions]: soft=50, hard=None
+
+    A call against categorize_transactions that crosses the 50-cent
+    feature soft cap sets a feature-scoped marker. A SAME-feature
+    follow-up call does NOT re-dispatch. A DIFFERENT-feature call
+    (smart_forecast) that crosses the 100-cent default soft cap fires
+    a NEW notification (separate marker scope).
+    """
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=100,
+            hard_cap_cents=200,
+            period="monthly",
+        )
+    )
+    db.add(
+        OrgAIFeatureCaps(
+            org_id=org.id,
+            feature_key="categorize_transactions",
+            soft_cap_cents=50,
+            hard_cap_cents=None,
+            period="monthly",
+        )
+    )
+    # 45 cents prior usage; a 10-cent categorize call crosses
+    # feature soft cap (50) on post-write.
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="categorize_transactions",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=45,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+    )
+    await db.commit()
+
+    redis_state: dict[str, str] = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in redis_state:
+                return False
+            redis_state[key] = value
+            return True
+
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client", lambda: fake
+    )
+
+    dispatch_mock = AsyncMock(side_effect=lambda *a, **k: None)
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.notification_service.dispatch_notification",
+        dispatch_mock,
+    )
+
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 10,
+    )
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="categorize_transactions",
+            request_payload={"messages": []},
+        )
+    # First crossing dispatched once with a feature-scoped marker.
+    assert dispatch_mock.await_count == 1
+    period = ai_dispatch._current_period()
+    feature_key_marker = (
+        f"ai_soft_cap_warned:{org.id}:categorize_transactions:{period}"
+    )
+    default_marker = f"ai_soft_cap_warned:{org.id}:__default__:{period}"
+    assert feature_key_marker in redis_state, (
+        f"expected feature-scoped marker, got keys: {sorted(redis_state)}"
+    )
+    assert default_marker not in redis_state, (
+        "default marker leaked despite feature row supplying its own soft cap"
+    )
+
+    # Same-feature follow-up call past the cap -> no dupe notification.
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 5,
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="categorize_transactions",
+            request_payload={"messages": []},
+        )
+    assert dispatch_mock.await_count == 1
+
+    # Different feature with no feature soft cap. The default soft (100)
+    # is now the effective soft cap. Ledger totals 60 cents after the
+    # previous calls; we need a smart_forecast call that crosses 100.
+    # Use a 50-cent call: cost_before=60, cost_after=110 -> crosses.
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 50,
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="smart_forecast",
+            request_payload={"messages": []},
+        )
+    # NEW notification fired — different marker scope (__default__).
+    assert dispatch_mock.await_count == 2
+    assert default_marker in redis_state

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -401,6 +401,272 @@ async def test_soft_cap_dispatches_notification_once_per_period(
     assert dispatch_mock.await_count == 1
 
 
+# ---------- soft cap boundary-crossing (post-write check) -----------
+
+
+@pytest.mark.asyncio
+async def test_soft_cap_crossing_warns_on_boundary_call(
+    db: AsyncSession,
+    org: Organization,
+    admin_user,
+    credential,
+    default_routing,
+    monkeypatch,
+):
+    """The call that takes usage from below to at-or-above the soft cap
+    must trigger the warning, not the NEXT call after the crossing.
+
+    Pre-condition: cost_before=90 cents, soft_cap=100 cents.
+    Call cost: 20 cents -> cost_after=110 cents.
+    Boundary condition cost_before < soft_cap <= cost_after holds, so
+    the post-write check fires exactly once.
+    """
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=100,
+            hard_cap_cents=None,
+            period="monthly",
+        )
+    )
+    # 90 cents of prior usage — below the 100-cent soft cap.
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="chat",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=90,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+    )
+    await db.commit()
+
+    redis_state: dict[str, str] = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in redis_state:
+                return False
+            redis_state[key] = value
+            return True
+
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client", lambda: fake
+    )
+
+    dispatch_mock = AsyncMock(side_effect=lambda *a, **k: None)
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.notification_service.dispatch_notification",
+        dispatch_mock,
+    )
+
+    # Pin the cost-estimate function so this call costs exactly 20 cents
+    # (cost_before=90, cost_after=110, crosses soft_cap=100).
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 20,
+    )
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    # Boundary call dispatched the warning exactly once.
+    assert dispatch_mock.await_count == 1
+    # Redis marker present after the crossing call.
+    assert any(k.startswith("ai_soft_cap_warned:") for k in redis_state)
+
+    # Make a follow-up call costing 5 cents (cost_before=110,
+    # cost_after=115, both >= soft_cap). Pre-call check would fire,
+    # but the marker is already set so notification is NOT re-dispatched.
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 5,
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    assert dispatch_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_soft_cap_not_crossed_no_warn(
+    db: AsyncSession,
+    org: Organization,
+    admin_user,
+    credential,
+    default_routing,
+    monkeypatch,
+):
+    """When neither the pre-call nor the post-write check matches, no
+    warning is dispatched. cost_before=50, cost_after=80, soft_cap=100.
+    """
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=100,
+            hard_cap_cents=None,
+            period="monthly",
+        )
+    )
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="chat",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=50,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+    )
+    await db.commit()
+
+    redis_state: dict[str, str] = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in redis_state:
+                return False
+            redis_state[key] = value
+            return True
+
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client", lambda: fake
+    )
+
+    dispatch_mock = AsyncMock(side_effect=lambda *a, **k: None)
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.notification_service.dispatch_notification",
+        dispatch_mock,
+    )
+
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 30,
+    )
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    assert dispatch_mock.await_count == 0
+    assert not any(k.startswith("ai_soft_cap_warned:") for k in redis_state)
+
+
+@pytest.mark.asyncio
+async def test_already_above_soft_cap_no_dupe_warn(
+    db: AsyncSession,
+    org: Organization,
+    admin_user,
+    credential,
+    default_routing,
+    monkeypatch,
+):
+    """If pre-existing usage is already past the soft cap, the pre-call
+    check fires once and sets the Redis marker. The post-write check
+    on the SAME call must not re-dispatch because the boundary
+    condition (cost_before < soft_cap) is false.
+    """
+    db.add(
+        OrgAIDefaultCaps(
+            org_id=org.id,
+            soft_cap_cents=100,
+            hard_cap_cents=None,
+            period="monthly",
+        )
+    )
+    # 150 cents of prior usage — already past the 100-cent soft cap.
+    db.add(
+        AIUsageLedger(
+            org_id=org.id,
+            credential_id=credential.id,
+            feature_key="chat",
+            model="gpt-4o-mini",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            est_cost_cents=150,
+            latency_ms=1,
+            success=True,
+            error_class=None,
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+    )
+    await db.commit()
+
+    redis_state: dict[str, str] = {}
+
+    class FakeRedis:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in redis_state:
+                return False
+            redis_state[key] = value
+            return True
+
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client", lambda: fake
+    )
+
+    dispatch_mock = AsyncMock(side_effect=lambda *a, **k: None)
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.notification_service.dispatch_notification",
+        dispatch_mock,
+    )
+
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.estimate_cost_cents",
+        lambda *, model, prompt_tokens, completion_tokens: 10,
+    )
+
+    adapter = _make_adapter()
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        await call_llm(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            request_payload={"messages": []},
+        )
+    # Pre-call check fired once. Post-write check skipped because the
+    # boundary condition (cost_before < soft_cap) is false.
+    assert dispatch_mock.await_count == 1
+
+
 # ---------- cap resolution ------------------------------------------
 
 

--- a/backend/tests/services/test_ai_dispatch.py
+++ b/backend/tests/services/test_ai_dispatch.py
@@ -260,7 +260,7 @@ async def test_hard_cap_blocks_dispatch_no_adapter_call_no_ledger_row(
             latency_ms=1,
             success=True,
             error_class=None,
-            dispatched_at=datetime.utcnow(),
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
         )
     )
     await db.commit()
@@ -347,7 +347,7 @@ async def test_soft_cap_dispatches_notification_once_per_period(
             latency_ms=1,
             success=True,
             error_class=None,
-            dispatched_at=datetime.utcnow(),
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
         )
     )
     await db.commit()
@@ -437,7 +437,7 @@ async def test_feature_cap_tighter_than_default_wins(
             latency_ms=1,
             success=True,
             error_class=None,
-            dispatched_at=datetime.utcnow(),
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
         )
     )
     await db.commit()
@@ -488,7 +488,7 @@ async def test_default_cap_tighter_than_feature_cap_wins(
             latency_ms=1,
             success=True,
             error_class=None,
-            dispatched_at=datetime.utcnow(),
+            dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
         )
     )
     await db.commit()

--- a/backend/tests/services/test_ai_pricing.py
+++ b/backend/tests/services/test_ai_pricing.py
@@ -1,0 +1,124 @@
+"""Pricing-table + cost-estimation tests (PR2 of AI tier train).
+
+Pins:
+
+- Each model in the v1 table returns its documented per-1M-token cost.
+- Unknown models fall through to ``_default``, which is conservatively
+  HIGHER than every shipped model (so unknown-model usage doesn't
+  silently under-meter).
+- ``estimate_cost_cents`` rounds UP to the nearest cent — the cap is
+  a ceiling, not a budget.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.ai_pricing import (
+    MODEL_PRICING,
+    estimate_cost_cents,
+    get_pricing,
+)
+
+
+def test_known_models_have_pricing():
+    for model in ("gpt-4o", "gpt-4o-mini", "claude-sonnet-4-7", "claude-haiku-4-5"):
+        p = get_pricing(model)
+        assert p.prompt_per_1m_cents > 0
+        assert p.completion_per_1m_cents > 0
+
+
+def test_unknown_model_falls_back_to_default():
+    p = get_pricing("future-unreleased-llm-v9")
+    default = MODEL_PRICING["_default"]
+    assert p is default
+
+
+def test_default_is_more_expensive_than_known_models():
+    """Conservative-high fallback invariant.
+
+    If the default pricing isn't strictly higher than every known
+    frontier model, unknown-model traffic will silently under-meter
+    and the cap will fire late. The default IS the safety net.
+    """
+    default = MODEL_PRICING["_default"]
+    for name, pricing in MODEL_PRICING.items():
+        if name == "_default":
+            continue
+        assert default.prompt_per_1m_cents >= pricing.prompt_per_1m_cents, name
+        assert (
+            default.completion_per_1m_cents >= pricing.completion_per_1m_cents
+        ), name
+
+
+def test_zero_tokens_zero_cost():
+    assert (
+        estimate_cost_cents(
+            model="gpt-4o-mini", prompt_tokens=0, completion_tokens=0
+        )
+        == 0
+    )
+
+
+def test_cost_computation_known_model():
+    # gpt-4o-mini: 15 cents per 1M prompt, 60 per 1M completion.
+    # 1_000_000 prompt + 1_000_000 completion = 15 + 60 = 75 cents.
+    cents = estimate_cost_cents(
+        model="gpt-4o-mini",
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+    )
+    assert cents == 75
+
+
+def test_cost_rounds_up_to_nearest_cent():
+    # gpt-4o-mini: 1 prompt token = 15 / 1_000_000 cent. Sub-cent
+    # cost must round UP to 1, not down to 0.
+    cents = estimate_cost_cents(
+        model="gpt-4o-mini", prompt_tokens=1, completion_tokens=0
+    )
+    assert cents == 1
+
+
+def test_cost_unknown_model_uses_default():
+    cents_known = estimate_cost_cents(
+        model="gpt-4o",
+        prompt_tokens=100_000,
+        completion_tokens=0,
+    )
+    cents_unknown = estimate_cost_cents(
+        model="future-llm-x9",
+        prompt_tokens=100_000,
+        completion_tokens=0,
+    )
+    assert cents_unknown >= cents_known
+
+
+def test_cost_integer_only_math_avoids_float_truncation():
+    # 3 tokens at 15 / 1_000_000 = 45 / 1_000_000 < 1 cent; ceil -> 1.
+    cents = estimate_cost_cents(
+        model="gpt-4o-mini", prompt_tokens=3, completion_tokens=0
+    )
+    assert cents == 1
+
+
+@pytest.mark.parametrize(
+    "model,p_tokens,c_tokens,expected",
+    [
+        # gpt-4o (250/1000): 500_000 prompt + 500_000 completion =
+        # 125 + 500 = 625 cents.
+        ("gpt-4o", 500_000, 500_000, 625),
+        # claude-sonnet-4-7 (300/1500): 1_000_000 + 0 = 300 cents.
+        ("claude-sonnet-4-7", 1_000_000, 0, 300),
+        # claude-haiku-4-5 (80/400): 0 + 1_000_000 = 400 cents.
+        ("claude-haiku-4-5", 0, 1_000_000, 400),
+    ],
+)
+def test_cost_table_values(model, p_tokens, c_tokens, expected):
+    assert (
+        estimate_cost_cents(
+            model=model,
+            prompt_tokens=p_tokens,
+            completion_tokens=c_tokens,
+        )
+        == expected
+    )


### PR DESCRIPTION
## Summary

PR2 of the AI Tier train: wires the dispatch chokepoint ``call_llm`` with cap enforcement and the per-call ledger. No feature surfaces are wired in this PR (categorization, chat, smart_forecast all land in PR3+).

Spec: ``specs/2026-05-22-ai-tier-byo-and-native-providers.md`` (§3 dispatch, §7 caps + ledger).

## What landed

- **Migration 058_ai_usage_ledger**: new ``ai_usage_ledger`` table with indexes ``(org_id, dispatched_at)`` and ``(org_id, feature_key, dispatched_at)`` for the rolling-window cap queries.
- **ai_pricing.py**: code-constant model -> per-1M-token cost table (gpt-4o, gpt-4o-mini, claude-sonnet-4-7, claude-haiku-4-5, plus a conservative ``_default`` for unknowns). Updated quarterly via manual PR per architect lock 18. ``estimate_cost_cents`` rounds up.
- **ai_dispatch.call_llm**: the chokepoint. Resolves routing -> pre-checks caps -> dispatches via the adapter -> writes a ledger row. Hard cap exceeded raises ``AICapExceeded`` (HTTP 402, code ``ai_hard_cap_exceeded``) BEFORE the adapter is called and writes NO ledger row for the rejected call. Missing routing raises ``NoRoutingConfigured`` (HTTP 412, code ``ai_routing_not_configured``).
- **Soft-cap warning**: dispatches a notification to every org owner+admin via the notification system when usage crosses the soft cap for the first time in the period. Idempotent via Redis marker ``ai_soft_cap_warned:{org}:{feature}:{period}`` with 35-day TTL.
- **Adapter chat() methods** on OpenAI, Anthropic, Ollama, OpenAI-compatible. 30s timeout, sanitized errors (no provider response body in wrapped exceptions per the PR1 sanitization lock). Native still raises ``NativeNotAvailable``.
- **StructuredOutputCapable.chat_structured** Protocol signature lives on ``base.py``; concrete adapters raise ``NotImplementedError('PR3')`` per architect lock.
- **GET /api/v1/admin/ai/usage** superadmin debug endpoint. Aggregates totals + per-feature breakdown for a given ``org_id`` + ``YYYY-MM`` period.
- **notification_templates.ai_cap_soft_warning** is the first centralized notification copy template (lightweight module shape so PR3+ can grow it).

## Punted to PR3+ explicitly

- ``chat_structured`` adapter implementations (with the retry-cap-of-2 contract).
- ``embed()``, ``function_call()``, ``stream()``.
- Native chat (still raises ``NativeNotAvailable``, even with the gate flipped on).
- Customer-facing usage page (admins use the new internal endpoint until then).

## Resolved spec ambiguity

"Does a hard-cap-rejected call write a ledger row?" — **No.** A rejected call never reaches the provider, so there is no cost or latency to record. Writing zero-cost rows would inflate the row count without adding ops signal. Hard-cap rejection surfaces via the ``ai.dispatch.cap.exceeded`` structlog event. Documented in the module docstring.

## Curl example for ops

\`\`\`
curl -H "Authorization: Bearer SUPERADMIN_TOKEN" \\
  "https://app.example.com/api/v1/admin/ai/usage?org_id=42&period=2026-05"
\`\`\`