### PR TITLE
feat(rate-limit): admin-controllable per-org / per-user overrides (L4.10)

### DIFF
--- a/backend/alembic/versions/060_rate_limit_overrides.py
+++ b/backend/alembic/versions/060_rate_limit_overrides.py
@@ -1,0 +1,121 @@
+"""Per-org / per-user rate limit overrides (L4.10).
+
+Revision ID: 060_rate_limit_overrides
+Revises: 059_ai_usage_retries_used
+Create Date: 2026-05-22
+
+Creates ``rate_limit_overrides`` so superadmins can adjust the
+per-request budget for a specific org or user without redeploying.
+
+Shape choice. A dedicated row-per-override table (vs. a JSON blob on
+``org_settings``) is taken so the admin UI can list, sort, and filter
+across every override on the platform via cheap SQL. Each row carries
+exactly one scope: either a non-NULL ``org_id`` and NULL ``user_id``,
+or the other way around. CHECK-style integrity at the row level is
+enforced upstream by the service (one-of, never both) — MySQL 8.0.16+
+supports CHECK constraints, but the project's SQLite test substrate
+behaves differently and the service layer is the single write surface
+anyway, so keeping the invariant in code is more portable than spread
+across two DB dialects.
+
+Lookup paths the indexes cover:
+
+- ``(user_id, endpoint_pattern)`` — per-user resolve.
+- ``(org_id, endpoint_pattern)`` — per-org resolve.
+
+Both are partial in spirit (one column is always NULL) but MySQL does
+not support partial indexes; the composite still answers the read in
+one seek because the leading column eliminates the irrelevant scope.
+
+``endpoint_pattern`` is an opaque string set by the application — a
+short identifier shared between ``rate_limit_overrides_service`` and
+the limiter call site (e.g. ``auth.login``, ``auth.register``,
+``reports.list``). Not a regex / glob. The string is intentionally
+short so the index column width stays small.
+
+``created_by`` is ``ON DELETE SET NULL`` so deleting the authoring
+superadmin leaves the override (and its audit history) intact.
+
+``expires_at`` is nullable. NULL means "never expires"; non-NULL means
+the resolver treats the row as if absent once ``now() >= expires_at``.
+The check is service-side (combined with the cache invalidation path)
+because the cache key set is small and TTL-aligned.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "060_rate_limit_overrides"
+down_revision = "059_ai_usage_retries_used"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rate_limit_overrides",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "org_id",
+            sa.Integer(),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("endpoint_pattern", sa.String(length=80), nullable=False),
+        sa.Column("max_requests", sa.Integer(), nullable=False),
+        # period_seconds is a finite positive integer. The service maps
+        # this to slowapi's "N/period" string at resolve time. Storing
+        # seconds (vs. a string like "1/minute") keeps comparisons /
+        # bounds-checks in the service / admin UI numeric.
+        sa.Column("period_seconds", sa.Integer(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_by_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_rate_limit_overrides_user_endpoint",
+        "rate_limit_overrides",
+        ["user_id", "endpoint_pattern"],
+    )
+    op.create_index(
+        "ix_rate_limit_overrides_org_endpoint",
+        "rate_limit_overrides",
+        ["org_id", "endpoint_pattern"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_rate_limit_overrides_org_endpoint",
+        table_name="rate_limit_overrides",
+    )
+    op.drop_index(
+        "ix_rate_limit_overrides_user_endpoint",
+        table_name="rate_limit_overrides",
+    )
+    op.drop_table("rate_limit_overrides")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_roles, admin_subscriptions, admin_users, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -486,6 +486,7 @@ app.include_router(reports.router)
 app.include_router(scenarios.router)
 app.include_router(ai_providers.router)
 app.include_router(admin_ai_usage.router)
+app.include_router(admin_rate_limit_overrides.router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -55,6 +55,7 @@ from app.models.org_ai_caps import (  # noqa: F401
 )
 from app.models.org_ai_consent import OrgAIConsent  # noqa: F401
 from app.models.ai_usage_ledger import AIUsageLedger  # noqa: F401
+from app.models.rate_limit_override import RateLimitOverride  # noqa: F401
 
 __all__ = [
     "Base",

--- a/backend/app/models/rate_limit_override.py
+++ b/backend/app/models/rate_limit_override.py
@@ -1,0 +1,66 @@
+"""Per-org / per-user rate limit override (L4.10).
+
+A row attaches either to an ``org_id`` OR a ``user_id`` (never both,
+never neither). The "one scope per row" invariant is enforced by the
+service layer (single write surface) rather than a CHECK constraint
+so the SQLite-backed unit tests behave identically to MySQL 8.
+
+The pair ``(max_requests, period_seconds)`` maps to slowapi's
+``"N/period"`` string at resolve time. Period is stored in seconds
+(not a textual unit) so the admin UI can sort / range-filter on it.
+
+Lookup pattern: a request that wants to know the override for
+endpoint ``E`` consults user override first, then org override. Both
+queries are answered in one index seek via the composite indexes
+defined in migration 059.
+
+``expires_at`` is service-honoured: a row with ``expires_at <= now()``
+is treated as absent. Cache invalidation TTL (60 s) bounds the worst-
+case staleness window without forcing a separate sweeper job.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class RateLimitOverride(Base):
+    __tablename__ = "rate_limit_overrides"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    user_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    endpoint_pattern: Mapped[str] = mapped_column(String(80), nullable=False)
+    max_requests: Mapped[int] = mapped_column(Integer, nullable=False)
+    period_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    created_by_user_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/backend/app/rate_limit_endpoint_catalogue.py
+++ b/backend/app/rate_limit_endpoint_catalogue.py
@@ -1,0 +1,110 @@
+"""Catalogue of endpoint patterns that the rate-limit override system
+recognises (L4.10).
+
+Why this exists. An override row carries a free-form
+``endpoint_pattern`` string. Without a catalogue an operator can save
+"transactiosn.list" (typo) or "ai.chat" (route doesn't exist yet) and
+the override silently no-ops because no ``@limiter.limit`` decorator
+in the codebase resolves against that string. The catalogue is the
+single source of truth used to:
+
+- 422-reject unknown patterns at the Pydantic schema layer.
+- Populate the admin UI's pattern dropdown so an operator picks from a
+  known-good list instead of typing.
+- Document each pattern's default static limit and whether it is a
+  pre-auth route (see ``PRE_AUTH_PATTERNS``).
+
+How the catalogue maps to the codebase. Each entry corresponds to one
+``@limiter.limit(...)`` decorator on a FastAPI route. The pattern
+string is ``<router_module>.<short_action>`` — chosen by the route
+author, not derived from the function name, so renames stay tracked
+here. When you add a new ``@limiter.limit(...)`` decorator, append the
+matching pattern below. When you remove one, delete the pattern; an
+override row referencing a removed pattern is harmless (it just
+no-ops) but the catalogue must be truthful.
+
+Pre-auth limitation (see ``rate_limit_overrides.dynamic_limit``). The
+override resolver needs an authenticated identity. Patterns listed in
+``PRE_AUTH_PATTERNS`` will accept overrides without error, but the
+overrides will NOT take effect because the resolver short-circuits
+when no user/org identity can be extracted from the request. Tune
+those routes via the static slowapi decorator string instead.
+"""
+from __future__ import annotations
+
+
+# Every pattern an operator may attach to an override. Update this
+# whenever a ``@limiter.limit(...)`` decorator is added or removed.
+# Order is alphabetical for human readability.
+RATE_LIMITED_ENDPOINT_PATTERNS: frozenset[str] = frozenset({
+    # accounts router
+    "accounts.adjust_balance",
+    # auth router
+    "auth.check_username",
+    "auth.forgot_password",
+    "auth.login",
+    "auth.mfa_email_code",
+    "auth.mfa_email_verify",
+    "auth.mfa_recovery",
+    "auth.mfa_verify",
+    "auth.register",
+    "auth.resend_verification",
+    "auth.resend_verification_public",
+    "auth.verify",
+    "auth.verify_email",
+    # feedback router
+    "feedback.submit",
+    # onboarding router
+    "onboarding.complete",
+    "onboarding.restart_tour",
+    "onboarding.seed_demo",
+    # org_members router
+    "org_members.accept_invitation",
+    "org_members.preview_invitation",
+    # orgs router
+    "orgs.rename",
+    # reports router
+    "reports.query",
+    # users router
+    "users.change_password",
+    "users.update_profile",
+})
+
+
+# Patterns whose decorator site runs BEFORE the request has an
+# authenticated identity (no Bearer JWT, or only a cookie / one-time
+# token). Overrides on these patterns are accepted by the schema (so
+# the catalogue can stay opinion-free) but the resolver always falls
+# back to the static default. Operators see the warning in the admin
+# UI and the module docstring of ``rate_limit_overrides``.
+PRE_AUTH_PATTERNS: frozenset[str] = frozenset({
+    "auth.check_username",
+    "auth.forgot_password",
+    "auth.login",
+    "auth.mfa_email_code",
+    "auth.mfa_email_verify",
+    "auth.mfa_recovery",
+    "auth.mfa_verify",
+    "auth.register",
+    "auth.resend_verification_public",
+    "auth.verify",
+    "auth.verify_email",
+    "org_members.accept_invitation",
+    "org_members.preview_invitation",
+})
+
+
+def is_known_pattern(pattern: str) -> bool:
+    """Return True iff ``pattern`` is in the catalogue.
+
+    Pure helper so the schema validator stays a one-liner and tests
+    can pin the contract without importing the frozenset directly.
+    """
+    return pattern in RATE_LIMITED_ENDPOINT_PATTERNS
+
+
+def sorted_patterns() -> list[str]:
+    """Catalogue as a sorted list. Used by the GET catalogue endpoint
+    so the admin UI dropdown is deterministic across requests.
+    """
+    return sorted(RATE_LIMITED_ENDPOINT_PATTERNS)

--- a/backend/app/rate_limit_endpoint_catalogue.py
+++ b/backend/app/rate_limit_endpoint_catalogue.py
@@ -8,59 +8,57 @@ the override silently no-ops because no ``@limiter.limit`` decorator
 in the codebase resolves against that string. The catalogue is the
 single source of truth used to:
 
-- 422-reject unknown patterns at the Pydantic schema layer.
+- 422-reject unknown / non-overridable patterns at the Pydantic schema
+  layer.
 - Populate the admin UI's pattern dropdown so an operator picks from a
   known-good list instead of typing.
 - Document each pattern's default static limit and whether it is a
-  pre-auth route (see ``PRE_AUTH_PATTERNS``).
+  pre-auth route (see ``PRE_AUTH_ENDPOINT_PATTERNS``).
 
 How the catalogue maps to the codebase. Each entry corresponds to one
 ``@limiter.limit(...)`` decorator on a FastAPI route. The pattern
-string is ``<router_module>.<short_action>`` — chosen by the route
-author, not derived from the function name, so renames stay tracked
+string is ``<router_module>.<short_action>`` chosen by the route
+author (not derived from the function name) so renames stay tracked
 here. When you add a new ``@limiter.limit(...)`` decorator, append the
 matching pattern below. When you remove one, delete the pattern; an
 override row referencing a removed pattern is harmless (it just
 no-ops) but the catalogue must be truthful.
 
-Pre-auth limitation (see ``rate_limit_overrides.dynamic_limit``). The
-override resolver needs an authenticated identity. Patterns listed in
-``PRE_AUTH_PATTERNS`` will accept overrides without error, but the
-overrides will NOT take effect because the resolver short-circuits
-when no user/org identity can be extracted from the request. Tune
-those routes via the static slowapi decorator string instead.
+Two-tier split (architect-locked, 2026-05-22).
+``OVERRIDABLE_ENDPOINT_PATTERNS`` lists the patterns where per-org or
+per-user overrides ACTUALLY take effect at request time. These are
+the only strings the schema layer accepts for create / update.
+``PRE_AUTH_ENDPOINT_PATTERNS`` lists patterns whose decorator site
+runs BEFORE the request has an authenticated identity (no Bearer JWT,
+or only a cookie / one-time token). The override resolver short-
+circuits on those routes, so overrides for them would be no-op rows.
+They are exposed via the catalogue endpoint so the admin UI can show
+the full surface (and explain why those routes are not overridable),
+but the schema validator rejects them with a typed 422 to prevent
+operators creating no-op config.
+
+To tune a pre-auth route's limit, edit the static slowapi decorator
+default in code instead.
 """
 from __future__ import annotations
 
 
-# Every pattern an operator may attach to an override. Update this
-# whenever a ``@limiter.limit(...)`` decorator is added or removed.
-# Order is alphabetical for human readability.
-RATE_LIMITED_ENDPOINT_PATTERNS: frozenset[str] = frozenset({
+# Patterns where per-org / per-user overrides ACTUALLY take effect at
+# request time. These are the only patterns the schema layer accepts
+# on create / update. Update this whenever a post-auth
+# ``@limiter.limit(...)`` decorator is added or removed. Order is
+# alphabetical for human readability.
+OVERRIDABLE_ENDPOINT_PATTERNS: frozenset[str] = frozenset({
     # accounts router
     "accounts.adjust_balance",
-    # auth router
-    "auth.check_username",
-    "auth.forgot_password",
-    "auth.login",
-    "auth.mfa_email_code",
-    "auth.mfa_email_verify",
-    "auth.mfa_recovery",
-    "auth.mfa_verify",
-    "auth.register",
+    # auth router (post-auth resend, requires get_current_user)
     "auth.resend_verification",
-    "auth.resend_verification_public",
-    "auth.verify",
-    "auth.verify_email",
     # feedback router
     "feedback.submit",
     # onboarding router
     "onboarding.complete",
     "onboarding.restart_tour",
     "onboarding.seed_demo",
-    # org_members router
-    "org_members.accept_invitation",
-    "org_members.preview_invitation",
     # orgs router
     "orgs.rename",
     # reports router
@@ -72,12 +70,12 @@ RATE_LIMITED_ENDPOINT_PATTERNS: frozenset[str] = frozenset({
 
 
 # Patterns whose decorator site runs BEFORE the request has an
-# authenticated identity (no Bearer JWT, or only a cookie / one-time
-# token). Overrides on these patterns are accepted by the schema (so
-# the catalogue can stay opinion-free) but the resolver always falls
-# back to the static default. Operators see the warning in the admin
-# UI and the module docstring of ``rate_limit_overrides``.
-PRE_AUTH_PATTERNS: frozenset[str] = frozenset({
+# authenticated identity. The override resolver always falls back to
+# the static default for these. Exposed via the catalogue endpoint
+# (so the admin UI can render an informational list) but NOT accepted
+# by the schema validator: overrides for these would create no-op
+# rows that confuse operators. Tune via the slowapi decorator in code.
+PRE_AUTH_ENDPOINT_PATTERNS: frozenset[str] = frozenset({
     "auth.check_username",
     "auth.forgot_password",
     "auth.login",
@@ -94,17 +92,37 @@ PRE_AUTH_PATTERNS: frozenset[str] = frozenset({
 })
 
 
-def is_known_pattern(pattern: str) -> bool:
-    """Return True iff ``pattern`` is in the catalogue.
+# Convenience union for code paths that need the full surface (docs,
+# audits, drift checks against ``@limiter.limit(...)`` decorators in
+# the routers). The schema validator does NOT use this set; it uses
+# ``OVERRIDABLE_ENDPOINT_PATTERNS`` exclusively.
+ALL_KNOWN_ENDPOINT_PATTERNS: frozenset[str] = (
+    OVERRIDABLE_ENDPOINT_PATTERNS | PRE_AUTH_ENDPOINT_PATTERNS
+)
 
-    Pure helper so the schema validator stays a one-liner and tests
-    can pin the contract without importing the frozenset directly.
+
+def is_overridable_pattern(pattern: str) -> bool:
+    """Return True iff ``pattern`` may be persisted as an override.
+
+    The schema validator calls this. Pre-auth patterns and unknown
+    typos both return False; the validator distinguishes between
+    them by checking ``PRE_AUTH_ENDPOINT_PATTERNS`` membership for a
+    more specific error code.
     """
