### PR TITLE
feat(ai): embed + structured (retry cap) + function_call + stream capabilities (PR3 of AI tier train)

### DIFF
--- a/backend/alembic/versions/059_ai_usage_retries_used.py
+++ b/backend/alembic/versions/059_ai_usage_retries_used.py
@@ -1,0 +1,49 @@
+"""AI usage ledger: add retries_used column (PR3 of AI tier train).
+
+Revision ID: 059_ai_usage_retries_used
+Revises: 058_ai_usage_ledger
+Create Date: 2026-05-22
+
+Architect lock #13 for ``StructuredOutputCapable`` caps retries at 2
+on JSON parse / schema-validation failure (3 total attempts) before
+``STATUS_ERROR_STRUCTURED_OUTPUT``. Ops needs the per-row count so a
+forensic query like
+
+  SELECT feature_key, AVG(retries_used)
+  FROM ai_usage_ledger
+  WHERE model = 'ollama-llama3'
+  GROUP BY feature_key;
+
+surfaces a model whose structured output is borderline-failing — that
+warning has to land before the cap eats meaningful budget.
+
+The column is NOT NULL with a server_default of 0 so historical rows
+(chat / embed / stream that have no retry concept) keep the
+sentinel 0. Only ``call_llm_structured`` writes a non-zero value.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "059_ai_usage_retries_used"
+down_revision = "058_ai_usage_ledger"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ai_usage_ledger",
+        sa.Column(
+            "retries_used",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ai_usage_ledger", "retries_used")

--- a/backend/app/models/ai_usage_ledger.py
+++ b/backend/app/models/ai_usage_ledger.py
@@ -110,3 +110,8 @@ class AIUsageLedger(Base):
     error_class: Mapped[Optional[str]] = mapped_column(
         String(120), nullable=True
     )
+    # PR3: structured-output retry budget counter (0/1/2). Stays 0 for
+    # every non-structured row (chat, embed, function_call, stream).
+    retries_used: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -1035,8 +1035,15 @@ async def call_llm_structured(
     attempt_messages = list(messages)
 
     start = time.perf_counter()
-    last_response: Optional[LLMResponse] = None
     last_error: Optional[str] = None
+    # Aggregate token spend across every attempt that successfully
+    # returned from the adapter. The ledger row written at the end
+    # (success or exhaustion) reflects the cumulative cost of THIS
+    # ``call_llm_structured`` invocation, so cap accounting captures
+    # tokens billed by intermediate retries that the previous
+    # last-attempt-only ledger row silently dropped.
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
 
     for attempt in range(STRUCTURED_OUTPUT_MAX_RETRIES + 1):
         try:
@@ -1061,15 +1068,24 @@ async def call_llm_structured(
                 if isinstance(exc, AIProviderError)
                 else "capability_not_supported"
             )
+            # Bill any tokens already consumed by previous attempts
+            # before the adapter raised; first-attempt failures
+            # naturally land at zero because no successful response
+            # ever returned.
+            cost = estimate_cost_cents(
+                model=prepared.model,
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_completion_tokens,
+            )
             await _write_ledger_row(
                 db,
                 org_id=org_id,
                 credential_id=prepared.credential_id,
                 feature_key=feature_key,
                 model=prepared.model,
-                prompt_tokens=0,
-                completion_tokens=0,
-                est_cost_cents_value=0,
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_completion_tokens,
+                est_cost_cents_value=cost,
                 latency_ms=latency_ms,
                 success=False,
                 error_class=error_code,
@@ -1084,7 +1100,11 @@ async def call_llm_structured(
             )
             raise AIDispatchFailed(error_code) from None
 
-        last_response = response
+        # Successful provider call — its tokens count regardless of
+        # whether downstream JSON parse / schema validation passes.
+        total_prompt_tokens += response.prompt_tokens
+        total_completion_tokens += response.completion_tokens
+
         try:
             parsed = json.loads(response.content)
         except (TypeError, ValueError) as exc:
@@ -1096,8 +1116,8 @@ async def call_llm_structured(
             latency_ms = int((time.perf_counter() - start) * 1000)
             cost = estimate_cost_cents(
                 model=prepared.model,
-                prompt_tokens=response.prompt_tokens,
-                completion_tokens=response.completion_tokens,
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_completion_tokens,
             )
             ledger = await _write_ledger_row(
                 db,
@@ -1105,8 +1125,8 @@ async def call_llm_structured(
                 credential_id=prepared.credential_id,
                 feature_key=feature_key,
                 model=prepared.model,
-                prompt_tokens=response.prompt_tokens,
-                completion_tokens=response.completion_tokens,
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_completion_tokens,
                 est_cost_cents_value=cost,
                 latency_ms=latency_ms,
                 success=True,
@@ -1127,6 +1147,8 @@ async def call_llm_structured(
                 feature_key=feature_key,
                 retries_used=attempt,
                 ledger_id=ledger.id,
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_completion_tokens,
             )
             asyncio.create_task(  # noqa: RUF006
                 _touch_last_used(prepared.credential_pk_id)
@@ -1135,8 +1157,8 @@ async def call_llm_structured(
                 response=StructuredResponse(
                     parsed=parsed,
                     raw_text=response.content,
-                    prompt_tokens=response.prompt_tokens,
-                    completion_tokens=response.completion_tokens,
+                    prompt_tokens=total_prompt_tokens,
+                    completion_tokens=total_completion_tokens,
                     model=response.model,
                     retries_used=attempt,
                 ),
@@ -1146,17 +1168,13 @@ async def call_llm_structured(
             last_error = f"schema:{err}"
             attempt_messages = attempt_messages + [retry_message]
 
-    # Exhausted retries.
+    # Exhausted retries. Bill the SUM of tokens consumed across all
+    # attempts so the cap accounting reflects real spend.
     latency_ms = int((time.perf_counter() - start) * 1000)
-    # Bill tokens from the LAST attempt so the cap accounting reflects
-    # actual spend; zeroing-out on the typed failure would under-count
-    # and let unbounded retry-forever patterns slip past the cap.
-    prompt_tokens = last_response.prompt_tokens if last_response else 0
-    completion_tokens = last_response.completion_tokens if last_response else 0
     cost = estimate_cost_cents(
         model=prepared.model,
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
+        prompt_tokens=total_prompt_tokens,
+        completion_tokens=total_completion_tokens,
     )
     ledger = await _write_ledger_row(
         db,
@@ -1164,8 +1182,8 @@ async def call_llm_structured(
         credential_id=prepared.credential_id,
         feature_key=feature_key,
         model=prepared.model,
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
+        prompt_tokens=total_prompt_tokens,
+        completion_tokens=total_completion_tokens,
         est_cost_cents_value=cost,
         latency_ms=latency_ms,
         success=False,
@@ -1187,6 +1205,8 @@ async def call_llm_structured(
         retries_used=STRUCTURED_OUTPUT_MAX_RETRIES,
         last_error=last_error,
         ledger_id=ledger.id,
+        prompt_tokens=total_prompt_tokens,
+        completion_tokens=total_completion_tokens,
     )
     raise StructuredOutputError("STATUS_ERROR_STRUCTURED_OUTPUT")
 

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -61,10 +61,12 @@ adding ops signal. Hard-cap events are surfaced via the structlog
 from __future__ import annotations
 
 import asyncio
+import json
 import time
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
 
 import structlog
 from fastapi import HTTPException, status
@@ -82,11 +84,25 @@ from app.services.ai_credential_crypto import decrypt
 from app.services.ai_pricing import estimate_cost_cents
 from app.services.ai_providers import (
     AIProviderError,
+    CapabilityNotSupported,
+    EmbedResponse,
+    FunctionCallResponse,
     LLMResponse,
     NativeNotAvailable,
+    StreamChunk,
+    StructuredOutputError,
+    StructuredResponse,
+    TokenUsage,
     get_adapter,
 )
 from app.services.notification_templates import ai_cap_soft_warning
+
+
+# Architect lock #13 (StructuredOutputCapable retry cap): max 2 retries
+# on JSON parse / schema-validation failure (3 total attempts) before
+# ``STATUS_ERROR_STRUCTURED_OUTPUT``. The counter lives at the SERVICE
+# level (not the adapter) — each adapter emits a single response.
+STRUCTURED_OUTPUT_MAX_RETRIES = 2
 
 
 logger = structlog.stdlib.get_logger()
@@ -138,6 +154,24 @@ class AIDispatchFailed(AIDispatchError):
         super().__init__(code)
 
 
+class AICapabilityNotSupported(AIDispatchError):
+    """The credential resolved by routing does not advertise the
+    requested capability in its ``discovered_capabilities``. Maps to
+    HTTP 412 ``ai_capability_not_supported``. Caller is expected to
+    surface a "reconfigure routing" hint to the user.
+
+    Distinct from ``CapabilityNotSupported`` (adapter-level — raised
+    when the wire-call itself isn't honored, e.g. Ollama function
+    calling on a non-tool model). This dispatch-level error fires
+    BEFORE the adapter call.
+    """
+
+    def __init__(self, *, capability: str, feature_key: str) -> None:
+        super().__init__("ai_capability_not_supported")
+        self.capability = capability
+        self.feature_key = feature_key
+
+
 # --- HTTPException mappers ------------------------------------------
 
 
@@ -154,6 +188,20 @@ def http_for_dispatch_error(exc: AIDispatchError) -> HTTPException:
         return HTTPException(
             status_code=status.HTTP_412_PRECONDITION_FAILED,
             detail={"code": exc.code},
+        )
+    if isinstance(exc, AICapabilityNotSupported):
+        return HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={
+                "code": exc.code,
+                "capability": exc.capability,
+                "feature_key": exc.feature_key,
+                "message": (
+                    f"Configured credential for {exc.feature_key} does not "
+                    f"support {exc.capability}. Reconfigure routing to use "
+                    "a provider that supports it."
+                ),
+            },
         )
     if isinstance(exc, AICapExceeded):
         return HTTPException(
@@ -439,6 +487,7 @@ async def _write_ledger_row(
     latency_ms: int,
     success: bool,
     error_class: Optional[str],
+    retries_used: int = 0,
 ) -> AIUsageLedger:
     row = AIUsageLedger(
         org_id=org_id,
@@ -452,6 +501,7 @@ async def _write_ledger_row(
         latency_ms=latency_ms,
         success=success,
         error_class=error_class,
+        retries_used=retries_used,
         dispatched_at=datetime.now(timezone.utc).replace(tzinfo=None),
     )
     db.add(row)
@@ -730,3 +780,753 @@ async def _touch_last_used(credential_id: int) -> None:  # pragma: no cover
     """
     _ = credential_id
     return
