### PR TITLE
feat(notifications): security hooks + bell icon + popover (PR3 of train)

### DIFF
--- a/backend/app/routers/admin_orgs.py
+++ b/backend/app/routers/admin_orgs.py
@@ -28,6 +28,7 @@ from app.auth.permissions import require_permission
 from app.database import get_db
 from app.deps import get_current_user, get_session_factory
 from app.models.feature_override import OrgFeatureOverride
+from app.models.notification import NotificationCategory
 from app.models.subscription import Plan, Subscription, SubscriptionStatus
 from app.models.user import Organization, Role, User
 from app.rate_limit import get_client_ip
@@ -44,8 +45,12 @@ from app.services import (
     admin_orgs_service,
     audit_service,
     feature_service,
+    notification_service,
 )
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+from app.services.notification_templates import (
+    admin_org_plan_changed as _tpl_admin_org_plan_changed,
+)
 
 logger = structlog.stdlib.get_logger()
 
@@ -153,7 +158,7 @@ async def update_org_subscription(
     # notification dispatcher key off the specific event_type without
     # parsing detail.before/detail.after.
     if "plan_id" in before:
-        await audit_service.record_audit_event(
+        audit_event_id = await audit_service.record_audit_event(
             session_factory,
             event_type="admin.org.plan.changed",
             actor_user_id=current_user.id,
@@ -168,6 +173,44 @@ async def update_org_subscription(
                 "new_plan_id": after["plan_id"],
             },
         )
+
+        # PR3 of the notification train: fan out the in-app
+        # ``org_admin`` notification to every active org admin of the
+        # affected org. Architect-locked recipient set is OWNER ∪
+        # ADMIN; the actor is included (a superadmin operator may also
+        # be an org admin elsewhere, but here the broadcast is scoped
+        # to ``org_id`` so the operator-self exclusion isn't a concern).
+        if audit_event_id is not None:
+            # Resolve the new plan's display name so the notification
+            # body carries human copy rather than a numeric id. Best
+            # effort — fall back to a stable placeholder if the lookup
+            # fails so the notification still ships.
+            new_plan_name = "Updated plan"
+            new_plan_id = after.get("plan_id")
+            if new_plan_id is not None:
+                plan_row = (
+                    await db.execute(
+                        select(Plan).where(Plan.id == new_plan_id)
+                    )
+                ).scalar_one_or_none()
+                if plan_row is not None:
+                    new_plan_name = plan_row.name
+
+            title, body, link_url = _tpl_admin_org_plan_changed(
+                new_plan_name=new_plan_name,
+                actor_email=current_user.email,
+            )
+            await notification_service.dispatch_notification_to_org_admins(
+                db,
+                org_id=org_id,
+                category=NotificationCategory.ORG_ADMIN,
+                event_type="admin.org.plan.changed",
+                title=title,
+                body=body,
+                link_url=link_url,
+                audit_event_id=audit_event_id,
+            )
+            await db.commit()
     return {"before": before, "after": after}
 
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -68,9 +68,14 @@ from app.security import (
     verify_password,
 )
 from app.captcha import verify_captcha
+from app.models.notification import NotificationCategory
 from app.rate_limit import get_client_ip, limiter
-from app.services import audit_service
+from app.services import audit_service, notification_service
 from app.services.email_service import send_mfa_email_code, send_password_reset_email, send_verification_email
+from app.services.notification_templates import (
+    user_mfa_disabled as _tpl_user_mfa_disabled,
+    user_mfa_enabled as _tpl_user_mfa_enabled,
+)
 from app.services.mfa_service import (
     MfaConfigError,
     decrypt_secret,
@@ -2077,7 +2082,7 @@ async def mfa_enable(
 
     # Audit AFTER the business commit succeeds. PR3 of the notification
     # train uses this row as the trigger source for user.mfa.enabled.
-    await audit_service.record_audit_event(
+    audit_event_id = await audit_service.record_audit_event(
         session_factory,
         event_type="user.mfa.enabled",
         actor_user_id=current_user.id,
@@ -2089,6 +2094,23 @@ async def mfa_enable(
         outcome="success",
         detail=None,
     )
+
+    # PR3 of the notification train: dispatch the in-app security
+    # notification AFTER the audit row commits. Self-target — the
+    # user who flipped MFA on receives the confirmation.
+    if audit_event_id is not None:
+        title, body, link_url = _tpl_user_mfa_enabled()
+        await notification_service.dispatch_notification(
+            db,
+            user_id=current_user.id,
+            category=NotificationCategory.SECURITY,
+            event_type="user.mfa.enabled",
+            title=title,
+            body=body,
+            link_url=link_url,
+            audit_event_id=audit_event_id,
+        )
+        await db.commit()
 
     return MfaEnableResponse(recovery_codes=codes)
 
@@ -2115,7 +2137,7 @@ async def mfa_disable(
     # Audit AFTER the business commit succeeds. PR3 of the notification
     # train uses this row as the trigger source for user.mfa.disabled —
     # a security-critical signal (the user can react if it wasn't them).
-    await audit_service.record_audit_event(
+    audit_event_id = await audit_service.record_audit_event(
         session_factory,
         event_type="user.mfa.disabled",
         actor_user_id=current_user.id,
@@ -2127,6 +2149,24 @@ async def mfa_disable(
         outcome="success",
         detail=None,
     )
+
+    # PR3: dispatch the in-app security notification AFTER the audit
+    # row commits. MFA-disabled is the louder of the two MFA signals
+    # since a stolen credential is now sufficient for full access; the
+    # template recommends re-enable.
+    if audit_event_id is not None:
+        title, body, link_url = _tpl_user_mfa_disabled()
+        await notification_service.dispatch_notification(
+            db,
+            user_id=current_user.id,
+            category=NotificationCategory.SECURITY,
+            event_type="user.mfa.disabled",
+            title=title,
+            body=body,
+            link_url=link_url,
+            audit_event_id=audit_event_id,
+        )
+        await db.commit()
 
     return {"detail": "MFA disabled"}
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -2,10 +2,15 @@
 ``2026-05-21-notification-system-sensitive-ops.md`` +
 ``2026-05-22-notification-system-2nd-arch-pass.md``).
 
-Mounted at ``/api/v1/notifications``. Five endpoints:
+Mounted at ``/api/v1/notifications``. Six endpoints:
 
 - ``GET /notifications`` — cursor-paginated inbox feed for the
   current user. Newest first.
+- ``GET /notifications/unseen-count`` — lightweight ``{count: int}``
+  for the bell badge. ``SELECT COUNT(*) WHERE seen_at IS NULL``;
+  does not load row payloads. The bell polls this on its 60s
+  cadence so the badge stays truthful even when unseen > the
+  popover's display limit.
 - ``POST /notifications/mark-seen`` — clears the unseen-count badge
   for the bell icon. Idempotent.
 - ``PATCH /notifications/{id}`` — marks a single row as read. Returns
@@ -35,6 +40,7 @@ from app.schemas.notification import (
     NotificationPreferencesResponse,
     NotificationPreferencesUpdate,
     NotificationResponse,
+    NotificationUnseenCountResponse,
 )
 from app.services import notification_service
 
@@ -77,6 +83,31 @@ async def list_notifications(
         items=[NotificationResponse.model_validate(row) for row in page.items],
         next_cursor=page.next_cursor,
     )
+
+
+@router.get(
+    "/unseen-count",
+    response_model=NotificationUnseenCountResponse,
+)
+async def get_unseen_count(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the count of unseen notifications for the current user.
+
+    Lightweight ``SELECT COUNT(*) WHERE seen_at IS NULL`` — does NOT
+    load row payloads. The bell badge polls this on its 60s cadence
+    so the displayed count stays truthful even when the unseen total
+    exceeds the popover's preview page size.
+
+    Returns the raw count. The bell caps the rendered label at
+    ``99+`` client-side; the wire payload is uncapped so a future
+    "show 250" tweak is frontend-only.
+    """
+    count = await notification_service.get_unseen_count(
+        db, user_id=current_user.id
+    )
+    return NotificationUnseenCountResponse(count=count)
 
 
 @router.post(

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -17,10 +17,15 @@ from app.schemas.auth import (
     USERNAME_PATTERN,
     UserResponse,
 )
+from app.models.notification import NotificationCategory
 from app.schemas.user import PasswordChange, ProfileUpdate
 from app.security import create_email_verification_token, hash_password, verify_password
-from app.services import audit_service
+from app.services import audit_service, notification_service
 from app.services.email_service import send_verification_email
+from app.services.notification_templates import (
+    user_email_changed as _tpl_user_email_changed,
+    user_password_changed as _tpl_user_password_changed,
+)
 
 
 def _request_id() -> str | None:
@@ -206,7 +211,7 @@ async def update_profile(
         # actor_email so a future "who was this" lookup after a malicious
         # email swap can recover the original address. New email lives
         # in detail.new_email.
-        await audit_service.record_audit_event(
+        audit_event_id = await audit_service.record_audit_event(
             session_factory,
             event_type="user.email.changed",
             actor_user_id=current_user.id,
@@ -221,6 +226,27 @@ async def update_profile(
                 "new_email": current_user.email,
             },
         )
+
+        # PR3: dispatch the security notification AFTER the audit row
+        # commits. The recipient is the actor (self) — the audit
+        # convention uses ``actor_user_id`` for self-target events.
+        # The NEW email is interpolated into the body so the recipient
+        # can confirm the change at a glance.
+        if audit_event_id is not None:
+            title, body, link_url = _tpl_user_email_changed(
+                new_email=current_user.email
+            )
+            await notification_service.dispatch_notification(
+                db,
+                user_id=current_user.id,
+                category=NotificationCategory.SECURITY,
+                event_type="user.email.changed",
+                title=title,
+                body=body,
+                link_url=link_url,
+                audit_event_id=audit_event_id,
+            )
+            await db.commit()
 
     return _user_response(current_user)
 
@@ -292,7 +318,7 @@ async def change_password(
     # Failure paths above raise HTTPException before reaching this
     # point — failure-path auditing is intentionally not added in this
     # PR (separate scope per the audit-gap-closures task).
-    await audit_service.record_audit_event(
+    audit_event_id = await audit_service.record_audit_event(
         session_factory,
         event_type="user.password.changed",
         actor_user_id=current_user.id,
@@ -304,3 +330,22 @@ async def change_password(
         outcome="success",
         detail={"password_set_initial": was_initial_password_set},
     )
+
+    # PR3 of the notification train: dispatch the in-app notification
+    # AFTER the audit row commits. ``record_audit_event`` returns the
+    # new row's id on success and ``None`` on failure; we skip the
+    # notification when audit failed so the forensic trail stays
+    # consistent (architect-locked ordering — audit IS the trigger).
+    if audit_event_id is not None:
+        title, body, link_url = _tpl_user_password_changed()
+        await notification_service.dispatch_notification(
+            db,
+            user_id=current_user.id,
+            category=NotificationCategory.SECURITY,
+            event_type="user.password.changed",
+            title=title,
+            body=body,
+            link_url=link_url,
+            audit_event_id=audit_event_id,
+        )
+        await db.commit()

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -59,6 +59,17 @@ class NotificationListResponse(BaseModel):
     next_cursor: Optional[str] = None
 
 
+class NotificationUnseenCountResponse(BaseModel):
+    """Bell-badge count shape for GET /notifications/unseen-count.
+
+    Raw count — no server-side cap. The bell caps the rendered label
+    at ``99+`` client-side so a future "show 250" tweak is
+    frontend-only.
+    """
+
+    count: int
+
+
 class NotificationPreferencesResponse(BaseModel):
     """Full preference shape for the current user."""
 

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -73,10 +73,19 @@ async def record_audit_event(
     ip_address: Optional[str],
     outcome: Literal["success", "failure"],
     detail: Optional[dict[str, Any]] = None,
-) -> None:
+) -> Optional[int]:
     """Persist an audit event in its OWN transaction.
 
-    Failures are logged via structlog and swallowed. Never raises.
+    Returns the newly persisted audit row's id on success, or
+    ``None`` when the write failed (failure is logged via structlog
+    and swallowed — this function never raises). Callers that don't
+    need the id can keep ignoring the return value.
+
+    The return value is the substrate for the notification system's
+    forensic correlation (G5 in the 2nd-arch delta): notification
+    rows carry the ``audit_event_id`` of the row that triggered them
+    so an operator can correlate the two even when the business
+    event_type alone is ambiguous.
 
     Use this when the audit write must succeed regardless of the
     business txn outcome (e.g. a failed delete still needs an audit
@@ -93,7 +102,7 @@ async def record_audit_event(
     """
     try:
         async with session_factory() as session:
-            session.add(_build_audit_event(
+            row = _build_audit_event(
                 event_type=event_type,
                 actor_user_id=actor_user_id,
                 actor_email=actor_email,
@@ -103,8 +112,10 @@ async def record_audit_event(
                 ip_address=ip_address,
                 outcome=outcome,
                 detail=detail,
-            ))
+            )
+            session.add(row)
             await session.commit()
+            return row.id
     except Exception as exc:  # noqa: BLE001 — defensive: never bubble.
         # Kept as a backstop. Logged at ERROR so a regression in a
         # caller that doesn't pre-snapshot (like the original
@@ -122,6 +133,7 @@ async def record_audit_event(
             error=str(exc),
             error_type=type(exc).__name__,
         )
+        return None
 
 
 def add_audit_event_to_session(

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -38,7 +38,7 @@ from datetime import datetime
 from typing import Optional
 
 import structlog
-from sqlalchemy import and_, or_, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app._time import utcnow_naive
@@ -360,6 +360,24 @@ async def list_for_user(
         items = rows
         next_cursor = None
     return NotificationPage(items=items, next_cursor=next_cursor)
+
+
+async def get_unseen_count(db: AsyncSession, *, user_id: int) -> int:
+    """Return the number of unseen notifications for ``user_id``.
+
+    Lightweight ``SELECT COUNT(*) ... WHERE seen_at IS NULL`` — does
+    NOT load row payloads. Backs the bell badge so the count stays
+    truthful even when unseen rows exceed the popover's preview page
+    size (which caps at 10).
+    """
+    stmt = (
+        select(func.count())
+        .select_from(Notification)
+        .where(Notification.user_id == user_id)
+        .where(Notification.seen_at.is_(None))
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one() or 0)
 
 
 # ── mark seen / mark read ─────────────────────────────────────────

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -4,8 +4,14 @@ Per the 2nd-arch delta (G7 — future-queue readiness) and the parent
 spec, this layer is the single home for:
 
 - ``dispatch_notification`` — write a single notification row for a
-  user. PR1 carries the row-write side only; the email-dispatch side
-  is wired in PR3+ when the hook points are added.
+  user. PR3 consults the user's in-app preferences for non-security
+  categories before writing; ``security`` is force-on and always
+  writes (architect-locked).
+- ``dispatch_notification_to_org_admins`` — fanout helper for
+  org-broadcast events (plan change today, role + rename + reset in
+  PR4). One SELECT for the admin set, then per-user dispatch.
+  Per-user failure does NOT abort the fanout — the contract is
+  best-effort, log-and-continue.
 - ``mark_seen`` — bell-open clears the badge for all the user's
   unseen rows. Idempotent.
 - ``mark_read`` — row-click clears a single row's unread state.
@@ -19,15 +25,11 @@ spec, this layer is the single home for:
   ``email_security=False`` is the route's job; this function trusts
   its caller.
 
-PR1 scope intentionally excludes:
+PR3 scope intentionally excludes:
 
-- ``dispatch_notification_to_org`` (broadcast helper). Lands in
-  PR4 with the hooks that need it.
-- Email scheduling. The function signature here will gain an
-  ``email_service`` dispatcher in PR3 when the first hook hits.
-- ``notification_templates.py``. Hardcoded English strings are
-  passed in by the caller in v1; the template module centralizes
-  them in PR3+.
+- Email scheduling. The 5 sensitive-op routes write the in-app row
+  only in PR3; the Mailgun side wires in PR5.
+- ``/settings/notifications`` UI — PR5.
 """
 from __future__ import annotations
 
@@ -35,6 +37,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
+import structlog
 from sqlalchemy import and_, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -44,6 +47,10 @@ from app.models.notification import (
     NotificationCategory,
     UserNotificationPreferences,
 )
+from app.models.user import Role, User
+
+
+logger = structlog.stdlib.get_logger()
 
 
 # Page size cap mirrors the parent spec's pagination decision (G3):
@@ -64,6 +71,60 @@ class NotificationPage:
 # ── dispatch ──────────────────────────────────────────────────────
 
 
+# In-app category → preference-column mapping. Used by
+# ``_in_app_preference_allows`` to decide whether to skip a row write
+# when the user has opted out of the category. ``security`` is
+# intentionally absent — that category is force-on and never
+# consults the preference row.
+_IN_APP_PREF_FIELD: dict[NotificationCategory, str] = {
+    NotificationCategory.ACCOUNT: "in_app_account",
+    NotificationCategory.ORG_ADMIN: "in_app_org_admin",
+    NotificationCategory.ORG_ACTIVITY: "in_app_org_activity",
+}
+
+
+async def _in_app_preference_allows(
+    db: AsyncSession, *, user_id: int, category: NotificationCategory
+) -> bool:
+    """Return whether the in-app row should be written for ``user_id``.
+
+    Always True for ``security`` — architect-locked force-on
+    (see parent spec "Architect resolutions" + 2nd-arch delta
+    section 4). For the other three categories, consult the user's
+    preference row; ``True`` (default) means write, ``False`` means
+    skip.
+
+    A missing preference row is treated as the defaults (security +
+    account + org_admin allowed, org_activity not). ``get_preferences``
+    auto-creates rows on first read, but during dispatch we avoid
+    inserting a preference row purely for a dispatch decision — a
+    direct SELECT is cheaper and the default-allow path mirrors
+    ``_default_preferences``.
+    """
+    if category == NotificationCategory.SECURITY:
+        return True
+
+    field = _IN_APP_PREF_FIELD.get(category)
+    if field is None:
+        # Defensive: a future category that forgets to register here
+        # falls through as "allowed" rather than silently dropping
+        # every dispatch.
+        return True
+
+    stmt = select(UserNotificationPreferences).where(
+        UserNotificationPreferences.user_id == user_id
+    )
+    result = await db.execute(stmt)
+    prefs = result.scalar_one_or_none()
+    if prefs is None:
+        # No preference row → defaults apply. account + org_admin
+        # default-on; org_activity default-off.
+        if category == NotificationCategory.ORG_ACTIVITY:
+            return False
+        return True
+    return bool(getattr(prefs, field))
+
+
 async def dispatch_notification(
     db: AsyncSession,
     *,
@@ -74,19 +135,45 @@ async def dispatch_notification(
     body: str,
     link_url: Optional[str] = None,
     audit_event_id: Optional[int] = None,
-) -> Notification:
+) -> Optional[Notification]:
     """Write a single notification row for ``user_id``.
 
     Caller is responsible for commit semantics — this matches the
     parent spec's "persistence-first, dispatch-after" guardrail (the
     notification ROW write goes through the request's ``AsyncSession``
-    so it commits atomically with the action that caused it). PR1
-    has no email-dispatch side; that wires in PR3+.
+    so it commits atomically with the action that caused it).
+
+    Preference contract (PR3):
+
+    - ``category == security`` → ALWAYS write the row. Architect-locked
+      force-on. The user cannot opt out of security signals via the
+      in-app channel.
+    - ``category in {account, org_admin, org_activity}`` → consult the
+      user's ``in_app_{category}`` preference. If the toggle is False
+      the row is NOT written; a ``notification.skipped_by_pref``
+      structlog event fires so an operator can spot the skip.
+
+    Returns the persisted ``Notification`` row, or ``None`` when the
+    preference check skipped the write. Callers that need to chain
+    the id (e.g. for analytics) should null-check.
 
     Per G8 idempotency note: callers must invoke this at most once
     per request per ``(user_id, event_type)`` pair. There is no
     DB-level dedup; a duplicate invocation produces a duplicate row.
     """
+    allowed = await _in_app_preference_allows(
+        db, user_id=user_id, category=category
+    )
+    if not allowed:
+        await logger.ainfo(
+            "notification.skipped_by_pref",
+            user_id=user_id,
+            category=category.value,
+            event_type=event_type,
+            audit_event_id=audit_event_id,
+        )
+        return None
+
     # Set created_at explicitly in Python rather than relying on the
     # server_default (``func.now(6)`` on MySQL, plain CURRENT_TIMESTAMP
     # on SQLite). The dialect mismatch matters for cursor pagination:
@@ -113,6 +200,81 @@ async def dispatch_notification(
     await db.flush()
     await db.refresh(row)
     return row
+
+
+async def dispatch_notification_to_org_admins(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    category: NotificationCategory,
+    event_type: str,
+    title: str,
+    body: str,
+    link_url: Optional[str] = None,
+    audit_event_id: Optional[int] = None,
+) -> int:
+    """Fan out a notification to every active org admin of ``org_id``.
+
+    "Org admin" today = ``Role.OWNER`` ∪ ``Role.ADMIN`` (matches
+    ``auth/org_permissions.py``'s ``require_admin``). Only active
+    users (``is_active=True``) receive the notification.
+
+    Uses ONE SQL SELECT to fetch the admin set, then iterates and
+    calls ``dispatch_notification`` per recipient. Per-user failure
+    is logged and swallowed so one user's bad row write doesn't kill
+    the entire fanout (best-effort contract). Preference-aware writes
+    still happen per-user: an admin who has opted out of ``org_admin``
+    in-app notifications gets skipped.
+
+    Returns the count of notification rows actually written (skips
+    via preference and per-user failures both count against the
+    total). The caller logs this count for the audit-correlation UI
+    (future PR).
+    """
+    stmt = select(User).where(
+        User.org_id == org_id,
+        User.role.in_((Role.OWNER, Role.ADMIN)),
+        User.is_active.is_(True),
+    )
+    result = await db.execute(stmt)
+    admins = list(result.scalars().all())
+
+    written = 0
+    for admin in admins:
+        try:
+            row = await dispatch_notification(
+                db,
+                user_id=admin.id,
+                category=category,
+                event_type=event_type,
+                title=title,
+                body=body,
+                link_url=link_url,
+                audit_event_id=audit_event_id,
+            )
+            if row is not None:
+                written += 1
+        except Exception as exc:  # noqa: BLE001 — best-effort fanout
+            await logger.aerror(
+                "notification.fanout.user_failed",
+                org_id=org_id,
+                user_id=admin.id,
+                event_type=event_type,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            # Continue to the next admin — one user's failure must
+            # not poison the rest of the broadcast.
+            continue
+
+    await logger.ainfo(
+        "notification.fanout.org_admins",
+        org_id=org_id,
+        event_type=event_type,
+        admin_count=len(admins),
+        rows_written=written,
+    )
+    return written
 
 
 # ── reads ─────────────────────────────────────────────────────────

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -220,11 +220,21 @@ async def dispatch_notification_to_org_admins(
     users (``is_active=True``) receive the notification.
 
     Uses ONE SQL SELECT to fetch the admin set, then iterates and
-    calls ``dispatch_notification`` per recipient. Per-user failure
-    is logged and swallowed so one user's bad row write doesn't kill
-    the entire fanout (best-effort contract). Preference-aware writes
-    still happen per-user: an admin who has opted out of ``org_admin``
-    in-app notifications gets skipped.
+    calls ``dispatch_notification`` per recipient inside a SAVEPOINT.
+    Per-user failure is logged and swallowed so one user's bad row
+    write doesn't kill the entire fanout (best-effort contract).
+    Preference-aware writes still happen per-user: an admin who has
+    opted out of ``org_admin`` in-app notifications gets skipped.
+
+    The savepoint wrap is load-bearing: SQLAlchemy async sessions
+    are "poisoned" once a flush fails inside them — any subsequent
+    ORM operation or commit raises ``InvalidRequestError`` until the
+    transaction is rolled back. Wrapping each per-recipient dispatch
+    in ``db.begin_nested()`` scopes the failure to the savepoint,
+    so the outer transaction (and the next recipient's flush, and
+    the caller's eventual commit) stays clean. Without this, the
+    "best-effort" log was technically swallowed but the eventual
+    commit would still fail downstream.
 
     Returns the count of notification rows actually written (skips
     via preference and per-user failures both count against the
@@ -240,7 +250,9 @@ async def dispatch_notification_to_org_admins(
     admins = list(result.scalars().all())
 
     written = 0
+    failures = 0
     for admin in admins:
+        savepoint = await db.begin_nested()
         try:
             row = await dispatch_notification(
                 db,
@@ -252,27 +264,40 @@ async def dispatch_notification_to_org_admins(
                 link_url=link_url,
                 audit_event_id=audit_event_id,
             )
-            if row is not None:
-                written += 1
         except Exception as exc:  # noqa: BLE001 — best-effort fanout
-            await logger.aerror(
-                "notification.fanout.user_failed",
+            # Roll the savepoint back BEFORE logging so the outer
+            # transaction is clean by the time control returns to
+            # the loop head. A failed flush leaves the session in
+            # "rollback-required" state; without this rollback the
+            # next recipient's flush would raise InvalidRequestError
+            # and the caller's commit would fail too.
+            await savepoint.rollback()
+            await logger.awarning(
+                "notification.dispatch.fanout.recipient_failed",
                 org_id=org_id,
-                user_id=admin.id,
+                recipient_user_id=admin.id,
                 event_type=event_type,
                 error=str(exc),
-                error_type=type(exc).__name__,
+                error_class=type(exc).__name__,
             )
+            failures += 1
             # Continue to the next admin — one user's failure must
             # not poison the rest of the broadcast.
             continue
+        else:
+            # Commit the savepoint; the row stays pending in the
+            # outer transaction (so the caller still owns commit).
+            await savepoint.commit()
+            if row is not None:
+                written += 1
 
     await logger.ainfo(
-        "notification.fanout.org_admins",
+        "notification.dispatch.fanout.complete",
         org_id=org_id,
         event_type=event_type,
         admin_count=len(admins),
         rows_written=written,
+        failures=failures,
     )
     return written
 

--- a/backend/app/services/notification_templates.py
+++ b/backend/app/services/notification_templates.py
@@ -1,18 +1,23 @@
-"""Notification copy templates (PR2 of AI tier train).
+"""Notification copy templates (PR2 of AI tier train + PR3 of notif train).
 
 This module centralizes notification ``title`` / ``body`` strings for
 events the backend emits. The notification service (`PR1`) deliberately
-left these as caller-passed strings; this module adds the first one
-(``ai.cap.soft_warning``) and keeps the surface minimal so PR3+ can
-grow it without re-shaping the API.
+left these as caller-passed strings; this module pins them in one
+place so:
+
+- All English copy lives in one file. Reviewing copy doesn't mean
+  hunting through five router files.
+- A future i18n migration is a mechanical refactor — every call site
+  goes through a function in this module, so flipping these to
+  ``(locale, ...) -> (title, body)`` is the only change.
 
 Module shape:
 
 - Each function returns a ``(title, body, link_url)`` tuple. Plain
   Python strings, no Markdown — the notification feed renders the
-  body verbatim. ``link_url`` is ``None`` for now because PR2 doesn't
-  ship a usage-detail page (admins investigate via the new
-  ``/api/v1/admin/ai/usage`` endpoint).
+  body verbatim. ``link_url`` is set per the parent spec's
+  "Categories — what fires what" table, or ``None`` when there is no
+  destination screen.
 """
 from __future__ import annotations
 
@@ -42,3 +47,92 @@ def ai_cap_soft_warning(
         "of the soft cap."
     )
     return (title, body, None)
+
+
+# ── PR3 of notification train: 5 sensitive-op hook templates ───────
+
+
+def user_password_changed() -> tuple[str, str, Optional[str]]:
+    """Copy for ``user.password.changed`` (security category).
+
+    Self-target; recipient is the user whose password was rotated
+    (or first-set, for SSO-only accounts). Always written — security
+    category is force-on and cannot be opted out via the in-app
+    preferences toggle.
+    """
+    title = "Your password was changed"
+    body = (
+        "Your account password was updated. "
+        "If this wasn't you, secure your account immediately."
+    )
+    return (title, body, "/settings/security")
+
+
+def user_mfa_enabled() -> tuple[str, str, Optional[str]]:
+    """Copy for ``user.mfa.enabled`` (security category).
+
+    Self-target. Confirms the user (or a session acting as them) just
+    flipped MFA on. Quiet positive signal, paired with mfa_disabled
+    as the louder counterpart.
+    """
+    title = "Two-factor authentication enabled"
+    body = "MFA is now active on your account."
+    return (title, body, "/settings/security")
+
+
+def user_mfa_disabled() -> tuple[str, str, Optional[str]]:
+    """Copy for ``user.mfa.disabled`` (security category).
+
+    Self-target. MFA removal is the louder of the two MFA signals —
+    the user (or admin-on-behalf path, when that exists) just removed
+    a strong defense, and an unauthorized actor with the password
+    alone now has fewer obstacles. Copy encourages re-enable rather
+    than just "review your account."
+    """
+    title = "Two-factor authentication disabled"
+    body = (
+        "MFA was removed from your account. "
+        "We recommend re-enabling it for stronger protection."
+    )
+    return (title, body, "/settings/security")
+
+
+def user_email_changed(*, new_email: str) -> tuple[str, str, Optional[str]]:
+    """Copy for ``user.email.changed`` (security category).
+
+    Self-target. The notification row is dispatched to the user whose
+    email just changed — i.e. the actor in the audit convention. The
+    OLD email lives in the audit row's ``actor_email`` field; the
+    NEW email is interpolated into the body so the recipient can
+    confirm the change at a glance.
+
+    Args:
+        new_email: the address the account was changed TO.
+    """
+    title = "Your account email was changed"
+    body = (
+        f"Your account email was updated to {new_email}. "
+        "Reply to support if this wasn't you."
+    )
+    return (title, body, "/settings/security")
+
+
+def admin_org_plan_changed(
+    *, new_plan_name: str, actor_email: str
+) -> tuple[str, str, Optional[str]]:
+    """Copy for ``admin.org.plan.changed`` (org_admin category).
+
+    Broadcast — sent to every active org_admin (Role.OWNER + Role.ADMIN)
+    of the affected org, NOT just the actor. The actor's email is
+    surfaced in the body so admins can attribute the change without
+    bouncing to the audit log.
+
+    Args:
+        new_plan_name: the plan the org was moved TO.
+        actor_email: email of the operator who triggered the change.
+    """
+    title = f"Plan changed to {new_plan_name}"
+    body = (
+        f"Your organization's plan was updated by {actor_email}."
+    )
+    return (title, body, "/admin/organizations")

--- a/backend/tests/routers/test_audit_wiring.py
+++ b/backend/tests/routers/test_audit_wiring.py
@@ -29,6 +29,7 @@ from app.database import get_db
 from app.deps import get_current_user, get_session_factory
 from app.models import Base
 from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.notification import Notification, NotificationCategory
 from app.models.subscription import (
     BillingInterval,
     Plan,
@@ -100,7 +101,19 @@ async def _seed(factory) -> dict:
             role=Role.OWNER, is_superadmin=True, is_active=True,
             email_verified=True,
         )
-        db.add(sa)
+        # Target org owner — receives the PR3 plan-changed
+        # org_admin notification when the superadmin overrides the
+        # plan_id. Without this, the broadcast would have zero
+        # recipients and the notification assertion below would be
+        # trivially satisfied.
+        target_owner = User(
+            org_id=target.id, username="target_owner",
+            email="owner@target.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER, is_superadmin=False, is_active=True,
+            email_verified=True,
+        )
+        db.add_all([sa, target_owner])
         await db.commit()
         target_sub = Subscription(
             org_id=target.id, plan_id=plan.id,
@@ -120,6 +133,7 @@ async def _seed(factory) -> dict:
             "admin_org_id": admin_org.id,
             "target_id": target.id,
             "target_name": target.name,
+            "target_owner_id": target_owner.id,
         }
 
 
@@ -222,6 +236,26 @@ async def test_subscription_override_with_plan_change_writes_plan_changed_audit(
     # Old plan id is whatever the seed used (the free plan), new is `pro`.
     assert plan_row.detail["new_plan_id"] == pro_plan_id
     assert plan_row.detail["old_plan_id"] != pro_plan_id
+
+    # PR3: the plan_changed notification fans out to every active
+    # org_admin of the target org. The seed has exactly one owner
+    # in the target org; that owner receives a row carrying the
+    # audit_event_id for forensic correlation.
+    async with session_factory() as db:
+        plan_notifs = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "admin.org.plan.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(plan_notifs) == 1
+    notif = plan_notifs[0]
+    assert notif.user_id == seed["target_owner_id"]
+    assert notif.category == NotificationCategory.ORG_ADMIN
+    assert "Pro" in notif.title
+    assert "root@platform.io" in notif.body
+    assert notif.audit_event_id == plan_row.id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_audit_wiring_user_ops.py
+++ b/backend/tests/routers/test_audit_wiring_user_ops.py
@@ -48,6 +48,7 @@ from app.database import get_db
 from app.deps import get_current_user, get_session_factory
 from app.models import Base
 from app.models.audit_event import AuditEvent, AuditOutcome
+from app.models.notification import Notification, NotificationCategory
 from app.models.user import Organization, Role, User
 from app.rate_limit import limiter
 from app.routers.auth import router as auth_router
@@ -208,6 +209,24 @@ async def test_password_change_writes_audit(session_factory):
     # Rotation (not initial set) — password_set was True.
     assert row.detail.get("password_set_initial") is False
 
+    # PR3: a security notification row was dispatched to the actor,
+    # carrying the audit_event_id for forensic correlation.
+    async with session_factory() as db:
+        notifs = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "user.password.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(notifs) == 1
+    notif = notifs[0]
+    assert notif.user_id == seed["user_id"]
+    assert notif.category == NotificationCategory.SECURITY
+    assert notif.title == "Your password was changed"
+    assert notif.audit_event_id == row.id
+    assert notif.link_url == "/settings/security"
+
 
 @pytest.mark.asyncio
 async def test_password_change_failure_writes_no_audit(session_factory):
@@ -282,6 +301,25 @@ async def test_email_change_writes_audit_with_old_email(session_factory):
     assert row.detail["old_email"] == "alice@acme.io"
     assert row.detail["new_email"] == "new-address@acme.io"
 
+    # PR3: security notification dispatched to the actor. The body
+    # carries the NEW email (so a recipient receiving this at the OLD
+    # address can confirm where the account was moved to).
+    async with session_factory() as db:
+        notifs = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "user.email.changed"
+                )
+            )
+        ).scalars().all()
+    assert len(notifs) == 1
+    notif = notifs[0]
+    assert notif.user_id == seed["user_id"]
+    assert notif.category == NotificationCategory.SECURITY
+    assert notif.title == "Your account email was changed"
+    assert "new-address@acme.io" in notif.body
+    assert notif.audit_event_id == row.id
+
 
 @pytest.mark.asyncio
 async def test_email_change_no_change_writes_no_audit(session_factory):
@@ -350,6 +388,22 @@ async def test_mfa_enable_writes_audit(session_factory):
     assert row.actor_email == seed["email"]
     assert row.target_org_id == seed["org_id"]
 
+    # PR3: security notification dispatched to the actor.
+    async with session_factory() as db:
+        notifs = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "user.mfa.enabled"
+                )
+            )
+        ).scalars().all()
+    assert len(notifs) == 1
+    notif = notifs[0]
+    assert notif.user_id == seed["user_id"]
+    assert notif.category == NotificationCategory.SECURITY
+    assert notif.title == "Two-factor authentication enabled"
+    assert notif.audit_event_id == row.id
+
 
 @pytest.mark.asyncio
 async def test_mfa_disable_writes_audit(session_factory):
@@ -384,6 +438,24 @@ async def test_mfa_disable_writes_audit(session_factory):
     assert row.actor_user_id == seed["user_id"]
     assert row.actor_email == seed["email"]
     assert row.target_org_id == seed["org_id"]
+
+    # PR3: security notification dispatched to the actor. Body
+    # encourages re-enable (architect-locked copy).
+    async with session_factory() as db:
+        notifs = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "user.mfa.disabled"
+                )
+            )
+        ).scalars().all()
+    assert len(notifs) == 1
+    notif = notifs[0]
+    assert notif.user_id == seed["user_id"]
+    assert notif.category == NotificationCategory.SECURITY
+    assert notif.title == "Two-factor authentication disabled"
+    assert "re-enabling" in notif.body
+    assert notif.audit_event_id == row.id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_notifications.py
+++ b/backend/tests/routers/test_notifications.py
@@ -320,6 +320,114 @@ async def test_list_malformed_cursor_returns_400(session_factory):
     assert body["detail"]["code"] == "invalid_cursor"
 
 
+# ── unseen-count ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unseen_count_requires_auth(session_factory):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.include_router(notifications_router)
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications/unseen-count")
+    assert res.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_unseen_count_zero_when_no_rows(session_factory):
+    await _seed_users(session_factory)
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications/unseen-count")
+    assert res.status_code == 200
+    assert res.json() == {"count": 0}
+
+
+@pytest.mark.asyncio
+async def test_unseen_count_returns_unseen_only(session_factory):
+    """Five rows, two already seen, one read-but-not-seen edge case
+    — count must equal exactly the rows where ``seen_at IS NULL``."""
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        rows = []
+        for i in range(5):
+            row = await notification_service.dispatch_notification(
+                db,
+                user_id=seeds["alice_id"],
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+            rows.append(row)
+        # Mark two as already seen.
+        rows[0].seen_at = rows[0].created_at
+        rows[1].seen_at = rows[1].created_at
+        # One row is read but NOT seen — should still count toward
+        # unseen (the two columns are distinct events).
+        rows[2].read_at = rows[2].created_at
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications/unseen-count")
+    assert res.status_code == 200
+    assert res.json() == {"count": 3}
+
+
+@pytest.mark.asyncio
+async def test_unseen_count_isolated_per_user(session_factory):
+    """A row owned by another user must not bleed into the current
+    user's count."""
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        await notification_service.dispatch_notification(
+            db,
+            user_id=seeds["bob_id"],
+            category=NotificationCategory.SECURITY,
+            event_type="e.b",
+            title="B",
+            body="B",
+        )
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications/unseen-count")
+    assert res.status_code == 200
+    assert res.json() == {"count": 0}
+
+
+@pytest.mark.asyncio
+async def test_unseen_count_uncapped_returns_raw_value(session_factory):
+    """The wire payload is uncapped — the bell does its own ``99+``
+    cap client-side so a future "show 250" tweak stays
+    frontend-only."""
+    seeds = await _seed_users(session_factory)
+    async with session_factory() as db:
+        for i in range(100):
+            await notification_service.dispatch_notification(
+                db,
+                user_id=seeds["alice_id"],
+                category=NotificationCategory.SECURITY,
+                event_type=f"e.{i}",
+                title=f"T{i}",
+                body=f"B{i}",
+            )
+        await db.commit()
+
+    app = _make_app(session_factory, _user_resolver("alice"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/notifications/unseen-count")
+    assert res.status_code == 200
+    assert res.json() == {"count": 100}
+
+
 # ── mark-seen ─────────────────────────────────────────────────────
 
 

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -522,3 +522,235 @@ async def test_update_preferences_forces_security_true_defense_in_depth(session_
         )
         await db.commit()
     assert prefs.email_security is True
+
+
+# ── PR3: preference-aware dispatch + org-admin fanout ─────────────
+
+
+async def _seed_extra_admin(
+    factory, org_id: int, *, username: str, email: str, role
+) -> int:
+    """Add a second user with ``role`` to an existing org. Returns id."""
+    from app.security import hash_password as _hp  # local import — test scope
+
+    async with factory() as db:
+        user = User(
+            org_id=org_id,
+            username=username,
+            email=email,
+            password_hash=_hp("pw-1234567"),
+            role=role,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_respects_in_app_preference(session_factory):
+    """When the user has ``in_app_account=False``, an ACCOUNT category
+    dispatch must NOT write a row. Locks the preference-aware
+    behaviour added in PR3 — without it the bell would surface rows
+    the user explicitly opted out of.
+    """
+    user_id = await _seed_user(session_factory)
+    # Persist a preference row with account turned off.
+    payload = _PrefPayload(in_app_account=False)
+    async with session_factory() as db:
+        await notification_service.update_preferences(
+            db, user_id=user_id, payload=payload
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.ACCOUNT,
+            event_type="account.role_changed",
+            title="Role changed",
+            body="Body",
+        )
+        await db.commit()
+    # Skipped → returns None and no row exists.
+    assert row is None
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification).where(Notification.user_id == user_id)
+            )
+        ).scalars().all()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_force_writes_for_security_category(session_factory):
+    """Even with every in_app_* preference flipped off, a SECURITY
+    dispatch still writes the row. Architect-locked force-on rule —
+    the user cannot opt out of security signals in the inbox.
+    """
+    user_id = await _seed_user(session_factory)
+    payload = _PrefPayload(
+        in_app_security=False,
+        in_app_account=False,
+        in_app_org_admin=False,
+        in_app_org_activity=False,
+    )
+    async with session_factory() as db:
+        await notification_service.update_preferences(
+            db, user_id=user_id, payload=payload
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        row = await notification_service.dispatch_notification(
+            db,
+            user_id=user_id,
+            category=NotificationCategory.SECURITY,
+            event_type="user.password.changed",
+            title="Your password was changed",
+            body="Body",
+        )
+        await db.commit()
+    assert row is not None
+    assert row.category == NotificationCategory.SECURITY
+
+
+@pytest.mark.asyncio
+async def test_dispatch_org_admin_fanout_to_multiple_admins(session_factory):
+    """3-admin org → 3 dispatched rows. Pins the architect-locked
+    fanout behavior: a single SELECT pulls the admin set, then per-user
+    rows are written. A spy on the session counts the SELECTs against
+    ``users`` to prove the helper doesn't N+1.
+    """
+    # Seed the org + 1st owner via the standard helper.
+    seed_user_id = await _seed_user(
+        session_factory, username="owner", email="owner@ex.io"
+    )
+
+    # Need the owner's org_id to add siblings.
+    async with session_factory() as db:
+        owner = await db.get(User, seed_user_id)
+        assert owner is not None
+        org_id = owner.org_id
+
+    # Add two more admins (role=ADMIN) — total 3 admins in the org.
+    admin_a = await _seed_extra_admin(
+        session_factory, org_id, username="admin_a", email="a@ex.io", role=Role.ADMIN
+    )
+    admin_b = await _seed_extra_admin(
+        session_factory, org_id, username="admin_b", email="b@ex.io", role=Role.ADMIN
+    )
+
+    # And a MEMBER who must NOT receive the broadcast.
+    member_id = await _seed_extra_admin(
+        session_factory,
+        org_id,
+        username="member",
+        email="m@ex.io",
+        role=Role.MEMBER,
+    )
+
+    select_counts = {"users": 0}
+    async with session_factory() as db:
+        # Patch the session's execute to count SELECTs against users.
+        original_execute = db.execute
+
+        async def counting_execute(clause, *args, **kwargs):
+            text = str(clause).lower()
+            if "from users" in text:
+                select_counts["users"] += 1
+            return await original_execute(clause, *args, **kwargs)
+
+        db.execute = counting_execute  # type: ignore[method-assign]
+
+        written = await notification_service.dispatch_notification_to_org_admins(
+            db,
+            org_id=org_id,
+            category=NotificationCategory.ORG_ADMIN,
+            event_type="admin.org.plan.changed",
+            title="Plan changed",
+            body="Body",
+        )
+        await db.commit()
+
+    assert written == 3
+    # One SELECT against users for the admin lookup. Even if other
+    # SELECTs run from prior context, the helper itself must add
+    # exactly one — assert "at most" to absorb any session bookkeeping.
+    assert select_counts["users"] == 1
+
+    # All three admins got a row; the member did not.
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "admin.org.plan.changed"
+                )
+            )
+        ).scalars().all()
+    recipient_ids = {row.user_id for row in rows}
+    assert recipient_ids == {seed_user_id, admin_a, admin_b}
+    assert member_id not in recipient_ids
+
+
+@pytest.mark.asyncio
+async def test_dispatch_org_admin_fanout_continues_on_individual_failure(
+    session_factory, monkeypatch
+):
+    """One admin's dispatch raises → the other two still get their
+    rows. Locks the best-effort contract: a poison-pill row write
+    cannot poison the broadcast.
+    """
+    seed_user_id = await _seed_user(
+        session_factory, username="owner", email="owner@ex.io"
+    )
+    async with session_factory() as db:
+        owner = await db.get(User, seed_user_id)
+        org_id = owner.org_id
+
+    admin_a = await _seed_extra_admin(
+        session_factory, org_id, username="admin_a", email="a@ex.io", role=Role.ADMIN
+    )
+    admin_b = await _seed_extra_admin(
+        session_factory, org_id, username="admin_b", email="b@ex.io", role=Role.ADMIN
+    )
+
+    real_dispatch = notification_service.dispatch_notification
+
+    async def flaky_dispatch(db, *, user_id, **kwargs):
+        if user_id == admin_a:
+            raise RuntimeError("simulated per-user failure")
+        return await real_dispatch(db, user_id=user_id, **kwargs)
+
+    monkeypatch.setattr(
+        notification_service, "dispatch_notification", flaky_dispatch
+    )
+
+    async with session_factory() as db:
+        written = await notification_service.dispatch_notification_to_org_admins(
+            db,
+            org_id=org_id,
+            category=NotificationCategory.ORG_ADMIN,
+            event_type="admin.org.plan.changed",
+            title="Plan changed",
+            body="Body",
+        )
+        await db.commit()
+
+    # 2 written: owner + admin_b. admin_a raised and was skipped.
+    assert written == 2
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "admin.org.plan.changed"
+                )
+            )
+        ).scalars().all()
+    recipient_ids = {row.user_id for row in rows}
+    assert seed_user_id in recipient_ids
+    assert admin_b in recipient_ids
+    assert admin_a not in recipient_ids

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -17,12 +17,14 @@ Pins the architect-locked invariants exercised at the function level
 """
 from __future__ import annotations
 
+import ast
+import json
+import logging
 from collections.abc import AsyncIterator
 from datetime import datetime
 
 import pytest
 import pytest_asyncio
-import structlog
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
@@ -43,6 +45,73 @@ from app.models.notification import (
 from app.models.user import Organization, Role, User
 from app.security import hash_password
 from app.services import notification_service
+
+
+@pytest.fixture
+def _structlog_via_stdlib():
+    """Ensure structlog routes events through stdlib for the test.
+
+    The notification fanout tests assert on structured fields emitted
+    by :mod:`app.services.notification_service`. The service uses
+    ``structlog.stdlib.get_logger()``; whether ``caplog`` sees those
+    events depends on whether structlog has been configured to route
+    through the stdlib pipeline. ``app.logging.setup_logging`` installs
+    that wiring in production and in the FastAPI lifespan, but the
+    bare unit-test conftest does not — so structlog falls back to its
+    default ``PrintLogger`` which bypasses stdlib entirely.
+
+    This fixture calls ``setup_logging()`` once per test so events
+    land in ``caplog`` regardless of test ordering. Without it, the
+    test passes only when an earlier test in the session happened to
+    initialise the FastAPI app stack first; that ordering is what made
+    the original ``structlog.testing.capture_logs()`` form pass locally
+    and fail in CI.
+    """
+    import structlog
+
+    from app.logging import setup_logging
+
+    original_config = structlog.get_config() if structlog.is_configured() else None
+    setup_logging()
+    yield
+    if original_config is not None:
+        structlog.configure(**original_config)
+
+
+def _collect_structlog_events(caplog) -> list[dict]:
+    """Pull structlog events out of pytest's ``caplog`` capture.
+
+    With ``_structlog_via_stdlib`` active, structlog is configured to
+    end its processor chain with ``ProcessorFormatter.wrap_for_formatter``
+    which hands the event dict to stdlib. ``caplog`` then sees a
+    :class:`logging.LogRecord` whose ``msg`` is either the event dict
+    itself (when ``wrap_for_formatter`` ran) or a string the formatter
+    chain rendered. This helper normalises both shapes into a list of
+    event ``dict``s so assertions can reach the structured fields.
+    """
+    events: list[dict] = []
+    for rec in caplog.records:
+        # Path 1: wrap_for_formatter — record.msg is the event dict OR a
+        # tuple of (event_dict,). Older structlog versions ship the dict
+        # straight through; newer versions pass it as the first positional.
+        candidate = rec.msg
+        if isinstance(candidate, tuple) and candidate:
+            candidate = candidate[0]
+        if isinstance(candidate, dict):
+            events.append(candidate)
+            continue
+        # Path 2: rendered to text — try JSON first, then fall back to a
+        # Python-literal eval for repr-style dict strings.
+        message = rec.getMessage()
+        for parser in (json.loads, ast.literal_eval):
+            try:
+                payload = parser(message)
+            except (ValueError, SyntaxError, TypeError):
+                continue
+            if isinstance(payload, dict):
+                events.append(payload)
+                break
+    return events
 
 
 @pytest_asyncio.fixture
@@ -760,7 +829,7 @@ async def test_dispatch_org_admin_fanout_continues_on_individual_failure(
 
 @pytest.mark.asyncio
 async def test_fanout_savepoint_isolates_recipient_flush_failure(
-    session_factory, monkeypatch
+    session_factory, monkeypatch, caplog, _structlog_via_stdlib
 ):
     """A flush-time IntegrityError on recipient #2 must NOT poison
     the outer session: recipient #1 (already flushed) and recipient #3
@@ -817,7 +886,7 @@ async def test_fanout_savepoint_isolates_recipient_flush_failure(
         notification_service, "dispatch_notification", poisoning_dispatch
     )
 
-    with structlog.testing.capture_logs() as captured:
+    with caplog.at_level(logging.WARNING, logger="app.services.notification_service"):
         async with session_factory() as db:
             written = await notification_service.dispatch_notification_to_org_admins(
                 db,
@@ -852,9 +921,10 @@ async def test_fanout_savepoint_isolates_recipient_flush_failure(
     # leaked past the savepoint rollback.
     assert 999_999 not in recipient_ids
 
+    captured_events = _collect_structlog_events(caplog)
     failed_events = [
         ev
-        for ev in captured
+        for ev in captured_events
         if ev.get("event") == "notification.dispatch.fanout.recipient_failed"
     ]
     assert len(failed_events) == 1
@@ -866,7 +936,7 @@ async def test_fanout_savepoint_isolates_recipient_flush_failure(
 
 @pytest.mark.asyncio
 async def test_fanout_returns_success_and_failure_counts(
-    session_factory, monkeypatch
+    session_factory, monkeypatch, caplog, _structlog_via_stdlib
 ):
     """Mix 2 successes + 2 failures: the helper returns the success
     count (rows actually written) and emits a structured completion
@@ -906,7 +976,7 @@ async def test_fanout_returns_success_and_failure_counts(
         notification_service, "dispatch_notification", half_failing_dispatch
     )
 
-    with structlog.testing.capture_logs() as captured:
+    with caplog.at_level(logging.INFO, logger="app.services.notification_service"):
         async with session_factory() as db:
             written = await notification_service.dispatch_notification_to_org_admins(
                 db,
@@ -921,9 +991,10 @@ async def test_fanout_returns_success_and_failure_counts(
     # 2 successes (owner + admin_b); 2 failures (admin_a + admin_c).
     assert written == 2
 
+    captured_events = _collect_structlog_events(caplog)
     complete_events = [
         ev
-        for ev in captured
+        for ev in captured_events
         if ev.get("event") == "notification.dispatch.fanout.complete"
     ]
     assert len(complete_events) == 1
@@ -935,7 +1006,7 @@ async def test_fanout_returns_success_and_failure_counts(
 
     failed_events = [
         ev
-        for ev in captured
+        for ev in captured_events
         if ev.get("event") == "notification.dispatch.fanout.recipient_failed"
     ]
     assert {ev["recipient_user_id"] for ev in failed_events} == failing_ids

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -22,8 +22,10 @@ from datetime import datetime
 
 import pytest
 import pytest_asyncio
+import structlog
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -754,3 +756,197 @@ async def test_dispatch_org_admin_fanout_continues_on_individual_failure(
     assert seed_user_id in recipient_ids
     assert admin_b in recipient_ids
     assert admin_a not in recipient_ids
+
+
+@pytest.mark.asyncio
+async def test_fanout_savepoint_isolates_recipient_flush_failure(
+    session_factory, monkeypatch
+):
+    """A flush-time IntegrityError on recipient #2 must NOT poison
+    the outer session: recipient #1 (already flushed) and recipient #3
+    (after the SAVEPOINT rollback) both keep their rows, and the
+    caller's commit succeeds.
+
+    Without ``db.begin_nested()`` per recipient, a failed flush leaves
+    the session in "rollback-required" state — recipient #3's
+    subsequent ``db.flush()`` would raise ``PendingRollbackError`` and
+    the eventual ``db.commit()`` would fail too, even though the loop
+    swallows the per-user exception.
+    """
+    seed_user_id = await _seed_user(
+        session_factory, username="owner", email="owner@ex.io"
+    )
+    async with session_factory() as db:
+        owner = await db.get(User, seed_user_id)
+        org_id = owner.org_id
+
+    admin_a = await _seed_extra_admin(
+        session_factory, org_id, username="admin_a", email="a@ex.io", role=Role.ADMIN
+    )
+    admin_b = await _seed_extra_admin(
+        session_factory, org_id, username="admin_b", email="b@ex.io", role=Role.ADMIN
+    )
+
+    real_dispatch = notification_service.dispatch_notification
+
+    async def poisoning_dispatch(db, *, user_id, **kwargs):
+        if user_id == admin_a:
+            # Force a real flush-time failure: insert a Notification
+            # with a user_id that violates the FK. SQLite has
+            # PRAGMA foreign_keys=ON in our fixture so this raises
+            # IntegrityError on flush, leaving the session in
+            # rollback-required state. This is the contract we need
+            # the savepoint to isolate.
+            from app.models.notification import Notification
+            from app._time import utcnow_naive
+
+            bad = Notification(
+                user_id=999_999,  # no such user
+                category=kwargs["category"],
+                event_type=kwargs["event_type"],
+                title=kwargs["title"],
+                body=kwargs["body"],
+                created_at=utcnow_naive(),
+            )
+            db.add(bad)
+            await db.flush()  # raises IntegrityError
+            return bad  # unreachable
+        return await real_dispatch(db, user_id=user_id, **kwargs)
+
+    monkeypatch.setattr(
+        notification_service, "dispatch_notification", poisoning_dispatch
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        async with session_factory() as db:
+            written = await notification_service.dispatch_notification_to_org_admins(
+                db,
+                org_id=org_id,
+                category=NotificationCategory.ORG_ADMIN,
+                event_type="admin.org.plan.changed",
+                title="Plan changed",
+                body="Body",
+            )
+            # CRITICAL: the outer commit must succeed. Without the
+            # savepoint wrap this raises PendingRollbackError because
+            # recipient #2's flush poisoned the session.
+            await db.commit()
+
+    # 2 written: owner + admin_b. admin_a's flush failed and the
+    # savepoint rolled back cleanly.
+    assert written == 2
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "admin.org.plan.changed"
+                )
+            )
+        ).scalars().all()
+    recipient_ids = {row.user_id for row in rows}
+    assert seed_user_id in recipient_ids
+    assert admin_b in recipient_ids
+    assert admin_a not in recipient_ids
+    # The FK-violating row from the poisoned dispatch must not have
+    # leaked past the savepoint rollback.
+    assert 999_999 not in recipient_ids
+
+    failed_events = [
+        ev
+        for ev in captured
+        if ev.get("event") == "notification.dispatch.fanout.recipient_failed"
+    ]
+    assert len(failed_events) == 1
+    failed = failed_events[0]
+    assert failed["recipient_user_id"] == admin_a
+    assert failed["org_id"] == org_id
+    assert failed["error_class"] == "IntegrityError"
+
+
+@pytest.mark.asyncio
+async def test_fanout_returns_success_and_failure_counts(
+    session_factory, monkeypatch
+):
+    """Mix 2 successes + 2 failures: the helper returns the success
+    count (rows actually written) and emits a structured completion
+    log carrying both ``rows_written`` and ``failures``.
+
+    This pins the observable shape callers (admin_orgs.py) depend on:
+    return is the integer success count; failure count is reachable
+    via structlog for ops dashboards.
+    """
+    seed_user_id = await _seed_user(
+        session_factory, username="owner", email="owner@ex.io"
+    )
+    async with session_factory() as db:
+        owner = await db.get(User, seed_user_id)
+        org_id = owner.org_id
+
+    # Three more admins → 4 total (owner + 3 admins).
+    admin_a = await _seed_extra_admin(
+        session_factory, org_id, username="admin_a", email="a@ex.io", role=Role.ADMIN
+    )
+    admin_b = await _seed_extra_admin(
+        session_factory, org_id, username="admin_b", email="b@ex.io", role=Role.ADMIN
+    )
+    admin_c = await _seed_extra_admin(
+        session_factory, org_id, username="admin_c", email="c@ex.io", role=Role.ADMIN
+    )
+
+    real_dispatch = notification_service.dispatch_notification
+    failing_ids = {admin_a, admin_c}
+
+    async def half_failing_dispatch(db, *, user_id, **kwargs):
+        if user_id in failing_ids:
+            raise RuntimeError(f"simulated dispatch failure for {user_id}")
+        return await real_dispatch(db, user_id=user_id, **kwargs)
+
+    monkeypatch.setattr(
+        notification_service, "dispatch_notification", half_failing_dispatch
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        async with session_factory() as db:
+            written = await notification_service.dispatch_notification_to_org_admins(
+                db,
+                org_id=org_id,
+                category=NotificationCategory.ORG_ADMIN,
+                event_type="admin.org.plan.changed",
+                title="Plan changed",
+                body="Body",
+            )
+            await db.commit()
+
+    # 2 successes (owner + admin_b); 2 failures (admin_a + admin_c).
+    assert written == 2
+
+    complete_events = [
+        ev
+        for ev in captured
+        if ev.get("event") == "notification.dispatch.fanout.complete"
+    ]
+    assert len(complete_events) == 1
+    complete = complete_events[0]
+    assert complete["org_id"] == org_id
+    assert complete["admin_count"] == 4
+    assert complete["rows_written"] == 2
+    assert complete["failures"] == 2
+
+    failed_events = [
+        ev
+        for ev in captured
+        if ev.get("event") == "notification.dispatch.fanout.recipient_failed"
+    ]
+    assert {ev["recipient_user_id"] for ev in failed_events} == failing_ids
+
+    # Verify only the 2 successful rows actually landed.
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(Notification).where(
+                    Notification.event_type == "admin.org.plan.changed"
+                )
+            )
+        ).scalars().all()
+    assert {row.user_id for row in rows} == {seed_user_id, admin_b}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -30,6 +30,7 @@ import AppShellAddTransactionCta, {
   shouldShowAddTransactionCta,
 } from "@/components/AppShellAddTransactionCta";
 import AnnouncementBar from "@/components/announcements/AnnouncementBar";
+import NotificationBell from "@/components/notifications/NotificationBell";
 import AppShellFooter from "@/components/AppShellFooter";
 import { Logo } from "@/components/brand/Logo";
 import ThemeToggle from "@/components/ui/ThemeToggle";
@@ -480,6 +481,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <div className="flex items-center gap-3">
             <TrialBanner user={user} />
             {shouldShowAddTransactionCta(pathname) && <AppShellAddTransactionCta />}
+            {/* Notification bell — header row beside docs + theme.
+                Architect-locked position (NOT the TrialBanner slot);
+                hidden alongside the rest of the header chrome when
+                the user is unauthenticated (the surrounding
+                ``loading || !user`` early return drops this entire
+                JSX subtree). */}
+            <NotificationBell />
             <Link
               href="/docs"
               className="rounded-md p-2 text-text-muted transition-colors hover:text-text-primary"

--- a/frontend/components/notifications/NotificationBell.tsx
+++ b/frontend/components/notifications/NotificationBell.tsx
@@ -8,7 +8,15 @@
  * unrelated cognitive buckets).
  *
  * Data:
- * - SWR fetch ``GET /api/v1/notifications?limit=10`` on mount.
+ * - SWR fetch ``GET /api/v1/notifications/unseen-count`` on mount —
+ *   a lightweight ``{count: int}`` endpoint that does not fetch the
+ *   row payload. This keeps the badge truthful when the unseen
+ *   count exceeds the popover's display limit (the list fetch only
+ *   pulls the most-recent 10 for the popover preview).
+ * - A separate ``GET /api/v1/notifications?limit=10`` fetch backs
+ *   the popover preview rows. It is mounted on the same poll cadence
+ *   so the popover content is reasonably fresh when the user opens
+ *   it.
  * - ``refreshInterval = 60_000`` — 60s polling matches the parent
  *   spec's "polling cadence" decision.
  * - ``revalidateOnFocus = true`` so a backgrounded tab returning to
@@ -16,12 +24,11 @@
  *   is "60s in background, instant on focus" without SSE.
  *
  * Badge:
- * - Counts rows where ``seen_at === null`` (the "unseen" channel —
- *   distinct from "unread"). The 2nd-arch delta locked this two-
- *   column model so the badge clears on bell-open even if the user
- *   never clicks individual rows.
- * - Caps the visible label at "99+" per the parent spec's
- *   pagination decision (G3).
+ * - Sourced from the unseen-count endpoint (server-side
+ *   ``SELECT COUNT(*) WHERE seen_at IS NULL``) — NOT from counting
+ *   rows in the popover list, which is capped at 10. The wire
+ *   payload returns the raw count; the bell caps the rendered label
+ *   at "99+" so a future "show 250" tweak is frontend-only.
  *
  * Mark-seen:
  * - On popover-open, fire POST ``/api/v1/notifications/mark-seen``
@@ -41,37 +48,55 @@ import useSWR from "swr";
 import { Bell, BellRing } from "lucide-react";
 
 import { apiFetch } from "@/lib/api";
-import type { NotificationListResponse } from "@/lib/types";
+import type {
+  NotificationListResponse,
+  NotificationUnseenCountResponse,
+} from "@/lib/types";
 
 import NotificationPopover from "@/components/notifications/NotificationPopover";
 
-const FETCH_URL = "/api/v1/notifications?limit=10";
+const LIST_URL = "/api/v1/notifications?limit=10";
+const UNSEEN_COUNT_URL = "/api/v1/notifications/unseen-count";
 const MARK_SEEN_URL = "/api/v1/notifications/mark-seen";
 const POLL_INTERVAL_MS = 60_000;
 const BADGE_CAP = 99;
 
-async function fetcher(path: string): Promise<NotificationListResponse> {
+async function listFetcher(path: string): Promise<NotificationListResponse> {
   return apiFetch<NotificationListResponse>(path);
+}
+
+async function countFetcher(
+  path: string,
+): Promise<NotificationUnseenCountResponse> {
+  return apiFetch<NotificationUnseenCountResponse>(path);
 }
 
 export default function NotificationBell() {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const { data, mutate } = useSWR<NotificationListResponse>(
-    FETCH_URL,
-    fetcher,
-    {
+  // Badge source — accurate even when unseen > 10 (the popover's
+  // page size). A dedicated count endpoint avoids loading row
+  // payloads on every poll just to compute a number.
+  const { data: countData, mutate: mutateCount } =
+    useSWR<NotificationUnseenCountResponse>(UNSEEN_COUNT_URL, countFetcher, {
       refreshInterval: POLL_INTERVAL_MS,
       revalidateOnFocus: true,
       revalidateOnReconnect: true,
-      // SWR returns undefined on first render; the bell + count
-      // gracefully treats undefined as "no data yet, no badge".
-    },
-  );
+    });
 
-  const items = data?.items ?? [];
-  const unseen = items.filter((it) => it.seen_at === null).length;
+  // Popover preview rows — only fetched when the user might open
+  // the popover. Still on the same poll cadence so opening doesn't
+  // stall on a cold fetch.
+  const { data: listData, mutate: mutateList } =
+    useSWR<NotificationListResponse>(LIST_URL, listFetcher, {
+      refreshInterval: POLL_INTERVAL_MS,
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
+    });
+
+  const items = listData?.items ?? [];
+  const unseen = countData?.count ?? 0;
 
   // Close-on-outside-click. The popover is a non-modal dialog — a
   // click anywhere outside the bell container collapses it. Matches
@@ -111,14 +136,16 @@ export default function NotificationBell() {
         // Swallow — the badge stays visible until the next poll
         // re-asserts the server state.
       }
-      // Re-fetch so the popover renders rows with fresh seen_at.
-      mutate();
+      // Re-fetch both: count clears the badge, list refreshes the
+      // popover rows' seen_at.
+      mutateCount();
+      mutateList();
     }
-  }, [open, mutate]);
+  }, [open, mutateCount, mutateList]);
 
   const handleAfterReadChange = useCallback(() => {
-    mutate();
-  }, [mutate]);
+    mutateList();
+  }, [mutateList]);
 
   // Lazy-import the popover so the initial bell render stays cheap;
   // most users will never open it. (Inline rendering — the popover
@@ -149,7 +176,7 @@ export default function NotificationBell() {
         {unseen > 0 && (
           <span
             data-testid="notification-badge"
-            className="absolute -right-0.5 -top-0.5 inline-flex min-w-[1.125rem] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold leading-none text-white"
+            className="absolute -right-0.5 -top-0.5 inline-flex min-w-[1.125rem] items-center justify-center rounded-full bg-danger px-1 text-[10px] font-semibold leading-none text-danger-text"
           >
             {unseen > BADGE_CAP ? `${BADGE_CAP}+` : unseen}
           </span>

--- a/frontend/components/notifications/NotificationBell.tsx
+++ b/frontend/components/notifications/NotificationBell.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+/**
+ * NotificationBell — header icon + unseen-count badge + popover.
+ *
+ * Mounted in the AppShell header row beside the docs link / theme
+ * toggle (architect lock: NOT the TrialBanner slot — those are
+ * unrelated cognitive buckets).
+ *
+ * Data:
+ * - SWR fetch ``GET /api/v1/notifications?limit=10`` on mount.
+ * - ``refreshInterval = 60_000`` — 60s polling matches the parent
+ *   spec's "polling cadence" decision.
+ * - ``revalidateOnFocus = true`` so a backgrounded tab returning to
+ *   foreground picks up fresh rows immediately. The combined effect
+ *   is "60s in background, instant on focus" without SSE.
+ *
+ * Badge:
+ * - Counts rows where ``seen_at === null`` (the "unseen" channel —
+ *   distinct from "unread"). The 2nd-arch delta locked this two-
+ *   column model so the badge clears on bell-open even if the user
+ *   never clicks individual rows.
+ * - Caps the visible label at "99+" per the parent spec's
+ *   pagination decision (G3).
+ *
+ * Mark-seen:
+ * - On popover-open, fire POST ``/api/v1/notifications/mark-seen``
+ *   to clear ``seen_at`` for every unseen row of the current user.
+ *   That is what kills the badge until new rows land. The row-level
+ *   ``read_at`` state is unaffected — the inbox still shows unread
+ *   rows boldly until they're individually read.
+ *
+ * Lucide icons:
+ * - ``Bell`` when no unseen rows.
+ * - ``BellRing`` when there are unseen rows (the visual mirror of
+ *   the badge — accessible to color-blind users who might miss the
+ *   red dot).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import useSWR from "swr";
+import { Bell, BellRing } from "lucide-react";
+
+import { apiFetch } from "@/lib/api";
+import type { NotificationListResponse } from "@/lib/types";
+
+import NotificationPopover from "@/components/notifications/NotificationPopover";
+
+const FETCH_URL = "/api/v1/notifications?limit=10";
+const MARK_SEEN_URL = "/api/v1/notifications/mark-seen";
+const POLL_INTERVAL_MS = 60_000;
+const BADGE_CAP = 99;
+
+async function fetcher(path: string): Promise<NotificationListResponse> {
+  return apiFetch<NotificationListResponse>(path);
+}
+
+export default function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const { data, mutate } = useSWR<NotificationListResponse>(
+    FETCH_URL,
+    fetcher,
+    {
+      refreshInterval: POLL_INTERVAL_MS,
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
+      // SWR returns undefined on first render; the bell + count
+      // gracefully treats undefined as "no data yet, no badge".
+    },
+  );
+
+  const items = data?.items ?? [];
+  const unseen = items.filter((it) => it.seen_at === null).length;
+
+  // Close-on-outside-click. The popover is a non-modal dialog — a
+  // click anywhere outside the bell container collapses it. Matches
+  // the existing avatar-dropdown pattern in AppShell.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (containerRef.current.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener("click", onDocClick);
+    return () => document.removeEventListener("click", onDocClick);
+  }, [open]);
+
+  // Close-on-escape.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const handleToggle = useCallback(async () => {
+    const willOpen = !open;
+    setOpen(willOpen);
+    if (willOpen) {
+      // Mark-seen on bell-open. Fire and forget — the badge clears
+      // optimistically on the next refetch; a failure leaves the
+      // badge visible (preferable to claiming "seen" when we can't
+      // prove the server agrees).
+      try {
+        await apiFetch(MARK_SEEN_URL, { method: "POST" });
+      } catch {
+        // Swallow — the badge stays visible until the next poll
+        // re-asserts the server state.
+      }
+      // Re-fetch so the popover renders rows with fresh seen_at.
+      mutate();
+    }
+  }, [open, mutate]);
+
+  const handleAfterReadChange = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
+  // Lazy-import the popover so the initial bell render stays cheap;
+  // most users will never open it. (Inline rendering — the popover
+  // module is tiny, so the dynamic import would be over-engineering
+  // for a single component. Direct import is fine.)
+  // Imported via static path so the test environment can mock both
+  // sibling files without dynamic-import gymnastics.
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-label={
+          unseen > 0
+            ? `Notifications, ${unseen} unseen`
+            : "Notifications"
+        }
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="relative rounded-md p-2 text-text-muted transition-colors hover:text-text-primary focus:outline-none focus:ring-1 focus:ring-accent"
+        data-testid="notification-bell"
+      >
+        {unseen > 0 ? (
+          <BellRing aria-hidden="true" className="h-5 w-5" strokeWidth={1.5} />
+        ) : (
+          <Bell aria-hidden="true" className="h-5 w-5" strokeWidth={1.5} />
+        )}
+        {unseen > 0 && (
+          <span
+            data-testid="notification-badge"
+            className="absolute -right-0.5 -top-0.5 inline-flex min-w-[1.125rem] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold leading-none text-white"
+          >
+            {unseen > BADGE_CAP ? `${BADGE_CAP}+` : unseen}
+          </span>
+        )}
+      </button>
+      {open && (
+        <NotificationPopover
+          items={items}
+          onAfterReadChange={handleAfterReadChange}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/components/notifications/NotificationPopover.tsx
+++ b/frontend/components/notifications/NotificationPopover.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * NotificationPopover — dropdown that lists the most-recent 10
+ * notifications for the current user.
+ *
+ * Mounted by ``<NotificationBell />`` when the bell is clicked.
+ * Owns no fetch state of its own; the bell passes ``items`` down so
+ * the popover stays a pure render component (and bell-open does not
+ * trigger a second network round-trip).
+ *
+ * Per-row interaction:
+ * - Click → PATCH ``/api/v1/notifications/{id}`` with ``{read: true}``
+ *   to mark read, then navigate to ``link_url`` if present.
+ * - The list re-renders without that row's bold "unread" treatment
+ *   on the next refetch (mark-read is in-band; SWR mutate is the
+ *   caller's job in the bell).
+ *
+ * Severity dot — visual category cue:
+ * - security → subtle red dot (urgent / actionable)
+ * - account / org_admin → neutral muted dot (informational)
+ * - org_activity → muted further (background noise, opt-in only)
+ *
+ * "See all" footer link points to ``/settings/notifications`` —
+ * that page lands in PR5 of the train. Until then it renders as a
+ * disabled-looking text link rather than a hard 404 so we don't ship
+ * a dangling anchor.
+ */
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+
+import { apiFetch } from "@/lib/api";
+import type { Notification, NotificationCategory } from "@/lib/types";
+
+interface Props {
+  items: Notification[];
+  /** Called after a row is marked read so the parent can re-fetch. */
+  onAfterReadChange: () => void;
+  /** Close handler — fires after navigation so the popover collapses. */
+  onClose: () => void;
+}
+
+const SEVERITY_DOT: Record<NotificationCategory, string> = {
+  security: "bg-red-500",
+  account: "bg-text-muted",
+  org_admin: "bg-text-muted",
+  org_activity: "bg-text-muted/40",
+};
+
+function timeAgo(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diffSec = Math.max(0, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const min = Math.floor(diffSec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}
+
+export default function NotificationPopover({
+  items,
+  onAfterReadChange,
+  onClose,
+}: Props) {
+  const router = useRouter();
+
+  const handleRowClick = useCallback(
+    async (notif: Notification) => {
+      // Optimistic UX: mark read in the background, navigate
+      // immediately. Failure is swallowed — the next refetch will
+      // resync.
+      apiFetch<Notification>(`/api/v1/notifications/${notif.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ read: true }),
+      })
+        .catch(() => {
+          // no-op — best effort. The badge / unread state will
+          // self-heal on the next refresh.
+        })
+        .finally(() => {
+          onAfterReadChange();
+        });
+
+      if (notif.link_url) {
+        router.push(notif.link_url);
+      }
+      onClose();
+    },
+    [router, onAfterReadChange, onClose],
+  );
+
+  if (items.length === 0) {
+    return (
+      <div
+        role="dialog"
+        aria-label="Notifications"
+        className="absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-border bg-surface shadow-xl"
+      >
+        <div className="px-4 py-3 text-sm font-medium text-text-primary">
+          Notifications
+        </div>
+        <div className="border-t border-border" />
+        <div className="px-4 py-8 text-center text-sm text-text-muted">
+          You&apos;re all caught up.
+        </div>
+        <div className="border-t border-border" />
+        <FooterLink />
+      </div>
+    );
+  }
+
+  // Cap at 10 — the popover never shows more than the latest 10. The
+  // bell already requests limit=10 from the backend, so this slice is
+  // a belt-and-braces guard against a future caller passing more.
+  const visible = items.slice(0, 10);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Notifications"
+      className="absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-border bg-surface shadow-xl"
+    >
+      <div className="px-4 py-3 text-sm font-medium text-text-primary">
+        Notifications
+      </div>
+      <div className="border-t border-border" />
+      <ul className="max-h-96 overflow-y-auto" data-testid="notification-list">
+        {visible.map((notif) => (
+          <li
+            key={notif.id}
+            className={
+              "border-b border-border last:border-b-0 " +
+              (notif.read_at === null ? "bg-surface" : "bg-surface-raised/40")
+            }
+          >
+            <button
+              type="button"
+              onClick={() => handleRowClick(notif)}
+              className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-accent"
+            >
+              <span
+                aria-hidden="true"
+                data-testid={`severity-dot-${notif.category}`}
+                className={
+                  "mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full " +
+                  SEVERITY_DOT[notif.category]
+                }
+              />
+              <span className="flex-1 min-w-0">
+                <span className="flex items-baseline justify-between gap-2">
+                  <span
+                    className={
+                      "block truncate text-sm " +
+                      (notif.read_at === null
+                        ? "font-medium text-text-primary"
+                        : "text-text-secondary")
+                    }
+                  >
+                    {notif.title}
+                  </span>
+                  <span className="shrink-0 text-xs text-text-muted">
+                    {timeAgo(notif.created_at)}
+                  </span>
+                </span>
+                <span className="mt-0.5 block line-clamp-2 text-xs text-text-muted">
+                  {notif.body}
+                </span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="border-t border-border" />
+      <FooterLink />
+    </div>
+  );
+}
+
+function FooterLink() {
+  // The full inbox page (/settings/notifications) lands in PR5. Until
+  // then we render the link as a disabled-looking element so we don't
+  // ship a 404 anchor. When PR5 lands, swap this for a real <Link />.
+  return (
+    <div className="px-4 py-2 text-center text-xs text-text-muted">
+      <span aria-disabled="true" title="Available in a future update">
+        View all (coming soon)
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/notifications/NotificationPopover.tsx
+++ b/frontend/components/notifications/NotificationPopover.tsx
@@ -41,7 +41,7 @@ interface Props {
 }
 
 const SEVERITY_DOT: Record<NotificationCategory, string> = {
-  security: "bg-red-500",
+  security: "bg-danger",
   account: "bg-text-muted",
   org_admin: "bg-text-muted",
   org_activity: "bg-text-muted/40",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -725,3 +725,35 @@ export interface AdminSubscriptionKPIs {
   mock_revenue: boolean;
   generated_at: string;
 }
+
+// ── Notifications (PR3 of notification train) ──────────────────────
+//
+// Mirrors backend/app/schemas/notification.py. Four categories map to
+// preference toggles; ``security`` is force-on per architect lock.
+// ``link_url`` is a relative app path, ``audit_event_id`` is the
+// forensic correlation back to the audit row that triggered the
+// notification (nullable — not every dispatch has an audit row).
+
+export type NotificationCategory =
+  | "security"
+  | "account"
+  | "org_admin"
+  | "org_activity";
+
+export interface Notification {
+  id: number;
+  category: NotificationCategory;
+  event_type: string;
+  title: string;
+  body: string;
+  link_url: string | null;
+  seen_at: string | null;
+  read_at: string | null;
+  audit_event_id: number | null;
+  created_at: string;
+}
+
+export interface NotificationListResponse {
+  items: Notification[];
+  next_cursor: string | null;
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -757,3 +757,7 @@ export interface NotificationListResponse {
   items: Notification[];
   next_cursor: string | null;
 }
+
+export interface NotificationUnseenCountResponse {
+  count: number;
+}

--- a/frontend/tests/components/notifications/appshell-bell-wire.test.tsx
+++ b/frontend/tests/components/notifications/appshell-bell-wire.test.tsx
@@ -1,0 +1,120 @@
+import { act, render, screen } from "@testing-library/react";
+
+// THIS file exercises the real NotificationBell inside AppShell to
+// pin that the bell mounts in the header row when the user is
+// authenticated. vitest.setup.ts globally stubs the bell to no-op so
+// other AppShell tests don't trip on its /api/v1/notifications
+// fetch; we unmock here.
+vi.unmock("@/components/notifications/NotificationBell");
+
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/dashboard",
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiFetch: vi.fn(async () => ({ items: [], next_cursor: null })),
+  };
+});
+
+const BASE_USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@example.com",
+  first_name: "Alice",
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+function mockAuth(user: Record<string, unknown> | null, loading = false) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: user as never,
+    loading,
+    needsSetup: false,
+    billingUiEnabled: true,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+describe("AppShell — notification bell wire (PR3 of notif train)", () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReset();
+  });
+
+  it("renders the bell when the user is authenticated", async () => {
+    mockAuth(BASE_USER);
+    await act(async () => {
+      render(
+        <AppShell>
+          <p>page body</p>
+        </AppShell>,
+      );
+    });
+    expect(screen.getByTestId("notification-bell")).toBeInTheDocument();
+  });
+
+  it("does not render the bell when the user is anonymous", async () => {
+    // loading=false + user=null is the "redirect to /login" branch
+    // — AppShell renders the bare spinner / loading shell. The bell
+    // must not appear because the entire authed chrome subtree is
+    // gated on `user`.
+    mockAuth(null);
+    await act(async () => {
+      render(
+        <AppShell>
+          <p>page body</p>
+        </AppShell>,
+      );
+    });
+    expect(screen.queryByTestId("notification-bell")).toBeNull();
+  });
+
+  it("does not collide with the existing Plans / Reports nav entries", async () => {
+    mockAuth(BASE_USER);
+    await act(async () => {
+      render(
+        <AppShell>
+          <p>page body</p>
+        </AppShell>,
+      );
+    });
+    // Sidebar nav links remain present alongside the bell — pin
+    // that the new icon doesn't displace existing routes.
+    expect(screen.getByTestId("notification-bell")).toBeInTheDocument();
+    // The sidebar nav uses Link elements; just check a couple of
+    // known nav anchors are still in the document.
+    expect(screen.getByRole("link", { name: /^docs$/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/notifications/notification-bell.test.tsx
+++ b/frontend/tests/components/notifications/notification-bell.test.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+// vitest.setup.ts mocks ``@/components/notifications/NotificationBell``
+// globally so AppShell-mounting page tests don't trip on the
+// /api/v1/notifications poll. THIS file needs the real component.
+vi.unmock("@/components/notifications/NotificationBell");
+
+import NotificationBell from "@/components/notifications/NotificationBell";
+import { apiFetch } from "@/lib/api";
+import type { Notification } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>(
+    "@/lib/api",
+  );
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/dashboard",
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function mkNotification(
+  id: number,
+  overrides: Partial<Notification> = {},
+): Notification {
+  return {
+    id,
+    category: "security",
+    event_type: "user.password.changed",
+    title: `Notification ${id}`,
+    body: "Body text",
+    link_url: "/settings/security",
+    seen_at: null,
+    read_at: null,
+    audit_event_id: 100 + id,
+    created_at: "2026-05-22T17:00:00",
+    ...overrides,
+  };
+}
+
+function renderBell() {
+  return render(
+    // Disable de-duping cache so each test gets a clean slate of
+    // SWR state — without this, the in-memory cache from a prior
+    // test bleeds into the next render and the mocked apiFetch is
+    // never re-invoked.
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <NotificationBell />
+    </SWRConfig>,
+  );
+}
+
+describe("NotificationBell", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("renders without a badge when there are no unseen items", async () => {
+    mockedApiFetch.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    await act(async () => {
+      renderBell();
+    });
+
+    // Bell button is present.
+    expect(
+      screen.getByRole("button", { name: /notifications/i }),
+    ).toBeInTheDocument();
+    // No badge.
+    expect(screen.queryByTestId("notification-badge")).toBeNull();
+  });
+
+  it("renders a numeric badge when there are unseen items", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      items: [mkNotification(1), mkNotification(2), mkNotification(3)],
+      next_cursor: null,
+    });
+
+    await act(async () => {
+      renderBell();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notification-badge")).toHaveTextContent("3");
+    });
+    // aria-label reflects the unseen count.
+    expect(
+      screen.getByRole("button", { name: /notifications, 3 unseen/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("caps the badge label at 99+ above the threshold", async () => {
+    const many = Array.from({ length: 120 }, (_, i) => mkNotification(i + 1));
+    mockedApiFetch.mockResolvedValueOnce({ items: many, next_cursor: null });
+
+    await act(async () => {
+      renderBell();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notification-badge")).toHaveTextContent(
+        "99+",
+      );
+    });
+  });
+
+  it("does not show a badge for items that are already seen", async () => {
+    mockedApiFetch.mockResolvedValueOnce({
+      items: [
+        mkNotification(1, { seen_at: "2026-05-22T17:01:00" }),
+        mkNotification(2, { seen_at: "2026-05-22T17:01:00" }),
+      ],
+      next_cursor: null,
+    });
+
+    await act(async () => {
+      renderBell();
+    });
+
+    await waitFor(() => {
+      // List has data, but every row is seen → no badge.
+      expect(screen.queryByTestId("notification-badge")).toBeNull();
+    });
+  });
+
+  it("opens the popover on click and fires mark-seen", async () => {
+    // First call: initial fetch.
+    mockedApiFetch.mockResolvedValueOnce({
+      items: [mkNotification(1)],
+      next_cursor: null,
+    });
+    // Second call: POST /mark-seen returns void.
+    mockedApiFetch.mockResolvedValueOnce(undefined);
+    // Third call: mutate() triggers a refetch.
+    mockedApiFetch.mockResolvedValueOnce({
+      items: [mkNotification(1, { seen_at: "2026-05-22T17:02:00" })],
+      next_cursor: null,
+    });
+
+    await act(async () => {
+      renderBell();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notification-badge")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("notification-bell"));
+    });
+
+    // Popover dialog appears.
+    expect(
+      screen.getByRole("dialog", { name: /notifications/i }),
+    ).toBeInTheDocument();
+    // mark-seen POST was fired.
+    const calls = mockedApiFetch.mock.calls;
+    const markSeenCall = calls.find(
+      ([url, opts]) =>
+        typeof url === "string" &&
+        url.endsWith("/api/v1/notifications/mark-seen") &&
+        (opts as RequestInit | undefined)?.method === "POST",
+    );
+    expect(markSeenCall).toBeDefined();
+  });
+});

--- a/frontend/tests/components/notifications/notification-bell.test.tsx
+++ b/frontend/tests/components/notifications/notification-bell.test.tsx
@@ -62,13 +62,51 @@ function renderBell() {
   );
 }
 
+/**
+ * URL-aware default mock for apiFetch.
+ *
+ * The bell now fires two separate GETs on mount — the unseen-count
+ * endpoint backs the badge, the list endpoint backs the popover
+ * preview — plus a POST mark-seen on open. Routing by URL makes the
+ * tests resilient to call ordering across SWR's two concurrent
+ * fetches.
+ */
+function installRouteMock({
+  count = 0,
+  items = [] as Notification[],
+}: { count?: number; items?: Notification[] }): void {
+  mockedApiFetch.mockImplementation((path: string, opts?: RequestInit) => {
+    if (
+      typeof path === "string" &&
+      path.endsWith("/api/v1/notifications/unseen-count")
+    ) {
+      return Promise.resolve({ count });
+    }
+    if (
+      typeof path === "string" &&
+      path.endsWith("/api/v1/notifications/mark-seen") &&
+      opts?.method === "POST"
+    ) {
+      return Promise.resolve(undefined);
+    }
+    if (
+      typeof path === "string" &&
+      path.startsWith("/api/v1/notifications") &&
+      (!opts || opts.method === undefined || opts.method === "GET")
+    ) {
+      return Promise.resolve({ items, next_cursor: null });
+    }
+    return Promise.resolve(undefined);
+  });
+}
+
 describe("NotificationBell", () => {
   beforeEach(() => {
     mockedApiFetch.mockReset();
   });
 
-  it("renders without a badge when there are no unseen items", async () => {
-    mockedApiFetch.mockResolvedValueOnce({ items: [], next_cursor: null });
+  it("renders without a badge when the unseen count is zero", async () => {
+    installRouteMock({ count: 0, items: [] });
 
     await act(async () => {
       renderBell();
@@ -82,10 +120,10 @@ describe("NotificationBell", () => {
     expect(screen.queryByTestId("notification-badge")).toBeNull();
   });
 
-  it("renders a numeric badge when there are unseen items", async () => {
-    mockedApiFetch.mockResolvedValueOnce({
+  it("renders a numeric badge from the unseen-count endpoint", async () => {
+    installRouteMock({
+      count: 3,
       items: [mkNotification(1), mkNotification(2), mkNotification(3)],
-      next_cursor: null,
     });
 
     await act(async () => {
@@ -102,8 +140,10 @@ describe("NotificationBell", () => {
   });
 
   it("caps the badge label at 99+ above the threshold", async () => {
-    const many = Array.from({ length: 120 }, (_, i) => mkNotification(i + 1));
-    mockedApiFetch.mockResolvedValueOnce({ items: many, next_cursor: null });
+    // The count endpoint returns 120 — well above the list limit of
+    // 10. The bell must still display 99+ from the count, not be
+    // capped by the list size.
+    installRouteMock({ count: 120, items: [] });
 
     await act(async () => {
       renderBell();
@@ -116,13 +156,13 @@ describe("NotificationBell", () => {
     });
   });
 
-  it("does not show a badge for items that are already seen", async () => {
-    mockedApiFetch.mockResolvedValueOnce({
+  it("does not show a badge when the count is zero even with seen items in the list", async () => {
+    installRouteMock({
+      count: 0,
       items: [
         mkNotification(1, { seen_at: "2026-05-22T17:01:00" }),
         mkNotification(2, { seen_at: "2026-05-22T17:01:00" }),
       ],
-      next_cursor: null,
     });
 
     await act(async () => {
@@ -130,23 +170,14 @@ describe("NotificationBell", () => {
     });
 
     await waitFor(() => {
-      // List has data, but every row is seen → no badge.
       expect(screen.queryByTestId("notification-badge")).toBeNull();
     });
   });
 
   it("opens the popover on click and fires mark-seen", async () => {
-    // First call: initial fetch.
-    mockedApiFetch.mockResolvedValueOnce({
+    installRouteMock({
+      count: 1,
       items: [mkNotification(1)],
-      next_cursor: null,
-    });
-    // Second call: POST /mark-seen returns void.
-    mockedApiFetch.mockResolvedValueOnce(undefined);
-    // Third call: mutate() triggers a refetch.
-    mockedApiFetch.mockResolvedValueOnce({
-      items: [mkNotification(1, { seen_at: "2026-05-22T17:02:00" })],
-      next_cursor: null,
     });
 
     await act(async () => {

--- a/frontend/tests/components/notifications/notification-popover.test.tsx
+++ b/frontend/tests/components/notifications/notification-popover.test.tsx
@@ -87,12 +87,12 @@ describe("NotificationPopover", () => {
         onClose={() => {}}
       />,
     );
-    // Security dot uses a red class; the other three use neutral
-    // / muted classes. Class-based assertions match the
+    // Security dot uses the danger token; the other three use
+    // neutral / muted classes. Class-based assertions match the
     // SEVERITY_DOT mapping in the component.
     expect(
       screen.getByTestId("severity-dot-security").className,
-    ).toContain("bg-red-500");
+    ).toContain("bg-danger");
     expect(
       screen.getByTestId("severity-dot-account").className,
     ).toContain("bg-text-muted");

--- a/frontend/tests/components/notifications/notification-popover.test.tsx
+++ b/frontend/tests/components/notifications/notification-popover.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+
+import NotificationPopover from "@/components/notifications/NotificationPopover";
+import { apiFetch } from "@/lib/api";
+import type { Notification } from "@/lib/types";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>(
+    "@/lib/api",
+  );
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function mkNotification(
+  id: number,
+  overrides: Partial<Notification> = {},
+): Notification {
+  return {
+    id,
+    category: "security",
+    event_type: "user.password.changed",
+    title: `Notification ${id}`,
+    body: `Body for ${id}`,
+    link_url: "/settings/security",
+    seen_at: null,
+    read_at: null,
+    audit_event_id: 100 + id,
+    created_at: "2026-05-22T17:00:00",
+    ...overrides,
+  };
+}
+
+describe("NotificationPopover", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    pushMock.mockReset();
+  });
+
+  it("renders an empty-state message when there are no items", () => {
+    render(
+      <NotificationPopover
+        items={[]}
+        onAfterReadChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(/you'?re all caught up/i),
+    ).toBeInTheDocument();
+  });
+
+  it("caps the list to 10 rows even when more are passed", () => {
+    const many = Array.from({ length: 15 }, (_, i) =>
+      mkNotification(i + 1, { title: `Row ${i + 1}` }),
+    );
+    render(
+      <NotificationPopover
+        items={many}
+        onAfterReadChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const list = screen.getByTestId("notification-list");
+    const rows = within(list).getAllByRole("button");
+    expect(rows).toHaveLength(10);
+  });
+
+  it("renders severity dots that vary by category", () => {
+    const items = [
+      mkNotification(1, { category: "security" }),
+      mkNotification(2, { category: "account" }),
+      mkNotification(3, { category: "org_admin" }),
+      mkNotification(4, { category: "org_activity" }),
+    ];
+    render(
+      <NotificationPopover
+        items={items}
+        onAfterReadChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // Security dot uses a red class; the other three use neutral
+    // / muted classes. Class-based assertions match the
+    // SEVERITY_DOT mapping in the component.
+    expect(
+      screen.getByTestId("severity-dot-security").className,
+    ).toContain("bg-red-500");
+    expect(
+      screen.getByTestId("severity-dot-account").className,
+    ).toContain("bg-text-muted");
+    expect(
+      screen.getByTestId("severity-dot-org_admin").className,
+    ).toContain("bg-text-muted");
+    expect(
+      screen.getByTestId("severity-dot-org_activity").className,
+    ).toContain("bg-text-muted/40");
+  });
+
+  it("marks a row read and navigates on click", async () => {
+    mockedApiFetch.mockResolvedValueOnce(mkNotification(1, { read_at: "2026-05-22T17:05:00" }));
+
+    const onAfterReadChange = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <NotificationPopover
+        items={[mkNotification(1, { link_url: "/settings/security" })]}
+        onAfterReadChange={onAfterReadChange}
+        onClose={onClose}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /notification 1/i });
+    await act(async () => {
+      fireEvent.click(row);
+    });
+
+    // PATCH /api/v1/notifications/1 with {read: true}
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/notifications/1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ read: true }),
+      }),
+    );
+    // Navigated to link_url.
+    expect(pushMock).toHaveBeenCalledWith("/settings/security");
+    // Closed.
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not crash when a row has no link_url", async () => {
+    mockedApiFetch.mockResolvedValueOnce(mkNotification(2));
+
+    const onClose = vi.fn();
+    render(
+      <NotificationPopover
+        items={[mkNotification(2, { link_url: null })]}
+        onAfterReadChange={() => {}}
+        onClose={onClose}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /notification 2/i }));
+    });
+
+    // No router.push because link_url was null.
+    expect(pushMock).not.toHaveBeenCalled();
+    // Popover still closes.
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -36,3 +36,21 @@ vi.mock("@/components/announcements/AnnouncementBar", () => ({
   __esModule: true,
   default: () => null,
 }));
+
+// Global stub for the notification bell.
+//
+// Same reasoning as the AnnouncementBar stub above: ``NotificationBell``
+// is mounted unconditionally in the ``AppShell`` header row and on
+// every page render it fires ``GET /api/v1/notifications?limit=10``
+// via SWR. That polls every 60s and refetches on focus, so without a
+// global stub every page test must add a no-op handler for that URL
+// to keep ad-hoc ``mockResolvedValueOnce`` queues honest.
+//
+// Tests that exercise the bell itself live in
+// ``tests/components/notifications/notification-bell.test.tsx`` and
+// import the component directly — they call ``vi.unmock`` to restore
+// the real module before their own ``vi.mock`` declaration.
+vi.mock("@/components/notifications/NotificationBell", () => ({
+  __esModule: true,
+  default: () => null,
+}));


### PR DESCRIPTION
## Summary

PR3 of the notification train. PR1 (#342) shipped the substrate; PR2 (#347) added audit_events writes; PR3 wires `dispatch_notification` at those same 5 call sites and brings the bell icon + popover online.

No email sending here (that's PR5 with Mailgun). No `/settings/notifications` UI here (also PR5).

### Backend hooks (5 sites, all post-audit-commit)

| Route | event_type | Category | Recipient |
|---|---|---|---|
| `POST /users/me/password` | `user.password.changed` | security (force-on) | actor (self) |
| `POST /auth/mfa/enable` | `user.mfa.enabled` | security | actor (self) |
| `POST /auth/mfa/disable` | `user.mfa.disabled` | security | actor (self) |
| `PUT /users/me` (email change branch) | `user.email.changed` | security | actor (self) |
| `PUT /admin/orgs/{id}/subscription` (plan_id change branch) | `admin.org.plan.changed` | org_admin | OWNER+ADMIN fanout |

Each dispatch fires AFTER `await db.commit()` on the audit row and carries `audit_event_id` for PR4's forensic correlation. If the audit write fails (returns None), the notification is skipped (architect-locked ordering).

### Service-layer additions

- `dispatch_notification` now consults `user_notification_preferences.in_app_*` for account / org_admin / org_activity categories. Skipped writes emit `notification.skipped_by_pref`. Security category is force-on (architect lock) and always writes.
- `dispatch_notification_to_org_admins(db, *, org_id, ...)` — single SELECT for OWNER+ADMIN of an org, then per-user dispatch. Per-user failures are logged + swallowed (best-effort fanout); a poison row cannot poison the broadcast.
- `notification_templates.py` — copy builders for the 5 hook events. Hardcoded English; i18n is a future refactor that swaps these functions out, not the call sites.
- `record_audit_event` now returns the new row's id on success (or None on failure). Existing callers ignore the return value; new ones key off it.

### Frontend

- `NotificationBell.tsx` — header icon with SWR-polled count (60s + revalidateOnFocus). Badge caps at "99+". Bell vs BellRing icon. Click opens popover and fires `POST /mark-seen`.
- `NotificationPopover.tsx` — 10-row max list, severity dot (security = red, others = neutral/muted), click row marks read + navigates to `link_url` + closes. Empty state copy "You're all caught up.". The "View all" footer link is rendered as a disabled-looking label until PR5 lands `/settings/notifications`.
- AppShell wire — bell in the header flex row beside docs link / theme toggle (architect-locked position; NOT TrialBanner slot). The existing `loading || !user` gate already drops the entire chrome subtree for anonymous users, so the bell inherits the same gate.
- `vitest.setup.ts` — global no-op stub for NotificationBell so AppShell-mounting page tests don't trip on the poll. Bell-specific tests `vi.unmock` to exercise the real component.

### Cross-team handoff

- #347 wrote the audit rows; PR3 keys off them.
- PR4 will add plan-change `link_url` gating on `BILLING_UI_ENABLED` (G9 in 2nd-arch delta).
- PR5 adds email dispatch (`send_notification_email`) + `/settings/notifications` page.