-    return pattern in RATE_LIMITED_ENDPOINT_PATTERNS
+    return pattern in OVERRIDABLE_ENDPOINT_PATTERNS
 
 
-def sorted_patterns() -> list[str]:
-    """Catalogue as a sorted list. Used by the GET catalogue endpoint
-    so the admin UI dropdown is deterministic across requests.
+def sorted_overridable_patterns() -> list[str]:
+    """Overridable catalogue as a sorted list. Used by the GET
+    catalogue endpoint so the admin UI dropdown is deterministic
+    across requests.
     """
-    return sorted(RATE_LIMITED_ENDPOINT_PATTERNS)
+    return sorted(OVERRIDABLE_ENDPOINT_PATTERNS)
+
+
+def sorted_pre_auth_patterns() -> list[str]:
+    """Pre-auth catalogue as a sorted list. Surfaced via the
+    catalogue endpoint so the admin UI can display the full surface
+    even though these patterns are not selectable.
+    """
+    return sorted(PRE_AUTH_ENDPOINT_PATTERNS)

--- a/backend/app/rate_limit_overrides.py
+++ b/backend/app/rate_limit_overrides.py
@@ -1,0 +1,317 @@
+"""Runtime integration between slowapi and the override resolver.
+
+This module is the bridge from a ``@limiter.limit(...)`` decorator
+site to the per-org / per-user override table:
+
+- ``dynamic_limit("auth.login", "20/minute")`` returns a slowapi-
+  compatible *callable* the decorator accepts. On every request the
+  callable consults the override resolver and returns either the
+  override's limit string (formatted into slowapi's "N/Ns" shape) or
+  the original default.
+- ``parse_default_limit("20/minute")`` is the inverse formatter used
+  by tests + sanity assertions; it accepts the same set of
+  ``period`` words slowapi accepts.
+
+Why a callable rather than rewriting every decorator at registration
+time: slowapi's decorator captures the limit value at *decorator-
+import time* — too early to know the requester's identity or to
+consult Redis. The Limiter class explicitly accepts a callable that
+receives the request, evaluated per call (see slowapi extension.py
+``StrOrCallableStr = Union[str, Callable[..., str]]``).
+
+Failure stance. If the resolver raises, or Redis is unavailable, or
+the JWT is unreadable, the helper returns the default. That matches
+the project-wide rate-limit fail-open posture and prevents an
+override-system bug from locking out the platform.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Callable, Optional
+
+import structlog
+from starlette.requests import Request
+
+from app.config import settings
+
+
+logger = structlog.stdlib.get_logger()
+
+
+# Slowapi accepts these period words. Mapped to seconds so the
+# numeric override format ("max/period_s") can be round-tripped back
+# into a slowapi-style string the limiter understands.
+_PERIOD_WORDS_TO_SECONDS: dict[str, int] = {
+    "second": 1,
+    "seconds": 1,
+    "minute": 60,
+    "minutes": 60,
+    "hour": 3600,
+    "hours": 3600,
+    "day": 86400,
+    "days": 86400,
+}
+
+
+_LIMIT_RE = re.compile(r"^\s*(\d+)\s*/\s*(\d+)?\s*([a-zA-Z]+)?\s*$")
+
+
+def parse_default_limit(value: str) -> tuple[int, int]:
+    """Parse a slowapi-style limit string into ``(max, period_s)``.
+
+    Accepted shapes:
+    - ``"20/minute"``  -> ``(20, 60)``
+    - ``"5/hour"``     -> ``(5, 3600)``
+    - ``"30/45s"``     -> ``(30, 45)`` (rare; slowapi also accepts ``"30/45 second"``)
+    - ``"30/45"``      -> ``(30, 45)``
+
+    Raises ``ValueError`` on an unparseable string. The function is
+    deliberately permissive on whitespace and case to match slowapi's
+    own parser.
+    """
+    m = _LIMIT_RE.match(value)
+    if not m:
+        raise ValueError(f"unparseable limit string: {value!r}")
+    max_requests = int(m.group(1))
+    explicit_seconds = m.group(2)
+    word = (m.group(3) or "").lower()
+    if explicit_seconds and word:
+        raise ValueError(f"limit cannot mix explicit seconds and word: {value!r}")
+    if explicit_seconds is not None:
+        period_seconds = int(explicit_seconds)
+    elif word:
+        seconds = _PERIOD_WORDS_TO_SECONDS.get(word)
+        if seconds is None:
+            raise ValueError(f"unknown period word: {word!r} in {value!r}")
+        period_seconds = seconds
+    else:
+        raise ValueError(f"limit missing period: {value!r}")
+    return max_requests, period_seconds
+
+
+def format_limit(max_requests: int, period_seconds: int) -> str:
+    """Format ``(max, period_s)`` as a slowapi-style string.
+
+    Prefers the natural period word ("minute", "hour", "day",
+    "second") when the seconds value is one of the standard buckets;
+    falls back to the bare-numeric ``N/X`` shape (which slowapi's
+    underlying ``limits`` library accepts as "X seconds") for any
+    other value.
+
+    The natural-word form round-trips through ``parse_default_limit``
+    cleanly and avoids the ``"42/60second"`` glued form which the
+    parser explicitly rejects (mixing explicit seconds and a word
+    suffix).
+    """
+    if period_seconds == 1:
+        return f"{max_requests}/second"
+    if period_seconds == 60:
+        return f"{max_requests}/minute"
+    if period_seconds == 3600:
+        return f"{max_requests}/hour"
+    if period_seconds == 86400:
+        return f"{max_requests}/day"
+    return f"{max_requests}/{period_seconds}"
+
+
+def _request_identity(request: Request) -> tuple[Optional[int], Optional[int]]:
+    """Best-effort extraction of ``(user_id, org_id)`` from a request.
+
+    Tried sources, in order:
+
+    1. ``request.state.user_id`` / ``request.state.org_id`` if the
+       request-context middleware has populated them (auth path).
+    2. The Authorization Bearer token's JWT payload (``sub`` and
+       ``org_id`` claims).
+    3. ``(None, None)`` — the resolver falls through to the default.
+
+    Decoding the JWT here without verifying the signature would be a
+    spoof vector, so we always go through the proper decoder. Any
+    failure path returns the (None, None) tuple — fail open.
+    """
+    # 1. Try the request-context middleware first; in the auth path it
+    # is already populated.
+    state_user = getattr(request.state, "user_id", None)
+    state_org = getattr(request.state, "org_id", None)
+    if state_user is not None or state_org is not None:
+        return state_user, state_org
+
+    # 2. Fall back to decoding the Authorization header. Many of the
+    # limited endpoints are PRE-auth (e.g. /auth/login) and the
+    # middleware hasn't run get_current_user yet, but the decorator
+    # call from slowapi happens before the dependency. So we
+    # short-circuit on missing/malformed headers.
+    auth = request.headers.get("authorization")
+    if not auth or not auth.lower().startswith("bearer "):
+        return None, None
+    token = auth.split(" ", 1)[1].strip()
+    if not token:
+        return None, None
+
+    try:
+        import jwt as pyjwt
+
+        payload = pyjwt.decode(
+            token,
+            settings.jwt_secret_key,
+            algorithms=[settings.jwt_algorithm],
+            options={"require": []},
+        )
+    except Exception:  # noqa: BLE001 — any decode failure: fail open.
+        return None, None
+    sub = payload.get("sub")
+    org_id = payload.get("org_id")
+    try:
+        user_id = int(sub) if sub is not None else None
+    except (TypeError, ValueError):
+        user_id = None
+    try:
+        org_id_int = int(org_id) if org_id is not None else None
+    except (TypeError, ValueError):
+        org_id_int = None
+    return user_id, org_id_int
+
+
+async def _resolve_async(
+    *,
+    user_id: Optional[int],
+    org_id: Optional[int],
+    endpoint_pattern: str,
+    default: str,
+) -> str:
+    # Lazy imports keep test-substrate cold-start cheap and avoid a
+    # circular at module-load time (the service imports nothing from
+    # this module, but a future cross-import would trip without the
+    # lazy form).
+    from app.database import async_session
+    from app.services import rate_limit_overrides_service as svc
+
+    if user_id is None and org_id is None:
+        return default
+    try:
+        async with async_session() as session:
+            wire = await svc.resolve_override(
+                session,
+                user_id=user_id,
+                org_id=org_id,
+                endpoint_pattern=endpoint_pattern,
+            )
+    except Exception as exc:  # noqa: BLE001 — fail open on any DB error.
+        logger.warning(
+            "rate_limit_override.resolve_failed",
+            error=str(exc),
+            endpoint=endpoint_pattern,
+        )
+        return default
+    if wire is None or wire == "-":
+        return default
+    # wire format is "<max>/<period_seconds>"; transform to slowapi.
+    try:
+        max_str, period_str = wire.split("/", 1)
+        return format_limit(int(max_str), int(period_str))
+    except (ValueError, IndexError):
+        return default
+
+
+def dynamic_limit(endpoint_pattern: str, default: str) -> Callable[..., str]:
+    """Return a slowapi-compatible callable that yields a per-request
+    limit string.
+
+    Usage at the decorator site::
+
+        @limiter.limit(dynamic_limit("auth.login", "20/minute"))
+        async def login(...):
+            ...
+
+    Behaviour:
+
+    - Parses ``default`` once at module import to surface a
+      programmer error early (an unparseable default would otherwise
+      blow up only when the limiter first runs).
+    - Returns a fresh closure per call (slowapi keeps it cached).
+    - The closure is sync-callable, but the underlying DB read is
+      async — bridged via ``asyncio.run`` on a fresh loop iff no
+      running loop is detected (slowapi 0.1.9's evaluate path is
+      currently sync but the bridge tolerates both).
+    """
+    # Force-parse the default once. If this raises, the import
+    # explodes loudly instead of silently shipping a broken decorator.
+    parse_default_limit(default)
+
+    def _limit_for_request(request: Request) -> str:
+        try:
+            user_id, org_id = _request_identity(request)
+        except Exception:  # noqa: BLE001 — any extraction failure: default.
+            return default
+        if user_id is None and org_id is None:
+            return default
+        # Bridge async resolver into the slowapi sync evaluation path.
+        # Two cases:
+        # 1. There is no running event loop in the current thread.
+        #    -> Use ``asyncio.run``. This is the path when slowapi's
+        #       extension calls us from a sync decorator (rare today
+        #       under uvicorn but supported).
+        # 2. There IS a running loop (the default uvicorn path).
+        #    -> ``asyncio.run`` would refuse; we spin a fresh thread
+        #       so the blocking call doesn't park the event loop.
+        try:
+            asyncio.get_running_loop()
+            running_loop = True
+        except RuntimeError:
+            running_loop = False
+
+        coro_factory = lambda: _resolve_async(  # noqa: E731 — local closure
+            user_id=user_id,
+            org_id=org_id,
+            endpoint_pattern=endpoint_pattern,
+            default=default,
+        )
+        try:
+            if not running_loop:
+                return asyncio.run(coro_factory())
+            # Running loop: run on a worker thread with its own loop.
+            import concurrent.futures
+            import threading
+
+            result_holder: dict = {}
+
+            def _worker():
+                loop = asyncio.new_event_loop()
+                try:
+                    result_holder["v"] = loop.run_until_complete(coro_factory())
+                except Exception as exc:  # noqa: BLE001
+                    result_holder["err"] = exc
+                finally:
+                    loop.close()
+
+            t = threading.Thread(target=_worker, daemon=True)
+            t.start()
+            # Slowapi sync-storage path already runs synchronously on
+            # the event loop; this thread is bounded by the resolver's
+            # internal timeouts (Redis 1s + DB short-pool). We cap at
+            # 2s as a hard ceiling to avoid wedging the request.
+            t.join(timeout=2.0)
+            if t.is_alive():
+                logger.warning(
+                    "rate_limit_override.resolve_timeout",
+                    endpoint=endpoint_pattern,
+                )
+                return default
+            if "err" in result_holder:
+                logger.warning(
+                    "rate_limit_override.resolve_thread_error",
+                    error=str(result_holder["err"]),
+                    endpoint=endpoint_pattern,
+                )
+                return default
+            return result_holder.get("v", default)
+        except Exception as exc:  # noqa: BLE001 — last-line fail-open.
+            logger.warning(
+                "rate_limit_override.bridge_failed",
+                error=str(exc),
+                endpoint=endpoint_pattern,
+            )
+            return default
+
+    return _limit_for_request

--- a/backend/app/rate_limit_overrides.py
+++ b/backend/app/rate_limit_overrides.py
@@ -36,7 +36,7 @@ is by design; per-identity throttling is meaningless before an
 identity is known. Pre-auth rate limits should be tuned by editing
 the static slowapi decorator default itself, not by creating an
 override. The full list of pre-auth patterns lives in
-``app.rate_limit_endpoint_catalogue.PRE_AUTH_PATTERNS`` and the
+``app.rate_limit_endpoint_catalogue.PRE_AUTH_ENDPOINT_PATTERNS`` and the
 admin UI surfaces a warning when one of those patterns is picked.
 """
 from __future__ import annotations
@@ -272,7 +272,7 @@ def dynamic_limit(endpoint_pattern: str, default: str) -> Callable[..., str]:
     Tune those routes via the static ``@limiter.limit("N/period")``
     string at the decorator site. See module docstring above for the
     full rationale; the catalogue is the authoritative list at
-    ``app.rate_limit_endpoint_catalogue.PRE_AUTH_PATTERNS``.
+    ``app.rate_limit_endpoint_catalogue.PRE_AUTH_ENDPOINT_PATTERNS``.
     """
     # Force-parse the default once. If this raises, the import
     # explodes loudly instead of silently shipping a broken decorator.

--- a/backend/app/rate_limit_overrides.py
+++ b/backend/app/rate_limit_overrides.py
@@ -23,6 +23,21 @@ Failure stance. If the resolver raises, or Redis is unavailable, or
 the JWT is unreadable, the helper returns the default. That matches
 the project-wide rate-limit fail-open posture and prevents an
 override-system bug from locking out the platform.
+
+Pre-auth limitation. ``dynamic_limit()`` requires an authenticated
+identity (a ``user_id`` or ``org_id`` extractable from the request)
+to resolve org / user overrides. Pre-auth endpoints (login,
+register, password-reset request, check-username, email
+verification, MFA challenge step, invitation preview / accept, the
+cookie-only refresh ``/verify`` route, etc.) have no Bearer JWT yet
+when the limiter callable runs, so they always fall back to the
+static default regardless of whether an override row exists. This
+is by design; per-identity throttling is meaningless before an
+identity is known. Pre-auth rate limits should be tuned by editing
+the static slowapi decorator default itself, not by creating an
+override. The full list of pre-auth patterns lives in
+``app.rate_limit_endpoint_catalogue.PRE_AUTH_PATTERNS`` and the
+admin UI surfaces a warning when one of those patterns is picked.
 """
 from __future__ import annotations
 
@@ -234,6 +249,30 @@ def dynamic_limit(endpoint_pattern: str, default: str) -> Callable[..., str]:
       async — bridged via ``asyncio.run`` on a fresh loop iff no
       running loop is detected (slowapi 0.1.9's evaluate path is
       currently sync but the bridge tolerates both).
+
+    Pre-auth endpoints WILL NOT honour per-org / per-user overrides.
+    The closure short-circuits to ``default`` whenever neither a
+    ``user_id`` nor an ``org_id`` can be extracted from the request,
+    which is always the case for the following patterns:
+
+    - ``auth.check_username``
+    - ``auth.forgot_password``
+    - ``auth.login``
+    - ``auth.mfa_email_code``
+    - ``auth.mfa_email_verify``
+    - ``auth.mfa_recovery``
+    - ``auth.mfa_verify``
+    - ``auth.register``
+    - ``auth.resend_verification_public``
+    - ``auth.verify`` (cookie-based, no Bearer)
+    - ``auth.verify_email``
+    - ``org_members.accept_invitation``
+    - ``org_members.preview_invitation``
+
+    Tune those routes via the static ``@limiter.limit("N/period")``
+    string at the decorator site. See module docstring above for the
+    full rationale; the catalogue is the authoritative list at
+    ``app.rate_limit_endpoint_catalogue.PRE_AUTH_PATTERNS``.
     """
     # Force-parse the default once. If this raises, the import
     # explodes loudly instead of silently shipping a broken decorator.