+
+
+# ----------------------------------------------------------------------
+# PR3 capability dispatch wrappers
+# ----------------------------------------------------------------------
+#
+# The chat path (``call_llm``) above stays unchanged. The PR3 wrappers
+# share a ``_prepare_dispatch`` helper that handles routing,
+# credential decryption, adapter construction, the capability check,
+# and the cap pre-check. Each wrapper then dispatches the adapter
+# method, writes the ledger row, and applies its capability-specific
+# post-processing (retry budget for structured output, end-of-stream
+# ledger write for streams, etc.).
+
+
+@dataclass(frozen=True)
+class _PreparedDispatch:
+    """Output of ``_prepare_dispatch``.
+
+    Carries everything ``call_llm_*`` wrappers need to talk to the
+    adapter and write the ledger row at the end.
+    """
+
+    adapter: Any
+    credential_id: int
+    credential_pk_id: int
+    model: str
+    resolved: _ResolvedCaps
+    cost_so_far: int
+
+
+async def _prepare_dispatch(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    capability: str,
+) -> _PreparedDispatch:
+    """Resolve routing + credential + caps for one dispatch.
+
+    Raises ``NoRoutingConfigured``, ``AICapExceeded``, or
+    ``AICapabilityNotSupported`` before the adapter is built. The
+    capability check uses ``discovered_capabilities`` on the
+    credential row (populated by the validate() probe) — if the
+    credential doesn't list the capability we refuse with a 412 so
+    the caller routes to a different provider.
+    """
+    routing = await ai_routing_service.get_routing_for_feature(
+        db, org_id=org_id, feature_name=feature_key
+    )
+    if routing is None:
+        logger.info(
+            "ai.dispatch.routing.missing",
+            org_id=org_id,
+            feature_key=feature_key,
+            capability=capability,
+        )
+        raise NoRoutingConfigured()
+    credential_id, model = routing
+
+    cred = (
+        await db.execute(
+            select(OrgAICredential).where(
+                OrgAICredential.id == credential_id,
+                OrgAICredential.org_id == org_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if cred is None:
+        logger.error(
+            "ai.dispatch.routing.dangling",
+            org_id=org_id,
+            feature_key=feature_key,
+            credential_id=credential_id,
+            capability=capability,
+        )
+        raise NoRoutingConfigured()
+
+    # Capability check — credential must advertise the capability.
+    # ``chat`` is always allowed (the original call_llm path doesn't
+    # do this check for backcompat); other capabilities check the
+    # credential's ``discovered_capabilities`` array. An empty/None
+    # array on a legacy credential row falls through to "no
+    # capabilities known" → refuse so the user re-runs validate.
+    if capability != "chat":
+        capabilities = cred.discovered_capabilities or []
+        if capability not in capabilities:
+            logger.info(
+                "ai.dispatch.capability.unsupported",
+                org_id=org_id,
+                feature_key=feature_key,
+                capability=capability,
+                credential_id=credential_id,
+                discovered=capabilities,
+            )
+            raise AICapabilityNotSupported(
+                capability=capability, feature_key=feature_key
+            )
+
+    resolved = await _resolve_caps(
+        db, org_id=org_id, feature_key=feature_key
+    )
+    cost_so_far = await _aggregate_cost_cents(
+        db, org_id=org_id, since=_month_start()
+    )
+    if (
+        resolved.hard_cap_cents is not None
+        and cost_so_far >= resolved.hard_cap_cents
+    ):
+        logger.info(
+            "ai.dispatch.cap.exceeded",
+            org_id=org_id,
+            feature_key=feature_key,
+            capability=capability,
+            cost_so_far=cost_so_far,
+            hard_cap_cents=resolved.hard_cap_cents,
+        )
+        raise AICapExceeded()
+
+    await _maybe_warn_soft_cap(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        resolved=resolved,
+        cost_before_call=cost_so_far,
+        period=_current_period(),
+    )
+
+    api_key = decrypt(cred.encrypted_api_key)
+    bearer = (
+        decrypt(cred.encrypted_bearer_token)
+        if cred.encrypted_bearer_token
+        else None
+    )
+    adapter = get_adapter(
+        cred.provider,
+        api_key=api_key,
+        bearer_token=bearer,
+        base_url=cred.base_url,
+    )
+
+    return _PreparedDispatch(
+        adapter=adapter,
+        credential_id=credential_id,
+        credential_pk_id=cred.id,
+        model=model,
+        resolved=resolved,
+        cost_so_far=cost_so_far,
+    )
+
+
+async def _post_write_soft_cap_crossing(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    resolved: _ResolvedCaps,
+    cost_so_far: int,
+    cost_this_call: int,
+) -> None:
+    """Catch the call that takes usage from below to at-or-above the
+    soft cap (post-write check). Mirrors step 7 of ``call_llm``.
+    """
+    if (
+        resolved.soft_cap_cents is not None
+        and cost_so_far < resolved.soft_cap_cents <= cost_so_far + cost_this_call
+    ):
+        await _maybe_warn_soft_cap(
+            db,
+            org_id=org_id,
+            feature_key=feature_key,
+            resolved=resolved,
+            cost_before_call=cost_so_far + cost_this_call,
+            period=_current_period(),
+        )
+
+
+# --- Schema validation -------------------------------------------------
+
+
+def _validate_json_against_schema(data: Any, schema: dict) -> Optional[str]:
+    """Minimal JSON-schema check for structured-output validation.
+
+    Returns ``None`` on success, or a short error string on failure.
+    Only checks the schema's ``type`` ("object" or "array") and
+    ``required`` keys — feature surfaces that need richer validation
+    should pair this with a Pydantic model and re-validate after the
+    dispatch returns.
+
+    A full JSON Schema validator is a PR3-followup candidate; the
+    retry-cap contract only requires "parse failure or structural
+    failure triggers a retry", and required-keys is the structural
+    property feature surfaces care about today.
+    """
+    schema_type = schema.get("type")
+    if schema_type == "object":
+        if not isinstance(data, dict):
+            return "expected object"
+        required = schema.get("required") or []
+        for key in required:
+            if key not in data:
+                return f"missing required key {key!r}"
+    elif schema_type == "array" and not isinstance(data, list):
+        return "expected array"
+    return None
+
+
+# --- call_llm_structured ---------------------------------------------
+
+
+@dataclass(frozen=True)
+class StructuredDispatchResult:
+    response: StructuredResponse
+    ledger_id: int
+
+
+async def call_llm_structured(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    messages: list[dict],
+    response_schema: dict,
+    max_tokens: Optional[int] = None,
+) -> StructuredDispatchResult:
+    """Dispatch a structured-output call with the architect-locked
+    retry cap (max 2 retries, 3 total attempts).
+
+    Flow:
+    1. Resolve routing/credential/caps via ``_prepare_dispatch``.
+    2. Call the adapter's ``chat_structured`` up to 3 times. After a
+       JSON parse / schema-validation failure, append a system message
+       asking for a valid JSON object and try again.
+    3. On the third failure, write the failure ledger row with
+       ``retries_used=2`` and raise ``StructuredOutputError``.
+    4. On success, the ledger row carries ``retries_used`` = the
+       number of retries actually taken.
+    """
+    prepared = await _prepare_dispatch(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        capability="structured_output",
+    )
+
+    retry_message = {
+        "role": "system",
+        "content": (
+            "Previous response was not valid JSON matching the schema. "
+            "Output ONLY the JSON object."
+        ),
+    }
+    attempt_messages = list(messages)
+
+    start = time.perf_counter()
+    last_response: Optional[LLMResponse] = None
+    last_error: Optional[str] = None
+
+    for attempt in range(STRUCTURED_OUTPUT_MAX_RETRIES + 1):
+        try:
+            response: LLMResponse = await prepared.adapter.chat_structured(
+                model=prepared.model,
+                messages=attempt_messages,
+                schema=response_schema,
+                max_tokens=max_tokens,
+            )
+        except NativeNotAvailable:
+            logger.info(
+                "ai.dispatch.native.unavailable",
+                org_id=org_id,
+                feature_key=feature_key,
+                capability="structured_output",
+            )
+            raise
+        except (AIProviderError, CapabilityNotSupported) as exc:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            error_code = (
+                exc.code
+                if isinstance(exc, AIProviderError)
+                else "capability_not_supported"
+            )
+            await _write_ledger_row(
+                db,
+                org_id=org_id,
+                credential_id=prepared.credential_id,
+                feature_key=feature_key,
+                model=prepared.model,
+                prompt_tokens=0,
+                completion_tokens=0,
+                est_cost_cents_value=0,
+                latency_ms=latency_ms,
+                success=False,
+                error_class=error_code,
+                retries_used=attempt,
+            )
+            logger.info(
+                "ai.dispatch.structured.failed",
+                org_id=org_id,
+                feature_key=feature_key,
+                error_class=error_code,
+                latency_ms=latency_ms,
+            )
+            raise AIDispatchFailed(error_code) from None
+
+        last_response = response
+        try:
+            parsed = json.loads(response.content)
+        except (TypeError, ValueError) as exc:
+            last_error = f"json_decode:{type(exc).__name__}"
+            attempt_messages = attempt_messages + [retry_message]
+            continue
+        err = _validate_json_against_schema(parsed, response_schema)
+        if err is None:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            cost = estimate_cost_cents(
+                model=prepared.model,
+                prompt_tokens=response.prompt_tokens,
+                completion_tokens=response.completion_tokens,
+            )
+            ledger = await _write_ledger_row(
+                db,
+                org_id=org_id,
+                credential_id=prepared.credential_id,
+                feature_key=feature_key,
+                model=prepared.model,
+                prompt_tokens=response.prompt_tokens,
+                completion_tokens=response.completion_tokens,
+                est_cost_cents_value=cost,
+                latency_ms=latency_ms,
+                success=True,
+                error_class=None,
+                retries_used=attempt,
+            )
+            await _post_write_soft_cap_crossing(
+                db,
+                org_id=org_id,
+                feature_key=feature_key,
+                resolved=prepared.resolved,
+                cost_so_far=prepared.cost_so_far,
+                cost_this_call=cost,
+            )
+            logger.info(
+                "ai.dispatch.structured.success",
+                org_id=org_id,
+                feature_key=feature_key,
+                retries_used=attempt,
+                ledger_id=ledger.id,
+            )
+            asyncio.create_task(  # noqa: RUF006
+                _touch_last_used(prepared.credential_pk_id)
+            )
+            return StructuredDispatchResult(
+                response=StructuredResponse(
+                    parsed=parsed,
+                    raw_text=response.content,
+                    prompt_tokens=response.prompt_tokens,
+                    completion_tokens=response.completion_tokens,
+                    model=response.model,
+                    retries_used=attempt,
+                ),
+                ledger_id=ledger.id,
+            )
+        else:
+            last_error = f"schema:{err}"
+            attempt_messages = attempt_messages + [retry_message]
+
+    # Exhausted retries.
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    # Bill tokens from the LAST attempt so the cap accounting reflects
+    # actual spend; zeroing-out on the typed failure would under-count
+    # and let unbounded retry-forever patterns slip past the cap.
+    prompt_tokens = last_response.prompt_tokens if last_response else 0
+    completion_tokens = last_response.completion_tokens if last_response else 0
+    cost = estimate_cost_cents(
+        model=prepared.model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
+    ledger = await _write_ledger_row(
+        db,
+        org_id=org_id,
+        credential_id=prepared.credential_id,
+        feature_key=feature_key,
+        model=prepared.model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        est_cost_cents_value=cost,
+        latency_ms=latency_ms,
+        success=False,
+        error_class="STATUS_ERROR_STRUCTURED_OUTPUT",
+        retries_used=STRUCTURED_OUTPUT_MAX_RETRIES,
+    )
+    await _post_write_soft_cap_crossing(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        resolved=prepared.resolved,
+        cost_so_far=prepared.cost_so_far,
+        cost_this_call=cost,
+    )
+    logger.warning(
+        "ai.dispatch.structured.exhausted",
+        org_id=org_id,
+        feature_key=feature_key,
+        retries_used=STRUCTURED_OUTPUT_MAX_RETRIES,
+        last_error=last_error,
+        ledger_id=ledger.id,
+    )
+    raise StructuredOutputError("STATUS_ERROR_STRUCTURED_OUTPUT")
+
+
+# --- call_llm_embed --------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmbedDispatchResult:
+    response: EmbedResponse
+    ledger_id: int
+
+
+async def call_llm_embed(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    texts: list[str],
+    model: Optional[str] = None,
+) -> EmbedDispatchResult:
+    """Dispatch an embedding call through the cap + ledger chokepoint.
+
+    The routing row's ``model`` is the default embedding model; the
+    caller can override with the ``model`` kwarg if a feature surface
+    pins a specific model.
+    """
+    prepared = await _prepare_dispatch(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        capability="embed",
+    )
+    embed_model = model or prepared.model
+
+    start = time.perf_counter()
+    try:
+        response: EmbedResponse = await prepared.adapter.embed(
+            texts=texts, model=embed_model
+        )
+    except NativeNotAvailable:
+        raise
+    except NotImplementedError:
+        # Anthropic path — surface as a typed dispatch error and log a
+        # failure ledger row so the misconfiguration is visible.
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        await _write_ledger_row(
+            db,
+            org_id=org_id,
+            credential_id=prepared.credential_id,
+            feature_key=feature_key,
+            model=embed_model,
+            prompt_tokens=0,
+            completion_tokens=0,
+            est_cost_cents_value=0,
+            latency_ms=latency_ms,
+            success=False,
+            error_class="embed_not_implemented",
+        )
+        raise AIDispatchFailed("embed_not_implemented") from None
+    except AIProviderError as exc:
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        await _write_ledger_row(
+            db,
+            org_id=org_id,
+            credential_id=prepared.credential_id,
+            feature_key=feature_key,
+            model=embed_model,
+            prompt_tokens=0,
+            completion_tokens=0,
+            est_cost_cents_value=0,
+            latency_ms=latency_ms,
+            success=False,
+            error_class=exc.code,
+        )
+        raise AIDispatchFailed(exc.code) from None
+
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    cost = estimate_cost_cents(
+        model=response.model,
+        prompt_tokens=response.prompt_tokens,
+        completion_tokens=0,
+    )
+    ledger = await _write_ledger_row(
+        db,
+        org_id=org_id,
+        credential_id=prepared.credential_id,
+        feature_key=feature_key,
+        model=response.model,
+        prompt_tokens=response.prompt_tokens,
+        completion_tokens=0,
+        est_cost_cents_value=cost,
+        latency_ms=latency_ms,
+        success=True,
+        error_class=None,
+    )
+    await _post_write_soft_cap_crossing(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        resolved=prepared.resolved,
+        cost_so_far=prepared.cost_so_far,
+        cost_this_call=cost,
+    )
+    logger.info(
+        "ai.dispatch.embed.success",
+        org_id=org_id,
+        feature_key=feature_key,
+        model=response.model,
+        prompt_tokens=response.prompt_tokens,
+        ledger_id=ledger.id,
+    )
+    asyncio.create_task(_touch_last_used(prepared.credential_pk_id))  # noqa: RUF006
+    return EmbedDispatchResult(response=response, ledger_id=ledger.id)
+
+
+# --- call_llm_function -----------------------------------------------
+
+
+@dataclass(frozen=True)
+class FunctionCallDispatchResult:
+    response: FunctionCallResponse
+    ledger_id: int
+
+
+async def call_llm_function(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    messages: list[dict],
+    tools: list[dict],
+    max_tokens: Optional[int] = None,
+) -> FunctionCallDispatchResult:
+    """Dispatch a function-calling chat through the chokepoint."""
+    prepared = await _prepare_dispatch(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        capability="function_call",
+    )
+
+    start = time.perf_counter()
+    try:
+        response: FunctionCallResponse = await prepared.adapter.function_call(
+            model=prepared.model,
+            messages=messages,
+            tools=tools,
+            max_tokens=max_tokens,
+        )
+    except NativeNotAvailable:
+        raise
+    except CapabilityNotSupported as exc:
+        # Adapter-level (model-level) refusal — Ollama with a non-tool
+        # model. Surface as a dispatch-level 412 so the caller can
+        # reconfigure to a supported model.
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        await _write_ledger_row(
+            db,
+            org_id=org_id,
+            credential_id=prepared.credential_id,
+            feature_key=feature_key,
+            model=prepared.model,
+            prompt_tokens=0,
+            completion_tokens=0,
+            est_cost_cents_value=0,
+            latency_ms=latency_ms,
+            success=False,
+            error_class="capability_not_supported",
+        )
+        logger.info(
+            "ai.dispatch.function_call.model_unsupported",
+            org_id=org_id,
+            feature_key=feature_key,
+            model=exc.model,
+        )
+        raise AICapabilityNotSupported(
+            capability="function_call", feature_key=feature_key
+        ) from None
+    except AIProviderError as exc:
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        await _write_ledger_row(
+            db,
+            org_id=org_id,
+            credential_id=prepared.credential_id,
+            feature_key=feature_key,
+            model=prepared.model,
+            prompt_tokens=0,
+            completion_tokens=0,
+            est_cost_cents_value=0,
+            latency_ms=latency_ms,
+            success=False,
+            error_class=exc.code,
+        )
+        raise AIDispatchFailed(exc.code) from None
+
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    cost = estimate_cost_cents(
+        model=prepared.model,
+        prompt_tokens=response.prompt_tokens,
+        completion_tokens=response.completion_tokens,
+    )
+    ledger = await _write_ledger_row(
+        db,
+        org_id=org_id,
+        credential_id=prepared.credential_id,
+        feature_key=feature_key,
+        model=prepared.model,
+        prompt_tokens=response.prompt_tokens,
+        completion_tokens=response.completion_tokens,
+        est_cost_cents_value=cost,
+        latency_ms=latency_ms,
+        success=True,
+        error_class=None,
+    )
+    await _post_write_soft_cap_crossing(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        resolved=prepared.resolved,
+        cost_so_far=prepared.cost_so_far,
+        cost_this_call=cost,
+    )
+    logger.info(
+        "ai.dispatch.function_call.success",
+        org_id=org_id,
+        feature_key=feature_key,
+        model=prepared.model,
+        tool_calls=len(response.tool_calls),
+        ledger_id=ledger.id,
+    )
+    asyncio.create_task(_touch_last_used(prepared.credential_pk_id))  # noqa: RUF006
+    return FunctionCallDispatchResult(response=response, ledger_id=ledger.id)
+
+
+# --- call_llm_stream -------------------------------------------------
+
+
+async def call_llm_stream(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    feature_key: str,
+    messages: list[dict],
+    max_tokens: Optional[int] = None,
+) -> AsyncIterator[StreamChunk]:
+    """Dispatch a streamed chat call.
+
+    Yields adapter ``StreamChunk``s. Writes exactly ONE ledger row at
+    end-of-stream — never per-chunk — using the final usage block
+    from the provider when available, falling back to a char/4
+    estimate of the accumulated delta text when not. Errors mid-stream
+    wrap into ``AIDispatchFailed`` and write a single failure ledger
+    row.
+    """
+    prepared = await _prepare_dispatch(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        capability="stream",
+    )
+
+    accumulated: list[str] = []
+    final_usage: Optional[TokenUsage] = None
+    start = time.perf_counter()
+    try:
+        async for chunk in prepared.adapter.stream(
+            model=prepared.model,
+            messages=messages,
+            max_tokens=max_tokens,
+        ):
+            if chunk.done:
+                final_usage = chunk.final_usage
+                yield chunk
+                break
+            accumulated.append(chunk.delta_text)
+            yield chunk
+    except NativeNotAvailable:
+        raise
+    except AIProviderError as exc:
+        latency_ms = int((time.perf_counter() - start) * 1000)
+        await _write_ledger_row(
+            db,
+            org_id=org_id,
+            credential_id=prepared.credential_id,
+            feature_key=feature_key,
+            model=prepared.model,
+            prompt_tokens=0,
+            completion_tokens=0,
+            est_cost_cents_value=0,
+            latency_ms=latency_ms,
+            success=False,
+            error_class=exc.code,
+        )
+        raise AIDispatchFailed(exc.code) from None
+
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    if final_usage is None:
+        # Fallback estimate when the provider doesn't emit usage at
+        # end-of-stream. Prompt tokens we can't estimate without the
+        # original messages, so 0; completion tokens via char/4 of the
+        # accumulated text.
+        full_text = "".join(accumulated)
+        final_usage = TokenUsage(
+            prompt_tokens=0,
+            completion_tokens=max(0, len(full_text) // 4),
+        )
+    cost = estimate_cost_cents(
+        model=prepared.model,
+        prompt_tokens=final_usage.prompt_tokens,
+        completion_tokens=final_usage.completion_tokens,
+    )
+    ledger = await _write_ledger_row(
+        db,
+        org_id=org_id,
+        credential_id=prepared.credential_id,
+        feature_key=feature_key,
+        model=prepared.model,
+        prompt_tokens=final_usage.prompt_tokens,
+        completion_tokens=final_usage.completion_tokens,
+        est_cost_cents_value=cost,
+        latency_ms=latency_ms,
+        success=True,
+        error_class=None,
+    )
+    await _post_write_soft_cap_crossing(
+        db,
+        org_id=org_id,
+        feature_key=feature_key,
+        resolved=prepared.resolved,
+        cost_so_far=prepared.cost_so_far,
+        cost_this_call=cost,
+    )
+    logger.info(
+        "ai.dispatch.stream.success",
+        org_id=org_id,
+        feature_key=feature_key,
+        model=prepared.model,
+        ledger_id=ledger.id,
+        prompt_tokens=final_usage.prompt_tokens,
+        completion_tokens=final_usage.completion_tokens,
+    )
+    asyncio.create_task(_touch_last_used(prepared.credential_pk_id))  # noqa: RUF006

--- a/backend/app/services/ai_pricing.py
+++ b/backend/app/services/ai_pricing.py
@@ -16,10 +16,13 @@ warning than to accidentally let an org rack up unmetered spend).
 
 ``estimate_cost_cents`` rounds **up** to the nearest cent — the cap
 is a ceiling, not a budget, and the rounding direction must match.
+
+PR3 adds embedding-model rows. Embeddings only charge on the input
+(``completion_per_1m_cents=0``) — feature surfaces hand
+``completion_tokens=0`` to ``estimate_cost_cents``.
 """
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 
 
@@ -40,10 +43,12 @@ class ModelPricing:
 # unknown models fall through to ``_default`` below.
 #
 # Pricing reference (2026-05-22, USD cents per 1M tokens):
-#   gpt-4o            : $2.50 in / $10.00 out   → 250 / 1000
-#   gpt-4o-mini       : $0.15 in / $0.60 out    → 15  / 60
-#   claude-sonnet-4-7 : $3.00 in / $15.00 out   → 300 / 1500
-#   claude-haiku-4-5  : $0.80 in / $4.00 out    → 80  / 400
+#   gpt-4o                  : $2.50 in / $10.00 out   → 250 / 1000
+#   gpt-4o-mini             : $0.15 in / $0.60 out    → 15  / 60
+#   claude-sonnet-4-7       : $3.00 in / $15.00 out   → 300 / 1500
+#   claude-haiku-4-5        : $0.80 in / $4.00 out    → 80  / 400
+#   text-embedding-3-small  : $0.02 in (no out)       → 2   / 0
+#   text-embedding-3-large  : $0.13 in (no out)       → 13  / 0
 MODEL_PRICING: dict[str, ModelPricing] = {
     "gpt-4o": ModelPricing(prompt_per_1m_cents=250, completion_per_1m_cents=1000),
     "gpt-4o-mini": ModelPricing(prompt_per_1m_cents=15, completion_per_1m_cents=60),
@@ -52,6 +57,15 @@ MODEL_PRICING: dict[str, ModelPricing] = {
     ),
     "claude-haiku-4-5": ModelPricing(
         prompt_per_1m_cents=80, completion_per_1m_cents=400
+    ),
+    # Embedding models — input-only pricing. Completion column held at
+    # zero so a future call site that accidentally passes
+    # completion_tokens still doesn't double-bill an embedding row.
+    "text-embedding-3-small": ModelPricing(
+        prompt_per_1m_cents=2, completion_per_1m_cents=0
+    ),
+    "text-embedding-3-large": ModelPricing(
+        prompt_per_1m_cents=13, completion_per_1m_cents=0
     ),
     # Conservative fallback — picked to be higher than every known
     # frontier model. Unknown-model usage gets counted at this rate so

--- a/backend/app/services/ai_providers/__init__.py
+++ b/backend/app/services/ai_providers/__init__.py
@@ -1,13 +1,20 @@
 """Provider adapter package for BYO AI credentials.
 
-PR1 shipped the ``ValidateCapable`` protocol. PR2 adds:
+PR1 shipped the ``ValidateCapable`` protocol. PR2 added ``ChatCapable``,
+``LLMResponse``, ``AIProviderError``. PR3 adds the remaining
+capabilities:
 
-- ``ChatCapable.chat`` — implementations on OpenAI, Anthropic,
-  Ollama, and OpenAI-compatible adapters.
-- ``LLMResponse`` — provider-neutral response shape.
-- ``AIProviderError`` — typed wrapper with a sanitized message.
-- ``StructuredOutputCapable.chat_structured`` — protocol signature
-  only (implementations deferred to PR3 per architect lock).
+- ``EmbedCapable.embed`` — OpenAI, Ollama, OpenAI-compatible (Anthropic
+  raises NotImplementedError).
+- ``StructuredOutputCapable.chat_structured`` — adapter-side
+  implementation; service layer applies the architect-locked retry cap
+  via ``ai_dispatch.call_llm_structured``.
+- ``FunctionCallCapable.function_call`` — OpenAI/Anthropic adapters;
+  Ollama raises ``CapabilityNotSupported`` for non-tool-using models.
+- ``StreamCapable.stream`` — async iterator over ``StreamChunk``s.
+
+Native still raises ``NativeNotAvailable`` for every capability until
+PR4 wires a real backend.
 
 Distinct from the older ``ai_adapters`` package (LAI foundation mock
 adapter) — that one is the call_llm() chokepoint; this one is the
@@ -15,13 +22,20 @@ provider abstraction for BYO credentials.
 """
 from app.services.ai_providers.base import (
     AIProviderError,
+    CapabilityNotSupported,
     ChatCapable,
     EmbedCapable,
+    EmbedResponse,
     FunctionCallCapable,
+    FunctionCallResponse,
     LLMResponse,
     NativeNotAvailable,
     StreamCapable,
+    StreamChunk,
     StructuredOutputCapable,
+    StructuredOutputError,
+    StructuredResponse,
+    TokenUsage,
     ValidateCapable,
     ValidateResult,
     get_adapter,
@@ -29,13 +43,20 @@ from app.services.ai_providers.base import (
 
 __all__ = [
     "AIProviderError",
+    "CapabilityNotSupported",
     "ChatCapable",
     "EmbedCapable",
+    "EmbedResponse",
     "FunctionCallCapable",
+    "FunctionCallResponse",
     "LLMResponse",
     "NativeNotAvailable",
     "StreamCapable",
+    "StreamChunk",
     "StructuredOutputCapable",
+    "StructuredOutputError",
+    "StructuredResponse",
+    "TokenUsage",
     "ValidateCapable",
     "ValidateResult",
     "get_adapter",

--- a/backend/app/services/ai_providers/anthropic.py
+++ b/backend/app/services/ai_providers/anthropic.py
@@ -1,25 +1,85 @@
-"""Anthropic adapter — validate via GET /v1/models, chat via /v1/messages."""
+"""Anthropic adapter — validate via GET /v1/models, chat via /v1/messages.
+
+PR3:
+- ``embed`` raises ``NotImplementedError`` — Anthropic does NOT expose
+  a public embeddings API. A future PR may add Voyage AI as a sibling
+  provider (Voyage was an Anthropic-recommended embedding partner
+  before Anthropic acquired it; v1 ships without it).
+- ``chat_structured`` uses the tool-use-as-JSON pattern: a single tool
+  with ``input_schema`` set to the response schema. The model returns
+  a ``tool_use`` block whose ``input`` is the parsed JSON.
+- ``function_call`` uses Anthropic's tool-use API natively. Tools are
+  normalized from the OpenAI shape (``{type:"function", function:{...}}``)
+  into Anthropic's flat shape (``{name, description, input_schema}``).
+- ``stream`` uses the Anthropic SSE messages stream API.
+"""
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import AsyncIterator, Optional
 
 import httpx
 
 from app.services.ai_providers.base import (
     AIProviderError,
+    EmbedResponse,
+    FunctionCallResponse,
     LLMResponse,
+    StreamChunk,
+    TokenUsage,
     ValidateResult,
 )
 
 
 VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
+STREAM_TIMEOUT_S = 60.0
 DEFAULT_CAPABILITIES = ["chat"]
 MODELS_URL = "https://api.anthropic.com/v1/models"
 MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
 # Anthropic requires max_tokens on every messages call.
 DEFAULT_CHAT_MAX_TOKENS = 1024
+
+
+def _split_system(messages: list[dict]) -> tuple[list[str], list[dict]]:
+    """Split a chat history into (system_parts, non_system_turns).
+
+    Anthropic separates ``system`` from the user/assistant turns —
+    keeping the split logic centralized so chat/structured/stream
+    share the same shape transformation.
+    """
+    system_parts: list[str] = []
+    chat_messages: list[dict] = []
+    for m in messages:
+        if m.get("role") == "system":
+            content = m.get("content") or ""
+            if content:
+                system_parts.append(str(content))
+        else:
+            chat_messages.append(m)
+    return system_parts, chat_messages
+
+
+def _normalize_tool_for_anthropic(tool: dict) -> dict:
+    """Accept OpenAI-shape tools and emit Anthropic-shape tools.
+
+    Caller is expected to pass the canonical OpenAI shape
+    ``{"type": "function", "function": {"name": ..., "description": ...,
+    "parameters": {...}}}``. We map it to Anthropic's
+    ``{"name": ..., "description": ..., "input_schema": {...}}``.
+
+    Tools that are already in Anthropic shape (have ``input_schema``)
+    are passed through unchanged so callers can mix shapes.
+    """
+    if "input_schema" in tool:
+        return tool
+    inner = tool.get("function") or {}
+    return {
+        "name": inner.get("name", ""),
+        "description": inner.get("description", ""),
+        "input_schema": inner.get("parameters") or {"type": "object"},
+    }
 
 
 class AnthropicAdapter:
@@ -70,23 +130,8 @@ class AnthropicAdapter:
         messages: list[dict],
         max_tokens: Optional[int] = None,
     ) -> LLMResponse:
-        """POST /v1/messages. Maps response.content[*].text -> content.
-
-        Anthropic separates ``system`` from the user/assistant turns.
-        We do the standard remap: any ``role == "system"`` message
-        becomes the top-level ``system`` field; the rest stay in
-        ``messages``.
-        """
-        system_parts: list[str] = []
-        chat_messages: list[dict] = []
-        for m in messages:
-            if m.get("role") == "system":
-                content = m.get("content") or ""
-                if content:
-                    system_parts.append(str(content))
-            else:
-                chat_messages.append(m)
-
+        """POST /v1/messages. Maps response.content[*].text -> content."""
+        system_parts, chat_messages = _split_system(messages)
         headers = {
             "x-api-key": self.api_key,
             "anthropic-version": ANTHROPIC_VERSION,
@@ -137,5 +182,265 @@ class AnthropicAdapter:
             model=payload.get("model", model) or model,
         )
 
-    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
-        raise NotImplementedError("PR3")
+    async def embed(
+        self,
+        *,
+        texts: list[str],
+        model: Optional[str] = None,
+    ) -> EmbedResponse:
+        """Anthropic does NOT expose a public embeddings API.
+
+        Documented refusal at the protocol layer so callers can detect
+        and fall back. A future PR may add Voyage AI as a sibling
+        provider entry.
+        """
+        raise NotImplementedError(
+            "Anthropic does not expose embeddings API"
+        )
+
+    async def chat_structured(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        schema: dict,
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """Anthropic structured output via tool-use-as-JSON.
+
+        We declare a single tool whose ``input_schema`` is the response
+        schema and force the model to call it. The tool_use block's
+        ``input`` is the parsed JSON; we serialize it back to text in
+        ``content`` so the service layer's schema validator sees the
+        same string shape across all adapters.
+        """
+        system_parts, chat_messages = _split_system(messages)
+        tool = {
+            "name": "respond_structured",
+            "description": "Return the response as a JSON object matching the schema.",
+            "input_schema": schema,
+        }
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+        }
+        body: dict = {
+            "model": model,
+            "messages": chat_messages,
+            "max_tokens": max_tokens or DEFAULT_CHAT_MAX_TOKENS,
+            "tools": [tool],
+            "tool_choice": {"type": "tool", "name": "respond_structured"},
+        }
+        if system_parts:
+            body["system"] = "\n\n".join(system_parts)
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(
+                    MESSAGES_URL, headers=headers, json=body
+                )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            blocks = payload.get("content", []) or []
+            tool_input: Optional[dict] = None
+            for b in blocks:
+                if isinstance(b, dict) and b.get("type") == "tool_use":
+                    inp = b.get("input")
+                    if isinstance(inp, dict):
+                        tool_input = inp
+                        break
+            # No tool_use block -> the service-layer retry budget will
+            # catch the empty-content case as a JSON parse failure.
+            content_text = json.dumps(tool_input) if tool_input is not None else ""
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("input_tokens", 0) or 0)
+            completion_tokens = int(usage.get("output_tokens", 0) or 0)
+        except (KeyError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content_text,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def function_call(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> FunctionCallResponse:
+        """POST /v1/messages with tool_use enabled.
+
+        Caller can pass either OpenAI-shape tools or native Anthropic
+        tools; both are normalized to Anthropic's flat shape.
+        """
+        system_parts, chat_messages = _split_system(messages)
+        normalized_tools = [_normalize_tool_for_anthropic(t) for t in tools]
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+        }
+        body: dict = {
+            "model": model,
+            "messages": chat_messages,
+            "max_tokens": max_tokens or DEFAULT_CHAT_MAX_TOKENS,
+            "tools": normalized_tools,
+        }
+        if system_parts:
+            body["system"] = "\n\n".join(system_parts)
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(
+                    MESSAGES_URL, headers=headers, json=body
+                )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            blocks = payload.get("content", []) or []
+            tool_calls: list[dict] = []
+            text_parts: list[str] = []
+            for b in blocks:
+                if not isinstance(b, dict):
+                    continue
+                if b.get("type") == "tool_use":
+                    inp = b.get("input")
+                    tool_calls.append(
+                        {
+                            "name": str(b.get("name") or ""),
+                            "arguments": inp if isinstance(inp, dict) else {},
+                        }
+                    )
+                elif b.get("type") == "text":
+                    text_parts.append(str(b.get("text") or ""))
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("input_tokens", 0) or 0)
+            completion_tokens = int(usage.get("output_tokens", 0) or 0)
+        except (KeyError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return FunctionCallResponse(
+            tool_calls=tool_calls,
+            content="".join(text_parts),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """POST /v1/messages with ``stream: true`` (SSE).
+
+        Anthropic SSE uses ``event:`` framing. We care about:
+        - ``content_block_delta`` (delta.text)        → delta_text chunk
+        - ``message_start`` (usage.input_tokens)      → prompt tokens
+        - ``message_delta`` (usage.output_tokens)     → completion tokens
+
+        Final ``StreamChunk(done=True, final_usage=...)`` is emitted
+        after the stream closes.
+        """
+        system_parts, chat_messages = _split_system(messages)
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }
+        body: dict = {
+            "model": model,
+            "messages": chat_messages,
+            "max_tokens": max_tokens or DEFAULT_CHAT_MAX_TOKENS,
+            "stream": True,
+        }
+        if system_parts:
+            body["system"] = "\n\n".join(system_parts)
+
+        prompt_tokens = 0
+        completion_tokens = 0
+        try:
+            async with httpx.AsyncClient(timeout=STREAM_TIMEOUT_S) as client:
+                async with client.stream(
+                    "POST", MESSAGES_URL, headers=headers, json=body
+                ) as resp:
+                    if resp.status_code != 200:
+                        raise AIProviderError(
+                            code=f"provider_status_{resp.status_code}",
+                            status_code=resp.status_code,
+                        )
+                    async for line in resp.aiter_lines():
+                        if not line or not line.startswith("data:"):
+                            continue
+                        data = line[len("data:"):].strip()
+                        if not data:
+                            continue
+                        try:
+                            event = json.loads(data)
+                        except ValueError:
+                            continue
+                        etype = event.get("type")
+                        if etype == "content_block_delta":
+                            delta = event.get("delta") or {}
+                            text = str(delta.get("text") or "")
+                            if text:
+                                yield StreamChunk(
+                                    delta_text=text, done=False
+                                )
+                        elif etype == "message_start":
+                            msg = event.get("message") or {}
+                            usage = msg.get("usage") or {}
+                            prompt_tokens = int(
+                                usage.get("input_tokens", 0) or 0
+                            )
+                            completion_tokens = int(
+                                usage.get("output_tokens", 0) or 0
+                            )
+                        elif etype == "message_delta":
+                            usage = event.get("usage") or {}
+                            completion_tokens = int(
+                                usage.get("output_tokens", completion_tokens)
+                                or completion_tokens
+                            )
+        except AIProviderError:
+            raise
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        yield StreamChunk(
+            delta_text="",
+            done=True,
+            final_usage=TokenUsage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            ),
+        )

--- a/backend/app/services/ai_providers/anthropic.py
+++ b/backend/app/services/ai_providers/anthropic.py
@@ -34,7 +34,11 @@ from app.services.ai_providers.base import (
 VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
 STREAM_TIMEOUT_S = 60.0
-DEFAULT_CAPABILITIES = ["chat"]
+# Anthropic advertises chat + tool use + structured output + streaming.
+# ``embed`` is intentionally absent — Anthropic has no embeddings API.
+# Orgs wanting embeddings must add a sibling Voyage AI credential
+# (the embed() method on this adapter raises NotImplementedError).
+DEFAULT_CAPABILITIES = ["chat", "structured_output", "function_call", "stream"]
 MODELS_URL = "https://api.anthropic.com/v1/models"
 MESSAGES_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"

--- a/backend/app/services/ai_providers/base.py
+++ b/backend/app/services/ai_providers/base.py
@@ -1,23 +1,35 @@
 """Capability protocols + adapter factory for BYO AI providers.
 
-PR1 shipped ``ValidateCapable`` only. PR2 adds:
+PR1 shipped ``ValidateCapable`` only. PR2 added ``ChatCapable.chat`` +
+``LLMResponse`` + ``AIProviderError``. PR3 (this layer) implements the
+remaining capability protocols:
 
-- ``LLMResponse`` — provider-neutral chat response shape consumed by
-  the dispatch chokepoint (``call_llm`` in ``ai_dispatch``).
-- ``AIProviderError`` — typed wrapper raised by every adapter when
-  the provider call fails. The wrapped message is **sanitized** (no
-  provider response body), per the PR1 SSRF / sanitization lock.
-- ``ChatCapable.chat`` — protocol signature for the chat dispatch.
-  OpenAI, Anthropic, Ollama, and OpenAI-compatible adapters implement
-  it as a thin pass-through; Native still raises ``NativeNotAvailable``.
-- ``StructuredOutputCapable.chat_structured`` — protocol signature
-  only. The implementation is deferred to PR3 (architect lock: retry
-  cap).
+- ``EmbedCapable.embed`` — vector embedding for OpenAI, Ollama,
+  OpenAI-compatible. Anthropic does not expose embeddings; the adapter
+  raises ``NotImplementedError`` so callers can fall back. A future PR
+  may add Voyage AI as a sibling provider.
+- ``StructuredOutputCapable.chat_structured`` — JSON-mode + schema
+  validation, with the architect-locked retry cap of 2 (3 attempts
+  total). Adapters return the raw provider response; the service layer
+  validates against the schema and applies the retry budget. On
+  exhaustion the service raises ``StructuredOutputError`` with code
+  ``STATUS_ERROR_STRUCTURED_OUTPUT``.
+- ``FunctionCallCapable.function_call`` — provider-side tool use
+  (OpenAI function-calling shape, Anthropic tool_use). Ollama is
+  model-dependent; the adapter raises ``CapabilityNotSupported`` for
+  models we know don't support it.
+- ``StreamCapable.stream`` — async-iterator streaming of chat
+  responses. The ledger is written once at end-of-stream with the
+  final token usage (estimated if the provider doesn't report tokens
+  for the streamed response).
+
+The Native adapter still raises ``NativeNotAvailable`` for every
+capability, including the PR3 ones, until PR4 wires a real backend.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional, Protocol, runtime_checkable
+from typing import AsyncIterator, Optional, Protocol, runtime_checkable
 
 from app.models.org_ai_credential import AiProvider
 
@@ -47,6 +59,80 @@ class LLMResponse:
     prompt_tokens: int
     completion_tokens: int
     model: str
+
+
+@dataclass(frozen=True)
+class EmbedResponse:
+    """Provider-neutral embedding response.
+
+    ``vectors`` is one float vector per input text (same order as the
+    request). ``prompt_tokens`` feeds the ledger / cap accounting;
+    embedding APIs charge per-input-token only (no completion side).
+    """
+
+    vectors: list[list[float]]
+    model: str
+    prompt_tokens: int
+
+
+@dataclass(frozen=True)
+class StructuredResponse:
+    """Provider-neutral structured-output response.
+
+    ``parsed`` is the JSON object after schema validation; ``raw_text``
+    is the raw assistant text (kept for forensic logging). ``retries_used``
+    is 0, 1, or 2 — the count of retries the SERVICE layer needed before
+    the parse succeeded. Architect lock #13: max 2 retries (3 total
+    attempts) before ``STATUS_ERROR_STRUCTURED_OUTPUT``.
+    """
+
+    parsed: dict
+    raw_text: str
+    prompt_tokens: int
+    completion_tokens: int
+    model: str
+    retries_used: int
+
+
+@dataclass(frozen=True)
+class FunctionCallResponse:
+    """Provider-neutral function-call response.
+
+    ``tool_calls`` is the structured list of tool invocations the model
+    requested. Each entry has ``name`` (the tool name) and
+    ``arguments`` (a dict — already JSON-parsed). ``content`` is any
+    free-text the model emitted alongside the tool call (typically
+    empty when a tool was invoked).
+    """
+
+    tool_calls: list[dict]
+    content: str
+    prompt_tokens: int
+    completion_tokens: int
+    model: str
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Token usage summary attached to the final stream chunk."""
+
+    prompt_tokens: int
+    completion_tokens: int
+
+
+@dataclass(frozen=True)
+class StreamChunk:
+    """One chunk of a streamed chat response.
+
+    ``delta_text`` is the incremental text since the previous chunk.
+    ``done`` is True for the final synthetic chunk (which carries
+    ``final_usage``); all other chunks have ``done=False`` and
+    ``final_usage=None``.
+    """
+
+    delta_text: str
+    done: bool
+    final_usage: Optional[TokenUsage] = None
 
 
 class NativeNotAvailable(Exception):
@@ -81,6 +167,37 @@ class AIProviderError(Exception):
         self.status_code = status_code
 
 
+class StructuredOutputError(Exception):
+    """Service-layer failure after the architect-locked retry budget.
+
+    Architect lock #13: max 2 retries (3 total attempts) on JSON
+    parse / schema-validation failure before this fires. The ledger
+    row still gets written (with ``retries_used=2``, success=False,
+    error_class=``STATUS_ERROR_STRUCTURED_OUTPUT``) so the failed
+    attempts count against the cap.
+    """
+
+    def __init__(self, code: str = "STATUS_ERROR_STRUCTURED_OUTPUT") -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class CapabilityNotSupported(Exception):
+    """Adapter refuses a capability the static class flag advertises.
+
+    Used by Ollama's ``function_call`` when the requested model isn't
+    known to support tool use — Ollama exposes function calling per
+    model, not per server. Callers (the service layer) decide whether
+    to fall back to free-text JSON, a smaller model, or surface a 412
+    to the user.
+    """
+
+    def __init__(self, *, model: str, capability: str = "function_call") -> None:
+        super().__init__(f"{capability} not supported by model {model!r}")
+        self.model = model
+        self.capability = capability
+
+
 @runtime_checkable
 class ValidateCapable(Protocol):
     async def validate(self) -> ValidateResult:
@@ -101,17 +218,24 @@ class ChatCapable(Protocol):
 
 @runtime_checkable
 class EmbedCapable(Protocol):
-    ...  # implemented in PR3+
+    async def embed(
+        self,
+        *,
+        texts: list[str],
+        model: Optional[str] = None,
+    ) -> EmbedResponse:
+        ...
 
 
 @runtime_checkable
 class StructuredOutputCapable(Protocol):
-    """Protocol signature only — implementation deferred to PR3.
+    """Adapter side of structured output.
 
-    Architect lock: ``chat_structured`` ships in PR3 with the
-    documented retry cap of 2 on JSON parse / schema-validation
-    failure. Defining the signature here lets PR3 add adapter
-    implementations without re-shaping the protocol layer.
+    Returns the raw provider response (text). The SERVICE layer
+    validates against the schema and applies the architect-locked
+    retry cap. Keeping the schema enforcement out of the adapter lets
+    the retry counter live in one place (``call_llm_structured``) and
+    keeps adapters thin.
     """
 
     async def chat_structured(
@@ -127,12 +251,27 @@ class StructuredOutputCapable(Protocol):
 
 @runtime_checkable
 class StreamCapable(Protocol):
-    ...  # implemented in PR3+
+    async def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> AsyncIterator[StreamChunk]:
+        ...
 
 
 @runtime_checkable
 class FunctionCallCapable(Protocol):
-    ...  # implemented in PR3+
+    async def function_call(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> FunctionCallResponse:
+        ...
 
 
 def get_adapter(

--- a/backend/app/services/ai_providers/native.py
+++ b/backend/app/services/ai_providers/native.py
@@ -1,14 +1,14 @@
 """TBD-native adapter shell (PR1 stub).
 
-Always returns ``not_yet_available`` in PR1. A future PR will gate this
-on ``AI_NATIVE_ENABLED`` once a real native backend exists. The
-substrate work for routing/caps/consent has to know "native is a thing
-that exists in the registry" — hence this stub — but no real native
-backend ships in PR1.
+Always raises ``NativeNotAvailable("not_yet_available")`` in PR1-PR3.
+A future PR (PR4 or later) will gate this on ``AI_NATIVE_ENABLED`` once
+a real native backend exists. The substrate work for routing/caps/
+consent has to know "native is a thing that exists in the registry" —
+hence this stub — but no real native backend ships in PR3.
 
 Behavior contract (spec §5):
 
-- Regardless of ``AI_NATIVE_ENABLED``, ``validate()`` raises
+- Regardless of ``AI_NATIVE_ENABLED``, every capability call raises
   ``NativeNotAvailable("not_yet_available")``. The env flag is read
   only to emit an operator warning when it's been flipped on without a
   backend behind it.
@@ -40,7 +40,7 @@ class NativeAdapter:
             logger.warning(
                 "ai.native.gate_on_but_backend_missing",
                 ai_native_enabled=True,
-                note="AI_NATIVE_ENABLED=true but no native backend ships in PR1",
+                note="AI_NATIVE_ENABLED=true but no native backend ships in PR3",
             )
 
     async def validate(self) -> ValidateResult:
@@ -52,10 +52,25 @@ class NativeAdapter:
 
     async def chat(self, *, model, messages, max_tokens=None):
         # PR4 will gate this on ``AI_NATIVE_ENABLED`` once a real native
-        # backend exists. For PR2 the adapter is wired into the
+        # backend exists. For PR2/PR3 the adapter is wired into the
         # registry so the dispatch layer is symmetric, but the chat
         # path still refuses immediately.
         raise NativeNotAvailable("not_yet_available")
 
+    async def embed(self, *, texts, model=None):
+        raise NativeNotAvailable("not_yet_available")
+
     async def chat_structured(self, *, model, messages, schema, max_tokens=None):
         raise NativeNotAvailable("not_yet_available")
+
+    async def function_call(self, *, model, messages, tools, max_tokens=None):
+        raise NativeNotAvailable("not_yet_available")
+
+    async def stream(self, *, model, messages, max_tokens=None):
+        # Note: this is a coroutine that, when called, should return an
+        # async iterator. To preserve symmetry with the protocol, we
+        # raise here — the call_llm_stream wrapper handles the "raise
+        # before iteration" shape.
+        raise NativeNotAvailable("not_yet_available")
+        # Make pyright happy:
+        yield  # pragma: no cover  # noqa: B901

--- a/backend/app/services/ai_providers/ollama.py
+++ b/backend/app/services/ai_providers/ollama.py
@@ -1,25 +1,58 @@
 """Ollama adapter — validates by GET {base_url}/api/tags.
 
-Auth on Ollama is rare in the wild but supported via an optional
-``Bearer`` token when fronting the server with a reverse proxy.
-PR2 adds the ``chat()`` pass-through against ``/api/chat``.
+PR3:
+- ``embed`` POSTs to ``/api/embeddings``.
+- ``chat_structured`` uses Ollama's ``format: "json"`` option plus
+  schema-in-system-message. The service layer enforces the retry cap.
+- ``function_call`` raises ``CapabilityNotSupported`` for models that
+  don't advertise tool use. Newer Ollama builds support OpenAI-shape
+  tools on a curated allowlist (llama3.1/3.2, mistral-nemo, etc.).
+  Rather than maintain a copy of that allowlist, we refuse by default
+  and let the routing capability check direct callers to a provider
+  that does support it. Models that DO support it can be allowlisted
+  via the ``KNOWN_FUNCTION_CALL_MODELS`` prefix list.
+- ``stream`` POSTs to ``/api/chat`` with ``stream: true``; Ollama
+  emits NDJSON (one JSON object per line) rather than SSE.
 """
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import AsyncIterator, Optional
 
 import httpx
 
 from app.services.ai_providers.base import (
     AIProviderError,
+    CapabilityNotSupported,
+    EmbedResponse,
+    FunctionCallResponse,
     LLMResponse,
+    StreamChunk,
+    TokenUsage,
     ValidateResult,
 )
 
 
 VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
+EMBED_TIMEOUT_S = 30.0
+STREAM_TIMEOUT_S = 60.0
 DEFAULT_CAPABILITIES = ["chat", "embed"]
+
+# Models Ollama is known to expose tool-calling on (best-effort —
+# refresh during the same quarterly window that touches the pricing
+# table). Caller can extend by passing through a provider that
+# reports its own capability via discovered_capabilities.
+KNOWN_FUNCTION_CALL_MODELS = (
+    "llama3.1",
+    "llama3.2",
+    "llama3.3",
+    "mistral-nemo",
+    "mistral-large",
+    "command-r",
+    "firefunction",
+    "qwen2.5",
+)
 
 
 class OllamaAdapter:
@@ -85,15 +118,7 @@ class OllamaAdapter:
         messages: list[dict],
         max_tokens: Optional[int] = None,
     ) -> LLMResponse:
-        """POST {base_url}/api/chat. ``stream=false`` so we get one
-        complete response back, not an NDJSON stream.
-
-        Ollama doesn't return a stable token-count contract — newer
-        builds emit ``prompt_eval_count`` / ``eval_count`` at the top
-        level, older ones don't. We use them when present and fall
-        back to 0 (cost falls back to the ``_default`` pricing row,
-        which is conservatively high — see ``ai_pricing``).
-        """
+        """POST {base_url}/api/chat with stream=False."""
         headers = {**self._headers(), "Content-Type": "application/json"}
         body: dict = {
             "model": model,
@@ -133,5 +158,276 @@ class OllamaAdapter:
             model=payload.get("model", model) or model,
         )
 
-    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
-        raise NotImplementedError("PR3")
+    async def embed(
+        self,
+        *,
+        texts: list[str],
+        model: Optional[str] = None,
+    ) -> EmbedResponse:
+        """POST {base_url}/api/embeddings — one POST per input text.
+
+        Ollama's ``/api/embeddings`` accepts a single prompt; we
+        sequentially fire one request per text to keep the contract
+        symmetric with the OpenAI batch shape. The vector order
+        matches the input order.
+        """
+        if not model:
+            raise AIProviderError(code="ollama_embed_model_required")
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        url = f"{self.base_url}/api/embeddings"
+        vectors: list[list[float]] = []
+        actual_model = model
+        try:
+            async with httpx.AsyncClient(timeout=EMBED_TIMEOUT_S) as client:
+                for text in texts:
+                    resp = await client.post(
+                        url,
+                        headers=headers,
+                        json={"model": model, "prompt": text},
+                    )
+                    if resp.status_code != 200:
+                        raise AIProviderError(
+                            code=f"provider_status_{resp.status_code}",
+                            status_code=resp.status_code,
+                        )
+                    try:
+                        payload = resp.json()
+                    except ValueError:
+                        raise AIProviderError(
+                            code="provider_invalid_json"
+                        ) from None
+                    embedding = payload.get("embedding")
+                    if not isinstance(embedding, list):
+                        raise AIProviderError(
+                            code="provider_unexpected_shape"
+                        ) from None
+                    vectors.append([float(x) for x in embedding])
+                    actual_model = payload.get("model", model) or model
+        except AIProviderError:
+            raise
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        return EmbedResponse(
+            vectors=vectors,
+            model=actual_model,
+            # Ollama's embeddings endpoint does NOT report a token
+            # count; estimate via 4 chars / token to keep the cap
+            # accounting non-zero.
+            prompt_tokens=max(1, sum(len(t) for t in texts) // 4),
+        )
+
+    async def chat_structured(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        schema: dict,
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """Ollama structured output via ``format: "json"`` + system
+        message describing the schema. The service layer's retry budget
+        catches the cases where the model emits malformed JSON or a
+        JSON that fails schema validation.
+        """
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        schema_hint = (
+            "Output ONLY a JSON object matching this schema: "
+            + json.dumps(schema, sort_keys=True)
+        )
+        # Prepend the schema hint as a system message so it sits ahead
+        # of any caller-supplied system messages without clobbering
+        # them.
+        prepended = [{"role": "system", "content": schema_hint}] + list(messages)
+        body: dict = {
+            "model": model,
+            "messages": prepended,
+            "stream": False,
+            "format": "json",
+        }
+        if max_tokens is not None:
+            body["options"] = {"num_predict": max_tokens}
+        url = f"{self.base_url}/api/chat"
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(url, headers=headers, json=body)
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            message = payload.get("message", {}) or {}
+            content = str(message.get("content", "") or "")
+            prompt_tokens = int(payload.get("prompt_eval_count", 0) or 0)
+            completion_tokens = int(payload.get("eval_count", 0) or 0)
+        except (KeyError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def function_call(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> FunctionCallResponse:
+        """Ollama function-calling is per-model.
+
+        We refuse with ``CapabilityNotSupported`` for any model whose
+        name doesn't start with one of the known function-calling
+        prefixes. The caller (service layer) is expected to surface a
+        412 ``ai_capability_not_supported`` so the user reconfigures
+        routing.
+
+        For supported models we POST to ``/api/chat`` with the tools
+        array passed through (Ollama accepts OpenAI-shape tools on
+        function-calling-capable models since v0.3+).
+        """
+        if not any(
+            model.startswith(prefix) for prefix in KNOWN_FUNCTION_CALL_MODELS
+        ):
+            raise CapabilityNotSupported(
+                model=model, capability="function_call"
+            )
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        body: dict = {
+            "model": model,
+            "messages": messages,
+            "tools": tools,
+            "stream": False,
+        }
+        if max_tokens is not None:
+            body["options"] = {"num_predict": max_tokens}
+        url = f"{self.base_url}/api/chat"
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(url, headers=headers, json=body)
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            message = payload.get("message", {}) or {}
+            raw_tool_calls = message.get("tool_calls") or []
+            tool_calls: list[dict] = []
+            for call in raw_tool_calls:
+                fn = call.get("function") or {}
+                args = fn.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except (TypeError, ValueError):
+                        args = {}
+                tool_calls.append(
+                    {
+                        "name": fn.get("name") or "",
+                        "arguments": args if isinstance(args, dict) else {},
+                    }
+                )
+            content = str(message.get("content") or "")
+            prompt_tokens = int(payload.get("prompt_eval_count", 0) or 0)
+            completion_tokens = int(payload.get("eval_count", 0) or 0)
+        except (KeyError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return FunctionCallResponse(
+            tool_calls=tool_calls,
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """POST {base_url}/api/chat with ``stream: true``.
+
+        Ollama streams NDJSON (one JSON object per line, not SSE).
+        Each line carries an incremental ``message.content`` delta plus
+        a ``done`` flag; the final line has ``done: true`` and the
+        token counts.
+        """
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        body: dict = {
+            "model": model,
+            "messages": messages,
+            "stream": True,
+        }
+        if max_tokens is not None:
+            body["options"] = {"num_predict": max_tokens}
+        url = f"{self.base_url}/api/chat"
+
+        prompt_tokens = 0
+        completion_tokens = 0
+        try:
+            async with httpx.AsyncClient(timeout=STREAM_TIMEOUT_S) as client:
+                async with client.stream(
+                    "POST", url, headers=headers, json=body
+                ) as resp:
+                    if resp.status_code != 200:
+                        raise AIProviderError(
+                            code=f"provider_status_{resp.status_code}",
+                            status_code=resp.status_code,
+                        )
+                    async for line in resp.aiter_lines():
+                        if not line:
+                            continue
+                        try:
+                            event = json.loads(line)
+                        except ValueError:
+                            continue
+                        msg = event.get("message") or {}
+                        delta = str(msg.get("content") or "")
+                        if delta:
+                            yield StreamChunk(delta_text=delta, done=False)
+                        if event.get("done"):
+                            prompt_tokens = int(
+                                event.get("prompt_eval_count", 0) or 0
+                            )
+                            completion_tokens = int(
+                                event.get("eval_count", 0) or 0
+                            )
+                            break
+        except AIProviderError:
+            raise
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        yield StreamChunk(
+            delta_text="",
+            done=True,
+            final_usage=TokenUsage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            ),
+        )

--- a/backend/app/services/ai_providers/ollama.py
+++ b/backend/app/services/ai_providers/ollama.py
@@ -37,7 +37,11 @@ VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
 EMBED_TIMEOUT_S = 30.0
 STREAM_TIMEOUT_S = 60.0
-DEFAULT_CAPABILITIES = ["chat", "embed"]
+# Baseline Ollama capabilities. ``function_call`` and
+# ``structured_output`` are conditional on whether any discovered model
+# matches the ``KNOWN_FUNCTION_CALL_MODELS`` prefix list — see
+# ``validate()`` below.
+BASELINE_CAPABILITIES = ["chat", "embed", "stream"]
 
 # Models Ollama is known to expose tool-calling on (best-effort —
 # refresh during the same quarterly window that touches the pricing
@@ -105,10 +109,22 @@ class OllamaAdapter:
             for m in payload.get("models", [])
             if isinstance(m, dict) and "name" in m
         ]
+        capabilities = list(BASELINE_CAPABILITIES)
+        # Ollama exposes function-calling + structured output only on a
+        # curated allowlist of models (llama3.1+, mistral-nemo, etc.).
+        # Advertise the capabilities only when at least one discovered
+        # model matches an allowlisted prefix.
+        if any(
+            m.startswith(prefix)
+            for m in models
+            for prefix in KNOWN_FUNCTION_CALL_MODELS
+        ):
+            capabilities.append("function_call")
+            capabilities.append("structured_output")
         return ValidateResult(
             ok=True,
             discovered_models=models,
-            discovered_capabilities=list(DEFAULT_CAPABILITIES),
+            discovered_capabilities=capabilities,
         )
 
     async def chat(

--- a/backend/app/services/ai_providers/openai.py
+++ b/backend/app/services/ai_providers/openai.py
@@ -1,22 +1,47 @@
-"""OpenAI adapter — validate via GET /v1/models, chat via /v1/chat/completions."""
+"""OpenAI adapter — validate via GET /v1/models, chat via /v1/chat/completions.
+
+PR3 adds the remaining capabilities: ``embed`` (text-embedding-3-small
+default), ``chat_structured`` (JSON-mode), ``function_call`` (tool use),
+``stream`` (SSE).
+"""
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import AsyncIterator, Optional
 
 import httpx
 
 from app.services.ai_providers.base import (
     AIProviderError,
+    EmbedResponse,
+    FunctionCallResponse,
     LLMResponse,
+    StreamChunk,
+    TokenUsage,
     ValidateResult,
 )
 
 
 VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
+EMBED_TIMEOUT_S = 30.0
+STREAM_TIMEOUT_S = 60.0
 DEFAULT_CAPABILITIES = ["chat", "embed"]
+DEFAULT_EMBED_MODEL = "text-embedding-3-small"
 MODELS_URL = "https://api.openai.com/v1/models"
 CHAT_URL = "https://api.openai.com/v1/chat/completions"
+EMBEDDINGS_URL = "https://api.openai.com/v1/embeddings"
+
+# Models that support the typed json_schema response_format (post 2024-08).
+# Older models fall through to plain json_object mode with the schema in
+# the system prompt.
+JSON_SCHEMA_MODELS = (
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4o-2024-08-06",
+    "gpt-4.1",
+    "gpt-5",
+)
 
 
 class OpenAIAdapter:
@@ -107,6 +132,275 @@ class OpenAIAdapter:
             model=payload.get("model", model) or model,
         )
 
-    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
-        # Architect lock: chat_structured is PR3 with retry cap.
-        raise NotImplementedError("PR3")
+    async def embed(
+        self,
+        *,
+        texts: list[str],
+        model: Optional[str] = None,
+    ) -> EmbedResponse:
+        """POST /v1/embeddings.
+
+        Defaults to ``text-embedding-3-small``. Same sanitized error
+        wrapping as ``chat``.
+        """
+        actual_model = model or DEFAULT_EMBED_MODEL
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body = {"model": actual_model, "input": texts}
+        try:
+            async with httpx.AsyncClient(timeout=EMBED_TIMEOUT_S) as client:
+                resp = await client.post(
+                    EMBEDDINGS_URL, headers=headers, json=body
+                )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            data = payload.get("data", []) or []
+            vectors = [
+                [float(x) for x in (row.get("embedding") or [])]
+                for row in data
+                if isinstance(row, dict)
+            ]
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+        except (KeyError, TypeError, ValueError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return EmbedResponse(
+            vectors=vectors,
+            model=payload.get("model", actual_model) or actual_model,
+            prompt_tokens=prompt_tokens,
+        )
+
+    async def chat_structured(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        schema: dict,
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """JSON-mode chat call. Schema-validation + retry budget live
+        in the SERVICE layer (``call_llm_structured``).
+
+        Newer models (gpt-4o family) use the typed ``json_schema``
+        response_format. Older models fall back to plain ``json_object``
+        with the schema injected into the system message. Choice is
+        based on model name prefix.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        use_json_schema = any(model.startswith(p) for p in JSON_SCHEMA_MODELS)
+        body: dict = {"model": model, "messages": list(messages)}
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        if use_json_schema:
+            body["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "structured_output",
+                    "strict": True,
+                    "schema": schema,
+                },
+            }
+        else:
+            body["response_format"] = {"type": "json_object"}
+            # Older models need the schema described in the messages.
+            schema_hint = (
+                "Output ONLY a JSON object matching this schema: "
+                + json.dumps(schema, sort_keys=True)
+            )
+            body["messages"] = [{"role": "system", "content": schema_hint}] + list(
+                messages
+            )
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(CHAT_URL, headers=headers, json=body)
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            content = payload["choices"][0]["message"]["content"] or ""
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+        except (KeyError, IndexError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def function_call(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> FunctionCallResponse:
+        """POST /v1/chat/completions with OpenAI tools array.
+
+        ``tools`` is the canonical OpenAI tool-calling shape:
+        ``[{"type": "function", "function": {"name": ..., "parameters": {...}}}]``.
+        Returns ``FunctionCallResponse.tool_calls`` with parsed arguments.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body: dict = {"model": model, "messages": messages, "tools": tools}
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(CHAT_URL, headers=headers, json=body)
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            message = payload["choices"][0]["message"]
+            raw_tool_calls = message.get("tool_calls") or []
+            tool_calls: list[dict] = []
+            for call in raw_tool_calls:
+                fn = call.get("function") or {}
+                args_text = fn.get("arguments") or "{}"
+                try:
+                    parsed_args = json.loads(args_text)
+                except (TypeError, ValueError):
+                    parsed_args = {}
+                tool_calls.append(
+                    {
+                        "name": fn.get("name") or "",
+                        "arguments": parsed_args,
+                    }
+                )
+            content = message.get("content") or ""
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+        except (KeyError, IndexError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return FunctionCallResponse(
+            tool_calls=tool_calls,
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """POST /v1/chat/completions with ``stream=true``.
+
+        Yields ``StreamChunk(delta_text=..., done=False)`` for each
+        incremental chunk; emits a final ``StreamChunk(done=True,
+        final_usage=...)`` after the SSE ``[DONE]`` sentinel. Token
+        usage comes from the optional ``stream_options.include_usage``
+        block when the provider sends one; otherwise the service
+        layer fills in an estimate from the accumulated text length.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }
+        body: dict = {
+            "model": model,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+
+        final_usage: Optional[TokenUsage] = None
+        try:
+            async with httpx.AsyncClient(timeout=STREAM_TIMEOUT_S) as client:
+                async with client.stream(
+                    "POST", CHAT_URL, headers=headers, json=body
+                ) as resp:
+                    if resp.status_code != 200:
+                        raise AIProviderError(
+                            code=f"provider_status_{resp.status_code}",
+                            status_code=resp.status_code,
+                        )
+                    async for line in resp.aiter_lines():
+                        if not line:
+                            continue
+                        if not line.startswith("data:"):
+                            continue
+                        data = line[len("data:"):].strip()
+                        if data == "[DONE]":
+                            break
+                        try:
+                            event = json.loads(data)
+                        except ValueError:
+                            # malformed line — skip; per-line resilience
+                            continue
+                        choices = event.get("choices") or []
+                        if choices:
+                            delta = choices[0].get("delta") or {}
+                            delta_text = str(delta.get("content") or "")
+                            if delta_text:
+                                yield StreamChunk(
+                                    delta_text=delta_text, done=False
+                                )
+                        usage = event.get("usage")
+                        if isinstance(usage, dict):
+                            final_usage = TokenUsage(
+                                prompt_tokens=int(
+                                    usage.get("prompt_tokens", 0) or 0
+                                ),
+                                completion_tokens=int(
+                                    usage.get("completion_tokens", 0) or 0
+                                ),
+                            )
+        except AIProviderError:
+            raise
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        yield StreamChunk(delta_text="", done=True, final_usage=final_usage)

--- a/backend/app/services/ai_providers/openai.py
+++ b/backend/app/services/ai_providers/openai.py
@@ -26,7 +26,10 @@ VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
 EMBED_TIMEOUT_S = 30.0
 STREAM_TIMEOUT_S = 60.0
-DEFAULT_CAPABILITIES = ["chat", "embed"]
+# Baseline capabilities advertised for any healthy OpenAI key. The
+# ``structured_output`` capability is gated to the json_schema-capable
+# model subset and added on top of the baseline in ``validate()``.
+BASELINE_CAPABILITIES = ["chat", "embed", "function_call", "stream"]
 DEFAULT_EMBED_MODEL = "text-embedding-3-small"
 MODELS_URL = "https://api.openai.com/v1/models"
 CHAT_URL = "https://api.openai.com/v1/chat/completions"
@@ -76,10 +79,18 @@ class OpenAIAdapter:
             for m in payload.get("data", [])
             if isinstance(m, dict) and "id" in m
         ]
+        capabilities = list(BASELINE_CAPABILITIES)
+        # ``structured_output`` is gated to the json_schema-capable
+        # subset (gpt-4o family, gpt-4.1, gpt-5). If the key has access
+        # to any of those, advertise the capability.
+        if any(
+            m.startswith(prefix) for m in models for prefix in JSON_SCHEMA_MODELS
+        ):
+            capabilities.append("structured_output")
         return ValidateResult(
             ok=True,
             discovered_models=models,
-            discovered_capabilities=list(DEFAULT_CAPABILITIES),
+            discovered_capabilities=capabilities,
         )
 
     async def chat(

--- a/backend/app/services/ai_providers/openai_compatible.py
+++ b/backend/app/services/ai_providers/openai_compatible.py
@@ -6,6 +6,15 @@ chat_structured, function_call, stream — but with hostile-endpoint
 sanitization on every error path (these endpoints can mirror request
 headers back, which would leak the plaintext API key that just left
 this process).
+
+Capability advertising: this adapter implements all 5 capabilities
+(chat, embed, structured_output, function_call, stream) against the
+OpenAI HTTP shape. The validate() probe advertises them all because
+the user explicitly opted into trusting their configured endpoint by
+typing in its URL. If the underlying server doesn't honor a request,
+the sanitized error path returns a generic ``Provider rejected the
+request (status)`` envelope rather than leaking provider response
+data — see the PR1 sanitization contract.
 """
 from __future__ import annotations
 
@@ -30,14 +39,22 @@ CHAT_TIMEOUT_S = 30.0
 EMBED_TIMEOUT_S = 30.0
 STREAM_TIMEOUT_S = 60.0
 # OpenAI-compatible endpoints (vLLM, llama.cpp, LM Studio, third-party
-# hosts) cannot be introspected for ``structured_output`` or
-# ``function_call`` support — the /v1/models response is just a list
-# of model IDs with no capability metadata. We advertise the baseline
-# capabilities the OpenAI HTTP shape always supports (chat, embed,
-# stream) and intentionally OMIT structured_output + function_call.
-# Operators who know their server supports those features can add a
-# capability override on the credential row in a future PR.
-DEFAULT_CAPABILITIES = ["chat", "embed", "stream"]
+# hosts) cannot be introspected for individual capability support — the
+# /v1/models response is just a list of model IDs with no capability
+# metadata. We advertise the full OpenAI HTTP capability surface that
+# this adapter actually implements (chat, embed, structured_output,
+# function_call, stream). The user opted into trusting the endpoint
+# when they typed in its URL; if the underlying server doesn't honor a
+# request, the sanitized error path returns a generic ``Provider
+# rejected the request (status)`` envelope without leaking provider
+# response data (PR1 sanitization contract).
+DEFAULT_CAPABILITIES = [
+    "chat",
+    "embed",
+    "structured_output",
+    "function_call",
+    "stream",
+]
 
 
 class OpenAICompatibleAdapter:
@@ -52,15 +69,16 @@ class OpenAICompatibleAdapter:
         }
 
     async def validate(self) -> ValidateResult:
-        """GET /v1/models and advertise the baseline capabilities.
+        """GET /v1/models and advertise the full capability surface.
 
-        OpenAI-compatible servers can't be introspected for advanced
-        capability support, so ``structured_output`` and
-        ``function_call`` are intentionally NOT advertised here even
-        if the underlying server happens to support them. Callers that
-        need those capabilities should route to a first-party provider
-        (OpenAI, Anthropic) or wait for the capability-override field
-        on the credential row in a future PR.
+        OpenAI-compatible servers can't be introspected for individual
+        capability support, so we advertise everything this adapter
+        implements (chat, embed, structured_output, function_call,
+        stream) and trust the user-configured endpoint. If the
+        underlying server doesn't honor a particular capability, the
+        sanitized error path (PR1 contract) surfaces a generic
+        ``Provider rejected the request (status)`` envelope without
+        leaking provider response data into the error.
         """
         headers = {"Authorization": f"Bearer {self.api_key}"}
         url = f"{self.base_url}/v1/models"

--- a/backend/app/services/ai_providers/openai_compatible.py
+++ b/backend/app/services/ai_providers/openai_compatible.py
@@ -29,7 +29,15 @@ VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
 EMBED_TIMEOUT_S = 30.0
 STREAM_TIMEOUT_S = 60.0
-DEFAULT_CAPABILITIES = ["chat", "embed"]
+# OpenAI-compatible endpoints (vLLM, llama.cpp, LM Studio, third-party
+# hosts) cannot be introspected for ``structured_output`` or
+# ``function_call`` support — the /v1/models response is just a list
+# of model IDs with no capability metadata. We advertise the baseline
+# capabilities the OpenAI HTTP shape always supports (chat, embed,
+# stream) and intentionally OMIT structured_output + function_call.
+# Operators who know their server supports those features can add a
+# capability override on the credential row in a future PR.
+DEFAULT_CAPABILITIES = ["chat", "embed", "stream"]
 
 
 class OpenAICompatibleAdapter:
@@ -44,6 +52,16 @@ class OpenAICompatibleAdapter:
         }
 
     async def validate(self) -> ValidateResult:
+        """GET /v1/models and advertise the baseline capabilities.
+
+        OpenAI-compatible servers can't be introspected for advanced
+        capability support, so ``structured_output`` and
+        ``function_call`` are intentionally NOT advertised here even
+        if the underlying server happens to support them. Callers that
+        need those capabilities should route to a first-party provider
+        (OpenAI, Anthropic) or wait for the capability-override field
+        on the credential row in a future PR.
+        """
         headers = {"Authorization": f"Bearer {self.api_key}"}
         url = f"{self.base_url}/v1/models"
         try:

--- a/backend/app/services/ai_providers/openai_compatible.py
+++ b/backend/app/services/ai_providers/openai_compatible.py
@@ -1,19 +1,34 @@
-"""OpenAI-compatible adapter — validates by GET {base_url}/v1/models."""
+"""OpenAI-compatible adapter — validates by GET {base_url}/v1/models.
+
+Same wire shape as the OpenAI adapter; the only difference is the
+URL prefix. PR3 mirrors the same capability surface — embed,
+chat_structured, function_call, stream — but with hostile-endpoint
+sanitization on every error path (these endpoints can mirror request
+headers back, which would leak the plaintext API key that just left
+this process).
+"""
 from __future__ import annotations
 
-from typing import Optional
+import json
+from typing import AsyncIterator, Optional
 
 import httpx
 
 from app.services.ai_providers.base import (
     AIProviderError,
+    EmbedResponse,
+    FunctionCallResponse,
     LLMResponse,
+    StreamChunk,
+    TokenUsage,
     ValidateResult,
 )
 
 
 VALIDATE_TIMEOUT_S = 10.0
 CHAT_TIMEOUT_S = 30.0
+EMBED_TIMEOUT_S = 30.0
+STREAM_TIMEOUT_S = 60.0
 DEFAULT_CAPABILITIES = ["chat", "embed"]
 
 
@@ -21,6 +36,12 @@ class OpenAICompatibleAdapter:
     def __init__(self, *, api_key: str, base_url: str) -> None:
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
 
     async def validate(self) -> ValidateResult:
         headers = {"Authorization": f"Bearer {self.api_key}"}
@@ -69,23 +90,16 @@ class OpenAICompatibleAdapter:
         messages: list[dict],
         max_tokens: Optional[int] = None,
     ) -> LLMResponse:
-        """POST {base_url}/v1/chat/completions.
-
-        Same response shape as the OpenAI adapter — hostile OAI-compatible
-        endpoints can still mirror the request body back, so error
-        wrapping never echoes provider content.
-        """
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
+        """POST {base_url}/v1/chat/completions."""
         body: dict = {"model": model, "messages": messages}
         if max_tokens is not None:
             body["max_tokens"] = max_tokens
         url = f"{self.base_url}/v1/chat/completions"
         try:
             async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
-                resp = await client.post(url, headers=headers, json=body)
+                resp = await client.post(
+                    url, headers=self._headers(), json=body
+                )
         except (httpx.HTTPError, httpx.TimeoutException) as exc:
             raise AIProviderError(
                 code=f"network_{type(exc).__name__}"
@@ -113,5 +127,254 @@ class OpenAICompatibleAdapter:
             model=payload.get("model", model) or model,
         )
 
-    async def chat_structured(self, *, model, messages, schema, max_tokens=None):
-        raise NotImplementedError("PR3")
+    async def embed(
+        self,
+        *,
+        texts: list[str],
+        model: Optional[str] = None,
+    ) -> EmbedResponse:
+        """POST {base_url}/v1/embeddings.
+
+        The model parameter is required — OpenAI-compatible servers
+        don't share OpenAI's default model name.
+        """
+        if not model:
+            raise AIProviderError(code="oai_compatible_embed_model_required")
+        body = {"model": model, "input": texts}
+        url = f"{self.base_url}/v1/embeddings"
+        try:
+            async with httpx.AsyncClient(timeout=EMBED_TIMEOUT_S) as client:
+                resp = await client.post(
+                    url, headers=self._headers(), json=body
+                )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            data = payload.get("data", []) or []
+            vectors = [
+                [float(x) for x in (row.get("embedding") or [])]
+                for row in data
+                if isinstance(row, dict)
+            ]
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+        except (KeyError, TypeError, ValueError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return EmbedResponse(
+            vectors=vectors,
+            model=payload.get("model", model) or model,
+            prompt_tokens=prompt_tokens,
+        )
+
+    async def chat_structured(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        schema: dict,
+        max_tokens: Optional[int] = None,
+    ) -> LLMResponse:
+        """OpenAI-compatible JSON-mode chat.
+
+        Conservatively uses plain ``response_format={"type": "json_object"}``
+        with the schema injected into the system prompt — the typed
+        ``json_schema`` mode is OpenAI-specific and may not be honored
+        by every compatible server.
+        """
+        schema_hint = (
+            "Output ONLY a JSON object matching this schema: "
+            + json.dumps(schema, sort_keys=True)
+        )
+        body: dict = {
+            "model": model,
+            "messages": [{"role": "system", "content": schema_hint}]
+            + list(messages),
+            "response_format": {"type": "json_object"},
+        }
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        url = f"{self.base_url}/v1/chat/completions"
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(
+                    url, headers=self._headers(), json=body
+                )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            content = payload["choices"][0]["message"]["content"] or ""
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+        except (KeyError, IndexError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return LLMResponse(
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def function_call(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> FunctionCallResponse:
+        """POST {base_url}/v1/chat/completions with tools.
+
+        If the actual server doesn't support function calling, the
+        upstream 4xx error will bubble through as a sanitized
+        ``AIProviderError`` — we let the caller decide rather than
+        block on a static allowlist (the OAI-compatible space is too
+        broad).
+        """
+        body: dict = {"model": model, "messages": messages, "tools": tools}
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        url = f"{self.base_url}/v1/chat/completions"
+        try:
+            async with httpx.AsyncClient(timeout=CHAT_TIMEOUT_S) as client:
+                resp = await client.post(
+                    url, headers=self._headers(), json=body
+                )
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        if resp.status_code != 200:
+            raise AIProviderError(
+                code=f"provider_status_{resp.status_code}",
+                status_code=resp.status_code,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            raise AIProviderError(code="provider_invalid_json") from None
+        try:
+            message = payload["choices"][0]["message"]
+            raw_tool_calls = message.get("tool_calls") or []
+            tool_calls: list[dict] = []
+            for call in raw_tool_calls:
+                fn = call.get("function") or {}
+                args_text = fn.get("arguments") or "{}"
+                try:
+                    parsed_args = json.loads(args_text)
+                except (TypeError, ValueError):
+                    parsed_args = {}
+                tool_calls.append(
+                    {
+                        "name": fn.get("name") or "",
+                        "arguments": parsed_args,
+                    }
+                )
+            content = message.get("content") or ""
+            usage = payload.get("usage", {}) or {}
+            prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+        except (KeyError, IndexError, TypeError):
+            raise AIProviderError(code="provider_unexpected_shape") from None
+        return FunctionCallResponse(
+            tool_calls=tool_calls,
+            content=content,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            model=payload.get("model", model) or model,
+        )
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict],
+        max_tokens: Optional[int] = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """POST {base_url}/v1/chat/completions with ``stream=true``.
+
+        Mirrors the OpenAI streaming shape. ``include_usage`` is
+        best-effort — compatible servers vary on whether they emit the
+        final usage block.
+        """
+        headers = {**self._headers(), "Accept": "text/event-stream"}
+        body: dict = {
+            "model": model,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        url = f"{self.base_url}/v1/chat/completions"
+
+        final_usage: Optional[TokenUsage] = None
+        try:
+            async with httpx.AsyncClient(timeout=STREAM_TIMEOUT_S) as client:
+                async with client.stream(
+                    "POST", url, headers=headers, json=body
+                ) as resp:
+                    if resp.status_code != 200:
+                        raise AIProviderError(
+                            code=f"provider_status_{resp.status_code}",
+                            status_code=resp.status_code,
+                        )
+                    async for line in resp.aiter_lines():
+                        if not line:
+                            continue
+                        if not line.startswith("data:"):
+                            continue
+                        data = line[len("data:"):].strip()
+                        if data == "[DONE]":
+                            break
+                        try:
+                            event = json.loads(data)
+                        except ValueError:
+                            continue
+                        choices = event.get("choices") or []
+                        if choices:
+                            delta = choices[0].get("delta") or {}
+                            delta_text = str(delta.get("content") or "")
+                            if delta_text:
+                                yield StreamChunk(
+                                    delta_text=delta_text, done=False
+                                )
+                        usage = event.get("usage")
+                        if isinstance(usage, dict):
+                            final_usage = TokenUsage(
+                                prompt_tokens=int(
+                                    usage.get("prompt_tokens", 0) or 0
+                                ),
+                                completion_tokens=int(
+                                    usage.get("completion_tokens", 0) or 0
+                                ),
+                            )
+        except AIProviderError:
+            raise
+        except (httpx.HTTPError, httpx.TimeoutException) as exc:
+            raise AIProviderError(
+                code=f"network_{type(exc).__name__}"
+            ) from None
+        yield StreamChunk(delta_text="", done=True, final_usage=final_usage)

--- a/backend/tests/services/test_ai_adapters_capability_advertising.py
+++ b/backend/tests/services/test_ai_adapters_capability_advertising.py
@@ -1,0 +1,231 @@
+"""Per-adapter ``validate()`` capability advertising.
+
+Blocker fix: the validate() probe must reflect what each provider /
+model actually supports, otherwise the dispatch capability gate at
+``_prepare_dispatch`` rejects every call beyond the legacy
+``chat``/``embed`` pair even when real credentials are present.
+
+Rules pinned here:
+- OpenAI: chat, embed, function_call, stream always; structured_output
+  only when the discovered model list includes a json_schema-capable
+  prefix (gpt-4o, gpt-4o-mini, gpt-4o-2024-08-06, gpt-4.1, gpt-5).
+- Anthropic: chat, structured_output, function_call, stream — no
+  embed (Anthropic has no embeddings API).
+- Ollama: chat, embed, stream always; function_call + structured_output
+  conditional on any discovered model matching the
+  ``KNOWN_FUNCTION_CALL_MODELS`` prefix allowlist.
+- OpenAI-compatible: chat, embed, stream only. structured_output and
+  function_call are intentionally NOT advertised because the
+  /v1/models response carries no capability metadata.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.services.ai_providers import anthropic as anthropic_mod
+from app.services.ai_providers import ollama as ollama_mod
+from app.services.ai_providers import openai as openai_mod
+from app.services.ai_providers import openai_compatible as oai_compat_mod
+from app.services.ai_providers.anthropic import AnthropicAdapter
+from app.services.ai_providers.ollama import OllamaAdapter
+from app.services.ai_providers.openai import OpenAIAdapter
+from app.services.ai_providers.openai_compatible import OpenAICompatibleAdapter
+
+
+_RealAsyncClient = httpx.AsyncClient
+
+
+def _patch_models_response(monkeypatch, module, payload: dict) -> None:
+    """Replace ``module.httpx.AsyncClient`` with a transport that
+    returns the supplied JSON payload for the /models GET call.
+    """
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=json.dumps(payload))
+
+    def _client(*_args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return _RealAsyncClient(**kwargs)
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _client)
+
+
+# ---------- OpenAI ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_validate_advertises_full_capability_set(monkeypatch):
+    """OpenAI key with access to gpt-4o-mini → chat, embed, stream,
+    function_call, structured_output. Pins the json_schema gate hits
+    when at least one capable model is present.
+    """
+    _patch_models_response(
+        monkeypatch,
+        openai_mod,
+        {
+            "data": [
+                {"id": "gpt-4o-mini"},
+                {"id": "text-embedding-3-small"},
+                {"id": "gpt-3.5-turbo"},
+            ]
+        },
+    )
+    adapter = OpenAIAdapter(api_key="sk-test")
+    result = await adapter.validate()
+    assert result.ok is True
+    caps = set(result.discovered_capabilities)
+    assert caps == {
+        "chat",
+        "embed",
+        "function_call",
+        "stream",
+        "structured_output",
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_validate_without_json_schema_model_omits_structured(
+    monkeypatch,
+):
+    """A legacy-only OpenAI key (gpt-3.5-turbo, no gpt-4o family) still
+    gets chat/embed/function_call/stream, but ``structured_output`` is
+    NOT advertised — the json_schema response_format requires the 2024-08
+    family or newer.
+    """
+    _patch_models_response(
+        monkeypatch,
+        openai_mod,
+        {"data": [{"id": "gpt-3.5-turbo"}]},
+    )
+    adapter = OpenAIAdapter(api_key="sk-test")
+    result = await adapter.validate()
+    assert result.ok is True
+    caps = set(result.discovered_capabilities)
+    assert caps == {"chat", "embed", "function_call", "stream"}
+    assert "structured_output" not in caps
+
+
+# ---------- Anthropic -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_validate_advertises_chat_structured_function_stream(
+    monkeypatch,
+):
+    """Anthropic exposes chat + tool use + structured output + streaming.
+    Embed is intentionally absent (no embeddings API).
+    """
+    _patch_models_response(
+        monkeypatch,
+        anthropic_mod,
+        {"data": [{"id": "claude-3-5-sonnet-20241022"}]},
+    )
+    adapter = AnthropicAdapter(api_key="sk-ant-test")
+    result = await adapter.validate()
+    assert result.ok is True
+    caps = set(result.discovered_capabilities)
+    assert caps == {"chat", "structured_output", "function_call", "stream"}
+    assert "embed" not in caps
+
+
+# ---------- Ollama ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_validate_with_function_capable_model_advertises_full(
+    monkeypatch,
+):
+    """An Ollama install whose model list intersects with
+    ``KNOWN_FUNCTION_CALL_MODELS`` (e.g. llama3.1) advertises chat,
+    embed, stream + function_call + structured_output.
+    """
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=json.dumps(
+                {
+                    "models": [
+                        {"name": "llama3.1:8b"},
+                        {"name": "nomic-embed-text"},
+                    ]
+                }
+            ),
+        )
+
+    def _client(*_args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return _RealAsyncClient(**kwargs)
+
+    monkeypatch.setattr(ollama_mod.httpx, "AsyncClient", _client)
+
+    adapter = OllamaAdapter(base_url="http://localhost:11434", api_key="")
+    result = await adapter.validate()
+    assert result.ok is True
+    caps = set(result.discovered_capabilities)
+    assert caps == {
+        "chat",
+        "embed",
+        "stream",
+        "function_call",
+        "structured_output",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ollama_validate_with_non_function_capable_model_omits_function(
+    monkeypatch,
+):
+    """An Ollama install with only legacy models (no llama3.1+,
+    mistral-nemo, etc.) advertises just the baseline:
+    chat, embed, stream.
+    """
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=json.dumps({"models": [{"name": "llama2:7b"}]}),
+        )
+
+    def _client(*_args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return _RealAsyncClient(**kwargs)
+
+    monkeypatch.setattr(ollama_mod.httpx, "AsyncClient", _client)
+
+    adapter = OllamaAdapter(base_url="http://localhost:11434", api_key="")
+    result = await adapter.validate()
+    assert result.ok is True
+    caps = set(result.discovered_capabilities)
+    assert caps == {"chat", "embed", "stream"}
+    assert "function_call" not in caps
+    assert "structured_output" not in caps
+
+
+# ---------- OpenAI-compatible ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_validate_omits_structured_and_function(
+    monkeypatch,
+):
+    """OpenAI-compatible endpoints (vLLM, llama.cpp, LM Studio, hosted
+    third parties) cannot be introspected for advanced capability
+    support, so structured_output and function_call are intentionally
+    NOT advertised even when the underlying server happens to support
+    them.
+    """
+    _patch_models_response(
+        monkeypatch,
+        oai_compat_mod,
+        {"data": [{"id": "mixtral-8x7b"}, {"id": "embed-large"}]},
+    )
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-test", base_url="https://api.example.com"
+    )
+    result = await adapter.validate()
+    assert result.ok is True
+    caps = set(result.discovered_capabilities)
+    assert caps == {"chat", "embed", "stream"}
+    assert "structured_output" not in caps
+    assert "function_call" not in caps

--- a/backend/tests/services/test_ai_adapters_capability_advertising.py
+++ b/backend/tests/services/test_ai_adapters_capability_advertising.py
@@ -14,9 +14,11 @@ Rules pinned here:
 - Ollama: chat, embed, stream always; function_call + structured_output
   conditional on any discovered model matching the
   ``KNOWN_FUNCTION_CALL_MODELS`` prefix allowlist.
-- OpenAI-compatible: chat, embed, stream only. structured_output and
-  function_call are intentionally NOT advertised because the
-  /v1/models response carries no capability metadata.
+- OpenAI-compatible: chat, embed, structured_output, function_call,
+  stream — the full surface this adapter implements. The /v1/models
+  response carries no capability metadata, so we trust the
+  user-configured endpoint and rely on the sanitized provider error
+  path (PR1) when the underlying server doesn't honor a request.
 """
 from __future__ import annotations
 
@@ -206,14 +208,18 @@ async def test_ollama_validate_with_non_function_capable_model_omits_function(
 
 
 @pytest.mark.asyncio
-async def test_openai_compatible_validate_omits_structured_and_function(
+async def test_openai_compatible_advertises_all_five_capabilities(
     monkeypatch,
 ):
     """OpenAI-compatible endpoints (vLLM, llama.cpp, LM Studio, hosted
-    third parties) cannot be introspected for advanced capability
-    support, so structured_output and function_call are intentionally
-    NOT advertised even when the underlying server happens to support
-    them.
+    third parties) advertise the full capability surface this adapter
+    implements: chat, embed, structured_output, function_call, stream.
+
+    The /v1/models response carries no capability metadata, so we can't
+    introspect individual support. Instead, the adapter trusts the
+    user-configured endpoint (they typed in its URL) and falls back on
+    the sanitized error path (PR1 contract) when the underlying server
+    doesn't honor a particular request.
     """
     _patch_models_response(
         monkeypatch,
@@ -226,6 +232,24 @@ async def test_openai_compatible_validate_omits_structured_and_function(
     result = await adapter.validate()
     assert result.ok is True
     caps = set(result.discovered_capabilities)
-    assert caps == {"chat", "embed", "stream"}
-    assert "structured_output" not in caps
-    assert "function_call" not in caps
+    assert caps == {
+        "chat",
+        "embed",
+        "structured_output",
+        "function_call",
+        "stream",
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_default_capabilities_constant(monkeypatch):
+    """Module-level DEFAULT_CAPABILITIES pins the full 5-cap set so
+    accidental edits to the constant fail loudly.
+    """
+    assert set(oai_compat_mod.DEFAULT_CAPABILITIES) == {
+        "chat",
+        "embed",
+        "structured_output",
+        "function_call",
+        "stream",
+    }

--- a/backend/tests/services/test_ai_adapters_embed.py
+++ b/backend/tests/services/test_ai_adapters_embed.py
@@ -1,0 +1,238 @@
+"""Adapter ``embed()`` tests (PR3 of AI tier train).
+
+OpenAI, Ollama, OpenAI-compatible: happy path + sanitized error.
+Anthropic: NotImplementedError (no public embeddings API).
+
+Sanitization invariant from PR2 carries through — provider error
+bodies must NEVER leak into the wrapped exception's message.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.services.ai_providers.anthropic import AnthropicAdapter
+from app.services.ai_providers.base import AIProviderError
+from app.services.ai_providers.ollama import OllamaAdapter
+from app.services.ai_providers.openai import OpenAIAdapter
+from app.services.ai_providers.openai_compatible import (
+    OpenAICompatibleAdapter,
+)
+
+
+LEAKED_SECRET_MARKER = "sk-LEAKED-XXX"
+
+
+def _install_transport(monkeypatch, handler) -> list[httpx.Request]:
+    captured: list[httpx.Request] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(_wrapped)
+    original = httpx.AsyncClient.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _patched_init)
+    return captured
+
+
+# ---------- OpenAI ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_embed_happy_path_default_model(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["model"] == "text-embedding-3-small"
+        assert body["input"] == ["hello", "world"]
+        return httpx.Response(
+            200,
+            json={
+                "model": "text-embedding-3-small",
+                "data": [
+                    {"embedding": [0.1, 0.2, 0.3]},
+                    {"embedding": [0.4, 0.5, 0.6]},
+                ],
+                "usage": {"prompt_tokens": 4},
+            },
+        )
+
+    captured = _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    resp = await adapter.embed(texts=["hello", "world"])
+    assert resp.vectors == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    assert resp.model == "text-embedding-3-small"
+    assert resp.prompt_tokens == 4
+    assert str(captured[0].url) == "https://api.openai.com/v1/embeddings"
+    assert captured[0].headers["Authorization"] == "Bearer sk-test"
+
+
+@pytest.mark.asyncio
+async def test_openai_embed_explicit_model_overrides_default(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["model"] == "text-embedding-3-large"
+        return httpx.Response(
+            200,
+            json={
+                "model": "text-embedding-3-large",
+                "data": [{"embedding": [0.1]}],
+                "usage": {"prompt_tokens": 1},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    resp = await adapter.embed(texts=["x"], model="text-embedding-3-large")
+    assert resp.model == "text-embedding-3-large"
+
+
+@pytest.mark.asyncio
+async def test_openai_embed_error_sanitized(monkeypatch):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500, text=f"crashed, key was {LEAKED_SECRET_MARKER}"
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.embed(texts=["x"])
+    assert LEAKED_SECRET_MARKER not in str(exc_info.value)
+    assert exc_info.value.code == "provider_status_500"
+
+
+# ---------- Anthropic ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_embed_raises_not_implemented():
+    """Anthropic does not expose a public embeddings API.
+
+    Documented refusal — caller (service or feature surface) can pick
+    a sibling provider that has embeddings configured.
+    """
+    adapter = AnthropicAdapter(api_key="sk-ant-test")
+    with pytest.raises(NotImplementedError) as exc_info:
+        await adapter.embed(texts=["x"])
+    assert "Anthropic" in str(exc_info.value)
+
+
+# ---------- Ollama ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_embed_no_bearer(monkeypatch):
+    requests_seen: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        requests_seen.append(body)
+        assert "Authorization" not in request.headers
+        return httpx.Response(
+            200,
+            json={
+                "model": "nomic-embed-text",
+                "embedding": [0.7, 0.8, 0.9],
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    resp = await adapter.embed(texts=["a", "b"], model="nomic-embed-text")
+    # One request per text.
+    assert len(requests_seen) == 2
+    assert resp.vectors == [[0.7, 0.8, 0.9], [0.7, 0.8, 0.9]]
+    assert resp.model == "nomic-embed-text"
+    # Estimated tokens (4 chars / token), minimum 1.
+    assert resp.prompt_tokens >= 1
+
+
+@pytest.mark.asyncio
+async def test_ollama_embed_with_bearer_token(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer secret-bearer"
+        return httpx.Response(
+            200,
+            json={"model": "nomic-embed-text", "embedding": [0.1, 0.2]},
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434",
+        api_key="x",
+        bearer_token="secret-bearer",
+    )
+    resp = await adapter.embed(texts=["x"], model="nomic-embed-text")
+    assert resp.vectors == [[0.1, 0.2]]
+
+
+@pytest.mark.asyncio
+async def test_ollama_embed_error_sanitized(monkeypatch):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            503, text=f"down — {LEAKED_SECRET_MARKER}"
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.embed(texts=["x"], model="nomic-embed-text")
+    assert LEAKED_SECRET_MARKER not in str(exc_info.value)
+
+
+# ---------- OpenAI-compatible ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_embed_happy(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["model"] == "my-embed-model"
+        assert request.headers["Authorization"] == "Bearer sk-compat"
+        return httpx.Response(
+            200,
+            json={
+                "model": "my-embed-model",
+                "data": [{"embedding": [1.0, 2.0]}],
+                "usage": {"prompt_tokens": 7},
+            },
+        )
+
+    captured = _install_transport(monkeypatch, handler)
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    resp = await adapter.embed(texts=["x"], model="my-embed-model")
+    assert resp.vectors == [[1.0, 2.0]]
+    assert resp.prompt_tokens == 7
+    assert (
+        str(captured[0].url) == "https://compat.example.org/v1/embeddings"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_embed_hostile_body_does_not_leak(monkeypatch):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            418, text=f"echo of request: {LEAKED_SECRET_MARKER}"
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.embed(texts=["x"], model="my-embed-model")
+    assert LEAKED_SECRET_MARKER not in str(exc_info.value)

--- a/backend/tests/services/test_ai_adapters_function.py
+++ b/backend/tests/services/test_ai_adapters_function.py
@@ -1,0 +1,284 @@
+"""Adapter ``function_call()`` tests (PR3 of AI tier train).
+
+Wire-shape pins per provider:
+
+- OpenAI: tools array passed through; ``tool_calls[*].function.arguments``
+  is a JSON string that the adapter parses into a dict.
+- Anthropic: OpenAI-shape tools normalized to ``{name, description,
+  input_schema}``; response ``content`` blocks of type ``tool_use``
+  parsed into ``FunctionCallResponse.tool_calls``.
+- Ollama: refuses with ``CapabilityNotSupported`` for models not on
+  the known function-call list; passes through for known prefixes.
+- OpenAI-compatible: same shape as OpenAI; provider-side rejection
+  surfaces as a sanitized ``AIProviderError``.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.services.ai_providers.anthropic import AnthropicAdapter
+from app.services.ai_providers.base import (
+    AIProviderError,
+    CapabilityNotSupported,
+)
+from app.services.ai_providers.ollama import OllamaAdapter
+from app.services.ai_providers.openai import OpenAIAdapter
+from app.services.ai_providers.openai_compatible import (
+    OpenAICompatibleAdapter,
+)
+
+
+TOOLS_OPENAI = [
+    {
+        "type": "function",
+        "function": {
+            "name": "set_category",
+            "description": "Assign a category to the transaction.",
+            "parameters": {
+                "type": "object",
+                "properties": {"slug": {"type": "string"}},
+                "required": ["slug"],
+            },
+        },
+    }
+]
+
+
+def _install_transport(monkeypatch, handler) -> list[httpx.Request]:
+    captured: list[httpx.Request] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(_wrapped)
+    original = httpx.AsyncClient.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _patched_init)
+    return captured
+
+
+# ---------- OpenAI ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_function_call_parses_tool_calls(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["tools"] == TOOLS_OPENAI
+        return httpx.Response(
+            200,
+            json={
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "set_category",
+                                        "arguments": '{"slug": "rent"}',
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    resp = await adapter.function_call(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "classify"}],
+        tools=TOOLS_OPENAI,
+    )
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0]["name"] == "set_category"
+    assert resp.tool_calls[0]["arguments"] == {"slug": "rent"}
+    assert resp.prompt_tokens == 9
+    assert resp.completion_tokens == 4
+
+
+# ---------- Anthropic ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_function_call_normalizes_oai_tools_and_parses_tool_use(
+    monkeypatch,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        # Tools were normalized from OAI shape into Anthropic shape.
+        assert len(body["tools"]) == 1
+        assert body["tools"][0]["name"] == "set_category"
+        assert "input_schema" in body["tools"][0]
+        assert "type" not in body["tools"][0]  # no "function" wrapper
+        return httpx.Response(
+            200,
+            json={
+                "model": "claude-haiku-4-5",
+                "content": [
+                    {"type": "text", "text": "Looks like rent."},
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "set_category",
+                        "input": {"slug": "rent"},
+                    },
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = AnthropicAdapter(api_key="sk-ant-test")
+    resp = await adapter.function_call(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "classify"}],
+        tools=TOOLS_OPENAI,
+    )
+    assert resp.tool_calls == [
+        {"name": "set_category", "arguments": {"slug": "rent"}}
+    ]
+    assert resp.content == "Looks like rent."
+
+
+# ---------- Ollama ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_function_call_refuses_unsupported_model():
+    """An Ollama model not on the known function-call prefix list must
+    raise ``CapabilityNotSupported`` — the caller (call_llm_function)
+    surfaces that as 412 ``ai_capability_not_supported``.
+    """
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    with pytest.raises(CapabilityNotSupported) as exc_info:
+        await adapter.function_call(
+            model="phi:latest",  # not on the list
+            messages=[],
+            tools=TOOLS_OPENAI,
+        )
+    assert exc_info.value.model == "phi:latest"
+    assert exc_info.value.capability == "function_call"
+
+
+@pytest.mark.asyncio
+async def test_ollama_function_call_supported_model_passes_through(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["tools"] == TOOLS_OPENAI
+        return httpx.Response(
+            200,
+            json={
+                "model": "llama3.1:8b",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "set_category",
+                                "arguments": {"slug": "food"},
+                            }
+                        }
+                    ],
+                },
+                "prompt_eval_count": 6,
+                "eval_count": 2,
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    resp = await adapter.function_call(
+        model="llama3.1:8b",
+        messages=[{"role": "user", "content": "classify"}],
+        tools=TOOLS_OPENAI,
+    )
+    assert resp.tool_calls == [
+        {"name": "set_category", "arguments": {"slug": "food"}}
+    ]
+
+
+# ---------- OpenAI-compatible ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_function_call_passes_through(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["tools"] == TOOLS_OPENAI
+        return httpx.Response(
+            200,
+            json={
+                "model": "any",
+                "choices": [
+                    {
+                        "message": {
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "function": {
+                                        "name": "set_category",
+                                        "arguments": '{"slug": "utilities"}',
+                                    }
+                                }
+                            ],
+                        }
+                    }
+                ],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 3},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    resp = await adapter.function_call(
+        model="any",
+        messages=[{"role": "user", "content": "x"}],
+        tools=TOOLS_OPENAI,
+    )
+    assert resp.tool_calls == [
+        {"name": "set_category", "arguments": {"slug": "utilities"}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_function_call_provider_400_bubbles(monkeypatch):
+    """An OAI-compatible server that doesn't support tool calls
+    typically returns 400. The adapter must surface that as a
+    sanitized ``AIProviderError`` so the caller can fall back.
+    """
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="tools unsupported by this model")
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.function_call(
+            model="any", messages=[], tools=TOOLS_OPENAI
+        )
+    assert exc_info.value.code == "provider_status_400"

--- a/backend/tests/services/test_ai_adapters_stream.py
+++ b/backend/tests/services/test_ai_adapters_stream.py
@@ -1,0 +1,184 @@
+"""Adapter ``stream()`` tests (PR3 of AI tier train).
+
+Pins:
+- OpenAI: SSE chunks ``data: {...}\\n\\n``; final ``data: [DONE]`` ends
+  the loop. ``stream_options.include_usage`` makes the provider emit a
+  final usage block that we capture into ``StreamChunk.final_usage``.
+- Anthropic: SSE with ``content_block_delta`` events. Token usage
+  comes from ``message_start`` (prompt) and ``message_delta`` (output).
+- Ollama: NDJSON (one JSON per line), final line has ``done: true``
+  with the eval counts.
+- OpenAI-compatible: same shape as OpenAI.
+- The ledger row written by ``call_llm_stream`` is exercised in
+  ``test_ai_dispatch_capabilities.py``.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.services.ai_providers.anthropic import AnthropicAdapter
+from app.services.ai_providers.ollama import OllamaAdapter
+from app.services.ai_providers.openai import OpenAIAdapter
+from app.services.ai_providers.openai_compatible import (
+    OpenAICompatibleAdapter,
+)
+
+
+def _install_streaming_transport(monkeypatch, response: httpx.Response):
+    """Install a transport that returns ``response`` from any request."""
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return response
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.AsyncClient.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _patched_init)
+
+
+# ---------- OpenAI ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_yields_chunks_and_captures_final_usage(monkeypatch):
+    sse_body = (
+        'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n'
+        'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'
+        'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n'
+        "data: [DONE]\n\n"
+    )
+    _install_streaming_transport(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=sse_body.encode("utf-8"),
+            headers={"Content-Type": "text/event-stream"},
+        ),
+    )
+    adapter = OpenAIAdapter(api_key="sk-test")
+    chunks = []
+    async for c in adapter.stream(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+    ):
+        chunks.append(c)
+    # 2 deltas + 1 done.
+    assert [c.delta_text for c in chunks if not c.done] == ["Hel", "lo"]
+    final = chunks[-1]
+    assert final.done is True
+    assert final.final_usage is not None
+    assert final.final_usage.prompt_tokens == 3
+    assert final.final_usage.completion_tokens == 2
+
+
+# ---------- Anthropic ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_yields_chunks_and_captures_usage(monkeypatch):
+    sse_body = (
+        'data: {"type":"message_start","message":{"usage":{"input_tokens":4,"output_tokens":0}}}\n\n'
+        'data: {"type":"content_block_delta","delta":{"text":"He"}}\n\n'
+        'data: {"type":"content_block_delta","delta":{"text":"llo"}}\n\n'
+        'data: {"type":"message_delta","usage":{"output_tokens":3}}\n\n'
+        'data: {"type":"message_stop"}\n\n'
+    )
+    _install_streaming_transport(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=sse_body.encode("utf-8"),
+            headers={"Content-Type": "text/event-stream"},
+        ),
+    )
+    adapter = AnthropicAdapter(api_key="sk-ant-test")
+    chunks = []
+    async for c in adapter.stream(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "hi"}],
+    ):
+        chunks.append(c)
+    assert [c.delta_text for c in chunks if not c.done] == ["He", "llo"]
+    final = chunks[-1]
+    assert final.done is True
+    assert final.final_usage.prompt_tokens == 4
+    assert final.final_usage.completion_tokens == 3
+
+
+# ---------- Ollama ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_stream_yields_chunks_and_captures_eval_counts(monkeypatch):
+    ndjson_body = (
+        json.dumps({"message": {"content": "Hi "}, "done": False})
+        + "\n"
+        + json.dumps({"message": {"content": "there"}, "done": False})
+        + "\n"
+        + json.dumps(
+            {
+                "message": {"content": ""},
+                "done": True,
+                "prompt_eval_count": 5,
+                "eval_count": 4,
+            }
+        )
+        + "\n"
+    )
+    _install_streaming_transport(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=ndjson_body.encode("utf-8"),
+            headers={"Content-Type": "application/x-ndjson"},
+        ),
+    )
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    chunks = []
+    async for c in adapter.stream(
+        model="llama3:8b",
+        messages=[{"role": "user", "content": "x"}],
+    ):
+        chunks.append(c)
+    assert [c.delta_text for c in chunks if not c.done] == ["Hi ", "there"]
+    final = chunks[-1]
+    assert final.done is True
+    assert final.final_usage.prompt_tokens == 5
+    assert final.final_usage.completion_tokens == 4
+
+
+# ---------- OpenAI-compatible ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_stream_yields_chunks(monkeypatch):
+    sse_body = (
+        'data: {"choices":[{"delta":{"content":"yo"}}]}\n\n'
+        'data: [DONE]\n\n'
+    )
+    _install_streaming_transport(
+        monkeypatch,
+        httpx.Response(
+            200,
+            content=sse_body.encode("utf-8"),
+            headers={"Content-Type": "text/event-stream"},
+        ),
+    )
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    chunks = []
+    async for c in adapter.stream(
+        model="any", messages=[{"role": "user", "content": "x"}]
+    ):
+        chunks.append(c)
+    assert [c.delta_text for c in chunks if not c.done] == ["yo"]
+    assert chunks[-1].done is True

--- a/backend/tests/services/test_ai_adapters_structured.py
+++ b/backend/tests/services/test_ai_adapters_structured.py
@@ -1,0 +1,256 @@
+"""Adapter ``chat_structured()`` tests (PR3 of AI tier train).
+
+These pin the WIRE shape each adapter sends to the provider, NOT the
+retry-cap budget — that lives in the service layer
+(``call_llm_structured`` in ``test_ai_dispatch``).
+
+Wire shape per provider:
+
+- OpenAI gpt-4o-mini: ``response_format = {"type": "json_schema",
+  "json_schema": {...}}``.
+- OpenAI legacy / non-4o: ``response_format = {"type": "json_object"}``
+  + schema in the system message.
+- Anthropic: single ``tools`` entry whose ``input_schema`` is the
+  response schema; ``tool_choice`` pins the tool.
+- Ollama: ``format: "json"`` + schema-hint system message.
+- OpenAI-compatible: same as legacy OpenAI (json_object only).
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.services.ai_providers.anthropic import AnthropicAdapter
+from app.services.ai_providers.base import AIProviderError
+from app.services.ai_providers.ollama import OllamaAdapter
+from app.services.ai_providers.openai import OpenAIAdapter
+from app.services.ai_providers.openai_compatible import (
+    OpenAICompatibleAdapter,
+)
+
+
+SCHEMA = {
+    "type": "object",
+    "required": ["category"],
+    "properties": {"category": {"type": "string"}},
+}
+LEAKED_SECRET_MARKER = "sk-LEAKED-XXX"
+
+
+def _install_transport(monkeypatch, handler) -> list[httpx.Request]:
+    captured: list[httpx.Request] = []
+
+    def _wrapped(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(_wrapped)
+    original = httpx.AsyncClient.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _patched_init)
+    return captured
+
+
+# ---------- OpenAI ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_structured_uses_json_schema_for_gpt4o(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["response_format"]["type"] == "json_schema"
+        assert body["response_format"]["json_schema"]["schema"] == SCHEMA
+        return httpx.Response(
+            200,
+            json={
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": '{"category": "groceries"}',
+                        }
+                    }
+                ],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    resp = await adapter.chat_structured(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "classify"}],
+        schema=SCHEMA,
+    )
+    assert resp.content == '{"category": "groceries"}'
+    assert resp.prompt_tokens == 5
+    assert resp.completion_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_structured_falls_back_to_json_object_for_legacy(
+    monkeypatch,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["response_format"] == {"type": "json_object"}
+        # Schema hint prepended as system message.
+        first = body["messages"][0]
+        assert first["role"] == "system"
+        assert "category" in first["content"]
+        return httpx.Response(
+            200,
+            json={
+                "model": "gpt-3.5-turbo",
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"category": "transport"}'
+                        }
+                    }
+                ],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    resp = await adapter.chat_structured(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "classify"}],
+        schema=SCHEMA,
+    )
+    assert resp.content == '{"category": "transport"}'
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_structured_error_sanitized(monkeypatch):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text=f"err {LEAKED_SECRET_MARKER}")
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAIAdapter(api_key="sk-test")
+    with pytest.raises(AIProviderError) as exc_info:
+        await adapter.chat_structured(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "x"}],
+            schema=SCHEMA,
+        )
+    assert LEAKED_SECRET_MARKER not in str(exc_info.value)
+
+
+# ---------- Anthropic ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_chat_structured_uses_tool_use(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert len(body["tools"]) == 1
+        assert body["tools"][0]["name"] == "respond_structured"
+        assert body["tools"][0]["input_schema"] == SCHEMA
+        assert body["tool_choice"]["name"] == "respond_structured"
+        return httpx.Response(
+            200,
+            json={
+                "model": "claude-haiku-4-5",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "respond_structured",
+                        "input": {"category": "utilities"},
+                    }
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 6},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = AnthropicAdapter(api_key="sk-ant-test")
+    resp = await adapter.chat_structured(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "classify"}],
+        schema=SCHEMA,
+    )
+    # Content is the JSON serialization of the tool_use.input dict.
+    parsed = json.loads(resp.content)
+    assert parsed == {"category": "utilities"}
+    assert resp.prompt_tokens == 10
+    assert resp.completion_tokens == 6
+
+
+# ---------- Ollama ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_chat_structured_uses_format_json(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["format"] == "json"
+        # Schema hint sits in the prepended system message.
+        first = body["messages"][0]
+        assert first["role"] == "system"
+        assert "category" in first["content"]
+        return httpx.Response(
+            200,
+            json={
+                "model": "llama3:8b",
+                "message": {
+                    "role": "assistant",
+                    "content": '{"category": "food"}',
+                },
+                "prompt_eval_count": 8,
+                "eval_count": 4,
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OllamaAdapter(
+        base_url="http://10.0.0.10:11434", api_key="x"
+    )
+    resp = await adapter.chat_structured(
+        model="llama3:8b",
+        messages=[{"role": "user", "content": "classify"}],
+        schema=SCHEMA,
+    )
+    assert json.loads(resp.content) == {"category": "food"}
+    assert resp.prompt_tokens == 8
+
+
+# ---------- OpenAI-compatible ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_chat_structured_uses_json_object(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        assert body["response_format"] == {"type": "json_object"}
+        return httpx.Response(
+            200,
+            json={
+                "model": "any",
+                "choices": [
+                    {"message": {"content": '{"category": "rent"}'}}
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    adapter = OpenAICompatibleAdapter(
+        api_key="sk-compat", base_url="https://compat.example.org"
+    )
+    resp = await adapter.chat_structured(
+        model="any",
+        messages=[{"role": "user", "content": "x"}],
+        schema=SCHEMA,
+    )
+    assert json.loads(resp.content) == {"category": "rent"}

--- a/backend/tests/services/test_ai_dispatch_capabilities.py
+++ b/backend/tests/services/test_ai_dispatch_capabilities.py
@@ -1,0 +1,601 @@
+"""Dispatch-layer tests for PR3 capability wrappers.
+
+Covers:
+- ``call_llm_embed`` happy path writes a ledger row.
+- ``call_llm_structured`` happy path on first attempt records
+  ``retries_used=0`` in the ledger row.
+- ``call_llm_structured`` retry on JSON parse failure succeeds on
+  second attempt with ``retries_used=1``.
+- ``call_llm_structured`` exhausts the retry budget after 3 failed
+  attempts and raises ``StructuredOutputError``; the failure ledger
+  row carries ``retries_used=2`` and
+  ``error_class="STATUS_ERROR_STRUCTURED_OUTPUT"``.
+- Routing capability mismatch → ``AICapabilityNotSupported`` →
+  HTTPException 412 with ``ai_capability_not_supported``.
+- ``call_llm_stream`` completes and writes exactly ONE ledger row at
+  end-of-stream (not per chunk).
+- ``call_llm_function`` happy path on OpenAI-shape tool_calls.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+from collections.abc import AsyncIterator
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.models import Base
+from app.models.ai_usage_ledger import AIUsageLedger
+from app.models.org_ai_credential import AiProvider, OrgAICredential
+from app.models.org_ai_routing import OrgAIDefaultRouting
+from app.models.user import Organization, Role, User
+from app.services.ai_credential_crypto import encrypt
+from app.services.ai_dispatch import (
+    AICapabilityNotSupported,
+    call_llm_embed,
+    call_llm_function,
+    call_llm_stream,
+    call_llm_structured,
+    http_for_dispatch_error,
+)
+from app.services.ai_providers.base import (
+    EmbedResponse,
+    FunctionCallResponse,
+    LLMResponse,
+    StreamChunk,
+    StructuredOutputError,
+    TokenUsage,
+)
+
+
+# ---------- fixtures --------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture(autouse=True)
+def _set_ai_key(monkeypatch):
+    monkeypatch.setattr(
+        app_settings,
+        "ai_credential_encryption_key",
+        base64.urlsafe_b64encode(os.urandom(32)).decode("ascii"),
+    )
+    monkeypatch.setattr(
+        app_settings, "ai_credential_encryption_key_prev", ""
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_redis(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.ai_dispatch.redis_client.get_client",
+        lambda: None,
+    )
+
+
+@pytest_asyncio.fixture
+async def org(db: AsyncSession) -> Organization:
+    org = Organization(name="Acme", billing_cycle_day=1)
+    db.add(org)
+    await db.commit()
+    return org
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession, org: Organization) -> User:
+    user = User(
+        org_id=org.id,
+        username="admin",
+        email="admin@example.com",
+        password_hash="x" * 64,
+        role=Role.OWNER,
+    )
+    db.add(user)
+    await db.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def credential(db: AsyncSession, org: Organization) -> OrgAICredential:
+    cred = OrgAICredential(
+        org_id=org.id,
+        provider=AiProvider.OPENAI,
+        encrypted_api_key=encrypt("sk-test-12345"),
+        encrypted_bearer_token=None,
+        base_url=None,
+        key_fingerprint="0123456789abcdef",
+        last_four="2345",
+        label="primary",
+        # PR3: capability check requires this list to advertise the
+        # capability the call requests.
+        discovered_capabilities=[
+            "chat",
+            "embed",
+            "structured_output",
+            "function_call",
+            "stream",
+        ],
+    )
+    db.add(cred)
+    await db.commit()
+    return cred
+
+
+@pytest_asyncio.fixture
+async def default_routing(
+    db: AsyncSession, org: Organization, credential: OrgAICredential
+) -> OrgAIDefaultRouting:
+    row = OrgAIDefaultRouting(
+        org_id=org.id, credential_id=credential.id, model="gpt-4o-mini"
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
+# ---------- call_llm_embed -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_llm_embed_happy_path_writes_ledger(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    adapter = MagicMock()
+    adapter.embed = AsyncMock(
+        return_value=EmbedResponse(
+            vectors=[[0.1, 0.2, 0.3]],
+            model="text-embedding-3-small",
+            prompt_tokens=7,
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_embed(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            texts=["x"],
+            model="text-embedding-3-small",
+        )
+    assert result.response.vectors == [[0.1, 0.2, 0.3]]
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.success is True
+    assert row.prompt_tokens == 7
+    assert row.completion_tokens == 0
+    assert row.model == "text-embedding-3-small"
+    assert row.retries_used == 0
+
+
+# ---------- call_llm_structured retry budget -------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_llm_structured_happy_path_no_retries(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        return_value=LLMResponse(
+            content='{"category": "groceries"}',
+            prompt_tokens=5,
+            completion_tokens=3,
+            model="gpt-4o-mini",
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema={
+                "type": "object",
+                "required": ["category"],
+                "properties": {"category": {"type": "string"}},
+            },
+        )
+    assert result.response.parsed == {"category": "groceries"}
+    assert result.response.retries_used == 0
+    adapter.chat_structured.assert_awaited_once()
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].retries_used == 0
+    assert rows[0].success is True
+
+
+@pytest.mark.asyncio
+async def test_call_llm_structured_retries_once_then_succeeds(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """First attempt returns malformed JSON; second attempt succeeds.
+
+    ``retries_used`` on the success ledger row = 1.
+    """
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        side_effect=[
+            LLMResponse(
+                content="not json at all",
+                prompt_tokens=4,
+                completion_tokens=2,
+                model="gpt-4o-mini",
+            ),
+            LLMResponse(
+                content='{"category": "rent"}',
+                prompt_tokens=4,
+                completion_tokens=3,
+                model="gpt-4o-mini",
+            ),
+        ]
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema={
+                "type": "object",
+                "required": ["category"],
+                "properties": {"category": {"type": "string"}},
+            },
+        )
+    assert result.response.retries_used == 1
+    assert adapter.chat_structured.await_count == 2
+    # Retry system message was injected on attempt #2.
+    second_call_kwargs = adapter.chat_structured.await_args_list[1].kwargs
+    assert any(
+        m.get("role") == "system"
+        and "Previous response was not valid JSON" in m.get("content", "")
+        for m in second_call_kwargs["messages"]
+    )
+    # Single ledger row, retries_used=1, success=True.
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].retries_used == 1
+    assert rows[0].success is True
+
+
+@pytest.mark.asyncio
+async def test_call_llm_structured_exhausts_retry_budget_raises_typed_error(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Three failed parses → ``StructuredOutputError``.
+
+    Architect lock #13: max 2 retries (3 total attempts).
+    """
+    bad_response = LLMResponse(
+        content="still not json",
+        prompt_tokens=2,
+        completion_tokens=2,
+        model="gpt-4o-mini",
+    )
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        side_effect=[bad_response, bad_response, bad_response]
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        with pytest.raises(StructuredOutputError) as exc_info:
+            await call_llm_structured(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "x"}],
+                response_schema={
+                    "type": "object",
+                    "required": ["category"],
+                    "properties": {"category": {"type": "string"}},
+                },
+            )
+    assert exc_info.value.code == "STATUS_ERROR_STRUCTURED_OUTPUT"
+    # Exactly 3 adapter invocations (1 initial + 2 retries).
+    assert adapter.chat_structured.await_count == 3
+    # Failure ledger row: retries_used=2, success=False.
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.retries_used == 2
+    assert row.success is False
+    assert row.error_class == "STATUS_ERROR_STRUCTURED_OUTPUT"
+
+
+@pytest.mark.asyncio
+async def test_call_llm_structured_schema_failure_triggers_retry(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """JSON parses fine but fails schema (missing required key) →
+    retry. Pins that schema-validation failure is wired into the
+    retry budget, not just JSON-parse failure.
+    """
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        side_effect=[
+            LLMResponse(
+                # Valid JSON but missing the required "category" key.
+                content='{"other": "value"}',
+                prompt_tokens=2,
+                completion_tokens=2,
+                model="gpt-4o-mini",
+            ),
+            LLMResponse(
+                content='{"category": "ok"}',
+                prompt_tokens=2,
+                completion_tokens=2,
+                model="gpt-4o-mini",
+            ),
+        ]
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema={
+                "type": "object",
+                "required": ["category"],
+                "properties": {"category": {"type": "string"}},
+            },
+        )
+    assert result.response.retries_used == 1
+
+
+# ---------- Routing capability check ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_routing_capability_mismatch_raises_412(
+    db: AsyncSession, org, admin_user, default_routing
+):
+    """Credential whose ``discovered_capabilities`` lacks ``embed`` ->
+    ``AICapabilityNotSupported`` -> HTTP 412 with
+    ``ai_capability_not_supported``.
+    """
+    # Routing already points at a credential. We swap its discovered
+    # caps to something that excludes embed.
+    cred = (
+        await db.execute(select(OrgAICredential))
+    ).scalar_one()
+    cred.discovered_capabilities = ["chat"]
+    await db.commit()
+
+    with pytest.raises(AICapabilityNotSupported) as exc_info:
+        await call_llm_embed(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            texts=["x"],
+            model="text-embedding-3-small",
+        )
+    assert exc_info.value.code == "ai_capability_not_supported"
+    assert exc_info.value.capability == "embed"
+    assert exc_info.value.feature_key == "chat"
+    # No ledger row written for the rejected call.
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert rows == []
+
+    # HTTPException mapper surfaces 412 + the helpful message.
+    http = http_for_dispatch_error(exc_info.value)
+    assert isinstance(http, HTTPException)
+    assert http.status_code == 412
+    assert http.detail["code"] == "ai_capability_not_supported"
+    assert http.detail["capability"] == "embed"
+    assert "Reconfigure routing" in http.detail["message"]
+
+
+# ---------- Function call -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_llm_function_happy_path(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    adapter = MagicMock()
+    adapter.function_call = AsyncMock(
+        return_value=FunctionCallResponse(
+            tool_calls=[
+                {"name": "set_category", "arguments": {"slug": "rent"}}
+            ],
+            content="",
+            prompt_tokens=12,
+            completion_tokens=6,
+            model="gpt-4o-mini",
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_function(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "classify"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "set_category",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+    assert result.response.tool_calls[0]["name"] == "set_category"
+    assert result.response.tool_calls[0]["arguments"] == {"slug": "rent"}
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].success is True
+    assert rows[0].prompt_tokens == 12
+    assert rows[0].completion_tokens == 6
+
+
+# ---------- Stream: ONE ledger row at end-of-stream ----------------
+
+
+@pytest.mark.asyncio
+async def test_call_llm_stream_writes_one_ledger_row_at_end(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Pins the "stream writes ONE row at end, not per chunk"
+    invariant. Three delta chunks + one done chunk → one ledger row.
+    """
+    chunks_sent = [
+        StreamChunk(delta_text="Hello ", done=False),
+        StreamChunk(delta_text="from ", done=False),
+        StreamChunk(delta_text="the model.", done=False),
+        StreamChunk(
+            delta_text="",
+            done=True,
+            final_usage=TokenUsage(prompt_tokens=5, completion_tokens=7),
+        ),
+    ]
+
+    async def fake_stream(*, model, messages, max_tokens=None):
+        for c in chunks_sent:
+            yield c
+
+    adapter = MagicMock()
+    adapter.stream = fake_stream
+
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        received = []
+        async for chunk in call_llm_stream(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "hi"}],
+        ):
+            received.append(chunk)
+        # 3 deltas + 1 done.
+        assert len(received) == 4
+        assert received[-1].done is True
+
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1, (
+        "stream MUST write exactly one ledger row at end-of-stream, "
+        "not one per chunk"
+    )
+    assert rows[0].success is True
+    assert rows[0].prompt_tokens == 5
+    assert rows[0].completion_tokens == 7
+
+
+@pytest.mark.asyncio
+async def test_call_llm_stream_falls_back_to_char_estimate_when_no_usage(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """When the provider doesn't emit final_usage, fall back to
+    char/4 on the accumulated text. Pins the estimation contract.
+    """
+    accumulated = "a" * 40  # 40 chars / 4 = 10 tokens
+
+    async def fake_stream(*, model, messages, max_tokens=None):
+        yield StreamChunk(delta_text=accumulated, done=False)
+        yield StreamChunk(delta_text="", done=True, final_usage=None)
+
+    adapter = MagicMock()
+    adapter.stream = fake_stream
+
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        async for _ in call_llm_stream(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[],
+        ):
+            pass
+
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    # Estimated 10 completion tokens (40 chars / 4).
+    assert rows[0].completion_tokens == 10

--- a/backend/tests/services/test_ai_dispatch_capabilities.py
+++ b/backend/tests/services/test_ai_dispatch_capabilities.py
@@ -599,3 +599,115 @@ async def test_call_llm_stream_falls_back_to_char_estimate_when_no_usage(
     assert len(rows) == 1
     # Estimated 10 completion tokens (40 chars / 4).
     assert rows[0].completion_tokens == 10
+
+
+# ---------- Structured-output token aggregation ---------------------
+
+
+@pytest.mark.asyncio
+async def test_call_llm_structured_aggregates_token_cost_across_retries(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """When the structured call retries, the ledger row must sum tokens
+    across ALL attempts that touched the provider — not just the last
+    one. Previously the ledger silently dropped tokens billed by the
+    first attempt, under-counting cap accounting.
+    """
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        side_effect=[
+            LLMResponse(
+                content="not json",
+                prompt_tokens=20,
+                completion_tokens=10,
+                model="gpt-4o-mini",
+            ),
+            LLMResponse(
+                content='{"category": "rent"}',
+                prompt_tokens=15,
+                completion_tokens=8,
+                model="gpt-4o-mini",
+            ),
+        ]
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema={
+                "type": "object",
+                "required": ["category"],
+                "properties": {"category": {"type": "string"}},
+            },
+        )
+
+    assert result.response.retries_used == 1
+    # StructuredResponse mirrors the aggregated counts so callers
+    # downstream of dispatch can also see the real spend.
+    assert result.response.prompt_tokens == 35
+    assert result.response.completion_tokens == 18
+
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.prompt_tokens == 35
+    assert row.completion_tokens == 18
+    assert row.retries_used == 1
+    assert row.success is True
+
+
+@pytest.mark.asyncio
+async def test_call_llm_structured_exhaustion_writes_aggregate_failure_row(
+    db: AsyncSession, org, admin_user, credential, default_routing
+):
+    """Three failed attempts each cost provider tokens. The single
+    failure ledger row must reflect the SUM across attempts, not
+    just the last one.
+    """
+    bad_response = LLMResponse(
+        content="still not json",
+        prompt_tokens=10,
+        completion_tokens=5,
+        model="gpt-4o-mini",
+    )
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        side_effect=[bad_response, bad_response, bad_response]
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        from app.services.ai_providers.base import StructuredOutputError
+        with pytest.raises(StructuredOutputError):
+            await call_llm_structured(
+                db,
+                org_id=org.id,
+                feature_key="chat",
+                messages=[{"role": "user", "content": "x"}],
+                response_schema={
+                    "type": "object",
+                    "required": ["category"],
+                    "properties": {"category": {"type": "string"}},
+                },
+            )
+
+    rows = (
+        await db.execute(
+            select(AIUsageLedger).where(AIUsageLedger.org_id == org.id)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.prompt_tokens == 30
+    assert row.completion_tokens == 15
+    assert row.retries_used == 2
+    assert row.success is False
+    assert row.error_class == "STATUS_ERROR_STRUCTURED_OUTPUT"

--- a/backend/tests/services/test_ai_dispatch_capabilities.py
+++ b/backend/tests/services/test_ai_dispatch_capabilities.py
@@ -165,6 +165,52 @@ async def credential(db: AsyncSession, org: Organization) -> OrgAICredential:
 
 
 @pytest_asyncio.fixture
+async def openai_compatible_credential(
+    db: AsyncSession, org: Organization
+) -> OrgAICredential:
+    """Credential row simulating a freshly-validated OpenAI-compatible
+    endpoint advertising the full 5-cap surface (chat, embed,
+    structured_output, function_call, stream).
+    """
+    cred = OrgAICredential(
+        org_id=org.id,
+        provider=AiProvider.OPENAI_COMPATIBLE,
+        encrypted_api_key=encrypt("sk-compat-12345"),
+        encrypted_bearer_token=None,
+        base_url="https://vllm.example.com",
+        key_fingerprint="fedcba9876543210",
+        last_four="2345",
+        label="compat-primary",
+        discovered_capabilities=[
+            "chat",
+            "embed",
+            "structured_output",
+            "function_call",
+            "stream",
+        ],
+    )
+    db.add(cred)
+    await db.commit()
+    return cred
+
+
+@pytest_asyncio.fixture
+async def openai_compatible_routing(
+    db: AsyncSession,
+    org: Organization,
+    openai_compatible_credential: OrgAICredential,
+) -> OrgAIDefaultRouting:
+    row = OrgAIDefaultRouting(
+        org_id=org.id,
+        credential_id=openai_compatible_credential.id,
+        model="mixtral-8x7b",
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
+@pytest_asyncio.fixture
 async def default_routing(
     db: AsyncSession, org: Organization, credential: OrgAICredential
 ) -> OrgAIDefaultRouting:
@@ -711,3 +757,100 @@ async def test_call_llm_structured_exhaustion_writes_aggregate_failure_row(
     assert row.retries_used == 2
     assert row.success is False
     assert row.error_class == "STATUS_ERROR_STRUCTURED_OUTPUT"
+
+
+# ---------- OpenAI-compatible reaches the adapter -------------------
+
+
+@pytest.mark.asyncio
+async def test_call_llm_structured_routes_to_openai_compatible_when_capability_advertised(
+    db: AsyncSession,
+    org,
+    admin_user,
+    openai_compatible_credential,
+    openai_compatible_routing,
+):
+    """Round-3 reversal: openai-compatible now advertises the full
+    5-cap surface. With ``structured_output`` in the credential's
+    discovered_capabilities, ``call_llm_structured`` must reach the
+    adapter (not raise ``AICapabilityNotSupported``).
+
+    Pins the behavior that depends on the
+    ``DEFAULT_CAPABILITIES = [..., "structured_output", ...]`` shape
+    in ``openai_compatible.py``.
+    """
+    adapter = MagicMock()
+    adapter.chat_structured = AsyncMock(
+        return_value=LLMResponse(
+            content='{"category": "rent"}',
+            prompt_tokens=8,
+            completion_tokens=4,
+            model="mixtral-8x7b",
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_structured(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "x"}],
+            response_schema={
+                "type": "object",
+                "required": ["category"],
+                "properties": {"category": {"type": "string"}},
+            },
+        )
+
+    # Adapter actually invoked — the capability gate did NOT trip.
+    adapter.chat_structured.assert_awaited_once()
+    assert result.response.parsed == {"category": "rent"}
+    assert result.response.retries_used == 0
+
+
+@pytest.mark.asyncio
+async def test_call_llm_function_routes_to_openai_compatible_when_capability_advertised(
+    db: AsyncSession,
+    org,
+    admin_user,
+    openai_compatible_credential,
+    openai_compatible_routing,
+):
+    """Same round-3 reversal but for ``function_call``: the adapter
+    implements it, and the credential's discovered_capabilities now
+    advertises it, so the dispatch gate must let the call through.
+    """
+    adapter = MagicMock()
+    adapter.function_call = AsyncMock(
+        return_value=FunctionCallResponse(
+            tool_calls=[
+                {"name": "set_category", "arguments": {"slug": "rent"}}
+            ],
+            content="",
+            prompt_tokens=9,
+            completion_tokens=3,
+            model="mixtral-8x7b",
+        )
+    )
+    with patch(
+        "app.services.ai_dispatch.get_adapter", return_value=adapter
+    ):
+        result = await call_llm_function(
+            db,
+            org_id=org.id,
+            feature_key="chat",
+            messages=[{"role": "user", "content": "classify"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "set_category",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+
+    adapter.function_call.assert_awaited_once()
+    assert result.response.tool_calls[0]["name"] == "set_category"


### PR DESCRIPTION
## Summary

PR3 of the AI tier rollout train. Wires the remaining four capability protocols (embed, chat_structured with retry cap, function_call, stream) on the four BYO adapters (OpenAI, Anthropic, Ollama, OpenAI-compatible), plus the dispatch chokepoint wrappers (call_llm_embed, call_llm_structured, call_llm_function, call_llm_stream) and a routing-level capability check.

Adapters wired; no feature surfaces. PR6+ wire the actual customer features (categorization, chat UI, smart_forecast, smart_budget). Native still raises NativeNotAvailable for every capability until PR4.

Spec: specs/2026-05-22-ai-tier-byo-and-native-providers.md

## What landed

- **embed()** on OpenAI, Ollama, OpenAI-compatible (POST /v1/embeddings or /api/embeddings). Anthropic raises NotImplementedError (no public embeddings API; future PR may add Voyage AI as a sibling provider).
- **chat_structured()** on OpenAI (JSON-schema for gpt-4o family, fallback json_object), Anthropic (tool-use-as-JSON), Ollama (format=json), OpenAI-compatible (json_object). Service-layer retry budget: max 2 retries on JSON parse / schema validation failure (architect lock #13). Exhaustion raises StructuredOutputError with STATUS_ERROR_STRUCTURED_OUTPUT and writes a failure ledger row with retries_used=2.
- **function_call()** on OpenAI, Anthropic (OAI-shape tools normalized to Anthropic's flat shape), Ollama (refuses with CapabilityNotSupported for non-tool-using models), OpenAI-compatible (passthrough; provider-side 4xx bubbles as sanitized AIProviderError).
- **stream()** on all four BYO adapters. ledger row is written ONCE at end-of-stream (never per chunk). Falls back to char/4 token estimation when the provider does not emit a final usage block.
- **Routing capability check**: dispatch refuses with HTTP 412 ai_capability_not_supported when the credential's discovered_capabilities array doesn't list the requested capability.
- **Embedding pricing**: text-embedding-3-small (2 cents/1M in) and text-embedding-3-large (13 cents/1M in) added to MODEL_PRICING.
- **Migration 059** (058_ai_usage_ledger -> 059_ai_usage_retries_used): adds NOT NULL retries_used INT with server_default=0.

Sanitization (PR1 SSRF lock) and soft-cap dispatch + ledger writes (PR2) apply to every PR3 dispatch path.