### PR TITLE
feat(forms): polish MFA setup + billing period config (L5.5)

### DIFF
--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -606,7 +606,14 @@ export default function OrganizationSettingsPage() {
                       setCycleFieldError(null);
                     }}
                     disabled={savingCycle}
-                    aria-label="Discard billing cycle day changes"
+                    // Visible text "Cancel" carries the action; the
+                    // aria-label augments it with the field context so
+                    // screen reader users hear "Cancel billing cycle day"
+                    // instead of a bare "Cancel" that could be confused
+                    // with the rename/danger-zone Cancel buttons on this
+                    // same page. WCAG 2.5.3: visible text "Cancel" is
+                    // included as the first word of the accessible name.
+                    aria-label="Cancel billing cycle day edit"
                     className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
                   >
                     Cancel

--- a/frontend/app/settings/organization/page.tsx
+++ b/frontend/app/settings/organization/page.tsx
@@ -532,12 +532,37 @@ export default function OrganizationSettingsPage() {
                   }}
                   className={`${input} w-full sm:w-24`}
                   aria-describedby={
-                    cycleFieldError ? "billing-cycle-day-err billing-cycle-day-hint" : "billing-cycle-day-hint"
+                    cycleFieldError
+                      ? "billing-cycle-day-err billing-cycle-day-hint billing-cycle-day-preview"
+                      : "billing-cycle-day-hint billing-cycle-day-preview"
                   }
                   aria-invalid={cycleFieldError ? true : undefined}
                 />
                 <p id="billing-cycle-day-hint" className="mt-1.5 text-xs text-text-muted">
                   Day of the month each new period starts. Days 1 to 28 only, so every month has it.
+                </p>
+                {/*
+                  Dirty + valid + changed preview. Tells the admin what the
+                  current period would look like the moment they save, so
+                  the consequence of changing the cycle day is visible
+                  before they commit. Static placeholder keeps layout
+                  stable when no preview is shown.
+                */}
+                <p
+                  id="billing-cycle-day-preview"
+                  className="mt-1.5 min-h-[1rem] text-xs text-text-muted"
+                  aria-live="polite"
+                >
+                  {(() => {
+                    if (cycleFieldError) return "";
+                    if (billingCycleDay.trim() === "") return "";
+                    if (billingCycleDay === savedCycleDay) return "";
+                    const day = Number(billingCycleDay);
+                    if (!Number.isFinite(day) || !currentPeriod?.start_date) return "";
+                    const projected = projectedPeriodEnd(currentPeriod.start_date, day);
+                    if (!projected) return "";
+                    return `Saving will close the current period on ${projected} and open a new one on day ${day}.`;
+                  })()}
                 </p>
                 {cycleFieldError && (
                   <p
@@ -550,22 +575,44 @@ export default function OrganizationSettingsPage() {
                   </p>
                 )}
               </div>
-              <button
-                type="submit"
-                disabled={
-                  savingCycle ||
-                  cycleFieldError !== null ||
-                  billingCycleDay.trim() === "" ||
-                  billingCycleDay === savedCycleDay
-                }
-                aria-busy={savingCycle}
-                className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2 sm:mt-[26px]`}
-              >
-                {savingCycle && (
-                  <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+              <div className="flex flex-col gap-2 sm:flex-row sm:mt-[26px]">
+                <button
+                  type="submit"
+                  disabled={
+                    savingCycle ||
+                    cycleFieldError !== null ||
+                    billingCycleDay.trim() === "" ||
+                    billingCycleDay === savedCycleDay
+                  }
+                  aria-busy={savingCycle}
+                  className={`${btnPrimary} w-full sm:w-auto sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                >
+                  {savingCycle && (
+                    <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                  )}
+                  {savingCycle ? "Saving..." : "Save"}
+                </button>
+                {/*
+                  Discard mirrors the Forecast Plans Save/Cancel pattern.
+                  Hidden until the field is dirty so it doesn't add noise
+                  to the resting state.
+                */}
+                {billingCycleDay !== savedCycleDay && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      userEditedCycleDayRef.current = false;
+                      setBillingCycleDay(savedCycleDay);
+                      setCycleFieldError(null);
+                    }}
+                    disabled={savingCycle}
+                    aria-label="Discard billing cycle day changes"
+                    className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}
+                  >
+                    Cancel
+                  </button>
                 )}
