### PR TITLE
feat(plans): UX polish + in-context copy + /docs/plans manual

### DIFF
--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -131,6 +131,19 @@ export default function DocsPage() {
                 forward-looking projections per category, used by the
                 dashboard to show what the period is on track for.
               </li>
+              <li>
+                <strong>Plans.</strong> A separate simulation sandbox
+                for one-off life events (trip, purchase, retirement).
+                Plans never touch your real transactions. See the{" "}
+                <Link
+                  href="/docs/plans"
+                  className="underline hover:text-text-primary"
+                  data-testid="docs-plans-link"
+                >
+                  Plans guide
+                </Link>{" "}
+                for the full mental model.
+              </li>
             </ul>
           </section>
 

--- a/frontend/app/docs/plans/page.tsx
+++ b/frontend/app/docs/plans/page.tsx
@@ -1,0 +1,291 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import ThemeToggle from "@/components/ui/ThemeToggle";
+import BackLink from "@/components/ui/BackLink";
+import { pageSocialMeta, siteName } from "@/lib/site";
+
+const description =
+  "How the Plans simulation sandbox works: plan types, verdict colors, the math, and the contribution curve.";
+
+export const metadata: Metadata = {
+  title: "Plans guide",
+  description,
+  alternates: {
+    canonical: "/docs/plans",
+  },
+  ...pageSocialMeta({
+    title: `Plans guide · ${siteName}`,
+    description,
+    path: "/docs/plans",
+  }),
+};
+
+const sections = [
+  { id: "what-is-plans", label: "What is Plans?" },
+  { id: "verdict-colors", label: "The verdict colors" },
+  { id: "math", label: "How the math works" },
+  { id: "how-to-use", label: "How to use Plans" },
+  { id: "curve", label: "The contribution curve" },
+];
+
+export default function PlansDocsPage() {
+  return (
+    <div className="relative min-h-screen px-4 py-12">
+      <ThemeToggle className="absolute right-6 top-6" />
+      <article className="mx-auto max-w-2xl">
+        <header className="mb-10">
+          <BackLink />
+          <p className="mt-6 text-xs uppercase tracking-[0.12em] text-text-muted">
+            Docs · Plans
+          </p>
+          <h1 className="mt-2 font-display text-3xl font-semibold text-text-primary">
+            Plans guide
+          </h1>
+          <p className="mt-2 text-sm text-text-muted">
+            How to model a trip, a purchase, retirement, or a custom life
+            event. Plans is read-only: nothing here touches your real
+            transactions.
+          </p>
+          <nav
+            aria-label="On this page"
+            className="mt-6 rounded-lg border border-border bg-surface p-4"
+            data-testid="plans-docs-nav"
+          >
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.12em] text-text-muted">
+              On this page
+            </p>
+            <ul className="grid gap-1.5 text-sm sm:grid-cols-2">
+              {sections.map((s) => (
+                <li key={s.id}>
+                  <a
+                    href={`#${s.id}`}
+                    className="text-text-secondary hover:text-text-primary"
+                  >
+                    {s.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </header>
+
+        <div className="space-y-8 text-text-primary [&_h2]:font-display [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:mb-3 [&_h2]:mt-8 [&_h3]:font-display [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mb-2 [&_h3]:mt-6 [&_p]:text-sm [&_p]:leading-relaxed [&_p]:text-text-secondary [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:text-sm [&_ul]:leading-relaxed [&_ul]:text-text-secondary [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:text-sm [&_ol]:leading-relaxed [&_ol]:text-text-secondary [&_li]:mt-1 [&_code]:rounded [&_code]:bg-surface [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-xs">
+          <section data-testid="plans-docs-section-what">
+            <h2 id="what-is-plans">What is Plans?</h2>
+            <p>
+              Plans is a simulation sandbox. Nothing here touches your
+              real transactions, accounts, or budgets. You can model
+              life events to see how they play out month by month before
+              you commit to anything.
+            </p>
+            <p>
+              There are four templates:
+            </p>
+            <ul>
+              <li>
+                <strong>Trip.</strong> Model a single trip's cost on a
+                start date (transport plus accommodation per night plus
+                a daily budget multiplied by duration). The cost lands
+                in one dip; the rest of the horizon is just your
+                regular cashflow.
+              </li>
+              <li>
+                <strong>Purchase.</strong> Model a one-off purchase
+                (car, house deposit, appliance). The down payment lands
+                on the target date.
+              </li>
+              <li>
+                <strong>Retirement.</strong> Model long-horizon savings.
+                Compound interest, monthly contributions, optional
+                step-function contribution curve, and an inflation-
+                adjusted real-terms overlay on the chart.
+              </li>
+              <li>
+                <strong>Custom.</strong> Reserved for a later release.
+                A bring-your-own-events editor for plans that don't fit
+                the three templates.
+              </li>
+            </ul>
+          </section>
+
+          <section data-testid="plans-docs-section-verdict">
+            <h2 id="verdict-colors">The verdict colors</h2>
+            <p>
+              Every simulated plan gets a verdict: green, yellow, or
+              red. The verdict reads what the chart shows.
+            </p>
+            <ul>
+              <li>
+                <strong>Green.</strong> Your accounts stay healthy and
+                the plan's end balance is at least 80 percent of where
+                it started (or, for retirement, at least the target).
+              </li>
+              <li>
+                <strong>Yellow.</strong> Either you'll briefly dip below
+                zero on an account, or the plan eats more than 20
+                percent of your starting net worth. Doable, but not
+                comfortable.
+              </li>
+              <li>
+                <strong>Red.</strong> The plan causes an extended cash
+                crunch, or (for retirement) you'll fall more than 15
+                percent short of your target. Tune the params and
+                re-simulate.
+              </li>
+            </ul>
+            <p>
+              Below the verdict, the projection panel lists alerts (any
+              month an account dips below zero) and suggestions
+              ("raise monthly contribution by 200 to close the gap").
+              Suggestions are advisory, never automatic; the plan only
+              changes when you change the params.
+            </p>
+          </section>
+
+          <section data-testid="plans-docs-section-math">
+            <h2 id="math">How the math works</h2>
+
+            <h3>Trip and Purchase</h3>
+            <p>
+              We project month by month. We start with your account
+              balances as of today, apply your recurring income and
+              expenses plus current budget pace, and drop in the plan's
+              cashflow events on their scheduled months. For a trip,
+              that's a single dip on the start month equal to transport
+              plus (accommodation per night times duration) plus (daily
+              budget times duration). For a purchase, it's the down
+              payment on the target date.
+            </p>
+
+            <h3>Retirement</h3>
+            <p>
+              Retirement uses compound interest, applied monthly. Each
+              month the balance grows by your annual return divided by
+              12, and your monthly contribution is added on top.
+            </p>
+            <p>
+              We also track the same balance in real (inflation-
+              adjusted) terms so the chart's red dashed line tells you
+              what your future money would be worth in today's pounds,
+              euros, or dollars. The formula:
+            </p>
+            <p>
+              <code>
+                real_balance = nominal_balance / ((1 + inflation_rate) ^
+                years)
+              </code>
+            </p>
+            <p>
+              Both annual return and annual inflation are expressed as
+              percentages and converted to monthly factors internally.
+              Long-term stock market average return is around 6 to 8
+              percent; the Eurozone inflation target is 2 percent and
+              the 30-year historical average is around 2.5 to 3
+              percent. Your own assumptions are what matters.
+            </p>
+
+            <h3>Smooth with regression</h3>
+            <p>
+              When the engine sees enough recent history, it can fit a
+              straight line through your last 12 months of cashflow and
+              use the trend instead of the raw recurring numbers. This
+              is helpful when your income has been growing or your
+              spending has shifted, and you don't want a one-off month
+              skewing the projection. The projection panel shows a
+              "Trend-adjusted" badge when this kicks in.
+            </p>
+          </section>
+
+          <section data-testid="plans-docs-section-howto">
+            <h2 id="how-to-use">How to use Plans</h2>
+            <ol>
+              <li>
+                Click <strong>+ New plan</strong> and pick a template.
+              </li>
+              <li>
+                Fill in the params. The chart re-simulates as you type
+                (about 400 ms after you stop). Inline validation
+                errors (a curve row missing its start date, for
+                example) skip the re-simulate until you fix them.
+              </li>
+              <li>
+                Read the verdict and the suggestions below the chart.
+              </li>
+              <li>
+                Tweak params (raise the monthly contribution, push the
+                retirement date out, lower the trip's daily budget) and
+                watch the chart respond.
+              </li>
+              <li>
+                Save the plan. It stays in your list under
+                <code>/plans</code>. You can come back later, edit it,
+                re-simulate.
+              </li>
+              <li>
+                When you have two or more plans, the Compare plans
+                surface lets you put up to three side by side on the
+                same chart.
+              </li>
+            </ol>
+            <p>
+              The right pane shows the projection; the left pane is the
+              editor. The two stay in sync on every keystroke. Use the
+              Re-simulate button if you want to force a fresh run after
+              switching accounts or after a recurring template change.
+            </p>
+          </section>
+
+          <section data-testid="plans-docs-section-curve">
+            <h2 id="curve">The contribution curve (step function)</h2>
+            <p>
+              Most people don't save a flat amount across 30 years.
+              Maybe you save 500 a month now but plan to bump to 1,000
+              a month once your mortgage is paid off, then 1,500 a
+              month when the kids leave school. The contribution curve
+              is how you model that.
+            </p>
+            <p>
+              Each row in the curve table sets a new monthly
+              contribution starting on a given date. Rows must be in
+              chronological order. The base contribution applies before
+              the first row's date.
+            </p>
+            <h3>Worked example</h3>
+            <p>
+              Current age 30, retirement at 65, base monthly
+              contribution 500. Add curve rows:
+            </p>
+            <ul>
+              <li>From age 40 (year + 10): 800 per month.</li>
+              <li>From age 50 (year + 20): 1,200 per month.</li>
+            </ul>
+            <p>The projection then runs:</p>
+            <ul>
+              <li>From age 30 to age 40: 500 per month (base).</li>
+              <li>From age 40 to age 50: 800 per month.</li>
+              <li>From age 50 to age 65: 1,200 per month.</li>
+            </ul>
+            <p>
+              If you fill in a curve row's amount but not its date, the
+              form shows an inline validation error and the auto re-
+              simulate pauses until you fix it. The error is intentional;
+              it stops a half-typed row from getting saved against your
+              plan.
+            </p>
+          </section>
+        </div>
+
+        <footer className="mt-12 border-t border-border pt-6 text-xs text-text-muted">
+          See also:{" "}
+          <Link href="/docs" className="underline hover:text-text-primary">
+            Docs home
+          </Link>{" "}
+          ·{" "}
+          <Link href="/plans" className="underline hover:text-text-primary">
+            Plans
+          </Link>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/frontend/app/docs/plans/page.tsx
+++ b/frontend/app/docs/plans/page.tsx
@@ -101,9 +101,41 @@ export default function PlansDocsPage() {
                 adjusted real-terms overlay on the chart.
               </li>
               <li>
-                <strong>Custom.</strong> Reserved for a later release.
-                A bring-your-own-events editor for plans that don't fit
-                the three templates.
+                <strong>Custom.</strong> A fully editable plan type for
+                anything that doesn't fit the three templates above.
+                You add a list of events to the timeline and the
+                simulator replays them month by month. Five event types
+                are available:
+                <ul>
+                  <li>
+                    <code>income_off</code>: silence your recurring
+                    income for a date range (sabbatical, parental leave,
+                    a planned career break).
+                  </li>
+                  <li>
+                    <code>expense_off</code>: silence recurring expenses
+                    for a date range, optionally scoped to a single
+                    category (cancel the gym while travelling).
+                  </li>
+                  <li>
+                    <code>recurring_on</code>: marker for the future
+                    exclude-recurring base flag. Currently a documented
+                    no-op; the event lands on the plan but the simulator
+                    does not yet alter the baseline.
+                  </li>
+                  <li>
+                    <code>one_off_income</code>: a single income lump on
+                    a given month (bonus, tax refund, gift).
+                  </li>
+                  <li>
+                    <code>one_off_expense</code>: a single expense lump
+                    on a given month (replacement laptop, vet bill).
+                  </li>
+                </ul>
+                Example: plan a 3-month sabbatical by adding an
+                <code>income_off</code> from month 6 to month 9 and
+                watch the chart show the dip and the recovery once
+                income resumes.
               </li>
             </ul>
           </section>
@@ -217,9 +249,12 @@ export default function PlansDocsPage() {
                 watch the chart respond.
               </li>
               <li>
-                Save the plan. It stays in your list under
-                <code>/plans</code>. You can come back later, edit it,
-                re-simulate.
+                The editor auto-saves as you type (about 400 ms after
+                you stop). Your plan stays in your list under
+                <code>/plans</code>, ready to revisit and edit later.
+                Use the Re-simulate button if you want to refresh the
+                chart with your latest changes without waiting for the
+                debounce.
               </li>
               <li>
                 When you have two or more plans, the Compare plans

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -312,6 +312,12 @@ export default function PlansPage() {
 
       {active ? (
         <PlanEditor
+          // Key by plan.id so React unmounts + remounts the editor when
+          // the active plan changes. This naturally resets all local
+          // state (editorValid, params draft, etc.) so a previous
+          // plan's invalid editor state can't leak into the next plan
+          // and silently suppress its debounced PATCHes.
+          key={active.id}
           plan={active}
           accounts={accounts}
           onBack={() => setActive(null)}

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -20,6 +20,7 @@
  */
 
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
@@ -271,11 +272,18 @@ export default function PlansPage() {
 
   return (
     <AppShell>
-      <header className="mb-4 flex items-center justify-between">
+      <header className="mb-4 flex items-center justify-between gap-3">
         <div>
           <h1 className={`${pageTitle} mb-0`}>Plans</h1>
           <p className="mt-1 text-sm text-text-muted">
-            Plan one-off life events. Nothing here touches your real transactions.
+            Plan one-off life events. Nothing here touches your real transactions.{" "}
+            <Link
+              href="/docs/plans"
+              className="underline-offset-2 hover:underline"
+              data-testid="plans-docs-link"
+            >
+              Read the Plans guide.
+            </Link>
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -472,7 +480,22 @@ function PlanEditor({
   const [horizon, setHorizon] = useState<number>(plan.horizon_months);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState("");
+  // Client-side validity flag set by child editors (RetirementParamsEditor
+  // owns curve validation). When any inline error is showing, the
+  // debounced PATCH below skips the network call so we don't spam the
+  // server with 422s while the user is still typing. The inline error
+  // is already visible to the user; firing the request on top of that
+  // is pure noise.
+  const [editorValid, setEditorValid] = useState(true);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Horizon bounds match the server-side validator. Pre-checking on the
+  // client keeps the debounced PATCH from firing 422s while the user
+  // walks an out-of-range number up or down with the spinner.
+  const horizonMax = plan.scenario_type === "retirement" ? 480 : 120;
+  const horizonValid = horizon >= 1 && horizon <= horizonMax;
+  const nameValid = name.trim().length > 0;
+  const isValid = editorValid && horizonValid && nameValid;
 
   // Reset state when switching plans.
   useEffect(() => {
@@ -512,12 +535,23 @@ function PlanEditor({
 
   // Debounced re-simulate when the editor's local params drift from the
   // server-side plan. Architect-locked 400ms.
+  //
+  // Gate on isValid so a typed-but-incomplete curve row (or any other
+  // inline validation error) doesn't fire a PATCH that the server will
+  // reject with 422. The inline error is already on screen; the
+  // network noise on top would just spam the console. Once the user
+  // fixes the offending field, isValid flips back to true and the next
+  // change-driven render schedules a fresh debounce.
   useEffect(() => {
     if (
       JSON.stringify(params) === JSON.stringify(plan.params_json)
       && name === plan.name
       && horizon === plan.horizon_months
     ) {
+      return;
+    }
+    if (!isValid) {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
       return;
     }
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -527,7 +561,7 @@ function PlanEditor({
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [params, name, horizon, plan, persist]);
+  }, [params, name, horizon, plan, persist, isValid]);
 
   async function manualSimulate() {
     setBusy(true);
@@ -573,11 +607,21 @@ function PlanEditor({
                 id="plan-horizon"
                 type="number"
                 min={1}
-                max={plan.scenario_type === "retirement" ? 480 : 120}
+                max={horizonMax}
                 value={horizon}
                 onChange={(e) => setHorizon(Number(e.target.value || 0))}
                 className={input}
+                aria-describedby="plan-horizon-hint"
               />
+              <p
+                id="plan-horizon-hint"
+                className="mt-1 max-w-prose text-xs text-text-muted"
+              >
+                How many months to project from today. Max{" "}
+                {plan.scenario_type === "retirement"
+                  ? "480 (40 years) for retirement"
+                  : "120 (10 years) for trip and purchase plans"}.
+              </p>
             </div>
             {plan.scenario_type === "trip" && (
               <TripParamsEditor params={params} setParams={setParams} accounts={accounts} />
@@ -590,7 +634,7 @@ function PlanEditor({
                 params={params}
                 setParams={setParams}
                 accounts={accounts}
-                onValidityChange={() => { /* server re-validates on PATCH */ }}
+                onValidityChange={setEditorValid}
               />
             )}
             {plan.scenario_type === "custom" && (
@@ -680,6 +724,11 @@ function ProjectionView({ projection }: { projection: ProjectionResult }) {
 }
 
 
+// Shared helper-text class. `max-w-prose` keeps the explanation
+// readable on wide layouts and prevents a long sentence from forcing
+// the right pane into horizontal scroll on narrow viewports.
+const fieldHelp = "mt-1 max-w-prose text-xs text-text-muted";
+
 function TripParamsEditor({
   params,
   setParams,
@@ -702,7 +751,11 @@ function TripParamsEditor({
           onChange={(e) => set("destination", e.target.value)}
           className={input}
           data-testid="trip-destination-input"
+          aria-describedby="trip-destination-hint"
         />
+        <p id="trip-destination-hint" className={fieldHelp}>
+          Free text. Used only as a label on the plan; the projection ignores it.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="trip-start">Start date</label>
@@ -712,7 +765,11 @@ function TripParamsEditor({
           value={(params.start_date as string) ?? ""}
           onChange={(e) => set("start_date", e.target.value)}
           className={input}
+          aria-describedby="trip-start-hint"
         />
+        <p id="trip-start-hint" className={fieldHelp}>
+          When the trip kicks off. The cost lands in a single dip on this month.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="trip-duration">Duration (days)</label>
@@ -724,7 +781,11 @@ function TripParamsEditor({
           value={(params.duration_days as number) ?? 1}
           onChange={(e) => set("duration_days", Number(e.target.value || 0))}
           className={input}
+          aria-describedby="trip-duration-hint"
         />
+        <p id="trip-duration-hint" className={fieldHelp}>
+          Multiplied by daily budget and accommodation per night to get the on-the-ground total.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="trip-transport">Transport cost</label>
@@ -736,7 +797,11 @@ function TripParamsEditor({
           value={(params.transport_cost as string) ?? "0"}
           onChange={(e) => set("transport_cost", e.target.value)}
           className={input}
+          aria-describedby="trip-transport-hint"
         />
+        <p id="trip-transport-hint" className={fieldHelp}>
+          Flights, trains, fuel. Counted once at the start of the trip.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="trip-accom">Accommodation per night</label>
@@ -748,7 +813,11 @@ function TripParamsEditor({
           value={(params.accommodation_per_night as string) ?? "0"}
           onChange={(e) => set("accommodation_per_night", e.target.value)}
           className={input}
+          aria-describedby="trip-accom-hint"
         />
+        <p id="trip-accom-hint" className={fieldHelp}>
+          Multiplied by duration to get the total stay cost.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="trip-daily">Daily budget</label>
@@ -760,7 +829,11 @@ function TripParamsEditor({
           value={(params.daily_budget as string) ?? "0"}
           onChange={(e) => set("daily_budget", e.target.value)}
           className={input}
+          aria-describedby="trip-daily-hint"
         />
+        <p id="trip-daily-hint" className={fieldHelp}>
+          Food, sights, ground transport. Multiplied by duration.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="trip-account">Source account</label>
@@ -769,6 +842,7 @@ function TripParamsEditor({
           value={(params.source_account_id as number) ?? ""}
           onChange={(e) => set("source_account_id", Number(e.target.value))}
           className={input}
+          aria-describedby="trip-account-hint"
         >
           {accounts.map((a) => (
             <option key={a.id} value={a.id}>
@@ -776,6 +850,9 @@ function TripParamsEditor({
             </option>
           ))}
         </select>
+        <p id="trip-account-hint" className={fieldHelp}>
+          Which account the trip's cash dip is deducted from in the projection.
+        </p>
       </div>
     </>
   );
@@ -803,7 +880,11 @@ function PurchaseParamsEditor({
           value={(params.subtype as string) ?? "car"}
           onChange={(e) => set("subtype", e.target.value)}
           className={input}
+          aria-describedby="p-subtype-hint"
         />
+        <p id="p-subtype-hint" className={fieldHelp}>
+          Free text (car, house, appliance, etc.). Used only as a label.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="p-label">Label</label>
@@ -812,7 +893,11 @@ function PurchaseParamsEditor({
           value={(params.label as string) ?? ""}
           onChange={(e) => set("label", e.target.value)}
           className={input}
+          aria-describedby="p-label-hint"
         />
+        <p id="p-label-hint" className={fieldHelp}>
+          Short name shown on the plan, for example "Family car 2027".
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="p-target">Target date</label>
@@ -822,7 +907,11 @@ function PurchaseParamsEditor({
           value={(params.target_date as string) ?? ""}
           onChange={(e) => set("target_date", e.target.value)}
           className={input}
+          aria-describedby="p-target-hint"
         />
+        <p id="p-target-hint" className={fieldHelp}>
+          When the purchase happens. The down payment lands on this month in the projection.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="p-price">Total price</label>
@@ -834,7 +923,11 @@ function PurchaseParamsEditor({
           value={(params.total_price as string) ?? "0"}
           onChange={(e) => set("total_price", e.target.value)}
           className={input}
+          aria-describedby="p-price-hint"
         />
+        <p id="p-price-hint" className={fieldHelp}>
+          Sticker price before any financing. Reference number only; the projection moves cash based on down payment and (later) monthly financing.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="p-down">Down payment</label>
@@ -846,7 +939,11 @@ function PurchaseParamsEditor({
           value={(params.down_payment as string) ?? "0"}
           onChange={(e) => set("down_payment", e.target.value)}
           className={input}
+          aria-describedby="p-down-hint"
         />
+        <p id="p-down-hint" className={fieldHelp}>
+          Cash you put up front on the target date. Comes out of the account you pick below.
+        </p>
       </div>
       <div>
         <label className={labelCls} htmlFor="p-account">Down-payment account</label>
@@ -855,6 +952,7 @@ function PurchaseParamsEditor({
           value={(params.down_payment_account_id as number) ?? ""}
           onChange={(e) => set("down_payment_account_id", Number(e.target.value))}
           className={input}
+          aria-describedby="p-account-hint"
         >
           {accounts.map((a) => (
             <option key={a.id} value={a.id}>
@@ -862,6 +960,9 @@ function PurchaseParamsEditor({
             </option>
           ))}
         </select>
+        <p id="p-account-hint" className={fieldHelp}>
+          Which account funds the down payment in the projection.
+        </p>
       </div>
     </>
   );

--- a/frontend/components/scenarios/ProjectionChart.tsx
+++ b/frontend/components/scenarios/ProjectionChart.tsx
@@ -22,7 +22,7 @@
  * scenarios" view (PR3) without coupling to API shape.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Area,
   CartesianGrid,
@@ -123,6 +123,18 @@ export function ProjectionChart({
   projection: ProjectionInput;
   testId?: string;
 }) {
+  // ResponsiveContainer measures its parent on mount. When the chart
+  // lives in a freshly painted flex/grid pane (the right column of the
+  // Plans editor), the parent's width can come back as -1 on the first
+  // synchronous read, which logs the loud "width(-1) and height(-1) of
+  // chart should be greater than 0" warning. Deferring the
+  // ResponsiveContainer render by one effect tick gives the layout
+  // engine a chance to commit before Recharts measures.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const months = useMemo(
     () =>
       projection.per_account_series.length > 0
@@ -172,11 +184,17 @@ export function ProjectionChart({
 
   return (
     <div
-      className="h-72 w-full"
+      // `min-w-0` is required because the chart sits in a CSS-grid
+      // column (`minmax(0, 2fr)`). Without it, a wide chart row can
+      // bully its grid track wider than the column's intrinsic min and
+      // ResponsiveContainer's parent read goes negative on the first
+      // measurement. `min-h-0` does the same for the vertical axis.
+      className="h-72 w-full min-w-0 min-h-0"
       data-testid={testId}
       role="img"
       aria-label="Projected account balances over the horizon"
     >
+      {!mounted ? null : (
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart
           data={rows}
@@ -250,6 +268,7 @@ export function ProjectionChart({
           ))}
         </ComposedChart>
       </ResponsiveContainer>
+      )}
     </div>
   );
 }

--- a/frontend/components/scenarios/RetirementParamsEditor.tsx
+++ b/frontend/components/scenarios/RetirementParamsEditor.tsx
@@ -56,6 +56,26 @@ function validateCurve(curve: RetirementCurveStep[]): string | null {
   return null;
 }
 
+// In-context microcopy lives next to the field it explains so the
+// "lazy user" path the product owner flagged (someone who opens the
+// form should not have to leave the page to learn what each input
+// means) stays satisfied without bloating component logic.
+const HELP_TARGET_DATE = "When you plan to stop earning income.";
+const HELP_TARGET_BALANCE =
+  "What you want to have invested at retirement, in today's money. The chart's red dashed line plots this in real (inflation-adjusted) terms.";
+const HELP_MONTHLY =
+  "Default amount you set aside each month. Override for specific date ranges using the curve below.";
+const HELP_RETURN =
+  "Expected annual investment return after fees. Long-term stock market average is around 6 to 8 percent.";
+const HELP_INFLATION =
+  "How fast prices rise per year. Eurozone target is 2 percent; historical 30-year average is around 2.5 to 3 percent.";
+const HELP_ACCOUNT =
+  "Which account receives the monthly contribution in the projection.";
+const HELP_CURVE =
+  "Optional. Each row sets a new monthly contribution starting on a given date. Useful when you expect to save more later (for example, after kids leave school). Rows must be in chronological order. The base contribution applies before the first row's date.";
+
+const helpText = "mt-1 max-w-prose text-xs text-text-muted";
+
 export function RetirementParamsEditor({
   params,
   setParams,
@@ -123,7 +143,9 @@ export function RetirementParamsEditor({
           onChange={(e) => set("target_retirement_date", e.target.value)}
           className={input}
           data-testid="ret-target-date"
+          aria-describedby="ret-target-date-hint"
         />
+        <p id="ret-target-date-hint" className={helpText}>{HELP_TARGET_DATE}</p>
       </div>
       <div>
         <label className={labelCls} htmlFor="ret-target-balance">Target balance</label>
@@ -136,7 +158,9 @@ export function RetirementParamsEditor({
           onChange={(e) => set("target_balance", e.target.value)}
           className={input}
           data-testid="ret-target-balance"
+          aria-describedby="ret-target-balance-hint"
         />
+        <p id="ret-target-balance-hint" className={helpText}>{HELP_TARGET_BALANCE}</p>
       </div>
       <div>
         <label className={labelCls} htmlFor="ret-monthly">Monthly contribution (base)</label>
@@ -149,7 +173,9 @@ export function RetirementParamsEditor({
           onChange={(e) => set("monthly_contribution", e.target.value)}
           className={input}
           data-testid="ret-monthly"
+          aria-describedby="ret-monthly-hint"
         />
+        <p id="ret-monthly-hint" className={helpText}>{HELP_MONTHLY}</p>
       </div>
       <div>
         <label className={labelCls} htmlFor="ret-return">Annual return percent</label>
@@ -163,7 +189,9 @@ export function RetirementParamsEditor({
           onChange={(e) => set("annual_return_pct", e.target.value)}
           className={input}
           data-testid="ret-return"
+          aria-describedby="ret-return-hint"
         />
+        <p id="ret-return-hint" className={helpText}>{HELP_RETURN}</p>
       </div>
       <div>
         <label className={labelCls} htmlFor="ret-inflation">Annual inflation percent</label>
@@ -177,7 +205,9 @@ export function RetirementParamsEditor({
           onChange={(e) => set("inflation_pct", e.target.value)}
           className={input}
           data-testid="ret-inflation"
+          aria-describedby="ret-inflation-hint"
         />
+        <p id="ret-inflation-hint" className={helpText}>{HELP_INFLATION}</p>
       </div>
       <div>
         <label className={labelCls} htmlFor="ret-account">Contribution account</label>
@@ -187,6 +217,7 @@ export function RetirementParamsEditor({
           onChange={(e) => set("contribution_account_id", Number(e.target.value))}
           className={input}
           data-testid="ret-account"
+          aria-describedby="ret-account-hint"
         >
           {accounts.map((a) => (
             <option key={a.id} value={a.id}>
@@ -194,13 +225,11 @@ export function RetirementParamsEditor({
             </option>
           ))}
         </select>
+        <p id="ret-account-hint" className={helpText}>{HELP_ACCOUNT}</p>
       </div>
       <div>
         <p className={`${labelCls} mb-2`}>Contribution curve (step function)</p>
-        <p className="mb-2 text-xs text-text-muted">
-          Optional. Each row sets a new monthly contribution starting on
-          the given date. Leave empty to use the base contribution throughout.
-        </p>
+        <p className={`${helpText} mt-0 mb-2`}>{HELP_CURVE}</p>
         {curveError && (
           <p className={`mb-2 text-xs ${errorCls}`} data-testid="ret-curve-error">
             {curveError}

--- a/frontend/tests/app/docs-plans-page.test.tsx
+++ b/frontend/tests/app/docs-plans-page.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Smoke test for /docs/plans, the in-app Plans guide added with the
+ * UX polish PR (2026-05-22). Verifies the page renders, all five
+ * documented sections are present, and the link from /docs back to
+ * the guide is wired.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import PlansDocsPage from "@/app/docs/plans/page";
+import DocsPage from "@/app/docs/page";
+
+vi.mock("@/components/ui/ThemeToggle", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/components/ui/BackLink", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe("/docs/plans", () => {
+  it("renders the page heading and all five sections", () => {
+    render(<PlansDocsPage />);
+    expect(
+      screen.getByRole("heading", { name: /plans guide/i, level: 1 }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("plans-docs-section-what")).toBeInTheDocument();
+    expect(screen.getByTestId("plans-docs-section-verdict")).toBeInTheDocument();
+    expect(screen.getByTestId("plans-docs-section-math")).toBeInTheDocument();
+    expect(screen.getByTestId("plans-docs-section-howto")).toBeInTheDocument();
+    expect(screen.getByTestId("plans-docs-section-curve")).toBeInTheDocument();
+  });
+
+  it("includes the contribution curve worked example", () => {
+    render(<PlansDocsPage />);
+    // The math example mentions specific figures that the product
+    // owner approved in the spec; pin them so they don't drift.
+    const curveSection = screen.getByTestId("plans-docs-section-curve");
+    expect(curveSection.textContent).toMatch(/age 30/i);
+    expect(curveSection.textContent).toMatch(/age 40/i);
+    expect(curveSection.textContent).toMatch(/800/);
+    expect(curveSection.textContent).toMatch(/1,200/);
+  });
+
+  it("explains the verdict colors", () => {
+    render(<PlansDocsPage />);
+    const section = screen.getByTestId("plans-docs-section-verdict");
+    expect(section.textContent).toMatch(/green/i);
+    expect(section.textContent).toMatch(/yellow/i);
+    expect(section.textContent).toMatch(/red/i);
+    expect(section.textContent).toMatch(/80 percent/i);
+  });
+
+  it("explains the smoothed-with-regression option in the math section", () => {
+    render(<PlansDocsPage />);
+    const section = screen.getByTestId("plans-docs-section-math");
+    expect(section.textContent).toMatch(/regression/i);
+  });
+
+  it("links back to the Plans page and the docs home from the footer", () => {
+    render(<PlansDocsPage />);
+    const plansLink = screen.getByRole("link", { name: /^plans$/i });
+    expect(plansLink).toHaveAttribute("href", "/plans");
+    const docsHome = screen.getByRole("link", { name: /docs home/i });
+    expect(docsHome).toHaveAttribute("href", "/docs");
+  });
+});
+
+describe("/docs has a link to /docs/plans", () => {
+  it("renders the Plans guide link in core concepts", () => {
+    render(<DocsPage />);
+    const link = screen.getByTestId("docs-plans-link");
+    expect(link).toHaveAttribute("href", "/docs/plans");
+  });
+});

--- a/frontend/tests/app/plans-page.test.tsx
+++ b/frontend/tests/app/plans-page.test.tsx
@@ -598,4 +598,115 @@ describe("/plans page", () => {
     expect(region.getAttribute("aria-live")).toBe("polite");
     expect(region.getAttribute("role")).toBe("status");
   });
+
+  // Regression: editorValid must not leak across plan switches. The
+  // RetirementParamsEditor is the only validity-bearing child today;
+  // its invalid state used to keep the debounced PATCH gate closed on
+  // the next plan the user opened. Fix is to remount the editor
+  // subtree per plan via key={plan.id}. See PR #356 architect notes.
+  it("resets validity state when switching plans (key remount)", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([RETIREMENT_PLAN, TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`
+        && options?.method === "POST"
+      ) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      if (
+        url === `/api/v1/scenarios/${RETIREMENT_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        return Promise.resolve(RETIREMENT_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<PlansPage />);
+    await screen.findByText("Retire at 65");
+
+    // Open the Retirement plan. The mocked RetirementParamsEditor (see
+    // the vi.doMock above this test file's local scope is not used —
+    // instead we rely on the real RetirementParamsEditor firing
+    // onValidityChange(false) for an empty curve added via the curve
+    // editor). Drive it via the real Add step + leave-from-blank path
+    // so the invalid path actually fires.
+    fireEvent.click(screen.getByTestId(`plan-row-${RETIREMENT_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+    const retirementEditorEl = screen.getByTestId("plan-editor");
+
+    // Add a curve row with `from` empty -> validity becomes false.
+    fireEvent.click(screen.getByTestId("ret-curve-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("ret-curve-error")).toBeInTheDocument();
+    });
+
+    // Snapshot how many PATCH calls were fired for the retirement
+    // plan up to now (should be zero — gate is closed).
+    const patchCountBeforeWait = apiFetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        url === `/api/v1/scenarios/${RETIREMENT_PLAN.id}`
+        && (opts as RequestInit | undefined)?.method === "PATCH",
+    ).length;
+
+    // Wait past the 400ms debounce window. No PATCH should fire while
+    // the curve row is invalid.
+    await new Promise((r) => setTimeout(r, 500));
+    const patchCountAfterWait = apiFetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        url === `/api/v1/scenarios/${RETIREMENT_PLAN.id}`
+        && (opts as RequestInit | undefined)?.method === "PATCH",
+    ).length;
+    expect(patchCountAfterWait).toBe(patchCountBeforeWait);
+
+    // Go back to the list view, then open the Trip plan. Without the
+    // key={plan.id} fix, editorValid would still be false here and
+    // the Trip plan's debounced PATCHes would be silently dropped.
+    fireEvent.click(screen.getByText(/Back to plans/i));
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+    const tripEditorEl = screen.getByTestId("plan-editor");
+
+    // Option B sanity check: the editor DOM node is a fresh one
+    // because we remount per plan (key={plan.id}). Same-identity
+    // would indicate React reused the instance and our reset
+    // mechanism is not actually unmounting the subtree.
+    expect(tripEditorEl).not.toBe(retirementEditorEl);
+
+    // Make a param change on the Trip plan. Use the name field — it
+    // lives in the parent PlanEditor (not the inner template editor)
+    // so this exercises the debounced PATCH path directly.
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon trip (renamed)" },
+    });
+
+    // Now the gate must be open (editorValid reset to true on
+    // remount). The debounced PATCH should fire within ~400ms.
+    await waitFor(
+      () => {
+        const tripPatch = apiFetchMock.mock.calls.find(
+          ([url, opts]) =>
+            url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+            && (opts as RequestInit | undefined)?.method === "PATCH",
+        );
+        expect(tripPatch).toBeDefined();
+        const body = JSON.parse((tripPatch![1] as RequestInit).body as string);
+        expect(body.name).toBe("Lisbon trip (renamed)");
+      },
+      { timeout: 2000 },
+    );
+  });
 });

--- a/frontend/tests/components/scenarios/ProjectionChart.test.tsx
+++ b/frontend/tests/components/scenarios/ProjectionChart.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * ProjectionChart regression test for the Recharts width(-1) / height(-1)
+ * warning that fired in production when the right pane of the Plans
+ * editor first mounted.
+ *
+ * Root cause:
+ *   `ResponsiveContainer` measures its parent on synchronous first
+ *   render. In a CSS-grid pane with `minmax(0, 2fr)`, that read can
+ *   come back as -1 before the layout engine has committed and
+ *   Recharts logs the loud `width(-1) and height(-1) of chart should
+ *   be greater than 0` warning.
+ *
+ * Guardrail:
+ *   The fix defers the ResponsiveContainer render by one effect tick
+ *   (a `mounted` flag), and pins `min-w-0 min-h-0` on the wrapper so
+ *   the grid track can shrink to fit. This test spies on
+ *   `console.warn` and asserts the bad string never reaches it after
+ *   the chart renders with valid fixture data.
+ */
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+import { ProjectionChart } from "@/components/scenarios/ProjectionChart";
+
+// Stub Recharts the same way the page test does. The structural stub
+// keeps it out of the way of jsdom's SVG pipeline while still letting
+// us assert that the chart wrapper renders.
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-responsive">{children}</div>
+  ),
+  ComposedChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="recharts-chart">{children}</div>
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  Area: () => null,
+  Line: () => null,
+  ReferenceDot: () => null,
+  Dot: () => null,
+}));
+
+const FIXTURE_PROJECTION = {
+  currency: "EUR",
+  per_account_series: [
+    {
+      account_id: 1,
+      account_name: "Main",
+      currency: "EUR",
+      points: [
+        { month: "2026-06", projected_balance: "1000.00" },
+        { month: "2026-07", projected_balance: "1100.00" },
+        { month: "2026-08", projected_balance: "1200.00" },
+      ],
+    },
+  ],
+  alerts: [],
+  real_terms_series: null,
+};
+
+describe("ProjectionChart", () => {
+  it("does not log the Recharts width(-1)/height(-1) warning on mount", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(<ProjectionChart projection={FIXTURE_PROJECTION} />);
+      // Wait through React's effect tick so the deferred
+      // ResponsiveContainer paint actually runs.
+      await waitFor(() => {
+        expect(screen.getByTestId("projection-chart")).toBeInTheDocument();
+      });
+      // Give effects another microtask to settle before we inspect
+      // the warn log; the symptom in prod was warnings firing right
+      // around the first paint.
+      await act(async () => {});
+      const badCalls = warnSpy.mock.calls.filter((call) =>
+        call.some(
+          (arg) =>
+            typeof arg === "string"
+            && /width.*height.*should be greater/i.test(arg),
+        ),
+      );
+      expect(badCalls).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("renders the empty placeholder when no months are projected", () => {
+    render(
+      <ProjectionChart
+        projection={{ ...FIXTURE_PROJECTION, per_account_series: [] }}
+      />,
+    );
+    expect(screen.getByTestId("projection-chart-empty")).toBeInTheDocument();
+  });
+
+  it("pins min-w-0 min-h-0 on the chart wrapper so the grid track can shrink", async () => {
+    render(<ProjectionChart projection={FIXTURE_PROJECTION} />);
+    const wrapper = await screen.findByTestId("projection-chart");
+    expect(wrapper.className).toMatch(/min-w-0/);
+    expect(wrapper.className).toMatch(/min-h-0/);
+  });
+});

--- a/frontend/tests/components/scenarios/RetirementParamsEditor.test.tsx
+++ b/frontend/tests/components/scenarios/RetirementParamsEditor.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Regression test for the debounced PATCH spam reported in production
+ * (2026-05-22): when the user typed in a retirement plan's Monthly
+ * field but the contribution curve still had a row with no `from`
+ * date, the editor kept firing PATCH /api/v1/scenarios/:id every 400
+ * ms and the server returned 422 each time.
+ *
+ * The fix gates the debounced effect on the editor's client-side
+ * validity flag (`onValidityChange` from RetirementParamsEditor flows
+ * up to the parent and short-circuits the persist call). This test
+ * drives the Plans page editor end-to-end and asserts no PATCH fires
+ * while the inline error is visible, then asserts the PATCH starts
+ * firing again once the user fills the missing date.
+ */
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import PlansPage from "@/app/plans/page";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch } from "@/lib/api";
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/plans",
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ComposedChart: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  Area: () => null,
+  Line: () => null,
+  ReferenceDot: () => null,
+  Dot: () => null,
+}));
+
+const USER = {
+  id: 1,
+  username: "alice",
+  email: "alice@acme.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner" as const,
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const RETIREMENT_PLAN = {
+  id: 8,
+  org_id: 1,
+  user_id: 1,
+  name: "Retire at 65",
+  scenario_type: "retirement" as const,
+  params_json: {
+    scenario_type: "retirement",
+    target_retirement_date: "2050-01-01",
+    currency: "EUR",
+    monthly_contribution: "500.00",
+    contribution_account_id: 12,
+    target_balance: "100000.00",
+    annual_return_pct: "6.0",
+    inflation_pct: "2.5",
+    contribution_curve: [],
+  },
+  projection_json: null,
+  projection_engine: null,
+  projection_computed_at: null,
+  horizon_months: 360,
+  is_active: true,
+  created_at: "2026-05-22T00:00:00",
+  updated_at: "2026-05-22T00:00:00",
+};
+
+const SAMPLE_ACCOUNT = {
+  id: 12,
+  name: "Main checking",
+  currency: "EUR",
+  balance: "5000.00",
+};
+
+function setUser() {
+  vi.mocked(useAuth).mockReturnValue({
+    user: USER as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  } as never);
+}
+
+describe("debounced PATCH gating via client-side validity", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips PATCH while a curve row is missing its `from` date", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !opts?.method) {
+        return Promise.resolve([RETIREMENT_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<PlansPage />);
+    await screen.findByText("Retire at 65");
+    fireEvent.click(screen.getByTestId(`plan-row-${RETIREMENT_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    // Add a curve row but leave its `from` empty. The editor's
+    // validateCurve() returns an inline error.
+    fireEvent.click(screen.getByTestId("ret-curve-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("ret-curve-error")).toBeInTheDocument();
+    });
+
+    // Now change the Monthly base field. Without the gate, this would
+    // schedule a debounced PATCH that the server would reject 422.
+    const before = apiFetchMock.mock.calls.length;
+    fireEvent.change(screen.getByTestId("ret-monthly"), {
+      target: { value: "750.00" },
+    });
+
+    // Walk well past the architect-locked 400 ms debounce.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    const patchCalls = apiFetchMock.mock.calls
+      .slice(before)
+      .filter(([, o]) => (o as RequestInit | undefined)?.method === "PATCH");
+    expect(patchCalls).toEqual([]);
+  });
+
+  it("resumes PATCH once the curve row's `from` date is filled in", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, opts?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !opts?.method) {
+        return Promise.resolve([RETIREMENT_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${RETIREMENT_PLAN.id}`
+        && opts?.method === "PATCH"
+      ) {
+        return Promise.resolve(RETIREMENT_PLAN);
+      }
+      if (
+        url === `/api/v1/scenarios/${RETIREMENT_PLAN.id}/simulate`
+        && opts?.method === "POST"
+      ) {
+        return Promise.resolve(RETIREMENT_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<PlansPage />);
+    await screen.findByText("Retire at 65");
+    fireEvent.click(screen.getByTestId(`plan-row-${RETIREMENT_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    // Step 1: add the empty-from row + change Monthly, confirm no PATCH.
+    fireEvent.click(screen.getByTestId("ret-curve-add"));
+    await waitFor(() => {
+      expect(screen.getByTestId("ret-curve-error")).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("ret-monthly"), {
+      target: { value: "750.00" },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(
+      apiFetchMock.mock.calls.filter(
+        ([, o]) => (o as RequestInit | undefined)?.method === "PATCH",
+      ),
+    ).toEqual([]);
+
+    // Step 2: fill the row's `from`. Editor flips back to valid. A
+    // subsequent edit should trigger PATCH within the debounce window.
+    fireEvent.change(screen.getByTestId("ret-curve-from-0"), {
+      target: { value: "2040-01-01" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("ret-curve-error")).not.toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByTestId("ret-monthly"), {
+      target: { value: "800.00" },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await waitFor(() => {
+      const patchCalls = apiFetchMock.mock.calls.filter(
+        ([url, o]) =>
+          url === `/api/v1/scenarios/${RETIREMENT_PLAN.id}`
+          && (o as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patchCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/frontend/tests/components/scenarios/RetirementParamsEditor.test.tsx
+++ b/frontend/tests/components/scenarios/RetirementParamsEditor.test.tsx
@@ -20,7 +20,7 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
 
 const replaceMock = vi.fn();
-let searchParamsString = "";
+const searchParamsString = "";
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/plans",

--- a/frontend/tests/components/scenarios/RetirementParamsEditor.test.tsx
+++ b/frontend/tests/components/scenarios/RetirementParamsEditor.test.tsx
@@ -20,9 +20,11 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch } from "@/lib/api";
 
 const replaceMock = vi.fn();
+let searchParamsString = "";
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
   usePathname: () => "/plans",
+  useSearchParams: () => new URLSearchParams(searchParamsString),
 }));
 
 vi.mock("@/components/AppShell", () => ({


### PR DESCRIPTION
Quiets the retirement-template console screenshot from prod (Recharts width(-1)/height(-1) warning + a stream of 422 PATCHes from the debounced auto-save) and gives the lazy-user path enough copy on the Plans page and in /docs to use the tool without reading the source.

Fixes:
1. Recharts width(-1)/height(-1) on initial mount. `ProjectionChart` now defers the `ResponsiveContainer` render by one effect tick and pins `min-w-0 min-h-0` on the wrapper so its grid track can shrink before Recharts measures.
2. PATCH spam while typing. `PlanEditor` gates the 400 ms debounced PATCH on a client-side validity flag (editor validity, horizon bounds, non-empty name). An incomplete curve row keeps the inline error visible but no longer fires 422s; filling the missing date resumes the auto-PATCH.
3. In-context field copy. Helper microcopy added under every Trip, Purchase, and Retirement input (mt-1 max-w-prose text-xs text-text-muted, aria-describedby wired) so the user does not have to leave the form to learn what each field does.
4. New /docs/plans page (5 sections: What is Plans, verdict colors, the math, how to use, the contribution curve with a worked example). Linked from the /plans header and from the /docs core-concepts list.

Tests:
- `tests/components/scenarios/ProjectionChart.test.tsx` (new): spies on `console.warn` and pins `min-w-0 min-h-0` on the wrapper.
- `tests/components/scenarios/RetirementParamsEditor.test.tsx` (new): empty curve `from` keeps PATCH from firing; filling it resumes PATCH.
- `tests/app/docs-plans-page.test.tsx` (new): renders, all five sections present, /docs links to /docs/plans.
- 160 test files / 1189 tests pass. `tsc --noEmit` clean.