### PR TITLE
feat(reports): canvas + KPI + bar widgets (PR2 of train, behind FEATURE_REPORTS_V2)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -174,12 +174,21 @@ async def auth_status(db: AsyncSession = Depends(get_db)):
     landing-page trial copy). Same flip-to-rollback contract as
     ``captcha_required`` — backend False hides the surface on the next
     page load, backend True restores it.
+
+    ``feature_reports_v2`` gates the Reports v2 surface (nav item,
+    ``/reports/*`` routes). Same flip-to-rollback contract as the other
+    feature flags here — when False the frontend hides the nav item and
+    every ``/reports`` route returns 404; when True the surface lights
+    up. The backend's own ``/api/v1/reports/*`` routes are independently
+    gated via the ``require_reports_v2_enabled`` router dependency, so
+    flipping this flag while the backend is False is a no-op.
     """
     user_count = await db.scalar(select(func.count()).select_from(User))
     return {
         "needs_setup": user_count == 0,
         "captcha_required": app_settings.captcha_required,
         "billing_ui_enabled": app_settings.billing_ui_enabled,
+        "feature_reports_v2": app_settings.feature_reports_v2,
     }
 
 

--- a/backend/tests/routers/test_auth_status.py
+++ b/backend/tests/routers/test_auth_status.py
@@ -114,3 +114,68 @@ async def test_status_billing_flag_is_independent_of_captcha_flag(
     body = resp.json()
     assert body["captcha_required"] is True
     assert body["billing_ui_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_status_exposes_feature_reports_v2_default_false(
+    session_factory, monkeypatch
+) -> None:
+    """Pre-launch default: feature_reports_v2=false in the response.
+
+    The Reports v2 nav item + ``/reports/*`` frontend routes consume
+    this signal. Default false until the canvas + widget catalog ship.
+    """
+    monkeypatch.setattr(app_settings, "feature_reports_v2", False)
+    monkeypatch.setattr(app_settings, "billing_ui_enabled", False)
+    monkeypatch.setattr(app_settings, "captcha_required", False)
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/auth/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["feature_reports_v2"] is False
+
+
+@pytest.mark.asyncio
+async def test_status_exposes_feature_reports_v2_true_when_flag_on(
+    session_factory, monkeypatch
+) -> None:
+    """When the operator flips ``FEATURE_REPORTS_V2`` to true, the
+    same endpoint must surface it so the next page load shows the
+    Reports nav item + lights up the ``/reports`` routes.
+    """
+    monkeypatch.setattr(app_settings, "feature_reports_v2", True)
+    monkeypatch.setattr(app_settings, "billing_ui_enabled", False)
+    monkeypatch.setattr(app_settings, "captcha_required", False)
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/auth/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["feature_reports_v2"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_reports_flag_is_independent_of_other_flags(
+    session_factory, monkeypatch
+) -> None:
+    """Defense against regression — feature_reports_v2 is an
+    independent control-plane signal, not coupled to captcha /
+    billing.
+    """
+    monkeypatch.setattr(app_settings, "feature_reports_v2", True)
+    monkeypatch.setattr(app_settings, "billing_ui_enabled", False)
+    monkeypatch.setattr(app_settings, "captcha_required", False)
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/auth/status")
+
+    body = resp.json()
+    assert body["feature_reports_v2"] is True
+    assert body["billing_ui_enabled"] is False
+    assert body["captcha_required"] is False

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+/**
+ * Reports v2 — single-report editor.
+ *
+ * Loads the report by id, hydrates the canvas + widgets, lets the
+ * user add / configure / resize / drag widgets, and saves the
+ * layout JSON via PATCH on explicit "Save" click.
+ *
+ * Save semantics (PR2 decision): explicit save button, NOT
+ * debounced auto-save. Reasoning:
+ *  - explicit save keeps every PATCH a user-initiated act and
+ *    keeps "dirty" state visible (Save → Saved transition).
+ *  - debounced auto-save tangles with the SWR query layer per
+ *    widget (rapid filter changes would churn the layout PATCH
+ *    AND fire 8 query refetches per debounce slot).
+ *  - explicit save fits PR2 scope; PR4 can layer auto-save on
+ *    top once sharing + templates land.
+ *
+ * Architect ambiguity resolved: spec §1 ASCII mockup shows a "Save"
+ * button in the header; the rollout-table PR2 row says "Save layout
+ * (PATCH)" — both align with explicit-save.
+ */
+import { use, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+import { useAuth } from "@/components/auth/AuthProvider";
+import { getReport, saveLayout } from "@/lib/reports/api";
+import type {
+  BarConfig,
+  CanvasFilters,
+  KPIConfig,
+  LayoutJson,
+  ReportSummary,
+  Widget,
+} from "@/lib/reports/types";
+import Canvas from "@/components/reports/Canvas";
+import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
+import ConfigRail from "@/components/reports/ConfigRail";
+import WidgetPicker from "@/components/reports/WidgetPicker";
+import WidgetShell from "@/components/reports/WidgetShell";
+import KPIWidget from "@/components/reports/widgets/KPIWidget";
+import BarWidget from "@/components/reports/widgets/BarWidget";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+const DEFAULT_LAYOUT: LayoutJson = { version: 1, widgets: [] };
+
+function emptyKPI(id: string): Widget {
+  const config: KPIConfig = {
+    dataset: "transactions",
+    measure: { agg: "sum", field: "amount" },
+    format: "currency",
+    compare_prior_period: false,
+  };
+  return {
+    id,
+    type: "kpi",
+    title: "New KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config,
+  };
+}
+
+function emptyBar(id: string): Widget {
+  const config: BarConfig = {
+    dataset: "transactions",
+    measure: { agg: "sum", field: "amount" },
+    dimensions: ["category"],
+    sort: { by: "value", dir: "desc" },
+    limit: 10,
+    format: "currency",
+  };
+  return {
+    id,
+    type: "bar",
+    title: "New bar chart",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config,
+  };
+}
+
+function newWidgetId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `w_${crypto.randomUUID().slice(0, 8)}`;
+  }
+  return `w_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export default function ReportEditorPage({ params }: PageProps) {
+  // Next 15 makes ``params`` a promise; ``use()`` unwraps it on the
+  // client without awaiting at the top level.
+  const { id } = use(params);
+  const router = useRouter();
+  const { user, loading: authLoading, featureReportsV2 } = useAuth();
+
+  const [report, setReport] = useState<ReportSummary | null>(null);
+  const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
+  const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
+  const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
+  const [editMode, setEditMode] = useState(true);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!featureReportsV2) {
+      router.replace("/dashboard");
+      return;
+    }
+    let cancelled = false;
+    getReport(Number(id))
+      .then((r) => {
+        if (cancelled) return;
+        setReport(r);
+        const lj = (r.layout_json ?? {}) as Partial<LayoutJson>;
+        setLayout(
+          lj && Array.isArray(lj.widgets)
+            ? { version: 1, widgets: lj.widgets as Widget[] }
+            : DEFAULT_LAYOUT,
+        );
+        setCanvasFilters((r.canvas_filters_json as CanvasFilters) ?? {});
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setLoadError(err.message || "Couldn't load report");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, user, authLoading, featureReportsV2, router]);
+
+  const selectedWidget = useMemo(
+    () => layout.widgets.find((w) => w.id === selectedWidgetId) ?? null,
+    [layout.widgets, selectedWidgetId],
+  );
+
+  function updateLayout(next: LayoutJson) {
+    setLayout(next);
+    setDirty(true);
+  }
+
+  function updateWidget(nextWidget: Widget) {
+    setLayout((prev) => ({
+      ...prev,
+      widgets: prev.widgets.map((w) =>
+        w.id === nextWidget.id ? nextWidget : w,
+      ),
+    }));
+    setDirty(true);
+  }
+
+  function addWidget(type: "kpi" | "bar") {
+    const id = newWidgetId();
+    const widget = type === "kpi" ? emptyKPI(id) : emptyBar(id);
+    // Drop the new widget at the bottom of the existing stack.
+    const maxY = layout.widgets.reduce(
+      (max, w) => Math.max(max, w.grid.y + w.grid.h),
+      0,
+    );
+    widget.grid = { ...widget.grid, x: 0, y: maxY };
+    setLayout((prev) => ({ ...prev, widgets: [...prev.widgets, widget] }));
+    setSelectedWidgetId(id);
+    setPickerOpen(false);
+    setDirty(true);
+  }
+
+  function removeWidget(widgetId: string) {
+    setLayout((prev) => ({
+      ...prev,
+      widgets: prev.widgets.filter((w) => w.id !== widgetId),
+    }));
+    if (selectedWidgetId === widgetId) setSelectedWidgetId(null);
+    setDirty(true);
+  }
+
+  function updateCanvasFilters(next: CanvasFilters) {
+    setCanvasFilters(next);
+    setDirty(true);
+  }
+
+  async function handleSave() {
+    if (!report || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const saved = await saveLayout(report.id, layout, canvasFilters);
+      setReport(saved);
+      setDirty(false);
+      setLastSavedAt(new Date());
+    } catch (err) {
+      const e = err as Error;
+      setSaveError(e.message || "Couldn't save layout");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (authLoading || (!report && !loadError)) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div
+          data-testid="report-editor-loading"
+          className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent"
+        />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <main className="mx-auto w-full max-w-3xl px-4 py-8">
+        <div
+          role="alert"
+          className="rounded-md border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger"
+        >
+          {loadError}
+        </div>
+        <Link
+          href="/reports"
+          className="mt-3 inline-block text-sm text-accent hover:underline"
+        >
+          Back to reports
+        </Link>
+      </main>
+    );
+  }
+
+  if (!report) return null;
+
+  return (
+    <main className="flex h-full flex-col" data-testid="report-editor">
+      <header className="flex items-center justify-between border-b border-border bg-surface px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/reports"
+            className="text-sm text-text-muted hover:text-text-primary"
+          >
+            Reports
+          </Link>
+          <span className="text-text-muted">/</span>
+          <span className="text-sm font-semibold text-text-primary">
+            {report.name}
+          </span>
+          {dirty && (
+            <span
+              data-testid="report-editor-dirty"
+              className="text-xs text-text-muted"
+            >
+              Unsaved changes
+            </span>
+          )}
+          {!dirty && lastSavedAt && (
+            <span className="text-xs text-text-muted">Saved</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setEditMode((v) => !v)}
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+            data-testid="report-editor-toggle-edit"
+          >
+            {editMode ? "View" : "Edit"}
+          </button>
+          {editMode && (
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              data-testid="report-editor-add-widget"
+            >
+              Add widget
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || !dirty}
+            className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="report-editor-save"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </header>
+
+      {saveError && (
+        <div
+          role="alert"
+          className="border-b border-danger/30 bg-danger/10 px-4 py-2 text-sm text-danger"
+        >
+          {saveError}
+        </div>
+      )}
+
+      <div className="border-b border-border bg-bg px-4 py-3">
+        <CanvasFiltersBar value={canvasFilters} onChange={updateCanvasFilters} />
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          {layout.widgets.length === 0 ? (
+            <div
+              data-testid="report-editor-empty"
+              className="rounded-md border border-dashed border-border bg-surface px-6 py-10 text-center text-sm text-text-muted"
+            >
+              No widgets yet. Click &quot;Add widget&quot; to start.
+            </div>
+          ) : (
+            <Canvas
+              layout={layout}
+              editMode={editMode}
+              onLayoutChange={updateLayout}
+              renderWidget={(w) => (
+                <WidgetShell
+                  widgetId={w.id}
+                  selected={selectedWidgetId === w.id}
+                  editMode={editMode}
+                  onSelect={() => setSelectedWidgetId(w.id)}
+                  onRemove={() => removeWidget(w.id)}
+                >
+                  {w.type === "kpi" ? (
+                    <KPIWidget widget={w} canvasFilters={canvasFilters} />
+                  ) : (
+                    <BarWidget widget={w} canvasFilters={canvasFilters} />
+                  )}
+                </WidgetShell>
+              )}
+            />
+          )}
+        </div>
+        {editMode && selectedWidget && (
+          <ConfigRail
+            widget={selectedWidget}
+            canvasFilters={canvasFilters}
+            onUpdate={updateWidget}
+            onClose={() => setSelectedWidgetId(null)}
+          />
+        )}
+      </div>
+
+      <WidgetPicker
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onPick={addWidget}
+      />
+    </main>
+  );
+}

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -25,6 +25,7 @@ import { use, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
+import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { getReport, saveLayout } from "@/lib/reports/api";
 import type {
@@ -221,18 +222,20 @@ export default function ReportEditorPage({ params }: PageProps) {
 
   if (authLoading || (!report && !loadError)) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div
-          data-testid="report-editor-loading"
-          className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent"
-        />
-      </div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center">
+          <div
+            data-testid="report-editor-loading"
+            className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent"
+          />
+        </div>
+      </AppShell>
     );
   }
 
   if (loadError) {
     return (
-      <main className="mx-auto w-full max-w-3xl px-4 py-8">
+      <AppShell>
         <div
           role="alert"
           className="rounded-md border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger"
@@ -245,14 +248,15 @@ export default function ReportEditorPage({ params }: PageProps) {
         >
           Back to reports
         </Link>
-      </main>
+      </AppShell>
     );
   }
 
   if (!report) return null;
 
   return (
-    <main className="flex h-full flex-col" data-testid="report-editor">
+    <AppShell>
+      <div className="flex h-full flex-col" data-testid="report-editor">
       <header className="flex items-center justify-between border-b border-border bg-surface px-4 py-3">
         <div className="flex items-center gap-3">
           <Link
@@ -363,11 +367,12 @@ export default function ReportEditorPage({ params }: PageProps) {
         )}
       </div>
 
-      <WidgetPicker
-        open={pickerOpen}
-        onClose={() => setPickerOpen(false)}
-        onPick={addWidget}
-      />
-    </main>
+        <WidgetPicker
+          open={pickerOpen}
+          onClose={() => setPickerOpen(false)}
+          onPick={addWidget}
+        />
+      </div>
+    </AppShell>
   );
 }

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -44,7 +44,10 @@ import KPIWidget from "@/components/reports/widgets/KPIWidget";
 import BarWidget from "@/components/reports/widgets/BarWidget";
 
 interface PageProps {
-  params: Promise<{ id: string }>;
+  // Next 15 makes ``params`` a promise on server-rendered pages; in
+  // tests we can also pass a plain object so we don't have to wrap
+  // every render in a Suspense boundary that handles ``use()``.
+  params: Promise<{ id: string }> | { id: string };
 }
 
 const DEFAULT_LAYOUT: LayoutJson = { version: 1, widgets: [] };
@@ -92,8 +95,14 @@ function newWidgetId(): string {
 
 export default function ReportEditorPage({ params }: PageProps) {
   // Next 15 makes ``params`` a promise; ``use()`` unwraps it on the
-  // client without awaiting at the top level.
-  const { id } = use(params);
+  // client without awaiting at the top level. In test harnesses we
+  // can pass a plain object and skip the promise branch entirely so
+  // the editor doesn't suspend.
+  const resolvedParams =
+    params && typeof (params as Promise<{ id: string }>).then === "function"
+      ? use(params as Promise<{ id: string }>)
+      : (params as { id: string });
+  const { id } = resolvedParams;
   const router = useRouter();
   const { user, loading: authLoading, featureReportsV2 } = useAuth();
 
@@ -138,7 +147,11 @@ export default function ReportEditorPage({ params }: PageProps) {
     return () => {
       cancelled = true;
     };
-  }, [id, user, authLoading, featureReportsV2, router]);
+    // ``router`` is intentionally omitted — useRouter() may not
+    // guarantee a referentially-stable identity across renders, and
+    // refiring the load effect would clobber unsaved canvas edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, user, authLoading, featureReportsV2]);
 
   const selectedWidget = useMemo(
     () => layout.widgets.find((w) => w.id === selectedWidgetId) ?? null,

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -48,7 +48,11 @@ export default function ReportsListPage() {
     return () => {
       cancelled = true;
     };
-  }, [user, authLoading, featureReportsV2, router]);
+    // ``router`` is intentionally omitted — useRouter() identity is
+    // not guaranteed stable across renders, and refiring the list
+    // effect on every render would churn the list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, authLoading, featureReportsV2]);
 
   async function handleNewReport() {
     if (creating) return;

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
+import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { createReport, listReports } from "@/lib/reports/api";
 import type { ReportSummary } from "@/lib/reports/types";
@@ -74,14 +75,16 @@ export default function ReportsListPage() {
 
   if (authLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent" />
-      </div>
+      <AppShell>
+        <div className="flex h-full items-center justify-center">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent" />
+        </div>
+      </AppShell>
     );
   }
 
   return (
-    <main className="mx-auto w-full max-w-5xl px-4 py-8">
+    <AppShell>
       <header className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-text-primary">Reports</h1>
@@ -153,6 +156,6 @@ export default function ReportsListPage() {
           ))}
         </ul>
       )}
-    </main>
+    </AppShell>
   );
 }

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+/**
+ * Reports v2 — list page.
+ *
+ * Shows reports visible to the caller (own + org-shared) and a
+ * "New report" button that creates an empty private report and
+ * navigates to the editor. Templates tab + visibility toggle are
+ * PR4 work; this page keeps the substrate ready for them.
+ *
+ * The page guards the ``feature_reports_v2`` signal client-side; if
+ * the operator hasn't flipped the flag, the user shouldn't be here.
+ * (The backend hard-404s its routes too, so even direct nav fails.)
+ */
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+import { useAuth } from "@/components/auth/AuthProvider";
+import { createReport, listReports } from "@/lib/reports/api";
+import type { ReportSummary } from "@/lib/reports/types";
+
+export default function ReportsListPage() {
+  const router = useRouter();
+  const { user, loading: authLoading, featureReportsV2 } = useAuth();
+  const [reports, setReports] = useState<ReportSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!featureReportsV2) {
+      router.replace("/dashboard");
+      return;
+    }
+    let cancelled = false;
+    listReports()
+      .then((data) => {
+        if (!cancelled) setReports(data);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message || "Couldn't load reports");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading, featureReportsV2, router]);
+
+  async function handleNewReport() {
+    if (creating) return;
+    setCreating(true);
+    try {
+      const created = await createReport({
+        name: "Untitled report",
+        visibility: "private",
+        layout_json: { version: 1, widgets: [] },
+        canvas_filters_json: {},
+      });
+      router.push(`/reports/${created.id}`);
+    } catch (err) {
+      const e = err as Error;
+      setError(e.message || "Couldn't create report");
+      setCreating(false);
+    }
+  }
+
+  if (authLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent" />
+      </div>
+    );
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-text-primary">Reports</h1>
+          <p className="text-sm text-text-muted">
+            Build a layout of KPIs and charts over your transactions.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleNewReport}
+          disabled={creating}
+          className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {creating ? "Creating..." : "New report"}
+        </button>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-md border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger"
+        >
+          {error}
+        </div>
+      )}
+
+      {reports === null && !error ? (
+        <div className="rounded-md border border-border bg-surface px-4 py-6 text-sm text-text-muted">
+          Loading...
+        </div>
+      ) : reports && reports.length === 0 ? (
+        <div
+          data-testid="reports-empty-state"
+          className="rounded-md border border-dashed border-border bg-surface px-6 py-10 text-center"
+        >
+          <p className="text-sm font-medium text-text-primary">
+            No reports yet
+          </p>
+          <p className="mt-1 text-sm text-text-muted">
+            Start a blank canvas to build your first one.
+          </p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-border rounded-md border border-border bg-surface">
+          {(reports ?? []).map((r) => (
+            <li key={r.id}>
+              <Link
+                href={`/reports/${r.id}`}
+                className="block px-4 py-3 hover:bg-bg-elevated"
+                data-testid={`report-row-${r.id}`}
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium text-text-primary">
+                      {r.name}
+                    </div>
+                    {r.description && (
+                      <div className="text-sm text-text-muted">
+                        {r.description}
+                      </div>
+                    )}
+                  </div>
+                  <span className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+                    {r.visibility}
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -55,7 +55,10 @@ const NAV_ICON_PROPS = {
   strokeWidth: 1.5,
 } as const;
 
-const navItems = [
+// Static base nav items. Reports v2 is injected conditionally based on
+// the ``feature_reports_v2`` signal from /auth/status; see the gated
+// build inside the AppShell component below.
+const baseNavItems = [
   {
     href: "/dashboard",
     label: "Dashboard",
@@ -97,6 +100,29 @@ const navItems = [
     icon: <Tag {...NAV_ICON_PROPS} />,
   },
 ];
+
+// Reports v2 entry. Inserted between Forecast Plans and Categories
+// when ``featureReportsV2`` resolves true. Kept as a top-level item
+// (NOT under Planning, NOT under Settings) per spec §10.
+const REPORTS_NAV_ITEM = {
+  href: "/reports",
+  label: "Reports",
+  icon: <BarChart3 {...NAV_ICON_PROPS} />,
+} as const;
+
+function buildNavItems(featureReportsV2: boolean) {
+  if (!featureReportsV2) return baseNavItems;
+  // Insert Reports just after Forecast Plans (index where Plans sits)
+  // so the order stays Dashboard / Transactions / Accounts / Recurring
+  // / Budgets / Forecast Plans / Reports / Plans / Categories.
+  const idx = baseNavItems.findIndex((i) => i.href === "/plans");
+  if (idx === -1) return [...baseNavItems, REPORTS_NAV_ITEM];
+  return [
+    ...baseNavItems.slice(0, idx),
+    REPORTS_NAV_ITEM,
+    ...baseNavItems.slice(idx),
+  ];
+}
 
 // Per-item permission gating: each System nav link declares the
 // platform permission its destination requires. AppShell renders only
@@ -168,7 +194,8 @@ const systemItems: readonly SystemNavItem[] = [
 ];
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
-  const { user, loading, logout } = useAuth();
+  const { user, loading, logout, featureReportsV2 } = useAuth();
+  const navItems = buildNavItems(Boolean(featureReportsV2));
   const router = useRouter();
   const pathname = usePathname();
   const [userExpanded, setUserExpanded] = useState(false);

--- a/frontend/components/auth/AuthProvider.tsx
+++ b/frontend/components/auth/AuthProvider.tsx
@@ -82,6 +82,16 @@ interface AuthContextValue {
    * hidden state.
    */
   billingUiEnabled?: boolean;
+  /**
+   * Reports v2 (flexible canvas + AST query engine) kill switch.
+   * Mirrors the backend's ``FEATURE_REPORTS_V2`` env via
+   * /api/v1/auth/status. Default false until the canvas + widget
+   * catalog ship and the operator flips the flag. Same shape as
+   * ``billingUiEnabled`` — optional in the interface so existing
+   * test mocks that pre-date this field still type-check; consumers
+   * treat ``undefined`` as ``false`` (the safe pre-launch state).
+   */
+  featureReportsV2?: boolean;
   login: (login: string, password: string) => Promise<void>;
   register: (
     username: string,
@@ -108,6 +118,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // (older API revision) is equivalent to "billing UI hidden" — the
   // safe default for the pre-payment state.
   const [billingUiEnabled, setBillingUiEnabled] = useState(false);
+  // Defaults to false until /auth/status resolves so the Reports nav
+  // item stays hidden on first render. Backend default is also false
+  // (pre-launch); a missing key in the status payload (older API
+  // revision) is equivalent to "Reports surface hidden" — the safe
+  // pre-launch default.
+  const [featureReportsV2, setFeatureReportsV2] = useState(false);
 
   const fetchMe = useCallback(async () => {
     // 2026-05-18 review fix: fetchMe is the shared current-user load
@@ -157,11 +173,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         // tab, and /settings/billing plan grid are gated on the
         // backend's BILLING_UI_ENABLED env on the next page load.
         const status = await withAuthRetry(() =>
-          apiFetch<{ needs_setup: boolean; billing_ui_enabled?: boolean }>(
-            "/api/v1/auth/status",
-          ),
+          apiFetch<{
+            needs_setup: boolean;
+            billing_ui_enabled?: boolean;
+            feature_reports_v2?: boolean;
+          }>("/api/v1/auth/status"),
         );
         setBillingUiEnabled(Boolean(status.billing_ui_enabled));
+        setFeatureReportsV2(Boolean(status.feature_reports_v2));
         if (status.needs_setup) {
           setNeedsSetup(true);
           setLoading(false);
@@ -277,6 +296,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         loading,
         needsSetup,
         billingUiEnabled,
+        featureReportsV2,
         login,
         register,
         logout,

--- a/frontend/components/reports/Canvas.tsx
+++ b/frontend/components/reports/Canvas.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * Reports v2 canvas substrate.
+ *
+ * Wraps ``react-grid-layout``'s ``Responsive`` + ``WidthProvider``
+ * combo to give a 12-column snap grid with drag + resize handles in
+ * edit mode. On the smallest breakpoint the grid collapses to a
+ * single column and resize handles are hidden (read-only mobile per
+ * spec §1 "Mobile fallback").
+ *
+ * The grid library renders its own DOM tree; widget contents are
+ * passed in as children keyed by widget id so layout JSON ↔ render
+ * order stay coupled.
+ */
+import { useMemo } from "react";
+// react-grid-layout ships its CSS as a separate import. Loading the
+// stylesheet at the canvas module keeps the dep colocated with the
+// only consumer, so removing Reports doesn't leave a dangling import
+// in app/layout.tsx.
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+import { Responsive, WidthProvider, type Layout } from "react-grid-layout";
+
+import type { LayoutJson, Widget } from "@/lib/reports/types";
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+interface Props {
+  layout: LayoutJson;
+  editMode: boolean;
+  onLayoutChange: (next: LayoutJson) => void;
+  /** Renders the body of each widget. The shell + chrome is up to the
+   * caller (so the editor can wrap with WidgetShell for click-to-select).
+   */
+  renderWidget: (widget: Widget) => React.ReactNode;
+}
+
+const COLS = { lg: 12, md: 12, sm: 6, xs: 1, xxs: 1 } as const;
+const BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 } as const;
+
+export default function Canvas({
+  layout,
+  editMode,
+  onLayoutChange,
+  renderWidget,
+}: Props) {
+  const items = layout.widgets ?? [];
+  const rgLayout = useMemo<Layout[]>(
+    () =>
+      items.map((w) => ({
+        i: w.id,
+        x: w.grid.x,
+        y: w.grid.y,
+        w: w.grid.w,
+        h: w.grid.h,
+        minW: 2,
+        minH: 2,
+      })),
+    [items],
+  );
+
+  function handleLayoutChange(next: Layout[]) {
+    if (!editMode) return;
+    const byId = new Map(next.map((l) => [l.i, l]));
+    const updated: Widget[] = items.map((w) => {
+      const l = byId.get(w.id);
+      if (!l) return w;
+      return {
+        ...w,
+        grid: { x: l.x, y: l.y, w: l.w, h: l.h },
+      };
+    });
+    onLayoutChange({ ...layout, widgets: updated });
+  }
+
+  return (
+    <div data-testid="reports-canvas" className="w-full">
+      <ResponsiveGridLayout
+        className="layout"
+        layouts={{ lg: rgLayout, md: rgLayout, sm: rgLayout, xs: rgLayout, xxs: rgLayout }}
+        breakpoints={BREAKPOINTS}
+        cols={COLS}
+        rowHeight={60}
+        isDraggable={editMode}
+        isResizable={editMode}
+        draggableHandle="[data-grid-drag-handle]"
+        onLayoutChange={handleLayoutChange}
+        margin={[12, 12]}
+      >
+        {items.map((w) => (
+          <div key={w.id} data-widget-id={w.id}>
+            {renderWidget(w)}
+          </div>
+        ))}
+      </ResponsiveGridLayout>
+    </div>
+  );
+}

--- a/frontend/components/reports/CanvasFiltersBar.tsx
+++ b/frontend/components/reports/CanvasFiltersBar.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * Canvas-wide filters row — sits above the canvas. Edits flow into
+ * the report's ``canvas_filters_json`` blob and cascade to every
+ * widget that doesn't override the same field (spec §4).
+ *
+ * v1 controls: date range (start + end), account ids (comma-list),
+ * category ids (comma-list). PR3 swaps the comma-list inputs for
+ * the proper chip pickers + tree picker.
+ */
+import type { CanvasFilters } from "@/lib/reports/types";
+
+interface Props {
+  value: CanvasFilters;
+  onChange: (next: CanvasFilters) => void;
+}
+
+export default function CanvasFiltersBar({ value, onChange }: Props) {
+  return (
+    <div
+      data-testid="canvas-filters-bar"
+      className="flex flex-wrap items-end gap-3 rounded-md border border-border bg-surface px-4 py-3"
+    >
+      <Field label="Date from">
+        <input
+          type="date"
+          aria-label="Canvas date from"
+          value={value.date_range?.start ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              date_range: {
+                ...(value.date_range ?? {}),
+                start: e.target.value || undefined,
+              },
+            })
+          }
+          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </Field>
+      <Field label="Date to">
+        <input
+          type="date"
+          aria-label="Canvas date to"
+          value={value.date_range?.end ?? ""}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              date_range: {
+                ...(value.date_range ?? {}),
+                end: e.target.value || undefined,
+              },
+            })
+          }
+          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </Field>
+      <Field label="Accounts (ids)">
+        <input
+          type="text"
+          inputMode="numeric"
+          aria-label="Canvas accounts"
+          placeholder="e.g. 12, 14"
+          value={(value.account_ids ?? []).join(",")}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              account_ids: parseIdList(e.target.value),
+            })
+          }
+          className="w-32 rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </Field>
+      <Field label="Categories (ids)">
+        <input
+          type="text"
+          inputMode="numeric"
+          aria-label="Canvas categories"
+          placeholder="e.g. 3, 5"
+          value={(value.category_ids ?? []).join(",")}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              category_ids: parseIdList(e.target.value),
+            })
+          }
+          className="w-32 rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function parseIdList(raw: string): number[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => Number(s))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}

--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+/**
+ * Right-rail widget configuration UI. Slides in when a widget is
+ * selected in edit mode. Mutations call back into the editor's
+ * ``onUpdate`` so the report's full layout state stays the single
+ * source of truth (debounced save handled at the editor level).
+ *
+ * For each field with a per-widget override, the rail surfaces an
+ * "Overrides canvas" pill (spec §4) computed via ``isFieldOverridden``.
+ */
+import type {
+  BarConfig,
+  CanvasFilters,
+  Dimension,
+  KPIConfig,
+  TagMatch,
+  Widget,
+  WidgetFilters,
+} from "@/lib/reports/types";
+import { isFieldOverridden } from "@/lib/reports/resolve";
+
+interface Props {
+  widget: Widget;
+  canvasFilters: CanvasFilters;
+  onUpdate: (next: Widget) => void;
+  onClose: () => void;
+}
+
+const AGG_OPTIONS: Array<{ value: "sum" | "count" | "avg" | "distinct"; label: string }> = [
+  { value: "sum", label: "Sum" },
+  { value: "count", label: "Count" },
+  { value: "avg", label: "Average" },
+  { value: "distinct", label: "Distinct count" },
+];
+
+const DIMENSION_OPTIONS: Array<{ value: Dimension; label: string }> = [
+  { value: "category", label: "Category" },
+  { value: "category_master", label: "Master category" },
+  { value: "account", label: "Account" },
+  { value: "tag", label: "Tag" },
+  { value: "txn_type", label: "Transaction type" },
+  { value: "status", label: "Status" },
+  { value: "month", label: "Month" },
+  { value: "week", label: "Week" },
+  { value: "day", label: "Day" },
+];
+
+export default function ConfigRail({
+  widget,
+  canvasFilters,
+  onUpdate,
+  onClose,
+}: Props) {
+  const filters: WidgetFilters = widget.config.filters ?? {};
+
+  function setTitle(title: string) {
+    onUpdate({ ...widget, title });
+  }
+
+  function setAgg(agg: "sum" | "count" | "avg" | "distinct") {
+    // Keep widget.config narrow per type — Bar and KPI share the
+    // measure shape.
+    const next = {
+      ...widget,
+      config: {
+        ...widget.config,
+        measure: { ...widget.config.measure, agg },
+      },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setFilters(nextFilters: WidgetFilters) {
+    const next = {
+      ...widget,
+      config: { ...widget.config, filters: nextFilters },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setDimension(dim: Dimension) {
+    if (widget.type !== "bar") return;
+    const next: Widget = {
+      ...widget,
+      config: { ...(widget.config as BarConfig), dimensions: [dim] },
+    };
+    onUpdate(next);
+  }
+
+  function setComparePrior(value: boolean) {
+    if (widget.type !== "kpi") return;
+    const next: Widget = {
+      ...widget,
+      config: {
+        ...(widget.config as KPIConfig),
+        compare_prior_period: value,
+      },
+    };
+    onUpdate(next);
+  }
+
+  return (
+    <aside
+      data-testid="config-rail"
+      className="flex h-full w-80 shrink-0 flex-col gap-4 border-l border-border bg-surface p-4 overflow-y-auto"
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-text-primary">
+          Widget settings
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-text-muted hover:text-text-primary"
+        >
+          Close
+        </button>
+      </div>
+
+      <Section label="Title">
+        <input
+          type="text"
+          value={widget.title}
+          onChange={(e) => setTitle(e.target.value)}
+          aria-label="Widget title"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </Section>
+
+      <Section label="Data source">
+        <select
+          disabled
+          value={widget.config.dataset}
+          aria-label="Data source"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-muted"
+        >
+          <option value="transactions">Transactions</option>
+        </select>
+      </Section>
+
+      <Section label="Aggregation">
+        <select
+          value={widget.config.measure.agg}
+          onChange={(e) =>
+            setAgg(e.target.value as "sum" | "count" | "avg" | "distinct")
+          }
+          aria-label="Aggregation"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        >
+          {AGG_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </Section>
+
+      {widget.type === "bar" && (
+        <Section label="Dimension">
+          <select
+            value={widget.config.dimensions[0] ?? "category"}
+            onChange={(e) => setDimension(e.target.value as Dimension)}
+            aria-label="Dimension"
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          >
+            {DIMENSION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </Section>
+      )}
+
+      {widget.type === "kpi" && (
+        <Section label="Compare to prior period">
+          <label className="flex items-center gap-2 text-sm text-text-primary">
+            <input
+              type="checkbox"
+              checked={Boolean(widget.config.compare_prior_period)}
+              onChange={(e) => setComparePrior(e.target.checked)}
+              aria-label="Compare to prior period"
+            />
+            <span>Show delta vs prior period</span>
+          </label>
+        </Section>
+      )}
+
+      <FilterEditor
+        filters={filters}
+        canvasFilters={canvasFilters}
+        onChange={setFilters}
+      />
+    </aside>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function OverridePill() {
+  return (
+    <span
+      data-testid="override-pill"
+      className="ml-2 inline-flex items-center rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-medium text-accent"
+    >
+      Overrides canvas
+    </span>
+  );
+}
+
+function FilterEditor({
+  filters,
+  canvasFilters,
+  onChange,
+}: {
+  filters: WidgetFilters;
+  canvasFilters: CanvasFilters;
+  onChange: (next: WidgetFilters) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4 rounded-md border border-border bg-bg p-3">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        Filters (this widget)
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center text-xs text-text-secondary">
+          Date range
+          {isFieldOverridden("date_range", filters, canvasFilters) && (
+            <OverridePill />
+          )}
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="date"
+            aria-label="Widget date from"
+            value={filters.date_range?.start ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                date_range: {
+                  ...(filters.date_range ?? {}),
+                  start: e.target.value || undefined,
+                },
+              })
+            }
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+          <input
+            type="date"
+            aria-label="Widget date to"
+            value={filters.date_range?.end ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                date_range: {
+                  ...(filters.date_range ?? {}),
+                  end: e.target.value || undefined,
+                },
+              })
+            }
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center text-xs text-text-secondary">
+          Accounts (ids)
+          {isFieldOverridden("account_ids", filters, canvasFilters) && (
+            <OverridePill />
+          )}
+        </div>
+        <input
+          type="text"
+          aria-label="Widget accounts"
+          inputMode="numeric"
+          placeholder="e.g. 12, 14"
+          value={(filters.account_ids ?? []).join(",")}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              account_ids: parseIdList(e.target.value),
+            })
+          }
+          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center text-xs text-text-secondary">
+          Categories (ids)
+          {isFieldOverridden("category_ids", filters, canvasFilters) && (
+            <OverridePill />
+          )}
+        </div>
+        <input
+          type="text"
+          aria-label="Widget categories"
+          inputMode="numeric"
+          placeholder="e.g. 3, 5"
+          value={(filters.category_ids ?? []).join(",")}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              category_ids: parseIdList(e.target.value),
+            })
+          }
+          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="text-xs text-text-secondary">Transaction type</div>
+        <select
+          value={filters.txn_type ?? ""}
+          aria-label="Widget transaction type"
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              txn_type:
+                e.target.value === ""
+                  ? undefined
+                  : (e.target.value as "income" | "expense" | "transfer"),
+            })
+          }
+          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        >
+          <option value="">Any</option>
+          <option value="income">Income</option>
+          <option value="expense">Expense</option>
+          <option value="transfer">Transfer</option>
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="text-xs text-text-secondary">Amount range</div>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            aria-label="Widget amount min"
+            placeholder="min"
+            value={filters.amount_range?.min ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                amount_range: {
+                  ...(filters.amount_range ?? {}),
+                  min: e.target.value === "" ? undefined : Number(e.target.value),
+                },
+              })
+            }
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+          <input
+            type="number"
+            aria-label="Widget amount max"
+            placeholder="max"
+            value={filters.amount_range?.max ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...filters,
+                amount_range: {
+                  ...(filters.amount_range ?? {}),
+                  max: e.target.value === "" ? undefined : Number(e.target.value),
+                },
+              })
+            }
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="text-xs text-text-secondary">Tags</div>
+        <input
+          type="text"
+          aria-label="Widget tags"
+          placeholder="comma list of tag names"
+          value={(filters.tag_names ?? []).join(",")}
+          onChange={(e) =>
+            onChange({
+              ...filters,
+              tag_names: e.target.value
+                .split(",")
+                .map((s) => s.trim().toLowerCase())
+                .filter(Boolean),
+            })
+          }
+          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        />
+        <div className="mt-1 flex gap-3 text-xs text-text-secondary">
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              name="tag-match"
+              aria-label="Tag match all"
+              checked={(filters.tag_match ?? "all") === "all"}
+              onChange={() => onChange({ ...filters, tag_match: "all" })}
+            />
+            <span>Match all</span>
+          </label>
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              name="tag-match"
+              aria-label="Tag match any"
+              checked={filters.tag_match === "any"}
+              onChange={() =>
+                onChange({ ...filters, tag_match: "any" as TagMatch })
+              }
+            />
+            <span>Match any</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function parseIdList(raw: string): number[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => Number(s))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}

--- a/frontend/components/reports/WidgetPicker.tsx
+++ b/frontend/components/reports/WidgetPicker.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * Widget picker modal — appears when the user clicks "Add widget."
+ *
+ * v1 catalog: KPI + Bar. The button list is structured so PR3 can
+ * grow it (line / area / pie / table / sparkline / stacked bar)
+ * without reshaping the call site.
+ */
+import { BarChart3, Hash } from "lucide-react";
+
+import type { WidgetTypeV1 } from "@/lib/reports/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onPick: (type: WidgetTypeV1) => void;
+}
+
+const OPTIONS: Array<{
+  type: WidgetTypeV1;
+  label: string;
+  description: string;
+  Icon: typeof BarChart3;
+}> = [
+  {
+    type: "kpi",
+    label: "KPI",
+    description: "Single number with an optional comparison.",
+    Icon: Hash,
+  },
+  {
+    type: "bar",
+    label: "Bar chart",
+    description: "Vertical bars over a category, account, or tag.",
+    Icon: BarChart3,
+  },
+];
+
+export default function WidgetPicker({ open, onClose, onPick }: Props) {
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add widget"
+      data-testid="widget-picker"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 px-4"
+    >
+      <div className="w-full max-w-md rounded-lg border border-border bg-surface p-5 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-text-primary">
+            Add widget
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-text-muted hover:text-text-primary"
+            aria-label="Close"
+          >
+            Close
+          </button>
+        </div>
+        <ul className="space-y-2">
+          {OPTIONS.map(({ type, label, description, Icon }) => (
+            <li key={type}>
+              <button
+                type="button"
+                onClick={() => onPick(type)}
+                data-testid={`widget-picker-option-${type}`}
+                className="flex w-full items-start gap-3 rounded-md border border-border bg-bg p-3 text-left transition hover:border-accent hover:bg-bg-elevated"
+              >
+                <Icon
+                  aria-hidden="true"
+                  className="mt-0.5 h-5 w-5 text-accent"
+                  strokeWidth={1.5}
+                />
+                <div>
+                  <div className="text-sm font-medium text-text-primary">
+                    {label}
+                  </div>
+                  <div className="text-xs text-text-muted">{description}</div>
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/WidgetShell.tsx
+++ b/frontend/components/reports/WidgetShell.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+/**
+ * Visual chrome around each canvas widget — drag handle (when in
+ * edit mode), title, error boundary surface, click-to-select. The
+ * widget itself renders inside ``children``.
+ *
+ * react-grid-layout requires the drag-handle class to live on a
+ * specific element; we expose it via the ``data-grid-drag-handle``
+ * attribute so the canvas wrapper can hook it without leaking the
+ * library detail into widget components.
+ */
+import { ReactNode } from "react";
+import { GripVertical, X } from "lucide-react";
+
+interface Props {
+  widgetId: string;
+  selected: boolean;
+  editMode: boolean;
+  onSelect: () => void;
+  onRemove?: () => void;
+  children: ReactNode;
+}
+
+export default function WidgetShell({
+  widgetId,
+  selected,
+  editMode,
+  onSelect,
+  onRemove,
+  children,
+}: Props) {
+  return (
+    <div
+      data-widget-shell={widgetId}
+      data-selected={selected}
+      onClick={onSelect}
+      className={`relative flex h-full flex-col rounded-lg ${
+        selected ? "ring-2 ring-accent" : ""
+      }`}
+    >
+      {editMode && (
+        <div className="absolute right-1 top-1 z-10 flex items-center gap-1">
+          <span
+            className="cursor-grab rounded p-1 text-text-muted hover:bg-surface hover:text-text-primary"
+            data-grid-drag-handle
+            aria-label="Drag widget"
+          >
+            <GripVertical aria-hidden="true" className="h-3.5 w-3.5" />
+          </span>
+          {onRemove && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove();
+              }}
+              className="rounded p-1 text-text-muted hover:bg-danger/10 hover:text-danger"
+              aria-label="Remove widget"
+            >
+              <X aria-hidden="true" className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+      <div className="h-full w-full">{children}</div>
+    </div>
+  );
+}

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * Bar widget — vertical bars over a single dimension. Pulls rows
+ * through ``useReportQuery``; takes the first dimension key from
+ * the widget config and treats ``value`` as the measure axis.
+ *
+ * Recharts is the canvas chart engine across the app (Dashboard,
+ * Budgets, Forecast Plans); reusing it here keeps visual register
+ * consistent.
+ */
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { chartColor } from "@/lib/chart-colors";
+import { useReportQuery } from "@/lib/reports/useReportQuery";
+import type {
+  BarWidget as BarWidgetType,
+  CanvasFilters,
+} from "@/lib/reports/types";
+
+interface Props {
+  widget: BarWidgetType;
+  canvasFilters?: CanvasFilters;
+}
+
+export default function BarWidget({ widget, canvasFilters }: Props) {
+  const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
+
+  const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const rows = (data?.rows ?? []).map((r) => ({
+    label: String(r[dimensionKey] ?? "—"),
+    value: typeof r.value === "number" ? r.value : Number(r.value ?? 0),
+  }));
+
+  return (
+    <div
+      data-testid="bar-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
+    >
+      <div className="mb-2 text-sm font-semibold text-text-primary">
+        {widget.title || "Bar chart"}
+      </div>
+      <div className="flex-1">
+        {isLoading ? (
+          <div
+            data-testid="bar-widget-loading"
+            className="h-full w-full animate-pulse rounded bg-border/40"
+          />
+        ) : error ? (
+          <div
+            role="alert"
+            data-testid="bar-widget-error"
+            className="text-sm text-danger"
+          >
+            Couldn&apos;t load
+          </div>
+        ) : rows.length === 0 ? (
+          <div
+            data-testid="bar-widget-empty"
+            className="flex h-full items-center justify-center text-sm text-text-muted"
+          >
+            No data
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+                interval={0}
+              />
+              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+              <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
+              <Bar
+                dataKey="value"
+                fill={chartColor.spent}
+                radius={[4, 4, 0, 0]}
+                animationDuration={400}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/widgets/KPIWidget.tsx
+++ b/frontend/components/reports/widgets/KPIWidget.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * KPI widget — single big number with an optional delta vs the
+ * prior period. Pulls its rows through ``useReportQuery``; failure
+ * renders an inline error inside this card and does not bubble to
+ * sibling widgets.
+ *
+ * Visual register intentionally minimal — a label, a value, an
+ * optional delta. Live in the canvas grid; the widget shell (drag
+ * handle, title bar) wraps it.
+ */
+import { useReportQuery } from "@/lib/reports/useReportQuery";
+import type { CanvasFilters, KPIWidget as KPIWidgetType } from "@/lib/reports/types";
+
+interface Props {
+  widget: KPIWidgetType;
+  canvasFilters?: CanvasFilters;
+  /**
+   * Optional injected prior-period value. Computed by the editor
+   * page (which can resolve the prior-period date range from the
+   * effective filters); the widget itself doesn't recompute the
+   * date arithmetic. Undefined means "no delta shown."
+   */
+  priorValue?: number | null;
+}
+
+export default function KPIWidget({
+  widget,
+  canvasFilters,
+  priorValue,
+}: Props) {
+  const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
+
+  const value = readValue(data?.rows[0]);
+  const format = widget.config.format ?? "number";
+  const showDelta =
+    widget.config.compare_prior_period === true &&
+    priorValue !== undefined &&
+    priorValue !== null &&
+    value !== null;
+  const delta =
+    showDelta && value !== null && priorValue !== null && priorValue !== 0
+      ? ((value - priorValue) / Math.abs(priorValue)) * 100
+      : null;
+
+  return (
+    <div
+      data-testid="kpi-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col justify-center gap-1 rounded-lg border border-border bg-surface p-4"
+    >
+      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        {widget.title || "KPI"}
+      </div>
+      {isLoading ? (
+        <div
+          data-testid="kpi-widget-loading"
+          className="h-7 w-24 animate-pulse rounded bg-border"
+        />
+      ) : error ? (
+        <div
+          role="alert"
+          data-testid="kpi-widget-error"
+          className="text-sm text-danger"
+        >
+          Couldn&apos;t load
+        </div>
+      ) : value === null ? (
+        <div className="text-2xl font-semibold text-text-muted">—</div>
+      ) : (
+        <>
+          <div
+            data-testid="kpi-widget-value"
+            className="text-2xl font-semibold text-text-primary"
+          >
+            {formatValue(value, format)}
+          </div>
+          {showDelta && delta !== null && (
+            <div
+              data-testid="kpi-widget-delta"
+              className={
+                delta >= 0
+                  ? "text-xs font-medium text-success"
+                  : "text-xs font-medium text-danger"
+              }
+            >
+              {delta >= 0 ? "+" : ""}
+              {delta.toFixed(1)}% vs prior period
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function readValue(
+  row: Record<string, string | number | null> | undefined,
+): number | null {
+  if (!row) return null;
+  const v = row.value;
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatValue(value: number, format: "currency" | "number" | "percent") {
+  if (format === "currency") {
+    return value.toLocaleString(undefined, {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 2,
+    });
+  }
+  if (format === "percent") {
+    return `${value.toFixed(1)}%`;
+  }
+  return value.toLocaleString();
+}

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -1,0 +1,76 @@
+/**
+ * Typed client for the Reports v2 REST surface.
+ *
+ * Goes through ``apiFetch`` so it inherits Bearer auth, silent
+ * refresh, and the proactive-refresh preflight. Calling these
+ * functions while ``FEATURE_REPORTS_V2`` is off backend-side will
+ * surface a 404 (the router dependency returns Not Found before the
+ * route handlers run) — callers should treat 404 here the same as
+ * "feature disabled."
+ */
+import { apiFetch } from "@/lib/api";
+import type {
+  CanvasFilters,
+  LayoutJson,
+  ReportCreatePayload,
+  ReportSummary,
+  ReportUpdatePayload,
+  ReportsQuery,
+  ReportsQueryResponse,
+} from "./types";
+
+export async function listReports(): Promise<ReportSummary[]> {
+  return apiFetch<ReportSummary[]>("/api/v1/reports");
+}
+
+export async function getReport(id: number): Promise<ReportSummary> {
+  return apiFetch<ReportSummary>(`/api/v1/reports/${id}`);
+}
+
+export async function createReport(
+  payload: ReportCreatePayload,
+): Promise<ReportSummary> {
+  return apiFetch<ReportSummary>("/api/v1/reports", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateReport(
+  id: number,
+  payload: ReportUpdatePayload,
+): Promise<ReportSummary> {
+  return apiFetch<ReportSummary>(`/api/v1/reports/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteReport(id: number): Promise<void> {
+  await apiFetch<void>(`/api/v1/reports/${id}`, { method: "DELETE" });
+}
+
+export async function runQuery(
+  body: ReportsQuery,
+): Promise<ReportsQueryResponse> {
+  return apiFetch<ReportsQueryResponse>("/api/v1/reports/query", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Save just the layout + canvas filters for an existing report. Thin
+ * wrapper around ``updateReport`` so save handlers in the editor
+ * read naturally.
+ */
+export async function saveLayout(
+  id: number,
+  layout_json: LayoutJson,
+  canvas_filters_json: CanvasFilters,
+): Promise<ReportSummary> {
+  return updateReport(id, { layout_json, canvas_filters_json });
+}

--- a/frontend/lib/reports/resolve.ts
+++ b/frontend/lib/reports/resolve.ts
@@ -171,14 +171,19 @@ export function resolveFilters(
   }
 
   if (widget?.tag_names && widget.tag_names.length > 0) {
-    for (const tag of widget.tag_names) {
-      out.push({
-        field: "tag_name",
-        op: "eq",
-        value: tag,
-        tag_match: widget.tag_match ?? "all",
-      });
-    }
+    // One ``in`` filter with the full tag list. The backend's tag
+    // compiler at ``backend/app/services/reports_query_service.py:185``
+    // reads ``tag_match`` off the single filter and either OR-combines
+    // the names (``any``) or AND-combines per-name IN subqueries
+    // (``all``). Emitting per-tag filters here would force the AST
+    // compiler to AND them together, which inverts the UI promise
+    // for ``tag_match=any``.
+    out.push({
+      field: "tag_name",
+      op: "in",
+      value: [...widget.tag_names],
+      tag_match: widget.tag_match ?? "all",
+    });
   }
 
   return out;

--- a/frontend/lib/reports/resolve.ts
+++ b/frontend/lib/reports/resolve.ts
@@ -1,0 +1,135 @@
+/**
+ * Filter-resolution utilities.
+ *
+ * The architect-locked hybrid scope (spec §4): canvas-wide cascades,
+ * per-widget overrides win on a per-field basis. ``resolveFilters``
+ * walks each widget-filter field and decides whether to use the
+ * widget value (if present) or fall back to the canvas value.
+ *
+ * Output is a list of AST filter primitives the backend understands
+ * (date BETWEEN, account_id IN, category_id IN, etc.). The compiler
+ * server-side appends ``org_id = current_user.org_id`` and applies
+ * the hard caps; this function only translates the user-facing UI
+ * state into AST shape.
+ */
+import type {
+  CanvasFilters,
+  Filter,
+  WidgetFilters,
+} from "./types";
+
+/**
+ * Returns true when a widget-level field overrides the canvas-level
+ * value. Used by the config rail to show the "Overrides canvas" pill.
+ *
+ * ``undefined`` / missing widget value = inherit. Empty array = inherit.
+ * Any other non-empty value = override.
+ */
+export function isFieldOverridden(
+  field: keyof WidgetFilters,
+  widgetFilters: WidgetFilters | undefined,
+  canvasFilters: CanvasFilters | undefined,
+): boolean {
+  if (!widgetFilters) return false;
+  const v = widgetFilters[field];
+  if (v === undefined || v === null) return false;
+  if (Array.isArray(v) && v.length === 0) return false;
+  // Date range with neither start nor end is treated as "inherit."
+  if (field === "date_range") {
+    const dr = v as { start?: string; end?: string };
+    if (!dr.start && !dr.end) return false;
+  }
+  // Amount range with neither min nor max is "inherit."
+  if (field === "amount_range") {
+    const ar = v as { min?: number; max?: number };
+    if (ar.min === undefined && ar.max === undefined) return false;
+  }
+  // If the corresponding canvas value is also unset, the widget
+  // value isn't really an override — it's just a widget-only setting.
+  // For pill rendering purposes we still call it "overrides canvas"
+  // when the canvas had a value AND the widget value differs.
+  const c = canvasFilters?.[field as keyof CanvasFilters];
+  if (c === undefined || c === null) return false;
+  if (Array.isArray(c) && c.length === 0) return false;
+  return true;
+}
+
+/**
+ * Resolves a widget's effective filters into a list of AST filter
+ * primitives. ``widget`` overrides on a per-field basis; otherwise
+ * the canvas value cascades through.
+ */
+export function resolveFilters(
+  canvas: CanvasFilters | undefined,
+  widget: WidgetFilters | undefined,
+): Filter[] {
+  const out: Filter[] = [];
+  const canvasDr = canvas?.date_range;
+  const widgetDr = widget?.date_range;
+  const dr = pickDateRange(widgetDr, canvasDr);
+  if (dr && dr.start && dr.end) {
+    out.push({
+      field: "date",
+      op: "between",
+      value: [dr.start, dr.end],
+    });
+  } else if (dr && dr.start) {
+    out.push({ field: "date", op: "gte", value: dr.start });
+  } else if (dr && dr.end) {
+    out.push({ field: "date", op: "lte", value: dr.end });
+  }
+
+  const accountIds = pickList(widget?.account_ids, canvas?.account_ids);
+  if (accountIds && accountIds.length > 0) {
+    out.push({ field: "account_id", op: "in", value: accountIds });
+  }
+
+  const categoryIds = pickList(widget?.category_ids, canvas?.category_ids);
+  if (categoryIds && categoryIds.length > 0) {
+    out.push({ field: "category_id", op: "in", value: categoryIds });
+  }
+
+  if (widget?.txn_type) {
+    out.push({ field: "txn_type", op: "eq", value: widget.txn_type });
+  }
+
+  if (widget?.amount_range) {
+    const { min, max } = widget.amount_range;
+    if (min !== undefined && max !== undefined) {
+      out.push({ field: "amount", op: "between", value: [min, max] });
+    } else if (min !== undefined) {
+      out.push({ field: "amount", op: "gte", value: min });
+    } else if (max !== undefined) {
+      out.push({ field: "amount", op: "lte", value: max });
+    }
+  }
+
+  if (widget?.tag_names && widget.tag_names.length > 0) {
+    for (const tag of widget.tag_names) {
+      out.push({
+        field: "tag_name",
+        op: "eq",
+        value: tag,
+        tag_match: widget.tag_match ?? "all",
+      });
+    }
+  }
+
+  return out;
+}
+
+function pickDateRange(
+  widget: CanvasFilters["date_range"] | undefined,
+  canvas: CanvasFilters["date_range"] | undefined,
+): CanvasFilters["date_range"] | undefined {
+  if (widget && (widget.start || widget.end)) return widget;
+  return canvas;
+}
+
+function pickList<T>(
+  widget: T[] | undefined,
+  canvas: T[] | undefined,
+): T[] | undefined {
+  if (widget && widget.length > 0) return widget;
+  return canvas;
+}

--- a/frontend/lib/reports/resolve.ts
+++ b/frontend/lib/reports/resolve.ts
@@ -22,8 +22,14 @@ import type {
  * Returns true when a widget-level field overrides the canvas-level
  * value. Used by the config rail to show the "Overrides canvas" pill.
  *
- * ``undefined`` / missing widget value = inherit. Empty array = inherit.
- * Any other non-empty value = override.
+ * Locked rule: pill fires ONLY when BOTH the widget and the canvas
+ * have a meaningful value for the field AND those values DIFFER.
+ *
+ * ``undefined`` / missing widget value = inherit (no pill).
+ * Empty array / empty range = inherit (no pill).
+ * Canvas has no value = widget-only, not an override (no pill).
+ * Both set and equal = no override (no pill).
+ * Both set and unequal = override (pill fires).
  */
 export function isFieldOverridden(
   field: keyof WidgetFilters,
@@ -31,26 +37,86 @@ export function isFieldOverridden(
   canvasFilters: CanvasFilters | undefined,
 ): boolean {
   if (!widgetFilters) return false;
-  const v = widgetFilters[field];
+  const widgetVal = widgetFilters[field];
+  if (!hasMeaningfulValue(field, widgetVal)) return false;
+
+  // Tag fields aren't on canvas at all (canvas only has date_range,
+  // account_ids, category_ids), so a widget value there isn't an
+  // override of canvas. Same for txn_type / amount_range.
+  if (
+    field === "tag_names" ||
+    field === "tag_match" ||
+    field === "txn_type" ||
+    field === "amount_range"
+  ) {
+    return false;
+  }
+
+  const canvasVal = canvasFilters?.[field as keyof CanvasFilters];
+  if (!hasMeaningfulValue(field, canvasVal)) return false;
+
+  // Both sides have a value. Pill fires only if they differ.
+  return !valuesEqual(field, widgetVal, canvasVal, widgetFilters);
+}
+
+function hasMeaningfulValue(
+  field: keyof WidgetFilters,
+  v: unknown,
+): boolean {
   if (v === undefined || v === null) return false;
-  if (Array.isArray(v) && v.length === 0) return false;
-  // Date range with neither start nor end is treated as "inherit."
+  if (Array.isArray(v)) return v.length > 0;
   if (field === "date_range") {
     const dr = v as { start?: string; end?: string };
-    if (!dr.start && !dr.end) return false;
+    return Boolean(dr.start || dr.end);
   }
-  // Amount range with neither min nor max is "inherit."
   if (field === "amount_range") {
     const ar = v as { min?: number; max?: number };
-    if (ar.min === undefined && ar.max === undefined) return false;
+    return ar.min !== undefined || ar.max !== undefined;
   }
-  // If the corresponding canvas value is also unset, the widget
-  // value isn't really an override — it's just a widget-only setting.
-  // For pill rendering purposes we still call it "overrides canvas"
-  // when the canvas had a value AND the widget value differs.
-  const c = canvasFilters?.[field as keyof CanvasFilters];
-  if (c === undefined || c === null) return false;
-  if (Array.isArray(c) && c.length === 0) return false;
+  return true;
+}
+
+function valuesEqual(
+  field: keyof WidgetFilters,
+  widgetVal: unknown,
+  canvasVal: unknown,
+  widgetFilters: WidgetFilters,
+): boolean {
+  if (field === "date_range") {
+    const a = widgetVal as { start?: string; end?: string };
+    const b = canvasVal as { start?: string; end?: string };
+    return (a.start ?? null) === (b.start ?? null)
+      && (a.end ?? null) === (b.end ?? null);
+  }
+  if (field === "account_ids" || field === "category_ids") {
+    return sameSet(widgetVal as number[], canvasVal as number[]);
+  }
+  if (field === "amount_range") {
+    const a = widgetVal as { min?: number; max?: number };
+    const b = canvasVal as { min?: number; max?: number };
+    return (a.min ?? null) === (b.min ?? null)
+      && (a.max ?? null) === (b.max ?? null);
+  }
+  if (field === "tag_names") {
+    if (!sameSet(widgetVal as string[], canvasVal as string[])) return false;
+    // tag_match flips "all" vs "any" semantics, so an identical tag
+    // list with a different match mode is still an override. Canvas
+    // doesn't model tag_match, so any widget-side tag_match value
+    // other than the implicit default counts as a difference.
+    const widgetMatch = widgetFilters.tag_match ?? "all";
+    return widgetMatch === "all";
+  }
+  // txn_type / tag_match handled above as widget-only; fall back to
+  // strict equality for safety.
+  return widgetVal === canvasVal;
+}
+
+function sameSet<T extends number | string>(a: T[], b: T[]): boolean {
+  if (a.length !== b.length) return false;
+  const bSet = new Set<T>(b);
+  for (const x of a) {
+    if (!bSet.has(x)) return false;
+  }
   return true;
 }
 

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -1,0 +1,214 @@
+/**
+ * Reports v2 — frontend types.
+ *
+ * Mirrors the backend Pydantic shapes from
+ * ``backend/app/schemas/reports_query.py`` and
+ * ``backend/app/schemas/report.py``. Kept narrow + closed so the
+ * widget components and config rail can rely on enum members being
+ * the only valid values. Anything outside these unions is a wire
+ * contract violation and the server will 422 it.
+ */
+
+export type WidgetType =
+  | "kpi"
+  | "bar"
+  | "stacked_bar"
+  | "line"
+  | "area"
+  | "pie"
+  | "sparkline"
+  | "table";
+
+// v1 only ships kpi + bar; the rest are declared so the layout JSON
+// schema is forward-compatible with PR3 widgets without a migration.
+export type WidgetTypeV1 = "kpi" | "bar";
+
+export type Dataset = "transactions";
+
+export type Aggregation = "sum" | "count" | "avg" | "distinct";
+
+export type MeasureField = "amount" | "id" | "category_id" | "account_id";
+
+export type Dimension =
+  | "category"
+  | "category_master"
+  | "account"
+  | "tag"
+  | "txn_type"
+  | "status"
+  | "month"
+  | "week"
+  | "day";
+
+export type FilterField =
+  | "date"
+  | "amount"
+  | "category_id"
+  | "account_id"
+  | "txn_type"
+  | "status"
+  | "tag_name";
+
+export type FilterOp = "eq" | "in" | "between" | "gte" | "lte";
+
+export type TagMatch = "all" | "any";
+
+export type FilterValue =
+  | string
+  | number
+  | boolean
+  | Array<string | number>;
+
+export interface Measure {
+  agg: Aggregation;
+  field: MeasureField;
+}
+
+export interface Filter {
+  field: FilterField;
+  op: FilterOp;
+  value: FilterValue;
+  // Tag-only knob; default ``all``. Ignored on non-tag filters.
+  tag_match?: TagMatch;
+}
+
+export interface SortSpec {
+  by: "value" | "dimension";
+  dir: "asc" | "desc";
+}
+
+export interface ReportsQuery {
+  dataset: Dataset;
+  measure: Measure;
+  dimensions: Dimension[];
+  filters: Filter[];
+  sort?: SortSpec;
+  limit?: number;
+}
+
+export interface QueryMeta {
+  row_count: number;
+  truncated: boolean;
+  query_ms: number;
+}
+
+export type QueryRow = Record<string, string | number | null>;
+
+export interface ReportsQueryResponse {
+  rows: QueryRow[];
+  meta: QueryMeta;
+}
+
+// ─── canvas filters (cascade source) ────────────────────────────
+
+export interface CanvasDateRange {
+  /** ISO date YYYY-MM-DD */
+  start?: string;
+  /** ISO date YYYY-MM-DD */
+  end?: string;
+}
+
+export interface CanvasFilters {
+  date_range?: CanvasDateRange;
+  account_ids?: number[];
+  category_ids?: number[];
+}
+
+// ─── widget layout / config ─────────────────────────────────────
+
+export interface WidgetGrid {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface WidgetFilters {
+  // Per-widget filter overrides. Any field present here overrides
+  // the canvas-wide value for the same field. Empty / undefined
+  // means "inherit from canvas filters."
+  date_range?: CanvasDateRange;
+  account_ids?: number[];
+  category_ids?: number[];
+  txn_type?: "income" | "expense" | "transfer";
+  amount_range?: { min?: number; max?: number };
+  tag_names?: string[];
+  tag_match?: TagMatch;
+}
+
+export interface KPIConfig {
+  dataset: Dataset;
+  measure: Measure;
+  filters?: WidgetFilters;
+  format?: "currency" | "number" | "percent";
+  /**
+   * When true, the KPI widget renders a delta versus the immediately-
+   * prior period of the same length as the resolved date range. v1
+   * only honors this when the resolved date range is bounded; an
+   * unbounded range hides the delta.
+   */
+  compare_prior_period?: boolean;
+}
+
+export interface BarConfig {
+  dataset: Dataset;
+  measure: Measure;
+  dimensions: Dimension[];
+  filters?: WidgetFilters;
+  sort?: SortSpec;
+  limit?: number;
+  format?: "currency" | "number" | "percent";
+}
+
+export interface BaseWidget<T extends WidgetType, C> {
+  id: string;
+  type: T;
+  title: string;
+  grid: WidgetGrid;
+  config: C;
+}
+
+export type KPIWidget = BaseWidget<"kpi", KPIConfig>;
+export type BarWidget = BaseWidget<"bar", BarConfig>;
+
+// v1 widget union. PR3 adds the rest.
+export type Widget = KPIWidget | BarWidget;
+
+export interface LayoutJson {
+  version: 1;
+  widgets: Widget[];
+}
+
+// ─── REST API shapes ────────────────────────────────────────────
+
+export type ReportVisibility = "private" | "org";
+
+export interface ReportSummary {
+  id: number;
+  owner_user_id: number;
+  org_id: number;
+  visibility: ReportVisibility;
+  name: string;
+  description: string | null;
+  layout_json: LayoutJson | Record<string, never>;
+  canvas_filters_json: CanvasFilters | Record<string, never>;
+  schema_version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ReportCreatePayload {
+  name: string;
+  description?: string;
+  visibility?: ReportVisibility;
+  layout_json?: LayoutJson | Record<string, never>;
+  canvas_filters_json?: CanvasFilters | Record<string, never>;
+}
+
+export interface ReportUpdatePayload {
+  name?: string;
+  description?: string | null;
+  visibility?: ReportVisibility;
+  layout_json?: LayoutJson | Record<string, never>;
+  canvas_filters_json?: CanvasFilters | Record<string, never>;
+}

--- a/frontend/lib/reports/useReportQuery.ts
+++ b/frontend/lib/reports/useReportQuery.ts
@@ -1,0 +1,90 @@
+/**
+ * SWR-backed query hook for Reports v2 widgets.
+ *
+ * The widget owns its own SWR cache entry keyed by widget id +
+ * serialized resolved query. Canvas filter change → widget re-renders
+ * with a new resolved query → SWR fires a new fetch. Failure of one
+ * widget shows an inline error inside that widget and does not block
+ * the others (per spec §7 "Frontend fetching").
+ */
+import useSWR from "swr";
+import { useMemo } from "react";
+
+import { runQuery } from "./api";
+import { resolveFilters } from "./resolve";
+import type {
+  CanvasFilters,
+  ReportsQuery,
+  ReportsQueryResponse,
+  Widget,
+  WidgetFilters,
+} from "./types";
+
+interface UseReportQueryResult {
+  data: ReportsQueryResponse | undefined;
+  error: Error | undefined;
+  isLoading: boolean;
+  /** The AST that produced this result; useful for tests + debugging. */
+  query: ReportsQuery;
+}
+
+/**
+ * Builds the AST for a widget and runs it through SWR. The cache key
+ * is ``["report-query", widgetId, JSON.stringify(query)]`` so two
+ * widgets with identical configs share the same fetch (and two
+ * different configs do not).
+ */
+export function useReportQuery(
+  widget: Widget,
+  canvasFilters: CanvasFilters | undefined,
+): UseReportQueryResult {
+  const query = useMemo<ReportsQuery>(() => {
+    return buildQueryAst(widget, canvasFilters);
+  }, [widget, canvasFilters]);
+
+  const swrKey = ["report-query", widget.id, JSON.stringify(query)];
+  const { data, error, isLoading } = useSWR<ReportsQueryResponse>(
+    swrKey,
+    () => runQuery(query),
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: true,
+      shouldRetryOnError: false,
+    },
+  );
+
+  return { data, error, isLoading, query };
+}
+
+/**
+ * Pure builder so tests + the editor's save handler can construct the
+ * exact AST a widget would query, without going through SWR.
+ */
+export function buildQueryAst(
+  widget: Widget,
+  canvasFilters: CanvasFilters | undefined,
+): ReportsQuery {
+  const widgetFilters: WidgetFilters | undefined =
+    "filters" in widget.config ? widget.config.filters : undefined;
+  const filters = resolveFilters(canvasFilters, widgetFilters);
+
+  if (widget.type === "kpi") {
+    return {
+      dataset: widget.config.dataset,
+      measure: widget.config.measure,
+      dimensions: [],
+      filters,
+      limit: 1,
+    };
+  }
+
+  // Bar widget.
+  return {
+    dataset: widget.config.dataset,
+    measure: widget.config.measure,
+    dimensions: widget.config.dimensions,
+    filters,
+    sort: widget.config.sort,
+    limit: widget.config.limit ?? 10,
+  };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "next": "16.2.4",
         "react": "19.2.5",
         "react-dom": "19.2.5",
+        "react-grid-layout": "^1.5.0",
         "recharts": "^3.8.1",
         "server-only": "^0.0.1",
         "swr": "^2.3.3"
@@ -25,6 +26,7 @@
         "@types/node": "^22.15.17",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
+        "@types/react-grid-layout": "^1.3.5",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.4",
         "jsdom": "^26.1.0",
@@ -35,9 +37,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -67,6 +69,13 @@
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
       }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -124,16 +133,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
@@ -166,26 +165,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -515,9 +494,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1714,16 +1693,22 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@next/env": {
@@ -1733,9 +1718,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.4.tgz",
-      "integrity": "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1919,9 +1904,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -1945,9 +1930,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1955,9 +1940,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
@@ -1969,9 +1954,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -1983,9 +1968,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -1997,9 +1982,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -2011,9 +1996,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
@@ -2025,9 +2010,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -2039,9 +2024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
@@ -2053,9 +2038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
@@ -2067,9 +2052,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
@@ -2081,9 +2066,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
@@ -2095,9 +2080,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
       "cpu": [
         "loong64"
       ],
@@ -2109,9 +2094,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
       ],
@@ -2123,9 +2108,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
@@ -2137,9 +2122,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
       ],
@@ -2151,9 +2136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
@@ -2165,9 +2150,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
@@ -2179,9 +2164,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
@@ -2193,9 +2178,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
@@ -2207,9 +2192,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
@@ -2221,9 +2206,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
       "cpu": [
         "x64"
       ],
@@ -2235,9 +2220,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -2249,9 +2234,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -2263,9 +2248,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
@@ -2277,9 +2262,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -2291,9 +2276,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -2333,49 +2318,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
-      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
+        "enhanced-resolve": "^5.21.0",
         "jiti": "^2.6.1",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
-      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-x64": "4.2.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
@@ -2390,9 +2375,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
-      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
@@ -2407,9 +2392,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
@@ -2424,9 +2409,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
@@ -2441,9 +2426,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
@@ -2458,9 +2443,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
@@ -2475,9 +2460,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
@@ -2492,9 +2477,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "cpu": [
         "x64"
       ],
@@ -2509,9 +2494,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
@@ -2526,9 +2511,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -2544,10 +2529,10 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
       },
@@ -2556,9 +2541,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
@@ -2573,9 +2558,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
@@ -2590,17 +2575,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
-      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
-        "postcss": "^8.5.6",
-        "tailwindcss": "4.2.2"
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -2780,9 +2765,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2801,9 +2786,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2830,6 +2815,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-grid-layout": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.6.tgz",
+      "integrity": "sha512-Cw7+sb3yyjtmxwwJiXtEXcu5h4cgs+sCGkHwHXsFmPyV30bf14LeD/fa2LwQovuD2HWxCcjIdNhDlcYGj95qGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -2837,17 +2832,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+      "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/type-utils": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2860,7 +2855,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.59.4",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2876,16 +2871,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2901,14 +2896,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.4",
+        "@typescript-eslint/types": "^8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2923,14 +2918,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2941,9 +2936,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2958,15 +2953,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+      "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2983,9 +2978,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2997,16 +2992,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.59.4",
+        "@typescript-eslint/tsconfig-utils": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3035,9 +3030,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3063,17 +3058,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+      "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3088,13 +3096,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.59.4",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3119,9 +3127,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
       "cpu": [
         "arm"
       ],
@@ -3133,9 +3141,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
       "cpu": [
         "arm64"
       ],
@@ -3147,9 +3155,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
       "cpu": [
         "arm64"
       ],
@@ -3161,9 +3169,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
       "cpu": [
         "x64"
       ],
@@ -3175,9 +3183,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
       "cpu": [
         "x64"
       ],
@@ -3189,9 +3197,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
       ],
@@ -3203,9 +3211,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"
       ],
@@ -3217,9 +3225,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
       "cpu": [
         "arm64"
       ],
@@ -3231,9 +3239,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
       ],
