### PR TITLE
docs(plans): soften unsourced return/inflation claims (follow-up to merged #356)

### DIFF
--- a/frontend/app/docs/plans/page.tsx
+++ b/frontend/app/docs/plans/page.tsx
@@ -210,10 +210,14 @@ export default function PlansDocsPage() {
             <p>
               Both annual return and annual inflation are expressed as
               percentages and converted to monthly factors internally.
-              Long-term stock market average return is around 6 to 8
-              percent; the Eurozone inflation target is 2 percent and
-              the 30-year historical average is around 2.5 to 3
-              percent. Your own assumptions are what matters.
+              Common assumptions for long-term diversified stock
+              portfolios range from 5 to 8 percent annually; check
+              your own risk tolerance and historical returns for your
+              asset mix. The European Central Bank targets 2 percent
+              annual inflation; actual long-run averages vary by
+              decade and by country, so use a value that matches your
+              assumptions for the period you are projecting. Your own
+              assumptions are what matters.
             </p>
 
             <h3>Smooth with regression</h3>


### PR DESCRIPTION
## Summary
Architect follow-up to merged PR #356. The math explainer in `/docs/plans` made two un-sourced quantitative claims (stock return 6 to 8 percent, 30-year inflation average 2.5 to 3 percent). This softens them to non-committal language that points readers to their own assumptions, keeping only the ECB 2 percent policy target since that one is a stable, citable fact.

Single file changed, copy-only, no behavior change. Existing tests pass; em-dash voice test passes.

## Before
> Long-term stock market average return is around 6 to 8 percent; the Eurozone inflation target is 2 percent and the 30-year historical average is around 2.5 to 3 percent. Your own assumptions are what matters.

## After
> Common assumptions for long-term diversified stock portfolios range from 5 to 8 percent annually; check your own risk tolerance and historical returns for your asset mix. The European Central Bank targets 2 percent annual inflation; actual long-run averages vary by decade and by country, so use a value that matches your assumptions for the period you are projecting. Your own assumptions are what matters.