### PR TITLE
feat(l4-4): permissions + audit-event taxonomy seed (PR1 of admin-slices train)

### DIFF
--- a/backend/app/auth/permissions.py
+++ b/backend/app/auth/permissions.py
@@ -30,6 +30,13 @@ Permission = Literal[
     "users.view",
     "users.delete",
     "subscriptions.view",
+    # L4.4 admin slices (2026-05-22). Superadmin-only via the
+    # is_superadmin short-circuit for v1; ROLE_PERMISSIONS stays
+    # empty for non-superadmin platform roles until L4.8 introduces
+    # the role editor. See specs/2026-05-22-l4-4-admin-slices.md §1.
+    "users.invite",            # platform-admin invite (mint new is_superadmin user)
+    "users.reset_credentials", # admin-triggered password / email / MFA reset
+    "users.impersonate",       # mint + exit a read-only impersonation session
 ]
 
 
@@ -42,6 +49,12 @@ Permission = Literal[
 # (search/detail) surface is widely useful for support work while
 # the destructive surface should remain superadmin-only even if a
 # future support role inherits users.view via ROLE_PERMISSIONS.
+#
+# users.invite / users.reset_credentials / users.impersonate (added
+# 2026-05-22) gate the three L4.4 admin slices. Kept distinct from
+# users.view + users.delete so a future support role can read users
+# without inheriting the ability to invite platform admins, reset
+# credentials out-of-band, or impersonate.
 ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "admin.view",
     "plans.manage",
@@ -53,6 +66,9 @@ ALL_PERMISSIONS: frozenset[Permission] = frozenset({
     "users.view",
     "users.delete",
     "subscriptions.view",
+    "users.invite",
+    "users.reset_credentials",
+    "users.impersonate",
 })
 
 

--- a/backend/app/models/audit_event.py
+++ b/backend/app/models/audit_event.py
@@ -25,6 +25,49 @@ Two design choices worth restating in code:
    org name at the moment of the event, which is the only sane
    thing to display in the UI after the org is gone. Same trick for
    ``actor_user_id`` / ``actor_email``.
+
+L4.4 admin-slices event-type taxonomy (seeded 2026-05-22, spec
+``specs/2026-05-22-l4-4-admin-slices.md`` §8). These strings are
+the durable contract every L4.4 router commits to emit; the
+implementation lives in PRs 2-5 of the train. Listed here so a
+``grep`` for the event-type string lands on a stable definition
+even before the emitting code arrives.
+
+* ``admin.platform_admin.invitation.sent`` — superadmin issues a
+  platform-admin invitation. actor=superadmin, target_org_id=NULL.
+* ``admin.platform_admin.invitation.revoked`` — pending invite
+  cancelled. actor=superadmin, target_org_id=NULL.
+* ``admin.platform_admin.invitation.accepted`` — invitee creates
+  their is_superadmin=True user. actor=new user (self-target),
+  target_org_id=new org's id.
+* ``admin.user.password_reset.triggered`` — admin-triggered
+  out-of-band password reset email. actor=superadmin,
+  target_org_id=target.org_id.
+* ``admin.user.email_change.triggered`` — admin-triggered email
+  change with two-key typed confirmation. actor=superadmin,
+  target_org_id=target.org_id. Note: when the target user later
+  confirms via verification link, an additional ``user.email.changed``
+  row is written (existing user-initiated convention).
+* ``admin.user.mfa_disabled`` — admin clears mfa_enabled +
+  totp_secret + recovery_codes server-side; user re-enrols on next
+  login. actor=superadmin, target_org_id=target.org_id. REQUIRED
+  ``detail.reason`` (free text, max 200).
+* ``admin.impersonation.entered`` — read-only impersonation session
+  starts; 15-min Redis-backed jti. actor=superadmin,
+  target_org_id=target.org_id.
+* ``admin.impersonation.exited`` — read-only impersonation session
+  ends (manual exit or natural expiry). actor=superadmin,
+  target_org_id=target.org_id. ``detail.ended_by`` distinguishes
+  ``manual`` from ``expiry``.
+* ``admin.impersonation.revoked`` — impersonation session force-
+  ended because the actor lost ``is_superadmin`` mid-session (Q6
+  lock, §5.7). actor=ex-superadmin, target_org_id from session
+  blob. ``detail.reason="actor_superadmin_revoked"``.
+
+The existing ``org.invitation.sent`` / ``org.invitation.accepted``
+event types gain a ``detail.via_platform_admin: true`` flag when
+issued by a superadmin acting on an org (no new event_type — the
+flag rides on the existing row). Implementation in PR 2.
 """
 from __future__ import annotations
 

--- a/backend/tests/auth/test_permissions.py
+++ b/backend/tests/auth/test_permissions.py
@@ -56,7 +56,39 @@ def test_all_permissions_contains_known_platform_permissions() -> None:
         "users.view",
         "users.delete",
         "subscriptions.view",
+        # L4.4 admin slices — see specs/2026-05-22-l4-4-admin-slices.md §1.
+        "users.invite",
+        "users.reset_credentials",
+        "users.impersonate",
     })
+
+
+def test_l4_4_permissions_grant_to_superadmin_via_short_circuit() -> None:
+    superadmin = make_user(is_superadmin=True)
+
+    assert has_permission(superadmin, "users.invite") is True
+    assert has_permission(superadmin, "users.reset_credentials") is True
+    assert has_permission(superadmin, "users.impersonate") is True
+
+
+def test_l4_4_permissions_denied_to_non_superadmin_by_default() -> None:
+    user = make_user()
+
+    assert has_permission(user, "users.invite") is False
+    assert has_permission(user, "users.reset_credentials") is False
+    assert has_permission(user, "users.impersonate") is False
+
+
+def test_require_permission_factory_accepts_l4_4_permission_strings() -> None:
+    # All three new permissions can be passed to require_permission()
+    # and produce stable dependency names. This pins the Literal-typed
+    # Permission contract so a future rename surfaces here, not at
+    # the call site.
+    for perm in ("users.invite", "users.reset_credentials", "users.impersonate"):
+        dependency = require_permission(perm)  # type: ignore[arg-type]
+        assert dependency.__name__ == (
+            f"require_permission_{perm.replace('.', '_')}"
+        )
 
 
 def test_has_permission_grants_everything_to_superadmins() -> None:

--- a/backend/tests/models/test_audit_event_taxonomy.py
+++ b/backend/tests/models/test_audit_event_taxonomy.py
@@ -1,7 +1,7 @@
 """Pins the L4.4 audit-event taxonomy seeded in ``audit_event.__doc__``.
 
 This is the substrate-PR (PR 1 of the L4.4 admin-slices train) safety
-net: the eight new event-type strings are documented in the model's
+net: the nine new event-type strings are documented in the model's
 module docstring. A future careless edit that drops the contract while
 the emitting routers (PRs 2-5) reference these strings would break this
 test and force a conscious update.
@@ -13,7 +13,7 @@ from __future__ import annotations
 import app.models.audit_event as audit_event_module
 
 
-# The eight new event-type strings PR 2-5 will emit. Listed verbatim
+# The nine new event-type strings PR 2-5 will emit. Listed verbatim
 # (no f-strings, no concatenation) so a grep on any one of these lands
 # both here and at the docstring.
 L4_4_NEW_AUDIT_EVENT_TYPES = (

--- a/backend/tests/models/test_audit_event_taxonomy.py
+++ b/backend/tests/models/test_audit_event_taxonomy.py
@@ -1,0 +1,53 @@
+"""Pins the L4.4 audit-event taxonomy seeded in ``audit_event.__doc__``.
+
+This is the substrate-PR (PR 1 of the L4.4 admin-slices train) safety
+net: the eight new event-type strings are documented in the model's
+module docstring. A future careless edit that drops the contract while
+the emitting routers (PRs 2-5) reference these strings would break this
+test and force a conscious update.
+
+Spec: ``specs/2026-05-22-l4-4-admin-slices.md`` §8.
+"""
+from __future__ import annotations
+
+import app.models.audit_event as audit_event_module
+
+
+# The eight new event-type strings PR 2-5 will emit. Listed verbatim
+# (no f-strings, no concatenation) so a grep on any one of these lands
+# both here and at the docstring.
+L4_4_NEW_AUDIT_EVENT_TYPES = (
+    "admin.platform_admin.invitation.sent",
+    "admin.platform_admin.invitation.revoked",
+    "admin.platform_admin.invitation.accepted",
+    "admin.user.password_reset.triggered",
+    "admin.user.email_change.triggered",
+    "admin.user.mfa_disabled",
+    "admin.impersonation.entered",
+    "admin.impersonation.exited",
+    "admin.impersonation.revoked",
+)
+
+
+def test_module_docstring_documents_each_l4_4_event_type() -> None:
+    doc = audit_event_module.__doc__ or ""
+
+    for event_type in L4_4_NEW_AUDIT_EVENT_TYPES:
+        assert event_type in doc, (
+            f"L4.4 event type {event_type!r} is missing from "
+            "audit_event.py's module docstring. The taxonomy seed "
+            "is the substrate contract for PRs 2-5 of the train; "
+            "see specs/2026-05-22-l4-4-admin-slices.md §8."
+        )
+
+
+def test_via_platform_admin_flag_documented() -> None:
+    # The org-admin invite reuses the existing org.invitation.sent /
+    # org.invitation.accepted event types; the L4.4 spec adds a
+    # detail.via_platform_admin flag instead of a new event type.
+    # PR 2 must hook this in; the seed records it in the docstring.
+    doc = audit_event_module.__doc__ or ""
+
+    assert "via_platform_admin" in doc
+    assert "org.invitation.sent" in doc
+    assert "org.invitation.accepted" in doc


### PR DESCRIPTION
## Summary

Substrate-only PR — the L4.4 admin-slices train's first step.

- Adds three superadmin-only permissions to `app/auth/permissions.py`: `users.invite`, `users.reset_credentials`, `users.impersonate`. Granted via the existing `is_superadmin` short-circuit; `ROLE_PERMISSIONS` stays empty until L4.8.
- Seeds the nine new audit `event_type` strings as a taxonomy table in `audit_event.py`'s module docstring so a `grep` for any string lands on a stable definition before PRs 2-5 emit the rows.
- Documents the `detail.via_platform_admin` flag that piggy-backs on the existing `org.invitation.sent` / `org.invitation.accepted` events.

No new endpoints, no migration, no service code, no frontend. 144 lines including tests.

## Train order

This is PR1 of 5. Following PRs are independent of each other and land in dependency order:

- **PR1 (this PR)** — permissions + audit taxonomy seed
- PR2 — admin invite (org-admin + platform-admin, new `platform_admin_invitations` table + migration `061`)
- PR3 — account-recovery resets (password / email / MFA) + reset-spike alert
- PR4 — impersonation backend (token + pure-ASGI middleware + Redis jti)
- PR5 — impersonation UI + session-end notification

Spec: `specs/2026-05-22-l4-4-admin-slices.md` §1, §8, §15.

## Tests

12 passing (6 existing + 4 new permission tests + 2 new taxonomy tests). Broader audit + auth sweep (127 tests) green.