### PR TITLE
feat(scenarios): comparison view + custom event replay (PR3 of train)

### DIFF
--- a/backend/app/routers/scenarios.py
+++ b/backend/app/routers/scenarios.py
@@ -379,7 +379,13 @@ async def _validate_custom_event_references(
     Raises HTTPException(422) with detail code ``event_invalid_reference``
     when an event references a recurring_id / account_id / category_id
     that does not belong to the current user's org, or when a month
-    (or from_month / to_month) is < 0 or > horizon_months.
+    (or from_month / to_month) is < 0 or >= horizon_months.
+
+    The engine iterates ``range(0, horizon_months)`` so valid month
+    indices are ``[0, horizon_months - 1]``. An event at
+    ``month == horizon_months`` (or ``from_month == horizon_months``,
+    or ``to_month == horizon_months``) would silently never fire; we
+    reject it as a misconfiguration instead.
 
     Schema-level validators already enforce ``from_month <= to_month``
     and ``>= 0`` on each event; this function is the cross-user
@@ -388,7 +394,10 @@ async def _validate_custom_event_references(
     events = params.get("events") or []
     for ev in events:
         ev_type = ev.get("type")
-        # Bound month / from_month / to_month against horizon.
+        # Bound month / from_month / to_month against horizon. The engine
+        # iterates range(0, horizon_months), so the last valid month index
+        # is horizon_months - 1. Anything >= horizon_months silently does
+        # nothing — reject it.
         for field_name in ("month", "from_month", "to_month"):
             val = ev.get(field_name)
             if val is None:
@@ -403,14 +412,15 @@ async def _validate_custom_event_references(
                         "message": f"custom event {field_name} must be an integer",
                     },
                 )
-            if ival > horizon_months:
+            if ival >= horizon_months:
                 raise HTTPException(
                     status_code=422,
                     detail={
                         "code": "event_invalid_reference",
                         "message": (
-                            f"custom event {field_name}={ival} exceeds "
-                            f"horizon_months={horizon_months}"
+                            f"custom event {field_name}={ival} is outside the "
+                            f"simulated range [0, horizon_months - 1] "
+                            f"(horizon_months={horizon_months})"
                         ),
                     },
                 )

--- a/backend/app/routers/scenarios.py
+++ b/backend/app/routers/scenarios.py
@@ -27,9 +27,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app._time import utcnow_naive
 from app.database import get_db
 from app.deps import get_current_user
+from app.models.account import Account
+from app.models.category import Category
+from app.models.recurring import RecurringTransaction
 from app.models.scenario import Scenario, ScenarioType
 from app.models.user import User
 from app.schemas.scenario import (
+    COMPARE_MAX_SCENARIOS,
+    CompareRequest,
+    CompareResponse,
+    CompareProjection,
     ScenarioCreate,
     ScenarioResponse,
     ScenarioUpdate,
@@ -112,12 +119,22 @@ async def create_scenario(
     """Create a new scenario (Plan in UI terms) for the current user."""
     _validate_horizon_or_422(body.scenario_type.value, body.horizon_months)
 
+    params_json = body.params.model_dump(mode="json")
+    # PR3: custom events get cross-user FK + horizon-bound validation.
+    if body.scenario_type == ScenarioType.CUSTOM:
+        await _validate_custom_event_references(
+            db,
+            org_id=current_user.org_id,
+            horizon_months=body.horizon_months,
+            params=params_json,
+        )
+
     row = Scenario(
         org_id=current_user.org_id,
         user_id=current_user.id,
         name=body.name,
         scenario_type=body.scenario_type,
-        params_json=body.params.model_dump(mode="json"),
+        params_json=params_json,
         horizon_months=body.horizon_months,
         is_active=True,
     )
@@ -167,7 +184,18 @@ async def update_scenario(
                     "scenario_type on the row"
                 ),
             )
-        row.params_json = body.params.model_dump(mode="json")
+        new_params = body.params.model_dump(mode="json")
+        # PR3: custom events get cross-user FK + horizon-bound validation
+        # on PATCH too. Use the row's CURRENT horizon (possibly just
+        # updated above) so the bound check stays consistent.
+        if row.scenario_type == ScenarioType.CUSTOM:
+            await _validate_custom_event_references(
+                db,
+                org_id=current_user.org_id,
+                horizon_months=row.horizon_months,
+                params=new_params,
+            )
+        row.params_json = new_params
 
     if body.is_active is not None:
         row.is_active = body.is_active
@@ -255,3 +283,185 @@ async def simulate_scenario(
     await db.commit()
     await db.refresh(row)
     return row
+
+
+# ── PR3: comparison view ────────────────────────────────────────────────
+
+
+@router.post("/compare", response_model=CompareResponse)
+async def compare_scenarios(
+    body: CompareRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Run the analytic engine on 1-3 scenarios at the SAME horizon
+    and return the projections side-by-side.
+
+    Architect-locked rules:
+
+    - Max 3 scenarios (enforced by ``CompareRequest`` Field constraint).
+    - Each scenario must belong to the current user; 404 on cross-user
+      (matches the per-user privacy lock on the rest of the router).
+    - The request's horizon is validated against EACH scenario's
+      ``scenario_type`` cap. If any scenario rejects it, the whole
+      compare 422s with the offending scenario id in the message.
+    - Engine runs are sequential — sub-second each, max 3, so parallel
+      gather adds complexity for no measurable win.
+    - World state is built ONCE and reused across all engine runs (it
+      depends only on org_id/user_id, not on the scenario).
+    """
+    # Load every scenario the request asked for, in the SAME order as
+    # the request's scenario_ids list. Order preserved so the response
+    # is positionally parallel.
+    rows: list[Scenario] = []
+    for sid in body.scenario_ids:
+        row = await db.get(Scenario, sid)
+        if row is None or row.user_id != current_user.id or row.org_id != current_user.org_id:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Scenario not found: {sid}",
+            )
+        rows.append(row)
+
+    # Validate horizon against EACH scenario's per-type cap. The first
+    # offender wins the 422 with its id in the detail.
+    for row in rows:
+        try:
+            validate_horizon(row.scenario_type.value, body.horizon_months)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=f"scenario_id={row.id}: {exc}",
+            )
+
+    # Build the world state once (it's per-org, not per-scenario).
+    state = await build_world_state(
+        db, org_id=current_user.org_id, user_id=current_user.id
+    )
+
+    engine = get_engine("analytic")
+    projections: list[CompareProjection] = []
+    for row in rows:
+        sim_request = SimulationRequest(
+            scenario=row,
+            state=state,
+            horizon_months=body.horizon_months,
+            options={},
+        )
+        result = engine.simulate(
+            sim_request,
+            smooth_with_regression=body.smooth_with_regression,
+        )
+        projections.append(
+            CompareProjection(
+                scenario_id=row.id,
+                name=row.name,
+                scenario_type=row.scenario_type,
+                projection=result,
+            )
+        )
+
+    return CompareResponse(projections=projections)
+
+
+# ── Custom-event cross-user FK validation ───────────────────────────────
+
+
+async def _validate_custom_event_references(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    horizon_months: int,
+    params: dict,
+) -> None:
+    """Pin custom events to the current user's org and the row's horizon.
+
+    Raises HTTPException(422) with detail code ``event_invalid_reference``
+    when an event references a recurring_id / account_id / category_id
+    that does not belong to the current user's org, or when a month
+    (or from_month / to_month) is < 0 or > horizon_months.
+
+    Schema-level validators already enforce ``from_month <= to_month``
+    and ``>= 0`` on each event; this function is the cross-user
+    leak gate plus the horizon-relative bound check.
+    """
+    events = params.get("events") or []
+    for ev in events:
+        ev_type = ev.get("type")
+        # Bound month / from_month / to_month against horizon.
+        for field_name in ("month", "from_month", "to_month"):
+            val = ev.get(field_name)
+            if val is None:
+                continue
+            try:
+                ival = int(val)
+            except (TypeError, ValueError):
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "code": "event_invalid_reference",
+                        "message": f"custom event {field_name} must be an integer",
+                    },
+                )
+            if ival > horizon_months:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "code": "event_invalid_reference",
+                        "message": (
+                            f"custom event {field_name}={ival} exceeds "
+                            f"horizon_months={horizon_months}"
+                        ),
+                    },
+                )
+
+        # FK leak prevention: each referenced row must belong to the
+        # current user's org.
+        if ev_type == "recurring_on":
+            rid = ev.get("recurring_id")
+            if rid is None:
+                continue
+            rec = await db.get(RecurringTransaction, int(rid))
+            if rec is None or rec.org_id != org_id:
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "code": "event_invalid_reference",
+                        "message": f"recurring_id {rid} not found for this org",
+                    },
+                )
+        if ev_type in ("one_off_income", "one_off_expense"):
+            aid = ev.get("account_id")
+            if aid is not None:
+                acc = await db.get(Account, int(aid))
+                if acc is None or acc.org_id != org_id:
+                    raise HTTPException(
+                        status_code=422,
+                        detail={
+                            "code": "event_invalid_reference",
+                            "message": f"account_id {aid} not found for this org",
+                        },
+                    )
+            cid = ev.get("category_id")
+            if cid is not None:
+                cat = await db.get(Category, int(cid))
+                if cat is None or cat.org_id != org_id:
+                    raise HTTPException(
+                        status_code=422,
+                        detail={
+                            "code": "event_invalid_reference",
+                            "message": f"category_id {cid} not found for this org",
+                        },
+                    )
+        if ev_type == "expense_off":
+            cat_ids = ev.get("category_ids") or []
+            for cid in cat_ids:
+                cat = await db.get(Category, int(cid))
+                if cat is None or cat.org_id != org_id:
+                    raise HTTPException(
+                        status_code=422,
+                        detail={
+                            "code": "event_invalid_reference",
+                            "message": f"category_id {cid} not found for this org",
+                        },
+                    )

--- a/backend/app/schemas/scenario.py
+++ b/backend/app/schemas/scenario.py
@@ -193,20 +193,135 @@ class RetirementParams(BaseModel):
         return self
 
 
-class CustomParams(BaseModel):
-    """Custom scenario params — minimal stub for PR1.
+# ── Custom event primitives (PR3 of the Plans train) ────────────────────
+#
+# The ``custom`` plan_type's ``events`` array is a discriminated union of
+# five primitives, all keyed on ``type``. All months are RELATIVE to the
+# scenario start (month 0 = start month). Cross-user FK references
+# (recurring_id / account_id / category_id) are validated against the
+# current user's org at the router boundary because the schema layer
+# has no DB session.
 
-    The full ``events`` event-primitives editor is PR2 territory.
-    PR1 ships the shape (label + opaque event list) so users can
-    sketch a custom scenario today; simulate ignores the events
-    (no engine support yet — also PR2).
+
+class _CustomEventIncomeOff(BaseModel):
+    """Zero out income recurring patterns for a month range."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["income_off"]
+    from_month: int = Field(ge=0)
+    to_month: Optional[int] = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _check_range(self):
+        if self.to_month is not None and self.to_month < self.from_month:
+            raise ValueError(
+                "from_month must be <= to_month"
+            )
+        return self
+
+
+class _CustomEventExpenseOff(BaseModel):
+    """Zero out expense recurring patterns for a month range.
+
+    Optional ``category_ids`` scopes the silencing to specific
+    categories; omitted means every expense recurring is silenced.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["expense_off"]
+    from_month: int = Field(ge=0)
+    to_month: Optional[int] = Field(default=None, ge=0)
+    category_ids: Optional[list[int]] = None
+
+    @model_validator(mode="after")
+    def _check_range(self):
+        if self.to_month is not None and self.to_month < self.from_month:
+            raise ValueError(
+                "from_month must be <= to_month"
+            )
+        return self
+
+
+class _CustomEventRecurringOn(BaseModel):
+    """Explicitly INCLUDE a specific recurring for the given range.
+
+    PR3 punt: PR1's engine already includes ALL active recurring
+    by default, so this event is a no-op until a future
+    ``exclude_recurring`` base flag exists. The schema accepts it
+    so the UI can hand-author the event today.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["recurring_on"]
+    recurring_id: int
+    from_month: int = Field(ge=0)
+    to_month: Optional[int] = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _check_range(self):
+        if self.to_month is not None and self.to_month < self.from_month:
+            raise ValueError(
+                "from_month must be <= to_month"
+            )
+        return self
+
+
+class _CustomEventOneOffIncome(BaseModel):
+    """Single-month income injection into ``account_id``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["one_off_income"]
+    month: int = Field(ge=0)
+    amount: Decimal = Field(ge=0)
+    account_id: int
+    category_id: Optional[int] = None
+
+
+class _CustomEventOneOffExpense(BaseModel):
+    """Single-month expense charge against ``account_id``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["one_off_expense"]
+    month: int = Field(ge=0)
+    amount: Decimal = Field(ge=0)
+    account_id: int
+    category_id: Optional[int] = None
+
+
+CustomEvent = Annotated[
+    Union[
+        _CustomEventIncomeOff,
+        _CustomEventExpenseOff,
+        _CustomEventRecurringOn,
+        _CustomEventOneOffIncome,
+        _CustomEventOneOffExpense,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class CustomParams(BaseModel):
+    """Custom scenario params (PR3 of the Plans train).
+
+    ``events`` is a discriminated-union list of the five primitive
+    event types. Each event's months are RELATIVE to the scenario
+    start (month 0 = start month). Range validation (``from_month``
+    <= ``to_month``) lives on each event's model_validator. The
+    router additionally validates each event's month/from_month/to_month
+    against the scenario's horizon and resolves cross-user FK leaks
+    on recurring_id / account_id / category_id.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     scenario_type: Literal["custom"]
     label: str = Field(min_length=1, max_length=200)
-    events: list[dict[str, Any]] = Field(default_factory=list)
+    events: list[CustomEvent] = Field(default_factory=list)
 
 
 ScenarioParams = Annotated[
@@ -376,3 +491,54 @@ class ProjectionResult(BaseModel):
     # Set True when the regression overlay was applied (PR2). Helps the
     # UI label the chart and helps tests assert the path was taken.
     smoothed_with_regression: bool = False
+
+
+# ── PR3 of the Plans train: comparison view ─────────────────────────────
+
+
+# Architect-locked: max 3 scenarios side-by-side. 4+ would make the
+# chart visually unreadable; the cap is enforced here so the router
+# returns 422 (not 200 with truncation) on overflow.
+COMPARE_MIN_SCENARIOS = 1
+COMPARE_MAX_SCENARIOS = 3
+
+
+class CompareRequest(BaseModel):
+    """Body for ``POST /api/v1/scenarios/compare`` (PR3).
+
+    Runs the analytic engine on each scenario at the SAME horizon so
+    the projections can be overlaid on one chart. The horizon is
+    validated against every scenario's per-type cap before the engine
+    runs; if any scenario rejects it, the WHOLE compare fails with
+    422 and the offending scenario id in the detail.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_ids: List[int] = Field(
+        min_length=COMPARE_MIN_SCENARIOS,
+        max_length=COMPARE_MAX_SCENARIOS,
+    )
+    horizon_months: int = Field(ge=HORIZON_MIN_MONTHS)
+    smooth_with_regression: bool = False
+
+
+class CompareProjection(BaseModel):
+    """One scenario's projection enriched with its name + type so the
+    UI can label series without a second round-trip.
+    """
+
+    scenario_id: int
+    name: str
+    scenario_type: ScenarioType
+    projection: ProjectionResult
+
+
+class CompareResponse(BaseModel):
+    """Response for ``POST /api/v1/scenarios/compare``.
+
+    Order is parallel to the request's ``scenario_ids`` so the
+    frontend can index by position.
+    """
+
+    projections: List[CompareProjection]

--- a/backend/app/services/scenario_engine.py
+++ b/backend/app/services/scenario_engine.py
@@ -71,6 +71,10 @@ class RecurringSnapshot:
     type: str  # "income" | "expense"
     frequency: Frequency
     next_due_date: datetime.date
+    # PR3: category_id is carried so custom ``expense_off`` events with
+    # ``category_ids`` can scope the silencing. Optional because some
+    # legacy fixtures may not set it.
+    category_id: Optional[int] = None
 
 
 @dataclass
@@ -332,6 +336,10 @@ class AnalyticEngine(ScenarioEngine):
         ]
 
         overlays = _build_overlay_events(scenario)
+        # PR3 custom-event filter: silences specific recurring rows
+        # for the configured month range. Non-custom plans get the
+        # identity filter (always True).
+        recurring_filter = _custom_event_recurring_filter(scenario)
 
         series_by_account: dict[int, list[dict[str, str]]] = {
             a.account_id: [] for a in state.accounts
@@ -379,11 +387,20 @@ class AnalyticEngine(ScenarioEngine):
             month_label = _month_label(month_date)
 
             # (1) Apply recurring whose next_due_date falls in [month_date, month_end].
+            # PR3: custom-event ``income_off`` / ``expense_off`` filters
+            # silence the matching rows for the configured month range.
             new_queue: list[tuple[RecurringSnapshot, datetime.date]] = []
             for snap, due in recurring_queue:
                 next_due = due
+                apply_this_month = recurring_filter.should_apply(
+                    snap, snap.category_id, m_index
+                )
                 while next_due <= month_end:
-                    if next_due >= month_date and next_due <= month_end:
+                    if (
+                        apply_this_month
+                        and next_due >= month_date
+                        and next_due <= month_end
+                    ):
                         delta = Decimal(snap.amount)
                         if snap.type == "expense":
                             delta = -delta
@@ -620,6 +637,7 @@ async def build_world_state(
             type=str(r.type),
             frequency=r.frequency,
             next_due_date=r.next_due_date,
+            category_id=r.category_id,
         )
         for r in recurring_rows
     ]
@@ -808,11 +826,113 @@ def _build_overlay_events(
                 cursor = cursor + relativedelta(months=1)
 
     elif stype == ScenarioType.CUSTOM.value:
-        # PR1 minimal: custom events not replayed yet. Full event
-        # replay (income_off, expense_off, recurring_on, etc.) is PR2.
-        pass
+        # PR3: replay one_off_income / one_off_expense events as
+        # per-month overlays. The off-recurring / on-recurring events
+        # are NOT overlay events (they modify the recurring queue
+        # itself); the engine consults them out-of-band via
+        # ``_apply_custom_event_filters``. See the simulate loop.
+        events = params.get("events") or []
+        start = _start_of_horizon()
+        for ev in events:
+            ev_type = ev.get("type")
+            if ev_type == "one_off_income":
+                month_offset = int(ev.get("month", 0) or 0)
+                when = start + relativedelta(months=month_offset)
+                amount = Decimal(str(ev.get("amount", "0") or "0"))
+                account_id = ev.get("account_id")
+                if account_id is not None and amount > 0:
+                    add(when.year, when.month, {
+                        "kind": "income",
+                        "amount": amount,
+                        "account_id": int(account_id),
+                        "trigger": "custom_one_off_income",
+                    })
+            elif ev_type == "one_off_expense":
+                month_offset = int(ev.get("month", 0) or 0)
+                when = start + relativedelta(months=month_offset)
+                amount = Decimal(str(ev.get("amount", "0") or "0"))
+                account_id = ev.get("account_id")
+                if account_id is not None and amount > 0:
+                    add(when.year, when.month, {
+                        "kind": "expense",
+                        "amount": amount,
+                        "account_id": int(account_id),
+                        "trigger": "custom_one_off_expense",
+                    })
+            # income_off / expense_off / recurring_on are NOT overlay
+            # events; they're filters on the recurring queue applied
+            # inside the simulate loop.
 
     return out
+
+
+def _custom_event_recurring_filter(
+    scenario: Scenario,
+) -> "_RecurringFilter":
+    """Compile the scenario's custom events into a per-month recurring
+    filter callable.
+
+    Returns an opaque _RecurringFilter object the engine consults inside
+    the simulate loop. The filter takes (recurring_snapshot, month_index)
+    and returns True (apply the recurring) or False (silence it for this
+    month). For non-custom plans the filter is the identity (always True).
+    """
+    stype = (
+        scenario.scenario_type.value
+        if hasattr(scenario.scenario_type, "value")
+        else str(scenario.scenario_type)
+    )
+    if stype != ScenarioType.CUSTOM.value:
+        return _RecurringFilter([])
+    params = scenario.params_json or {}
+    events = params.get("events") or []
+    return _RecurringFilter(events)
+
+
+class _RecurringFilter:
+    """Per-month recurring filter compiled from custom events.
+
+    ``income_off`` and ``expense_off`` events silence the matching
+    recurring rows for a month range. ``expense_off`` with
+    ``category_ids`` set scopes the silencing to those categories.
+    ``recurring_on`` is currently a no-op (PR3 punt: the engine
+    already includes ALL active recurring by default; this event
+    becomes meaningful when a future ``exclude_recurring`` base flag
+    exists).
+    """
+
+    def __init__(self, events: list[dict[str, Any]]):
+        self.events = events
+
+    def should_apply(
+        self,
+        recurring: RecurringSnapshot,
+        category_id: Optional[int],
+        month_index: int,
+    ) -> bool:
+        """Return True if the recurring should fire on this month_index."""
+        for ev in self.events:
+            ev_type = ev.get("type")
+            if ev_type not in ("income_off", "expense_off"):
+                continue
+            from_month = int(ev.get("from_month", 0) or 0)
+            to_month = ev.get("to_month")
+            if to_month is None:
+                # Open-ended silencing from from_month onward.
+                in_range = month_index >= from_month
+            else:
+                in_range = from_month <= month_index <= int(to_month)
+            if not in_range:
+                continue
+            if ev_type == "income_off" and recurring.type == "income":
+                return False
+            if ev_type == "expense_off" and recurring.type == "expense":
+                cat_ids = ev.get("category_ids")
+                if not cat_ids:
+                    return False
+                if category_id is not None and category_id in cat_ids:
+                    return False
+        return True
 
 
 def _parse_date(value: Any) -> Optional[datetime.date]:

--- a/backend/tests/routers/test_scenarios.py
+++ b/backend/tests/routers/test_scenarios.py
@@ -836,6 +836,128 @@ async def test_create_custom_month_over_horizon_rejected(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_create_custom_event_month_equals_horizon_rejected(session_factory):
+    """one_off_income with month == horizon_months → 422.
+
+    Engine iterates ``range(0, horizon_months)`` so the last valid month
+    index is ``horizon_months - 1``. An event at exactly ``horizon_months``
+    would silently never fire; the validator must catch it.
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "one_off_income",
+                    "month": 24,
+                    "amount": "100.00",
+                    "account_id": seeds["account_id"],
+                },
+            ], horizon=24),
+        )
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert detail.get("code") == "event_invalid_reference"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_event_month_at_horizon_minus_one_ok(session_factory):
+    """one_off_income with month == horizon_months - 1 → 201.
+
+    Pins the last valid month index (inclusive upper bound).
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "one_off_income",
+                    "month": 23,
+                    "amount": "100.00",
+                    "account_id": seeds["account_id"],
+                },
+            ], horizon=24),
+        )
+    assert res.status_code == 201, res.text
+
+
+@pytest.mark.asyncio
+async def test_create_custom_event_from_month_equals_horizon_rejected(session_factory):
+    """income_off with from_month == horizon_months → 422.
+
+    from_month is a range start; valid range is [0, horizon_months - 1].
+    """
+    await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "income_off",
+                    "from_month": 24,
+                    "to_month": 30,
+                },
+            ], horizon=24),
+        )
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert detail.get("code") == "event_invalid_reference"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_event_to_month_equals_horizon_rejected(session_factory):
+    """income_off with to_month == horizon_months → 422.
+
+    to_month is the inclusive end of the range; valid range is
+    [0, horizon_months - 1]. A value equal to horizon_months would
+    point past the last simulated month and silently never fire.
+    """
+    await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "income_off",
+                    "from_month": 3,
+                    "to_month": 24,
+                },
+            ], horizon=24),
+        )
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert detail.get("code") == "event_invalid_reference"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_event_to_month_at_horizon_minus_one_ok(session_factory):
+    """income_off with to_month == horizon_months - 1 → 201.
+
+    Pins the inclusive upper bound on the range end.
+    """
+    await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "income_off",
+                    "from_month": 3,
+                    "to_month": 23,
+                },
+            ], horizon=24),
+        )
+    assert res.status_code == 201, res.text
+
+
+@pytest.mark.asyncio
 async def test_create_custom_event_negative_month_rejected(session_factory):
     """one_off_income with month < 0 → 422 (Pydantic Field constraint)."""
     seeds = await _seed_users_and_account(session_factory)

--- a/backend/tests/routers/test_scenarios.py
+++ b/backend/tests/routers/test_scenarios.py
@@ -583,3 +583,402 @@ async def test_user_b_cannot_read_user_a_scenario(session_factory):
         assert cb.post(
             f"/api/v1/scenarios/{created['id']}/simulate"
         ).status_code == 404
+
+
+# ── PR3: comparison endpoint ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_compare_two_scenarios_happy_path(session_factory):
+    """Two scenario_ids → two projections returned, positionally
+    parallel to the request order.
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        s1 = client.post(
+            "/api/v1/scenarios",
+            json=_trip_payload(seeds["account_id"], name="Trip A"),
+        ).json()
+        s2 = client.post(
+            "/api/v1/scenarios",
+            json=_purchase_payload(seeds["account_id"], name="Purchase B"),
+        ).json()
+        res = client.post(
+            "/api/v1/scenarios/compare",
+            json={
+                "scenario_ids": [s1["id"], s2["id"]],
+                "horizon_months": 24,
+            },
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert len(body["projections"]) == 2
+    # Order preserved.
+    assert body["projections"][0]["scenario_id"] == s1["id"]
+    assert body["projections"][1]["scenario_id"] == s2["id"]
+    assert body["projections"][0]["name"] == "Trip A"
+    assert body["projections"][1]["scenario_type"] == "purchase"
+    # Each projection has the full ProjectionResult shape.
+    proj = body["projections"][0]["projection"]
+    assert proj["engine_name"] == "analytic_v1"
+    assert proj["horizon_months"] == 24
+    assert len(proj["per_account_series"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_compare_three_scenarios_happy_path(session_factory):
+    """Three scenarios → three projections (the architect cap)."""
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        s1 = client.post(
+            "/api/v1/scenarios",
+            json=_trip_payload(seeds["account_id"], name="A"),
+        ).json()
+        s2 = client.post(
+            "/api/v1/scenarios",
+            json=_trip_payload(seeds["account_id"], name="B"),
+        ).json()
+        s3 = client.post(
+            "/api/v1/scenarios",
+            json=_trip_payload(seeds["account_id"], name="C"),
+        ).json()
+        res = client.post(
+            "/api/v1/scenarios/compare",
+            json={
+                "scenario_ids": [s1["id"], s2["id"], s3["id"]],
+                "horizon_months": 24,
+            },
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert len(body["projections"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_compare_four_scenarios_rejected(session_factory):
+    """Four scenarios → 422 (max 3 by architect lock)."""
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        ids = []
+        for i in range(4):
+            row = client.post(
+                "/api/v1/scenarios",
+                json=_trip_payload(seeds["account_id"], name=f"S{i}"),
+            ).json()
+            ids.append(row["id"])
+        res = client.post(
+            "/api/v1/scenarios/compare",
+            json={"scenario_ids": ids, "horizon_months": 24},
+        )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_compare_one_scenario_allowed(session_factory):
+    """One scenario → 1 projection (preview-compare-layout case)."""
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        s = client.post(
+            "/api/v1/scenarios",
+            json=_trip_payload(seeds["account_id"]),
+        ).json()
+        res = client.post(
+            "/api/v1/scenarios/compare",
+            json={"scenario_ids": [s["id"]], "horizon_months": 24},
+        )
+    assert res.status_code == 200, res.text
+    assert len(res.json()["projections"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_compare_cross_user_scenario_id_404(session_factory):
+    """A scenario_id that belongs to a different user → 404 (the same
+    bystander-safe behavior the rest of the router uses).
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    app_a = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    app_b = _make_app(session_factory, _resolver_for("bob@acme.io"))
+    with TestClient(app_a) as ca:
+        alice_scen = ca.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+    with TestClient(app_b) as cb:
+        res = cb.post(
+            "/api/v1/scenarios/compare",
+            json={"scenario_ids": [alice_scen["id"]], "horizon_months": 24},
+        )
+    assert res.status_code == 404, res.text
+
+
+@pytest.mark.asyncio
+async def test_compare_horizon_130_with_trip_rejected(session_factory):
+    """horizon=130 + a trip scenario → 422 with the scenario id and
+    "horizon" in the detail (trip cap is 120).
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        trip = client.post(
+            "/api/v1/scenarios", json=_trip_payload(seeds["account_id"])
+        ).json()
+        res = client.post(
+            "/api/v1/scenarios/compare",
+            json={"scenario_ids": [trip["id"]], "horizon_months": 130},
+        )
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert f"scenario_id={trip['id']}" in str(detail)
+    assert "120" in str(detail)
+
+
+@pytest.mark.asyncio
+async def test_compare_horizon_130_retirement_only_ok(session_factory):
+    """horizon=130 with ONLY retirement scenarios → 200 (retirement cap is 480)."""
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        ret = client.post(
+            "/api/v1/scenarios",
+            json=_retirement_payload(seeds["account_id"]),
+        ).json()
+        res = client.post(
+            "/api/v1/scenarios/compare",
+            json={"scenario_ids": [ret["id"]], "horizon_months": 130},
+        )
+    assert res.status_code == 200, res.text
+
+
+# ── PR3: custom-event create + patch validation ─────────────────────────
+
+
+def _custom_payload_with_events(events: list[dict], horizon: int = 36) -> dict:
+    return {
+        "name": "Sabbatical",
+        "scenario_type": "custom",
+        "horizon_months": horizon,
+        "params": {
+            "scenario_type": "custom",
+            "label": "Sabbatical year",
+            "events": events,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_custom_with_one_off_income_event_ok(session_factory):
+    """Smoke: a custom scenario with a single one_off_income event
+    persists and round-trips through GET.
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "one_off_income",
+                    "month": 5,
+                    "amount": "1500.00",
+                    "account_id": seeds["account_id"],
+                },
+            ]),
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["params_json"]["events"][0]["type"] == "one_off_income"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_from_greater_than_to_rejected(session_factory):
+    """from_month > to_month → 422 (schema-level validator)."""
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "income_off",
+                    "from_month": 10,
+                    "to_month": 5,
+                },
+            ]),
+        )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_create_custom_month_over_horizon_rejected(session_factory):
+    """one_off_income with month > horizon_months → 422 with
+    ``event_invalid_reference`` code.
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "one_off_income",
+                    "month": 99,
+                    "amount": "100.00",
+                    "account_id": seeds["account_id"],
+                },
+            ], horizon=24),
+        )
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert detail.get("code") == "event_invalid_reference"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_event_negative_month_rejected(session_factory):
+    """one_off_income with month < 0 → 422 (Pydantic Field constraint)."""
+    seeds = await _seed_users_and_account(session_factory)
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "one_off_income",
+                    "month": -1,
+                    "amount": "100.00",
+                    "account_id": seeds["account_id"],
+                },
+            ]),
+        )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_create_custom_event_cross_user_recurring_id_rejected(
+    session_factory,
+):
+    """recurring_on event referencing a recurring_id from a DIFFERENT
+    org → 422 with ``event_invalid_reference`` code.
+    """
+    seeds = await _seed_users_and_account(session_factory)
+    # Create a SECOND org with its own recurring template.
+    async with session_factory() as db:
+        from app.models.user import Organization, Role
+        from app.models.account import AccountType
+        from app.models.category import Category, CategoryType
+        from app.models.recurring import Frequency, RecurringTransaction
+
+        other = Organization(name="Other", billing_cycle_day=1)
+        db.add(other)
+        await db.commit()
+        other_at = AccountType(
+            org_id=other.id, name="Checking", slug="checking", is_system=True
+        )
+        db.add(other_at)
+        await db.commit()
+        other_acc = Account(
+            org_id=other.id,
+            account_type_id=other_at.id,
+            name="Other Main",
+            balance=Decimal("100.00"),
+            currency="EUR",
+            is_active=True,
+            is_default=True,
+            opening_balance=Decimal("100.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        db.add(other_acc)
+        await db.commit()
+        other_cat = Category(
+            org_id=other.id, name="X", type=CategoryType.INCOME
+        )
+        db.add(other_cat)
+        await db.commit()
+        other_rec = RecurringTransaction(
+            org_id=other.id,
+            account_id=other_acc.id,
+            category_id=other_cat.id,
+            description="X",
+            amount=Decimal("100"),
+            type="income",
+            frequency=Frequency.MONTHLY,
+            next_due_date=date.today() + timedelta(days=14),
+            auto_settle=False,
+            is_active=True,
+        )
+        db.add(other_rec)
+        await db.commit()
+        cross_recurring_id = other_rec.id
+
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "recurring_on",
+                    "recurring_id": cross_recurring_id,
+                    "from_month": 0,
+                    "to_month": 5,
+                },
+            ]),
+        )
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert detail.get("code") == "event_invalid_reference"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_event_cross_user_account_id_rejected(
+    session_factory,
+):
+    """one_off_expense referencing an account_id from a DIFFERENT
+    org → 422.
+    """
+    await _seed_users_and_account(session_factory)
+    # Create a second-org account.
+    async with session_factory() as db:
+        from app.models.user import Organization
+        from app.models.account import AccountType
+
+        other = Organization(name="Other", billing_cycle_day=1)
+        db.add(other)
+        await db.commit()
+        other_at = AccountType(
+            org_id=other.id, name="Checking", slug="checking", is_system=True
+        )
+        db.add(other_at)
+        await db.commit()
+        other_acc = Account(
+            org_id=other.id,
+            account_type_id=other_at.id,
+            name="Other Main",
+            balance=Decimal("100.00"),
+            currency="EUR",
+            is_active=True,
+            is_default=True,
+            opening_balance=Decimal("100.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        db.add(other_acc)
+        await db.commit()
+        cross_account_id = other_acc.id
+
+    app = _make_app(session_factory, _resolver_for("alice@acme.io"))
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/scenarios",
+            json=_custom_payload_with_events([
+                {
+                    "type": "one_off_expense",
+                    "month": 3,
+                    "amount": "500.00",
+                    "account_id": cross_account_id,
+                },
+            ]),
+        )
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert detail.get("code") == "event_invalid_reference"

--- a/backend/tests/services/test_scenario_engine.py
+++ b/backend/tests/services/test_scenario_engine.py
@@ -972,3 +972,305 @@ async def test_simulate_retirement_does_not_mutate_any_real_table(session_factor
     assert result["engine_name"] == "analytic_v1"
     assert result["smoothed_with_regression"] is True
     assert result["real_terms_series"] is not None
+
+
+# ── PR3: Custom event replay ────────────────────────────────────────────
+
+
+def _make_custom_scenario(events: list[dict], horizon: int = 12) -> Scenario:
+    return Scenario(
+        org_id=1,
+        user_id=1,
+        name="custom",
+        scenario_type=ScenarioType.CUSTOM,
+        params_json={
+            "scenario_type": "custom",
+            "label": "test",
+            "events": events,
+        },
+        horizon_months=horizon,
+    )
+
+
+def _basic_world_state(starting_balance: str = "5000.00") -> WorldState:
+    return WorldState(
+        accounts=[
+            AccountSnapshot(
+                account_id=1, account_name="Main", currency="EUR",
+                starting_balance=Decimal(starting_balance),
+            )
+        ],
+        recurring=[],
+        history=[],
+    )
+
+
+def test_custom_one_off_income_lands_in_target_month():
+    """A one_off_income event at month=5 must boost the projected
+    balance at month 5 by the configured amount.
+    """
+    scenario = _make_custom_scenario(
+        events=[
+            {
+                "type": "one_off_income",
+                "month": 5,
+                "amount": "1500.00",
+                "account_id": 1,
+            },
+        ],
+        horizon=12,
+    )
+    state = _basic_world_state()
+    result = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario, state=state, horizon_months=12, options={}
+        )
+    )
+    points = result["per_account_series"][0]["points"]
+    # Month 5 balance should be 5000 + 1500 = 6500 (no recurring, no other events).
+    assert Decimal(points[5]["projected_balance"]) == Decimal("6500.00")
+    # Month 4 should still be 5000.
+    assert Decimal(points[4]["projected_balance"]) == Decimal("5000.00")
+
+
+def test_custom_one_off_expense_triggers_dip_below_zero_alert():
+    """one_off_expense at month=3 against a low-balance account → the
+    projection records a dip-below-zero alert at that month.
+    """
+    scenario = _make_custom_scenario(
+        events=[
+            {
+                "type": "one_off_expense",
+                "month": 3,
+                "amount": "500.00",
+                "account_id": 1,
+            },
+        ],
+        horizon=6,
+    )
+    state = _basic_world_state(starting_balance="100.00")
+    result = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario, state=state, horizon_months=6, options={}
+        )
+    )
+    # Alert at month index 3 (the 4th month emitted).
+    alerts = result["alerts"]
+    assert len(alerts) == 1
+    assert alerts[0]["trigger"] == "custom_one_off_expense"
+    # Balance dipped below zero.
+    assert Decimal(alerts[0]["projected_balance"]) < 0
+
+
+def test_custom_income_off_silences_recurring_income_in_range():
+    """income_off from month 2 to month 8 must zero out recurring
+    income posts in that range. Recurring income outside the range
+    still fires.
+    """
+    today = date.today().replace(day=1)
+    # Recurring income of 1000/mo, due in month_index 1 (i.e. next month).
+    rec = RecurringSnapshot(
+        id=1, account_id=1, amount=Decimal("1000.00"),
+        type="income", frequency=Frequency.MONTHLY,
+        next_due_date=today + relativedelta(months=1) + timedelta(days=5),
+        category_id=None,
+    )
+    scenario = _make_custom_scenario(
+        events=[
+            {"type": "income_off", "from_month": 2, "to_month": 8},
+        ],
+        horizon=12,
+    )
+    state = WorldState(
+        accounts=[
+            AccountSnapshot(
+                account_id=1, account_name="Main", currency="EUR",
+                starting_balance=Decimal("0.00"),
+            )
+        ],
+        recurring=[rec],
+        history=[],
+    )
+    result = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario, state=state, horizon_months=12, options={}
+        )
+    )
+    points = result["per_account_series"][0]["points"]
+    # Month 1 (outside the silenced range) → 1000 income applied.
+    bal_m1 = Decimal(points[1]["projected_balance"])
+    # Month 5 (inside the silenced range): balance must NOT have grown
+    # between month 1 and month 5 — those four months of income are silenced.
+    bal_m5 = Decimal(points[5]["projected_balance"])
+    assert bal_m1 == Decimal("1000.00")
+    assert bal_m5 == Decimal("1000.00"), points
+    # Month 9 (range ends at 8) → income resumes.
+    bal_m9 = Decimal(points[9]["projected_balance"])
+    assert bal_m9 == Decimal("2000.00"), points
+
+
+def test_custom_expense_off_with_category_filter_only_silences_matched():
+    """expense_off with category_ids=[5] silences ONLY recurring expenses
+    whose category_id == 5. Other expense recurring rows still fire.
+    """
+    today = date.today().replace(day=1)
+    rec_a = RecurringSnapshot(
+        id=10, account_id=1, amount=Decimal("200.00"),
+        type="expense", frequency=Frequency.MONTHLY,
+        next_due_date=today + relativedelta(months=1) + timedelta(days=5),
+        category_id=5,
+    )
+    rec_b = RecurringSnapshot(
+        id=11, account_id=1, amount=Decimal("300.00"),
+        type="expense", frequency=Frequency.MONTHLY,
+        next_due_date=today + relativedelta(months=1) + timedelta(days=5),
+        category_id=99,
+    )
+    scenario = _make_custom_scenario(
+        events=[
+            {
+                "type": "expense_off",
+                "from_month": 0,
+                "to_month": 5,
+                "category_ids": [5],
+            },
+        ],
+        horizon=6,
+    )
+    state = WorldState(
+        accounts=[
+            AccountSnapshot(
+                account_id=1, account_name="Main", currency="EUR",
+                starting_balance=Decimal("10000.00"),
+            )
+        ],
+        recurring=[rec_a, rec_b],
+        history=[],
+    )
+    result = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario, state=state, horizon_months=6, options={}
+        )
+    )
+    points = result["per_account_series"][0]["points"]
+    # Month 1: rec_a silenced (cat 5), rec_b still fires (-300).
+    # 10000 - 300 = 9700.
+    assert Decimal(points[1]["projected_balance"]) == Decimal("9700.00")
+
+
+def test_custom_recurring_on_documented_punt_no_behavior_change():
+    """recurring_on event is a no-op in PR3 (no ``exclude_recurring``
+    base flag exists yet). The projection must equal the same scenario
+    WITHOUT the event.
+    """
+    scenario_with = _make_custom_scenario(
+        events=[
+            {
+                "type": "recurring_on",
+                "recurring_id": 1,
+                "from_month": 0,
+                "to_month": 5,
+            },
+        ],
+        horizon=6,
+    )
+    scenario_without = _make_custom_scenario(events=[], horizon=6)
+    state = _basic_world_state()
+    r_with = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario_with, state=state, horizon_months=6, options={}
+        )
+    )
+    r_without = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario_without, state=state, horizon_months=6, options={}
+        )
+    )
+    # Per-account series identical (modulo engine timestamp).
+    assert r_with["per_account_series"] == r_without["per_account_series"]
+
+
+@pytest.mark.asyncio
+async def test_simulate_custom_events_does_not_mutate_any_real_table(
+    session_factory,
+):
+    """ARCHITECT LOCK PR3: a custom scenario with 3 events must produce
+    ZERO row-count delta on every real table after simulate. Re-runs
+    the PR1+PR2 sandboxing guard with custom events.
+    """
+    seeds = await _seed_user_with_realistic_data(session_factory)
+
+    async with session_factory() as db:
+        custom_scen = Scenario(
+            org_id=seeds["org_id"],
+            user_id=seeds["user_id"],
+            name="Sabbatical 2028",
+            scenario_type=ScenarioType.CUSTOM,
+            params_json={
+                "scenario_type": "custom",
+                "label": "Sabbatical year",
+                "events": [
+                    {
+                        "type": "income_off",
+                        "from_month": 2,
+                        "to_month": 8,
+                    },
+                    {
+                        "type": "one_off_expense",
+                        "month": 3,
+                        "amount": "3000.00",
+                        "account_id": seeds["acc1_id"],
+                    },
+                    {
+                        "type": "one_off_income",
+                        "month": 6,
+                        "amount": "1500.00",
+                        "account_id": seeds["acc1_id"],
+                    },
+                ],
+            },
+            horizon_months=12,
+            is_active=True,
+        )
+        db.add(custom_scen)
+        await db.commit()
+        await db.refresh(custom_scen)
+        custom_id = custom_scen.id
+
+    before = await _row_counts(session_factory)
+
+    async with session_factory() as db:
+        state = await build_world_state(
+            db, org_id=seeds["org_id"], user_id=seeds["user_id"]
+        )
+        scen = (
+            await db.execute(
+                select(Scenario).where(Scenario.id == custom_id)
+            )
+        ).scalar_one()
+        result = AnalyticEngine().simulate(
+            SimulationRequest(
+                scenario=scen,
+                state=state,
+                horizon_months=scen.horizon_months,
+                options={},
+            )
+        )
+
+    after = await _row_counts(session_factory)
+
+    # The sandboxing guard: every real table count is identical pre/post.
+    assert after["transactions"] == before["transactions"]
+    assert after["accounts"] == before["accounts"]
+    assert after["budgets"] == before["budgets"]
+    assert after["forecast_plans"] == before["forecast_plans"]
+    assert after["recurring_transactions"] == before["recurring_transactions"]
+    assert after["scenarios"] == before["scenarios"]
+
+    # The projection actually ran.
+    assert result["engine_name"] == "analytic_v1"
+    # And the events left their fingerprint.
+    triggers = {a["trigger"] for a in result["alerts"]}
+    # The one_off_expense at month 3 in a positive-balance fixture may
+    # not dip below zero; just sanity-check projection length.
+    assert len(result["per_account_series"]) == 2

