### PR TITLE
feat(reports): full widget catalog + filter primitives (PR3 of train)

### DIFF
--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -43,6 +43,13 @@ import WidgetPicker from "@/components/reports/WidgetPicker";
 import WidgetShell from "@/components/reports/WidgetShell";
 import KPIWidget from "@/components/reports/widgets/KPIWidget";
 import BarWidget from "@/components/reports/widgets/BarWidget";
+import LineWidget from "@/components/reports/widgets/LineWidget";
+import AreaWidget from "@/components/reports/widgets/AreaWidget";
+import PieWidget from "@/components/reports/widgets/PieWidget";
+import SparklineWidget from "@/components/reports/widgets/SparklineWidget";
+import StackedBarWidget from "@/components/reports/widgets/StackedBarWidget";
+import TableWidget from "@/components/reports/widgets/TableWidget";
+import type { WidgetType } from "@/lib/reports/types";
 
 interface PageProps {
   // Next 15 makes ``params`` a promise on server-rendered pages; in
@@ -85,6 +92,112 @@ function emptyBar(id: string): Widget {
     grid: { x: 0, y: 0, w: 6, h: 4 },
     config,
   };
+}
+
+function emptyMultiSeries(
+  id: string,
+  type: "line" | "area" | "stacked_bar" | "table",
+): Widget {
+  const baseConfig = {
+    dataset: "transactions" as const,
+    measures: [{ measure: { agg: "sum" as const, field: "amount" as const } }],
+    dimensions: [type === "table" ? ("category" as const) : ("month" as const)],
+    sort: { by: "value" as const, dir: "desc" as const },
+    limit: type === "table" ? 50 : 100,
+    format: "currency" as const,
+  };
+  const baseGrid = type === "table" ? { x: 0, y: 0, w: 12, h: 6 } : { x: 0, y: 0, w: 6, h: 4 };
+  return {
+    id,
+    type,
+    title:
+      type === "line"
+        ? "New line chart"
+        : type === "area"
+          ? "New area chart"
+          : type === "stacked_bar"
+            ? "New stacked bar chart"
+            : "New table",
+    grid: baseGrid,
+    config: baseConfig,
+  } as Widget;
+}
+
+function emptyPie(id: string): Widget {
+  return {
+    id,
+    type: "pie",
+    title: "New pie chart",
+    grid: { x: 0, y: 0, w: 4, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      sort: { by: "value", dir: "desc" },
+      limit: 50,
+      format: "currency",
+      top_n: 8,
+    },
+  };
+}
+
+function emptySparkline(id: string): Widget {
+  return {
+    id,
+    type: "sparkline",
+    title: "New sparkline",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["month"],
+      sort: { by: "dimension", dir: "asc" },
+      limit: 50,
+      format: "number",
+    },
+  };
+}
+
+function emptyWidget(type: WidgetType, id: string): Widget {
+  switch (type) {
+    case "kpi":
+      return emptyKPI(id);
+    case "bar":
+      return emptyBar(id);
+    case "line":
+      return emptyMultiSeries(id, "line");
+    case "area":
+      return emptyMultiSeries(id, "area");
+    case "stacked_bar":
+      return emptyMultiSeries(id, "stacked_bar");
+    case "table":
+      return emptyMultiSeries(id, "table");
+    case "pie":
+      return emptyPie(id);
+    case "sparkline":
+      return emptySparkline(id);
+  }
+}
+
+function renderWidgetByType(w: Widget, canvasFilters: CanvasFilters) {
+  switch (w.type) {
+    case "kpi":
+      return <KPIWidget widget={w} canvasFilters={canvasFilters} />;
+    case "bar":
+      return <BarWidget widget={w} canvasFilters={canvasFilters} />;
+    case "line":
+      return <LineWidget widget={w} canvasFilters={canvasFilters} />;
+    case "area":
+      return <AreaWidget widget={w} canvasFilters={canvasFilters} />;
+    case "pie":
+      return <PieWidget widget={w} canvasFilters={canvasFilters} />;
+    case "sparkline":
+      return <SparklineWidget widget={w} canvasFilters={canvasFilters} />;
+    case "stacked_bar":
+      return <StackedBarWidget widget={w} canvasFilters={canvasFilters} />;
+    case "table":
+      return <TableWidget widget={w} canvasFilters={canvasFilters} />;
+  }
 }
 
 function newWidgetId(): string {
@@ -174,9 +287,9 @@ export default function ReportEditorPage({ params }: PageProps) {
     setDirty(true);
   }
 
-  function addWidget(type: "kpi" | "bar") {
+  function addWidget(type: WidgetType) {
     const id = newWidgetId();
-    const widget = type === "kpi" ? emptyKPI(id) : emptyBar(id);
+    const widget = emptyWidget(type, id);
     // Drop the new widget at the bottom of the existing stack.
     const maxY = layout.widgets.reduce(
       (max, w) => Math.max(max, w.grid.y + w.grid.h),
@@ -347,11 +460,7 @@ export default function ReportEditorPage({ params }: PageProps) {
                   onSelect={() => setSelectedWidgetId(w.id)}
                   onRemove={() => removeWidget(w.id)}
                 >
-                  {w.type === "kpi" ? (
-                    <KPIWidget widget={w} canvasFilters={canvasFilters} />
-                  ) : (
-                    <BarWidget widget={w} canvasFilters={canvasFilters} />
-                  )}
+                  {renderWidgetByType(w, canvasFilters)}
                 </WidgetShell>
               )}
             />

--- a/frontend/components/reports/CanvasFiltersBar.tsx
+++ b/frontend/components/reports/CanvasFiltersBar.tsx
@@ -3,12 +3,23 @@
 /**
  * Canvas-wide filters row — sits above the canvas. Edits flow into
  * the report's ``canvas_filters_json`` blob and cascade to every
- * widget that doesn't override the same field (spec §4).
+ * widget that doesn't override the same field (spec section 4).
  *
- * v1 controls: date range (start + end), account ids (comma-list),
- * category ids (comma-list). PR3 swaps the comma-list inputs for
- * the proper chip pickers + tree picker.
+ * PR3 swaps the comma-list inputs for the proper filter primitives:
+ *  - Date range  -> ``DatePresetChips`` (preset chips + custom
+ *    absolute inputs).
+ *  - Accounts    -> ``AccountFilter`` (chip picker, fetches the org's
+ *    accounts on mount).
+ *  - Categories  -> ``CategoryPicker`` (tree picker with master /
+ *    sub cascade, multi-select).
+ *
+ * Tag-based filters DO NOT appear on the canvas — they're a
+ * per-widget knob per spec section 4 ("the canvas filter shape is
+ * date range + accounts + categories; tag filters are widget-only").
  */
+import AccountFilter from "@/components/reports/filters/AccountFilter";
+import CategoryPicker from "@/components/reports/filters/CategoryPicker";
+import DatePresetChips from "@/components/reports/filters/DatePresetChips";
 import type { CanvasFilters } from "@/lib/reports/types";
 
 interface Props {
@@ -20,100 +31,39 @@ export default function CanvasFiltersBar({ value, onChange }: Props) {
   return (
     <div
       data-testid="canvas-filters-bar"
-      className="flex flex-wrap items-end gap-3 rounded-md border border-border bg-surface px-4 py-3"
+      className="grid grid-cols-1 gap-4 rounded-md border border-border bg-surface px-4 py-3 lg:grid-cols-3"
     >
-      <Field label="Date from">
-        <input
-          type="date"
-          aria-label="Canvas date from"
-          value={value.date_range?.start ?? ""}
-          onChange={(e) =>
-            onChange({
-              ...value,
-              date_range: {
-                ...(value.date_range ?? {}),
-                start: e.target.value || undefined,
-              },
-            })
+      <div>
+        <span className="mb-1 block text-[10px] font-medium uppercase tracking-wider text-text-muted">
+          Date range
+        </span>
+        <DatePresetChips
+          value={value.date_range}
+          ariaPrefix="Canvas"
+          onChange={(next) =>
+            onChange({ ...value, date_range: next || undefined })
           }
-          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
         />
-      </Field>
-      <Field label="Date to">
-        <input
-          type="date"
-          aria-label="Canvas date to"
-          value={value.date_range?.end ?? ""}
-          onChange={(e) =>
-            onChange({
-              ...value,
-              date_range: {
-                ...(value.date_range ?? {}),
-                end: e.target.value || undefined,
-              },
-            })
-          }
-          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        />
-      </Field>
-      <Field label="Accounts (ids)">
-        <input
-          type="text"
-          inputMode="numeric"
-          aria-label="Canvas accounts"
-          placeholder="e.g. 12, 14"
-          value={(value.account_ids ?? []).join(",")}
-          onChange={(e) =>
-            onChange({
-              ...value,
-              account_ids: parseIdList(e.target.value),
-            })
-          }
-          className="w-32 rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        />
-      </Field>
-      <Field label="Categories (ids)">
-        <input
-          type="text"
-          inputMode="numeric"
-          aria-label="Canvas categories"
-          placeholder="e.g. 3, 5"
-          value={(value.category_ids ?? []).join(",")}
-          onChange={(e) =>
-            onChange({
-              ...value,
-              category_ids: parseIdList(e.target.value),
-            })
-          }
-          className="w-32 rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        />
-      </Field>
+      </div>
+      <AccountFilter
+        value={value.account_ids ?? []}
+        ariaPrefix="Canvas account"
+        onChange={(account_ids) =>
+          onChange({
+            ...value,
+            account_ids: account_ids.length > 0 ? account_ids : undefined,
+          })
+        }
+      />
+      <CategoryPicker
+        value={value.category_ids ?? []}
+        onChange={(category_ids) =>
+          onChange({
+            ...value,
+            category_ids: category_ids.length > 0 ? category_ids : undefined,
+          })
+        }
+      />
     </div>
   );
-}
-
-function Field({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <label className="flex flex-col gap-1">
-      <span className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
-        {label}
-      </span>
-      {children}
-    </label>
-  );
-}
-
-function parseIdList(raw: string): number[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map((s) => Number(s))
-    .filter((n) => Number.isInteger(n) && n > 0);
 }

--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -6,14 +6,42 @@
  * ``onUpdate`` so the report's full layout state stays the single
  * source of truth (debounced save handled at the editor level).
  *
- * For each field with a per-widget override, the rail surfaces an
- * "Overrides canvas" pill (spec §4) computed via ``isFieldOverridden``.
+ * PR3 expands this rail to support:
+ *
+ *  - All 8 v1 widget types via the ``WidgetType`` union.
+ *  - Multi-series widgets (line / area / stacked bar / table) expose
+ *    one aggregation row per entry in ``config.measures`` with an
+ *    "Add series" button to grow the list. Table caps at 5 columns;
+ *    series widgets cap at 5 too (visual register breaks past that).
+ *  - Pie / Sparkline are locked to a single dimension + single
+ *    aggregation (no add-series button).
+ *  - Per-widget filter overrides go through the new filter
+ *    primitives (CategoryPicker, TagFilter, AccountFilter,
+ *    DatePresetChips); the "Overrides canvas" pill from PR2 still
+ *    fires when the widget value DIFFERS from the canvas value on
+ *    the same field.
  */
+import { useId } from "react";
+
+import AccountFilter from "@/components/reports/filters/AccountFilter";
+import CategoryPicker from "@/components/reports/filters/CategoryPicker";
+import DatePresetChips from "@/components/reports/filters/DatePresetChips";
+import TagFilter from "@/components/reports/filters/TagFilter";
 import type {
+  AreaConfig,
+  Aggregation,
   BarConfig,
   CanvasFilters,
   Dimension,
   KPIConfig,
+  LineConfig,
+  Measure,
+  MeasureField,
+  PieConfig,
+  SeriesConfig,
+  SparklineConfig,
+  StackedBarConfig,
+  TableConfig,
   TagMatch,
   Widget,
   WidgetFilters,
@@ -27,11 +55,18 @@ interface Props {
   onClose: () => void;
 }
 
-const AGG_OPTIONS: Array<{ value: "sum" | "count" | "avg" | "distinct"; label: string }> = [
+const AGG_OPTIONS: Array<{ value: Aggregation; label: string }> = [
   { value: "sum", label: "Sum" },
   { value: "count", label: "Count" },
   { value: "avg", label: "Average" },
   { value: "distinct", label: "Distinct count" },
+];
+
+const FIELD_OPTIONS: Array<{ value: MeasureField; label: string }> = [
+  { value: "amount", label: "Amount" },
+  { value: "id", label: "Row count (id)" },
+  { value: "category_id", label: "Category" },
+  { value: "account_id", label: "Account" },
 ];
 
 const DIMENSION_OPTIONS: Array<{ value: Dimension; label: string }> = [
@@ -46,6 +81,26 @@ const DIMENSION_OPTIONS: Array<{ value: Dimension; label: string }> = [
   { value: "day", label: "Day" },
 ];
 
+const MAX_SERIES = 5;
+const MAX_TABLE_COLUMNS = 5;
+
+/** Widget types that carry ``config.measures`` (multi-series). */
+function isMultiSeries(
+  w: Widget,
+): w is Widget & { config: LineConfig | AreaConfig | StackedBarConfig | TableConfig } {
+  return (
+    w.type === "line" ||
+    w.type === "area" ||
+    w.type === "stacked_bar" ||
+    w.type === "table"
+  );
+}
+
+/** Widget types locked to a single dimension + single aggregation. */
+function isSingleAggLocked(w: Widget): boolean {
+  return w.type === "pie" || w.type === "sparkline";
+}
+
 export default function ConfigRail({
   widget,
   canvasFilters,
@@ -58,19 +113,6 @@ export default function ConfigRail({
     onUpdate({ ...widget, title });
   }
 
-  function setAgg(agg: "sum" | "count" | "avg" | "distinct") {
-    // Keep widget.config narrow per type — Bar and KPI share the
-    // measure shape.
-    const next = {
-      ...widget,
-      config: {
-        ...widget.config,
-        measure: { ...widget.config.measure, agg },
-      },
-    } as Widget;
-    onUpdate(next);
-  }
-
   function setFilters(nextFilters: WidgetFilters) {
     const next = {
       ...widget,
@@ -79,12 +121,64 @@ export default function ConfigRail({
     onUpdate(next);
   }
 
-  function setDimension(dim: Dimension) {
-    if (widget.type !== "bar") return;
+  function setSingleMeasure(measure: Measure) {
+    if (isMultiSeries(widget)) return;
+    const next = {
+      ...widget,
+      config: {
+        ...(widget.config as KPIConfig | BarConfig | PieConfig | SparklineConfig),
+        measure,
+      },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setSeries(measures: SeriesConfig[]) {
+    if (!isMultiSeries(widget)) return;
     const next: Widget = {
       ...widget,
-      config: { ...(widget.config as BarConfig), dimensions: [dim] },
-    };
+      config: { ...widget.config, measures },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setPrimaryDimension(dim: Dimension) {
+    if (widget.type === "kpi") return; // KPI has no dimensions
+    const cfg = widget.config as
+      | BarConfig
+      | LineConfig
+      | AreaConfig
+      | PieConfig
+      | SparklineConfig
+      | StackedBarConfig
+      | TableConfig;
+    const dims = [...(cfg.dimensions ?? [])];
+    dims[0] = dim;
+    const next: Widget = {
+      ...widget,
+      config: { ...cfg, dimensions: dims },
+    } as Widget;
+    onUpdate(next);
+  }
+
+  function setSecondaryDimension(dim: Dimension | "") {
+    if (widget.type === "kpi" || isSingleAggLocked(widget)) return;
+    const cfg = widget.config as
+      | BarConfig
+      | LineConfig
+      | AreaConfig
+      | StackedBarConfig
+      | TableConfig;
+    const dims = [...(cfg.dimensions ?? [])];
+    if (dim === "") {
+      dims.splice(1, 1);
+    } else {
+      dims[1] = dim;
+    }
+    const next: Widget = {
+      ...widget,
+      config: { ...cfg, dimensions: dims },
+    } as Widget;
     onUpdate(next);
   }
 
@@ -100,10 +194,31 @@ export default function ConfigRail({
     onUpdate(next);
   }
 
+  function setTopN(value: number) {
+    if (widget.type !== "pie") return;
+    const next: Widget = {
+      ...widget,
+      config: { ...(widget.config as PieConfig), top_n: value },
+    };
+    onUpdate(next);
+  }
+
+  function setStacked(value: boolean) {
+    if (widget.type !== "area" && widget.type !== "stacked_bar") return;
+    const next: Widget = {
+      ...widget,
+      config: {
+        ...(widget.config as AreaConfig | StackedBarConfig),
+        stacked: value,
+      },
+    } as Widget;
+    onUpdate(next);
+  }
+
   return (
     <aside
       data-testid="config-rail"
-      className="flex h-full w-80 shrink-0 flex-col gap-4 border-l border-border bg-surface p-4 overflow-y-auto"
+      className="flex h-full w-80 shrink-0 flex-col gap-4 overflow-y-auto border-l border-border bg-surface p-4"
     >
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold text-text-primary">
@@ -139,31 +254,56 @@ export default function ConfigRail({
         </select>
       </Section>
 
-      <Section label="Aggregation">
-        <select
-          value={widget.config.measure.agg}
-          onChange={(e) =>
-            setAgg(e.target.value as "sum" | "count" | "avg" | "distinct")
+      {/* Aggregation / measures section. Single-measure widgets show
+          one row; multi-series widgets show one row per series with
+          an "Add series" button at the bottom. */}
+      {isMultiSeries(widget) ? (
+        <MeasuresEditor
+          widget={widget}
+          onChange={setSeries}
+        />
+      ) : (
+        <SingleMeasureEditor
+          measure={
+            (widget.config as KPIConfig | BarConfig | PieConfig | SparklineConfig)
+              .measure
           }
-          aria-label="Aggregation"
-          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        >
-          {AGG_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </Section>
+          onChange={setSingleMeasure}
+        />
+      )}
 
-      {widget.type === "bar" && (
-        <Section label="Dimension">
+      {widget.type !== "kpi" && (
+        <Section label="Primary dimension">
           <select
-            value={widget.config.dimensions[0] ?? "category"}
-            onChange={(e) => setDimension(e.target.value as Dimension)}
-            aria-label="Dimension"
+            value={
+              ((widget.config as BarConfig).dimensions ?? [])[0] ?? "category"
+            }
+            onChange={(e) => setPrimaryDimension(e.target.value as Dimension)}
+            aria-label="Primary dimension"
             className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
           >
+            {DIMENSION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </Section>
+      )}
+
+      {widget.type !== "kpi" && !isSingleAggLocked(widget) && (
+        <Section label="Secondary dimension (optional)">
+          <select
+            value={
+              ((widget.config as BarConfig).dimensions ?? [])[1] ?? ""
+            }
+            onChange={(e) =>
+              setSecondaryDimension((e.target.value || "") as Dimension | "")
+            }
+            aria-label="Secondary dimension"
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          >
+            <option value="">None</option>
             {DIMENSION_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
@@ -178,11 +318,45 @@ export default function ConfigRail({
           <label className="flex items-center gap-2 text-sm text-text-primary">
             <input
               type="checkbox"
-              checked={Boolean(widget.config.compare_prior_period)}
+              checked={Boolean(
+                (widget.config as KPIConfig).compare_prior_period,
+              )}
               onChange={(e) => setComparePrior(e.target.checked)}
               aria-label="Compare to prior period"
             />
             <span>Show delta vs prior period</span>
+          </label>
+        </Section>
+      )}
+
+      {widget.type === "pie" && (
+        <Section label="Top N slices">
+          <input
+            type="number"
+            min={2}
+            max={20}
+            value={(widget.config as PieConfig).top_n ?? 8}
+            onChange={(e) => setTopN(Number(e.target.value) || 8)}
+            aria-label="Top N slices"
+            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+          />
+        </Section>
+      )}
+
+      {(widget.type === "area" || widget.type === "stacked_bar") && (
+        <Section label={widget.type === "stacked_bar" ? "Stack mode" : "Stack series"}>
+          <label className="flex items-center gap-2 text-sm text-text-primary">
+            <input
+              type="checkbox"
+              checked={
+                widget.type === "stacked_bar"
+                  ? (widget.config as StackedBarConfig).stacked !== false
+                  : Boolean((widget.config as AreaConfig).stacked)
+              }
+              onChange={(e) => setStacked(e.target.checked)}
+              aria-label="Stack series"
+            />
+            <span>Stack multiple series</span>
           </label>
         </Section>
       )}
@@ -224,6 +398,174 @@ function OverridePill() {
   );
 }
 
+function SingleMeasureEditor({
+  measure,
+  onChange,
+}: {
+  measure: Measure;
+  onChange: (m: Measure) => void;
+}) {
+  return (
+    <>
+      <Section label="Aggregation">
+        <select
+          value={measure.agg}
+          onChange={(e) =>
+            onChange({ ...measure, agg: e.target.value as Aggregation })
+          }
+          aria-label="Aggregation"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        >
+          {AGG_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </Section>
+      <Section label="Field">
+        <select
+          value={measure.field}
+          onChange={(e) =>
+            onChange({ ...measure, field: e.target.value as MeasureField })
+          }
+          aria-label="Field"
+          className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+        >
+          {FIELD_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </Section>
+    </>
+  );
+}
+
+function MeasuresEditor({
+  widget,
+  onChange,
+}: {
+  widget: Widget & { config: LineConfig | AreaConfig | StackedBarConfig | TableConfig };
+  onChange: (m: SeriesConfig[]) => void;
+}) {
+  const measures = widget.config.measures;
+  const cap = widget.type === "table" ? MAX_TABLE_COLUMNS : MAX_SERIES;
+
+  function update(idx: number, next: SeriesConfig) {
+    const copy = [...measures];
+    copy[idx] = next;
+    onChange(copy);
+  }
+
+  function add() {
+    if (measures.length >= cap) return;
+    onChange([
+      ...measures,
+      { measure: { agg: "sum", field: "amount" } },
+    ]);
+  }
+
+  function remove(idx: number) {
+    if (measures.length <= 1) return;
+    onChange(measures.filter((_, i) => i !== idx));
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        {widget.type === "table" ? "Columns" : "Series"}
+      </div>
+      {measures.map((s, idx) => (
+        <div
+          key={idx}
+          data-testid={`measure-row-${idx}`}
+          className="flex flex-col gap-1 rounded-md border border-border bg-bg p-2"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-muted">
+              {widget.type === "table" ? `Column ${idx + 1}` : `Series ${idx + 1}`}
+            </span>
+            {measures.length > 1 && (
+              <button
+                type="button"
+                data-testid={`measure-remove-${idx}`}
+                onClick={() => remove(idx)}
+                className="text-xs text-text-muted hover:text-danger"
+                aria-label={`Remove ${widget.type === "table" ? "column" : "series"} ${idx + 1}`}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+          <input
+            type="text"
+            value={s.label ?? ""}
+            onChange={(e) =>
+              update(idx, { ...s, label: e.target.value || undefined })
+            }
+            placeholder={
+              widget.type === "table" ? "Column label" : "Series label"
+            }
+            aria-label={`Series ${idx + 1} label`}
+            className="rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
+          />
+          <div className="flex gap-1">
+            <select
+              value={s.measure.agg}
+              onChange={(e) =>
+                update(idx, {
+                  ...s,
+                  measure: { ...s.measure, agg: e.target.value as Aggregation },
+                })
+              }
+              aria-label={`Series ${idx + 1} aggregation`}
+              className="flex-1 rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
+            >
+              {AGG_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={s.measure.field}
+              onChange={(e) =>
+                update(idx, {
+                  ...s,
+                  measure: {
+                    ...s.measure,
+                    field: e.target.value as MeasureField,
+                  },
+                })
+              }
+              aria-label={`Series ${idx + 1} field`}
+              className="flex-1 rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
+            >
+              {FIELD_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      ))}
+      {measures.length < cap && (
+        <button
+          type="button"
+          data-testid="measure-add"
+          onClick={add}
+          className="rounded-md border border-dashed border-border px-2 py-1 text-xs text-text-secondary transition hover:border-accent hover:text-accent"
+        >
+          + Add {widget.type === "table" ? "column" : "series"}
+        </button>
+      )}
+    </div>
+  );
+}
+
 function FilterEditor({
   filters,
   canvasFilters,
@@ -246,107 +588,62 @@ function FilterEditor({
             <OverridePill />
           )}
         </div>
-        <div className="flex gap-2">
-          <input
-            type="date"
-            aria-label="Widget date from"
-            value={filters.date_range?.start ?? ""}
-            onChange={(e) =>
-              onChange({
-                ...filters,
-                date_range: {
-                  ...(filters.date_range ?? {}),
-                  start: e.target.value || undefined,
-                },
-              })
-            }
-            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-          />
-          <input
-            type="date"
-            aria-label="Widget date to"
-            value={filters.date_range?.end ?? ""}
-            onChange={(e) =>
-              onChange({
-                ...filters,
-                date_range: {
-                  ...(filters.date_range ?? {}),
-                  end: e.target.value || undefined,
-                },
-              })
-            }
-            className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-          />
-        </div>
+        <DatePresetChips
+          value={filters.date_range}
+          ariaPrefix="Widget"
+          onChange={(next) =>
+            onChange({
+              ...filters,
+              date_range: next || undefined,
+            })
+          }
+        />
       </div>
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center text-xs text-text-secondary">
-          Accounts (ids)
+          Accounts
           {isFieldOverridden("account_ids", filters, canvasFilters) && (
             <OverridePill />
           )}
         </div>
-        <input
-          type="text"
-          aria-label="Widget accounts"
-          inputMode="numeric"
-          placeholder="e.g. 12, 14"
-          value={(filters.account_ids ?? []).join(",")}
-          onChange={(e) =>
+        <AccountFilter
+          value={filters.account_ids ?? []}
+          ariaPrefix="Widget account"
+          label=""
+          onChange={(account_ids) =>
             onChange({
               ...filters,
-              account_ids: parseIdList(e.target.value),
+              account_ids: account_ids.length > 0 ? account_ids : undefined,
             })
           }
-          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
         />
       </div>
 
       <div className="flex flex-col gap-1">
         <div className="flex items-center text-xs text-text-secondary">
-          Categories (ids)
+          Categories
           {isFieldOverridden("category_ids", filters, canvasFilters) && (
             <OverridePill />
           )}
         </div>
-        <input
-          type="text"
-          aria-label="Widget categories"
-          inputMode="numeric"
-          placeholder="e.g. 3, 5"
-          value={(filters.category_ids ?? []).join(",")}
-          onChange={(e) =>
+        <CategoryPicker
+          value={filters.category_ids ?? []}
+          label=""
+          onChange={(category_ids) =>
             onChange({
               ...filters,
-              category_ids: parseIdList(e.target.value),
+              category_ids: category_ids.length > 0 ? category_ids : undefined,
             })
           }
-          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
         />
       </div>
 
       <div className="flex flex-col gap-1">
-        <div className="text-xs text-text-secondary">Transaction type</div>
-        <select
-          value={filters.txn_type ?? ""}
-          aria-label="Widget transaction type"
-          onChange={(e) =>
-            onChange({
-              ...filters,
-              txn_type:
-                e.target.value === ""
-                  ? undefined
-                  : (e.target.value as "income" | "expense" | "transfer"),
-            })
-          }
-          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        >
-          <option value="">Any</option>
-          <option value="income">Income</option>
-          <option value="expense">Expense</option>
-          <option value="transfer">Transfer</option>
-        </select>
+        <TxnTypeRadioRow
+          value={filters.txn_type}
+          onChange={(txn_type) => onChange({ ...filters, txn_type })}
+        />
       </div>
 
       <div className="flex flex-col gap-1">
@@ -387,58 +684,52 @@ function FilterEditor({
         </div>
       </div>
 
-      <div className="flex flex-col gap-1">
-        <div className="text-xs text-text-secondary">Tags</div>
-        <input
-          type="text"
-          aria-label="Widget tags"
-          placeholder="comma list of tag names"
-          value={(filters.tag_names ?? []).join(",")}
-          onChange={(e) =>
-            onChange({
-              ...filters,
-              tag_names: e.target.value
-                .split(",")
-                .map((s) => s.trim().toLowerCase())
-                .filter(Boolean),
-            })
-          }
-          className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
-        />
-        <div className="mt-1 flex gap-3 text-xs text-text-secondary">
-          <label className="flex items-center gap-1">
-            <input
-              type="radio"
-              name="tag-match"
-              aria-label="Tag match all"
-              checked={(filters.tag_match ?? "all") === "all"}
-              onChange={() => onChange({ ...filters, tag_match: "all" })}
-            />
-            <span>Match all</span>
-          </label>
-          <label className="flex items-center gap-1">
-            <input
-              type="radio"
-              name="tag-match"
-              aria-label="Tag match any"
-              checked={filters.tag_match === "any"}
-              onChange={() =>
-                onChange({ ...filters, tag_match: "any" as TagMatch })
-              }
-            />
-            <span>Match any</span>
-          </label>
-        </div>
-      </div>
+      <TagFilter
+        value={filters.tag_names ?? []}
+        match={(filters.tag_match ?? "all") as TagMatch}
+        onChange={({ tag_names, tag_match }) =>
+          onChange({
+            ...filters,
+            tag_names: tag_names.length > 0 ? tag_names : undefined,
+            tag_match: tag_names.length > 0 ? tag_match : undefined,
+          })
+        }
+      />
     </div>
   );
 }
 
-function parseIdList(raw: string): number[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map((s) => Number(s))
-    .filter((n) => Number.isInteger(n) && n > 0);
+function TxnTypeRadioRow({
+  value,
+  onChange,
+}: {
+  value: "income" | "expense" | "transfer" | undefined;
+  onChange: (next: "income" | "expense" | "transfer" | undefined) => void;
+}) {
+  const name = useId();
+  const choices: Array<{ value: "" | "income" | "expense" | "transfer"; label: string }> = [
+    { value: "", label: "Any" },
+    { value: "income", label: "Income" },
+    { value: "expense", label: "Expense" },
+    { value: "transfer", label: "Transfer" },
+  ];
+  return (
+    <>
+      <div className="text-xs text-text-secondary">Transaction type</div>
+      <div className="flex flex-wrap gap-3 text-xs text-text-secondary">
+        {choices.map((c) => (
+          <label key={c.value} className="flex items-center gap-1">
+            <input
+              type="radio"
+              name={name}
+              aria-label={`Widget transaction type ${c.label}`}
+              checked={(value ?? "") === c.value}
+              onChange={() => onChange(c.value === "" ? undefined : (c.value as "income" | "expense" | "transfer"))}
+            />
+            <span>{c.label}</span>
+          </label>
+        ))}
+      </div>
+    </>
+  );
 }

--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -291,11 +291,16 @@ export default function ConfigRail({
         </Section>
       )}
 
-      {widget.type !== "kpi" && !isSingleAggLocked(widget) && (
+      {/* Secondary dimension picker — Table-only in v1. Bar / line /
+          area / stacked widgets currently only consume ``dimensions[0]``,
+          so exposing a secondary picker for them would be a no-op UX
+          (architect-locked). Split-series rendering is a follow-up if
+          users ask for it. */}
+      {widget.type === "table" && (
         <Section label="Secondary dimension (optional)">
           <select
             value={
-              ((widget.config as BarConfig).dimensions ?? [])[1] ?? ""
+              ((widget.config as TableConfig).dimensions ?? [])[1] ?? ""
             }
             onChange={(e) =>
               setSecondaryDimension((e.target.value || "") as Dimension | "")

--- a/frontend/components/reports/WidgetPicker.tsx
+++ b/frontend/components/reports/WidgetPicker.tsx
@@ -3,11 +3,25 @@
 /**
  * Widget picker modal — appears when the user clicks "Add widget."
  *
- * v1 catalog: KPI + Bar. The button list is structured so PR3 can
- * grow it (line / area / pie / table / sparkline / stacked bar)
- * without reshaping the call site.
+ * PR3 lights up the full v1 catalog (8 types) grouped by analytical
+ * intent so users land on the right widget for the question they're
+ * asking:
+ *
+ * - Numbers     — KPI
+ * - Trends      — Line, Area, Sparkline
+ * - Categories  — Bar, Stacked Bar, Pie
+ * - Tables      — Table
  */
-import { BarChart3, Hash } from "lucide-react";
+import {
+  AreaChart as AreaIcon,
+  BarChart3,
+  BarChartHorizontal,
+  Hash,
+  LineChart as LineIcon,
+  PieChart as PieIcon,
+  Table as TableIcon,
+  TrendingUp,
+} from "lucide-react";
 
 import type { WidgetTypeV1 } from "@/lib/reports/types";
 
@@ -17,23 +31,86 @@ interface Props {
   onPick: (type: WidgetTypeV1) => void;
 }
 
-const OPTIONS: Array<{
+interface Option {
   type: WidgetTypeV1;
   label: string;
   description: string;
   Icon: typeof BarChart3;
-}> = [
+}
+
+interface Group {
+  label: string;
+  options: Option[];
+}
+
+const GROUPS: Group[] = [
   {
-    type: "kpi",
-    label: "KPI",
-    description: "Single number with an optional comparison.",
-    Icon: Hash,
+    label: "Numbers",
+    options: [
+      {
+        type: "kpi",
+        label: "KPI",
+        description: "Single number with an optional comparison.",
+        Icon: Hash,
+      },
+    ],
   },
   {
-    type: "bar",
-    label: "Bar chart",
-    description: "Vertical bars over a category, account, or tag.",
-    Icon: BarChart3,
+    label: "Trends",
+    options: [
+      {
+        type: "line",
+        label: "Line",
+        description: "Time series over a date bucket; one line per series.",
+        Icon: LineIcon,
+      },
+      {
+        type: "area",
+        label: "Area",
+        description: "Filled time series. Stack multiple series on top.",
+        Icon: AreaIcon,
+      },
+      {
+        type: "sparkline",
+        label: "Sparkline",
+        description: "Compact trend line with the latest value.",
+        Icon: TrendingUp,
+      },
+    ],
+  },
+  {
+    label: "Categories",
+    options: [
+      {
+        type: "bar",
+        label: "Bar",
+        description: "Vertical bars over a category, account, or tag.",
+        Icon: BarChart3,
+      },
+      {
+        type: "stacked_bar",
+        label: "Stacked bar",
+        description: "Bars with stacked sub-series per bucket.",
+        Icon: BarChartHorizontal,
+      },
+      {
+        type: "pie",
+        label: "Pie",
+        description: "Share-of-total with an 'Other' bucket past the top 8.",
+        Icon: PieIcon,
+      },
+    ],
+  },
+  {
+    label: "Tables",
+    options: [
+      {
+        type: "table",
+        label: "Table",
+        description: "Sortable, paginated rows. Up to five numeric columns.",
+        Icon: TableIcon,
+      },
+    ],
   },
 ];
 
@@ -47,7 +124,7 @@ export default function WidgetPicker({ open, onClose, onPick }: Props) {
       data-testid="widget-picker"
       className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 px-4"
     >
-      <div className="w-full max-w-md rounded-lg border border-border bg-surface p-5 shadow-xl">
+      <div className="w-full max-w-2xl rounded-lg border border-border bg-surface p-5 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-base font-semibold text-text-primary">
             Add widget
@@ -61,30 +138,41 @@ export default function WidgetPicker({ open, onClose, onPick }: Props) {
             Close
           </button>
         </div>
-        <ul className="space-y-2">
-          {OPTIONS.map(({ type, label, description, Icon }) => (
-            <li key={type}>
-              <button
-                type="button"
-                onClick={() => onPick(type)}
-                data-testid={`widget-picker-option-${type}`}
-                className="flex w-full items-start gap-3 rounded-md border border-border bg-bg p-3 text-left transition hover:border-accent hover:bg-bg-elevated"
-              >
-                <Icon
-                  aria-hidden="true"
-                  className="mt-0.5 h-5 w-5 text-accent"
-                  strokeWidth={1.5}
-                />
-                <div>
-                  <div className="text-sm font-medium text-text-primary">
-                    {label}
-                  </div>
-                  <div className="text-xs text-text-muted">{description}</div>
-                </div>
-              </button>
-            </li>
+        <div className="space-y-4">
+          {GROUPS.map((group) => (
+            <div key={group.label} data-testid={`widget-picker-group-${group.label}`}>
+              <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+                {group.label}
+              </div>
+              <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {group.options.map(({ type, label, description, Icon }) => (
+                  <li key={type}>
+                    <button
+                      type="button"
+                      onClick={() => onPick(type)}
+                      data-testid={`widget-picker-option-${type}`}
+                      className="flex w-full items-start gap-3 rounded-md border border-border bg-bg p-3 text-left transition hover:border-accent hover:bg-bg-elevated"
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        className="mt-0.5 h-5 w-5 text-accent"
+                        strokeWidth={1.5}
+                      />
+                      <div>
+                        <div className="text-sm font-medium text-text-primary">
+                          {label}
+                        </div>
+                        <div className="text-xs text-text-muted">
+                          {description}
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
           ))}
-        </ul>
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/reports/filters/AccountFilter.tsx
+++ b/frontend/components/reports/filters/AccountFilter.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * Account filter — chip picker over the org's accounts. Replaces the
+ * PR2 comma-list ``account_ids`` input on both the canvas filters bar
+ * and the per-widget config rail.
+ *
+ * Fetches the org's accounts on mount via SWR and renders each as a
+ * toggleable chip. Selecting / deselecting a chip flips its id in
+ * the ``value`` list. Empty list = no filter (inherit / unfiltered).
+ */
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+import type { Account } from "@/lib/types";
+
+interface Props {
+  value: number[];
+  onChange: (next: number[]) => void;
+  /** Label shown above the chip strip. */
+  label?: string;
+  /** Aria-prefix on chip remove buttons + the empty hint. */
+  ariaPrefix?: string;
+}
+
+const ACCOUNTS_SWR_KEY = "/api/v1/accounts?for=reports-filter";
+
+async function fetchAccounts(): Promise<Account[]> {
+  return apiFetch<Account[]>("/api/v1/accounts");
+}
+
+export default function AccountFilter({
+  value,
+  onChange,
+  label = "Accounts",
+  ariaPrefix = "Account",
+}: Props) {
+  const { data, error, isLoading } = useSWR<Account[]>(
+    ACCOUNTS_SWR_KEY,
+    fetchAccounts,
+    { revalidateOnFocus: false },
+  );
+
+  const accounts = data ?? [];
+  const selectedSet = new Set(value);
+
+  function toggle(id: number) {
+    const next = selectedSet.has(id)
+      ? value.filter((v) => v !== id)
+      : [...value, id];
+    onChange(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-1" data-testid="account-filter">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-text-muted">
+        {label}
+      </span>
+      {error ? (
+        <div
+          role="alert"
+          data-testid="account-filter-error"
+          className="text-xs text-danger"
+        >
+          Couldn&apos;t load accounts
+        </div>
+      ) : isLoading ? (
+        <div
+          data-testid="account-filter-loading"
+          className="h-6 w-32 animate-pulse rounded bg-border/40"
+        />
+      ) : accounts.length === 0 ? (
+        <span className="text-xs text-text-muted">No accounts yet</span>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {accounts.map((a) => {
+            const active = selectedSet.has(a.id);
+            return (
+              <button
+                key={a.id}
+                type="button"
+                data-testid={`account-filter-chip-${a.id}`}
+                aria-pressed={active}
+                aria-label={`${ariaPrefix} ${a.name}`}
+                onClick={() => toggle(a.id)}
+                className={`rounded-full border px-2.5 py-0.5 text-xs transition ${
+                  active
+                    ? "border-accent bg-accent text-accent-foreground"
+                    : "border-border text-text-secondary hover:bg-bg-elevated"
+                }`}
+              >
+                {a.name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/reports/filters/CategoryPicker.tsx
+++ b/frontend/components/reports/filters/CategoryPicker.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * Category filter — tree-style picker that respects the
+ * master / sub category hierarchy from the existing
+ * ``backend/app/models/category.py`` model.
+ *
+ * Master row: checkbox toggles ALL sub categories under that master.
+ * When some but not all subs are selected, the master shows the
+ * indeterminate / partial state.
+ * Sub row: checkbox toggles its own id. Unselecting a sub while the
+ * master is fully checked leaves the master partial.
+ *
+ * Search input filters the tree by name; matching subs keep their
+ * master visible (collapsed if the master itself doesn't match).
+ *
+ * Returns ``category_ids: number[]`` — IDs of every selected master
+ * AND sub. The widget AST filter on ``category_id IN (...)`` doesn't
+ * understand the hierarchy, so we always materialize the full list.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+import type { Category } from "@/lib/types";
+
+interface Props {
+  value: number[];
+  onChange: (next: number[]) => void;
+  label?: string;
+}
+
+const CATEGORIES_SWR_KEY = "/api/v1/categories?for=reports-filter";
+
+async function fetchCategories(): Promise<Category[]> {
+  return apiFetch<Category[]>("/api/v1/categories");
+}
+
+interface TreeNode {
+  master: Category;
+  subs: Category[];
+}
+
+function buildTree(cats: Category[]): TreeNode[] {
+  const masters = cats.filter((c) => c.parent_id === null);
+  return masters
+    .map((m) => ({
+      master: m,
+      subs: cats.filter((c) => c.parent_id === m.id),
+    }))
+    .sort((a, b) => a.master.name.localeCompare(b.master.name));
+}
+
+export default function CategoryPicker({
+  value,
+  onChange,
+  label = "Categories",
+}: Props) {
+  const { data, error, isLoading } = useSWR<Category[]>(
+    CATEGORIES_SWR_KEY,
+    fetchCategories,
+    { revalidateOnFocus: false },
+  );
+
+  const [search, setSearch] = useState("");
+  const selected = useMemo(() => new Set(value), [value]);
+  const cats = data ?? [];
+  const tree = useMemo(() => buildTree(cats), [cats]);
+
+  const visibleTree = useMemo(() => {
+    if (!search.trim()) return tree;
+    const q = search.toLowerCase();
+    return tree
+      .map((node) => {
+        const masterMatches = node.master.name.toLowerCase().includes(q);
+        const subs = node.subs.filter((s) => s.name.toLowerCase().includes(q));
+        if (masterMatches) return { master: node.master, subs: node.subs };
+        if (subs.length > 0) return { master: node.master, subs };
+        return null;
+      })
+      .filter((n): n is TreeNode => n !== null);
+  }, [tree, search]);
+
+  function toggleMaster(node: TreeNode) {
+    const ids = [node.master.id, ...node.subs.map((s) => s.id)];
+    const allSelected = ids.every((id) => selected.has(id));
+    if (allSelected) {
+      onChange(value.filter((v) => !ids.includes(v)));
+    } else {
+      const next = new Set(value);
+      for (const id of ids) next.add(id);
+      onChange([...next]);
+    }
+  }
+
+  function toggleSub(sub: Category) {
+    const next = selected.has(sub.id)
+      ? value.filter((v) => v !== sub.id)
+      : [...value, sub.id];
+    onChange(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5" data-testid="category-picker">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-text-muted">
+        {label}
+      </span>
+      {error ? (
+        <div
+          role="alert"
+          data-testid="category-picker-error"
+          className="text-xs text-danger"
+        >
+          Couldn&apos;t load categories
+        </div>
+      ) : isLoading ? (
+        <div
+          data-testid="category-picker-loading"
+          className="h-6 w-32 animate-pulse rounded bg-border/40"
+        />
+      ) : cats.length === 0 ? (
+        <span className="text-xs text-text-muted">No categories yet</span>
+      ) : (
+        <>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            data-testid="category-picker-search"
+            aria-label="Search categories"
+            placeholder="Search categories..."
+            className="rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
+          />
+          <div className="max-h-56 overflow-y-auto rounded-md border border-border bg-bg p-2">
+            {visibleTree.length === 0 ? (
+              <span className="text-xs text-text-muted">No categories match</span>
+            ) : (
+              <ul className="flex flex-col gap-1">
+                {visibleTree.map((node) => (
+                  <CategoryTreeRow
+                    key={node.master.id}
+                    node={node}
+                    selected={selected}
+                    onToggleMaster={() => toggleMaster(node)}
+                    onToggleSub={toggleSub}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function CategoryTreeRow({
+  node,
+  selected,
+  onToggleMaster,
+  onToggleSub,
+}: {
+  node: TreeNode;
+  selected: Set<number>;
+  onToggleMaster: () => void;
+  onToggleSub: (sub: Category) => void;
+}) {
+  const masterRef = useRef<HTMLInputElement>(null);
+  const allIds = [node.master.id, ...node.subs.map((s) => s.id)];
+  const selCount = allIds.filter((id) => selected.has(id)).length;
+  const total = allIds.length;
+  const allChecked = selCount === total;
+  const partial = selCount > 0 && selCount < total;
+
+  // The HTML input doesn't have an attribute for indeterminate; it's
+  // a DOM-only property. Sync it whenever the count changes.
+  useEffect(() => {
+    if (masterRef.current) masterRef.current.indeterminate = partial;
+  }, [partial]);
+
+  return (
+    <li>
+      <label className="flex items-center gap-2 text-sm text-text-primary">
+        <input
+          ref={masterRef}
+          type="checkbox"
+          data-testid={`category-master-${node.master.id}`}
+          checked={allChecked}
+          onChange={onToggleMaster}
+          aria-checked={partial ? "mixed" : allChecked}
+          aria-label={`Category ${node.master.name}`}
+        />
+        <span className="font-medium">{node.master.name}</span>
+        <span className="text-[10px] text-text-muted">
+          {selCount}/{total}
+        </span>
+      </label>
+      {node.subs.length > 0 && (
+        <ul className="ml-5 mt-1 flex flex-col gap-0.5">
+          {node.subs.map((s) => (
+            <li key={s.id}>
+              <label className="flex items-center gap-2 text-xs text-text-secondary">
+                <input
+                  type="checkbox"
+                  data-testid={`category-sub-${s.id}`}
+                  checked={selected.has(s.id)}
+                  onChange={() => onToggleSub(s)}
+                  aria-label={`Category ${s.name}`}
+                />
+                <span>{s.name}</span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/frontend/components/reports/filters/DatePresetChips.tsx
+++ b/frontend/components/reports/filters/DatePresetChips.tsx
@@ -42,8 +42,19 @@ export default function DatePresetChips({
   now,
   ariaPrefix = "Date",
 }: Props) {
-  const today = now ?? new Date();
-  const presetRanges = useMemo(() => buildPresetRanges(today), [today.toDateString()]);
+  // ``todayKey`` is a stable YYYY-MM-DD-ish string that only changes
+  // when the calendar day flips (or the test override changes). The
+  // original code passed ``today.toDateString()`` directly as a useMemo
+  // dep, which fails react-hooks/exhaustive-deps because (a) the
+  // linter rejects method calls as stable deps and (b) the expression
+  // is recomputed on every render. Pinning the string in its own
+  // variable and listing both inputs (string + raw ``now`` reference)
+  // keeps the memo stable AND silences the lint rule cleanly.
+  const todayKey = (now ?? new Date()).toDateString();
+  const presetRanges = useMemo(
+    () => buildPresetRanges(now ?? new Date(todayKey)),
+    [now, todayKey],
+  );
 
   // Detect which preset matches the current value (if any). The check
   // is exact ISO equality on start + end; user-typed custom ranges fall

--- a/frontend/components/reports/filters/DatePresetChips.tsx
+++ b/frontend/components/reports/filters/DatePresetChips.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+/**
+ * Date range filter — a row of preset chips above the absolute date
+ * inputs. Clicking a chip fills both ``from`` and ``to`` with the
+ * resolved ISO date range. Clicking "Custom" clears the chip
+ * selection and exposes the absolute date inputs.
+ *
+ * Presets resolved relative to the local clock at click time so the
+ * stored value is an absolute window. The architect-locked AST
+ * doesn't model relative ranges; freezing the absolute window at
+ * authoring time keeps the same report layout reproducible across
+ * sessions until the user picks a new preset.
+ */
+import { useMemo } from "react";
+
+import type { CanvasDateRange } from "@/lib/reports/types";
+
+interface Props {
+  value: CanvasDateRange | undefined;
+  onChange: (next: CanvasDateRange | undefined) => void;
+  /** Optional override for "today" — primarily for tests so a real
+   * clock doesn't make the assertions wobble across the month flip. */
+  now?: Date;
+  /** Label prefix applied to aria-labels (e.g. "Canvas" vs "Widget"). */
+  ariaPrefix?: string;
+}
+
+type PresetKey = "this_month" | "last_month" | "ytd" | "last_12_months" | "custom";
+
+const PRESETS: Array<{ key: PresetKey; label: string }> = [
+  { key: "this_month", label: "This month" },
+  { key: "last_month", label: "Last month" },
+  { key: "ytd", label: "YTD" },
+  { key: "last_12_months", label: "Last 12 months" },
+  { key: "custom", label: "Custom" },
+];
+
+export default function DatePresetChips({
+  value,
+  onChange,
+  now,
+  ariaPrefix = "Date",
+}: Props) {
+  const today = now ?? new Date();
+  const presetRanges = useMemo(() => buildPresetRanges(today), [today.toDateString()]);
+
+  // Detect which preset matches the current value (if any). The check
+  // is exact ISO equality on start + end; user-typed custom ranges fall
+  // through to "custom".
+  const activePreset = matchPreset(value, presetRanges);
+  const showDateInputs = activePreset === "custom" || (!activePreset && value);
+
+  function pick(key: PresetKey) {
+    if (key === "custom") {
+      // Don't clobber the user's typed dates if they had them; just
+      // keep the current value but flag it as custom.
+      if (!value) {
+        onChange({});
+      }
+      return;
+    }
+    onChange(presetRanges[key]);
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        data-testid="date-preset-chips"
+        className="flex flex-wrap gap-1.5"
+      >
+        {PRESETS.map((p) => {
+          const isActive = activePreset === p.key;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              data-testid={`date-preset-${p.key}`}
+              aria-pressed={isActive}
+              onClick={() => pick(p.key)}
+              className={`rounded-full border px-3 py-1 text-xs transition ${
+                isActive
+                  ? "border-accent bg-accent text-accent-foreground"
+                  : "border-border text-text-secondary hover:bg-bg-elevated"
+              }`}
+            >
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+      {showDateInputs && (
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] font-medium uppercase tracking-wider text-text-muted">
+              From
+            </span>
+            <input
+              type="date"
+              data-testid="date-preset-from"
+              aria-label={`${ariaPrefix} date from`}
+              value={value?.start ?? ""}
+              onChange={(e) =>
+                onChange({
+                  ...(value ?? {}),
+                  start: e.target.value || undefined,
+                })
+              }
+              className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] font-medium uppercase tracking-wider text-text-muted">
+              To
+            </span>
+            <input
+              type="date"
+              data-testid="date-preset-to"
+              aria-label={`${ariaPrefix} date to`}
+              value={value?.end ?? ""}
+              onChange={(e) =>
+                onChange({
+                  ...(value ?? {}),
+                  end: e.target.value || undefined,
+                })
+              }
+              className="rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function isoDate(d: Date): string {
+  // Build YYYY-MM-DD from local-clock components so a UTC-shifting
+  // ``toISOString`` doesn't shove the date back by a day in negative-
+  // offset timezones.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+function endOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth() + 1, 0);
+}
+
+export function buildPresetRanges(
+  now: Date,
+): Record<Exclude<PresetKey, "custom">, CanvasDateRange> {
+  const startThisMonth = startOfMonth(now);
+  const endThisMonth = endOfMonth(now);
+
+  const startLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const endLastMonth = new Date(now.getFullYear(), now.getMonth(), 0);
+
+  const startOfYear = new Date(now.getFullYear(), 0, 1);
+
+  const startLast12 = new Date(now.getFullYear() - 1, now.getMonth(), 1);
+
+  return {
+    this_month: { start: isoDate(startThisMonth), end: isoDate(endThisMonth) },
+    last_month: { start: isoDate(startLastMonth), end: isoDate(endLastMonth) },
+    ytd: { start: isoDate(startOfYear), end: isoDate(now) },
+    last_12_months: { start: isoDate(startLast12), end: isoDate(now) },
+  };
+}
+
+function matchPreset(
+  value: CanvasDateRange | undefined,
+  ranges: Record<Exclude<PresetKey, "custom">, CanvasDateRange>,
+): PresetKey | null {
+  if (!value || (!value.start && !value.end)) return null;
+  for (const k of Object.keys(ranges) as Array<keyof typeof ranges>) {
+    const r = ranges[k];
+    if (r.start === value.start && r.end === value.end) return k;
+  }
+  return "custom";
+}

--- a/frontend/components/reports/filters/TagFilter.tsx
+++ b/frontend/components/reports/filters/TagFilter.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * Tag filter — chip picker over the org's tags. Suggestions are
+ * fetched on mount via ``GET /api/v1/tags``. Selecting a tag adds it
+ * to the chip strip; clicking an active chip removes it. A radio
+ * row below the chip input toggles ``tag_match`` between "all"
+ * (every tag must be present) and "any" (at least one tag must be
+ * present), mirroring the transactions-list contract.
+ *
+ * Spec section 4: default is ``all``. The architect-locked tag-match
+ * inversion bug PR2 fixed lives at the wire layer (one ``in`` filter
+ * carrying the whole list) — this picker only shapes the user-facing
+ * UI. ``resolveFilters`` still emits the correct AST.
+ */
+import { useId } from "react";
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+import type { TagMatch } from "@/lib/reports/types";
+
+interface TagResponse {
+  id: number;
+  name: string;
+  name_normalized: string;
+  usage_count: number;
+}
+
+interface Props {
+  value: string[];
+  match: TagMatch;
+  onChange: (next: { tag_names: string[]; tag_match: TagMatch }) => void;
+  /** Label shown above the chip strip. */
+  label?: string;
+  /** Aria-prefix on chip toggle buttons. */
+  ariaPrefix?: string;
+}
+
+const TAGS_SWR_KEY = "/api/v1/tags?for=reports-filter";
+
+async function fetchTags(): Promise<TagResponse[]> {
+  return apiFetch<TagResponse[]>("/api/v1/tags");
+}
+
+export default function TagFilter({
+  value,
+  match,
+  onChange,
+  label = "Tags",
+  ariaPrefix = "Tag",
+}: Props) {
+  const { data, error, isLoading } = useSWR<TagResponse[]>(
+    TAGS_SWR_KEY,
+    fetchTags,
+    { revalidateOnFocus: false },
+  );
+
+  const radioName = useId();
+  const tags = data ?? [];
+  const selectedSet = new Set(value);
+
+  function toggle(name: string) {
+    const next = selectedSet.has(name)
+      ? value.filter((n) => n !== name)
+      : [...value, name];
+    onChange({ tag_names: next, tag_match: match });
+  }
+
+  function setMatch(next: TagMatch) {
+    onChange({ tag_names: value, tag_match: next });
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5" data-testid="tag-filter">
+      <span className="text-[10px] font-medium uppercase tracking-wider text-text-muted">
+        {label}
+      </span>
+      {error ? (
+        <div
+          role="alert"
+          data-testid="tag-filter-error"
+          className="text-xs text-danger"
+        >
+          Couldn&apos;t load tags
+        </div>
+      ) : isLoading ? (
+        <div
+          data-testid="tag-filter-loading"
+          className="h-6 w-28 animate-pulse rounded bg-border/40"
+        />
+      ) : tags.length === 0 ? (
+        <span className="text-xs text-text-muted">No tags yet</span>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {tags.map((t) => {
+            const active = selectedSet.has(t.name);
+            return (
+              <button
+                key={t.id}
+                type="button"
+                data-testid={`tag-filter-chip-${t.name}`}
+                aria-pressed={active}
+                aria-label={`${ariaPrefix} ${t.name}`}
+                onClick={() => toggle(t.name)}
+                className={`rounded-full border px-2.5 py-0.5 text-xs transition ${
+                  active
+                    ? "border-accent bg-accent text-accent-foreground"
+                    : "border-border text-text-secondary hover:bg-bg-elevated"
+                }`}
+              >
+                {t.name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <div className="mt-1 flex gap-3 text-xs text-text-secondary">
+        <label className="flex items-center gap-1">
+          <input
+            type="radio"
+            name={radioName}
+            data-testid="tag-filter-match-all"
+            aria-label="Tag match all"
+            checked={match === "all"}
+            onChange={() => setMatch("all")}
+          />
+          <span>Match all</span>
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            type="radio"
+            name={radioName}
+            data-testid="tag-filter-match-any"
+            aria-label="Tag match any"
+            checked={match === "any"}
+            onChange={() => setMatch("any")}
+          />
+          <span>Match any</span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/widgets/AreaWidget.tsx
+++ b/frontend/components/reports/widgets/AreaWidget.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * Area widget — same data shape as Line, filled under the curve. When
+ * multiple series are configured AND ``stacked`` is true, the areas
+ * stack (each series sums on top of the prior). When ``stacked`` is
+ * false, overlapping areas render with transparency.
+ */
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { chartColor } from "@/lib/chart-colors";
+import { useSeriesQueries } from "@/lib/reports/useReportQuery";
+import { mergeSeriesRows, seriesLabel } from "@/lib/reports/series";
+import type {
+  AreaWidget as AreaWidgetType,
+  CanvasFilters,
+} from "@/lib/reports/types";
+
+interface Props {
+  widget: AreaWidgetType;
+  canvasFilters?: CanvasFilters;
+}
+
+const AREA_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+];
+
+export default function AreaWidget({ widget, canvasFilters }: Props) {
+  const measures = widget.config.measures.map((m) => m.measure);
+  const { series, isLoading, error } = useSeriesQueries(
+    widget,
+    canvasFilters,
+    measures,
+  );
+
+  const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
+  const rows = mergeSeriesRows(series, dimensionKey, seriesKeys);
+  const labels = widget.config.measures.map((m, i) =>
+    seriesLabel(m, i, widget.config.measures.length),
+  );
+  const stackId = widget.config.stacked && seriesKeys.length > 1 ? "stack" : undefined;
+
+  return (
+    <div
+      data-testid="area-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
+    >
+      <div
+        className="mb-2 text-sm font-semibold text-text-primary"
+        aria-label={widget.title || "Area chart"}
+      >
+        {widget.title || "Area chart"}
+      </div>
+      <div className="flex-1">
+        {isLoading ? (
+          <div
+            data-testid="area-widget-loading"
+            className="h-full w-full animate-pulse rounded bg-border/40"
+          />
+        ) : error ? (
+          <div
+            role="alert"
+            data-testid="area-widget-error"
+            className="text-sm text-danger"
+          >
+            Couldn&apos;t load
+          </div>
+        ) : rows.length === 0 ? (
+          <div
+            data-testid="area-widget-empty"
+            className="flex h-full items-center justify-center text-sm text-text-muted"
+          >
+            No data
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+                interval={0}
+              />
+              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+              <Tooltip cursor={{ stroke: "var(--color-border)" }} />
+              {seriesKeys.length > 1 && (
+                <Legend wrapperStyle={{ fontSize: 11 }} />
+              )}
+              {seriesKeys.map((key, i) => (
+                <Area
+                  key={key}
+                  type="monotone"
+                  dataKey={key}
+                  name={labels[i]}
+                  stackId={stackId}
+                  stroke={AREA_COLORS[i % AREA_COLORS.length]}
+                  fill={AREA_COLORS[i % AREA_COLORS.length]}
+                  fillOpacity={seriesKeys.length > 1 ? 0.35 : 0.55}
+                  strokeWidth={2}
+                  isAnimationActive={false}
+                />
+              ))}
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/widgets/LineWidget.tsx
+++ b/frontend/components/reports/widgets/LineWidget.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+/**
+ * Line widget — time-series over ``dimensions[0]``. Multiple series
+ * are supported via ``config.measures`` (one entry per line). Each
+ * series fires its own AST query and the rows are merged client-side
+ * by the dimension key.
+ *
+ * Recharts is the canvas chart engine across the app (Dashboard,
+ * Budgets, Forecast Plans); reusing it here keeps visual register
+ * consistent.
+ */
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { chartColor } from "@/lib/chart-colors";
+import { useSeriesQueries } from "@/lib/reports/useReportQuery";
+import { mergeSeriesRows, seriesLabel } from "@/lib/reports/series";
+import type {
+  CanvasFilters,
+  LineWidget as LineWidgetType,
+} from "@/lib/reports/types";
+
+interface Props {
+  widget: LineWidgetType;
+  canvasFilters?: CanvasFilters;
+}
+
+const LINE_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+];
+
+export default function LineWidget({ widget, canvasFilters }: Props) {
+  const measures = widget.config.measures.map((m) => m.measure);
+  const { series, isLoading, error } = useSeriesQueries(
+    widget,
+    canvasFilters,
+    measures,
+  );
+
+  const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
+  const rows = mergeSeriesRows(series, dimensionKey, seriesKeys);
+  const labels = widget.config.measures.map((m, i) =>
+    seriesLabel(m, i, widget.config.measures.length),
+  );
+
+  return (
+    <div
+      data-testid="line-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
+    >
+      <div
+        className="mb-2 text-sm font-semibold text-text-primary"
+        aria-label={widget.title || "Line chart"}
+      >
+        {widget.title || "Line chart"}
+      </div>
+      <div className="flex-1">
+        {isLoading ? (
+          <div
+            data-testid="line-widget-loading"
+            className="h-full w-full animate-pulse rounded bg-border/40"
+          />
+        ) : error ? (
+          <div
+            role="alert"
+            data-testid="line-widget-error"
+            className="text-sm text-danger"
+          >
+            Couldn&apos;t load
+          </div>
+        ) : rows.length === 0 ? (
+          <div
+            data-testid="line-widget-empty"
+            className="flex h-full items-center justify-center text-sm text-text-muted"
+          >
+            No data
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+                interval={0}
+              />
+              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+              <Tooltip cursor={{ stroke: "var(--color-border)" }} />
+              {seriesKeys.length > 1 && (
+                <Legend wrapperStyle={{ fontSize: 11 }} />
+              )}
+              {seriesKeys.map((key, i) => (
+                <Line
+                  key={key}
+                  type={widget.config.smooth === false ? "linear" : "monotone"}
+                  dataKey={key}
+                  name={labels[i]}
+                  stroke={LINE_COLORS[i % LINE_COLORS.length]}
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/widgets/PieWidget.tsx
+++ b/frontend/components/reports/widgets/PieWidget.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * Pie widget — share-of-total over a single dimension. The spec caps
+ * the visible slice count: anything beyond ``top_n`` (default 8) is
+ * rolled into a single "Other" slice. Legend renders below the pie.
+ *
+ * Single dimension, single aggregation — the config rail locks both
+ * to length 1 when the widget type is ``pie``.
+ */
+import {
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+
+import { useReportQuery } from "@/lib/reports/useReportQuery";
+import { topNWithOther } from "@/lib/reports/series";
+import type {
+  CanvasFilters,
+  PieWidget as PieWidgetType,
+} from "@/lib/reports/types";
+
+interface Props {
+  widget: PieWidgetType;
+  canvasFilters?: CanvasFilters;
+}
+
+const PIE_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+  "var(--color-text-secondary)",
+  "var(--color-border)",
+  "var(--color-text-muted)",
+  "var(--color-bg-elevated, var(--color-border))",
+];
+
+export default function PieWidget({ widget, canvasFilters }: Props) {
+  const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
+
+  const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const topN = widget.config.top_n ?? 8;
+  const rawRows = (data?.rows ?? []).map((r) => ({
+    label: String(r[dimensionKey] ?? "—"),
+    value: typeof r.value === "number" ? r.value : Number(r.value ?? 0),
+  }));
+  const rows = topNWithOther(rawRows, topN);
+
+  return (
+    <div
+      data-testid="pie-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
+    >
+      <div
+        className="mb-2 text-sm font-semibold text-text-primary"
+        aria-label={widget.title || "Pie chart"}
+      >
+        {widget.title || "Pie chart"}
+      </div>
+      <div className="flex-1">
+        {isLoading ? (
+          <div
+            data-testid="pie-widget-loading"
+            className="h-full w-full animate-pulse rounded bg-border/40"
+          />
+        ) : error ? (
+          <div
+            role="alert"
+            data-testid="pie-widget-error"
+            className="text-sm text-danger"
+          >
+            Couldn&apos;t load
+          </div>
+        ) : rows.length === 0 ? (
+          <div
+            data-testid="pie-widget-empty"
+            className="flex h-full items-center justify-center text-sm text-text-muted"
+          >
+            No data
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={rows}
+                dataKey="value"
+                nameKey="label"
+                innerRadius="40%"
+                outerRadius="75%"
+                stroke="var(--color-surface)"
+                isAnimationActive={false}
+              >
+                {rows.map((row, i) => (
+                  <Cell
+                    key={row.label}
+                    fill={
+                      row.label === "Other"
+                        ? "var(--color-border)"
+                        : PIE_COLORS[i % PIE_COLORS.length]
+                    }
+                  />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend
+                verticalAlign="bottom"
+                wrapperStyle={{ fontSize: 11 }}
+                iconSize={8}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/widgets/SparklineWidget.tsx
+++ b/frontend/components/reports/widgets/SparklineWidget.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * Sparkline widget — compact trend line designed for a small grid
+ * slot. No axes, no legend, no axis rulers. Tooltip on hover. The
+ * widget surfaces the LAST data point as a big number alongside the
+ * trend line so a single glance gives both the latest value and the
+ * direction of travel.
+ *
+ * Single dimension, single aggregation — the config rail locks both
+ * when the widget type is ``sparkline``.
+ */
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+
+import { useReportQuery } from "@/lib/reports/useReportQuery";
+import type {
+  CanvasFilters,
+  SparklineWidget as SparklineWidgetType,
+} from "@/lib/reports/types";
+
+interface Props {
+  widget: SparklineWidgetType;
+  canvasFilters?: CanvasFilters;
+}
+
+export default function SparklineWidget({ widget, canvasFilters }: Props) {
+  const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
+
+  const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const rows = (data?.rows ?? []).map((r) => ({
+    label: String(r[dimensionKey] ?? "—"),
+    value: typeof r.value === "number" ? r.value : Number(r.value ?? 0),
+  }));
+  const lastValue = rows.length > 0 ? rows[rows.length - 1].value : null;
+  const format = widget.config.format ?? "number";
+
+  return (
+    <div
+      data-testid="sparkline-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col justify-center gap-1 rounded-lg border border-border bg-surface p-3"
+      aria-label={widget.title || "Sparkline"}
+    >
+      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        {widget.title || "Sparkline"}
+      </div>
+      {isLoading ? (
+        <div
+          data-testid="sparkline-widget-loading"
+          className="h-6 w-20 animate-pulse rounded bg-border"
+        />
+      ) : error ? (
+        <div
+          role="alert"
+          data-testid="sparkline-widget-error"
+          className="text-sm text-danger"
+        >
+          Couldn&apos;t load
+        </div>
+      ) : rows.length === 0 ? (
+        <div
+          data-testid="sparkline-widget-empty"
+          className="text-2xl font-semibold text-text-muted"
+        >
+          —
+        </div>
+      ) : (
+        <>
+          <div
+            data-testid="sparkline-widget-value"
+            className="text-xl font-semibold text-text-primary"
+          >
+            {formatValue(lastValue ?? 0, format)}
+          </div>
+          <div className="-mx-1 h-10">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={rows} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+                <Tooltip cursor={false} />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke="var(--color-accent)"
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function formatValue(value: number, format: "currency" | "number" | "percent") {
+  if (format === "currency") {
+    return value.toLocaleString(undefined, {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    });
+  }
+  if (format === "percent") {
+    return `${value.toFixed(1)}%`;
+  }
+  return value.toLocaleString();
+}

--- a/frontend/components/reports/widgets/SparklineWidget.tsx
+++ b/frontend/components/reports/widgets/SparklineWidget.tsx
@@ -66,9 +66,7 @@ export default function SparklineWidget({ widget, canvasFilters }: Props) {
         <div
           data-testid="sparkline-widget-empty"
           className="text-2xl font-semibold text-text-muted"
-        >
-          —
-        </div>
+        >—</div>
       ) : (
         <>
           <div

--- a/frontend/components/reports/widgets/StackedBarWidget.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidget.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+/**
+ * Stacked bar widget — extends the bar pattern with ``stackId`` on
+ * every bar so multiple series stack on top of one another. Up to two
+ * dimensions are allowed (the AST hard cap from PR1); the first
+ * becomes the x-axis label and each entry in ``config.measures``
+ * becomes a stacked series.
+ *
+ * With a single measure this falls back to a plain bar visual; the
+ * config rail still lets the user add additional series.
+ */
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { chartColor } from "@/lib/chart-colors";
+import { useSeriesQueries } from "@/lib/reports/useReportQuery";
+import { mergeSeriesRows, seriesLabel } from "@/lib/reports/series";
+import type {
+  CanvasFilters,
+  StackedBarWidget as StackedBarWidgetType,
+} from "@/lib/reports/types";
+
+interface Props {
+  widget: StackedBarWidgetType;
+  canvasFilters?: CanvasFilters;
+}
+
+const BAR_COLORS = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+];
+
+export default function StackedBarWidget({ widget, canvasFilters }: Props) {
+  const measures = widget.config.measures.map((m) => m.measure);
+  const { series, isLoading, error } = useSeriesQueries(
+    widget,
+    canvasFilters,
+    measures,
+  );
+
+  const dimensionKey = widget.config.dimensions[0] ?? "dimension";
+  const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
+  const rows = mergeSeriesRows(series, dimensionKey, seriesKeys);
+  const labels = widget.config.measures.map((m, i) =>
+    seriesLabel(m, i, widget.config.measures.length),
+  );
+  // Default to stacking unless the user explicitly turned it off.
+  const stackId =
+    widget.config.stacked === false || seriesKeys.length < 2
+      ? undefined
+      : "stack";
+
+  return (
+    <div
+      data-testid="stacked-bar-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
+    >
+      <div
+        className="mb-2 text-sm font-semibold text-text-primary"
+        aria-label={widget.title || "Stacked bar chart"}
+      >
+        {widget.title || "Stacked bar chart"}
+      </div>
+      <div className="flex-1">
+        {isLoading ? (
+          <div
+            data-testid="stacked-bar-widget-loading"
+            className="h-full w-full animate-pulse rounded bg-border/40"
+          />
+        ) : error ? (
+          <div
+            role="alert"
+            data-testid="stacked-bar-widget-error"
+            className="text-sm text-danger"
+          >
+            Couldn&apos;t load
+          </div>
+        ) : rows.length === 0 ? (
+          <div
+            data-testid="stacked-bar-widget-empty"
+            className="flex h-full items-center justify-center text-sm text-text-muted"
+          >
+            No data
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={rows} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: chartColor.axisTick, fontSize: 11 }}
+                interval={0}
+              />
+              <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
+              <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
+              {seriesKeys.length > 1 && (
+                <Legend wrapperStyle={{ fontSize: 11 }} />
+              )}
+              {seriesKeys.map((key, i) => (
+                <Bar
+                  key={key}
+                  dataKey={key}
+                  name={labels[i]}
+                  stackId={stackId}
+                  fill={BAR_COLORS[i % BAR_COLORS.length]}
+                  radius={
+                    stackId && i === seriesKeys.length - 1
+                      ? [4, 4, 0, 0]
+                      : stackId
+                        ? 0
+                        : [4, 4, 0, 0]
+                  }
+                  isAnimationActive={false}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/widgets/TableWidget.tsx
+++ b/frontend/components/reports/widgets/TableWidget.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+/**
+ * Table widget — sortable, paginated rows. Columns are
+ * ``dimensions`` (categorical) followed by one column per entry in
+ * ``config.measures`` (numeric). Click a header to sort ascending /
+ * descending; click again to flip. Pagination kicks in past 50 rows
+ * with a fixed 50-rows-per-page chunk.
+ *
+ * **Spec ambiguity resolved (PR3, 2026-05-22):** each ``measures``
+ * entry is its own column with its OWN aggregation. A report can mix
+ * "Sum of amount" and "Count of id" side by side. Documented in the
+ * task report.
+ *
+ * Currency formatting follows ``config.format`` for every numeric
+ * column; if a single column needs a different format, future PRs
+ * can extend ``SeriesConfig`` with a per-column ``format`` override.
+ */
+import { useMemo, useState } from "react";
+
+import { useSeriesQueries } from "@/lib/reports/useReportQuery";
+import { mergeSeriesRowsForTable, seriesLabel } from "@/lib/reports/series";
+import type {
+  CanvasFilters,
+  Dimension,
+  TableWidget as TableWidgetType,
+} from "@/lib/reports/types";
+
+interface Props {
+  widget: TableWidgetType;
+  canvasFilters?: CanvasFilters;
+}
+
+const PAGE_SIZE = 50;
+
+const DIMENSION_HEADERS: Record<Dimension, string> = {
+  category: "Category",
+  category_master: "Master category",
+  account: "Account",
+  tag: "Tag",
+  txn_type: "Type",
+  status: "Status",
+  month: "Month",
+  week: "Week",
+  day: "Day",
+};
+
+export default function TableWidget({ widget, canvasFilters }: Props) {
+  const measures = widget.config.measures.map((m) => m.measure);
+  const { series, isLoading, error } = useSeriesQueries(
+    widget,
+    canvasFilters,
+    measures,
+  );
+
+  const seriesKeys = widget.config.measures.map((_, i) => `s${i}`);
+  const seriesLabels = widget.config.measures.map((m, i) =>
+    seriesLabel(m, i, widget.config.measures.length),
+  );
+  const dimensions = widget.config.dimensions;
+  const rows = mergeSeriesRowsForTable(series, dimensions, seriesKeys);
+
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [page, setPage] = useState(0);
+
+  const sortedRows = useMemo(() => {
+    if (!sortKey) return rows;
+    const copy = [...rows];
+    copy.sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      if (typeof av === "number" && typeof bv === "number") {
+        return sortDir === "asc" ? av - bv : bv - av;
+      }
+      const as = String(av ?? "");
+      const bs = String(bv ?? "");
+      return sortDir === "asc" ? as.localeCompare(bs) : bs.localeCompare(as);
+    });
+    return copy;
+  }, [rows, sortKey, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(sortedRows.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const pagedRows = sortedRows.slice(
+    safePage * PAGE_SIZE,
+    safePage * PAGE_SIZE + PAGE_SIZE,
+  );
+
+  function toggleSort(key: string) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+    setPage(0);
+  }
+
+  const format = widget.config.format ?? "number";
+
+  return (
+    <div
+      data-testid="table-widget"
+      data-widget-id={widget.id}
+      className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
+    >
+      <div
+        className="mb-2 text-sm font-semibold text-text-primary"
+        aria-label={widget.title || "Table"}
+      >
+        {widget.title || "Table"}
+      </div>
+      <div className="flex-1 overflow-auto">
+        {isLoading ? (
+          <div
+            data-testid="table-widget-loading"
+            className="h-12 w-full animate-pulse rounded bg-border/40"
+          />
+        ) : error ? (
+          <div
+            role="alert"
+            data-testid="table-widget-error"
+            className="text-sm text-danger"
+          >
+            Couldn&apos;t load
+          </div>
+        ) : rows.length === 0 ? (
+          <div
+            data-testid="table-widget-empty"
+            className="flex h-full items-center justify-center text-sm text-text-muted"
+          >
+            No data
+          </div>
+        ) : (
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-border text-[11px] uppercase tracking-wider text-text-muted">
+                {dimensions.map((d) => (
+                  <th key={d} className="py-2 pr-3">
+                    <button
+                      type="button"
+                      data-testid={`table-widget-sort-${d}`}
+                      onClick={() => toggleSort(d)}
+                      className="font-semibold hover:text-text-primary"
+                    >
+                      {DIMENSION_HEADERS[d] ?? d}
+                      {sortKey === d ? (sortDir === "asc" ? " ↑" : " ↓") : ""}
+                    </button>
+                  </th>
+                ))}
+                {seriesKeys.map((key, i) => (
+                  <th key={key} className="py-2 pr-3 text-right">
+                    <button
+                      type="button"
+                      data-testid={`table-widget-sort-${key}`}
+                      onClick={() => toggleSort(key)}
+                      className="font-semibold hover:text-text-primary"
+                    >
+                      {seriesLabels[i]}
+                      {sortKey === key ? (sortDir === "asc" ? " ↑" : " ↓") : ""}
+                    </button>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {pagedRows.map((row, ridx) => (
+                <tr
+                  key={`row-${safePage}-${ridx}`}
+                  className="border-b border-border-subtle text-text-primary"
+                >
+                  {dimensions.map((d) => (
+                    <td key={d} className="py-1.5 pr-3">
+                      {String(row[d] ?? "—")}
+                    </td>
+                  ))}
+                  {seriesKeys.map((key) => (
+                    <td key={key} className="py-1.5 pr-3 text-right font-mono">
+                      {formatCell(row[key], format)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+      {sortedRows.length > PAGE_SIZE && (
+        <div
+          data-testid="table-widget-pagination"
+          className="mt-2 flex items-center justify-between text-xs text-text-muted"
+        >
+          <span>
+            Page {safePage + 1} of {totalPages} · {sortedRows.length} rows
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              data-testid="table-widget-prev-page"
+              disabled={safePage === 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-40"
+            >
+              Prev
+            </button>
+            <button
+              type="button"
+              data-testid="table-widget-next-page"
+              disabled={safePage >= totalPages - 1}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              className="rounded border border-border px-2 py-0.5 hover:bg-bg-elevated disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatCell(
+  v: string | number | null | undefined,
+  format: "currency" | "number" | "percent",
+): string {
+  if (v === null || v === undefined) return "";
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n)) return String(v);
+  if (format === "currency") {
+    return n.toLocaleString(undefined, {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 2,
+    });
+  }
+  if (format === "percent") return `${n.toFixed(1)}%`;
+  return n.toLocaleString();
+}

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -1,0 +1,148 @@
+/**
+ * Helpers for multi-series widgets (Line / Area / StackedBar / Table).
+ *
+ * Backend AST carries one ``measure`` per request, so a widget with N
+ * series fires N parallel queries and stitches the rows here by the
+ * shared dimension key.
+ */
+import type {
+  Measure,
+  QueryRow,
+  ReportsQueryResponse,
+  SeriesConfig,
+} from "./types";
+
+const HUMAN_AGG: Record<Measure["agg"], string> = {
+  sum: "Sum",
+  count: "Count",
+  avg: "Average",
+  distinct: "Distinct",
+};
+
+/**
+ * Stable human label for a series. Uses the optional ``label`` if
+ * present; otherwise falls back to "<Agg> of <field>". A single-
+ * series widget shows just the field name to avoid the noisy
+ * "Sum of amount" register for the common case.
+ */
+export function seriesLabel(
+  s: SeriesConfig,
+  index: number,
+  total: number,
+): string {
+  if (s.label && s.label.trim()) return s.label.trim();
+  if (total === 1) return s.measure.field;
+  return `${HUMAN_AGG[s.measure.agg]} of ${s.measure.field}`;
+}
+
+/**
+ * Merge per-series query responses into a single row list, keyed by
+ * the dimension value. Each series' rows are aligned by their
+ * dimension key and the measure value lands under ``seriesKeys[i]``.
+ *
+ * Missing dimension values across series are filled with 0 so
+ * Recharts doesn't drop the data point.
+ */
+export function mergeSeriesRows(
+  series: Array<ReportsQueryResponse | undefined>,
+  dimensionKey: string,
+  seriesKeys: string[],
+): Array<{ label: string } & Record<string, number | string>> {
+  const byLabel = new Map<string, Record<string, number | string>>();
+  const order: string[] = [];
+  series.forEach((resp, i) => {
+    if (!resp) return;
+    const key = seriesKeys[i];
+    for (const row of resp.rows ?? []) {
+      const label = readLabel(row, dimensionKey);
+      let existing = byLabel.get(label);
+      if (!existing) {
+        existing = { label };
+        byLabel.set(label, existing);
+        order.push(label);
+      }
+      existing[key] = readNumber(row.value);
+    }
+  });
+  // Backfill zeros so Recharts renders flat segments instead of gaps.
+  for (const label of order) {
+    const row = byLabel.get(label)!;
+    for (const key of seriesKeys) {
+      if (typeof row[key] !== "number") row[key] = 0;
+    }
+  }
+  return order.map((l) => byLabel.get(l)!) as Array<
+    { label: string } & Record<string, number | string>
+  >;
+}
+
+/**
+ * Merge per-series responses into a table-shaped row list. Used by
+ * the table widget: each row carries the dimension columns plus one
+ * numeric column per series.
+ */
+export function mergeSeriesRowsForTable(
+  series: Array<ReportsQueryResponse | undefined>,
+  dimensions: string[],
+  seriesKeys: string[],
+): Array<Record<string, number | string>> {
+  const byKey = new Map<string, Record<string, number | string>>();
+  const order: string[] = [];
+  series.forEach((resp, i) => {
+    if (!resp) return;
+    const key = seriesKeys[i];
+    for (const row of resp.rows ?? []) {
+      const dimensionValues = dimensions.map((d) => readLabel(row, d));
+      const rowKey = dimensionValues.join("");
+      let existing = byKey.get(rowKey);
+      if (!existing) {
+        existing = {};
+        dimensions.forEach((d, j) => {
+          existing![d] = dimensionValues[j];
+        });
+        byKey.set(rowKey, existing);
+        order.push(rowKey);
+      }
+      existing[key] = readNumber(row.value);
+    }
+  });
+  for (const rowKey of order) {
+    const row = byKey.get(rowKey)!;
+    for (const key of seriesKeys) {
+      if (typeof row[key] !== "number") row[key] = 0;
+    }
+  }
+  return order.map((k) => byKey.get(k)!);
+}
+
+function readLabel(
+  row: QueryRow,
+  key: string,
+): string {
+  const v = row[key];
+  if (v === null || v === undefined) return "—";
+  return String(v);
+}
+
+function readNumber(v: string | number | null | undefined): number {
+  if (v === null || v === undefined) return 0;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Pie-specific top-N + "Other" bucket helper. Sorts by value desc,
+ * keeps the top ``topN`` slices, and rolls the remainder into a
+ * single "Other" slice when there are more.
+ */
+export function topNWithOther(
+  rows: Array<{ label: string; value: number }>,
+  topN: number,
+): Array<{ label: string; value: number }> {
+  if (rows.length <= topN) return rows;
+  const sorted = [...rows].sort((a, b) => b.value - a.value);
+  const head = sorted.slice(0, topN);
+  const tail = sorted.slice(topN);
+  const other = tail.reduce((sum, r) => sum + r.value, 0);
+  return [...head, { label: "Other", value: other }];
+}

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -19,9 +19,10 @@ export type WidgetType =
   | "sparkline"
   | "table";
 
-// v1 only ships kpi + bar; the rest are declared so the layout JSON
-// schema is forward-compatible with PR3 widgets without a migration.
-export type WidgetTypeV1 = "kpi" | "bar";
+// PR3 exposes the full v1 catalog. ``WidgetTypeV1`` retains its name
+// as the "widgets shipped in v1" union; the picker hands one of these
+// values to the editor's ``addWidget`` factory.
+export type WidgetTypeV1 = WidgetType;
 
 export type Dataset = "transactions";
 
@@ -168,11 +169,100 @@ export interface BaseWidget<T extends WidgetType, C> {
   config: C;
 }
 
+export interface SeriesConfig {
+  measure: Measure;
+  /** Optional label override; defaults to "<agg> of <field>" when blank. */
+  label?: string;
+}
+
+/**
+ * Multi-series widget config. The backend AST carries one ``measure``
+ * per request, so widgets that render multiple series (line, area,
+ * stacked bar) fire one ``runQuery`` per entry in ``measures`` and the
+ * client merges the rows by the dimension key. ``measures`` always
+ * has at least one entry; UIs that pin to a single series (pie,
+ * sparkline) keep this list at length 1.
+ */
+export interface SeriesWidgetConfig {
+  dataset: Dataset;
+  measures: SeriesConfig[];
+  dimensions: Dimension[];
+  filters?: WidgetFilters;
+  sort?: SortSpec;
+  limit?: number;
+  format?: "currency" | "number" | "percent";
+}
+
+export interface LineConfig extends SeriesWidgetConfig {
+  /** Visual register only; no AST impact. */
+  smooth?: boolean;
+}
+
+export interface AreaConfig extends SeriesWidgetConfig {
+  /** When multiple series are configured, stack them. */
+  stacked?: boolean;
+}
+
+export interface PieConfig {
+  dataset: Dataset;
+  measure: Measure;
+  dimensions: Dimension[]; // pinned to length 1 by the UI
+  filters?: WidgetFilters;
+  sort?: SortSpec;
+  limit?: number;
+  format?: "currency" | "number" | "percent";
+  /** Slices beyond ``top_n`` are folded into an "Other" bucket. */
+  top_n?: number;
+}
+
+export interface SparklineConfig {
+  dataset: Dataset;
+  measure: Measure;
+  dimensions: Dimension[]; // exactly one time-bucket dimension
+  filters?: WidgetFilters;
+  sort?: SortSpec;
+  limit?: number;
+  format?: "currency" | "number" | "percent";
+}
+
+export interface StackedBarConfig extends SeriesWidgetConfig {
+  /** Defaults to true — a stacked bar with stacking off is just a bar
+   * chart, so this only flips off when the user explicitly wants
+   * grouped (side-by-side) bars from the same widget. */
+  stacked?: boolean;
+}
+
+export interface TableConfig {
+  dataset: Dataset;
+  /** 1..5 entries. Each becomes a numeric column on the table. */
+  measures: SeriesConfig[];
+  dimensions: Dimension[];
+  filters?: WidgetFilters;
+  sort?: SortSpec;
+  limit?: number;
+  format?: "currency" | "number" | "percent";
+}
+
 export type KPIWidget = BaseWidget<"kpi", KPIConfig>;
 export type BarWidget = BaseWidget<"bar", BarConfig>;
+export type LineWidget = BaseWidget<"line", LineConfig>;
+export type AreaWidget = BaseWidget<"area", AreaConfig>;
+export type PieWidget = BaseWidget<"pie", PieConfig>;
+export type SparklineWidget = BaseWidget<"sparkline", SparklineConfig>;
+export type StackedBarWidget = BaseWidget<"stacked_bar", StackedBarConfig>;
+export type TableWidget = BaseWidget<"table", TableConfig>;
 
-// v1 widget union. PR3 adds the rest.
-export type Widget = KPIWidget | BarWidget;
+// Full v1 widget union. PR3 expands this from KPI + Bar to the
+// architect-locked eight-widget catalog (spec §2 "Widget catalog v1").
+export type Widget =
+  | KPIWidget
+  | BarWidget
+  | LineWidget
+  | AreaWidget
+  | PieWidget
+  | SparklineWidget
+  | StackedBarWidget
+  | TableWidget;
 
 export interface LayoutJson {
   version: 1;

--- a/frontend/lib/reports/useReportQuery.ts
+++ b/frontend/lib/reports/useReportQuery.ts
@@ -14,6 +14,7 @@ import { runQuery } from "./api";
 import { resolveFilters } from "./resolve";
 import type {
   CanvasFilters,
+  Measure,
   ReportsQuery,
   ReportsQueryResponse,
   Widget,
@@ -78,13 +79,128 @@ export function buildQueryAst(
     };
   }
 
-  // Bar widget.
+  if (widget.type === "bar") {
+    return {
+      dataset: widget.config.dataset,
+      measure: widget.config.measure,
+      dimensions: widget.config.dimensions,
+      filters,
+      sort: widget.config.sort,
+      limit: widget.config.limit ?? 10,
+    };
+  }
+
+  if (
+    widget.type === "line" ||
+    widget.type === "area" ||
+    widget.type === "stacked_bar" ||
+    widget.type === "table"
+  ) {
+    // Multi-series widgets: ``buildQueryAst`` returns the FIRST series'
+    // AST as a convenience for callers that just need the shared
+    // dimension/filter shape; widgets that render >1 series compose
+    // multiple queries via ``buildSeriesQueryAst``.
+    const firstMeasure: Measure =
+      widget.config.measures[0]?.measure ?? { agg: "sum", field: "amount" };
+    return {
+      dataset: widget.config.dataset,
+      measure: firstMeasure,
+      dimensions: widget.config.dimensions,
+      filters,
+      sort: widget.config.sort,
+      limit: widget.config.limit ?? 100,
+    };
+  }
+
+  if (widget.type === "pie") {
+    return {
+      dataset: widget.config.dataset,
+      measure: widget.config.measure,
+      dimensions: widget.config.dimensions,
+      filters,
+      sort: widget.config.sort,
+      limit: widget.config.limit ?? 50,
+    };
+  }
+
+  // Sparkline.
   return {
     dataset: widget.config.dataset,
     measure: widget.config.measure,
     dimensions: widget.config.dimensions,
     filters,
     sort: widget.config.sort,
-    limit: widget.config.limit ?? 10,
+    limit: widget.config.limit ?? 50,
+  };
+}
+
+/**
+ * Per-series AST builder. Reuses the widget's resolved filters and
+ * dimension list, swapping the ``measure`` in for the specific series.
+ * Used by multi-series widgets (line / area / stacked bar / table)
+ * that fire one query per measure and merge the rows client-side by
+ * the first dimension key.
+ */
+export function buildSeriesQueryAst(
+  widget: Widget,
+  measure: Measure,
+  canvasFilters: CanvasFilters | undefined,
+): ReportsQuery {
+  const widgetFilters: WidgetFilters | undefined =
+    "filters" in widget.config ? widget.config.filters : undefined;
+  const filters = resolveFilters(canvasFilters, widgetFilters);
+  const dimensions =
+    "dimensions" in widget.config ? widget.config.dimensions : [];
+  const sort = "sort" in widget.config ? widget.config.sort : undefined;
+  const limit = "limit" in widget.config ? widget.config.limit : undefined;
+  return {
+    dataset: widget.config.dataset,
+    measure,
+    dimensions,
+    filters,
+    sort,
+    limit: limit ?? 100,
+  };
+}
+
+/**
+ * Multi-series query hook. Returns one ``data`` entry per series in
+ * the widget config, plus a combined loading / error state.
+ *
+ * Implementation note: React's rules of hooks forbid calling hooks
+ * inside a variable-length loop. Instead of pre-allocating N SWR
+ * hooks, we use ONE ``useSWR`` whose fetcher fires the per-series
+ * queries in parallel via ``Promise.all``. The cache key includes a
+ * serialized list of all per-series ASTs, so editing any series
+ * invalidates the combined fetch.
+ */
+export function useSeriesQueries(
+  widget: Widget,
+  canvasFilters: CanvasFilters | undefined,
+  measures: Measure[],
+): {
+  series: Array<ReportsQueryResponse | undefined>;
+  isLoading: boolean;
+  error: Error | undefined;
+} {
+  const queries = useMemo(
+    () => measures.map((m) => buildSeriesQueryAst(widget, m, canvasFilters)),
+    [widget, canvasFilters, measures],
+  );
+  const swrKey = ["report-series-query", widget.id, JSON.stringify(queries)];
+  const { data, error, isLoading } = useSWR<ReportsQueryResponse[]>(
+    swrKey,
+    () => Promise.all(queries.map((q) => runQuery(q))),
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: true,
+      shouldRetryOnError: false,
+    },
+  );
+
+  return {
+    series: data ?? measures.map(() => undefined),
+    isLoading: !!isLoading,
+    error: (error as Error | undefined) ?? undefined,
   };
 }

--- a/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
+++ b/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Regression: the "Secondary dimension" picker is Table-only in v1.
+ * Bar / line / area / stacked-bar / kpi / pie / sparkline widgets
+ * only consume ``dimensions[0]``, so exposing the picker for them
+ * would be a no-op UX. Architect-locked Option A — split-series
+ * rendering is a follow-up if users ask for it.
+ */
+import { render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import ConfigRail from "@/components/reports/ConfigRail";
+import { apiFetch } from "@/lib/api";
+import type {
+  AreaWidget,
+  BarWidget,
+  KPIWidget,
+  LineWidget,
+  PieWidget,
+  SparklineWidget,
+  StackedBarWidget,
+  TableWidget,
+  Widget,
+} from "@/lib/reports/types";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  vi.mocked(apiFetch).mockImplementation(() =>
+    Promise.resolve([]) as Promise<unknown>,
+  );
+});
+
+function makeBar(): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeLine(): LineWidget {
+  return {
+    id: "w_line",
+    type: "line",
+    title: "Line",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeArea(): AreaWidget {
+  return {
+    id: "w_area",
+    type: "area",
+    title: "Area",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeStacked(): StackedBarWidget {
+  return {
+    id: "w_stacked",
+    type: "stacked_bar",
+    title: "Stacked",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeKpi(): KPIWidget {
+  return {
+    id: "w_kpi",
+    type: "kpi",
+    title: "KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+    },
+  };
+}
+
+function makePie(): PieWidget {
+  return {
+    id: "w_pie",
+    type: "pie",
+    title: "Pie",
+    grid: { x: 0, y: 0, w: 4, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeSparkline(): SparklineWidget {
+  return {
+    id: "w_spark",
+    type: "sparkline",
+    title: "Spark",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["month"],
+    },
+  };
+}
+
+function makeTable(): TableWidget {
+  return {
+    id: "w_table",
+    type: "table",
+    title: "Table",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["category"],
+    },
+  };
+}
+
+const HIDDEN_CASES: Array<{ name: string; widget: Widget }> = [
+  { name: "bar", widget: makeBar() },
+  { name: "line", widget: makeLine() },
+  { name: "area", widget: makeArea() },
+  { name: "stacked_bar", widget: makeStacked() },
+  { name: "kpi", widget: makeKpi() },
+  { name: "pie", widget: makePie() },
+  { name: "sparkline", widget: makeSparkline() },
+];
+
+describe("ConfigRail — secondary dimension picker visibility", () => {
+  for (const { name, widget } of HIDDEN_CASES) {
+    it(`does NOT render the secondary dimension picker for ${name}`, () => {
+      renderIsolated(
+        <ConfigRail
+          widget={widget}
+          canvasFilters={{}}
+          onUpdate={() => {}}
+          onClose={() => {}}
+        />,
+      );
+      expect(
+        screen.queryByLabelText("Secondary dimension"),
+      ).not.toBeInTheDocument();
+    });
+  }
+
+  it("DOES render the secondary dimension picker for table", () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeTable()}
+        canvasFilters={{}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(
+      screen.getByLabelText("Secondary dimension"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/reports/filters/account-filter.test.tsx
+++ b/frontend/tests/components/reports/filters/account-filter.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import AccountFilter from "@/components/reports/filters/AccountFilter";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const ACCOUNTS = [
+  {
+    id: 1,
+    name: "Checking",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: true,
+  },
+  {
+    id: 2,
+    name: "Credit Card",
+    account_type_id: 2,
+    account_type_name: "Credit",
+    account_type_slug: "credit",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: false,
+  },
+];
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+describe("AccountFilter", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("fetches accounts on mount and renders one chip per account", async () => {
+    apiFetchMock.mockResolvedValueOnce(ACCOUNTS);
+
+    renderIsolated(<AccountFilter value={[]} onChange={() => {}} />);
+
+    expect(await screen.findByTestId("account-filter-chip-1")).toBeInTheDocument();
+    expect(screen.getByTestId("account-filter-chip-2")).toBeInTheDocument();
+    expect(apiFetchMock).toHaveBeenCalledWith("/api/v1/accounts");
+  });
+
+  it("toggles a chip on and reports the new value via onChange", async () => {
+    apiFetchMock.mockResolvedValueOnce(ACCOUNTS);
+    const onChange = vi.fn();
+
+    renderIsolated(<AccountFilter value={[]} onChange={onChange} />);
+
+    const chip = await screen.findByTestId("account-filter-chip-1");
+    fireEvent.click(chip);
+    expect(onChange).toHaveBeenCalledWith([1]);
+  });
+
+  it("toggles a chip off when its id is already selected", async () => {
+    apiFetchMock.mockResolvedValueOnce(ACCOUNTS);
+    const onChange = vi.fn();
+
+    renderIsolated(<AccountFilter value={[1, 2]} onChange={onChange} />);
+
+    const chip = await screen.findByTestId("account-filter-chip-1");
+    fireEvent.click(chip);
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
+
+  it("renders an error state when the fetch fails", async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error("boom"));
+
+    renderIsolated(<AccountFilter value={[]} onChange={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("account-filter-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/components/reports/filters/category-picker.test.tsx
+++ b/frontend/tests/components/reports/filters/category-picker.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import CategoryPicker from "@/components/reports/filters/CategoryPicker";
+import { apiFetch } from "@/lib/api";
+import type { Category } from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const CATEGORIES: Category[] = [
+  {
+    id: 10,
+    name: "Food",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "food",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 11,
+    name: "Groceries",
+    type: "expense",
+    parent_id: 10,
+    parent_name: "Food",
+    description: null,
+    slug: "groceries",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 12,
+    name: "Restaurants",
+    type: "expense",
+    parent_id: 10,
+    parent_name: "Food",
+    description: null,
+    slug: "restaurants",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 20,
+    name: "Transport",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "transport",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 21,
+    name: "Fuel",
+    type: "expense",
+    parent_id: 20,
+    parent_name: "Transport",
+    description: null,
+    slug: "fuel",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+describe("CategoryPicker", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("fetches categories on mount and renders the master/sub tree", async () => {
+    apiFetchMock.mockResolvedValueOnce(CATEGORIES);
+
+    renderIsolated(<CategoryPicker value={[]} onChange={() => {}} />);
+
+    expect(await screen.findByTestId("category-master-10")).toBeInTheDocument();
+    expect(screen.getByTestId("category-master-20")).toBeInTheDocument();
+    expect(screen.getByTestId("category-sub-11")).toBeInTheDocument();
+    expect(screen.getByTestId("category-sub-12")).toBeInTheDocument();
+    expect(screen.getByTestId("category-sub-21")).toBeInTheDocument();
+  });
+
+  it("cascades the master selection into every sub", async () => {
+    apiFetchMock.mockResolvedValueOnce(CATEGORIES);
+    const onChange = vi.fn();
+
+    renderIsolated(<CategoryPicker value={[]} onChange={onChange} />);
+
+    const masterFood = await screen.findByTestId("category-master-10");
+    fireEvent.click(masterFood);
+
+    // Master + both subs of Food should now be selected.
+    expect(onChange).toHaveBeenCalledWith(expect.arrayContaining([10, 11, 12]));
+    expect((onChange.mock.calls[0][0] as number[]).sort()).toEqual([10, 11, 12]);
+  });
+
+  it("leaves the master partial-checked when only one sub is unselected", async () => {
+    apiFetchMock.mockResolvedValueOnce(CATEGORIES);
+
+    renderIsolated(
+      <CategoryPicker value={[10, 11]} onChange={() => {}} />,
+    );
+
+    const master = await screen.findByTestId("category-master-10");
+    await waitFor(() => {
+      // ``indeterminate`` is a DOM-only flag. The component syncs it
+      // via a ref; assert against the live element.
+      expect((master as HTMLInputElement).indeterminate).toBe(true);
+    });
+  });
+
+  it("filters the tree by the search input", async () => {
+    apiFetchMock.mockResolvedValueOnce(CATEGORIES);
+
+    renderIsolated(<CategoryPicker value={[]} onChange={() => {}} />);
+
+    await screen.findByTestId("category-master-10");
+    fireEvent.change(screen.getByTestId("category-picker-search"), {
+      target: { value: "fuel" },
+    });
+
+    await waitFor(() => {
+      // The Food tree disappears since neither it nor its subs match
+      // "fuel"; Transport stays because its sub "Fuel" matches.
+      expect(screen.queryByTestId("category-master-10")).toBeNull();
+      expect(screen.getByTestId("category-master-20")).toBeInTheDocument();
+      expect(screen.getByTestId("category-sub-21")).toBeInTheDocument();
+    });
+  });
+
+  it("renders an error state when the fetch fails", async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error("boom"));
+
+    renderIsolated(<CategoryPicker value={[]} onChange={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("category-picker-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/components/reports/filters/date-preset-chips.test.tsx
+++ b/frontend/tests/components/reports/filters/date-preset-chips.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import DatePresetChips, {
+  buildPresetRanges,
+} from "@/components/reports/filters/DatePresetChips";
+
+describe("DatePresetChips", () => {
+  it("renders the five preset chips", () => {
+    render(<DatePresetChips value={undefined} onChange={() => {}} />);
+    expect(screen.getByTestId("date-preset-this_month")).toBeInTheDocument();
+    expect(screen.getByTestId("date-preset-last_month")).toBeInTheDocument();
+    expect(screen.getByTestId("date-preset-ytd")).toBeInTheDocument();
+    expect(screen.getByTestId("date-preset-last_12_months")).toBeInTheDocument();
+    expect(screen.getByTestId("date-preset-custom")).toBeInTheDocument();
+  });
+
+  it("fills the correct ISO range when 'This month' is clicked", () => {
+    const now = new Date(2026, 4, 15); // May 15, 2026
+    const ranges = buildPresetRanges(now);
+    const onChange = vi.fn();
+
+    render(<DatePresetChips value={undefined} onChange={onChange} now={now} />);
+    fireEvent.click(screen.getByTestId("date-preset-this_month"));
+
+    expect(onChange).toHaveBeenCalledWith(ranges.this_month);
+    expect(ranges.this_month).toEqual({ start: "2026-05-01", end: "2026-05-31" });
+  });
+
+  it("fills the correct ISO range when 'Last month' is clicked", () => {
+    const now = new Date(2026, 4, 15); // May 15, 2026
+    const onChange = vi.fn();
+
+    render(<DatePresetChips value={undefined} onChange={onChange} now={now} />);
+    fireEvent.click(screen.getByTestId("date-preset-last_month"));
+
+    expect(onChange).toHaveBeenCalledWith({ start: "2026-04-01", end: "2026-04-30" });
+  });
+
+  it("fills the correct ISO range when 'YTD' is clicked", () => {
+    const now = new Date(2026, 4, 15); // May 15, 2026
+    const onChange = vi.fn();
+
+    render(<DatePresetChips value={undefined} onChange={onChange} now={now} />);
+    fireEvent.click(screen.getByTestId("date-preset-ytd"));
+
+    expect(onChange).toHaveBeenCalledWith({ start: "2026-01-01", end: "2026-05-15" });
+  });
+
+  it("fills the correct ISO range when 'Last 12 months' is clicked", () => {
+    const now = new Date(2026, 4, 15); // May 15, 2026
+    const onChange = vi.fn();
+
+    render(<DatePresetChips value={undefined} onChange={onChange} now={now} />);
+    fireEvent.click(screen.getByTestId("date-preset-last_12_months"));
+
+    expect(onChange).toHaveBeenCalledWith({ start: "2025-05-01", end: "2026-05-15" });
+  });
+
+  it("opens the date inputs when 'Custom' is clicked", () => {
+    const onChange = vi.fn();
+    render(<DatePresetChips value={undefined} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("date-preset-custom"));
+    // Custom path doesn't auto-fill a range; it just enables the inputs.
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it("marks the active preset with aria-pressed", () => {
+    const now = new Date(2026, 4, 15);
+    const ranges = buildPresetRanges(now);
+    render(
+      <DatePresetChips value={ranges.this_month} onChange={() => {}} now={now} />,
+    );
+    expect(
+      screen.getByTestId("date-preset-this_month").getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+});

--- a/frontend/tests/components/reports/filters/tag-filter.test.tsx
+++ b/frontend/tests/components/reports/filters/tag-filter.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import TagFilter from "@/components/reports/filters/TagFilter";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const TAGS = [
+  { id: 1, name: "groceries", name_normalized: "groceries", usage_count: 5 },
+  { id: 2, name: "essentials", name_normalized: "essentials", usage_count: 2 },
+];
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+describe("TagFilter", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("fetches tags on mount and renders chips", async () => {
+    apiFetchMock.mockResolvedValueOnce(TAGS);
+
+    renderIsolated(
+      <TagFilter value={[]} match="all" onChange={() => {}} />,
+    );
+
+    expect(
+      await screen.findByTestId("tag-filter-chip-groceries"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("tag-filter-chip-essentials"),
+    ).toBeInTheDocument();
+    expect(apiFetchMock).toHaveBeenCalledWith("/api/v1/tags");
+  });
+
+  it("toggles a chip on and reports the new value", async () => {
+    apiFetchMock.mockResolvedValueOnce(TAGS);
+    const onChange = vi.fn();
+
+    renderIsolated(
+      <TagFilter value={[]} match="all" onChange={onChange} />,
+    );
+
+    const chip = await screen.findByTestId("tag-filter-chip-groceries");
+    fireEvent.click(chip);
+    expect(onChange).toHaveBeenCalledWith({
+      tag_names: ["groceries"],
+      tag_match: "all",
+    });
+  });
+
+  it("toggles a chip off when already selected", async () => {
+    apiFetchMock.mockResolvedValueOnce(TAGS);
+    const onChange = vi.fn();
+
+    renderIsolated(
+      <TagFilter
+        value={["groceries", "essentials"]}
+        match="all"
+        onChange={onChange}
+      />,
+    );
+
+    const chip = await screen.findByTestId("tag-filter-chip-groceries");
+    fireEvent.click(chip);
+    expect(onChange).toHaveBeenCalledWith({
+      tag_names: ["essentials"],
+      tag_match: "all",
+    });
+  });
+
+  it("flips tag_match between all and any via the radios", async () => {
+    apiFetchMock.mockResolvedValueOnce(TAGS);
+    const onChange = vi.fn();
+
+    renderIsolated(
+      <TagFilter
+        value={["groceries"]}
+        match="all"
+        onChange={onChange}
+      />,
+    );
+
+    await screen.findByTestId("tag-filter-chip-groceries");
+    fireEvent.click(screen.getByTestId("tag-filter-match-any"));
+    expect(onChange).toHaveBeenLastCalledWith({
+      tag_names: ["groceries"],
+      tag_match: "any",
+    });
+  });
+
+  it("renders an error state when the fetch fails", async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error("boom"));
+
+    renderIsolated(
+      <TagFilter value={[]} match="all" onChange={() => {}} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tag-filter-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/components/reports/override-pill-pickers.test.tsx
+++ b/frontend/tests/components/reports/override-pill-pickers.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Regression: the "Overrides canvas" pill fires when the widget-level
+ * filter actually DIFFERS from the canvas-level value (and never when
+ * they match). PR2 fixed the equality bug for the comma-list inputs;
+ * PR3 swaps those for picker components. The pickers feed the same
+ * ``WidgetFilters`` shape — these tests pin the equality semantics
+ * survive the swap.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import ConfigRail from "@/components/reports/ConfigRail";
+import { apiFetch } from "@/lib/api";
+import type { BarWidget } from "@/lib/reports/types";
+import type { Category, Account } from "@/lib/types";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const CATEGORIES: Category[] = [
+  {
+    id: 1,
+    name: "Food",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "food",
+    is_system: false,
+    transaction_count: 0,
+  },
+  {
+    id: 2,
+    name: "Transport",
+    type: "expense",
+    parent_id: null,
+    parent_name: null,
+    description: null,
+    slug: "transport",
+    is_system: false,
+    transaction_count: 0,
+  },
+];
+
+const ACCOUNTS: Account[] = [
+  {
+    id: 1,
+    name: "Checking",
+    account_type_id: 1,
+    account_type_name: "Bank",
+    account_type_slug: "bank",
+    balance: 0,
+    currency: "USD",
+    is_active: true,
+    close_day: null,
+    is_default: true,
+  },
+];
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(filters: BarWidget["config"]["filters"] = undefined): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Spend by category",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      sort: { by: "value", dir: "desc" },
+      limit: 10,
+      format: "currency",
+      filters,
+    },
+  };
+}
+
+function mockApi() {
+  const apiFetchMock = vi.mocked(apiFetch);
+  apiFetchMock.mockImplementation((path) => {
+    if (String(path).startsWith("/api/v1/categories")) {
+      return Promise.resolve(CATEGORIES) as Promise<unknown>;
+    }
+    if (String(path).startsWith("/api/v1/accounts")) {
+      return Promise.resolve(ACCOUNTS) as Promise<unknown>;
+    }
+    if (String(path).startsWith("/api/v1/tags")) {
+      return Promise.resolve([]) as Promise<unknown>;
+    }
+    return Promise.resolve([]);
+  });
+}
+
+describe("Override pill — picker-based filters", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    mockApi();
+  });
+
+  it("does NOT show the pill when the widget category selection matches the canvas selection", async () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeWidget({ category_ids: [1, 2] })}
+        canvasFilters={{ category_ids: [2, 1] }}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    // Wait a tick for the SWR fetches to resolve so the picker has
+    // populated the tree (pill renders synchronously off the prop
+    // values).
+    await screen.findByTestId("category-picker");
+    // Pill is keyed by data-testid="override-pill"; assert none on
+    // category_ids equality.
+    const pills = screen.queryAllByTestId("override-pill");
+    expect(pills.length).toBe(0);
+  });
+
+  it("DOES show the pill when the widget category selection differs from the canvas", async () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeWidget({ category_ids: [1] })}
+        canvasFilters={{ category_ids: [2] }}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    await screen.findByTestId("category-picker");
+    const pills = screen.queryAllByTestId("override-pill");
+    expect(pills.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT show the pill when the widget account selection matches the canvas selection", async () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeWidget({ account_ids: [1] })}
+        canvasFilters={{ account_ids: [1] }}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    await screen.findByTestId("account-filter");
+    const pills = screen.queryAllByTestId("override-pill");
+    expect(pills.length).toBe(0);
+  });
+
+  it("DOES show the pill once the user toggles a different account chip", async () => {
+    const onUpdate = vi.fn();
+    const { rerender } = renderIsolated(
+      <ConfigRail
+        widget={makeWidget({ account_ids: [1] })}
+        canvasFilters={{ account_ids: [1] }}
+        onUpdate={onUpdate}
+        onClose={() => {}}
+      />,
+    );
+
+    await screen.findByTestId("account-filter");
+    // Deselect the matching account — now widget=[] (inherit, no pill)
+    // and then re-select but with a different list. Simulate the
+    // "different list" case directly by rerendering with the updated
+    // widget value, since picker click → onUpdate flows through the
+    // parent in real use.
+    rerender(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ConfigRail
+          widget={makeWidget({ account_ids: [] })}
+          canvasFilters={{ account_ids: [1] }}
+          onUpdate={onUpdate}
+          onClose={() => {}}
+        />
+      </SWRConfig>,
+    );
+    // Empty widget account_ids means inherit — pill stays off.
+    expect(screen.queryAllByTestId("override-pill").length).toBe(0);
+  });
+});

--- a/frontend/tests/components/reports/widgets/area-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/area-widget.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import AreaWidget from "@/components/reports/widgets/AreaWidget";
+import type { AreaWidget as AreaWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(): AreaWidgetType {
+  return {
+    id: `w_area_${Math.random().toString(36).slice(2, 10)}`,
+    type: "area",
+    title: "Spend trend",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+      sort: { by: "dimension", dir: "asc" },
+      limit: 12,
+      format: "currency",
+      stacked: false,
+    },
+  };
+}
+
+describe("AreaWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders the chart wrapper and title when rows arrive", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [{ month: "2026-01", value: 100 }],
+      meta: { row_count: 1, truncated: false, query_ms: 2 },
+    });
+
+    renderIsolated(<AreaWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("area-widget-loading")).toBeNull(),
+    );
+    expect(screen.getByTestId("area-widget")).toBeInTheDocument();
+    expect(screen.getByText("Spend trend")).toBeInTheDocument();
+  });
+
+  it("renders the empty state with no rows", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 0 },
+    });
+
+    renderIsolated(<AreaWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("area-widget-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("nope"));
+
+    renderIsolated(<AreaWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("area-widget-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/components/reports/widgets/line-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/line-widget.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import LineWidget from "@/components/reports/widgets/LineWidget";
+import type { LineWidget as LineWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(overrides: Partial<LineWidgetType["config"]> = {}): LineWidgetType {
+  return {
+    id: `w_line_${Math.random().toString(36).slice(2, 10)}`,
+    type: "line",
+    title: "Income vs expense",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+      sort: { by: "dimension", dir: "asc" },
+      limit: 12,
+      format: "currency",
+      ...overrides,
+    },
+  };
+}
+
+describe("LineWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders the chart wrapper and title when rows arrive", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { month: "2026-01", value: 100 },
+        { month: "2026-02", value: 180 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 5 },
+    });
+
+    renderIsolated(<LineWidget widget={makeWidget()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("line-widget-empty")).toBeNull();
+      expect(screen.queryByTestId("line-widget-loading")).toBeNull();
+    });
+    expect(screen.getByTestId("line-widget")).toBeInTheDocument();
+    expect(screen.getByText("Income vs expense")).toBeInTheDocument();
+  });
+
+  it("renders the empty state with no rows", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<LineWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("line-widget-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("boom"));
+
+    renderIsolated(<LineWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("line-widget-error")).toBeInTheDocument(),
+    );
+  });
+
+  it("fires one query per series when multiple measures are configured", async () => {
+    runQueryMock.mockResolvedValue({
+      rows: [{ month: "2026-01", value: 100 }],
+      meta: { row_count: 1, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(
+      <LineWidget
+        widget={makeWidget({
+          measures: [
+            { measure: { agg: "sum", field: "amount" }, label: "Total" },
+            { measure: { agg: "count", field: "id" }, label: "Count" },
+          ],
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      // The hook issues both queries in parallel; assert the count.
+      expect(runQueryMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/tests/components/reports/widgets/pie-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/pie-widget.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import PieWidget from "@/components/reports/widgets/PieWidget";
+import type { PieWidget as PieWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(overrides: Partial<PieWidgetType["config"]> = {}): PieWidgetType {
+  return {
+    id: `w_pie_${Math.random().toString(36).slice(2, 10)}`,
+    type: "pie",
+    title: "Spend share",
+    grid: { x: 0, y: 0, w: 4, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      sort: { by: "value", dir: "desc" },
+      limit: 50,
+      format: "currency",
+      top_n: 8,
+      ...overrides,
+    },
+  };
+}
+
+describe("PieWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders the pie wrapper and title when rows arrive", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 100 },
+        { category: "Transport", value: 80 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 3 },
+    });
+
+    renderIsolated(<PieWidget widget={makeWidget()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("pie-widget-empty")).toBeNull();
+      expect(screen.queryByTestId("pie-widget-loading")).toBeNull();
+    });
+    expect(screen.getByTestId("pie-widget")).toBeInTheDocument();
+    expect(screen.getByText("Spend share")).toBeInTheDocument();
+  });
+
+  it("renders the empty state with no rows", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 0 },
+    });
+
+    renderIsolated(<PieWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("pie-widget-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("nope"));
+
+    renderIsolated(<PieWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("pie-widget-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/components/reports/widgets/sparkline-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/sparkline-widget.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import SparklineWidget from "@/components/reports/widgets/SparklineWidget";
+import type { SparklineWidget as SparklineWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(): SparklineWidgetType {
+  return {
+    id: `w_spark_${Math.random().toString(36).slice(2, 10)}`,
+    type: "sparkline",
+    title: "Cash flow",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["month"],
+      sort: { by: "dimension", dir: "asc" },
+      limit: 12,
+      format: "number",
+    },
+  };
+}
+
+describe("SparklineWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders the last value as the headline number", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { month: "2026-01", value: 100 },
+        { month: "2026-02", value: 220 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<SparklineWidget widget={makeWidget()} />);
+
+    const value = await screen.findByTestId("sparkline-widget-value");
+    // Last row was 220 -> headline shows it.
+    expect(value.textContent).toContain("220");
+  });
+
+  it("renders the empty fallback with no rows", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 0 },
+    });
+
+    renderIsolated(<SparklineWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("sparkline-widget-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("nope"));
+
+    renderIsolated(<SparklineWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("sparkline-widget-error")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/tests/components/reports/widgets/stacked-bar-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/stacked-bar-widget.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import StackedBarWidget from "@/components/reports/widgets/StackedBarWidget";
+import type { StackedBarWidget as StackedBarWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(overrides: Partial<StackedBarWidgetType["config"]> = {}): StackedBarWidgetType {
+  return {
+    id: `w_sb_${Math.random().toString(36).slice(2, 10)}`,
+    type: "stacked_bar",
+    title: "Income vs expense by month",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["month"],
+      sort: { by: "dimension", dir: "asc" },
+      limit: 12,
+      format: "currency",
+      stacked: true,
+      ...overrides,
+    },
+  };
+}
+
+describe("StackedBarWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders the chart wrapper and title when rows arrive", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [{ month: "2026-01", value: 100 }],
+      meta: { row_count: 1, truncated: false, query_ms: 2 },
+    });
+
+    renderIsolated(<StackedBarWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("stacked-bar-widget-loading")).toBeNull(),
+    );
+    expect(screen.getByTestId("stacked-bar-widget")).toBeInTheDocument();
+    expect(screen.getByText("Income vs expense by month")).toBeInTheDocument();
+  });
+
+  it("renders the empty state with no rows", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 0 },
+    });
+
+    renderIsolated(<StackedBarWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("stacked-bar-widget-empty"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("nope"));
+
+    renderIsolated(<StackedBarWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("stacked-bar-widget-error"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("fires one query per series when multiple measures are configured", async () => {
+    runQueryMock.mockResolvedValue({
+      rows: [{ month: "2026-01", value: 100 }],
+      meta: { row_count: 1, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(
+      <StackedBarWidget
+        widget={makeWidget({
+          measures: [
+            { measure: { agg: "sum", field: "amount" } },
+            { measure: { agg: "count", field: "id" } },
+            { measure: { agg: "avg", field: "amount" } },
+          ],
+        })}
+      />,
+    );
+
+    await waitFor(() => expect(runQueryMock).toHaveBeenCalledTimes(3));
+  });
+});

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import TableWidget from "@/components/reports/widgets/TableWidget";
+import type { TableWidget as TableWidgetType } from "@/lib/reports/types";
+import { runQuery } from "@/lib/reports/api";
+
+vi.mock("@/lib/reports/api", () => ({
+  runQuery: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+function makeWidget(overrides: Partial<TableWidgetType["config"]> = {}): TableWidgetType {
+  return {
+    id: `w_table_${Math.random().toString(36).slice(2, 10)}`,
+    type: "table",
+    title: "Top categories",
+    grid: { x: 0, y: 0, w: 12, h: 6 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "sum", field: "amount" } }],
+      dimensions: ["category"],
+      sort: { by: "value", dir: "desc" },
+      limit: 100,
+      format: "currency",
+      ...overrides,
+    },
+  };
+}
+
+describe("TableWidget", () => {
+  const runQueryMock = vi.mocked(runQuery);
+
+  beforeEach(() => {
+    runQueryMock.mockReset();
+  });
+
+  it("renders rows with dimension + measure columns when data arrives", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 200 },
+        { category: "Transport", value: 80 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    expect(await screen.findByText("Food")).toBeInTheDocument();
+    expect(screen.getByText("Transport")).toBeInTheDocument();
+  });
+
+  it("renders an empty state with no rows", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [],
+      meta: { row_count: 0, truncated: false, query_ms: 0 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-widget-empty")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders an inline error when the query fails", async () => {
+    runQueryMock.mockRejectedValueOnce(new Error("nope"));
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("table-widget-error")).toBeInTheDocument(),
+    );
+  });
+
+  it("sorts ascending by dimension when the header is clicked", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 200 },
+        { category: "Books", value: 80 },
+        { category: "Coffee", value: 30 },
+      ],
+      meta: { row_count: 3, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    await screen.findByText("Food");
+    // First click on a fresh header => sortKey=category, dir=desc
+    // (Food, Coffee, Books). Second click flips to ascending
+    // (Books, Coffee, Food).
+    fireEvent.click(screen.getByTestId("table-widget-sort-category"));
+    fireEvent.click(screen.getByTestId("table-widget-sort-category"));
+    await waitFor(() => {
+      const widget = screen.getByTestId("table-widget");
+      const cells = Array.from(widget.querySelectorAll("td"))
+        .map((td) => td.textContent ?? "")
+        .filter((t) => /^(Books|Coffee|Food)$/.test(t));
+      // In ascending order the category column should read
+      // Books, Coffee, Food top to bottom.
+      expect(cells).toEqual(["Books", "Coffee", "Food"]);
+    });
+  });
+
+  it("renders pagination when rows exceed PAGE_SIZE (50)", async () => {
+    const rows = Array.from({ length: 75 }, (_, i) => ({
+      category: `Cat ${i}`,
+      value: i,
+    }));
+    runQueryMock.mockResolvedValueOnce({
+      rows,
+      meta: { row_count: 75, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    await screen.findByText("Cat 0");
+    expect(
+      screen.getByTestId("table-widget-pagination"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("table-widget-next-page")).toBeInTheDocument();
+  });
+
+  it("fires one query per column when multiple measures are configured", async () => {
+    runQueryMock.mockResolvedValue({
+      rows: [{ category: "Food", value: 50 }],
+      meta: { row_count: 1, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(
+      <TableWidget
+        widget={makeWidget({
+          measures: [
+            { measure: { agg: "sum", field: "amount" }, label: "Total" },
+            { measure: { agg: "count", field: "id" }, label: "Count" },
+            { measure: { agg: "avg", field: "amount" }, label: "Avg" },
+          ],
+        })}
+      />,
+    );
+
+    await waitFor(() => expect(runQueryMock).toHaveBeenCalledTimes(3));
+  });
+});


### PR DESCRIPTION
## Summary

PR3 of the Reports v2 train. Fills out the widget catalog (six new
types) and replaces the comma-list filter inputs with proper
pickers. Behind ``FEATURE_REPORTS_V2``; the flag stays false until
PR4 ships CSV export, sharing, and templates.

## Widget catalog (8 total)

- Numbers: KPI (PR2)
- Trends: Line, Area, Sparkline (new)
- Categories: Bar (PR2), Stacked Bar, Pie (new)
- Tables: Table (new)

Each widget owns its own SWR cache key per series so a failure in
one does not block the others. Multi-series widgets (line, area,
stacked bar, table) fire one parallel query per ``measures`` entry
and merge rows client-side by the shared dimension key. The backend
AST stays single-measure, keeping PR1's locked schema intact.

Spec ambiguity resolved (table): each column carries its own
aggregation. A report can sit 'Sum of amount', 'Count of id', and
'Avg of amount' side by side.

## Filter primitives

New under ``frontend/components/reports/filters/``:

- ``CategoryPicker`` — tree picker with master / sub cascade,
  search, indeterminate state on partial-selected masters.
- ``TagFilter`` — chip picker over ``GET /api/v1/tags`` with
  ``tag_match=all|any`` radio (default ``all``).
- ``AccountFilter`` — chip picker over ``GET /api/v1/accounts``.
- ``DatePresetChips`` — This month, Last month, YTD, Last 12
  months, Custom. Each preset resolves to an absolute ISO window
  at click time.

Wired into both ``CanvasFiltersBar`` and the per-widget
``ConfigRail``. The 'Overrides canvas' pill from PR2 survives the
swap; a new regression test pins the equality semantics across
picker-backed filters.

## Test count

Frontend: **1226 / 1226** (was 1174 after PR2). ``tsc --noEmit``
clean. No backend changes, no new npm deps.

## Out of scope (deferred to PR4)

CSV export, sharing UI (private vs org toggle), templates fixtures
and the 'Use template' button, owner-delete reassignment.

## Spec

[specs/2026-05-22-reports-v2-flexible-canvas.md](specs/2026-05-22-reports-v2-flexible-canvas.md)