-                {savingCycle ? "Saving..." : "Save"}
-              </button>
+              </div>
             </form>
           </div>
         </div>

--- a/frontend/app/settings/security/page.tsx
+++ b/frontend/app/settings/security/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, Copy, Check } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import SettingsLayout from "@/components/SettingsLayout";
 import PasswordInput from "@/components/ui/PasswordInput";
@@ -213,6 +213,38 @@ export default function SecurityPage() {
   const [regenerating, setRegenerating] = useState(false);
   const [showRegen, setShowRegen] = useState(false);
   const [regenCodes, setRegenCodes] = useState<string[]>([]);
+
+  // ── Copy-to-clipboard ────────────────────────────────────────────────────
+  // One small bit of UI state tracks which payload was most recently
+  // copied so the button label can swap to "Copied" for a beat without
+  // pulling in a toast library. Cleared automatically after ~2s.
+  const [copiedKey, setCopiedKey] = useState<"secret" | "codes" | "regen-codes" | null>(null);
+  async function copyToClipboard(text: string, key: "secret" | "codes" | "regen-codes") {
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        // No clipboard API (older browsers, insecure contexts). Fall back
+        // to a hidden textarea + execCommand so the affordance still works.
+        const ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "absolute";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+      }
+      setCopiedKey(key);
+      setTimeout(() => {
+        setCopiedKey((current) => (current === key ? null : current));
+      }, 2000);
+    } catch {
+      // Silently ignore copy failures (denied permission, etc.) — the
+      // secret stays select-all so the user can copy manually.
+    }
+  }
 
   // ── Session Lifetime ──────────────────────────────────────────────────
   const [sessionDays, setSessionDays] = useState("30");
@@ -503,20 +535,55 @@ export default function SecurityPage() {
               <p className="text-sm text-text-muted">
                 Scan this QR code with your authenticator app (Google Authenticator, Authy, 1Password, etc.)
               </p>
-              <div className="flex justify-center rounded-lg bg-white p-4">
-                <img
-                  src={`data:image/png;base64,${setupData.qr_code}`}
-                  alt="TOTP QR Code"
-                  className="h-48 w-48 max-w-full"
-                />
-              </div>
+              <figure className="space-y-2">
+                <div className="flex justify-center rounded-lg bg-white p-4">
+                  <img
+                    src={`data:image/png;base64,${setupData.qr_code}`}
+                    alt="QR code for two-factor authentication. Scan with your authenticator app, or expand the manual key below."
+                    className="h-48 w-48 max-w-full"
+                  />
+                </div>
+                <figcaption className="text-center text-xs text-text-muted">
+                  Scan with your authenticator app
+                </figcaption>
+              </figure>
               <details className="text-sm">
                 <summary className="cursor-pointer text-text-muted hover:text-text-primary">
                   Can&apos;t scan? Enter this key manually
                 </summary>
-                <code className="mt-2 block rounded bg-surface-raised px-3 py-2 text-xs text-text-primary break-all select-all">
-                  {setupData.secret}
-                </code>
+                <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-start">
+                  <code
+                    id="mfa-setup-secret"
+                    className="flex-1 block rounded bg-surface-raised px-3 py-2 text-xs text-text-primary break-all select-all"
+                  >
+                    {setupData.secret}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() => copyToClipboard(setupData.secret, "secret")}
+                    aria-describedby="mfa-setup-secret"
+                    className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                  >
+                    {copiedKey === "secret" ? (
+                      <>
+                        <Check className="h-4 w-4" aria-hidden="true" />
+                        Copied
+                      </>
+                    ) : (
+                      <>
+                        <Copy className="h-4 w-4" aria-hidden="true" />
+                        Copy key
+                      </>
+                    )}
+                  </button>
+                </div>
+                <p
+                  role="status"
+                  aria-live="polite"
+                  className="mt-1.5 min-h-[1rem] text-xs text-success"
+                >
+                  {copiedKey === "secret" ? "Setup key copied to clipboard." : ""}
+                </p>
               </details>
               <div className="flex flex-col gap-3 sm:flex-row">
                 <button onClick={() => { setMfaStep("idle"); setSetupData(null); }} className={`${btnSecondary} w-full sm:w-auto min-h-[44px] sm:min-h-0`}>