@@ -3244,10 +3252,38 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
       "cpu": [
         "ppc64"
       ],
@@ -3259,9 +3295,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
       ],
@@ -3273,9 +3309,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
       "cpu": [
         "riscv64"
       ],
@@ -3287,9 +3323,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
       ],
@@ -3301,9 +3337,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
       "cpu": [
         "x64"
       ],
@@ -3315,9 +3351,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
       ],
@@ -3328,10 +3364,24 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
       "cpu": [
         "wasm32"
       ],
@@ -3339,16 +3389,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
       "cpu": [
         "arm64"
       ],
@@ -3360,9 +3412,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
       "cpu": [
         "ia32"
       ],
@@ -3374,9 +3426,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "cpu": [
         "x64"
       ],
@@ -3564,14 +3616,16 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -3825,9 +3879,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3965,9 +4019,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001782",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4016,22 +4070,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -4472,9 +4510,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.351",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
-      "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4486,14 +4524,14 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -4637,9 +4675,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4697,9 +4735,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -4832,13 +4870,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
-      "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
+      "integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.4",
+        "@next/eslint-plugin-next": "16.2.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5000,16 +5038,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
@@ -5101,16 +5129,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-scope": {
@@ -5240,6 +5258,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
@@ -5292,24 +5316,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -5928,6 +5934,19 @@
         "semver": "^7.7.1"
       }
     },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -6289,9 +6308,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6302,7 +6321,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6753,7 +6771,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6770,16 +6787,19 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
     },
     "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6840,19 +6860,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -6894,9 +6901,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -7034,22 +7041,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/node-exports-info/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
