### PR TITLE
fix(plans): list-row Simulate UX, in-flight disabling + spinner + a11y feedback

### DIFF
--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -21,6 +21,7 @@
 
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -146,6 +147,23 @@ export default function PlansPage() {
   // (and open the plan) or fail to match, we clear the query string so a
   // refresh doesn't re-trigger and re-open repeatedly.
   const openParamConsumedRef = useRef(false);
+  // Per-plan in-flight tracking so multiple list-row Simulate clicks
+  // (across different plans) can run in parallel, while a second click
+  // on the same plan is blocked. A single boolean would falsely lock
+  // every row when any one is in flight.
+  const [simulating, setSimulating] = useState<Set<number>>(() => new Set());
+  // Per-plan "just simulated at <ts>" microcopy. Each entry clears
+  // ~3s after a simulate resolves so a fresh result is visibly
+  // acknowledged even if the verdict color didn't change.
+  const [lastSimulatedAt, setLastSimulatedAt] = useState<Record<number, string>>({});
+  const flashTimersRef = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
+
+  useEffect(() => {
+    const timers = flashTimersRef.current;
+    return () => {
+      for (const t of Object.values(timers)) clearTimeout(t);
+    };
+  }, []);
 
   useEffect(() => {
     if (loading) return;
@@ -203,6 +221,11 @@ export default function PlansPage() {
   }
 
   async function simulate(plan: Scenario): Promise<Scenario | null> {
+    setSimulating((prev) => {
+      const next = new Set(prev);
+      next.add(plan.id);
+      return next;
+    });
     try {
       const next = await apiFetch<Scenario>(
         `/api/v1/scenarios/${plan.id}/simulate`,
@@ -210,10 +233,35 @@ export default function PlansPage() {
       );
       setItems((rows) => rows.map((r) => (r.id === next.id ? next : r)));
       if (active && active.id === next.id) setActive(next);
+      // Flash an "Updated," timestamp next to the verdict pill so the
+      // user has visible feedback even when the verdict color is
+      // identical to the previous run. The flash clears after ~3s.
+      const stamp = new Date().toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      setLastSimulatedAt((prev) => ({ ...prev, [plan.id]: stamp }));
+      if (flashTimersRef.current[plan.id]) {
+        clearTimeout(flashTimersRef.current[plan.id]);
+      }
+      flashTimersRef.current[plan.id] = setTimeout(() => {
+        setLastSimulatedAt((prev) => {
+          const { [plan.id]: _drop, ...rest } = prev;
+          return rest;
+        });
+        delete flashTimersRef.current[plan.id];
+      }, 3000);
       return next;
     } catch (e) {
       setLoadErr(extractErrorMessage(e, "Simulate failed"));
       return null;
+    } finally {
+      setSimulating((prev) => {
+        const next = new Set(prev);
+        next.delete(plan.id);
+        return next;
+      });
     }
   }
 
@@ -271,6 +319,8 @@ export default function PlansPage() {
           onOpen={setActive}
           onDelete={deletePlan}
           onSimulate={simulate}
+          isSimulating={(id) => simulating.has(id)}
+          lastSimulatedAt={lastSimulatedAt}
         />
       )}
 
@@ -300,11 +350,15 @@ function PlansList({
   onOpen,
   onDelete,
   onSimulate,
+  isSimulating,
+  lastSimulatedAt,
 }: {
   items: Scenario[];
   onOpen: (plan: Scenario) => void;
   onDelete: (id: number) => void;
   onSimulate: (plan: Scenario) => Promise<Scenario | null>;
+  isSimulating: (planId: number) => boolean;
+  lastSimulatedAt: Record<number, string>;
 }) {
   if (items.length === 0) {
     return (
@@ -320,49 +374,77 @@ function PlansList({
   return (
     <section className={`${card} p-0`} data-testid="plans-list">
       <ul className="divide-y divide-border">
-        {items.map((plan) => (
-          <li
-            key={plan.id}
-            className="flex items-center justify-between gap-4 px-5 py-3"
-          >
-            <button
-              type="button"
-              className="flex-1 text-left"
-              onClick={() => onOpen(plan)}
-              data-testid={`plan-row-${plan.id}`}
+        {items.map((plan) => {
+          const busy = isSimulating(plan.id);
+          const flashStamp = lastSimulatedAt[plan.id];
+          return (
+            <li
+              key={plan.id}
+              className="flex items-center justify-between gap-4 px-5 py-3"
             >
-              <p className="text-sm font-medium text-text-primary">{plan.name}</p>
-              <p className="text-xs text-text-muted">
-                {TYPE_LABEL[plan.scenario_type]} · Horizon {plan.horizon_months}mo
-              </p>
-            </button>
-            {plan.projection_json && (
-              <span
-                className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                  VERDICT_BADGE[plan.projection_json.verdict.color]
-                }`}
+              <button
+                type="button"
+                className="flex-1 text-left"
+                onClick={() => onOpen(plan)}
+                data-testid={`plan-row-${plan.id}`}
               >
-                {plan.projection_json.verdict.color.toUpperCase()}
-              </span>
-            )}
-            <button
-              type="button"
-              className={`${btnSecondary} sm:min-h-0`}
-              onClick={() => void onSimulate(plan)}
-              data-testid={`plan-simulate-${plan.id}`}
-            >
-              Simulate
-            </button>
-            <button
-              type="button"
-              className="text-xs text-danger underline-offset-2 hover:underline"
-              onClick={() => onDelete(plan.id)}
-              data-testid={`plan-delete-${plan.id}`}
-            >
-              Delete
-            </button>
-          </li>
-        ))}
+                <p className="text-sm font-medium text-text-primary">{plan.name}</p>
+                <p className="text-xs text-text-muted">
+                  {TYPE_LABEL[plan.scenario_type]} · Horizon {plan.horizon_months}mo
+                </p>
+              </button>
+              <div
+                className="flex items-center gap-2"
+                role="status"
+                aria-live="polite"
+                data-testid={`plan-verdict-region-${plan.id}`}
+              >
+                {plan.projection_json && (
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                      VERDICT_BADGE[plan.projection_json.verdict.color]
+                    }`}
+                  >
+                    {plan.projection_json.verdict.color.toUpperCase()}
+                  </span>
+                )}
+                {flashStamp && (
+                  <span
+                    className="text-[11px] text-text-muted"
+                    data-testid={`plan-simulate-flash-${plan.id}`}
+                  >
+                    Updated, {flashStamp}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                className={`${btnSecondary} sm:min-h-0 inline-flex items-center justify-center gap-1.5`}
+                onClick={() => void onSimulate(plan)}
+                disabled={busy}
+                aria-busy={busy}
+                data-testid={`plan-simulate-${plan.id}`}
+              >
+                {busy && (
+                  <Loader2
+                    className="h-3.5 w-3.5 animate-spin motion-reduce:animate-none"
+                    aria-hidden="true"
+                    data-testid={`plan-simulate-spinner-${plan.id}`}
+                  />
+                )}
+                {busy ? "Simulating..." : "Simulate"}
+              </button>
+              <button
+                type="button"
+                className="text-xs text-danger underline-offset-2 hover:underline"
+                onClick={() => onDelete(plan.id)}
+                data-testid={`plan-delete-${plan.id}`}
+              >
+                Delete
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/frontend/tests/app/plans-page.test.tsx
+++ b/frontend/tests/app/plans-page.test.tsx
@@ -477,4 +477,125 @@ describe("/plans page", () => {
       });
     },
   );
+  it("disables the Simulate button and shows a spinner while in flight", async () => {
+    setUser();
+    let resolveSimulate: ((value: typeof TRIP_PLAN) => void) | null = null;
+    const simulatePromise = new Promise<typeof TRIP_PLAN>((resolve) => {
+      resolveSimulate = resolve;
+    });
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`
+        && options?.method === "POST"
+      ) {
+        return simulatePromise;
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    const btn = screen.getByTestId(`plan-simulate-${TRIP_PLAN.id}`) as HTMLButtonElement;
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(btn).toBeDisabled();
+    });
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+    expect(
+      screen.getByTestId(`plan-simulate-spinner-${TRIP_PLAN.id}`),
+    ).toBeInTheDocument();
+    expect(btn).toHaveTextContent(/Simulating/i);
+    // Resolve and verify the button comes back.
+    resolveSimulate!(TRIP_PLAN);
+    await waitFor(() => {
+      expect(btn).not.toBeDisabled();
+    });
+    expect(
+      screen.queryByTestId(`plan-simulate-spinner-${TRIP_PLAN.id}`),
+    ).not.toBeInTheDocument();
+    expect(btn).toHaveTextContent(/^Simulate$/);
+  });
+
+  it("only disables the simulated plan's button, leaving other rows clickable", async () => {
+    setUser();
+    const SECOND_PLAN = { ...TRIP_PLAN, id: 99, name: "Porto trip" };
+    let resolveSimulate: ((value: typeof TRIP_PLAN) => void) | null = null;
+    const simulatePromise = new Promise<typeof TRIP_PLAN>((resolve) => {
+      resolveSimulate = resolve;
+    });
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN, SECOND_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`
+        && options?.method === "POST"
+      ) {
+        return simulatePromise;
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    await screen.findByText("Porto trip");
+    const btnA = screen.getByTestId(`plan-simulate-${TRIP_PLAN.id}`) as HTMLButtonElement;
+    const btnB = screen.getByTestId(`plan-simulate-${SECOND_PLAN.id}`) as HTMLButtonElement;
+    fireEvent.click(btnA);
+    await waitFor(() => {
+      expect(btnA).toBeDisabled();
+    });
+    // Plan B's button must NOT be disabled — that was the broken
+    // shape of a single shared boolean.
+    expect(btnB).not.toBeDisabled();
+    resolveSimulate!(TRIP_PLAN);
+    await waitFor(() => {
+      expect(btnA).not.toBeDisabled();
+    });
+  });
+
+  it("shows the 'Updated' microcopy flash after a successful simulate", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`
+        && options?.method === "POST"
+      ) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-simulate-${TRIP_PLAN.id}`));
+    const flash = await screen.findByTestId(`plan-simulate-flash-${TRIP_PLAN.id}`);
+    expect(flash).toHaveTextContent(/Updated,/i);
+  });
+
+  it("wraps the verdict pill area in an aria-live polite region", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve([TRIP_PLAN]);
+      if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    const region = screen.getByTestId(`plan-verdict-region-${TRIP_PLAN.id}`);
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.getAttribute("role")).toBe("status");
+  });
 });


### PR DESCRIPTION
## Summary

User clicked Simulate on a Plans list row in prod, saw no apparent feedback (button stayed enabled, no spinner, verdict pill kept the same color), clicked twice more, then deleted the plan. Backend returned 200 every call (16:12:07, :31, :33 in the session), a pure feedback / discoverability gap.

This PR:

- Tracks in-flight simulates with a per-plan `Set<number>` (one boolean would falsely lock every row when any one is in flight), so list rows can simulate in parallel while a repeat click on the same plan is blocked.
- Disables the row's Simulate button while it is busy, swaps the label to "Simulating..." with a `Loader2` spinner (matches the existing settings/security pattern), and sets `aria-busy="true"`.
- Wraps the verdict pill in a `role="status" aria-live="polite"` region so the verdict change is announced to screen readers.
- Shows a brief "Updated, hh:mm:ss" microcopy next to the verdict pill on a successful simulate (clears after ~3s) so the user has visible feedback even when the verdict color did not change.

Editor's Re-simulate button is untouched, it already has the right pattern.

**Feedback option chosen: A (inline "Updated," microcopy).** Codebase has no toast lib (rules out C), and the existing success-feedback idiom across `settings/security` and `settings/organization` is exactly this: `role="status" aria-live="polite"` text. B (animate the badge) would mean inventing a new pattern.