### PR TITLE
feat(plans): explicit Save + Discard buttons in editor

### DIFF
--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -42,6 +42,19 @@ import {
   pageTitle,
 } from "@/lib/styles";
 
+// Editor snapshot — the "committed" state Save/Discard pivot around.
+// PR #plans-editor-save-discard adds explicit Save and Discard buttons
+// on top of the existing debounced auto-PATCH behaviour. The snapshot
+// captures the state the editor "considers committed"; Save advances
+// the snapshot to the current local state, Discard rolls local state
+// (and the server row) back to the snapshot. Auto-PATCH keeps firing
+// for live projection feedback — the buttons are a UX layer on top.
+type EditorSnapshot = {
+  name: string;
+  horizon: number;
+  params: Record<string, unknown>;
+};
+
 // Internal type name uses the DB / API word; the UI label is "Plans".
 export type ScenarioType = "trip" | "purchase" | "retirement" | "custom";
 
@@ -495,6 +508,24 @@ function PlanEditor({
   const [editorValid, setEditorValid] = useState(true);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Save/Discard snapshot. We use state (not useRef) because isDirty
+  // is computed against the snapshot DURING render, and the new
+  // react-hooks/refs lint rule forbids reading refs in the render
+  // phase. Storing the snapshot in state keeps it observable as part
+  // of the render contract while still letting Save/Discard advance
+  // or restore it imperatively. setSnapshot does not need to be in
+  // any dep arrays beyond the switching-plans reset effect; Save
+  // calls it explicitly.
+  const [snapshot, setSnapshot] = useState<EditorSnapshot>({
+    name: plan.name,
+    horizon: plan.horizon_months,
+    params: plan.params_json,
+  });
+  // Microcopy line announced via aria-live so screen readers and a
+  // glanceable visual indicator both see "Saved" / "Discarded" after
+  // the corresponding action.
+  const [statusMsg, setStatusMsg] = useState<string>("");
+
   // Horizon bounds match the server-side validator. Pre-checking on the
   // client keeps the debounced PATCH from firing 422s while the user
   // walks an out-of-range number up or down with the spinner.
@@ -503,12 +534,41 @@ function PlanEditor({
   const nameValid = name.trim().length > 0;
   const isValid = editorValid && horizonValid && nameValid;
 
-  // Reset state when switching plans.
+  // isDirty compares current editor state to the snapshot (NOT to
+  // `plan`). The debounced auto-PATCH keeps the server in sync with
+  // every keystroke; the snapshot moves only when the user clicks
+  // Save (or when they switch plans / open a different row). That's
+  // why "Save" is meaningful even though every change already round-
+  // tripped to the server: Save advances the pivot Discard reverts to.
+  const isDirty =
+    name !== snapshot.name ||
+    horizon !== snapshot.horizon ||
+    JSON.stringify(params) !== JSON.stringify(snapshot.params);
+
+  // Reset state AND snapshot when switching plans. Opening a different
+  // plan must start with a clean "no unsaved changes" baseline; without
+  // this, the snapshot from the previous plan would mark every field
+  // as dirty the moment the new plan paints.
   useEffect(() => {
     setParams(plan.params_json);
     setName(plan.name);
     setHorizon(plan.horizon_months);
+    setSnapshot({
+      name: plan.name,
+      horizon: plan.horizon_months,
+      params: plan.params_json,
+    });
+    setStatusMsg("");
   }, [plan.id, plan.params_json, plan.name, plan.horizon_months]);
+
+  // Stale-status guard: once the user makes a fresh change after a
+  // "Saved" / "Discarded" microcopy, the message is no longer accurate.
+  // Clear it as soon as the editor goes dirty again.
+  useEffect(() => {
+    if (isDirty && statusMsg) {
+      setStatusMsg("");
+    }
+  }, [isDirty, statusMsg]);
 
   const persist = useCallback(async () => {
     setBusy(true);
@@ -574,6 +634,57 @@ function PlanEditor({
     setErr("");
     try {
       await onSimulate(plan);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Save advances the snapshot to the current local state. The auto-PATCH
+  // has already persisted those values; Save's job is to update the
+  // pivot point Discard will revert to, plus give the user the
+  // psychological hand-off they asked for ("this is the version I
+  // intended to keep"). No additional network call from this path.
+  function handleSave() {
+    if (!isDirty) return;
+    setSnapshot({ name, horizon, params });
+    setStatusMsg("Saved");
+  }
+
+  // Discard rolls local state back to the snapshot AND PATCHes the
+  // server row with the snapshot values. The server PATCH is required
+  // because the auto-PATCH layer has already written every interim
+  // edit; Discard is the only way to undo those server-side writes.
+  async function handleDiscard() {
+    if (!isDirty) return;
+    const target = snapshot;
+    setBusy(true);
+    setErr("");
+    try {
+      const updated = await apiFetch<Scenario>(
+        `/api/v1/scenarios/${plan.id}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            name: target.name,
+            horizon_months: target.horizon,
+            params: {
+              scenario_type: plan.scenario_type,
+              ...target.params,
+            },
+          }),
+        },
+      );
+      // Reset local editor state in lockstep with the rolled-back
+      // server row. Don't await onUpdated — its `setActive` would loop
+      // through the snapshot-resetting effect we already control here.
+      setParams(target.params);
+      setName(target.name);
+      setHorizon(target.horizon);
+      onUpdated(updated);
+      await onSimulate(updated);
+      setStatusMsg("Discarded");
+    } catch (e) {
+      setErr(extractErrorMessage(e, "Discard failed"));
     } finally {
       setBusy(false);
     }
@@ -650,15 +761,58 @@ function PlanEditor({
                 accounts={accounts}
               />
             )}
-            <button
-              type="button"
-              className={`${btnPrimary} sm:min-h-0`}
-              onClick={manualSimulate}
-              disabled={busy}
-              data-testid="plan-simulate-now"
+            {/* Save / Discard / Re-simulate cluster.
+                isDirty drives both Save and Discard so an unchanged
+                editor doesn't offer either control. The "Unsaved
+                changes" hint is the visual mirror of isDirty for the
+                user; the aria-live region beneath it announces the
+                resulting state ("Saved" / "Discarded") for assistive
+                tech and as a glanceable confirmation. */}
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                className={`${btnPrimary} sm:min-h-0`}
+                onClick={handleSave}
+                disabled={!isDirty || busy}
+                data-testid="plan-save"
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                className={`${btnSecondary} sm:min-h-0`}
+                onClick={handleDiscard}
+                disabled={!isDirty || busy}
+                data-testid="plan-discard"
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                className={`${btnSecondary} sm:min-h-0`}
+                onClick={manualSimulate}
+                disabled={busy}
+                data-testid="plan-simulate-now"
+              >
+                Re-simulate
+              </button>
+              {isDirty && (
+                <span
+                  className="text-xs text-text-muted"
+                  data-testid="plan-dirty-indicator"
+                >
+                  Unsaved changes
+                </span>
+              )}
+            </div>
+            <p
+              role="status"
+              aria-live="polite"
+              className="min-h-[1rem] text-xs text-text-muted"
+              data-testid="plan-save-status"
             >
-              Re-simulate
-            </button>
+              {statusMsg}
+            </p>
           </div>
         </div>
         <div className={`${card} p-5`}>

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -639,15 +639,64 @@ function PlanEditor({
     }
   }
 
-  // Save advances the snapshot to the current local state. The auto-PATCH
-  // has already persisted those values; Save's job is to update the
-  // pivot point Discard will revert to, plus give the user the
-  // psychological hand-off they asked for ("this is the version I
-  // intended to keep"). No additional network call from this path.
-  function handleSave() {
-    if (!isDirty) return;
-    setSnapshot({ name, horizon, params });
-    setStatusMsg("Saved");
+  // Save persists the current local state to the server and only then
+  // advances the snapshot. The auto-PATCH layer keeps the chart in
+  // sync between edits, but it's *gated* on isValid — when the editor
+  // is invalid (e.g., a retirement curve row missing `from`), the
+  // auto-PATCH intentionally short-circuits. Without the explicit
+  // server round-trip here, clicking Save in an invalid state would
+  // advance the snapshot to a value the server never accepted, and
+  // Discard would happily roll forward to that broken state. So Save
+  // is also gated on isValid (button disabled below), and we still
+  // PATCH explicitly so the snapshot only advances on the server-
+  // acknowledged value.
+  async function handleSave() {
+    if (!isDirty || !isValid) return;
+    // Cancel any pending debounced PATCH so the explicit Save isn't
+    // racing the auto-PATCH for the same row. Content is identical
+    // either way; killing the debounce just keeps the call count
+    // tight and avoids ordering surprises in tests.
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setBusy(true);
+    setErr("");
+    try {
+      const updated = await apiFetch<Scenario>(
+        `/api/v1/scenarios/${plan.id}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            name,
+            horizon_months: horizon,
+            params: {
+              scenario_type: plan.scenario_type,
+              ...params,
+            },
+          }),
+        },
+      );
+      // Advance the snapshot to the server-acknowledged value. If the
+      // PATCH rejected (422 / 500 / network blip), the catch branch
+      // leaves the snapshot at its previous good state, so Discard
+      // can still bail the user out.
+      const serverParams =
+        (updated.params_json as Record<string, unknown>) ?? params;
+      setSnapshot({
+        name: updated.name,
+        horizon: updated.horizon_months,
+        params: serverParams,
+      });
+      onUpdated(updated);
+      await onSimulate(updated);
+      setStatusMsg("Saved");
+    } catch (e) {
+      setStatusMsg("");
+      setErr(`Save failed: ${extractErrorMessage(e, "unknown error")}`);
+    } finally {
+      setBusy(false);
+    }
   }
 
   // Discard rolls local state back to the snapshot AND PATCHes the
@@ -773,7 +822,7 @@ function PlanEditor({
                 type="button"
                 className={`${btnPrimary} sm:min-h-0`}
                 onClick={handleSave}
-                disabled={!isDirty || busy}
+                disabled={!isDirty || busy || !isValid}
                 data-testid="plan-save"
               >
                 Save
@@ -796,12 +845,20 @@ function PlanEditor({
               >
                 Re-simulate
               </button>
-              {isDirty && (
+              {isDirty && isValid && (
                 <span
                   className="text-xs text-text-muted"
                   data-testid="plan-dirty-indicator"
                 >
                   Unsaved changes
+                </span>
+              )}
+              {isDirty && !isValid && (
+                <span
+                  className="text-xs text-text-muted"
+                  data-testid="plan-invalid-hint"
+                >
+                  Fix validation errors before saving.
                 </span>
               )}
             </div>

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -513,14 +513,25 @@ function PlanEditor({
   // react-hooks/refs lint rule forbids reading refs in the render
   // phase. Storing the snapshot in state keeps it observable as part
   // of the render contract while still letting Save/Discard advance
-  // or restore it imperatively. setSnapshot does not need to be in
-  // any dep arrays beyond the switching-plans reset effect; Save
-  // calls it explicitly.
-  const [snapshot, setSnapshot] = useState<EditorSnapshot>({
+  // or restore it imperatively.
+  //
+  // The initializer captures the editor's starting baseline ONCE per
+  // mount. The snapshot then advances only via handleSave (after the
+  // server PATCH acks the new value) or handleDiscard (after the
+  // server PATCH acks the rollback). Crucially there is no effect
+  // tying the snapshot to the `plan` prop: the parent feeds every
+  // auto-PATCH response back through `onUpdated -> setItems ->
+  // active`, which would re-fire such an effect and silently advance
+  // the snapshot to the just-PATCHed value, collapsing dirty state
+  // and destroying Discard's rollback target. The PlanEditor is
+  // keyed by `plan.id` upstream, so switching plans remounts the
+  // component and re-runs this initializer with the new plan's
+  // baseline — that's the only path that resets the snapshot.
+  const [snapshot, setSnapshot] = useState<EditorSnapshot>(() => ({
     name: plan.name,
     horizon: plan.horizon_months,
     params: plan.params_json,
-  });
+  }));
   // Microcopy line announced via aria-live so screen readers and a
   // glanceable visual indicator both see "Saved" / "Discarded" after
   // the corresponding action.
@@ -537,29 +548,15 @@ function PlanEditor({
   // isDirty compares current editor state to the snapshot (NOT to
   // `plan`). The debounced auto-PATCH keeps the server in sync with
   // every keystroke; the snapshot moves only when the user clicks
-  // Save (or when they switch plans / open a different row). That's
-  // why "Save" is meaningful even though every change already round-
-  // tripped to the server: Save advances the pivot Discard reverts to.
+  // Save or Discard. Switching plans remounts the editor (via
+  // key={plan.id} upstream), which re-runs the snapshot initializer
+  // against the new plan's baseline. That's why "Save" is meaningful
+  // even though every change already round-tripped to the server:
+  // Save advances the pivot Discard reverts to.
   const isDirty =
     name !== snapshot.name ||
     horizon !== snapshot.horizon ||
     JSON.stringify(params) !== JSON.stringify(snapshot.params);
-
-  // Reset state AND snapshot when switching plans. Opening a different
-  // plan must start with a clean "no unsaved changes" baseline; without
-  // this, the snapshot from the previous plan would mark every field
-  // as dirty the moment the new plan paints.
-  useEffect(() => {
-    setParams(plan.params_json);
-    setName(plan.name);
-    setHorizon(plan.horizon_months);
-    setSnapshot({
-      name: plan.name,
-      horizon: plan.horizon_months,
-      params: plan.params_json,
-    });
-    setStatusMsg("");
-  }, [plan.id, plan.params_json, plan.name, plan.horizon_months]);
 
   // Stale-status guard: once the user makes a fresh change after a
   // "Saved" / "Discarded" microcopy, the message is no longer accurate.

--- a/frontend/tests/app/plans-page.test.tsx
+++ b/frontend/tests/app/plans-page.test.tsx
@@ -394,6 +394,241 @@ describe("/plans page", () => {
     );
   });
 
+  // ── Save / Discard editor controls (PR #plans-editor-save-discard) ──
+  //
+  // The /plans editor auto-PATCHes on every param change. That makes the
+  // chart respond live but leaves the user without an explicit handle on
+  // "this is the version I want to keep" vs "throw this away." These
+  // tests lock the Save+Discard contract:
+  //   - dirty -> Save/Discard enabled + "Unsaved changes" hint shown
+  //   - clean -> both disabled
+  //   - Save advances the snapshot WITHOUT firing an extra PATCH
+  //   - Discard fires a PATCH with the snapshot values and reverts
+  //     local state
+  //   - Saved/Discarded microcopy fires in the aria-live region
+  it("Save + Discard are disabled and the dirty hint is hidden until a change is made", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve([TRIP_PLAN]);
+      if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    expect(screen.getByTestId("plan-save")).toBeDisabled();
+    expect(screen.getByTestId("plan-discard")).toBeDisabled();
+    expect(screen.queryByTestId("plan-dirty-indicator")).toBeNull();
+  });
+
+  it("typing into the editor enables Save + Discard and shows 'Unsaved changes'", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve([TRIP_PLAN]);
+      if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon trip (revised)" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save")).not.toBeDisabled();
+    });
+    expect(screen.getByTestId("plan-discard")).not.toBeDisabled();
+    expect(screen.getByTestId("plan-dirty-indicator")).toHaveTextContent(
+      /Unsaved changes/i,
+    );
+  });
+
+  it("Save advances the snapshot, clears dirty, and announces 'Saved' — without an extra PATCH from the click", async () => {
+    setUser();
+    let lastPatchBody: Record<string, unknown> | null = null;
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        lastPatchBody = JSON.parse((options.body as string) ?? "{}");
+        return Promise.resolve({ ...TRIP_PLAN, name: lastPatchBody?.name as string });
+      }
+      if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    // Type a change — auto-PATCH will fire (debounced). We're testing
+    // that Save does NOT additionally PATCH on top of the auto-PATCH.
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon revised" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save")).not.toBeDisabled();
+    });
+
+    // Snapshot how many PATCHes the auto-debounce has fired by now.
+    const patchCountBeforeSave = apiFetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && (opts as RequestInit | undefined)?.method === "PATCH",
+    ).length;
+
+    fireEvent.click(screen.getByTestId("plan-save"));
+
+    // Dirty hint vanishes; both buttons re-disable; "Saved" lights up
+    // in the aria-live region.
+    await waitFor(() => {
+      expect(screen.queryByTestId("plan-dirty-indicator")).toBeNull();
+    });
+    expect(screen.getByTestId("plan-save")).toBeDisabled();
+    expect(screen.getByTestId("plan-discard")).toBeDisabled();
+    expect(screen.getByTestId("plan-save-status")).toHaveTextContent(/^Saved$/);
+
+    // No additional PATCH from the click itself.
+    const patchCountAfterSave = apiFetchMock.mock.calls.filter(
+      ([url, opts]) =>
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && (opts as RequestInit | undefined)?.method === "PATCH",
+    ).length;
+    expect(patchCountAfterSave).toBe(patchCountBeforeSave);
+  });
+
+  it("Discard PATCHes the snapshot back, reverts local state, and announces 'Discarded'", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        const body = JSON.parse((options.body as string) ?? "{}");
+        return Promise.resolve({
+          ...TRIP_PLAN,
+          name: body.name,
+          horizon_months: body.horizon_months ?? TRIP_PLAN.horizon_months,
+        });
+      }
+      if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    // Edit the name.
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon revised" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-discard")).not.toBeDisabled();
+    });
+
+    // Click Discard — it must PATCH with the snapshot name ("Lisbon
+    // trip"), not the typed-over "Lisbon revised" value.
+    fireEvent.click(screen.getByTestId("plan-discard"));
+
+    await waitFor(() => {
+      const discardPatch = apiFetchMock.mock.calls.findLast(
+        ([url, opts]) =>
+          url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+          && (opts as RequestInit | undefined)?.method === "PATCH"
+          && JSON.parse(((opts as RequestInit).body as string) ?? "{}").name
+            === "Lisbon trip",
+      );
+      expect(discardPatch).toBeDefined();
+    });
+
+    // Local state reverts (input shows the snapshot name again) and
+    // the "Discarded" microcopy fires.
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("plan-name-input") as HTMLInputElement).value,
+      ).toBe("Lisbon trip");
+    });
+    expect(screen.getByTestId("plan-save-status")).toHaveTextContent(
+      /^Discarded$/,
+    );
+    // Buttons re-disable now that local == snapshot.
+    expect(screen.getByTestId("plan-save")).toBeDisabled();
+    expect(screen.getByTestId("plan-discard")).toBeDisabled();
+  });
+
+  it("Save / Discard status microcopy clears when the user edits again", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        const body = JSON.parse((options.body as string) ?? "{}");
+        return Promise.resolve({ ...TRIP_PLAN, name: body.name });
+      }
+      if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "v2" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save")).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByTestId("plan-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save-status")).toHaveTextContent(
+        /^Saved$/,
+      );
+    });
+
+    // Make a fresh change — the stale "Saved" message must clear so
+    // the aria-live region doesn't lie about state.
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "v3" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save-status")).toHaveTextContent("");
+    });
+    expect(screen.getByTestId("plan-dirty-indicator")).toBeInTheDocument();
+  });
+
   it("Simulate button on a row POSTs to /api/v1/scenarios/{id}/simulate", async () => {
     setUser();
     apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {

--- a/frontend/tests/app/plans-page.test.tsx
+++ b/frontend/tests/app/plans-page.test.tsx
@@ -1111,4 +1111,192 @@ describe("/plans page", () => {
       { timeout: 2000 },
     );
   });
+
+  // Regression for the snapshot-init bug. The original implementation
+  // had a useEffect that reset the snapshot whenever
+  // plan.params_json / plan.name / plan.horizon_months changed.
+  // Because the parent feeds every auto-PATCH response back through
+  // onUpdated -> setItems -> active, the prop changed on every
+  // debounced PATCH, the effect re-fired, and the snapshot advanced
+  // to the just-PATCHed value — silently collapsing dirty state and
+  // destroying Discard's rollback target. Fix: drop the effect; the
+  // initializer captures the baseline once per mount, and remount on
+  // plan switch (key={plan.id}) handles the only legitimate reset
+  // path. These two tests pin that contract.
+  it("snapshot does not advance on auto-PATCH while the user keeps editing", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        const body = JSON.parse((options.body as string) ?? "{}");
+        // Echo the server row back with the patched name applied so
+        // the parent's onUpdated -> setActive cycle feeds a fresh
+        // plan prop to the editor.
+        return Promise.resolve({
+          ...TRIP_PLAN,
+          name: body.name,
+          horizon_months: body.horizon_months ?? TRIP_PLAN.horizon_months,
+          params_json: {
+            ...(TRIP_PLAN.params_json as Record<string, unknown>),
+            ...((body.params as Record<string, unknown>) ?? {}),
+          },
+        });
+      }
+      if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    // First edit: change the name. The debounced auto-PATCH fires
+    // ~400ms later and the parent re-feeds the updated plan prop.
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon edit 1" },
+    });
+
+    // Wait for the auto-PATCH to round-trip.
+    await waitFor(
+      () => {
+        const autoPatch = apiFetchMock.mock.calls.find(
+          ([url, opts]) =>
+            url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+            && (opts as RequestInit | undefined)?.method === "PATCH"
+            && JSON.parse(((opts as RequestInit).body as string) ?? "{}")
+              .name === "Lisbon edit 1",
+        );
+        expect(autoPatch).toBeDefined();
+      },
+      { timeout: 2000 },
+    );
+
+    // The dirty indicator must STILL be visible. With the bug, the
+    // effect would have rebuilt the snapshot from the just-PATCHed
+    // prop, the editor would equal the snapshot, and the indicator
+    // would disappear.
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-dirty-indicator")).toBeInTheDocument();
+    });
+
+    // Second edit on top of the first one. The dirty indicator
+    // must remain visible across both edits.
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon edit 2" },
+    });
+    expect(screen.getByTestId("plan-dirty-indicator")).toBeInTheDocument();
+
+    // And Discard must roll all the way back to the ORIGINAL name
+    // ("Lisbon trip"), not the auto-PATCHed intermediate.
+    fireEvent.click(screen.getByTestId("plan-discard"));
+    await waitFor(() => {
+      const discardPatch = apiFetchMock.mock.calls.findLast(
+        ([url, opts]) =>
+          url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+          && (opts as RequestInit | undefined)?.method === "PATCH"
+          && JSON.parse(((opts as RequestInit).body as string) ?? "{}")
+            .name === "Lisbon trip",
+      );
+      expect(discardPatch).toBeDefined();
+    });
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("plan-name-input") as HTMLInputElement).value,
+      ).toBe("Lisbon trip");
+    });
+  });
+
+  it("Discard reverts to the initial snapshot even after an auto-PATCH has fired", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([{ ...TRIP_PLAN, name: "Vacation" }]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        const body = JSON.parse((options.body as string) ?? "{}");
+        return Promise.resolve({
+          ...TRIP_PLAN,
+          name: body.name,
+          horizon_months: body.horizon_months ?? TRIP_PLAN.horizon_months,
+          params_json: {
+            ...(TRIP_PLAN.params_json as Record<string, unknown>),
+            ...((body.params as Record<string, unknown>) ?? {}),
+          },
+        });
+      }
+      if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+
+    render(<PlansPage />);
+    await screen.findByText("Vacation");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    // Type into the name field: "Vacation" -> "Vacation A".
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Vacation A" },
+    });
+
+    // Wait for the auto-PATCH to land "Vacation A" server-side.
+    await waitFor(
+      () => {
+        const autoPatch = apiFetchMock.mock.calls.find(
+          ([url, opts]) =>
+            url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+            && (opts as RequestInit | undefined)?.method === "PATCH"
+            && JSON.parse(((opts as RequestInit).body as string) ?? "{}")
+              .name === "Vacation A",
+        );
+        expect(autoPatch).toBeDefined();
+      },
+      { timeout: 2000 },
+    );
+
+    // Now type again: "Vacation A" -> "Vacation AB".
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Vacation AB" },
+    });
+
+    // Click Discard. The rollback target is the ORIGINAL name
+    // ("Vacation"), not the auto-PATCHed intermediate ("Vacation A").
+    fireEvent.click(screen.getByTestId("plan-discard"));
+
+    await waitFor(() => {
+      const discardPatch = apiFetchMock.mock.calls.findLast(
+        ([url, opts]) =>
+          url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+          && (opts as RequestInit | undefined)?.method === "PATCH"
+          && JSON.parse(((opts as RequestInit).body as string) ?? "{}")
+            .name === "Vacation",
+      );
+      expect(discardPatch).toBeDefined();
+    });
+
+    // Local state shows the original name, not the intermediate.
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("plan-name-input") as HTMLInputElement).value,
+      ).toBe("Vacation");
+    });
+  });
 });