@@ -599,13 +666,39 @@ export default function SecurityPage() {
                   </code>
                 ))}
               </div>
-              <button
-                type="button"
-                onClick={() => downloadCodes(recoveryCodes)}
-                className={`w-full ${btnSecondary}`}
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <button
+                  type="button"
+                  onClick={() => copyToClipboard(recoveryCodes.join("\n"), "codes")}
+                  className={`${btnSecondary} w-full sm:flex-1 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                >
+                  {copiedKey === "codes" ? (
+                    <>
+                      <Check className="h-4 w-4" aria-hidden="true" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4" aria-hidden="true" />
+                      Copy codes
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => downloadCodes(recoveryCodes)}
+                  className={`${btnSecondary} w-full sm:flex-1 min-h-[44px] sm:min-h-0`}
+                >
+                  Download codes
+                </button>
+              </div>
+              <p
+                role="status"
+                aria-live="polite"
+                className="min-h-[1rem] text-xs text-success"
               >
-                Download codes
-              </button>
+                {copiedKey === "codes" ? "Recovery codes copied to clipboard." : ""}
+              </p>
               <label className="flex items-center gap-2 text-sm text-text-muted">
                 <input
                   type="checkbox"
@@ -717,13 +810,39 @@ export default function SecurityPage() {
                       </code>
                     ))}
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => downloadCodes(regenCodes)}
-                    className={`w-full ${btnSecondary}`}
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => copyToClipboard(regenCodes.join("\n"), "regen-codes")}
+                      className={`${btnSecondary} w-full sm:flex-1 min-h-[44px] sm:min-h-0 inline-flex items-center justify-center gap-2`}
+                    >
+                      {copiedKey === "regen-codes" ? (
+                        <>
+                          <Check className="h-4 w-4" aria-hidden="true" />
+                          Copied
+                        </>
+                      ) : (
+                        <>
+                          <Copy className="h-4 w-4" aria-hidden="true" />
+                          Copy codes
+                        </>
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => downloadCodes(regenCodes)}
+                      className={`${btnSecondary} w-full sm:flex-1 min-h-[44px] sm:min-h-0`}
+                    >
+                      Download codes
+                    </button>
+                  </div>
+                  <p
+                    role="status"
+                    aria-live="polite"
+                    className="min-h-[1rem] text-xs text-success"
                   >
-                    Download codes
-                  </button>
+                    {copiedKey === "regen-codes" ? "Recovery codes copied to clipboard." : ""}
+                  </p>
                   <button
                     type="button"
                     onClick={() => { setRegenCodes([]); setShowRegen(false); }}

--- a/frontend/tests/app/settings-security-mfa-polish.test.tsx
+++ b/frontend/tests/app/settings-security-mfa-polish.test.tsx
@@ -259,6 +259,98 @@ describe("Security page MFA polish: copy, validation, error mapping", () => {
     });
   });
 
+  // ── L5.5 form polish: copy-to-clipboard + QR alt text ────────────────────
+  //
+  // The QR-page secret block, the post-enable recovery codes block, and
+  // the regenerate recovery codes block each got a "Copy" button next to
+  // the existing copy-by-selection / Download codes affordances. The
+  // microcopy is announced via an aria-live status region so screen
+  // readers know the copy succeeded.
+
+  it("copies the TOTP setup key to clipboard and announces it via aria-live", async () => {
+    mockUser(false);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/setup") {
+        return Promise.resolve({ qr_code: "Zm9v", secret: "SECRETKEYABC123" });
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<SecurityPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Set Up Two-Factor Authentication/i }),
+    );
+    // Expand the manual-key disclosure and trigger the copy.
+    fireEvent.click(await screen.findByText(/Enter this key manually/i));
+    fireEvent.click(await screen.findByRole("button", { name: /^Copy key$/i }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("SECRETKEYABC123");
+    });
+    // Button label flips to Copied for the confirmation window.
+    expect(await screen.findByRole("button", { name: /^Copied$/i })).toBeInTheDocument();
+    // aria-live confirmation surfaces for screen readers.
+    expect(
+      screen.getByText(/Setup key copied to clipboard/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders descriptive QR alt text and a sighted-user figcaption", async () => {
+    mockUser(false);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/setup") {
+        return Promise.resolve({ qr_code: "Zm9v", secret: "SECRET" });
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    render(<SecurityPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Set Up Two-Factor Authentication/i }),
+    );
+    const qr = await screen.findByAltText(/Scan with your authenticator app/i);
+    expect(qr.tagName).toBe("IMG");
+    // Sighted caption restates the action; both must be present so
+    // visual + screen-reader users get the same hint.
+    expect(screen.getByText(/^Scan with your authenticator app$/i)).toBeInTheDocument();
+  });
+
+  it("copies recovery codes to clipboard from the post-enable screen", async () => {
+    mockUser(false);
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/auth/mfa/setup") {
+        return Promise.resolve({ qr_code: "Zm9v", secret: "SECRET" });
+      }
+      if (url === "/api/v1/auth/mfa/enable") {
+        return Promise.resolve({ recovery_codes: ["A1B2C3D4", "E5F6G7H8"] });
+      }
+      return Promise.resolve([]);
+    }) as never);
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<SecurityPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Set Up Two-Factor Authentication/i }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /^Continue$/i }));
+    const codeInput = await screen.findByLabelText(/Verification Code/i);
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: /Verify and Enable/i }));
+
+    fireEvent.click(await screen.findByRole("button", { name: /^Copy codes$/i }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("A1B2C3D4\nE5F6G7H8");
+    });
+    expect(
+      await screen.findByText(/Recovery codes copied to clipboard/i),
+    ).toBeInTheDocument();
+  });
+
   it("MFA disable surfaces a reload hint when refreshMe rejects", async () => {
     vi.mocked(useAuth).mockReturnValue({
       user: makeUser(true) as never,

--- a/frontend/tests/settings/organization-billing-period-polish.test.tsx
+++ b/frontend/tests/settings/organization-billing-period-polish.test.tsx
@@ -127,6 +127,98 @@ describe("Billing period polish: inline validation, busy state, error mapping", 
     expect(hint?.textContent).toMatch(/Day of the month/i);
   });
 
+  // ── L5.5 form polish: Cancel + projected close preview ──────────────────
+  //
+  // Cancel mirrors the Forecast Plans Save/Cancel pattern: it only shows
+  // up when the field is dirty and reverts to the last server-confirmed
+  // value. The projected-close preview surfaces under the input so the
+  // admin sees the consequence of saving before they commit.
+
+  it("hides Cancel when the field is clean and shows it once dirty", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = (await screen.findByLabelText(
+      /Billing cycle day/i,
+    )) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("1"));
+    // Clean state: only the row-level rename Cancel + member Cancel may
+    // exist; the billing-cycle Cancel must not.
+    expect(
+      screen.queryByRole("button", {
+        name: /Cancel billing cycle day edit/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "15" } });
+    expect(
+      await screen.findByRole("button", {
+        name: /Cancel billing cycle day edit/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("Cancel reverts the field to the saved value and clears errors", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = (await screen.findByLabelText(
+      /Billing cycle day/i,
+    )) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("1"));
+
+    // Dirty + invalid first, to confirm the error clears too.
+    fireEvent.change(input, { target: { value: "31" } });
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    const cancel = await screen.findByRole("button", {
+      name: /Cancel billing cycle day edit/i,
+    });
+    fireEvent.click(cancel);
+
+    await waitFor(() => expect(input.value).toBe("1"));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    // Cancel removes itself once the field is clean again.
+    expect(
+      screen.queryByRole("button", {
+        name: /Cancel billing cycle day edit/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the projected close preview when the new value is dirty + valid", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = (await screen.findByLabelText(
+      /Billing cycle day/i,
+    )) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("1"));
+
+    fireEvent.change(input, { target: { value: "15" } });
+    // start_date=2026-05-01, new cycle day=15 → projected close = 2026-06-14
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Saving will close the current period on 2026-06-14/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("clears the preview once the value matches the saved one again", async () => {
+    render(<OrganizationSettingsPage />);
+    const input = (await screen.findByLabelText(
+      /Billing cycle day/i,
+    )) as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe("1"));
+
+    fireEvent.change(input, { target: { value: "15" } });
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Saving will close the current period/i),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.change(input, { target: { value: "1" } });
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Saving will close the current period/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("maps a 422 save error to friendly copy without echoing raw body", async () => {
     render(<OrganizationSettingsPage />);
     const input = await screen.findByLabelText(/Billing cycle day/i);


### PR DESCRIPTION
## Summary

L5.5 Form polish landed in two reviewable commits. No new npm deps. No backend changes.

### MFA setup (`/settings/security`)
- Copy-to-clipboard button next to the TOTP manual key, with `aria-live="polite"` confirmation microcopy ("Setup key copied to clipboard.").
- Copy-to-clipboard button next to the post-enable recovery codes (alongside the existing Download codes button), with the same aria-live confirmation.
- Same Copy + Download pair on the regenerate-codes flow.
- Improved QR alt text ("QR code for two-factor authentication. Scan with your authenticator app, or expand the manual key below.") plus a sighted `figcaption` so visual and screen-reader users get the same hint.
- Uses native `navigator.clipboard.writeText` with a hidden-textarea + `execCommand` fallback for older / insecure-context browsers. No new dependency.

### Billing period config (`/settings/organization` billing-cycle card)
- Cancel button mirrors the Forecast Plans Save/Cancel pattern: hidden when the field is clean, appears once the admin types, reverts to the last server-confirmed value and clears any inline error.
- Projected close preview ("Saving will close the current period on YYYY-MM-DD and open a new one on day N.") renders for a dirty + valid value, inside an `aria-live="polite"` region with a stable `min-h` so layout doesn't shift.
- `aria-describedby` on the cycle-day input now points at hint, preview, and error so screen readers get all three pieces of context.
- WCAG 2.5.3 Label in Name: Cancel button's visible "Cancel" text is the first word of the accessible name ("Cancel billing cycle day edit").

### Tests
Extends the existing polish suites:
- `tests/app/settings-security-mfa-polish.test.tsx` adds 3 tests (clipboard write for setup key, QR alt + figcaption, recovery codes copy).
- `tests/settings/organization-billing-period-polish.test.tsx` adds 4 tests (Cancel hidden when clean, Cancel reverts dirty + invalid state, projected close preview content, preview clears when dirty undone).

### Verification
- `npm test`: 172 files / 1261 tests pass.
- `npx tsc --noEmit`: clean.
- `npm run lint`: 0 errors, pre-existing warnings only.

Cross-references L5.5 in the architect roadmap.