@@ -7062,7 +7062,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7326,13 +7325,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -7349,9 +7348,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7369,7 +7368,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7403,6 +7402,20 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -7415,7 +7428,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7427,7 +7439,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -7482,17 +7493,49 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.3.tgz",
+      "integrity": "sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.0.5",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -7510,6 +7553,20 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
+      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/recharts": {
@@ -7621,15 +7678,21 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -7677,9 +7740,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7693,33 +7756,40 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
@@ -7834,16 +7904,13 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/server-only": {
@@ -7944,6 +8011,19 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -8335,16 +8415,16 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8390,6 +8470,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -8632,16 +8743,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
+      "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.59.4",
+        "@typescript-eslint/parser": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8682,38 +8793,41 @@
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.3.0"
+        "napi-postinstall": "^0.3.4"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -8789,9 +8903,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8886,6 +9000,37 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -8957,6 +9102,19 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -9153,9 +9311,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "next": "16.2.4",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "react-grid-layout": "^1.5.0",
     "recharts": "^3.8.1",
     "server-only": "^0.0.1",
     "swr": "^2.3.3"
@@ -30,6 +31,7 @@
     "@types/node": "^22.15.17",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@types/react-grid-layout": "^1.3.5",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.4",
     "jsdom": "^26.1.0",

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -1,0 +1,353 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+// Stub the canvas (react-grid-layout) — jsdom can't measure container
+// width so the responsive grid silently collapses to width=-1 and
+// neither widgets nor drag handles render. The stub keeps the
+// render-tree shape (calls ``renderWidget`` for each widget) so
+// downstream interactions inside widget shells still work.
+vi.mock("@/components/reports/Canvas", () => ({
+  default: ({ layout, renderWidget }: {
+    layout: { widgets: { id: string }[] };
+    renderWidget: (w: { id: string }) => React.ReactNode;
+  }) => (
+    <div data-testid="reports-canvas">
+      {layout.widgets.map((w) => (
+        <div key={w.id} data-widget-id={w.id}>
+          {renderWidget(w as never)}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/reports/api", () => ({
+  getReport: vi.fn(),
+  saveLayout: vi.fn(),
+  runQuery: vi.fn(),
+}));
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/AuthProvider")
+  >("@/components/auth/AuthProvider");
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+// Stable router object — returning a fresh literal every call would
+// invalidate the editor's useEffect deps on each render and re-fire
+// getReport in a loop that resets layout state under us.
+const stableRouter = { push: pushMock, replace: replaceMock };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/reports/10",
+}));
+
+import ReportEditorPage from "@/app/reports/[id]/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import * as reportsApi from "@/lib/reports/api";
+
+const BASE_USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@example.com",
+  first_name: "Alice",
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+function mockUser(featureReportsV2 = true) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: BASE_USER as never,
+    loading: false,
+    needsSetup: false,
+    featureReportsV2,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+function makeParams(id = "10") {
+  // The editor page accepts either a Promise (production / Next 15
+  // routing) or a plain object (test harness). We pass the plain
+  // object so the page doesn't suspend on ``use()``.
+  return { id };
+}
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+describe("ReportEditorPage", () => {
+  const getReportMock = vi.mocked(reportsApi.getReport);
+  const saveLayoutMock = vi.mocked(reportsApi.saveLayout);
+  const runQueryMock = vi.mocked(reportsApi.runQuery);
+
+  beforeEach(() => {
+    getReportMock.mockReset();
+    saveLayoutMock.mockReset();
+    runQueryMock.mockReset();
+    runQueryMock.mockResolvedValue({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 1 },
+    });
+    pushMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  it("renders the canvas for an empty report and opens the widget picker", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    expect(screen.getByTestId("report-editor-empty")).toBeInTheDocument();
+
+    // Add widget opens the picker dialog.
+    fireEvent.click(screen.getByTestId("report-editor-add-widget"));
+    expect(screen.getByTestId("widget-picker")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("widget-picker-option-kpi"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("widget-picker-option-bar"),
+    ).toBeInTheDocument();
+  });
+
+  it("adds a KPI widget through the picker and surfaces it on the canvas", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    fireEvent.click(screen.getByTestId("report-editor-add-widget"));
+    fireEvent.click(screen.getByTestId("widget-picker-option-kpi"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("kpi-widget")).toBeInTheDocument(),
+    );
+    // Picker dismisses after pick.
+    expect(screen.queryByTestId("widget-picker")).toBeNull();
+    // The newly added widget is selected → ConfigRail mounts.
+    await waitFor(() =>
+      expect(screen.getByTestId("config-rail")).toBeInTheDocument(),
+    );
+  });
+
+  it("saves the layout via PATCH when 'Save' is clicked", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+    saveLayoutMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:01",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    // Make the report dirty by adding a widget.
+    fireEvent.click(screen.getByTestId("report-editor-add-widget"));
+    fireEvent.click(screen.getByTestId("widget-picker-option-bar"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("report-editor-dirty")).toBeInTheDocument(),
+    );
+    // Wait for the bar widget to land so the Save button reflects the
+    // dirty layout state on click.
+    await waitFor(() =>
+      expect(screen.getByTestId("bar-widget")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("report-editor-save"));
+
+    await waitFor(() => expect(saveLayoutMock).toHaveBeenCalledTimes(1));
+    // Args: report id, layout, canvas filters.
+    const [calledId, calledLayout] = saveLayoutMock.mock.calls[0];
+    expect(calledId).toBe(10);
+    expect(calledLayout.version).toBe(1);
+    expect(calledLayout.widgets).toHaveLength(1);
+    expect(calledLayout.widgets[0].type).toBe("bar");
+  });
+
+  it("propagates the canvas-wide date filter into widget queries (cascade)", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: {
+        version: 1,
+        widgets: [
+          {
+            id: "w_1",
+            type: "kpi",
+            title: "Total",
+            grid: { x: 0, y: 0, w: 3, h: 2 },
+            config: {
+              dataset: "transactions",
+              measure: { agg: "sum", field: "amount" },
+              format: "currency",
+            },
+          },
+        ],
+      },
+      canvas_filters_json: {
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      },
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await waitFor(() => expect(runQueryMock).toHaveBeenCalled());
+    const lastCall = runQueryMock.mock.calls[runQueryMock.mock.calls.length - 1];
+    const ast = lastCall[0];
+    // The canvas date range cascaded into the widget's resolved AST.
+    const dateFilter = ast.filters.find(
+      (f: { field: string }) => f.field === "date",
+    );
+    expect(dateFilter).toBeDefined();
+    expect(dateFilter!.op).toBe("between");
+    expect(dateFilter!.value).toEqual(["2026-01-01", "2026-01-31"]);
+  });
+
+  it("shows the 'Overrides canvas' pill when a widget overrides a canvas filter", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: {
+        version: 1,
+        widgets: [
+          {
+            id: "w_1",
+            type: "kpi",
+            title: "Total",
+            grid: { x: 0, y: 0, w: 3, h: 2 },
+            config: {
+              dataset: "transactions",
+              measure: { agg: "sum", field: "amount" },
+              format: "currency",
+              filters: {
+                date_range: { start: "2026-02-01", end: "2026-02-15" },
+              },
+            },
+          },
+        ],
+      },
+      canvas_filters_json: {
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      },
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    // Click the widget shell to select it; config rail mounts.
+    const shell = await screen.findByTestId("kpi-widget");
+    fireEvent.click(shell);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("config-rail")).toBeInTheDocument(),
+    );
+    // Override pill appears on the overridden date field.
+    expect(screen.getByTestId("override-pill")).toBeInTheDocument();
+  });
+
+  it("redirects to /dashboard when feature_reports_v2 is false", async () => {
+    mockUser(false);
+    getReportMock.mockResolvedValue({
+      id: 10,
+    } as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await waitFor(() =>
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard"),
+    );
+    expect(getReportMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -27,6 +27,12 @@ vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
 
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
 vi.mock("@/components/auth/AuthProvider", async () => {
   const actual = await vi.importActual<
     typeof import("@/components/auth/AuthProvider")
@@ -140,6 +146,9 @@ describe("ReportEditorPage", () => {
     renderIsolated(<ReportEditorPage params={makeParams()} />);
 
     await screen.findByTestId("report-editor");
+    // The editor renders inside AppShell so users keep the
+    // sidebar/nav frame + shell-level surfaces.
+    expect(screen.getByTestId("app-shell")).toBeInTheDocument();
     expect(screen.getByTestId("report-editor-empty")).toBeInTheDocument();
 
     // Add widget opens the picker dialog.

--- a/frontend/tests/app/reports-page.test.tsx
+++ b/frontend/tests/app/reports-page.test.tsx
@@ -1,0 +1,153 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ReportsListPage from "@/app/reports/page";
+import * as reportsApi from "@/lib/reports/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/reports/api", () => ({
+  listReports: vi.fn(),
+  createReport: vi.fn(),
+}));
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/AuthProvider")
+  >("@/components/auth/AuthProvider");
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => "/reports",
+}));
+
+const BASE_USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@example.com",
+  first_name: "Alice",
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+function mockUser(featureReportsV2 = true) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: BASE_USER as never,
+    loading: false,
+    needsSetup: false,
+    featureReportsV2,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+describe("ReportsListPage", () => {
+  const listMock = vi.mocked(reportsApi.listReports);
+  const createMock = vi.mocked(reportsApi.createReport);
+
+  beforeEach(() => {
+    listMock.mockReset();
+    createMock.mockReset();
+    pushMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  it("renders the list of reports from the API", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([
+      {
+        id: 10,
+        owner_user_id: 1,
+        org_id: 1,
+        visibility: "private",
+        name: "Monthly review",
+        description: "January numbers",
+        layout_json: {},
+        canvas_filters_json: {},
+        schema_version: 1,
+        created_at: "2026-05-21T10:00:00",
+        updated_at: "2026-05-22T10:00:00",
+      },
+    ]);
+
+    render(<ReportsListPage />);
+
+    await screen.findByText("Monthly review");
+    expect(screen.getByText("January numbers")).toBeInTheDocument();
+    expect(screen.getByTestId("report-row-10")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when the user has no reports yet", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([]);
+
+    render(<ReportsListPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("reports-empty-state")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/No reports yet/i)).toBeInTheDocument();
+  });
+
+  it("creates a new report and navigates to its editor on 'New report'", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([]);
+    createMock.mockResolvedValue({
+      id: 42,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "Untitled report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+
+    render(<ReportsListPage />);
+
+    await screen.findByTestId("reports-empty-state");
+    fireEvent.click(screen.getByRole("button", { name: /new report/i }));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/42"));
+  });
+
+  it("redirects to /dashboard when feature_reports_v2 is false", async () => {
+    mockUser(false);
+    listMock.mockResolvedValue([]);
+
+    render(<ReportsListPage />);
+
+    await waitFor(() =>
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard"),
+    );
+    // Should not have queried the API at all.
+    expect(listMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/app/reports-page.test.tsx
+++ b/frontend/tests/app/reports-page.test.tsx
@@ -9,6 +9,12 @@ vi.mock("@/lib/reports/api", () => ({
   createReport: vi.fn(),
 }));
 
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
 vi.mock("@/components/auth/AuthProvider", async () => {
   const actual = await vi.importActual<
     typeof import("@/components/auth/AuthProvider")
@@ -73,6 +79,16 @@ describe("ReportsListPage", () => {
     createMock.mockReset();
     pushMock.mockReset();
     replaceMock.mockReset();
+  });
+
+  it("renders inside AppShell so users see the sidebar/nav frame", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([]);
+
+    render(<ReportsListPage />);
+
+    await screen.findByTestId("reports-empty-state");
+    expect(screen.getByTestId("app-shell")).toBeInTheDocument();
   });
 
   it("renders the list of reports from the API", async () => {

--- a/frontend/tests/components/app-shell.test.tsx
+++ b/frontend/tests/components/app-shell.test.tsx
@@ -191,6 +191,52 @@ describe("AppShell — system nav gating", () => {
     expect(screen.queryByRole("link", { name: "Plan Catalog" })).toBeNull();
   });
 
+  it("hides the Reports nav entry when feature_reports_v2 is false", async () => {
+    useAuthMock.mockReturnValue({
+      user: BASE_USER as never,
+      loading: false,
+      needsSetup: false,
+      featureReportsV2: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    await renderShell();
+
+    // "Reports" should not appear in the sidebar when the flag is off.
+    // Use exact-match so neighboring labels (e.g. "Forecast Plans",
+    // "Plans") don't accidentally satisfy the assertion.
+    expect(screen.queryByRole("link", { name: "Reports" })).toBeNull();
+    // Sanity: the rest of the nav still renders.
+    expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
+  });
+
+  it("shows the Reports nav entry when feature_reports_v2 is true", async () => {
+    useAuthMock.mockReturnValue({
+      user: BASE_USER as never,
+      loading: false,
+      needsSetup: false,
+      featureReportsV2: true,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    await renderShell();
+
+    // Exact-match by accessible role so neither "Forecast Plans" nor
+    // the existing "Plans" frame item satisfies a substring query.
+    expect(
+      screen.getByRole("link", { name: "Reports" }),
+    ).toBeInTheDocument();
+    // Plans entry must remain (architect-locked: Reports is a peer of
+    // Plans, not a replacement).
+    expect(screen.getByRole("link", { name: "Plans" })).toBeInTheDocument();
+  });
+
   it("shows only the Plan Catalog link for a non-superadmin with plans.manage alone", async () => {
     useAuthMock.mockReturnValue({
       user: { ...BASE_USER, permissions: ["plans.manage"] } as never,

--- a/frontend/tests/components/reports/widgets/bar-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/bar-widget.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import BarWidget from "@/components/reports/widgets/BarWidget";
+import type { BarWidget as BarWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+// Recharts renders SVG via ResponsiveContainer; jsdom doesn't compute
+// layout, so the ResponsiveContainer collapses to 0×0 and skips the
+// chart body. We assert on the data-binding path (chart container
+// present, no error / empty state) rather than the rendered bars.
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(): BarWidgetType {
+  return {
+    id: `w_bar_${Math.random().toString(36).slice(2, 10)}`,
+    type: "bar",
+    title: "Spend by category",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      sort: { by: "value", dir: "desc" },
+      limit: 10,
+      format: "currency",
+    },
+  };
+}
+
+describe("BarWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders the chart surface and the title when rows are present", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 200 },
+        { category: "Transport", value: 80 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 4 },
+    });
+
+    renderIsolated(<BarWidget widget={makeWidget()} />);
+
+    await waitFor(() => {
+      // Empty / loading states must NOT be shown when rows arrive.
+      expect(screen.queryByTestId("bar-widget-empty")).toBeNull();
+      expect(screen.queryByTestId("bar-widget-loading")).toBeNull();
+    });
+    // The widget container always renders; the title comes from
+    // ``widget.title`` so the chart wrapper is locatable.
+    expect(screen.getByTestId("bar-widget")).toBeInTheDocument();
+    expect(screen.getByText("Spend by category")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when rows is an empty array", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 2 },
+    });
+
+    renderIsolated(<BarWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("bar-widget-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("nope"));
+
+    renderIsolated(<BarWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("bar-widget-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/components/reports/widgets/kpi-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/kpi-widget.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import KPIWidget from "@/components/reports/widgets/KPIWidget";
+import type { KPIWidget as KPIWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+// Fresh SWR provider per test prevents cache reuse from leaking
+// a previous test's resolved value into the next test's mount.
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(overrides: Partial<KPIWidgetType> = {}): KPIWidgetType {
+  return {
+    id: `w_kpi_${Math.random().toString(36).slice(2, 10)}`,
+    type: "kpi",
+    title: "Total spend",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      format: "currency",
+    },
+    ...overrides,
+  };
+}
+
+describe("KPIWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders the value returned by the AST query", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [{ value: 1234.56 }],
+      meta: { row_count: 1, truncated: false, query_ms: 12 },
+    });
+
+    renderIsolated(<KPIWidget widget={makeWidget()} />);
+
+    const value = await screen.findByTestId("kpi-widget-value");
+    // Currency formatting renders the symbol; assert the digits are
+    // present so the test is locale-tolerant.
+    expect(value.textContent).toContain("1,234");
+    expect(value.textContent).toContain("56");
+  });
+
+  it("renders a delta vs the supplied prior-period value when compare_prior_period is on", async () => {
+    const widget = makeWidget({
+      config: {
+        dataset: "transactions",
+        measure: { agg: "sum", field: "amount" },
+        format: "currency",
+        compare_prior_period: true,
+      },
+    });
+    runQueryMock.mockResolvedValueOnce({
+      rows: [{ value: 200 }],
+      meta: { row_count: 1, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<KPIWidget widget={widget} priorValue={100} />);
+
+    const delta = await screen.findByTestId("kpi-widget-delta");
+    // 100 → 200 is a +100% change.
+    expect(delta.textContent).toContain("100");
+    expect(delta.textContent).toContain("%");
+    expect(delta.textContent).toContain("+");
+  });
+
+  it("does NOT render a delta when compare_prior_period is off", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [{ value: 200 }],
+      meta: { row_count: 1, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<KPIWidget widget={makeWidget()} priorValue={100} />);
+
+    await screen.findByTestId("kpi-widget-value");
+    expect(screen.queryByTestId("kpi-widget-delta")).toBeNull();
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("boom"));
+
+    renderIsolated(<KPIWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("kpi-widget-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/lib/reports/resolve.test.ts
+++ b/frontend/tests/lib/reports/resolve.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isFieldOverridden } from "@/lib/reports/resolve";
+import { isFieldOverridden, resolveFilters } from "@/lib/reports/resolve";
 import type { CanvasFilters, WidgetFilters } from "@/lib/reports/types";
 
 /**
@@ -160,6 +160,109 @@ describe("isFieldOverridden", () => {
       const canvas: CanvasFilters = {};
       const widget: WidgetFilters = { tag_match: "any" };
       expect(isFieldOverridden("tag_match", widget, canvas)).toBe(false);
+    });
+  });
+});
+
+/**
+ * Architect bug fix: the previous emitter looped over ``tag_names`` and
+ * pushed one ``{op: "eq"}`` filter per tag. The AST compiler AND-combines
+ * filters, so ``tag_match="any"`` with N tags actually ran as "match ALL"
+ * — the opposite of the UI promise. The canonical shape is ONE ``in``
+ * filter carrying the full list, with ``tag_match`` riding on that single
+ * filter. Backend reference:
+ * ``backend/app/services/reports_query_service.py:185``.
+ */
+describe("resolveFilters — tag emission", () => {
+  it("emits a single 'in' filter with one tag when tag_match='any' and 1 tag is selected", () => {
+    const widget: WidgetFilters = {
+      tag_names: ["groceries"],
+      tag_match: "any",
+    };
+    const out = resolveFilters(undefined, widget);
+    const tagFilters = out.filter((f) => f.field === "tag_name");
+    expect(tagFilters).toHaveLength(1);
+    expect(tagFilters[0]).toEqual({
+      field: "tag_name",
+      op: "in",
+      value: ["groceries"],
+      tag_match: "any",
+    });
+  });
+
+  it("emits ONE filter (not N) with the full tag list when tag_match='any' and 3 tags are selected", () => {
+    const widget: WidgetFilters = {
+      tag_names: ["groceries", "essentials", "treat"],
+      tag_match: "any",
+    };
+    const out = resolveFilters(undefined, widget);
+    const tagFilters = out.filter((f) => f.field === "tag_name");
+    // The bug: previously this would have been 3 separate eq filters,
+    // which the AST compiler AND-combines — collapsing "any" into "all".
+    expect(tagFilters).toHaveLength(1);
+    expect(tagFilters[0]).toEqual({
+      field: "tag_name",
+      op: "in",
+      value: ["groceries", "essentials", "treat"],
+      tag_match: "any",
+    });
+  });
+
+  it("emits a single 'in' filter with one tag when tag_match='all' and 1 tag is selected", () => {
+    const widget: WidgetFilters = {
+      tag_names: ["essentials"],
+      tag_match: "all",
+    };
+    const out = resolveFilters(undefined, widget);
+    const tagFilters = out.filter((f) => f.field === "tag_name");
+    expect(tagFilters).toHaveLength(1);
+    expect(tagFilters[0]).toEqual({
+      field: "tag_name",
+      op: "in",
+      value: ["essentials"],
+      tag_match: "all",
+    });
+  });
+
+  it("emits ONE filter with the full tag list when tag_match='all' and 3 tags are selected", () => {
+    const widget: WidgetFilters = {
+      tag_names: ["groceries", "essentials", "treat"],
+      tag_match: "all",
+    };
+    const out = resolveFilters(undefined, widget);
+    const tagFilters = out.filter((f) => f.field === "tag_name");
+    // The backend's tag compiler handles ``tag_match=all`` server-side
+    // by AND-combining per-name IN subqueries; the wire shape stays
+    // ONE filter with the full list.
+    expect(tagFilters).toHaveLength(1);
+    expect(tagFilters[0]).toEqual({
+      field: "tag_name",
+      op: "in",
+      value: ["groceries", "essentials", "treat"],
+      tag_match: "all",
+    });
+  });
+
+  it("emits no tag filter when tag_names is an empty array", () => {
+    const widget: WidgetFilters = {
+      tag_names: [],
+      tag_match: "any",
+    };
+    const out = resolveFilters(undefined, widget);
+    const tagFilters = out.filter((f) => f.field === "tag_name");
+    expect(tagFilters).toHaveLength(0);
+  });
+
+  it("defaults tag_match to 'all' when only tag_names is set", () => {
+    const widget: WidgetFilters = { tag_names: ["essentials"] };
+    const out = resolveFilters(undefined, widget);
+    const tagFilters = out.filter((f) => f.field === "tag_name");
+    expect(tagFilters).toHaveLength(1);
+    expect(tagFilters[0]).toEqual({
+      field: "tag_name",
+      op: "in",
+      value: ["essentials"],
+      tag_match: "all",
     });
   });
 });

--- a/frontend/tests/lib/reports/resolve.test.ts
+++ b/frontend/tests/lib/reports/resolve.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import { isFieldOverridden } from "@/lib/reports/resolve";
+import type { CanvasFilters, WidgetFilters } from "@/lib/reports/types";
+
+/**
+ * Locked rule (spec §4): the "Overrides canvas" pill fires ONLY
+ * when BOTH widget and canvas have a meaningful value AND the
+ * values differ. Identical values must NOT show the pill.
+ *
+ * These tests pin the five canonical cases across each field type:
+ *   1. identical -> no pill
+ *   2. different by one element -> pill
+ *   3. partial overlap -> pill
+ *   4. canvas-only -> no pill
+ *   5. widget-only -> no pill
+ */
+describe("isFieldOverridden", () => {
+  describe("date_range", () => {
+    it("returns false when widget and canvas date ranges are identical", () => {
+      const canvas: CanvasFilters = {
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      };
+      const widget: WidgetFilters = {
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      };
+      expect(isFieldOverridden("date_range", widget, canvas)).toBe(false);
+    });
+
+    it("returns true when only the end date differs", () => {
+      const canvas: CanvasFilters = {
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      };
+      const widget: WidgetFilters = {
+        date_range: { start: "2026-01-01", end: "2026-02-15" },
+      };
+      expect(isFieldOverridden("date_range", widget, canvas)).toBe(true);
+    });
+
+    it("returns true when only the start date differs", () => {
+      const canvas: CanvasFilters = {
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      };
+      const widget: WidgetFilters = {
+        date_range: { start: "2026-01-05", end: "2026-01-31" },
+      };
+      expect(isFieldOverridden("date_range", widget, canvas)).toBe(true);
+    });
+
+    it("returns false when canvas has a date range but the widget doesn't", () => {
+      const canvas: CanvasFilters = {
+        date_range: { start: "2026-01-01", end: "2026-01-31" },
+      };
+      const widget: WidgetFilters = {};
+      expect(isFieldOverridden("date_range", widget, canvas)).toBe(false);
+    });
+
+    it("returns false when only the widget has a date range (no canvas value)", () => {
+      const canvas: CanvasFilters = {};
+      const widget: WidgetFilters = {
+        date_range: { start: "2026-02-01", end: "2026-02-15" },
+      };
+      expect(isFieldOverridden("date_range", widget, canvas)).toBe(false);
+    });
+  });
+
+  describe("account_ids", () => {
+    it("returns false when both lists contain the same ids regardless of order", () => {
+      const canvas: CanvasFilters = { account_ids: [3, 1, 2] };
+      const widget: WidgetFilters = { account_ids: [1, 2, 3] };
+      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
+    });
+
+    it("returns true when the widget list has an extra id", () => {
+      const canvas: CanvasFilters = { account_ids: [1, 2] };
+      const widget: WidgetFilters = { account_ids: [1, 2, 3] };
+      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(true);
+    });
+
+    it("returns true when the lists partially overlap", () => {
+      const canvas: CanvasFilters = { account_ids: [1, 2, 3] };
+      const widget: WidgetFilters = { account_ids: [2, 3, 4] };
+      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(true);
+    });
+
+    it("returns false when canvas has account_ids but the widget doesn't", () => {
+      const canvas: CanvasFilters = { account_ids: [1, 2, 3] };
+      const widget: WidgetFilters = {};
+      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
+    });
+
+    it("returns false when only the widget has account_ids (no canvas value)", () => {
+      const canvas: CanvasFilters = {};
+      const widget: WidgetFilters = { account_ids: [5] };
+      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
+    });
+
+    it("treats an empty widget account_ids array as inherit (no pill)", () => {
+      const canvas: CanvasFilters = { account_ids: [1, 2, 3] };
+      const widget: WidgetFilters = { account_ids: [] };
+      expect(isFieldOverridden("account_ids", widget, canvas)).toBe(false);
+    });
+  });
+
+  describe("category_ids", () => {
+    it("returns false when both lists contain the same ids regardless of order", () => {
+      const canvas: CanvasFilters = { category_ids: [10, 20, 30] };
+      const widget: WidgetFilters = { category_ids: [30, 20, 10] };
+      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(false);
+    });
+
+    it("returns true when one id differs", () => {
+      const canvas: CanvasFilters = { category_ids: [10, 20] };
+      const widget: WidgetFilters = { category_ids: [10, 21] };
+      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(true);
+    });
+
+    it("returns true on partial overlap", () => {
+      const canvas: CanvasFilters = { category_ids: [10, 20, 30] };
+      const widget: WidgetFilters = { category_ids: [20, 30, 40] };
+      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(true);
+    });
+
+    it("returns false when canvas has category_ids but the widget doesn't", () => {
+      const canvas: CanvasFilters = { category_ids: [10, 20] };
+      const widget: WidgetFilters = {};
+      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(false);
+    });
+
+    it("returns false when only the widget has category_ids", () => {
+      const canvas: CanvasFilters = {};
+      const widget: WidgetFilters = { category_ids: [10] };
+      expect(isFieldOverridden("category_ids", widget, canvas)).toBe(false);
+    });
+  });
+
+  describe("widget-only fields (txn_type, amount_range, tag_names, tag_match)", () => {
+    // These fields don't exist on CanvasFilters at all, so a widget
+    // value can never "override" a canvas value for them. The pill
+    // must never render for these fields.
+    it("never reports txn_type as overriding canvas", () => {
+      const canvas: CanvasFilters = {};
+      const widget: WidgetFilters = { txn_type: "expense" };
+      expect(isFieldOverridden("txn_type", widget, canvas)).toBe(false);
+    });
+
+    it("never reports amount_range as overriding canvas", () => {
+      const canvas: CanvasFilters = {};
+      const widget: WidgetFilters = { amount_range: { min: 0, max: 100 } };
+      expect(isFieldOverridden("amount_range", widget, canvas)).toBe(false);
+    });
+
+    it("never reports tag_names as overriding canvas", () => {
+      const canvas: CanvasFilters = {};
+      const widget: WidgetFilters = { tag_names: ["groceries"] };
+      expect(isFieldOverridden("tag_names", widget, canvas)).toBe(false);
+    });
+
+    it("never reports tag_match as overriding canvas", () => {
+      const canvas: CanvasFilters = {};
+      const widget: WidgetFilters = { tag_match: "any" };
+      expect(isFieldOverridden("tag_match", widget, canvas)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR2 of the Reports v2 rollout train. Brings the user-facing canvas online with the KPI and bar widgets plus the full config UX, on top of the AST + CRUD that landed in PR1 (#343).

- `react-grid-layout` canvas (12-col snap, drag + resize, mobile collapses to read-only single column).
- Two widgets: KPI (single number, optional prior-period delta) and Bar (vertical bars over a dimension).
- Right-rail ConfigRail with data source picker, aggregation picker, dimension picker, filter primitives (date range, accounts, categories, transaction type, amount range, tags with `tag_match` defaulting to `all`).
- Canvas-wide filters bar with per-widget override (each overridden field surfaces an "Overrides canvas" pill).
- `useReportQuery` SWR hook keyed by widget id + serialized AST; per-widget cache and per-widget error isolation.
- `feature_reports_v2` added to `/api/v1/auth/status` and consumed by `AuthProvider`; the Reports nav item is hidden until the flag is true.
- Explicit Save semantics (not auto-save) — see the editor page header for the decision note.

The flag stays false by default; the operator flips it when PR3 (full widget catalog + richer filter primitives) and PR4 (sharing, templates, mobile polish) complete the surface.

Spec: `specs/2026-05-22-reports-v2-flexible-canvas.md`.