--- a/frontend/tests/app/plans-page.test.tsx
+++ b/frontend/tests/app/plans-page.test.tsx
@@ -448,9 +448,8 @@ describe("/plans page", () => {
     );
   });
 
-  it("Save advances the snapshot, clears dirty, and announces 'Saved' — without an extra PATCH from the click", async () => {
+  it("Save PATCHes the current value to the server, advances the snapshot, clears dirty, and announces 'Saved'", async () => {
     setUser();
-    let lastPatchBody: Record<string, unknown> | null = null;
     apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
       if (url === "/api/v1/scenarios" && !options?.method) {
         return Promise.resolve([TRIP_PLAN]);
@@ -462,8 +461,16 @@ describe("/plans page", () => {
         url === `/api/v1/scenarios/${TRIP_PLAN.id}`
         && options?.method === "PATCH"
       ) {
-        lastPatchBody = JSON.parse((options.body as string) ?? "{}");
-        return Promise.resolve({ ...TRIP_PLAN, name: lastPatchBody?.name as string });
+        const body = JSON.parse((options.body as string) ?? "{}");
+        return Promise.resolve({
+          ...TRIP_PLAN,
+          name: body.name,
+          horizon_months: body.horizon_months ?? TRIP_PLAN.horizon_months,
+          params_json: {
+            ...(TRIP_PLAN.params_json as Record<string, unknown>),
+            ...((body.params as Record<string, unknown>) ?? {}),
+          },
+        });
       }
       if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
         return Promise.resolve(TRIP_PLAN);
@@ -475,8 +482,6 @@ describe("/plans page", () => {
     fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
     await screen.findByTestId("plan-editor");
 
-    // Type a change — auto-PATCH will fire (debounced). We're testing
-    // that Save does NOT additionally PATCH on top of the auto-PATCH.
     fireEvent.change(screen.getByTestId("plan-name-input"), {
       target: { value: "Lisbon revised" },
     });
@@ -484,31 +489,193 @@ describe("/plans page", () => {
       expect(screen.getByTestId("plan-save")).not.toBeDisabled();
     });
 
-    // Snapshot how many PATCHes the auto-debounce has fired by now.
-    const patchCountBeforeSave = apiFetchMock.mock.calls.filter(
-      ([url, opts]) =>
-        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
-        && (opts as RequestInit | undefined)?.method === "PATCH",
-    ).length;
-
     fireEvent.click(screen.getByTestId("plan-save"));
 
-    // Dirty hint vanishes; both buttons re-disable; "Saved" lights up
-    // in the aria-live region.
+    // The click MUST trigger a PATCH with the current typed value
+    // before the snapshot advances — that's the whole point of the
+    // explicit Save flow.
+    await waitFor(() => {
+      const savePatch = apiFetchMock.mock.calls.findLast(
+        ([url, opts]) =>
+          url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+          && (opts as RequestInit | undefined)?.method === "PATCH"
+          && JSON.parse(((opts as RequestInit).body as string) ?? "{}").name
+            === "Lisbon revised",
+      );
+      expect(savePatch).toBeDefined();
+    });
+
+    // After the PATCH resolves, dirty hint vanishes, both buttons
+    // re-disable, and "Saved" lights up the aria-live region.
     await waitFor(() => {
       expect(screen.queryByTestId("plan-dirty-indicator")).toBeNull();
     });
     expect(screen.getByTestId("plan-save")).toBeDisabled();
     expect(screen.getByTestId("plan-discard")).toBeDisabled();
     expect(screen.getByTestId("plan-save-status")).toHaveTextContent(/^Saved$/);
+  });
 
-    // No additional PATCH from the click itself.
-    const patchCountAfterSave = apiFetchMock.mock.calls.filter(
-      ([url, opts]) =>
+  it("Save is disabled when the editor is invalid and shows the validation hint", async () => {
+    setUser();
+    apiFetchMock.mockImplementation(((url: string) => {
+      if (url === "/api/v1/scenarios") return Promise.resolve([RETIREMENT_PLAN]);
+      if (url === "/api/v1/accounts") return Promise.resolve([SAMPLE_ACCOUNT]);
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Retire at 65");
+    fireEvent.click(screen.getByTestId(`plan-row-${RETIREMENT_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    // Force the editor into an invalid state: add two curve rows with
+    // out-of-order dates. RetirementParamsEditor flips
+    // onValidityChange(false) for that case (see the "rejects out-of-
+    // order" test above) — meaning isValid in the parent is now false
+    // and we've touched params, so the editor is dirty AND invalid.
+    fireEvent.click(screen.getByTestId("ret-curve-add"));
+    fireEvent.click(screen.getByTestId("ret-curve-add"));
+    fireEvent.change(screen.getByTestId("ret-curve-from-0"), {
+      target: { value: "2030-01-01" },
+    });
+    fireEvent.change(screen.getByTestId("ret-curve-from-1"), {
+      target: { value: "2028-01-01" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ret-curve-error")).toBeInTheDocument();
+    });
+
+    // Save is disabled even though the editor is dirty.
+    expect(screen.getByTestId("plan-save")).toBeDisabled();
+    // The "Unsaved changes" hint is swapped for the validation hint so
+    // the user knows WHY Save isn't doing anything.
+    expect(screen.queryByTestId("plan-dirty-indicator")).toBeNull();
+    expect(screen.getByTestId("plan-invalid-hint")).toHaveTextContent(
+      /Fix validation errors before saving\./,
+    );
+    // Discard stays available — the whole point is to bail out of the
+    // invalid state.
+    expect(screen.getByTestId("plan-discard")).not.toBeDisabled();
+  });
+
+  it("Save awaits the PATCH before advancing the snapshot", async () => {
+    setUser();
+    // Stash the resolver so the test controls when the PATCH settles.
+    let resolvePatch: ((value: unknown) => void) | null = null;
+    const patchPromise = new Promise((resolve) => {
+      resolvePatch = resolve;
+    });
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
         url === `/api/v1/scenarios/${TRIP_PLAN.id}`
-        && (opts as RequestInit | undefined)?.method === "PATCH",
-    ).length;
-    expect(patchCountAfterSave).toBe(patchCountBeforeSave);
+        && options?.method === "PATCH"
+      ) {
+        const body = JSON.parse((options.body as string) ?? "{}");
+        return patchPromise.then(() => ({
+          ...TRIP_PLAN,
+          name: body.name,
+        }));
+      }
+      if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon revised" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save")).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByTestId("plan-save"));
+
+    // While the PATCH is in flight, snapshot has NOT advanced — the
+    // editor is still dirty and the "Saved" microcopy hasn't fired.
+    // The button is disabled (busy=true) but the dirty hint is still
+    // showing because local !== snapshot.
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save")).toBeDisabled();
+    });
+    expect(screen.getByTestId("plan-dirty-indicator")).toBeInTheDocument();
+    expect(screen.getByTestId("plan-save-status")).toHaveTextContent("");
+
+    // Resolve the PATCH — snapshot now advances and "Saved" lights up.
+    resolvePatch!(undefined);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save-status")).toHaveTextContent(
+        /^Saved$/,
+      );
+    });
+    expect(screen.queryByTestId("plan-dirty-indicator")).toBeNull();
+  });
+
+  it("Save failure does NOT advance the snapshot — Save button re-enables and the error surfaces", async () => {
+    setUser();
+    let patchCallCount = 0;
+    apiFetchMock.mockImplementation(((url: string, options?: RequestInit) => {
+      if (url === "/api/v1/scenarios" && !options?.method) {
+        return Promise.resolve([TRIP_PLAN]);
+      }
+      if (url === "/api/v1/accounts") {
+        return Promise.resolve([SAMPLE_ACCOUNT]);
+      }
+      if (
+        url === `/api/v1/scenarios/${TRIP_PLAN.id}`
+        && options?.method === "PATCH"
+      ) {
+        patchCallCount += 1;
+        // Reject every PATCH so the auto-debounce can't accidentally
+        // succeed in the background.
+        return Promise.reject(new Error("server exploded"));
+      }
+      if (url === `/api/v1/scenarios/${TRIP_PLAN.id}/simulate`) {
+        return Promise.resolve(TRIP_PLAN);
+      }
+      return Promise.resolve(undefined);
+    }) as never);
+    render(<PlansPage />);
+    await screen.findByText("Lisbon trip");
+    fireEvent.click(screen.getByTestId(`plan-row-${TRIP_PLAN.id}`));
+    await screen.findByTestId("plan-editor");
+
+    fireEvent.change(screen.getByTestId("plan-name-input"), {
+      target: { value: "Lisbon revised" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save")).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByTestId("plan-save"));
+
+    // After the PATCH rejects, the editor stays dirty (snapshot did
+    // NOT advance), Save is re-enabled so the user can retry, and the
+    // error microcopy surfaces.
+    await waitFor(() => {
+      expect(patchCallCount).toBeGreaterThan(0);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-save")).not.toBeDisabled();
+    });
+    expect(screen.getByTestId("plan-dirty-indicator")).toBeInTheDocument();
+    // "Saved" must NOT appear — the save failed.
+    expect(screen.getByTestId("plan-save-status")).not.toHaveTextContent(
+      /^Saved$/,
+    );
+    // The Params card surfaces the error so the user can see why.
+    expect(screen.getByText(/Save failed/i)).toBeInTheDocument();
   });
 
   it("Discard PATCHes the snapshot back, reverts local state, and announces 'Discarded'", async () => {


### PR DESCRIPTION
## Summary

The /plans editor auto-PATCHes on every param change so the projection chart responds live, leaving the user without an explicit "this is the version I want to keep" or "throw this away" handle.

Model 1 design (UX layer on top of auto-PATCH, no engine rewiring): snapshot the row's params on editor open, Save advances the snapshot to current state (no extra PATCH from the click since auto-PATCH already persisted), Discard PATCHes the snapshot back and reverts local state. "Unsaved changes" hint mirrors isDirty; aria-live status region announces "Saved" / "Discarded" and clears on the next edit so stale microcopy never lies.

Composes with the polish PR's debounced-PATCH validity gate — both behaviors coexist. Base branch is `feat/plans-ux-polish-and-docs` (PR #356) to avoid touching the same file in two open trains.