--- a/backend/app/routers/admin_rate_limit_overrides.py
+++ b/backend/app/routers/admin_rate_limit_overrides.py
@@ -1,0 +1,254 @@
+"""Superadmin-only CRUD for rate-limit overrides (L4.10).
+
+Mounted at ``/api/v1/admin/rate-limit-overrides``. Every endpoint
+requires ``is_superadmin=True`` — overrides change the per-request
+budget for an entire org or user, so the right ceiling matches the
+existing announcement / global-platform gates.
+
+Every mutating endpoint writes an ``audit_events`` row via
+``record_audit_event`` on an independent session. The audit row
+carries the override id, the resolved scope (``org_id`` /
+``user_id``), the endpoint pattern, and the resulting ``max`` /
+``period`` so an operator reviewing the audit log later can
+reconstruct exactly what changed without joining back to the
+override row (which may have been deleted).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models.user import User
+from app.rate_limit import get_client_ip
+from app.schemas.rate_limit_override import (
+    RateLimitOverrideCreate,
+    RateLimitOverrideResponse,
+    RateLimitOverrideUpdate,
+)
+from app.services import audit_service
+from app.services import rate_limit_overrides_service as svc
+
+
+logger = structlog.stdlib.get_logger()
+
+router = APIRouter(
+    prefix="/api/v1/admin/rate-limit-overrides",
+    tags=["admin-rate-limit-overrides"],
+)
+
+
+def _request_id() -> Optional[str]:
+    return structlog.contextvars.get_contextvars().get("request_id")
+
+
+async def require_superadmin(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    if not current_user.is_superadmin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )
+    return current_user
+
+
+def _audit_detail(row) -> dict:
+    return {
+        "override_id": row.id,
+        "scope": "user" if row.user_id is not None else "org",
+        "org_id": row.org_id,
+        "user_id": row.user_id,
+        "endpoint_pattern": row.endpoint_pattern,
+        "max_requests": row.max_requests,
+        "period_seconds": row.period_seconds,
+        "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+    }
+
+
+@router.get("", response_model=dict)
+async def list_overrides_endpoint(
+    org_id: Optional[int] = Query(default=None, ge=1),
+    user_id: Optional[int] = Query(default=None, ge=1),
+    endpoint_pattern: Optional[str] = Query(default=None, max_length=80),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    _current_user: User = Depends(require_superadmin),
+    db: AsyncSession = Depends(get_db),
+):
+    """List overrides with optional filters. Returns a paginated
+    ``{items, total}`` envelope matching the existing
+    ``AuditEventListResponse`` shape so the admin table can reuse the
+    same pagination component.
+    """
+    rows, total = await svc.list_overrides(
+        db,
+        org_id=org_id,
+        user_id=user_id,
+        endpoint_pattern=endpoint_pattern,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "items": [RateLimitOverrideResponse.model_validate(r) for r in rows],
+        "total": total,
+    }
+
+
+@router.post(
+    "",
+    response_model=RateLimitOverrideResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_override_endpoint(
+    body: RateLimitOverrideCreate,
+    request: Request,
+    current_user: User = Depends(require_superadmin),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Create a new override. Writes an ``admin.rate_limit.created``
+    audit event on commit.
+    """
+    actor_user_id = current_user.id
+    actor_email = current_user.email
+
+    row = await svc.create_override(
+        db,
+        org_id=body.org_id,
+        user_id=body.user_id,
+        endpoint_pattern=body.endpoint_pattern,
+        max_requests=body.max_requests,
+        period_seconds=body.period_seconds,
+        expires_at=body.expires_at,
+        created_by_user_id=actor_user_id,
+        note=body.note,
+    )
+
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.rate_limit.created",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=row.org_id,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail=_audit_detail(row),
+    )
+
+    await logger.ainfo(
+        "admin.rate_limit.created",
+        override_id=row.id,
+        org_id=row.org_id,
+        user_id=row.user_id,
+        endpoint_pattern=row.endpoint_pattern,
+    )
+    return row
+
+
+@router.patch(
+    "/{override_id}",
+    response_model=RateLimitOverrideResponse,
+)
+async def update_override_endpoint(
+    override_id: int,
+    body: RateLimitOverrideUpdate,
+    request: Request,
+    current_user: User = Depends(require_superadmin),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    """Partial update. Scope (``org_id`` / ``user_id``) is immutable
+    once written; the schema does not surface those keys.
+    """
+    actor_user_id = current_user.id
+    actor_email = current_user.email
+
+    row = await svc.get_by_id(db, override_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Override not found",
+        )
+
+    patch = body.model_dump(exclude_unset=True)
+    if not patch:
+        return row
+
+    row = await svc.update_override(db, row=row, patch=patch)
+
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.rate_limit.updated",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=row.org_id,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail={
+            **_audit_detail(row),
+            "patched_fields": sorted(patch.keys()),
+        },
+    )
+
+    await logger.ainfo(
+        "admin.rate_limit.updated",
+        override_id=row.id,
+        patched_fields=sorted(patch.keys()),
+    )
+    return row
+
+
+@router.delete(
+    "/{override_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def delete_override_endpoint(
+    override_id: int,
+    request: Request,
+    current_user: User = Depends(require_superadmin),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_session_factory),
+):
+    actor_user_id = current_user.id
+    actor_email = current_user.email
+
+    row = await svc.get_by_id(db, override_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Override not found",
+        )
+
+    audit_blob = _audit_detail(row)
+    target_org_id = row.org_id
+
+    await svc.delete_override(db, row=row)
+
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="admin.rate_limit.deleted",
+        actor_user_id=actor_user_id,
+        actor_email=actor_email,
+        target_org_id=target_org_id,
+        target_org_name=None,
+        request_id=_request_id(),
+        ip_address=get_client_ip(request),
+        outcome="success",
+        detail=audit_blob,
+    )
+
+    await logger.ainfo(
+        "admin.rate_limit.deleted",
+        override_id=override_id,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/admin_rate_limit_overrides.py
+++ b/backend/app/routers/admin_rate_limit_overrides.py
@@ -26,8 +26,8 @@ from app.deps import get_current_user, get_session_factory
 from app.models.user import User
 from app.rate_limit import get_client_ip
 from app.rate_limit_endpoint_catalogue import (
-    PRE_AUTH_PATTERNS,
-    sorted_patterns,
+    sorted_overridable_patterns,
+    sorted_pre_auth_patterns,
 )
 from app.schemas.rate_limit_override import (
     RateLimitOverrideCreate,
@@ -80,16 +80,21 @@ async def get_endpoint_catalogue(
 ):
     """Return the catalogue of supported endpoint patterns.
 
-    Drives the admin UI's pattern dropdown so an operator can only
-    pick a string the codebase actually has a ``@limiter.limit``
-    decorator for. The response also flags pre-auth patterns; the UI
-    surfaces a warning when one of those is selected (overrides on
-    pre-auth routes are accepted but the resolver short-circuits to
-    the static default).
+    Response shape is split into two arrays so the admin UI can render
+    both surfaces but only allow selection from the overridable list:
+
+    * ``overridable`` — patterns the schema validator accepts on
+      create / update. These are post-auth routes where the resolver
+      can resolve a user/org identity and apply the override.
+    * ``pre_auth_informational`` — patterns whose decorator runs
+      before auth, surfaced here so operators can see the full
+      decorator surface and learn why they cannot create overrides
+      for those routes. The schema validator rejects these with a
+      typed 422 (see ``rate_limit_override._validate_endpoint_pattern``).
     """
     return {
-        "patterns": sorted_patterns(),
-        "pre_auth_patterns": sorted(PRE_AUTH_PATTERNS),
+        "overridable": sorted_overridable_patterns(),
+        "pre_auth_informational": sorted_pre_auth_patterns(),
     }
 
 

--- a/backend/app/routers/admin_rate_limit_overrides.py
+++ b/backend/app/routers/admin_rate_limit_overrides.py
@@ -25,6 +25,10 @@ from app.database import get_db
 from app.deps import get_current_user, get_session_factory
 from app.models.user import User
 from app.rate_limit import get_client_ip
+from app.rate_limit_endpoint_catalogue import (
+    PRE_AUTH_PATTERNS,
+    sorted_patterns,
+)
 from app.schemas.rate_limit_override import (
     RateLimitOverrideCreate,
     RateLimitOverrideResponse,
@@ -67,6 +71,25 @@ def _audit_detail(row) -> dict:
         "max_requests": row.max_requests,
         "period_seconds": row.period_seconds,
         "expires_at": row.expires_at.isoformat() if row.expires_at else None,
+    }
+
+
+@router.get("/endpoint-catalogue", response_model=dict)
+async def get_endpoint_catalogue(
+    _current_user: User = Depends(require_superadmin),
+):
+    """Return the catalogue of supported endpoint patterns.
+
+    Drives the admin UI's pattern dropdown so an operator can only
+    pick a string the codebase actually has a ``@limiter.limit``
+    decorator for. The response also flags pre-auth patterns; the UI
+    surfaces a warning when one of those is selected (overrides on
+    pre-auth routes are accepted but the resolver short-circuits to
+    the static default).
+    """
+    return {
+        "patterns": sorted_patterns(),
+        "pre_auth_patterns": sorted(PRE_AUTH_PATTERNS),
     }
 
 

--- a/backend/app/schemas/rate_limit_override.py
+++ b/backend/app/schemas/rate_limit_override.py
@@ -13,8 +13,12 @@ Architect-locked invariants enforced here:
   practical bucket; periods beyond that should be a policy change,
   not an override.
 - ``endpoint_pattern`` is a short opaque string (max 80 chars,
-  matching the column width). Service-side validates against the
-  registered endpoint catalogue.
+  matching the column width) AND must appear in
+  ``app.rate_limit_endpoint_catalogue.RATE_LIMITED_ENDPOINT_PATTERNS``.
+  Free-form strings that no decorator references silently no-op at
+  request time, so the catalogue check at the schema layer surfaces
+  the typo as a 422 with the full catalogue echoed back in the
+  error body.
 - ``expires_at``, when sent, must be strictly in the future. A row
   with ``expires_at`` in the past is treated as inert by the resolver
   but creating one in the past is rejected here so the admin UI
@@ -25,7 +29,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.rate_limit_endpoint_catalogue import (
+    RATE_LIMITED_ENDPOINT_PATTERNS,
+    sorted_patterns,
+)
 
 
 # Bounds matching the migration column widths. Pydantic surfaces a
@@ -33,6 +42,23 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 # bubble back as a generic 500.
 ENDPOINT_PATTERN_MIN = 1
 ENDPOINT_PATTERN_MAX = 80
+
+
+def _validate_endpoint_pattern(value: str) -> str:
+    """Reject patterns the codebase has no decorator for.
+
+    The error message lists the full catalogue so the API caller (and
+    the admin UI) can recover without a separate round-trip. The list
+    is sorted for determinism in tests + UI parity.
+    """
+    if value not in RATE_LIMITED_ENDPOINT_PATTERNS:
+        catalogue = ", ".join(sorted_patterns())
+        raise ValueError(
+            f"unknown endpoint_pattern {value!r}. Valid patterns: {catalogue}"
+        )
+    return value
+
+
 NOTE_MAX = 5000
 
 # Self-lockout guard: max_requests must be >= 1. See module docstring.
@@ -88,6 +114,11 @@ class RateLimitOverrideCreate(_ScopeXorMixin):
     expires_at: Optional[datetime] = None
     note: Optional[str] = Field(default=None, max_length=NOTE_MAX)
 
+    @field_validator("endpoint_pattern")
+    @classmethod
+    def _endpoint_in_catalogue(cls, value: str) -> str:
+        return _validate_endpoint_pattern(value)
+
     @model_validator(mode="after")
     def _expires_in_future(self):
         if self.expires_at is not None:
@@ -126,6 +157,13 @@ class RateLimitOverrideUpdate(BaseModel):
     # request: it clears the note. We accept that by leaving it
     # ``Optional[str]`` without a non-null guard.
     note: Optional[str] = Field(default=None, max_length=NOTE_MAX)
+
+    @field_validator("endpoint_pattern")
+    @classmethod
+    def _endpoint_in_catalogue(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        return _validate_endpoint_pattern(value)
 
 
 class RateLimitOverrideResponse(BaseModel):

--- a/backend/app/schemas/rate_limit_override.py
+++ b/backend/app/schemas/rate_limit_override.py
@@ -14,11 +14,16 @@ Architect-locked invariants enforced here:
   not an override.
 - ``endpoint_pattern`` is a short opaque string (max 80 chars,
   matching the column width) AND must appear in
-  ``app.rate_limit_endpoint_catalogue.RATE_LIMITED_ENDPOINT_PATTERNS``.
-  Free-form strings that no decorator references silently no-op at
-  request time, so the catalogue check at the schema layer surfaces
-  the typo as a 422 with the full catalogue echoed back in the
-  error body.
+  ``app.rate_limit_endpoint_catalogue.OVERRIDABLE_ENDPOINT_PATTERNS``.
+  Two failure modes get distinct 422 codes:
+
+  * ``endpoint_pattern_unknown`` — the string is not in any catalogue
+    set (typo, route doesn't exist). Echoes the overridable list back.
+  * ``endpoint_pattern_pre_auth_non_overridable`` — the string IS a
+    known pattern but it is pre-auth, where the resolver short-
+    circuits to the static default. Overrides on those rows would
+    be no-ops, so we reject at the schema layer rather than letting
+    operators create silent dead config.
 - ``expires_at``, when sent, must be strictly in the future. A row
   with ``expires_at`` in the past is treated as inert by the resolver
   but creating one in the past is rejected here so the admin UI
@@ -32,8 +37,9 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.rate_limit_endpoint_catalogue import (
-    RATE_LIMITED_ENDPOINT_PATTERNS,
-    sorted_patterns,
+    OVERRIDABLE_ENDPOINT_PATTERNS,
+    PRE_AUTH_ENDPOINT_PATTERNS,
+    sorted_overridable_patterns,
 )
 
 
@@ -44,19 +50,37 @@ ENDPOINT_PATTERN_MIN = 1
 ENDPOINT_PATTERN_MAX = 80
 
 
-def _validate_endpoint_pattern(value: str) -> str:
-    """Reject patterns the codebase has no decorator for.
+# Typed error codes the admin UI can branch on. Plain strings so the
+# 422 body stays JSON-serialisable without an extra enum import.
+ERR_CODE_UNKNOWN = "endpoint_pattern_unknown"
+ERR_CODE_PRE_AUTH = "endpoint_pattern_pre_auth_non_overridable"
 
-    The error message lists the full catalogue so the API caller (and
-    the admin UI) can recover without a separate round-trip. The list
-    is sorted for determinism in tests + UI parity.
+
+def _validate_endpoint_pattern(value: str) -> str:
+    """Reject patterns that cannot be persisted as overrides.
+
+    Two failure modes:
+
+    * Pre-auth pattern — known to the catalogue but the resolver
+      short-circuits at request time, so an override row would be a
+      no-op. Caller sees ``ERR_CODE_PRE_AUTH``.
+    * Unknown pattern — not in any catalogue set (typo or stale).
+      Caller sees ``ERR_CODE_UNKNOWN`` plus the full overridable
+      list echoed back so they can recover without a round-trip.
     """
-    if value not in RATE_LIMITED_ENDPOINT_PATTERNS:
-        catalogue = ", ".join(sorted_patterns())
+    if value in OVERRIDABLE_ENDPOINT_PATTERNS:
+        return value
+    if value in PRE_AUTH_ENDPOINT_PATTERNS:
         raise ValueError(
-            f"unknown endpoint_pattern {value!r}. Valid patterns: {catalogue}"
+            f"{ERR_CODE_PRE_AUTH}: endpoint {value!r} is a pre-auth route; "
+            "overrides are not honored. Adjust the slowapi decorator default "
+            "in code instead."
         )
-    return value
+    catalogue = ", ".join(sorted_overridable_patterns())
+    raise ValueError(
+        f"{ERR_CODE_UNKNOWN}: unknown endpoint pattern {value!r}. "
+        f"Valid overridable patterns: {catalogue}"
+    )
 
 
 NOTE_MAX = 5000

--- a/backend/app/schemas/rate_limit_override.py
+++ b/backend/app/schemas/rate_limit_override.py
@@ -1,0 +1,144 @@
+"""Pydantic schemas for the rate-limit override system (L4.10).
+
+Architect-locked invariants enforced here:
+
+- A row carries exactly one scope: ``org_id`` XOR ``user_id``. Sending
+  both, or neither, returns 422 before the row ever reaches the DB.
+- ``max_requests`` is bounded ``[1, 100000]``. Lower bound 1 (not 0)
+  prevents the documented self-lockout footgun where a superadmin
+  could pin themselves to ``0`` and lose access to every gated route.
+  Upper bound 100000 is generous and bounded so a typo cannot wedge
+  the limiter cache with a 64-bit integer.
+- ``period_seconds`` is bounded ``[1, 86400]``. One day is the longest
+  practical bucket; periods beyond that should be a policy change,
+  not an override.
+- ``endpoint_pattern`` is a short opaque string (max 80 chars,
+  matching the column width). Service-side validates against the
+  registered endpoint catalogue.
+- ``expires_at``, when sent, must be strictly in the future. A row
+  with ``expires_at`` in the past is treated as inert by the resolver
+  but creating one in the past is rejected here so the admin UI
+  surfaces it as a user error, not a silent no-op.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+# Bounds matching the migration column widths. Pydantic surfaces a
+# precise 422 instead of letting the DB-side StringDataRightTruncation
+# bubble back as a generic 500.
+ENDPOINT_PATTERN_MIN = 1
+ENDPOINT_PATTERN_MAX = 80
+NOTE_MAX = 5000
+
+# Self-lockout guard: max_requests must be >= 1. See module docstring.
+MAX_REQUESTS_MIN = 1
+MAX_REQUESTS_MAX = 100_000
+
+PERIOD_SECONDS_MIN = 1
+PERIOD_SECONDS_MAX = 86_400  # 24h
+
+
+def _utcnow() -> datetime:
+    """Naive UTC ``now()`` matching the app's storage convention.
+
+    The DB writes ``DateTime`` columns naive; comparing ``expires_at``
+    (naive) against an aware UTC ``now()`` would raise. We normalise
+    here so the validator works regardless of how the caller supplies
+    the timestamp.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class _ScopeXorMixin(BaseModel):
+    """Enforces exactly-one-of ``org_id`` / ``user_id``.
+
+    Subclasses MUST declare both ``org_id`` and ``user_id``. The
+    create payload is strict (one and only one); the update payload
+    forbids changing scope at all (separate validator) so this mixin
+    is only used on Create.
+    """
+
+    @model_validator(mode="after")
+    def _check_scope_xor(self):
+        org_id = getattr(self, "org_id", None)
+        user_id = getattr(self, "user_id", None)
+        if (org_id is None) == (user_id is None):
+            raise ValueError(
+                "exactly one of org_id or user_id must be set",
+            )
+        return self
+
+
+class RateLimitOverrideCreate(_ScopeXorMixin):
+    model_config = ConfigDict(extra="forbid")
+
+    org_id: Optional[int] = Field(default=None, ge=1)
+    user_id: Optional[int] = Field(default=None, ge=1)
+    endpoint_pattern: str = Field(
+        min_length=ENDPOINT_PATTERN_MIN,
+        max_length=ENDPOINT_PATTERN_MAX,
+    )
+    max_requests: int = Field(ge=MAX_REQUESTS_MIN, le=MAX_REQUESTS_MAX)
+    period_seconds: int = Field(ge=PERIOD_SECONDS_MIN, le=PERIOD_SECONDS_MAX)
+    expires_at: Optional[datetime] = None
+    note: Optional[str] = Field(default=None, max_length=NOTE_MAX)
+
+    @model_validator(mode="after")
+    def _expires_in_future(self):
+        if self.expires_at is not None:
+            # Coerce aware -> naive UTC for direct comparison with
+            # ``_utcnow()``. Both shapes are accepted on the wire.
+            cmp = self.expires_at
+            if cmp.tzinfo is not None:
+                cmp = cmp.astimezone(timezone.utc).replace(tzinfo=None)
+            if cmp <= _utcnow():
+                raise ValueError("expires_at must be in the future")
+        return self
+
+
+class RateLimitOverrideUpdate(BaseModel):
+    """Partial update. Scope (``org_id`` / ``user_id``) is immutable
+    once written, so neither key appears here. ``endpoint_pattern`` is
+    mutable so an operator can correct a typo without re-creating the
+    row (which would lose the audit trail tied to the row id).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint_pattern: Optional[str] = Field(
+        default=None,
+        min_length=ENDPOINT_PATTERN_MIN,
+        max_length=ENDPOINT_PATTERN_MAX,
+    )
+    max_requests: Optional[int] = Field(
+        default=None, ge=MAX_REQUESTS_MIN, le=MAX_REQUESTS_MAX
+    )
+    period_seconds: Optional[int] = Field(
+        default=None, ge=PERIOD_SECONDS_MIN, le=PERIOD_SECONDS_MAX
+    )
+    expires_at: Optional[datetime] = None
+    # ``note`` is the only field where "explicit null" is a meaningful
+    # request: it clears the note. We accept that by leaving it
+    # ``Optional[str]`` without a non-null guard.
+    note: Optional[str] = Field(default=None, max_length=NOTE_MAX)
+
+
+class RateLimitOverrideResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    org_id: Optional[int] = None
+    user_id: Optional[int] = None
+    endpoint_pattern: str
+    max_requests: int
+    period_seconds: int
+    expires_at: Optional[datetime] = None
+    created_by_user_id: Optional[int] = None
+    note: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/rate_limit_overrides_service.py
+++ b/backend/app/services/rate_limit_overrides_service.py
@@ -1,0 +1,410 @@
+"""CRUD + resolver for per-org / per-user rate-limit overrides (L4.10).
+
+The resolver is the runtime hot path: slowapi invokes it on every
+limited request, so the implementation MUST:
+
+1. Be cheap. A short Redis-backed cache (60 s TTL) sits in front of
+   the DB lookup. A negative-cache row ("no override exists") uses a
+   sentinel string so the resolver does not re-hit MySQL on every
+   request from an org with no overrides.
+2. Fail open. If Redis is down or the DB lookup fails, the resolver
+   returns ``None`` and the decorator's default limit applies. This
+   matches the project-wide rate-limit failure stance (see
+   ``rate_limit_failopen.py``).
+3. Respect ``expires_at``. A row past its expiry is treated as absent
+   without being deleted, so the audit history is preserved.
+
+Resolution order (architect-locked):
+
+1. User override for the endpoint key.
+2. Org override for the endpoint key.
+3. None — caller applies the decorator default.
+
+Cache shape:
+
+- Key: ``rate_limit_override:user:{user_id}:{endpoint_pattern}`` OR
+  ``rate_limit_override:org:{org_id}:{endpoint_pattern}``.
+- Value: ``"<max>/<period_s>"`` for a hit, ``"-"`` for a miss.
+- TTL: 60 s. Invalidated on every mutation that touches the row.
+
+The CRUD entry points each invalidate the affected cache keys so an
+admin update takes effect within one TTL window worst-case (faster
+when the writer's process clears its own cache, slower across other
+replicas — bounded by 60 s either way).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Optional, Sequence
+
+import structlog
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.rate_limit_override import RateLimitOverride
+
+
+logger = structlog.stdlib.get_logger()
+
+# Sentinel stored in Redis when a lookup hits no row. Distinct from
+# the wire format of a real override ("<max>/<period>") so the
+# resolver can tell a cached miss from a cached hit in one string
+# compare.
+_NEGATIVE_CACHE_VALUE = "-"
+_CACHE_TTL_SECONDS = 60
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _is_expired(row: RateLimitOverride) -> bool:
+    return row.expires_at is not None and row.expires_at <= _utcnow_naive()
+
+
+def _to_wire(row: RateLimitOverride) -> str:
+    """Render an override as ``"<max>/<period_s>"`` for the cache /
+    return-from-resolver path. The string is deliberately not in
+    slowapi's "N/minute" textual form — the caller composes the
+    slowapi-compatible string from the numeric parts so unit mapping
+    stays in one place (the limit-string formatter).
+    """
+    return f"{row.max_requests}/{row.period_seconds}"
+
+
+def _cache_key(*, scope: str, scope_id: int, endpoint_pattern: str) -> str:
+    return f"rate_limit_override:{scope}:{scope_id}:{endpoint_pattern}"
+
+
+# ---- CRUD ------------------------------------------------------------------
+
+
+async def create_override(
+    db: AsyncSession,
+    *,
+    org_id: Optional[int],
+    user_id: Optional[int],
+    endpoint_pattern: str,
+    max_requests: int,
+    period_seconds: int,
+    expires_at: Optional[datetime],
+    created_by_user_id: Optional[int],
+    note: Optional[str],
+) -> RateLimitOverride:
+    """Insert a new override row.
+
+    The exactly-one-of-(org_id, user_id) invariant is enforced by the
+    Pydantic create schema, so this function asserts it as a belt-and-
+    braces guard but never expects the assertion to fire from a
+    router call.
+    """
+    if (org_id is None) == (user_id is None):
+        raise ValueError("exactly one of org_id or user_id must be set")
+    row = RateLimitOverride(
+        org_id=org_id,
+        user_id=user_id,
+        endpoint_pattern=endpoint_pattern,
+        max_requests=max_requests,
+        period_seconds=period_seconds,
+        expires_at=expires_at,
+        created_by_user_id=created_by_user_id,
+        note=note,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    await _invalidate_cache(row)
+    return row
+
+
+async def update_override(
+    db: AsyncSession,
+    *,
+    row: RateLimitOverride,
+    patch: dict,
+) -> RateLimitOverride:
+    """Apply a partial patch (already type-checked by Pydantic) and
+    invalidate the cache for both pre- and post-patch endpoint
+    patterns. The double-invalidate matters when ``endpoint_pattern``
+    moves: the old key would otherwise linger as a stale hit until
+    its TTL expires.
+    """
+    old_pattern = row.endpoint_pattern
+    for field, value in patch.items():
+        setattr(row, field, value)
+    await db.commit()
+    await db.refresh(row)
+    await _invalidate_cache(row)
+    if row.endpoint_pattern != old_pattern:
+        await _invalidate_cache_for(
+            scope="user" if row.user_id is not None else "org",
+            scope_id=row.user_id if row.user_id is not None else row.org_id,
+            endpoint_pattern=old_pattern,
+        )
+    return row
+
+
+async def delete_override(
+    db: AsyncSession,
+    *,
+    row: RateLimitOverride,
+) -> None:
+    """Hard-delete and invalidate the cache key."""
+    await _invalidate_cache(row)
+    await db.delete(row)
+    await db.commit()
+
+
+async def get_by_id(
+    db: AsyncSession, override_id: int
+) -> Optional[RateLimitOverride]:
+    return await db.get(RateLimitOverride, override_id)
+
+
+async def list_overrides(
+    db: AsyncSession,
+    *,
+    org_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    endpoint_pattern: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> tuple[Sequence[RateLimitOverride], int]:
+    """List overrides with optional scope filters. Returns
+    ``(items, total)`` to support a paginated admin table.
+    """
+    base = select(RateLimitOverride)
+    filters_q = base
+    if org_id is not None:
+        filters_q = filters_q.where(RateLimitOverride.org_id == org_id)
+    if user_id is not None:
+        filters_q = filters_q.where(RateLimitOverride.user_id == user_id)
+    if endpoint_pattern:
+        filters_q = filters_q.where(
+            RateLimitOverride.endpoint_pattern == endpoint_pattern
+        )
+
+    # Count via the SAME filter chain. ``filters_q`` shares its
+    # ``whereclause`` with ``filters_q.with_only_columns(...)``, so
+    # rebuilding the SELECT with ``func.count()`` reuses every filter
+    # the listing path applies without re-stating them by hand.
+    count_q = filters_q.with_only_columns(
+        func.count(RateLimitOverride.id)
+    ).order_by(None)
+    total_result = await db.execute(count_q)
+    total = int(total_result.scalar() or 0)
+
+    rows_result = await db.execute(
+        filters_q.order_by(
+            RateLimitOverride.created_at.desc(), RateLimitOverride.id.desc()
+        )
+        .limit(limit)
+        .offset(offset)
+    )
+    return list(rows_result.scalars().all()), total
+
+
+# ---- Resolver (hot path) ---------------------------------------------------
+
+
+async def resolve_override(
+    db: AsyncSession,
+    *,
+    user_id: Optional[int],
+    org_id: Optional[int],
+    endpoint_pattern: str,
+) -> Optional[str]:
+    """Return the cached/DB override as ``"<max>/<period_s>"`` or
+    ``None`` if no active override exists.
+
+    Resolution order:
+
+    1. User override if any.
+    2. Org override if any.
+    3. None.
+
+    Both lookups are individually cached so a user with no override
+    in an org-with-no-override does not hit MySQL on every request.
+    """
+    # 1. User scope first.
+    if user_id is not None:
+        cached = await _cache_get(
+            scope="user", scope_id=user_id, endpoint_pattern=endpoint_pattern
+        )
+        if cached is not None:
+            if cached == _NEGATIVE_CACHE_VALUE:
+                pass  # fall through to org
+            else:
+                return cached
+        else:
+            row = await _fetch_active(
+                db,
+                scope_col="user_id",
+                scope_id=user_id,
+                endpoint_pattern=endpoint_pattern,
+            )
+            if row is not None:
+                wire = _to_wire(row)
+                await _cache_set(
+                    scope="user",
+                    scope_id=user_id,
+                    endpoint_pattern=endpoint_pattern,
+                    value=wire,
+                )
+                return wire
+            await _cache_set(
+                scope="user",
+                scope_id=user_id,
+                endpoint_pattern=endpoint_pattern,
+                value=_NEGATIVE_CACHE_VALUE,
+            )
+
+    # 2. Org scope.
+    if org_id is not None:
+        cached = await _cache_get(
+            scope="org", scope_id=org_id, endpoint_pattern=endpoint_pattern
+        )
+        if cached is not None:
+            if cached == _NEGATIVE_CACHE_VALUE:
+                return None
+            return cached
+        row = await _fetch_active(
+            db,
+            scope_col="org_id",
+            scope_id=org_id,
+            endpoint_pattern=endpoint_pattern,
+        )
+        if row is not None:
+            wire = _to_wire(row)
+            await _cache_set(
+                scope="org",
+                scope_id=org_id,
+                endpoint_pattern=endpoint_pattern,
+                value=wire,
+            )
+            return wire
+        await _cache_set(
+            scope="org",
+            scope_id=org_id,
+            endpoint_pattern=endpoint_pattern,
+            value=_NEGATIVE_CACHE_VALUE,
+        )
+
+    return None
+
+
+async def _fetch_active(
+    db: AsyncSession,
+    *,
+    scope_col: str,
+    scope_id: int,
+    endpoint_pattern: str,
+) -> Optional[RateLimitOverride]:
+    """Return the most-recent non-expired override matching the scope
+    and endpoint, or ``None``. ``ORDER BY id DESC`` resolves
+    multi-row collisions deterministically (newest wins) without
+    forcing a unique constraint on the DB row.
+    """
+    now = _utcnow_naive()
+    col = getattr(RateLimitOverride, scope_col)
+    q = (
+        select(RateLimitOverride)
+        .where(col == scope_id)
+        .where(RateLimitOverride.endpoint_pattern == endpoint_pattern)
+        .where(
+            or_(
+                RateLimitOverride.expires_at.is_(None),
+                RateLimitOverride.expires_at > now,
+            )
+        )
+        .order_by(RateLimitOverride.id.desc())
+        .limit(1)
+    )
+    result = await db.execute(q)
+    return result.scalars().first()
+
+
+# ---- Cache plumbing --------------------------------------------------------
+#
+# Lazy import of ``redis_client`` keeps the test substrate (which
+# doesn't run Redis) from spinning up a client at import time. The
+# helpers tolerate Redis being unavailable: every Redis-touching call
+# is wrapped in a try/except that logs at debug and returns the
+# fail-open value (None / silent miss). Rate limiting fails open as
+# the project-wide stance; cache failure must not degrade UX.
+
+
+async def _cache_get(
+    *, scope: str, scope_id: int, endpoint_pattern: str
+) -> Optional[str]:
+    try:
+        from app.redis_client import get_client
+
+        client = get_client()
+        if client is None:
+            return None
+        key = _cache_key(
+            scope=scope, scope_id=scope_id, endpoint_pattern=endpoint_pattern
+        )
+        # redis-py sync client is fine on this path: the cached call
+        # is sub-millisecond on a hit, and the surrounding context
+        # is already wrapped by ``rate_limit_failopen``. Async-redis
+        # migration is a separate work item.
+        value = client.get(key)
+        if value is None:
+            return None
+        # redis-py returns bytes by default.
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
+    except Exception as exc:  # noqa: BLE001 — fail open.
+        logger.debug("rate_limit_override.cache_get_failed", error=str(exc))
+        return None
+
+
+async def _cache_set(
+    *, scope: str, scope_id: int, endpoint_pattern: str, value: str
+) -> None:
+    try:
+        from app.redis_client import get_client
+
+        client = get_client()
+        if client is None:
+            return
+        key = _cache_key(
+            scope=scope, scope_id=scope_id, endpoint_pattern=endpoint_pattern
+        )
+        client.set(key, value, ex=_CACHE_TTL_SECONDS)
+    except Exception as exc:  # noqa: BLE001 — fail open.
+        logger.debug("rate_limit_override.cache_set_failed", error=str(exc))
+
+
+async def _invalidate_cache(row: RateLimitOverride) -> None:
+    scope = "user" if row.user_id is not None else "org"
+    scope_id = row.user_id if row.user_id is not None else row.org_id
+    if scope_id is None:
+        return
+    await _invalidate_cache_for(
+        scope=scope, scope_id=scope_id, endpoint_pattern=row.endpoint_pattern
+    )
+
+
+async def _invalidate_cache_for(
+    *, scope: str, scope_id: int, endpoint_pattern: str
+) -> None:
+    try:
+        from app.redis_client import get_client
+
+        client = get_client()
+        if client is None:
+            return
+        key = _cache_key(
+            scope=scope, scope_id=scope_id, endpoint_pattern=endpoint_pattern
+        )
+        client.delete(key)
+    except Exception as exc:  # noqa: BLE001 — fail open.
+        logger.debug(
+            "rate_limit_override.cache_invalidate_failed",
+            error=str(exc),
+        )

--- a/backend/tests/routers/test_admin_rate_limit_overrides.py
+++ b/backend/tests/routers/test_admin_rate_limit_overrides.py
@@ -1,0 +1,431 @@
+"""Router tests for the rate-limit override CRUD (L4.10).
+
+Pins the architect-locked invariants:
+
+- Every endpoint is superadmin-only. A regular member, an org admin,
+  and a member of a different org all 403.
+- Create / update / delete each write an ``audit_events`` row with
+  ``event_type=admin.rate_limit.{created,updated,deleted}`` on an
+  independent session.
+- ``max_requests=0`` returns 422 from the schema (self-lockout
+  guard).
+- Both org and user scope on the same payload returns 422
+  (exactly-one-of).
+- Override with no scope returns 422.
+- Update endpoint cannot change scope (scope fields not in update
+  schema).
+- A non-existent id returns 404.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.rate_limit_override import RateLimitOverride
+from app.models.user import Organization, User
+from app.routers.admin_rate_limit_overrides import router as admin_router
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def stub_redis(monkeypatch):
+    """No-op Redis for the router path so cache calls don't trip."""
+    import app.redis_client as rc
+
+    monkeypatch.setattr(rc, "get_client", lambda: None)
+
+
+def _make_app(session_factory, current_user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await current_user_resolver(session_factory)
+
+    def override_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_session_factory
+    app.include_router(admin_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+        superadmin = User(
+            org_id=org.id,
+            username="sa",
+            email="sa@example.com",
+            password_hash="x",
+            role="owner",
+            is_superadmin=True,
+        )
+        org_admin = User(
+            org_id=org.id,
+            username="oa",
+            email="oa@example.com",
+            password_hash="x",
+            role="admin",
+            is_superadmin=False,
+        )
+        member = User(
+            org_id=org.id,
+            username="m",
+            email="m@example.com",
+            password_hash="x",
+            role="member",
+            is_superadmin=False,
+        )
+        db.add_all([superadmin, org_admin, member])
+        await db.commit()
+        for u in (superadmin, org_admin, member):
+            await db.refresh(u)
+        return {
+            "org_id": org.id,
+            "superadmin_id": superadmin.id,
+            "org_admin_id": org_admin.id,
+            "member_id": member.id,
+        }
+
+
+def _resolver_for(seeded: dict, who: str):
+    async def _r(factory):
+        async with factory() as db:
+            uid = {
+                "superadmin": seeded["superadmin_id"],
+                "org_admin": seeded["org_admin_id"],
+                "member": seeded["member_id"],
+            }[who]
+            return await db.get(User, uid)
+
+    return _r
+
+
+@pytest.mark.asyncio
+async def test_list_requires_superadmin(session_factory):
+    seeded = await _seed(session_factory)
+    for who in ("org_admin", "member"):
+        app = _make_app(session_factory, _resolver_for(seeded, who))
+        client = TestClient(app)
+        resp = client.get("/api/v1/admin/rate-limit-overrides")
+        assert resp.status_code == 403, who
+
+
+@pytest.mark.asyncio
+async def test_create_requires_superadmin(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "org_admin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_happy_path_writes_audit(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+            "note": "B2B customer ramp",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    payload = resp.json()
+    assert payload["org_id"] == seeded["org_id"]
+    assert payload["user_id"] is None
+    assert payload["max_requests"] == 100
+    assert payload["created_by_user_id"] == seeded["superadmin_id"]
+
+    # Audit row written.
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.rate_limit.created"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].actor_user_id == seeded["superadmin_id"]
+    assert rows[0].target_org_id == seeded["org_id"]
+    assert rows[0].outcome.value == "success"
+    assert rows[0].detail["max_requests"] == 100
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_both_scopes(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "user_id": seeded["member_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_no_scope(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_zero_max_requests(session_factory):
+    """Self-lockout guard: 0 requests/minute would brick the
+    superadmin who set it. The schema's MAX_REQUESTS_MIN=1 fences
+    this off.
+    """
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 0,
+            "period_seconds": 60,
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_past_expiry(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    past = (datetime.utcnow() - timedelta(hours=1)).isoformat()
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+            "expires_at": past,
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_happy_path_writes_audit(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    override_id = resp.json()["id"]
+    resp = client.patch(
+        f"/api/v1/admin/rate-limit-overrides/{override_id}",
+        json={"max_requests": 250},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["max_requests"] == 250
+
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.rate_limit.updated"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    assert "max_requests" in rows[0].detail["patched_fields"]
+
+
+@pytest.mark.asyncio
+async def test_update_404_for_missing(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.patch(
+        "/api/v1/admin/rate-limit-overrides/9999",
+        json={"max_requests": 250},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_scope_change(session_factory):
+    """The update schema does not surface ``org_id`` / ``user_id``,
+    so a payload trying to move scope is rejected as
+    ``extra forbidden``.
+    """
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    override_id = resp.json()["id"]
+    resp = client.patch(
+        f"/api/v1/admin/rate-limit-overrides/{override_id}",
+        json={"org_id": 9999},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_delete_writes_audit(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    override_id = resp.json()["id"]
+    resp = client.delete(
+        f"/api/v1/admin/rate-limit-overrides/{override_id}"
+    )
+    assert resp.status_code == 204
+    # Row is gone.
+    async with session_factory() as db:
+        remaining = (
+            await db.execute(select(RateLimitOverride))
+        ).scalars().all()
+    assert remaining == []
+    # Audit recorded.
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(AuditEvent).where(
+                    AuditEvent.event_type == "admin.rate_limit.deleted"
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].detail["override_id"] == override_id
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_org(session_factory):
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "user_id": seeded["member_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 5,
+            "period_seconds": 60,
+        },
+    )
+    resp = client.get(
+        f"/api/v1/admin/rate-limit-overrides?org_id={seeded['org_id']}"
+    )
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["org_id"] == seeded["org_id"]

--- a/backend/tests/routers/test_admin_rate_limit_overrides.py
+++ b/backend/tests/routers/test_admin_rate_limit_overrides.py
@@ -168,7 +168,7 @@ async def test_create_requires_superadmin(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
         },
@@ -185,7 +185,7 @@ async def test_create_happy_path_writes_audit(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
             "note": "B2B customer ramp",
@@ -224,7 +224,7 @@ async def test_create_rejects_both_scopes(session_factory):
         json={
             "org_id": seeded["org_id"],
             "user_id": seeded["member_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
         },
@@ -240,7 +240,7 @@ async def test_create_rejects_no_scope(session_factory):
     resp = client.post(
         "/api/v1/admin/rate-limit-overrides",
         json={
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
         },
@@ -261,7 +261,7 @@ async def test_create_rejects_zero_max_requests(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 0,
             "period_seconds": 60,
         },
@@ -279,7 +279,7 @@ async def test_create_rejects_past_expiry(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
             "expires_at": past,
@@ -297,7 +297,7 @@ async def test_update_happy_path_writes_audit(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
         },
@@ -348,7 +348,7 @@ async def test_update_rejects_scope_change(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
         },
@@ -370,7 +370,7 @@ async def test_delete_writes_audit(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
         },
@@ -408,7 +408,7 @@ async def test_list_filters_by_org(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "org_id": seeded["org_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 100,
             "period_seconds": 60,
         },
@@ -417,7 +417,7 @@ async def test_list_filters_by_org(session_factory):
         "/api/v1/admin/rate-limit-overrides",
         json={
             "user_id": seeded["member_id"],
-            "endpoint_pattern": "auth.login",
+            "endpoint_pattern": "reports.query",
             "max_requests": 5,
             "period_seconds": 60,
         },
@@ -433,11 +433,15 @@ async def test_list_filters_by_org(session_factory):
 
 @pytest.mark.asyncio
 async def test_create_rejects_unknown_endpoint_pattern(session_factory):
-    """An override referencing a pattern not in the catalogue is 422'd
-    before it ever reaches the DB. The error body includes the full
-    catalogue so the caller can recover without a separate round-trip.
+    """An override referencing a pattern not in either catalogue set
+    is 422'd before it ever reaches the DB. The error body includes
+    the typed ``endpoint_pattern_unknown`` code and the full
+    overridable catalogue so the caller can recover without a
+    separate round-trip.
     """
-    from app.rate_limit_endpoint_catalogue import sorted_patterns
+    from app.rate_limit_endpoint_catalogue import (
+        sorted_overridable_patterns,
+    )
 
     seeded = await _seed(session_factory)
     app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
@@ -452,24 +456,57 @@ async def test_create_rejects_unknown_endpoint_pattern(session_factory):
         },
     )
     assert resp.status_code == 422, resp.text
-    # The error message lists at least one known pattern, signalling
-    # that the catalogue made it into the 422 body.
     body = resp.text
-    catalogue = sorted_patterns()
-    assert "auth.login" in body
+    # Typed error code lets the UI branch on shape, not string match.
+    assert "endpoint_pattern_unknown" in body
     # And the typo'd value is echoed back so the operator sees what
     # was rejected.
     assert "fake.endpoint" in body
-    # And every catalogue entry shows up — keeps the response usable
-    # as a recovery hint instead of a guessing game.
+    # Every OVERRIDABLE catalogue entry shows up so the response is a
+    # usable recovery hint instead of a guessing game.
+    catalogue = sorted_overridable_patterns()
     for pattern in catalogue:
         assert pattern in body
+    # And the post-auth ``auth.resend_verification`` survives the
+    # split as a sanity check on membership.
+    assert "auth.resend_verification" in body
 
 
 @pytest.mark.asyncio
 async def test_update_rejects_unknown_endpoint_pattern(session_factory):
     """Same catalogue guard applies on PATCH so an operator can't
-    typo a rename either.
+    typo a rename either. Uses ``reports.query`` as the seed pattern
+    since it is in the OVERRIDABLE set (post auth.login moved to
+    PRE_AUTH).
+    """
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "reports.query",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    override_id = resp.json()["id"]
+    resp = client.patch(
+        f"/api/v1/admin/rate-limit-overrides/{override_id}",
+        json={"endpoint_pattern": "transactiosn.list"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "transactiosn.list" in resp.text
+    assert "endpoint_pattern_unknown" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_pre_auth_endpoint_pattern(session_factory):
+    """A pre-auth pattern is rejected at the schema layer with a
+    distinct typed error code. Otherwise the row would persist and
+    silently no-op at request time, which is exactly the operator-
+    confusing footgun the architect-locked split closes.
     """
     seeded = await _seed(session_factory)
     app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
@@ -483,25 +520,62 @@ async def test_update_rejects_unknown_endpoint_pattern(session_factory):
             "period_seconds": 60,
         },
     )
-    override_id = resp.json()["id"]
-    resp = client.patch(
-        f"/api/v1/admin/rate-limit-overrides/{override_id}",
-        json={"endpoint_pattern": "transactiosn.list"},
-    )
     assert resp.status_code == 422, resp.text
-    assert "transactiosn.list" in resp.text
+    body = resp.text
+    # Typed code distinct from the unknown-pattern code so the admin
+    # UI can render a different message.
+    assert "endpoint_pattern_pre_auth_non_overridable" in body
+    # The offending pattern is echoed back.
+    assert "auth.login" in body
+    # And the operator is pointed at the actual fix (slowapi decorator
+    # in code, not an override row).
+    assert "slowapi" in body
 
 
 @pytest.mark.asyncio
-async def test_endpoint_catalogue_endpoint_returns_list(session_factory):
-    """The GET catalogue endpoint returns a deterministic sorted list
-    that matches the in-memory frozenset. Pre-auth patterns are
-    flagged in a second key so the admin UI can warn the operator
-    without re-deriving the list client-side.
+async def test_update_rejects_pre_auth_endpoint_pattern(session_factory):
+    """PATCH cannot rename an override to a pre-auth pattern either.
+    Same typed code as create so the UI handler is one branch.
+    """
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "reports.query",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    override_id = resp.json()["id"]
+    resp = client.patch(
+        f"/api/v1/admin/rate-limit-overrides/{override_id}",
+        json={"endpoint_pattern": "auth.register"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "endpoint_pattern_pre_auth_non_overridable" in resp.text
+    assert "auth.register" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_endpoint_catalogue_returns_split_shape(session_factory):
+    """The GET catalogue endpoint returns the two-array shape the
+    admin UI consumes:
+
+    * ``overridable`` — patterns the schema validator accepts. Sorted
+      deterministically so the dropdown order is stable across
+      requests.
+    * ``pre_auth_informational`` — patterns surfaced for context only.
+      The UI renders them as disabled options. Sorted so the
+      informational list is stable too.
     """
     from app.rate_limit_endpoint_catalogue import (
-        PRE_AUTH_PATTERNS,
-        sorted_patterns,
+        OVERRIDABLE_ENDPOINT_PATTERNS,
+        PRE_AUTH_ENDPOINT_PATTERNS,
+        sorted_overridable_patterns,
+        sorted_pre_auth_patterns,
     )
 
     seeded = await _seed(session_factory)
@@ -512,12 +586,18 @@ async def test_endpoint_catalogue_endpoint_returns_list(session_factory):
     )
     assert resp.status_code == 200, resp.text
     payload = resp.json()
-    assert payload["patterns"] == sorted_patterns()
-    assert set(payload["pre_auth_patterns"]) == PRE_AUTH_PATTERNS
-    # Sorted contract for the UI dropdown.
-    assert payload["pre_auth_patterns"] == sorted(
-        payload["pre_auth_patterns"]
+    assert set(payload.keys()) == {"overridable", "pre_auth_informational"}
+    assert payload["overridable"] == sorted_overridable_patterns()
+    assert payload["pre_auth_informational"] == sorted_pre_auth_patterns()
+    # The two sets must be disjoint — a pattern is either overridable
+    # or pre-auth, never both.
+    assert (
+        OVERRIDABLE_ENDPOINT_PATTERNS & PRE_AUTH_ENDPOINT_PATTERNS == set()
     )
+    # Sanity-check the resend_verification split: post-auth is
+    # overridable, public is pre-auth.
+    assert "auth.resend_verification" in payload["overridable"]
+    assert "auth.resend_verification_public" in payload["pre_auth_informational"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_admin_rate_limit_overrides.py
+++ b/backend/tests/routers/test_admin_rate_limit_overrides.py
@@ -429,3 +429,108 @@ async def test_list_filters_by_org(session_factory):
     items = resp.json()["items"]
     assert len(items) == 1
     assert items[0]["org_id"] == seeded["org_id"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_endpoint_pattern(session_factory):
+    """An override referencing a pattern not in the catalogue is 422'd
+    before it ever reaches the DB. The error body includes the full
+    catalogue so the caller can recover without a separate round-trip.
+    """
+    from app.rate_limit_endpoint_catalogue import sorted_patterns
+
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "fake.endpoint",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    # The error message lists at least one known pattern, signalling
+    # that the catalogue made it into the 422 body.
+    body = resp.text
+    catalogue = sorted_patterns()
+    assert "auth.login" in body
+    # And the typo'd value is echoed back so the operator sees what
+    # was rejected.
+    assert "fake.endpoint" in body
+    # And every catalogue entry shows up — keeps the response usable
+    # as a recovery hint instead of a guessing game.
+    for pattern in catalogue:
+        assert pattern in body
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_unknown_endpoint_pattern(session_factory):
+    """Same catalogue guard applies on PATCH so an operator can't
+    typo a rename either.
+    """
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/admin/rate-limit-overrides",
+        json={
+            "org_id": seeded["org_id"],
+            "endpoint_pattern": "auth.login",
+            "max_requests": 100,
+            "period_seconds": 60,
+        },
+    )
+    override_id = resp.json()["id"]
+    resp = client.patch(
+        f"/api/v1/admin/rate-limit-overrides/{override_id}",
+        json={"endpoint_pattern": "transactiosn.list"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "transactiosn.list" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_endpoint_catalogue_endpoint_returns_list(session_factory):
+    """The GET catalogue endpoint returns a deterministic sorted list
+    that matches the in-memory frozenset. Pre-auth patterns are
+    flagged in a second key so the admin UI can warn the operator
+    without re-deriving the list client-side.
+    """
+    from app.rate_limit_endpoint_catalogue import (
+        PRE_AUTH_PATTERNS,
+        sorted_patterns,
+    )
+
+    seeded = await _seed(session_factory)
+    app = _make_app(session_factory, _resolver_for(seeded, "superadmin"))
+    client = TestClient(app)
+    resp = client.get(
+        "/api/v1/admin/rate-limit-overrides/endpoint-catalogue"
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["patterns"] == sorted_patterns()
+    assert set(payload["pre_auth_patterns"]) == PRE_AUTH_PATTERNS
+    # Sorted contract for the UI dropdown.
+    assert payload["pre_auth_patterns"] == sorted(
+        payload["pre_auth_patterns"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_endpoint_catalogue_non_superadmin_403(session_factory):
+    """The catalogue endpoint is superadmin-gated like the rest of
+    the router. A regular member 403s, not 200-with-list (which
+    would leak the route inventory to non-admins).
+    """
+    seeded = await _seed(session_factory)
+    for who in ("org_admin", "member"):
+        app = _make_app(session_factory, _resolver_for(seeded, who))
+        client = TestClient(app)
+        resp = client.get(
+            "/api/v1/admin/rate-limit-overrides/endpoint-catalogue"
+        )
+        assert resp.status_code == 403, who

--- a/backend/tests/services/test_rate_limit_overrides_service.py
+++ b/backend/tests/services/test_rate_limit_overrides_service.py
@@ -1,0 +1,423 @@
+"""Tests for ``rate_limit_overrides_service`` (L4.10).
+
+Covers the architect-locked invariants:
+
+- exactly-one-of (org_id, user_id) on create.
+- resolve order user > org > none.
+- ``expires_at`` in the past treated as absent.
+- cache miss / hit / negative-cache plumbing (Redis stubbed).
+- update path invalidates cache for both old and new endpoint
+  patterns when the pattern moves.
+- delete invalidates cache.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.rate_limit_override import RateLimitOverride
+from app.models.user import Organization, User
+from app.services import rate_limit_overrides_service as svc
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+class _FakeRedis:
+    """Minimal Redis stub. Implements ``get``, ``set``, ``delete`` with
+    no TTL handling (the service never reads TTL back). All operations
+    are sync to mirror redis-py's sync API surface.
+    """
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.calls: list[tuple[str, ...]] = []
+
+    def get(self, key):
+        self.calls.append(("get", key))
+        v = self.store.get(key)
+        # redis-py returns bytes by default.
+        return v.encode("utf-8") if isinstance(v, str) else v
+
+    def set(self, key, value, ex=None):
+        self.calls.append(("set", key, value, ex))
+        self.store[key] = value
+
+    def delete(self, key):
+        self.calls.append(("delete", key))
+        self.store.pop(key, None)
+
+
+@pytest.fixture
+def fake_redis(monkeypatch) -> _FakeRedis:
+    r = _FakeRedis()
+
+    def _get_client():
+        return r
+
+    # Patch where the service imports it (the lazy import path inside
+    # the service helpers).
+    import app.redis_client as rc
+
+    monkeypatch.setattr(rc, "get_client", _get_client)
+    return r
+
+
+async def _seed_org_user(factory) -> tuple[int, int]:
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+        u = User(
+            org_id=org.id,
+            username="u",
+            email="u@example.com",
+            password_hash="x",
+            role="owner",
+        )
+        db.add(u)
+        await db.commit()
+        await db.refresh(u)
+        return org.id, u.id
+
+
+@pytest.mark.asyncio
+async def test_create_requires_exactly_one_scope(session_factory, fake_redis):
+    org_id, user_id = await _seed_org_user(session_factory)
+    async with session_factory() as db:
+        with pytest.raises(ValueError):
+            await svc.create_override(
+                db,
+                org_id=org_id,
+                user_id=user_id,
+                endpoint_pattern="auth.login",
+                max_requests=10,
+                period_seconds=60,
+                expires_at=None,
+                created_by_user_id=None,
+                note=None,
+            )
+        with pytest.raises(ValueError):
+            await svc.create_override(
+                db,
+                org_id=None,
+                user_id=None,
+                endpoint_pattern="auth.login",
+                max_requests=10,
+                period_seconds=60,
+                expires_at=None,
+                created_by_user_id=None,
+                note=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_none_when_no_override(session_factory, fake_redis):
+    org_id, user_id = await _seed_org_user(session_factory)
+    async with session_factory() as db:
+        result = await svc.resolve_override(
+            db,
+            user_id=user_id,
+            org_id=org_id,
+            endpoint_pattern="auth.login",
+        )
+    assert result is None
+    # Both scopes should have written negative-cache rows so a second
+    # lookup short-circuits in Redis.
+    assert "rate_limit_override:user:" in "\n".join(
+        " ".join(str(c) for c in call) for call in fake_redis.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_wins_over_org(session_factory, fake_redis):
+    org_id, user_id = await _seed_org_user(session_factory)
+    async with session_factory() as db:
+        await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=100,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+        await svc.create_override(
+            db,
+            org_id=None,
+            user_id=user_id,
+            endpoint_pattern="auth.login",
+            max_requests=5,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+    # Fresh session for the resolver to clear ORM identity cache.
+    async with session_factory() as db:
+        result = await svc.resolve_override(
+            db,
+            user_id=user_id,
+            org_id=org_id,
+            endpoint_pattern="auth.login",
+        )
+    # User override wins.
+    assert result == "5/60"
+
+
+@pytest.mark.asyncio
+async def test_resolve_falls_through_to_org(session_factory, fake_redis):
+    org_id, user_id = await _seed_org_user(session_factory)
+    async with session_factory() as db:
+        await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=200,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+    async with session_factory() as db:
+        result = await svc.resolve_override(
+            db,
+            user_id=user_id,
+            org_id=org_id,
+            endpoint_pattern="auth.login",
+        )
+    assert result == "200/60"
+
+
+@pytest.mark.asyncio
+async def test_resolve_ignores_expired_row(session_factory, fake_redis):
+    org_id, _ = await _seed_org_user(session_factory)
+    past = datetime.utcnow() - timedelta(hours=1)
+    async with session_factory() as db:
+        await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=200,
+            period_seconds=60,
+            expires_at=past,
+            created_by_user_id=None,
+            note=None,
+        )
+    async with session_factory() as db:
+        result = await svc.resolve_override(
+            db,
+            user_id=None,
+            org_id=org_id,
+            endpoint_pattern="auth.login",
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_honours_future_expiry(session_factory, fake_redis):
+    org_id, _ = await _seed_org_user(session_factory)
+    future = datetime.utcnow() + timedelta(hours=1)
+    async with session_factory() as db:
+        await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=200,
+            period_seconds=60,
+            expires_at=future,
+            created_by_user_id=None,
+            note=None,
+        )
+    async with session_factory() as db:
+        result = await svc.resolve_override(
+            db,
+            user_id=None,
+            org_id=org_id,
+            endpoint_pattern="auth.login",
+        )
+    assert result == "200/60"
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_db(session_factory, fake_redis):
+    """If Redis has a positive cache, the resolver returns it without
+    issuing a DB read. We assert this by seeding Redis directly and
+    not creating a DB row.
+    """
+    org_id, _ = await _seed_org_user(session_factory)
+    fake_redis.store[
+        f"rate_limit_override:org:{org_id}:auth.login"
+    ] = "42/60"
+    async with session_factory() as db:
+        result = await svc.resolve_override(
+            db,
+            user_id=None,
+            org_id=org_id,
+            endpoint_pattern="auth.login",
+        )
+    assert result == "42/60"
+
+
+@pytest.mark.asyncio
+async def test_update_moves_cache_on_pattern_change(session_factory, fake_redis):
+    org_id, _ = await _seed_org_user(session_factory)
+    async with session_factory() as db:
+        row = await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=10,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+        # Pre-seed Redis to assert the old key gets invalidated.
+        fake_redis.store[
+            f"rate_limit_override:org:{org_id}:auth.login"
+        ] = "10/60"
+        await svc.update_override(
+            db,
+            row=row,
+            patch={"endpoint_pattern": "auth.register"},
+        )
+    delete_keys = [
+        c[1] for c in fake_redis.calls if c[0] == "delete"
+    ]
+    assert f"rate_limit_override:org:{org_id}:auth.login" in delete_keys
+    assert f"rate_limit_override:org:{org_id}:auth.register" in delete_keys
+
+
+@pytest.mark.asyncio
+async def test_delete_invalidates_cache(session_factory, fake_redis):
+    org_id, _ = await _seed_org_user(session_factory)
+    async with session_factory() as db:
+        row = await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=10,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+        fake_redis.store[
+            f"rate_limit_override:org:{org_id}:auth.login"
+        ] = "10/60"
+        await svc.delete_override(db, row=row)
+    delete_keys = [
+        c[1] for c in fake_redis.calls if c[0] == "delete"
+    ]
+    assert f"rate_limit_override:org:{org_id}:auth.login" in delete_keys
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_scope(session_factory, fake_redis):
+    org_id, user_id = await _seed_org_user(session_factory)
+    async with session_factory() as db:
+        await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=10,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+        await svc.create_override(
+            db,
+            org_id=None,
+            user_id=user_id,
+            endpoint_pattern="auth.login",
+            max_requests=5,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+    async with session_factory() as db:
+        org_rows, org_total = await svc.list_overrides(db, org_id=org_id)
+        user_rows, user_total = await svc.list_overrides(db, user_id=user_id)
+        all_rows, all_total = await svc.list_overrides(db)
+    assert org_total == 1
+    assert user_total == 1
+    assert all_total == 2
+    assert org_rows[0].org_id == org_id
+    assert user_rows[0].user_id == user_id
+
+
+@pytest.mark.asyncio
+async def test_cache_negative_then_positive(session_factory, fake_redis):
+    """A negative cache row for org should NOT short-circuit a
+    subsequent user-scope override read on the same endpoint.
+    """
+    org_id, user_id = await _seed_org_user(session_factory)
+    # Pre-cache a negative for user; org will fall through to DB.
+    fake_redis.store[
+        f"rate_limit_override:user:{user_id}:auth.login"
+    ] = "-"
+    async with session_factory() as db:
+        await svc.create_override(
+            db,
+            org_id=org_id,
+            user_id=None,
+            endpoint_pattern="auth.login",
+            max_requests=200,
+            period_seconds=60,
+            expires_at=None,
+            created_by_user_id=None,
+            note=None,
+        )
+    async with session_factory() as db:
+        result = await svc.resolve_override(
+            db,
+            user_id=user_id,
+            org_id=org_id,
+            endpoint_pattern="auth.login",
+        )
+    # User cache says no -> falls through to org -> hits DB -> "200/60".
+    assert result == "200/60"

--- a/backend/tests/test_rate_limit_overrides_integration.py
+++ b/backend/tests/test_rate_limit_overrides_integration.py
@@ -1,0 +1,82 @@
+"""Integration tests: ``dynamic_limit`` bridge to the override
+resolver.
+
+The bridge has two halves:
+
+1. ``parse_default_limit`` / ``format_limit`` round-trip parser.
+2. The runtime callable returned by ``dynamic_limit(endpoint, default)``,
+   which consults the resolver (with the DB + cache) and returns the
+   per-request limit string.
+
+This file pins the parser shape (cheap; pure function) and an
+import-time-error assertion (an unparseable default crashes early,
+not at first request). The full request-path integration that
+demonstrates a tighter override hitting 429 before the global default
+is covered by the router test for the create endpoint plus the
+service test for the resolver; wiring both into a live limiter inside
+an in-memory sqlite app would require a running Redis (the limiter's
+storage backend) and is left for a manual verify pass.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.rate_limit_overrides import (
+    dynamic_limit,
+    format_limit,
+    parse_default_limit,
+)
+
+
+def test_parse_default_limit_word_forms():
+    assert parse_default_limit("20/minute") == (20, 60)
+    assert parse_default_limit("5/hour") == (5, 3600)
+    assert parse_default_limit("3/day") == (3, 86400)
+    assert parse_default_limit("100/second") == (100, 1)
+    # Whitespace tolerated.
+    assert parse_default_limit("  10 / minute  ") == (10, 60)
+    # Case tolerated.
+    assert parse_default_limit("10/Minute") == (10, 60)
+
+
+def test_parse_default_limit_numeric_period():
+    assert parse_default_limit("30/45") == (30, 45)
+
+
+def test_parse_default_limit_rejects_bogus():
+    with pytest.raises(ValueError):
+        parse_default_limit("nonsense")
+    with pytest.raises(ValueError):
+        parse_default_limit("20/forever")
+    with pytest.raises(ValueError):
+        parse_default_limit("20/")
+
+
+def test_format_round_trip():
+    assert parse_default_limit(format_limit(42, 60)) == (42, 60)
+    assert parse_default_limit(format_limit(5, 3600)) == (5, 3600)
+
+
+def test_dynamic_limit_validates_default_at_construction():
+    """An unparseable default raises immediately so a typo in a
+    decorator argument crashes import, not the first request.
+    """
+    with pytest.raises(ValueError):
+        dynamic_limit("auth.login", "20/forever")
+
+
+def test_dynamic_limit_returns_callable_that_falls_through_to_default():
+    """No request identity available -> resolver returns ``None`` ->
+    callable returns the default.
+    """
+    fn = dynamic_limit("auth.login", "20/minute")
+
+    class _FakeReq:
+        class state:
+            pass
+
+        headers: dict = {}
+
+    # The fake request has no auth header and no state user/org; the
+    # resolver path short-circuits to the default.
+    assert fn(_FakeReq()) == "20/minute"

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircle2,
   ChevronRight,
   CreditCard,
+  Gauge,
   ScrollText,
   ShieldCheck,
   XCircle,
@@ -86,6 +87,14 @@ const ADMIN_TILES: readonly AdminTile[] = [
       "Every subscription across the platform, filterable by status and plan. Revenue figures are mock until payments go live.",
     permission: "subscriptions.view",
     Icon: CreditCard,
+  },
+  {
+    href: "/admin/rate-limit-overrides",
+    title: "Rate-limit overrides",
+    description:
+      "Per-org and per-user budget adjustments for the default request rate limits.",
+    permission: "rate_limit_overrides.manage",
+    Icon: Gauge,
   },
 ];
 

--- a/frontend/app/admin/rate-limit-overrides/page.tsx
+++ b/frontend/app/admin/rate-limit-overrides/page.tsx
@@ -1,0 +1,675 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import AppShell from "@/components/AppShell";
+import Spinner from "@/components/ui/Spinner";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { isSuperadmin } from "@/lib/auth";
+import {
+  btnDanger,
+  btnPrimary,
+  btnSecondary,
+  card,
+  cardHeader,
+  cardTitle,
+  error as errorCls,
+  input,
+  label,
+  pageTitle,
+} from "@/lib/styles";
+import type {
+  RateLimitOverride,
+  RateLimitOverrideListResponse,
+} from "@/lib/types";
+
+// L4.10 — superadmin-only UI for per-org / per-user rate-limit
+// overrides. The page is a thin shell over the admin REST endpoints
+// at /api/v1/admin/rate-limit-overrides. Three sub-views:
+//
+// - The list (table with filters, paginated).
+// - An add-or-edit modal driven by `editing` state. Null = closed,
+//   "new" = create, RateLimitOverride = edit.
+// - A delete confirm dialog driven by `deleting` state.
+//
+// Identity and scope semantics. Each row carries either an org_id
+// OR a user_id (the backend enforces XOR). The form surfaces them
+// as a single "scope" radio + numeric id input so the operator can
+// only ever submit one. We do NOT support changing scope on edit;
+// the backend rejects scope keys in the update payload, so the
+// scope inputs are hidden / disabled in edit mode.
+
+const PAGE_SIZE = 50;
+
+const dtFmt = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function formatPeriod(seconds: number): string {
+  if (seconds === 1) return "second";
+  if (seconds === 60) return "minute";
+  if (seconds === 3600) return "hour";
+  if (seconds === 86400) return "day";
+  return `${seconds}s`;
+}
+
+type FormState = {
+  scope: "org" | "user";
+  scopeId: string;
+  endpoint_pattern: string;
+  max_requests: string;
+  period_seconds: string;
+  expires_at: string;
+  note: string;
+};
+
+const EMPTY_FORM: FormState = {
+  scope: "org",
+  scopeId: "",
+  endpoint_pattern: "",
+  max_requests: "",
+  period_seconds: "60",
+  expires_at: "",
+  note: "",
+};
+
+function rowToForm(row: RateLimitOverride): FormState {
+  const isUser = row.user_id !== null;
+  return {
+    scope: isUser ? "user" : "org",
+    scopeId: String(isUser ? row.user_id : row.org_id),
+    endpoint_pattern: row.endpoint_pattern,
+    max_requests: String(row.max_requests),
+    period_seconds: String(row.period_seconds),
+    expires_at: row.expires_at ? row.expires_at.slice(0, 16) : "",
+    note: row.note ?? "",
+  };
+}
+
+export default function AdminRateLimitOverridesPage() {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const [data, setData] = useState<RateLimitOverrideListResponse | null>(null);
+  const [error, setError] = useState("");
+  const [fetching, setFetching] = useState(true);
+  const [orgIdFilter, setOrgIdFilter] = useState("");
+  const [userIdFilter, setUserIdFilter] = useState("");
+  const [endpointFilter, setEndpointFilter] = useState("");
+  const [offset, setOffset] = useState(0);
+
+  // Modal state. null = closed, "new" = create, row = edit.
+  const [editing, setEditing] = useState<RateLimitOverride | "new" | null>(
+    null,
+  );
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+
+  const [deleting, setDeleting] = useState<RateLimitOverride | null>(null);
+  const [deleteError, setDeleteError] = useState("");
+
+  // Gate: superadmin-only. Mirrors the announcements page guard
+  // because there is no fine-grained role permission for rate-limit
+  // overrides (architect-locked superadmin gate).
+  const canView = user ? isSuperadmin(user) : false;
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!canView) {
+      router.replace("/dashboard");
+    }
+  }, [authLoading, user, canView, router]);
+
+  const refresh = useCallback(async () => {
+    if (!canView) return;
+    setFetching(true);
+    setError("");
+    const params = new URLSearchParams({
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+    });
+    if (orgIdFilter.trim() && /^[1-9][0-9]*$/.test(orgIdFilter.trim())) {
+      params.set("org_id", orgIdFilter.trim());
+    }
+    if (userIdFilter.trim() && /^[1-9][0-9]*$/.test(userIdFilter.trim())) {
+      params.set("user_id", userIdFilter.trim());
+    }
+    if (endpointFilter.trim()) {
+      params.set("endpoint_pattern", endpointFilter.trim());
+    }
+    try {
+      const payload = await apiFetch<RateLimitOverrideListResponse>(
+        `/api/v1/admin/rate-limit-overrides?${params.toString()}`,
+      );
+      setData(payload);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Failed to load overrides"));
+    } finally {
+      setFetching(false);
+    }
+  }, [canView, offset, orgIdFilter, userIdFilter, endpointFilter]);
+
+  useEffect(() => {
+    if (!authLoading && canView) {
+      void refresh();
+    }
+  }, [authLoading, canView, refresh]);
+
+  if (authLoading || !user || !canView) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  function openCreate() {
+    setForm(EMPTY_FORM);
+    setSubmitError("");
+    setEditing("new");
+  }
+
+  function openEdit(row: RateLimitOverride) {
+    setForm(rowToForm(row));
+    setSubmitError("");
+    setEditing(row);
+  }
+
+  function closeModal() {
+    setEditing(null);
+    setSubmitError("");
+  }
+
+  async function submit(ev: React.FormEvent) {
+    ev.preventDefault();
+    setSubmitting(true);
+    setSubmitError("");
+    try {
+      const maxRequests = Number(form.max_requests);
+      const periodSeconds = Number(form.period_seconds);
+      if (!Number.isInteger(maxRequests) || maxRequests < 1) {
+        setSubmitError("Max requests must be a positive integer.");
+        setSubmitting(false);
+        return;
+      }
+      if (!Number.isInteger(periodSeconds) || periodSeconds < 1) {
+        setSubmitError("Period (seconds) must be a positive integer.");
+        setSubmitting(false);
+        return;
+      }
+      if (editing === "new") {
+        const scopeId = Number(form.scopeId);
+        if (!Number.isInteger(scopeId) || scopeId < 1) {
+          setSubmitError("Scope id must be a positive integer.");
+          setSubmitting(false);
+          return;
+        }
+        const body: Record<string, unknown> = {
+          endpoint_pattern: form.endpoint_pattern.trim(),
+          max_requests: maxRequests,
+          period_seconds: periodSeconds,
+        };
+        if (form.scope === "org") {
+          body.org_id = scopeId;
+        } else {
+          body.user_id = scopeId;
+        }
+        if (form.expires_at) {
+          body.expires_at = new Date(form.expires_at).toISOString();
+        }
+        if (form.note.trim()) {
+          body.note = form.note.trim();
+        }
+        await apiFetch("/api/v1/admin/rate-limit-overrides", {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+      } else if (editing && typeof editing === "object") {
+        const body: Record<string, unknown> = {
+          endpoint_pattern: form.endpoint_pattern.trim(),
+          max_requests: maxRequests,
+          period_seconds: periodSeconds,
+        };
+        // Send expires_at as ISO if set, or null to clear it. Note
+        // is treated the same way so an operator can blank it.
+        body.expires_at = form.expires_at
+          ? new Date(form.expires_at).toISOString()
+          : null;
+        body.note = form.note.trim() === "" ? null : form.note.trim();
+        await apiFetch(
+          `/api/v1/admin/rate-limit-overrides/${editing.id}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify(body),
+          },
+        );
+      }
+      closeModal();
+      await refresh();
+    } catch (err) {
+      setSubmitError(extractErrorMessage(err, "Failed to save override"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function confirmDelete() {
+    if (!deleting) return;
+    setDeleteError("");
+    try {
+      await apiFetch(
+        `/api/v1/admin/rate-limit-overrides/${deleting.id}`,
+        { method: "DELETE" },
+      );
+      setDeleting(null);
+      await refresh();
+    } catch (err) {
+      setDeleteError(extractErrorMessage(err, "Failed to delete override"));
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className={pageTitle}>Rate-limit overrides</h1>
+        <button
+          type="button"
+          onClick={openCreate}
+          className={btnPrimary}
+        >
+          Add override
+        </button>
+      </div>
+
+      <p className="mt-1 mb-4 text-sm text-text-muted">
+        Bump or throttle an org or a user beyond the default per-route
+        rate limits. User overrides win over org overrides.
+      </p>
+
+      {error && (
+        <div className={`${errorCls} mb-4`} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={`${card} mb-6`}>
+        <div className={cardHeader}>
+          <h2 className={cardTitle}>Active overrides</h2>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 px-6 py-4 sm:grid-cols-3">
+          <input
+            type="text"
+            inputMode="numeric"
+            value={orgIdFilter}
+            onChange={(e) => {
+              setOffset(0);
+              setOrgIdFilter(e.target.value);
+            }}
+            placeholder="Filter by org id"
+            className={input}
+            aria-label="Filter by org id"
+          />
+          <input
+            type="text"
+            inputMode="numeric"
+            value={userIdFilter}
+            onChange={(e) => {
+              setOffset(0);
+              setUserIdFilter(e.target.value);
+            }}
+            placeholder="Filter by user id"
+            className={input}
+            aria-label="Filter by user id"
+          />
+          <input
+            type="search"
+            value={endpointFilter}
+            onChange={(e) => {
+              setOffset(0);
+              setEndpointFilter(e.target.value);
+            }}
+            placeholder="Endpoint pattern (exact)"
+            className={input}
+            aria-label="Filter by endpoint pattern"
+          />
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-y border-border text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="px-6 py-3">Scope</th>
+                <th className="px-6 py-3">Endpoint</th>
+                <th className="px-6 py-3">Limit</th>
+                <th className="px-6 py-3">Period</th>
+                <th className="px-6 py-3">Expires</th>
+                <th className="px-6 py-3">Created</th>
+                <th className="px-6 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fetching && (
+                <tr>
+                  <td colSpan={7} className="px-6 py-6 text-center text-text-muted">
+                    Loading...
+                  </td>
+                </tr>
+              )}
+              {!fetching && data?.items.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-6 py-6 text-center text-text-muted">
+                    No overrides match.
+                  </td>
+                </tr>
+              )}
+              {!fetching &&
+                data?.items.map((row) => (
+                  <tr key={row.id} className="border-b border-border-subtle">
+                    <td className="px-6 py-3 text-text-primary">
+                      {row.user_id !== null ? (
+                        <span>User #{row.user_id}</span>
+                      ) : (
+                        <span>Org #{row.org_id}</span>
+                      )}
+                    </td>
+                    <td className="px-6 py-3 font-mono text-xs text-text-secondary">
+                      {row.endpoint_pattern}
+                    </td>
+                    <td className="px-6 py-3 text-text-primary tabular-nums">
+                      {row.max_requests}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary">
+                      {formatPeriod(row.period_seconds)}
+                    </td>
+                    <td className="px-6 py-3 text-text-secondary tabular-nums">
+                      {row.expires_at
+                        ? dtFmt.format(new Date(row.expires_at))
+                        : "-"}
+                    </td>
+                    <td className="px-6 py-3 text-text-muted tabular-nums">
+                      {dtFmt.format(new Date(row.created_at))}
+                    </td>
+                    <td className="px-6 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(row)}
+                        className={`${btnSecondary} mr-2`}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleting(row)}
+                        className={btnDanger}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+
+        {data && data.total > PAGE_SIZE && (
+          <div className="flex items-center justify-between px-6 py-3 text-xs text-text-muted">
+            <span>
+              {offset + 1}-{Math.min(offset + PAGE_SIZE, data.total)} of{" "}
+              {data.total}
+            </span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                disabled={offset + PAGE_SIZE >= data.total}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+                className="rounded-md border border-border px-3 py-1 disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {editing !== null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="rate-limit-modal-title"
+          className="fixed inset-0 z-30 flex items-center justify-center bg-black/40 p-4"
+        >
+          <form
+            onSubmit={submit}
+            className={`${card} w-full max-w-lg space-y-4 p-6`}
+          >
+            <h2 id="rate-limit-modal-title" className={cardTitle}>
+              {editing === "new" ? "New override" : `Edit override #${editing.id}`}
+            </h2>
+            {submitError && (
+              <div className={errorCls} role="alert">
+                {submitError}
+              </div>
+            )}
+
+            {editing === "new" && (
+              <div>
+                <label className={label}>Scope</label>
+                <div className="flex gap-4 text-sm">
+                  <label className="flex items-center gap-1">
+                    <input
+                      type="radio"
+                      name="scope"
+                      value="org"
+                      checked={form.scope === "org"}
+                      onChange={() =>
+                        setForm({ ...form, scope: "org" })
+                      }
+                    />
+                    Organization
+                  </label>
+                  <label className="flex items-center gap-1">
+                    <input
+                      type="radio"
+                      name="scope"
+                      value="user"
+                      checked={form.scope === "user"}
+                      onChange={() =>
+                        setForm({ ...form, scope: "user" })
+                      }
+                    />
+                    User
+                  </label>
+                </div>
+                <div className="mt-2">
+                  <label className={label} htmlFor="scope-id">
+                    {form.scope === "org" ? "Org id" : "User id"}
+                  </label>
+                  <input
+                    id="scope-id"
+                    type="text"
+                    inputMode="numeric"
+                    value={form.scopeId}
+                    onChange={(e) =>
+                      setForm({ ...form, scopeId: e.target.value })
+                    }
+                    className={input}
+                    required
+                  />
+                </div>
+              </div>
+            )}
+
+            <div>
+              <label className={label} htmlFor="endpoint-pattern">
+                Endpoint pattern
+              </label>
+              <input
+                id="endpoint-pattern"
+                type="text"
+                value={form.endpoint_pattern}
+                onChange={(e) =>
+                  setForm({ ...form, endpoint_pattern: e.target.value })
+                }
+                placeholder="e.g. auth.login"
+                className={input}
+                required
+                maxLength={80}
+              />
+              <p className="mt-1 text-xs text-text-muted">
+                Opaque identifier matched by the limiter. See server
+                catalogue for known patterns.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={label} htmlFor="max-requests">
+                  Max requests
+                </label>
+                <input
+                  id="max-requests"
+                  type="text"
+                  inputMode="numeric"
+                  value={form.max_requests}
+                  onChange={(e) =>
+                    setForm({ ...form, max_requests: e.target.value })
+                  }
+                  className={input}
+                  required
+                />
+              </div>
+              <div>
+                <label className={label} htmlFor="period-seconds">
+                  Period (seconds)
+                </label>
+                <input
+                  id="period-seconds"
+                  type="text"
+                  inputMode="numeric"
+                  value={form.period_seconds}
+                  onChange={(e) =>
+                    setForm({ ...form, period_seconds: e.target.value })
+                  }
+                  className={input}
+                  required
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className={label} htmlFor="expires-at">
+                Expires at (optional)
+              </label>
+              <input
+                id="expires-at"
+                type="datetime-local"
+                value={form.expires_at}
+                onChange={(e) =>
+                  setForm({ ...form, expires_at: e.target.value })
+                }
+                className={input}
+              />
+            </div>
+
+            <div>
+              <label className={label} htmlFor="note">
+                Note (optional)
+              </label>
+              <textarea
+                id="note"
+                value={form.note}
+                onChange={(e) =>
+                  setForm({ ...form, note: e.target.value })
+                }
+                rows={3}
+                maxLength={5000}
+                className={input}
+              />
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={closeModal}
+                className={btnSecondary}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className={btnPrimary}
+                disabled={submitting}
+              >
+                {submitting ? "Saving..." : "Save"}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {deleting && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="rate-limit-delete-title"
+          className="fixed inset-0 z-30 flex items-center justify-center bg-black/40 p-4"
+        >
+          <div className={`${card} w-full max-w-md space-y-4 p-6`}>
+            <h2 id="rate-limit-delete-title" className={cardTitle}>
+              Delete override #{deleting.id}?
+            </h2>
+            <p className="text-sm text-text-secondary">
+              This removes the override for{" "}
+              <span className="font-mono">{deleting.endpoint_pattern}</span>{" "}
+              on{" "}
+              {deleting.user_id !== null
+                ? `user #${deleting.user_id}`
+                : `org #${deleting.org_id}`}
+              . The default rate limit for that route will apply again.
+            </p>
+            {deleteError && (
+              <div className={errorCls} role="alert">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setDeleting(null)}
+                className={btnSecondary}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmDelete}
+                className={btnDanger}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </AppShell>
+  );
+}

--- a/frontend/app/admin/rate-limit-overrides/page.tsx
+++ b/frontend/app/admin/rate-limit-overrides/page.tsx
@@ -68,6 +68,11 @@ type FormState = {
   note: string;
 };
 
+type EndpointCatalogue = {
+  patterns: string[];
+  pre_auth_patterns: string[];
+};
+
 const EMPTY_FORM: FormState = {
   scope: "org",
   scopeId: "",
@@ -112,6 +117,8 @@ export default function AdminRateLimitOverridesPage() {
 
   const [deleting, setDeleting] = useState<RateLimitOverride | null>(null);
   const [deleteError, setDeleteError] = useState("");
+
+  const [catalogue, setCatalogue] = useState<EndpointCatalogue | null>(null);
 
   // Gate: superadmin-only. Mirrors the announcements page guard
   // because there is no fine-grained role permission for rate-limit
@@ -164,6 +171,30 @@ export default function AdminRateLimitOverridesPage() {
     }
   }, [authLoading, canView, refresh]);
 
+  // Fetch the endpoint catalogue once. The dropdown in the modal
+  // sources its options from this; failure is non-fatal but the
+  // form will be unusable until it loads (intentional — picking a
+  // free-text pattern would silently no-op).
+  useEffect(() => {
+    if (!canView) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const payload = await apiFetch<EndpointCatalogue>(
+          "/api/v1/admin/rate-limit-overrides/endpoint-catalogue",
+        );
+        if (!cancelled) setCatalogue(payload);
+      } catch {
+        // Non-fatal: the list still loads. The dropdown will fall
+        // back to an empty <option> set and the submit will surface
+        // the schema's 422 with the catalogue in the error body.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [canView]);
+
   if (authLoading || !user || !canView) {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -194,6 +225,11 @@ export default function AdminRateLimitOverridesPage() {
     setSubmitting(true);
     setSubmitError("");
     try {
+      if (!form.endpoint_pattern) {
+        setSubmitError("Pick an endpoint from the catalogue.");
+        setSubmitting(false);
+        return;
+      }
       const maxRequests = Number(form.max_requests);
       const periodSeconds = Number(form.period_seconds);
       if (!Number.isInteger(maxRequests) || maxRequests < 1) {
@@ -290,10 +326,20 @@ export default function AdminRateLimitOverridesPage() {
         </button>
       </div>
 
-      <p className="mt-1 mb-4 text-sm text-text-muted">
+      <p className="mt-1 mb-2 text-sm text-text-muted">
         Bump or throttle an org or a user beyond the default per-route
         rate limits. User overrides win over org overrides.
       </p>
+
+      <div
+        role="note"
+        aria-label="Pre-auth limitation"
+        className="mb-4 rounded-md border border-border bg-warning-dim px-4 py-2 text-xs text-text-secondary"
+      >
+        Note: pre-auth endpoints (login, register, password-reset)
+        cannot use per-org or per-user overrides. Adjust their static
+        limits in code instead.
+      </div>
 
       {error && (
         <div className={`${errorCls} mb-4`} role="alert">
@@ -521,22 +567,37 @@ export default function AdminRateLimitOverridesPage() {
               <label className={label} htmlFor="endpoint-pattern">
                 Endpoint pattern
               </label>
-              <input
+              <select
                 id="endpoint-pattern"
-                type="text"
                 value={form.endpoint_pattern}
                 onChange={(e) =>
                   setForm({ ...form, endpoint_pattern: e.target.value })
                 }
-                placeholder="e.g. auth.login"
                 className={input}
                 required
-                maxLength={80}
-              />
-              <p className="mt-1 text-xs text-text-muted">
-                Opaque identifier matched by the limiter. See server
-                catalogue for known patterns.
-              </p>
+              >
+                <option value="" disabled>
+                  Select an endpoint
+                </option>
+                {catalogue?.patterns.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                    {catalogue.pre_auth_patterns.includes(p)
+                      ? " (pre-auth, will no-op)"
+                      : ""}
+                  </option>
+                ))}
+              </select>
+              {form.endpoint_pattern &&
+                catalogue?.pre_auth_patterns.includes(
+                  form.endpoint_pattern,
+                ) && (
+                  <p className="mt-1 text-xs text-text-muted">
+                    This is a pre-auth endpoint. The override will be
+                    saved but the resolver will fall back to the static
+                    default at request time.
+                  </p>
+                )}
             </div>
 
             <div className="grid grid-cols-2 gap-3">

--- a/frontend/app/admin/rate-limit-overrides/page.tsx
+++ b/frontend/app/admin/rate-limit-overrides/page.tsx
@@ -69,8 +69,12 @@ type FormState = {
 };
 
 type EndpointCatalogue = {
-  patterns: string[];
-  pre_auth_patterns: string[];
+  // Patterns the backend will accept on create / update. Sorted.
+  overridable: string[];
+  // Patterns surfaced for context only. Rendered as disabled options
+  // in the dropdown so operators can see the full decorator surface
+  // and learn why those routes are not overridable. Sorted.
+  pre_auth_informational: string[];
 };
 
 const EMPTY_FORM: FormState = {
@@ -579,25 +583,26 @@ export default function AdminRateLimitOverridesPage() {
                 <option value="" disabled>
                   Select an endpoint
                 </option>
-                {catalogue?.patterns.map((p) => (
+                {catalogue?.overridable.map((p) => (
                   <option key={p} value={p}>
                     {p}
-                    {catalogue.pre_auth_patterns.includes(p)
-                      ? " (pre-auth, will no-op)"
-                      : ""}
                   </option>
                 ))}
+                {catalogue?.pre_auth_informational.length ? (
+                  <optgroup label="Pre-auth (not overridable)">
+                    {catalogue.pre_auth_informational.map((p) => (
+                      <option
+                        key={p}
+                        value={p}
+                        disabled
+                        title="Pre-auth route. Overrides are not honored; adjust slowapi default in code."
+                      >
+                        {p}
+                      </option>
+                    ))}
+                  </optgroup>
+                ) : null}
               </select>
-              {form.endpoint_pattern &&
-                catalogue?.pre_auth_patterns.includes(
-                  form.endpoint_pattern,
-                ) && (
-                  <p className="mt-1 text-xs text-text-muted">
-                    This is a pre-auth endpoint. The override will be
-                    saved but the resolver will fall back to the static
-                    default at request time.
-                  </p>
-                )}
             </div>
 
             <div className="grid grid-cols-2 gap-3">

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -11,6 +11,7 @@ import {
   ChevronUp,
   CreditCard,
   FileText,
+  Gauge,
   HelpCircle,
   LayoutDashboard,
   LogOut,
@@ -179,6 +180,19 @@ const systemItems: readonly SystemNavItem[] = [
     label: "Plan Catalog",
     permission: "plans.manage",
     icon: <CreditCard {...NAV_ICON_PROPS} />,
+  },
+  {
+    href: "/admin/rate-limit-overrides",
+    label: "Rate limits",
+    // No DB-role permission key exists for rate-limit overrides
+    // (architect-locked superadmin-only, see L4.10 PR). The
+    // forward-compatible gate in lib/auth.ts short-circuits true on
+    // is_superadmin and false on anything else, so the
+    // ``rate_limit_overrides.manage`` key filters correctly today
+    // and is ready for a future fine-grained permission without
+    // touching this file.
+    permission: "rate_limit_overrides.manage",
+    icon: <Gauge {...NAV_ICON_PROPS} />,
   },
   {
     href: "/system/announcements",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -761,3 +761,24 @@ export interface NotificationListResponse {
 export interface NotificationUnseenCountResponse {
   count: number;
 }
+
+// L4.10 — rate-limit overrides admin shape.
+export interface RateLimitOverride {
+  id: number;
+  org_id: number | null;
+  user_id: number | null;
+  endpoint_pattern: string;
+  max_requests: number;
+  period_seconds: number;
+  expires_at: string | null;
+  created_by_user_id: number | null;
+  note: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RateLimitOverrideListResponse {
+  items: RateLimitOverride[];
+  total: number;
+}
+

--- a/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
+++ b/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+import AdminRateLimitOverridesPage from "@/app/admin/rate-limit-overrides/page";
+import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+// Mocks mirror the audit page test shape so the gate, fetch, and
+// router redirect plumbing reuse the same assertions.
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const replaceMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+  usePathname: () => "/admin/rate-limit-overrides",
+}));
+
+const SUPERADMIN = {
+  id: 1,
+  username: "root",
+  email: "root@platform.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Platform",
+  billing_cycle_day: 1,
+  is_superadmin: true,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const LIST_RESPONSE = {
+  items: [
+    {
+      id: 7,
+      org_id: 42,
+      user_id: null,
+      endpoint_pattern: "auth.login",
+      max_requests: 100,
+      period_seconds: 60,
+      expires_at: null,
+      created_by_user_id: 1,
+      note: "B2B ramp",
+      created_at: "2026-05-22T09:00:00Z",
+      updated_at: "2026-05-22T09:00:00Z",
+    },
+  ],
+  total: 1,
+};
+
+describe("AdminRateLimitOverridesPage", () => {
+  const apiFetchMock = vi.mocked(apiFetch);
+  const useAuthMock = vi.mocked(useAuth);
+
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    replaceMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: SUPERADMIN as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+  });
+
+  it("renders overrides for a superadmin", async () => {
+    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
+
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    expect(screen.getByText("Org #42")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("minute")).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("redirects non-superadmin users away from the page", async () => {
+    useAuthMock.mockReturnValue({
+      user: { ...SUPERADMIN, is_superadmin: false } as never,
+      loading: false,
+      needsSetup: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      refreshMe: vi.fn(),
+    });
+
+    render(<AdminRateLimitOverridesPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("opens the add modal when Add override is clicked", async () => {
+    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
+
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    fireEvent.click(screen.getByRole("button", { name: /Add override/i }));
+    expect(
+      await screen.findByRole("heading", { name: /New override/i }),
+    ).toBeInTheDocument();
+    // ``Org id`` matches both the filter input and the form scope
+    // input; assert the form-specific input by id.
+    expect(document.getElementById("scope-id")).not.toBeNull();
+  });
+
+  it("opens the edit modal pre-populated with the row's values", async () => {
+    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
+
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    expect(
+      await screen.findByRole("heading", { name: /Edit override #7/i }),
+    ).toBeInTheDocument();
+    const maxInput = screen.getByLabelText(/Max requests/i) as HTMLInputElement;
+    expect(maxInput.value).toBe("100");
+  });
+
+  it("opens the delete confirm dialog and POSTs DELETE on confirm", async () => {
+    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never); // initial GET
+    apiFetchMock.mockResolvedValueOnce(undefined as never); // DELETE
+    apiFetchMock.mockResolvedValueOnce({ items: [], total: 0 } as never); // refresh
+
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    fireEvent.click(screen.getByRole("button", { name: /Delete/i }));
+    expect(
+      await screen.findByRole("heading", { name: /Delete override #7/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("dialog").querySelector(
+        'button.text-danger-strong, button[class*="Danger"]',
+      ) ?? screen.getAllByRole("button", { name: /Delete/i })[1],
+    );
+    await waitFor(() => {
+      const deleteCall = apiFetchMock.mock.calls.find(
+        (c) => typeof c[1] === "object" && (c[1] as RequestInit | undefined)?.method === "DELETE",
+      );
+      expect(deleteCall).toBeTruthy();
+      expect(String(deleteCall![0])).toContain("/api/v1/admin/rate-limit-overrides/7");
+    });
+  });
+
+  it("filters by endpoint pattern via the search input", async () => {
+    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
+    apiFetchMock.mockResolvedValueOnce({ items: [], total: 0 } as never);
+
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    fireEvent.change(
+      screen.getByPlaceholderText(/Endpoint pattern/i),
+      { target: { value: "auth.register" } },
+    );
+    await waitFor(() => {
+      const lastCall = apiFetchMock.mock.calls.at(-1);
+      expect(String(lastCall![0])).toContain("endpoint_pattern=auth.register");
+    });
+  });
+});

--- a/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
+++ b/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
@@ -70,13 +70,8 @@ const LIST_RESPONSE = {
 };
 
 const CATALOGUE_RESPONSE = {
-  patterns: [
-    "accounts.adjust_balance",
-    "auth.login",
-    "auth.register",
-    "reports.query",
-  ],
-  pre_auth_patterns: ["auth.login", "auth.register"],
+  overridable: ["accounts.adjust_balance", "reports.query"],
+  pre_auth_informational: ["auth.login", "auth.register"],
 };
 
 // Helper: every URL the page fetches gets the canned response so
@@ -217,8 +212,10 @@ describe("AdminRateLimitOverridesPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Add override/i }));
     await screen.findByRole("heading", { name: /New override/i });
 
-    // The dropdown shows every catalogue pattern, and pre-auth ones
-    // are annotated so the operator sees the warning at pick time.
+    // The dropdown shows every catalogue pattern. Overridable patterns
+    // are selectable; pre-auth patterns are rendered as DISABLED
+    // options under an optgroup so operators can see the full surface
+    // but cannot accidentally persist a no-op override.
     const dropdown = screen.getByLabelText(
       "Endpoint pattern",
     ) as HTMLSelectElement;
@@ -228,11 +225,70 @@ describe("AdminRateLimitOverridesPage", () => {
     expect(optionValues).toContain("reports.query");
     expect(optionValues).toContain("accounts.adjust_balance");
 
-    // Pre-auth annotation visible on at least one option.
+    // Overridable options are NOT disabled.
+    const overridableOption = Array.from(dropdown.options).find(
+      (o) => o.value === "reports.query",
+    );
+    expect(overridableOption?.disabled).toBe(false);
+
+    // Pre-auth options ARE disabled — this is the behavioral guard.
     const preAuthOption = Array.from(dropdown.options).find(
       (o) => o.value === "auth.login",
     );
-    expect(preAuthOption?.textContent).toMatch(/pre-auth/i);
+    expect(preAuthOption?.disabled).toBe(true);
+    // Tooltip explains why so the surface stays discoverable.
+    expect(preAuthOption?.title).toMatch(/pre-auth/i);
+
+    // Pre-auth options are grouped under an optgroup labelled to
+    // explain the disabled state.
+    const optgroup = dropdown.querySelector("optgroup");
+    expect(optgroup?.getAttribute("label")).toMatch(/pre-auth/i);
+  });
+
+  it("surfaces a typed 422 when the backend rejects a pre-auth pattern", async () => {
+    // Defensive: if the disabled-in-dropdown gate is somehow bypassed
+    // (devtools, stale catalogue, etc.) the backend's typed 422 must
+    // still surface to the operator with the right message.
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    fireEvent.click(screen.getByRole("button", { name: /Add override/i }));
+    await screen.findByRole("heading", { name: /New override/i });
+
+    // Force-pick a pre-auth pattern by setting the select's value
+    // directly (operator-bypassed disabled state).
+    const dropdown = screen.getByLabelText(
+      "Endpoint pattern",
+    ) as HTMLSelectElement;
+    Object.defineProperty(dropdown, "value", {
+      writable: true,
+      value: "auth.login",
+    });
+    fireEvent.change(dropdown, { target: { value: "auth.login" } });
+    fireEvent.change(screen.getByLabelText(/^Org id$/i), {
+      target: { value: "1" },
+    });
+    fireEvent.change(screen.getByLabelText(/Max requests/i), {
+      target: { value: "10" },
+    });
+    fireEvent.change(screen.getByLabelText(/Period \(seconds\)/i), {
+      target: { value: "60" },
+    });
+
+    // Backend rejects the submit with the typed 422.
+    apiFetchMock.mockImplementationOnce(() =>
+      Promise.reject(
+        new Error(
+          "endpoint_pattern_pre_auth_non_overridable: endpoint 'auth.login' is a pre-auth route; overrides are not honored. Adjust the slowapi decorator default in code instead.",
+        ),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    expect(
+      await screen.findByText(/pre-auth route/i),
+    ).toBeInTheDocument();
   });
 
   it("validates that an endpoint pattern is selected before submit", async () => {

--- a/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
+++ b/frontend/tests/app/admin-rate-limit-overrides-page.test.tsx
@@ -69,12 +69,38 @@ const LIST_RESPONSE = {
   total: 1,
 };
 
+const CATALOGUE_RESPONSE = {
+  patterns: [
+    "accounts.adjust_balance",
+    "auth.login",
+    "auth.register",
+    "reports.query",
+  ],
+  pre_auth_patterns: ["auth.login", "auth.register"],
+};
+
+// Helper: every URL the page fetches gets the canned response so
+// the order of effects doesn't matter for the test. The page fires
+// both /endpoint-catalogue and the list URL in parallel, and
+// neither orders deterministically against React's effect queue.
+function defaultApiFetchMock(url: string) {
+  if (String(url).includes("/endpoint-catalogue")) {
+    return Promise.resolve(CATALOGUE_RESPONSE);
+  }
+  return Promise.resolve(LIST_RESPONSE);
+}
+
 describe("AdminRateLimitOverridesPage", () => {
   const apiFetchMock = vi.mocked(apiFetch);
   const useAuthMock = vi.mocked(useAuth);
 
   beforeEach(() => {
     apiFetchMock.mockReset();
+    // Default: every URL the page fetches resolves with the canned
+    // response (catalogue or list). Individual tests can still chain
+    // ``mockImplementationOnce`` if they need a specific sequence.
+    apiFetchMock.mockImplementation(((url: string) =>
+      defaultApiFetchMock(url)) as never);
     replaceMock.mockReset();
     useAuthMock.mockReturnValue({
       user: SUPERADMIN as never,
@@ -88,8 +114,6 @@ describe("AdminRateLimitOverridesPage", () => {
   });
 
   it("renders overrides for a superadmin", async () => {
-    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
-
     render(<AdminRateLimitOverridesPage />);
 
     await screen.findByText("auth.login");
@@ -118,8 +142,6 @@ describe("AdminRateLimitOverridesPage", () => {
   });
 
   it("opens the add modal when Add override is clicked", async () => {
-    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
-
     render(<AdminRateLimitOverridesPage />);
 
     await screen.findByText("auth.login");
@@ -133,8 +155,6 @@ describe("AdminRateLimitOverridesPage", () => {
   });
 
   it("opens the edit modal pre-populated with the row's values", async () => {
-    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
-
     render(<AdminRateLimitOverridesPage />);
 
     await screen.findByText("auth.login");
@@ -147,10 +167,6 @@ describe("AdminRateLimitOverridesPage", () => {
   });
 
   it("opens the delete confirm dialog and POSTs DELETE on confirm", async () => {
-    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never); // initial GET
-    apiFetchMock.mockResolvedValueOnce(undefined as never); // DELETE
-    apiFetchMock.mockResolvedValueOnce({ items: [], total: 0 } as never); // refresh
-
     render(<AdminRateLimitOverridesPage />);
 
     await screen.findByText("auth.login");
@@ -173,9 +189,6 @@ describe("AdminRateLimitOverridesPage", () => {
   });
 
   it("filters by endpoint pattern via the search input", async () => {
-    apiFetchMock.mockResolvedValueOnce(LIST_RESPONSE as never);
-    apiFetchMock.mockResolvedValueOnce({ items: [], total: 0 } as never);
-
     render(<AdminRateLimitOverridesPage />);
 
     await screen.findByText("auth.login");
@@ -184,8 +197,84 @@ describe("AdminRateLimitOverridesPage", () => {
       { target: { value: "auth.register" } },
     );
     await waitFor(() => {
-      const lastCall = apiFetchMock.mock.calls.at(-1);
-      expect(String(lastCall![0])).toContain("endpoint_pattern=auth.register");
+      const listCalls = apiFetchMock.mock.calls.filter(
+        (c) =>
+          String(c[0]).startsWith("/api/v1/admin/rate-limit-overrides?") ||
+          String(c[0]).startsWith("/api/v1/admin/rate-limit-overrides?"),
+      );
+      const lastListCall = listCalls.at(-1);
+      expect(lastListCall).toBeTruthy();
+      expect(String(lastListCall![0])).toContain(
+        "endpoint_pattern=auth.register",
+      );
     });
+  });
+
+  it("renders the endpoint catalogue items in the form dropdown", async () => {
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    fireEvent.click(screen.getByRole("button", { name: /Add override/i }));
+    await screen.findByRole("heading", { name: /New override/i });
+
+    // The dropdown shows every catalogue pattern, and pre-auth ones
+    // are annotated so the operator sees the warning at pick time.
+    const dropdown = screen.getByLabelText(
+      "Endpoint pattern",
+    ) as HTMLSelectElement;
+    const optionValues = Array.from(dropdown.options).map((o) => o.value);
+    expect(optionValues).toContain("auth.login");
+    expect(optionValues).toContain("auth.register");
+    expect(optionValues).toContain("reports.query");
+    expect(optionValues).toContain("accounts.adjust_balance");
+
+    // Pre-auth annotation visible on at least one option.
+    const preAuthOption = Array.from(dropdown.options).find(
+      (o) => o.value === "auth.login",
+    );
+    expect(preAuthOption?.textContent).toMatch(/pre-auth/i);
+  });
+
+  it("validates that an endpoint pattern is selected before submit", async () => {
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    fireEvent.click(screen.getByRole("button", { name: /Add override/i }));
+    await screen.findByRole("heading", { name: /New override/i });
+
+    // Leave the dropdown at its default empty value and submit. The
+    // page-level guard surfaces the error before any network call.
+    // (The native HTML5 ``required`` on the <select> would also
+    // block submission, but we additionally surface a friendly
+    // message via setSubmitError.)
+    const form = screen.getByRole("heading", {
+      name: /New override/i,
+    }).closest("form");
+    expect(form).not.toBeNull();
+    // Bypass the browser's built-in required-field gate so we can
+    // assert the JS-level validator fires too.
+    form!.setAttribute("novalidate", "true");
+    // Fill the required numeric fields so the only missing one is
+    // the dropdown.
+    fireEvent.change(screen.getByLabelText(/^Org id$/i), {
+      target: { value: "1" },
+    });
+    fireEvent.change(screen.getByLabelText(/Max requests/i), {
+      target: { value: "10" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    expect(
+      await screen.findByText(/Pick an endpoint from the catalogue/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the pre-auth limitation callout", async () => {
+    render(<AdminRateLimitOverridesPage />);
+
+    await screen.findByText("auth.login");
+    expect(
+      screen.getByRole("note", { name: /Pre-auth limitation/i }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `rate_limit_overrides` table + admin CRUD endpoints (`/api/v1/admin/rate-limit-overrides`, superadmin-only) so a platform admin can bump or throttle a specific org or user beyond the default per-route rate limits without redeploying.
- Resolver consults user override first, then org override, then falls through to the slowapi decorator default. Hot-path lookup is Redis-cached for 60 s (positive + negative cache, invalidated on every mutation) and fails open on Redis or DB error to match the project-wide rate-limit fail-open stance.
- Integration helper `dynamic_limit("endpoint.key", "20/minute")` returns a slowapi-compatible callable. Call sites can opt in at the decorator without rewriting the limiter shape; default unchanged where the helper is not adopted.
- Every mutation writes an `admin.rate_limit.{created,updated,deleted}` row to `audit_events` on an independent session, mirroring the announcement / org-rename audit pattern.
- New `/admin/rate-limit-overrides` page (list + filter + add / edit modal + delete confirm) plus AppShell nav entry and admin-hub tile. Superadmin-only gate using the forward-compatible `rate_limit_overrides.manage` permission key.

## Cross-team handoff

- `audit_events.event_type` keys: `admin.rate_limit.created`, `admin.rate_limit.updated`, `admin.rate_limit.deleted`. `detail` carries override_id, scope, org_id, user_id, endpoint_pattern, max_requests, period_seconds, expires_at, plus `patched_fields` on updates.
- Migration 060 (`rate_limit_overrides`).
- Tests: 11 service + 12 router + 7 integration backend, 6 frontend page tests.