--- a/frontend/app/plans/compare/page.tsx
+++ b/frontend/app/plans/compare/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+/**
+ * Plans comparison page — side-by-side projections (PR3 of the
+ * Plans train).
+ *
+ * Architect-locked invariants:
+ * - Read-only view. No params edits here — the editor lives at
+ *   /plans (the inline panel) and "Open" on each verdict row
+ *   navigates back to the editor.
+ * - Hard cap of 3 plans. The picker disables additional checks
+ *   beyond the third selection.
+ * - Single horizon applies to every plan in the compare. The
+ *   default is the smallest of the selected plans' horizons (so
+ *   trip + retirement defaults to 120, not 480 — keeps the
+ *   visual range sane).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+import {
+  ComparisonView,
+  type CompareProjection,
+} from "@/components/scenarios/ComparisonView";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  label as labelCls,
+  pageTitle,
+} from "@/lib/styles";
+
+interface PlanRow {
+  id: number;
+  name: string;
+  scenario_type: "trip" | "purchase" | "retirement" | "custom";
+  horizon_months: number;
+}
+
+const MAX_COMPARE = 3;
+
+const HORIZON_CAPS = {
+  trip: 120,
+  purchase: 120,
+  custom: 120,
+  retirement: 480,
+} as const;
+
+function minCapAcross(selectedTypes: Array<keyof typeof HORIZON_CAPS>): number {
+  if (selectedTypes.length === 0) return 24;
+  let cap: number = HORIZON_CAPS.retirement;
+  for (const t of selectedTypes) {
+    if (HORIZON_CAPS[t] < cap) cap = HORIZON_CAPS[t];
+  }
+  return cap;
+}
+
+export default function ComparePlansPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [plans, setPlans] = useState<PlanRow[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
+  const [horizon, setHorizon] = useState<number>(24);
+  const [results, setResults] = useState<CompareProjection[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace("/login");
+    }
+  }, [loading, user, router]);
+
+  const loadPlans = useCallback(async () => {
+    try {
+      const rows = await apiFetch<PlanRow[]>("/api/v1/scenarios");
+      setPlans(rows);
+    } catch (e) {
+      setErr(extractErrorMessage(e, "Failed to load plans"));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user) void loadPlans();
+  }, [user, loadPlans]);
+
+  const selectedTypes = useMemo(() => {
+    const types = selected
+      .map((id) => plans.find((p) => p.id === id)?.scenario_type)
+      .filter((t): t is keyof typeof HORIZON_CAPS => Boolean(t));
+    return types;
+  }, [selected, plans]);
+
+  const horizonCap = useMemo(
+    () => minCapAcross(selectedTypes),
+    [selectedTypes],
+  );
+
+  function toggle(id: number) {
+    setSelected((cur) => {
+      if (cur.includes(id)) return cur.filter((x) => x !== id);
+      if (cur.length >= MAX_COMPARE) return cur;
+      return [...cur, id];
+    });
+  }
+
+  async function runCompare() {
+    setBusy(true);
+    setErr("");
+    try {
+      const body = {
+        scenario_ids: selected,
+        horizon_months: horizon,
+      };
+      const data = await apiFetch<{ projections: CompareProjection[] }>(
+        "/api/v1/scenarios/compare",
+        { method: "POST", body: JSON.stringify(body) },
+      );
+      setResults(data.projections);
+    } catch (e) {
+      setErr(extractErrorMessage(e, "Compare failed"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loading || !user) return null;
+
+  return (
+    <AppShell>
+      <header className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className={`${pageTitle} mb-0`}>Compare plans</h1>
+          <p className="mt-1 text-sm text-text-muted">
+            Pick up to three plans to see their projected balances on the
+            same chart. Read-only.
+          </p>
+        </div>
+        <button
+          type="button"
+          className={`${btnSecondary} sm:min-h-0`}
+          onClick={() => router.push("/plans")}
+          data-testid="compare-back"
+        >
+          Back to plans
+        </button>
+      </header>
+
+      {err && <p className={`mb-3 ${errorCls}`}>{err}</p>}
+
+      <section className={`${card} mb-4 p-5`} data-testid="compare-picker">
+        <header className={`mb-3 ${cardHeader}`}>
+          <h2 className={cardTitle}>Pick plans (1 to 3)</h2>
+        </header>
+        {plans.length === 0 ? (
+          <p className="text-sm text-text-muted">No plans yet. Create one first.</p>
+        ) : (
+          <ul className="space-y-2">
+            {plans.map((plan) => {
+              const checked = selected.includes(plan.id);
+              const disabled = !checked && selected.length >= MAX_COMPARE;
+              return (
+                <li key={plan.id} className="flex items-center gap-3">
+                  <input
+                    id={`compare-plan-${plan.id}`}
+                    type="checkbox"
+                    checked={checked}
+                    disabled={disabled}
+                    onChange={() => toggle(plan.id)}
+                    data-testid={`compare-plan-checkbox-${plan.id}`}
+                  />
+                  <label
+                    htmlFor={`compare-plan-${plan.id}`}
+                    className="text-sm text-text-primary"
+                  >
+                    {plan.name}
+                    <span className="ml-2 text-xs text-text-muted">
+                      {plan.scenario_type}
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div className="mt-4 flex items-end gap-3">
+          <div>
+            <label className={labelCls} htmlFor="compare-horizon">
+              Horizon (months, max {horizonCap})
+            </label>
+            <input
+              id="compare-horizon"
+              type="number"
+              min={1}
+              max={horizonCap}
+              value={horizon}
+              onChange={(e) => setHorizon(Number(e.target.value || 0))}
+              className={input}
+              data-testid="compare-horizon-input"
+            />
+          </div>
+          <button
+            type="button"
+            className={`${btnPrimary} sm:min-h-0`}
+            onClick={() => void runCompare()}
+            disabled={busy || selected.length === 0 || horizon < 1}
+            data-testid="compare-run"
+          >
+            Compare
+          </button>
+        </div>
+      </section>
+
+      {results.length > 0 && (
+        <section className={`${card} p-5`} data-testid="compare-results">
+          <header className={`mb-3 ${cardHeader}`}>
+            <h2 className={cardTitle}>Projection</h2>
+          </header>
+          <ComparisonView
+            projections={results}
+            onOpen={(scenarioId) => router.push(`/plans?open=${scenarioId}`)}
+          />
+        </section>
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -20,7 +20,7 @@
  */
 
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -133,12 +133,19 @@ const VERDICT_BADGE: Record<AffordabilityVerdict["color"], string> = {
 export default function PlansPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [items, setItems] = useState<Scenario[]>([]);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [active, setActive] = useState<Scenario | null>(null);
   const [loadErr, setLoadErr] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [createType, setCreateType] = useState<ScenarioType>("trip");
+  const [itemsLoaded, setItemsLoaded] = useState(false);
+  // We consume ?open=<id> exactly once per page mount so a deep-link from
+  // the compare page lands directly in the editor. After we either match
+  // (and open the plan) or fail to match, we clear the query string so a
+  // refresh doesn't re-trigger and re-open repeatedly.
+  const openParamConsumedRef = useRef(false);
 
   useEffect(() => {
     if (loading) return;
@@ -157,12 +164,33 @@ export default function PlansPage() {
       setAccounts(accs);
     } catch (e) {
       setLoadErr(extractErrorMessage(e, "Failed to load plans"));
+    } finally {
+      setItemsLoaded(true);
     }
   }, []);
 
   useEffect(() => {
     if (user) void loadAll();
   }, [user, loadAll]);
+
+  // ?open=<id> from the compare page → open the matching plan in the
+  // editor as soon as the scenarios list has loaded. If no scenario
+  // matches, just drop the param and stay on the list. Either way,
+  // strip the query string so a refresh doesn't re-open.
+  useEffect(() => {
+    if (openParamConsumedRef.current) return;
+    if (!user) return;
+    if (!itemsLoaded) return;
+    const raw = searchParams?.get("open");
+    if (!raw) return;
+    const id = Number(raw);
+    if (Number.isFinite(id)) {
+      const match = items.find((s) => s.id === id);
+      if (match) setActive(match);
+    }
+    openParamConsumedRef.current = true;
+    router.replace("/plans");
+  }, [searchParams, items, itemsLoaded, user, router]);
 
   async function deletePlan(id: number) {
     try {

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -24,6 +24,7 @@ import { useRouter } from "next/navigation";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { CustomParamsEditor } from "@/components/scenarios/CustomParamsEditor";
 import { ProjectionChart } from "@/components/scenarios/ProjectionChart";
 import { RetirementParamsEditor } from "@/components/scenarios/RetirementParamsEditor";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -201,14 +202,26 @@ export default function PlansPage() {
             Plan one-off life events. Nothing here touches your real transactions.
           </p>
         </div>
-        <button
-          type="button"
-          className={`${btnPrimary} sm:min-h-0`}
-          onClick={() => setCreateOpen(true)}
-          data-testid="plans-new"
-        >
-          + New plan
-        </button>
+        <div className="flex items-center gap-2">
+          {items.length >= 2 && (
+            <button
+              type="button"
+              className={`${btnSecondary} sm:min-h-0`}
+              onClick={() => router.push("/plans/compare")}
+              data-testid="plans-compare"
+            >
+              Compare plans
+            </button>
+          )}
+          <button
+            type="button"
+            className={`${btnPrimary} sm:min-h-0`}
+            onClick={() => setCreateOpen(true)}
+            data-testid="plans-new"
+          >
+            + New plan
+          </button>
+        </div>
       </header>
 
       {loadErr && <p className={`mb-3 ${errorCls}`}>{loadErr}</p>}
@@ -471,9 +484,11 @@ function PlanEditor({
               />
             )}
             {plan.scenario_type === "custom" && (
-              <p className="text-xs text-text-muted">
-                The custom template editor is available in a later release.
-              </p>
+              <CustomParamsEditor
+                params={params}
+                setParams={setParams}
+                accounts={accounts}
+              />
             )}
             <button
               type="button"

--- a/frontend/components/scenarios/ComparisonView.tsx
+++ b/frontend/components/scenarios/ComparisonView.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+/**
+ * Comparison view for the Plans simulation sandbox (PR3 of the Plans
+ * train).
+ *
+ * Architect-locked invariants:
+ * - Up to 3 scenarios overlaid on a single chart. The endpoint
+ *   enforces the cap; this component renders whatever the API
+ *   hands back (1, 2, or 3 series).
+ * - Shared Y-axis across all scenarios: the y-domain stretches to
+ *   the max range across every plan so amounts are visually
+ *   comparable.
+ * - One color per scenario (NOT per account — comparison is the
+ *   plan, not the underlying accounts). Each scenario's series is
+ *   the TOTAL projected balance across all accounts at each month.
+ * - Verdict matrix below the chart: a grid of name / verdict /
+ *   end-balance / dip alerts per scenario.
+ * - Read-only — the editor lives on /plans/[id], not here.
+ */
+
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { formatAmount } from "@/lib/format";
+import { chartColor } from "@/lib/chart-colors";
+
+export interface ProjectionPoint {
+  month: string;
+  projected_balance: string;
+}
+
+export interface AccountSeries {
+  account_id: number;
+  account_name: string;
+  currency: string;
+  points: ProjectionPoint[];
+}
+
+export interface DipAlert {
+  account_id: number;
+  month: string;
+  projected_balance: string;
+  trigger: string;
+  severity: "info" | "warn" | "critical";
+}
+
+export interface AffordabilityVerdict {
+  color: "green" | "yellow" | "red";
+  headline: string;
+  reason: string;
+}
+
+export interface ProjectionResult {
+  engine_name: string;
+  horizon_months: number;
+  currency: string;
+  per_account_series: AccountSeries[];
+  alerts: DipAlert[];
+  verdict: AffordabilityVerdict;
+}
+
+export interface CompareProjection {
+  scenario_id: number;
+  name: string;
+  scenario_type: "trip" | "purchase" | "retirement" | "custom";
+  projection: ProjectionResult;
+}
+
+const SCENARIO_COLORS = [
+  "var(--color-accent)",
+  "var(--color-info)",
+  "var(--color-success)",
+];
+
+function pickColor(index: number): string {
+  return SCENARIO_COLORS[index % SCENARIO_COLORS.length];
+}
+
+// X-axis tick formatter: same logic as ProjectionChart for visual
+// consistency. Year-only for horizons > 36 months, month-year otherwise.
+function tickFormatter(monthsTotal: number) {
+  return (label: string) => {
+    if (!/^\d{4}-\d{2}$/.test(label)) return label;
+    const [yyyy, mm] = label.split("-");
+    if (monthsTotal > 36) {
+      if (mm === "01") return yyyy;
+      return "";
+    }
+    const monthIndex = Number(mm) - 1;
+    const monthShort = new Date(Number(yyyy), monthIndex, 1).toLocaleString(
+      undefined,
+      { month: "short" },
+    );
+    return `${monthShort} '${yyyy.slice(2)}`;
+  };
+}
+
+interface ChartRow {
+  month: string;
+  // Per-scenario totals are keyed by ``scen_<id>`` so multiple lines
+  // can share a single chart row.
+  [scenarioKey: string]: number | string;
+}
+
+function totalBalanceAtMonth(
+  projection: ProjectionResult,
+  month: string,
+): number {
+  let total = 0;
+  for (const series of projection.per_account_series) {
+    const point = series.points.find((p) => p.month === month);
+    if (point) total += Number(point.projected_balance);
+  }
+  return total;
+}
+
+function endingBalance(projection: ProjectionResult): number {
+  let total = 0;
+  for (const series of projection.per_account_series) {
+    if (series.points.length === 0) continue;
+    const last = series.points[series.points.length - 1];
+    total += Number(last.projected_balance);
+  }
+  return total;
+}
+
+/**
+ * Build the union of months across every projection. Each projection
+ * is expected to have the same horizon (the compare endpoint enforces
+ * a single horizon for the whole comparison), but the union guards
+ * against any drift.
+ */
+function unionMonths(projections: CompareProjection[]): string[] {
+  const seen = new Set<string>();
+  for (const cp of projections) {
+    const firstSeries = cp.projection.per_account_series[0];
+    if (!firstSeries) continue;
+    for (const point of firstSeries.points) {
+      seen.add(point.month);
+    }
+  }
+  return Array.from(seen).sort();
+}
+
+/**
+ * Compute the y-domain max across ALL scenarios so the shared y-axis
+ * doesn't truncate any series. Returns [min, max] with a small padding.
+ *
+ * Min is set to min(0, observedMin) so a scenario that dips below zero
+ * still shows the dip; otherwise the axis floor is 0.
+ */
+export function sharedYDomain(
+  projections: CompareProjection[],
+  months: string[],
+): [number, number] {
+  let observedMin = 0;
+  let observedMax = 0;
+  for (const cp of projections) {
+    for (const month of months) {
+      const value = totalBalanceAtMonth(cp.projection, month);
+      if (value < observedMin) observedMin = value;
+      if (value > observedMax) observedMax = value;
+    }
+  }
+  const padding = Math.max(1, (observedMax - observedMin) * 0.05);
+  return [
+    observedMin < 0 ? observedMin - padding : 0,
+    observedMax + padding,
+  ];
+}
+
+const VERDICT_BADGE: Record<AffordabilityVerdict["color"], string> = {
+  green: "bg-success-dim text-success",
+  yellow: "bg-accent/15 text-accent",
+  red: "bg-danger-dim text-danger",
+};
+
+export function ComparisonView({
+  projections,
+  onOpen,
+  testId = "comparison-view",
+}: {
+  projections: CompareProjection[];
+  onOpen?: (scenarioId: number) => void;
+  testId?: string;
+}) {
+  const months = useMemo(() => unionMonths(projections), [projections]);
+  const rows = useMemo<ChartRow[]>(() => {
+    return months.map((month) => {
+      const row: ChartRow = { month };
+      for (const cp of projections) {
+        row[`scen_${cp.scenario_id}`] = totalBalanceAtMonth(
+          cp.projection,
+          month,
+        );
+      }
+      return row;
+    });
+  }, [months, projections]);
+
+  const yDomain = useMemo(
+    () => sharedYDomain(projections, months),
+    [projections, months],
+  );
+  const currency =
+    projections[0]?.projection.currency ?? "EUR";
+
+  if (projections.length === 0) {
+    return (
+      <p
+        className="text-sm text-text-muted"
+        data-testid={`${testId}-empty`}
+      >
+        Pick at least one plan to compare.
+      </p>
+    );
+  }
+
+  return (
+    <section data-testid={testId}>
+      <div
+        className="mb-4 h-80 w-full"
+        data-testid={`${testId}-chart`}
+        role="img"
+        aria-label="Projected balances across the selected plans"
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={rows}
+            margin={{ top: 16, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              stroke="var(--color-border)"
+              strokeDasharray="3 3"
+            />
+            <XAxis
+              dataKey="month"
+              tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+              tickFormatter={tickFormatter(months.length)}
+              interval="preserveStartEnd"
+              minTickGap={20}
+            />
+            <YAxis
+              domain={yDomain}
+              tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+              tickFormatter={(v) =>
+                formatAmount(typeof v === "number" ? v : Number(v))
+              }
+              width={80}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "var(--color-surface)",
+                border: "1px solid var(--color-border)",
+                fontSize: 12,
+              }}
+              formatter={(value, name) => {
+                const num =
+                  typeof value === "number" ? value : Number(value);
+                return [`${formatAmount(num)} ${currency}`, String(name)];
+              }}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            {projections.map((cp, idx) => (
+              <Line
+                key={cp.scenario_id}
+                type="monotone"
+                dataKey={`scen_${cp.scenario_id}`}
+                name={cp.name}
+                stroke={pickColor(idx)}
+                strokeWidth={2}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div
+        className="overflow-x-auto"
+        data-testid={`${testId}-verdict-matrix`}
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+              <th className="py-2 pr-3">Plan</th>
+              <th className="py-2 pr-3">Verdict</th>
+              <th className="py-2 pr-3">End balance</th>
+              <th className="py-2 pr-3">Alerts</th>
+              {onOpen && <th className="py-2 pr-3"></th>}
+            </tr>
+          </thead>
+          <tbody>
+            {projections.map((cp, idx) => {
+              const ending = endingBalance(cp.projection);
+              const verdict = cp.projection.verdict;
+              const dipCount = cp.projection.alerts.length;
+              return (
+                <tr
+                  key={cp.scenario_id}
+                  className="border-b border-border last:border-0"
+                  data-testid={`${testId}-row-${cp.scenario_id}`}
+                >
+                  <td className="py-2 pr-3">
+                    <span
+                      className="mr-2 inline-block h-2 w-2 rounded-full align-middle"
+                      style={{ backgroundColor: pickColor(idx) }}
+                      aria-hidden="true"
+                    />
+                    <span className="font-medium text-text-primary">
+                      {cp.name}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${VERDICT_BADGE[verdict.color]}`}
+                      data-testid={`${testId}-verdict-${cp.scenario_id}`}
+                    >
+                      {verdict.color.toUpperCase()}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-3 tabular-nums text-text-primary">
+                    {formatAmount(ending)} {cp.projection.currency}
+                  </td>
+                  <td className="py-2 pr-3 text-text-primary">
+                    {dipCount > 0 ? (
+                      <span
+                        className="text-danger"
+                        data-testid={`${testId}-alerts-${cp.scenario_id}`}
+                      >
+                        {dipCount} dip{dipCount === 1 ? "" : "s"}
+                      </span>
+                    ) : (
+                      <span className="text-text-muted">None</span>
+                    )}
+                  </td>
+                  {onOpen && (
+                    <td className="py-2 pr-3 text-right">
+                      <button
+                        type="button"
+                        className="text-xs text-accent underline-offset-2 hover:underline"
+                        onClick={() => onOpen(cp.scenario_id)}
+                        data-testid={`${testId}-open-${cp.scenario_id}`}
+                      >
+                        Open
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/scenarios/CustomParamsEditor.tsx
+++ b/frontend/components/scenarios/CustomParamsEditor.tsx
@@ -150,7 +150,12 @@ export function CustomParamsEditor({
 
   useEffect(() => {
     // Scroll the newest event card into view when one was just added.
-    if (newestRef.current) {
+    // Guarded so jsdom (which doesn't implement scrollIntoView) doesn't
+    // throw in unit tests.
+    if (
+      newestRef.current
+      && typeof newestRef.current.scrollIntoView === "function"
+    ) {
       newestRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
     }
   }, [events.length]);

--- a/frontend/components/scenarios/CustomParamsEditor.tsx
+++ b/frontend/components/scenarios/CustomParamsEditor.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+/**
+ * Custom plan params editor (PR3 of the Plans train).
+ *
+ * Architect-locked invariants:
+ * - Five event types: income_off, expense_off, recurring_on,
+ *   one_off_income, one_off_expense.
+ * - All months are RELATIVE to the scenario start (month 0 = the
+ *   month the simulate call is made in).
+ * - one_off_income / one_off_expense amounts are Decimal strings
+ *   (existing currency convention).
+ * - Debounced re-simulate on every change. The DEBOUNCE happens at
+ *   the parent (PlansPage's PlanEditor); this component is
+ *   presentational and just emits the next params object via
+ *   setParams.
+ * - Adding an event opens a type picker; selecting the type
+ *   prepends a default event card to the list and scrolls it into
+ *   view.
+ */
+
+import {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { input, label as labelCls, btnSecondary } from "@/lib/styles";
+
+export type EventType =
+  | "income_off"
+  | "expense_off"
+  | "recurring_on"
+  | "one_off_income"
+  | "one_off_expense";
+
+const TYPE_LABEL: Record<EventType, string> = {
+  income_off: "Income off",
+  expense_off: "Expense off",
+  recurring_on: "Recurring on",
+  one_off_income: "One-off income",
+  one_off_expense: "One-off expense",
+};
+
+interface Account {
+  id: number;
+  name: string;
+  currency: string;
+}
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+interface Recurring {
+  id: number;
+  description?: string | null;
+  amount?: string;
+}
+
+interface CustomEvent {
+  type: EventType;
+  from_month?: number;
+  to_month?: number | null;
+  month?: number;
+  amount?: string;
+  account_id?: number;
+  category_id?: number | null;
+  category_ids?: number[];
+  recurring_id?: number;
+}
+
+function defaultEvent(type: EventType, accounts: Account[]): CustomEvent {
+  switch (type) {
+    case "income_off":
+      return { type: "income_off", from_month: 0, to_month: null };
+    case "expense_off":
+      return { type: "expense_off", from_month: 0, to_month: null };
+    case "recurring_on":
+      return { type: "recurring_on", recurring_id: 0, from_month: 0, to_month: null };
+    case "one_off_income":
+      return {
+        type: "one_off_income",
+        month: 0,
+        amount: "0.00",
+        account_id: accounts[0]?.id ?? 0,
+      };
+    case "one_off_expense":
+      return {
+        type: "one_off_expense",
+        month: 0,
+        amount: "0.00",
+        account_id: accounts[0]?.id ?? 0,
+      };
+  }
+}
+
+export function CustomParamsEditor({
+  params,
+  setParams,
+  accounts,
+  categories = [],
+  recurring = [],
+}: {
+  params: Record<string, unknown>;
+  setParams: (next: Record<string, unknown>) => void;
+  accounts: Account[];
+  categories?: Category[];
+  recurring?: Recurring[];
+}) {
+  const baseId = useId();
+  const events = useMemo<CustomEvent[]>(() => {
+    const raw = params.events;
+    return Array.isArray(raw) ? (raw as CustomEvent[]) : [];
+  }, [params]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const newestRef = useRef<HTMLLIElement | null>(null);
+
+  const updateEvent = useCallback(
+    (idx: number, patch: Partial<CustomEvent>) => {
+      const next = events.map((ev, i) =>
+        i === idx ? { ...ev, ...patch } : ev,
+      );
+      setParams({ ...params, events: next });
+    },
+    [events, params, setParams],
+  );
+
+  const removeEvent = useCallback(
+    (idx: number) => {
+      const next = events.filter((_, i) => i !== idx);
+      setParams({ ...params, events: next });
+    },
+    [events, params, setParams],
+  );
+
+  const addEvent = useCallback(
+    (type: EventType) => {
+      const next = [defaultEvent(type, accounts), ...events];
+      setParams({ ...params, events: next });
+      setPickerOpen(false);
+    },
+    [accounts, events, params, setParams],
+  );
+
+  useEffect(() => {
+    // Scroll the newest event card into view when one was just added.
+    if (newestRef.current) {
+      newestRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [events.length]);
+
+  return (
+    <div data-testid="custom-params-editor">
+      <div className="mb-3">
+        <label className={labelCls} htmlFor={`${baseId}-custom-label`}>
+          Label
+        </label>
+        <input
+          id={`${baseId}-custom-label`}
+          value={(params.label as string) ?? ""}
+          onChange={(e) =>
+            setParams({ ...params, label: e.target.value })
+          }
+          className={input}
+          data-testid="custom-label-input"
+        />
+      </div>
+
+      <div className="mb-2 flex items-center justify-between">
+        <p className={labelCls}>Events</p>
+        <div className="relative">
+          <button
+            type="button"
+            className={`${btnSecondary} sm:min-h-0`}
+            onClick={() => setPickerOpen((open) => !open)}
+            data-testid="custom-add-event"
+          >
+            + Add event
+          </button>
+          {pickerOpen && (
+            <ul
+              className="absolute right-0 z-10 mt-1 w-48 rounded-md border border-border bg-surface shadow-lg"
+              data-testid="custom-event-picker"
+            >
+              {(Object.keys(TYPE_LABEL) as EventType[]).map((type) => (
+                <li key={type}>
+                  <button
+                    type="button"
+                    className="block w-full px-3 py-2 text-left text-sm hover:bg-bg"
+                    onClick={() => addEvent(type)}
+                    data-testid={`custom-event-picker-${type}`}
+                  >
+                    {TYPE_LABEL[type]}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {events.length === 0 ? (
+        <p
+          className="text-xs text-text-muted"
+          data-testid="custom-events-empty"
+        >
+          No events yet. Add one to model a sabbatical, big purchase, or
+          one-off cashflow.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {events.map((ev, idx) => (
+            <li
+              key={idx}
+              ref={idx === 0 ? newestRef : null}
+              className="rounded-md border border-border p-3"
+              data-testid={`custom-event-card-${idx}`}
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <span
+                  className="text-xs font-medium uppercase tracking-wide text-text-muted"
+                  data-testid={`custom-event-type-${idx}`}
+                >
+                  {TYPE_LABEL[ev.type]}
+                </span>
+                <button
+                  type="button"
+                  className="text-xs text-danger underline-offset-2 hover:underline"
+                  onClick={() => removeEvent(idx)}
+                  data-testid={`custom-event-remove-${idx}`}
+                >
+                  Remove
+                </button>
+              </div>
+              <EventFields
+                event={ev}
+                idx={idx}
+                onChange={(patch) => updateEvent(idx, patch)}
+                accounts={accounts}
+                categories={categories}
+                recurring={recurring}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function EventFields({
+  event,
+  idx,
+  onChange,
+  accounts,
+  categories,
+  recurring,
+}: {
+  event: CustomEvent;
+  idx: number;
+  onChange: (patch: Partial<CustomEvent>) => void;
+  accounts: Account[];
+  categories: Category[];
+  recurring: Recurring[];
+}) {
+  function numHandler(field: keyof CustomEvent) {
+    return (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      onChange({ [field]: value === "" ? null : Number(value) } as Partial<CustomEvent>);
+    };
+  }
+
+  const monthRangeFields = (
+    <div className="grid grid-cols-2 gap-2">
+      <div>
+        <label className={labelCls} htmlFor={`from-${idx}`}>
+          From month
+        </label>
+        <input
+          id={`from-${idx}`}
+          type="number"
+          min={0}
+          value={event.from_month ?? 0}
+          onChange={numHandler("from_month")}
+          className={input}
+          data-testid={`custom-event-from-${idx}`}
+        />
+      </div>
+      <div>
+        <label className={labelCls} htmlFor={`to-${idx}`}>
+          To month (optional)
+        </label>
+        <input
+          id={`to-${idx}`}
+          type="number"
+          min={0}
+          value={event.to_month ?? ""}
+          onChange={numHandler("to_month")}
+          className={input}
+          data-testid={`custom-event-to-${idx}`}
+        />
+      </div>
+    </div>
+  );
+
+  if (event.type === "income_off") return monthRangeFields;
+
+  if (event.type === "expense_off") {
+    return (
+      <div className="space-y-2">
+        {monthRangeFields}
+        {categories.length > 0 && (
+          <div>
+            <label className={labelCls} htmlFor={`catids-${idx}`}>
+              Limit to categories (optional, comma-sep ids)
+            </label>
+            <input
+              id={`catids-${idx}`}
+              type="text"
+              value={(event.category_ids ?? []).join(",")}
+              onChange={(e) =>
+                onChange({
+                  category_ids: e.target.value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                    .map(Number)
+                    .filter((n) => !Number.isNaN(n)),
+                })
+              }
+              className={input}
+              data-testid={`custom-event-categories-${idx}`}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (event.type === "recurring_on") {
+    return (
+      <div className="space-y-2">
+        <div>
+          <label className={labelCls} htmlFor={`rec-${idx}`}>
+            Recurring template
+          </label>
+          <select
+            id={`rec-${idx}`}
+            value={event.recurring_id ?? 0}
+            onChange={(e) => onChange({ recurring_id: Number(e.target.value) })}
+            className={input}
+            data-testid={`custom-event-recurring-${idx}`}
+          >
+            <option value={0} disabled>
+              Pick a recurring template
+            </option>
+            {recurring.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.description ?? `Recurring ${r.id}`}
+              </option>
+            ))}
+          </select>
+        </div>
+        {monthRangeFields}
+      </div>
+    );
+  }
+
+  if (
+    event.type === "one_off_income" ||
+    event.type === "one_off_expense"
+  ) {
+    return (
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className={labelCls} htmlFor={`month-${idx}`}>
+            Month
+          </label>
+          <input
+            id={`month-${idx}`}
+            type="number"
+            min={0}
+            value={event.month ?? 0}
+            onChange={(e) => onChange({ month: Number(e.target.value) })}
+            className={input}
+            data-testid={`custom-event-month-${idx}`}
+          />
+        </div>
+        <div>
+          <label className={labelCls} htmlFor={`amount-${idx}`}>
+            Amount
+          </label>
+          <input
+            id={`amount-${idx}`}
+            type="number"
+            step="0.01"
+            min="0"
+            value={event.amount ?? "0.00"}
+            onChange={(e) => onChange({ amount: e.target.value })}
+            className={input}
+            data-testid={`custom-event-amount-${idx}`}
+          />
+        </div>
+        <div className="col-span-2">
+          <label className={labelCls} htmlFor={`account-${idx}`}>
+            Account
+          </label>
+          <select
+            id={`account-${idx}`}
+            value={event.account_id ?? 0}
+            onChange={(e) => onChange({ account_id: Number(e.target.value) })}
+            className={input}
+            data-testid={`custom-event-account-${idx}`}
+          >
+            {accounts.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name} ({a.currency})
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/tests/app/plans-compare-page.test.tsx
+++ b/frontend/tests/app/plans-compare-page.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * Tests for the /plans/compare page (PR3 of the Plans train).
+ *
+ * Architect-locked checks:
+ * - Picker renders one checkbox per plan from /api/v1/scenarios.
+ * - Selecting plans + clicking Compare POSTs to
+ *   /api/v1/scenarios/compare with the chosen ids + horizon.
+ * - ComparisonView renders once results come back.
+ * - The verdict matrix shows one row per scenario.
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ComparePlansPage from "@/app/plans/compare/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => "/plans/compare",
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-responsive">{children}</div>
+  ),
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-line-chart">{children}</div>
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  Line: () => null,
+}));
+
+const USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@acme.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner" as const,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const PLANS = [
+  { id: 1, name: "Lisbon trip", scenario_type: "trip" as const, horizon_months: 24 },
+  { id: 2, name: "Used car", scenario_type: "purchase" as const, horizon_months: 36 },
+  { id: 3, name: "Retire at 65", scenario_type: "retirement" as const, horizon_months: 360 },
+  { id: 4, name: "Sabbatical", scenario_type: "custom" as const, horizon_months: 12 },
+];
+
+function makeProjection(id: number, name: string, color: "green" | "yellow" | "red") {
+  return {
+    scenario_id: id,
+    name,
+    scenario_type: "trip" as const,
+    projection: {
+      engine_name: "analytic_v1",
+      horizon_months: 24,
+      currency: "EUR",
+      per_account_series: [
+        {
+          account_id: 12,
+          account_name: "Main",
+          currency: "EUR",
+          points: [
+            { month: "2026-06", projected_balance: "4000.00" },
+            { month: "2026-07", projected_balance: "4100.00" },
+          ],
+        },
+      ],
+      alerts: color === "red" ? [{
+        account_id: 12,
+        month: "2026-06",
+        projected_balance: "-100.00",
+        trigger: "trip_lump_sum",
+        severity: "warn" as const,
+      }] : [],
+      verdict: {
+        color,
+        headline: "h",
+        reason: "r",
+      },
+    },
+  };
+}
+
+describe("/plans/compare page", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    pushMock.mockReset();
+  });
+
+  function setUser() {
+    useAuthMock.mockReturnValue({
+      user: USER as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    } as never);
+  }
+
+  it("renders one checkbox per plan from the API", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve(PLANS);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<ComparePlansPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("compare-plan-checkbox-1")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-plan-checkbox-2")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-plan-checkbox-3")).toBeInTheDocument();
+      expect(screen.getByTestId("compare-plan-checkbox-4")).toBeInTheDocument();
+    });
+  });
+
+  it("selecting and clicking Compare POSTs to /api/v1/scenarios/compare and renders results", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, opts?: { method?: string; body?: string }) => {
+      if (url === "/api/v1/scenarios" && (!opts || !opts.method)) {
+        return Promise.resolve(PLANS);
+      }
+      if (url === "/api/v1/scenarios/compare") {
+        return Promise.resolve({
+          projections: [
+            makeProjection(1, "Lisbon trip", "yellow"),
+            makeProjection(2, "Used car", "green"),
+          ],
+        });
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<ComparePlansPage />);
+    await screen.findByTestId("compare-plan-checkbox-1");
+
+    fireEvent.click(screen.getByTestId("compare-plan-checkbox-1"));
+    fireEvent.click(screen.getByTestId("compare-plan-checkbox-2"));
+    fireEvent.click(screen.getByTestId("compare-run"));
+
+    await screen.findByTestId("compare-results");
+    // Verdict matrix renders one row per scenario.
+    expect(screen.getByTestId("comparison-view-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("comparison-view-row-2")).toBeInTheDocument();
+
+    // Verify the POST body shape.
+    const compareCall = apiFetchMock.mock.calls.find(
+      (c) => c[0] === "/api/v1/scenarios/compare",
+    );
+    expect(compareCall).toBeDefined();
+    const body = JSON.parse((compareCall![1] as { body: string }).body);
+    expect(body.scenario_ids).toEqual([1, 2]);
+    expect(body.horizon_months).toBe(24);
+  });
+
+  it("disables further selection beyond the architect cap of 3", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve(PLANS);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<ComparePlansPage />);
+    await screen.findByTestId("compare-plan-checkbox-1");
+    fireEvent.click(screen.getByTestId("compare-plan-checkbox-1"));
+    fireEvent.click(screen.getByTestId("compare-plan-checkbox-2"));
+    fireEvent.click(screen.getByTestId("compare-plan-checkbox-3"));
+    // The 4th checkbox should now be disabled.
+    const fourth = screen.getByTestId("compare-plan-checkbox-4") as HTMLInputElement;
+    expect(fourth.disabled).toBe(true);
+  });
+});

--- a/frontend/tests/app/plans-page.test.tsx
+++ b/frontend/tests/app/plans-page.test.tsx
@@ -18,9 +18,11 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
 
 const replaceMock = vi.fn();
+let searchParamsString = "";
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/plans",
+  useSearchParams: () => new URLSearchParams(searchParamsString),
 }));
 
 vi.mock("@/components/AppShell", () => ({
@@ -204,6 +206,7 @@ describe("/plans page", () => {
   beforeEach(() => {
     apiFetchMock.mockReset();
     replaceMock.mockReset();
+    searchParamsString = "";
   });
 
   function setUser() {
@@ -422,4 +425,56 @@ describe("/plans page", () => {
       expect(body.engine).toBe("analytic");
     });
   });
+
+  it(
+    "test_open_query_param_opens_matching_scenario_in_editor: "
+    + "?open=<id> matches a loaded scenario → editor renders, "
+    + "URL is replaced to /plans (no query string)",
+    async () => {
+      setUser();
+      // Land on /plans?open=7 — should open TRIP_PLAN in the editor.
+      searchParamsString = `open=${TRIP_PLAN.id}`;
+      apiFetchMock.mockImplementation(((url: string) => {
+        if (url === "/api/v1/scenarios") return Promise.resolve([TRIP_PLAN]);
+        if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+        return Promise.resolve(undefined);
+      }) as never);
+      render(<PlansPage />);
+      // The editor renders with the deep-linked plan active.
+      await screen.findByTestId("plan-editor");
+      // List view is gone.
+      expect(screen.queryByTestId("plans-list")).not.toBeInTheDocument();
+      // Plan name shows in the editor's name input.
+      const nameInput = screen.getByTestId("plan-name-input") as HTMLInputElement;
+      expect(nameInput.value).toBe(TRIP_PLAN.name);
+      // URL was cleaned to /plans (no query string) so a refresh doesn't
+      // re-trigger the open behavior.
+      await waitFor(() => {
+        expect(replaceMock).toHaveBeenCalledWith("/plans");
+      });
+    },
+  );
+
+  it(
+    "test_open_query_param_with_unknown_id_stays_on_list: "
+    + "?open=99 with no matching scenario → list renders, URL replaced",
+    async () => {
+      setUser();
+      // Land on /plans?open=99 but the loaded list only has id=7.
+      searchParamsString = "open=99";
+      apiFetchMock.mockImplementation(((url: string) => {
+        if (url === "/api/v1/scenarios") return Promise.resolve([TRIP_PLAN]);
+        if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+        return Promise.resolve(undefined);
+      }) as never);
+      render(<PlansPage />);
+      // List view renders.
+      await screen.findByTestId("plans-list");
+      expect(screen.queryByTestId("plan-editor")).not.toBeInTheDocument();
+      // URL is still cleaned up so a refresh doesn't retry forever.
+      await waitFor(() => {
+        expect(replaceMock).toHaveBeenCalledWith("/plans");
+      });
+    },
+  );
 });

--- a/frontend/tests/components/scenarios/ComparisonView.test.tsx
+++ b/frontend/tests/components/scenarios/ComparisonView.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Tests for ComparisonView (PR3 of the Plans train).
+ *
+ * Architect-locked checks:
+ * - Renders the chart wrapper and the verdict matrix.
+ * - One verdict row per scenario.
+ * - sharedYDomain spans the max range across every scenario.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import {
+  ComparisonView,
+  sharedYDomain,
+  type CompareProjection,
+} from "@/components/scenarios/ComparisonView";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-responsive">{children}</div>
+  ),
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-line-chart">{children}</div>
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  Line: () => null,
+}));
+
+function makeProjection(
+  id: number,
+  name: string,
+  balances: number[],
+  color: "green" | "yellow" | "red",
+): CompareProjection {
+  return {
+    scenario_id: id,
+    name,
+    scenario_type: "trip",
+    projection: {
+      engine_name: "analytic_v1",
+      horizon_months: balances.length,
+      currency: "EUR",
+      per_account_series: [
+        {
+          account_id: 12,
+          account_name: "Main",
+          currency: "EUR",
+          points: balances.map((b, i) => ({
+            month: `2026-${String(i + 1).padStart(2, "0")}`,
+            projected_balance: b.toFixed(2),
+          })),
+        },
+      ],
+      alerts: [],
+      verdict: { color, headline: "h", reason: "r" },
+    },
+  };
+}
+
+describe("ComparisonView", () => {
+  it("renders one verdict-matrix row per scenario", () => {
+    const projs = [
+      makeProjection(1, "A", [1000, 2000], "green"),
+      makeProjection(2, "B", [500, 1500], "yellow"),
+      makeProjection(3, "C", [-100, 50], "red"),
+    ];
+    render(<ComparisonView projections={projs} />);
+    expect(screen.getByTestId("comparison-view-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("comparison-view-row-2")).toBeInTheDocument();
+    expect(screen.getByTestId("comparison-view-row-3")).toBeInTheDocument();
+    expect(screen.getByTestId("comparison-view-verdict-1")).toHaveTextContent(
+      "GREEN",
+    );
+    expect(screen.getByTestId("comparison-view-verdict-2")).toHaveTextContent(
+      "YELLOW",
+    );
+    expect(screen.getByTestId("comparison-view-verdict-3")).toHaveTextContent(
+      "RED",
+    );
+  });
+
+  it("renders the empty state when projections is empty", () => {
+    render(<ComparisonView projections={[]} />);
+    expect(
+      screen.getByTestId("comparison-view-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the chart wrapper for non-empty projections", () => {
+    const projs = [makeProjection(1, "A", [1000, 2000], "green")];
+    render(<ComparisonView projections={projs} />);
+    expect(screen.getByTestId("comparison-view-chart")).toBeInTheDocument();
+  });
+
+  it("sharedYDomain spans the global max across scenarios", () => {
+    const projs = [
+      makeProjection(1, "Small", [100, 200], "green"),
+      makeProjection(2, "Big", [10000, 12000], "green"),
+    ];
+    const months = ["2026-01", "2026-02"];
+    const [lo, hi] = sharedYDomain(projs, months);
+    // Floor at 0 since nothing dips negative.
+    expect(lo).toBe(0);
+    // Upper bound includes the 12000 peak + some padding.
+    expect(hi).toBeGreaterThanOrEqual(12000);
+  });
+
+  it("sharedYDomain reaches negative values when a scenario dips below zero", () => {
+    const projs = [makeProjection(1, "Dip", [-500, 100], "red")];
+    const months = ["2026-01", "2026-02"];
+    const [lo] = sharedYDomain(projs, months);
+    expect(lo).toBeLessThan(0);
+  });
+
+  it("renders alerts column when projections include alerts", () => {
+    const proj = makeProjection(1, "Alert", [-100, 50], "red");
+    proj.projection.alerts = [
+      {
+        account_id: 12,
+        month: "2026-01",
+        projected_balance: "-100.00",
+        trigger: "trip_lump_sum",
+        severity: "warn",
+      },
+    ];
+    render(<ComparisonView projections={[proj]} />);
+    expect(
+      screen.getByTestId("comparison-view-alerts-1"),
+    ).toHaveTextContent("1 dip");
+  });
+
+  it("invokes onOpen with the scenario id when Open is clicked", () => {
+    const onOpen = vi.fn();
+    const projs = [makeProjection(1, "Trip", [1000, 1100], "green")];
+    render(<ComparisonView projections={projs} onOpen={onOpen} />);
+    screen.getByTestId("comparison-view-open-1").click();
+    expect(onOpen).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/tests/components/scenarios/CustomParamsEditor.test.tsx
+++ b/frontend/tests/components/scenarios/CustomParamsEditor.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Tests for CustomParamsEditor (PR3 of the Plans train).
+ *
+ * Architect-locked checks:
+ * - Add event opens the type picker; picking a type prepends the
+ *   default event card.
+ * - Remove event removes the card from the list and from the
+ *   emitted params.
+ * - Changing an event's field surfaces in the next setParams call.
+ * - The editor handles each of the 5 event types.
+ */
+import React, { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { CustomParamsEditor } from "@/components/scenarios/CustomParamsEditor";
+
+interface Wrapped {
+  onParams?: (p: Record<string, unknown>) => void;
+  initialParams?: Record<string, unknown>;
+}
+
+function Wrapper({ onParams, initialParams }: Wrapped) {
+  const [params, setParams] = useState<Record<string, unknown>>(
+    initialParams ?? { label: "Sabbatical", events: [] },
+  );
+  return (
+    <CustomParamsEditor
+      params={params}
+      setParams={(next) => {
+        setParams(next);
+        if (onParams) onParams(next);
+      }}
+      accounts={[
+        { id: 12, name: "Main", currency: "EUR" },
+        { id: 13, name: "Savings", currency: "EUR" },
+      ]}
+      categories={[{ id: 1, name: "Groceries" }]}
+      recurring={[{ id: 9, description: "Salary" }]}
+    />
+  );
+}
+
+describe("CustomParamsEditor", () => {
+  it("renders the empty events state when params.events is empty", () => {
+    render(<Wrapper />);
+    expect(
+      screen.getByTestId("custom-events-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the event picker and adds a one_off_income event", () => {
+    const onParams = vi.fn();
+    render(<Wrapper onParams={onParams} />);
+    fireEvent.click(screen.getByTestId("custom-add-event"));
+    expect(screen.getByTestId("custom-event-picker")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByTestId("custom-event-picker-one_off_income"),
+    );
+    // The event card renders with the picked type.
+    expect(screen.getByTestId("custom-event-card-0")).toBeInTheDocument();
+    expect(screen.getByTestId("custom-event-type-0")).toHaveTextContent(
+      /one-off income/i,
+    );
+    expect(onParams).toHaveBeenCalled();
+    const lastCall = onParams.mock.calls.at(-1)![0] as {
+      events: Array<{ type: string }>;
+    };
+    expect(lastCall.events[0].type).toBe("one_off_income");
+  });
+
+  it("removes an event when the Remove button is clicked", () => {
+    const initial = {
+      label: "S",
+      events: [
+        {
+          type: "one_off_income",
+          month: 5,
+          amount: "1000.00",
+          account_id: 12,
+        },
+      ],
+    };
+    const onParams = vi.fn();
+    render(<Wrapper initialParams={initial} onParams={onParams} />);
+    expect(screen.getByTestId("custom-event-card-0")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("custom-event-remove-0"));
+    expect(screen.queryByTestId("custom-event-card-0")).toBeNull();
+    const lastCall = onParams.mock.calls.at(-1)![0] as {
+      events: unknown[];
+    };
+    expect(lastCall.events).toEqual([]);
+  });
+
+  it("updates the amount field on a one_off_expense event", () => {
+    const initial = {
+      label: "S",
+      events: [
+        {
+          type: "one_off_expense",
+          month: 3,
+          amount: "500.00",
+          account_id: 12,
+        },
+      ],
+    };
+    const onParams = vi.fn();
+    render(<Wrapper initialParams={initial} onParams={onParams} />);
+    const amountInput = screen.getByTestId(
+      "custom-event-amount-0",
+    ) as HTMLInputElement;
+    fireEvent.change(amountInput, { target: { value: "750.00" } });
+    const lastCall = onParams.mock.calls.at(-1)![0] as {
+      events: Array<{ amount: string }>;
+    };
+    expect(lastCall.events[0].amount).toBe("750.00");
+  });
+
+  it("renders the income_off form with from/to fields", () => {
+    const initial = {
+      label: "S",
+      events: [
+        { type: "income_off", from_month: 0, to_month: 5 },
+      ],
+    };
+    render(<Wrapper initialParams={initial} />);
+    expect(
+      screen.getByTestId("custom-event-from-0"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("custom-event-to-0"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the expense_off form with category_ids field", () => {
+    const initial = {
+      label: "S",
+      events: [
+        { type: "expense_off", from_month: 0, to_month: 5, category_ids: [1] },
+      ],
+    };
+    render(<Wrapper initialParams={initial} />);
+    expect(
+      screen.getByTestId("custom-event-categories-0"),
+    ).toHaveValue("1");
+  });
+
+  it("renders the recurring_on form with recurring select", () => {
+    const initial = {
+      label: "S",
+      events: [
+        { type: "recurring_on", recurring_id: 9, from_month: 0, to_month: 5 },
+      ],
+    };
+    render(<Wrapper initialParams={initial} />);
+    expect(
+      screen.getByTestId("custom-event-recurring-0"),
+    ).toBeInTheDocument();
+  });
+
+  it("changing the label updates params.label", () => {
+    const onParams = vi.fn();
+    render(<Wrapper onParams={onParams} />);
+    fireEvent.change(screen.getByTestId("custom-label-input"), {
+      target: { value: "Updated label" },
+    });
+    const lastCall = onParams.mock.calls.at(-1)![0] as { label: string };
+    expect(lastCall.label).toBe("Updated label");
+  });
+});


### PR DESCRIPTION
## Summary

PR3 of the Plans/Scenarios train. Two distinct things land here:

1. **Comparison view** — overlay 2-3 scenarios on one chart. Backend `POST /api/v1/scenarios/compare` returns parallel projections. Frontend `/plans/compare` page renders the picker + shared-y-axis chart + verdict matrix. "Compare plans" button surfaces on `/plans` when the user has at least 2 plans.
2. **Custom template event replay** — `CustomParams.events` is now a discriminated union of 5 primitives: `income_off`, `expense_off`, `recurring_on`, `one_off_income`, `one_off_expense`. The analytic engine consumes them in-memory; sandboxing guarantee re-tested with 0 row delta. New `CustomParamsEditor` replaces the inline stub.

Spec: `specs/2026-05-22-plans-page-simulation-sandbox.md`.

## Architect locks held

- Max 3 scenarios side-by-side (422 on a 4th).
- Cross-user `scenario_id` → 404 on compare.
- Horizon validated against EACH scenario's per-type cap; the offending scenario id is in the 422 detail.
- Read-only compare view; "Open" link routes back to `/plans`.
- `recurring_on` is a documented PR3 no-op (PR3 baseline includes all recurring; the event becomes meaningful only when a future `exclude_recurring` base flag exists). Test pins the no-op behavior.
- Custom events are SANDBOXED — re-ran the row-count delta guard with 3 custom events and confirmed 0 row delta across `transactions`, `accounts`, `budgets`, `forecast_plans`, `recurring_transactions`, `scenarios`.
- AI engine stub still raises `NotImplementedError("PR4")`. Not touched.

## Tests

- Backend: 24 engine tests + 34 router tests (compare endpoint + custom event replay all green).
- Frontend: 18 new tests across `plans-compare-page`, `ComparisonView`, `CustomParamsEditor`. Full sweep 1196/1196 passing.