### PR TITLE
feat(plans): AI engine wrapper around analytic baseline (PR4)

### DIFF
--- a/backend/app/routers/scenarios.py
+++ b/backend/app/routers/scenarios.py
@@ -15,18 +15,20 @@ Mounted at ``/api/v1/scenarios``. Architect-locked:
   ``WorldState`` snapshot. It writes the projection blob back onto
   the ``Scenario`` row and commits — nothing else.
 - ``compare`` endpoint is PR3 (out of scope for PR1).
-- ``ai_enhanced`` engine raises NotImplementedError (PR4 stub).
+- ``ai_enhanced`` engine routes through ``scenario_engine_ai.run_ai_simulation``
+  which gate-checks ``ai.smart_plan`` + smart_plan routing and falls
+  back to the analytic baseline on any failure (PR4).
 """
 from __future__ import annotations
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app._time import utcnow_naive
 from app.database import get_db
-from app.deps import get_current_user
+from app.deps import get_current_user, get_session_factory
 from app.models.account import Account
 from app.models.category import Category
 from app.models.recurring import RecurringTransaction
@@ -48,6 +50,7 @@ from app.services.scenario_engine import (
     build_world_state,
     get_engine,
 )
+from app.services.scenario_engine_ai import run_ai_simulation
 
 
 logger = structlog.stdlib.get_logger()
@@ -228,9 +231,13 @@ async def delete_scenario(
 )
 async def simulate_scenario(
     scenario_id: int,
+    request: Request,
     body: SimulateRequest | None = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(
+        get_session_factory
+    ),
 ):
     """Run the configured engine and cache the projection on the row.
 
@@ -243,7 +250,14 @@ async def simulate_scenario(
          against the per-type cap.
       3. Builds a frozen WorldState snapshot via build_world_state
          (READ-ONLY).
-      4. Runs the engine (no DB session inside the engine).
+      4. Runs the engine. For ``engine="analytic"`` the sync analytic
+         engine runs directly; for ``engine="ai_enhanced"`` we
+         delegate to the async ``run_ai_simulation`` orchestrator,
+         which calls the LLM via ``call_llm_structured``, adjusts
+         assumptions, and re-runs the analytic engine. The
+         orchestrator always falls back to the analytic baseline on
+         any failure (gate closed, no routing, dispatch error,
+         schema mismatch) so the frontend never crashes.
       5. Writes the projection back onto the scenario row and commits.
 
     Sandboxing: the engine has no path to mutate accounts /
@@ -260,25 +274,48 @@ async def simulate_scenario(
         db, org_id=current_user.org_id, user_id=current_user.id
     )
 
-    engine = get_engine(payload.engine)
-    sim_request = SimulationRequest(
-        scenario=row,
-        state=state,
-        horizon_months=horizon,
-        options=payload.options,
-    )
-
-    # The regression-overlay flag is a top-level field on
-    # ``SimulateRequest`` (architect-locked spec), passed explicitly as
-    # a kwarg to the engine. The engine never reads it from
-    # ``req.options`` — there is exactly one source of truth.
-    result = engine.simulate(
-        sim_request,
-        smooth_with_regression=payload.smooth_with_regression,
-    )
+    if payload.engine == "ai_enhanced":
+        # AI orchestrator: gate-check, call LLM, adjust assumptions,
+        # re-run analytic, audit. Falls back to analytic baseline on
+        # any failure mode (see scenario_engine_ai.run_ai_simulation).
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=current_user.org_id,
+            user_id=current_user.id,
+            actor_email=current_user.email,
+            scenario=row,
+            state=state,
+            horizon_months=horizon,
+            options=payload.options,
+            smooth_with_regression=payload.smooth_with_regression,
+            request_id=getattr(request.state, "request_id", None),
+            ip_address=getattr(request.client, "host", None),
+        )
+        engine_name = result.get("engine_name") or "ai_enhanced"
+    else:
+        # Analytic baseline (default). Sync engine; no DB session
+        # passed in — the engine math has no path to the DB.
+        engine = get_engine(payload.engine)
+        sim_request = SimulationRequest(
+            scenario=row,
+            state=state,
+            horizon_months=horizon,
+            options=payload.options,
+        )
+        # The regression-overlay flag is a top-level field on
+        # ``SimulateRequest`` (architect-locked spec), passed
+        # explicitly as a kwarg to the engine. The engine never reads
+        # it from ``req.options`` — there is exactly one source of
+        # truth.
+        result = engine.simulate(
+            sim_request,
+            smooth_with_regression=payload.smooth_with_regression,
+        )
+        engine_name = result.get("engine_name") or engine.name
 
     row.projection_json = result
-    row.projection_engine = result.get("engine_name") or engine.name
+    row.projection_engine = engine_name
     row.projection_computed_at = utcnow_naive()
     await db.commit()
     await db.refresh(row)

--- a/backend/app/services/scenario_engine.py
+++ b/backend/app/services/scenario_engine.py
@@ -11,9 +11,12 @@ Architect-locked invariants:
   ``tests/services/test_scenario_engine.py`` pins this with a
   row-count delta assertion.
 - ``ScenarioEngine`` is the ABC. ``AnalyticEngine`` is the
-  deterministic baseline. ``AIEngine`` is the PR4 stub that raises
-  ``NotImplementedError("PR4")`` on simulate; ``analytic`` is the
-  default everywhere.
+  deterministic baseline. ``AIEngine`` is the registry stub whose
+  sync ``simulate`` returns the analytic baseline (safe fallback);
+  the real AI orchestration is async and lives in
+  ``scenario_engine_ai.run_ai_simulation``, called by the router
+  when ``engine="ai_enhanced"``. ``analytic`` is the default
+  everywhere.
 - Output shape is engine-agnostic so the UI doesn't care which engine
   ran. Mirrors ``schemas/scenario.py::ProjectionResult``.
 - Math reuses ``app/services/date_utils.py::advance_date`` for
@@ -557,20 +560,24 @@ class AnalyticEngine(ScenarioEngine):
         return result
 
 
-# ── AI engine (stub for PR4) ────────────────────────────────────────────
+# ── AI engine ───────────────────────────────────────────────────────────
 
 
 class AIEngine(ScenarioEngine):
-    """AI-enhanced engine — STUB for PR1.
+    """AI-enhanced engine.
 
-    Real implementation lands in PR4 when Team E's AI Tier SDK is
-    available. Until then, calling ``simulate`` raises
-    ``NotImplementedError("PR4")`` so the engine selector in the
-    router stays honest (a misconfigured request gets a hard error,
-    not a silent analytic fallback).
+    The real AI orchestration lives in ``scenario_engine_ai.py`` and is
+    async (it needs a DB session to read feature gates, talk to the
+    LLM dispatcher, and write audit rows). The router calls that
+    orchestrator directly when ``engine="ai_enhanced"``.
 
-    The signature is identical to ``AnalyticEngine.simulate`` so the
-    router can swap engines without any other change.
+    This class stays in the engine registry so ``get_engine`` keeps
+    returning a typed instance for callers that need the engine
+    contract (e.g. tests, future synchronous code paths). The
+    sync ``simulate`` method here delegates to the analytic baseline
+    — it is the "safe fallback" when an AI invocation cannot run for
+    any reason. The wrapper's full output shape (with provenance) is
+    only produced by the async orchestrator, NOT by this sync path.
     """
 
     name = "ai_enhanced"
@@ -580,8 +587,13 @@ class AIEngine(ScenarioEngine):
         req: SimulationRequest,
         *,
         smooth_with_regression: bool = False,
-    ) -> dict[str, Any]:  # pragma: no cover
-        raise NotImplementedError("PR4")
+    ) -> dict[str, Any]:
+        # Sync fallback. Returns the analytic baseline so callers that
+        # cannot orchestrate the async AI path (e.g. compare endpoint,
+        # tests) still get a sensible projection.
+        return AnalyticEngine().simulate(
+            req, smooth_with_regression=smooth_with_regression
+        )
 
 
 # ── World-state assembler (DB → engine boundary) ────────────────────────

--- a/backend/app/services/scenario_engine_ai.py
+++ b/backend/app/services/scenario_engine_ai.py
@@ -200,9 +200,16 @@ async def run_ai_simulation(
         horizon_months=horizon_months,
         options=options,
     )
-    baseline = analytic.simulate(
-        baseline_request, smooth_with_regression=smooth_with_regression
-    )
+
+    def _baseline() -> dict[str, Any]:
+        """Compute the analytic baseline. Called only on fallback paths;
+        the AI-success path re-runs analytic with adjusted params
+        instead, so computing eagerly would double the simulator work
+        for every AI-engaged request.
+        """
+        return analytic.simulate(
+            baseline_request, smooth_with_regression=smooth_with_regression
+        )
 
     # 1. Gate check. AI Tier off → return the baseline unchanged. No
     #    LLM call, no audit row (audit fires only when the AI path
@@ -218,30 +225,39 @@ async def run_ai_simulation(
             scenario_id=scenario.id,
             error_class=type(exc).__name__,
         )
-        return baseline
+        return _baseline()
     if not gate_open:
         logger.info(
             "plans.ai.gate.closed",
             org_id=org_id,
             scenario_id=scenario.id,
         )
-        return baseline
+        return _baseline()
 
     # 2. Build the prompt and call the dispatcher. The dispatcher
     #    handles routing, cap enforcement, ledger writes, and retries
     #    on schema mismatch — we just consume its result.
+    #
+    # The dispatcher commits the session it's given (the ledger row
+    # write does an `await db.commit()`). To keep that commit
+    # isolated from the request transaction — and from any other
+    # work the wrapper might stage on `db` — we open a dedicated
+    # session for the dispatch call. Same pattern as the audit
+    # pipeline below.
     prompt_messages = _build_prompt_messages(scenario, state, horizon_months)
     fallback_reason: Optional[str] = None
+    validation_errors: Optional[dict[str, Any]] = None
     delta: Optional[AIAssumptionDelta] = None
 
     try:
-        dispatch_result = await call_llm_structured(
-            db,
-            org_id=org_id,
-            feature_key=ROUTING_FEATURE_KEY,
-            messages=prompt_messages,
-            response_schema=AI_ASSUMPTION_SCHEMA,
-        )
+        async with session_factory() as dispatch_db:
+            dispatch_result = await call_llm_structured(
+                dispatch_db,
+                org_id=org_id,
+                feature_key=ROUTING_FEATURE_KEY,
+                messages=prompt_messages,
+                response_schema=AI_ASSUMPTION_SCHEMA,
+            )
     except NoRoutingConfigured:
         fallback_reason = "no_routing"
     except AICapExceeded:
@@ -272,23 +288,42 @@ async def run_ai_simulation(
         # Parse strictly via Pydantic. The dispatcher's structural
         # validator only checks top-level required keys; the Pydantic
         # model rejects malformed adjustment objects (the real
-        # tripwire). On parse failure we fall back to analytic — the
-        # operator sees the schema error in the audit row's detail.
+        # tripwire). On parse failure we fall back to analytic and
+        # surface a compact error summary in the audit row's detail
+        # so an operator can tell at-a-glance why the LLM was
+        # rejected without having to grep logs.
         try:
             delta = AIAssumptionDelta.model_validate(
                 dispatch_result.response.parsed
             )
         except ValidationError as exc:
+            errs = exc.errors()
+            validation_errors = {
+                "count": len(errs),
+                "first_type": errs[0].get("type") if errs else None,
+                "first_loc": (
+                    ".".join(str(p) for p in errs[0].get("loc", ()))
+                    if errs
+                    else None
+                ),
+            }
             logger.warning(
                 "plans.ai.schema.invalid",
                 org_id=org_id,
                 scenario_id=scenario.id,
-                error_count=len(exc.errors()),
+                **validation_errors,
             )
             fallback_reason = "schema_invalid"
 
     # 3. If anything went wrong, return baseline + audit the fallback.
     if delta is None:
+        failure_detail: dict[str, Any] = {
+            "scenario_id": scenario.id,
+            "reason": fallback_reason or "unknown",
+            "applied_adjustments": 0,
+        }
+        if validation_errors is not None:
+            failure_detail["validation_errors"] = validation_errors
         await _record_audit(
             session_factory,
             org_id=org_id,
@@ -296,15 +331,11 @@ async def run_ai_simulation(
             actor_email=actor_email,
             scenario=scenario,
             outcome="failure",
-            detail={
-                "scenario_id": scenario.id,
-                "reason": fallback_reason or "unknown",
-                "applied_adjustments": 0,
-            },
+            detail=failure_detail,
             request_id=request_id,
             ip_address=ip_address,
         )
-        return baseline
+        return _baseline()
 
     # 4. Apply whitelisted adjustments to a deep-copied params blob and
     #    re-run the analytic engine. Track every adjustment in
@@ -349,7 +380,7 @@ async def run_ai_simulation(
             request_id=request_id,
             ip_address=ip_address,
         )
-        return baseline
+        return _baseline()
 
     # 5. Re-run analytic engine with the adjusted params. The scenario
     #    object's params_json is mutated in-place for the duration of

--- a/backend/app/services/scenario_engine_ai.py
+++ b/backend/app/services/scenario_engine_ai.py
@@ -89,6 +89,20 @@ ASSUMPTION_FIELD_WHITELIST: frozenset[str] = frozenset(
     }
 )
 
+# Per-field numeric bounds for LLM-proposed values. The whitelist
+# guards WHICH fields can change; these bounds guard WHAT VALUES are
+# allowed. An LLM hallucinating a 500% annual return or a negative
+# monthly contribution silently distorts the projection — out-of-range
+# values are rejected before the analytic engine sees them. Ranges are
+# intentionally permissive (e.g. allow negative annual return for
+# declining-asset scenarios, allow up to 50% inflation for stress
+# tests) so legitimate edge cases still pass.
+_FIELD_BOUNDS: dict[str, tuple[Decimal, Decimal]] = {
+    "annual_return_pct": (Decimal("-50"), Decimal("50")),
+    "inflation_pct": (Decimal("-10"), Decimal("50")),
+    "monthly_contribution": (Decimal("0"), Decimal("1000000")),
+}
+
 # JSON schema we hand to ``call_llm_structured``. The dispatcher's
 # structural validator only checks ``type``/``required`` (a deeper
 # validator is reserved for a future PR), so this is intentionally
@@ -301,8 +315,7 @@ async def run_ai_simulation(
     applied_count = 0
     for adj in delta.adjustments:
         is_whitelisted = adj.field in ASSUMPTION_FIELD_WHITELIST
-        is_numeric = _is_numeric_decimal(adj.new_value)
-        applied = is_whitelisted and is_numeric
+        applied = is_whitelisted and _is_within_bounds(adj.field, adj.new_value)
         if applied:
             new_params[adj.field] = adj.new_value
             applied_count += 1
@@ -476,16 +489,26 @@ def _build_prompt_messages(
     ]
 
 
-def _is_numeric_decimal(value: str) -> bool:
-    """True if ``value`` parses as a finite Decimal. Used to defensively
-    reject non-numeric LLM outputs (e.g. "high") before they reach
-    Decimal math in ``AnalyticEngine``.
+def _is_within_bounds(field: str, value: str) -> bool:
+    """True if ``value`` parses as a finite Decimal AND lies within
+    the per-field bounds in ``_FIELD_BOUNDS``. Used to reject both
+    non-numeric LLM outputs (e.g. ``"high"``) and out-of-range numeric
+    proposals (e.g. ``"-50.0"`` for an annual return) before they
+    reach Decimal math in ``AnalyticEngine``.
+
+    Fields not in ``_FIELD_BOUNDS`` always return False — callers
+    should pair this with the ``ASSUMPTION_FIELD_WHITELIST`` check.
     """
+    if field not in _FIELD_BOUNDS:
+        return False
     try:
         d = Decimal(value)
     except (InvalidOperation, TypeError, ValueError):
         return False
-    return d.is_finite()
+    if not d.is_finite():
+        return False
+    lo, hi = _FIELD_BOUNDS[field]
+    return lo <= d <= hi
 
 
 async def _record_audit(

--- a/backend/app/services/scenario_engine_ai.py
+++ b/backend/app/services/scenario_engine_ai.py
@@ -1,0 +1,515 @@
+"""AI-enhanced Plans simulation orchestrator (PR4 of the Plans train).
+
+Spec: ``specs/2026-05-22-plans-page-simulation-sandbox.md`` §"Simulation
+engine, AI path (layered)".
+
+Architectural shape:
+
+- ``AIEngine`` is the registry stub (sync; returns the analytic baseline
+  for safety when invoked without a DB context). The real AI flow runs
+  through ``run_ai_simulation`` below, which the router calls when the
+  request asks for ``engine="ai_enhanced"``.
+- The wrapper is purely additive — it never replaces the analytic
+  engine, it just adjusts a small whitelisted set of assumptions
+  (annual_return_pct, inflation_pct, monthly_contribution) and
+  re-runs the analytic engine. The output shape is identical; only the
+  numbers and an additional ``ai_assumptions`` provenance block
+  differ.
+- Every failure mode falls back to the analytic baseline. The frontend
+  must never crash because an LLM call timed out, returned malformed
+  JSON, or had its credentials revoked.
+- Every AI invocation (success OR fallback) emits an audit event so
+  operators can see how often the path engages and how often it
+  degrades.
+
+The AI feature gate (``ai.smart_plan``) AND a configured ``smart_plan``
+routing row are BOTH required. Gate off → analytic-only (no LLM call).
+Routing missing or any dispatch error → analytic-only with an audit row
+recording the fallback reason.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional
+
+import structlog
+from pydantic import BaseModel, ConfigDict, ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.scenario import Scenario
+from app.services import audit_service, feature_service
+from app.services.ai_dispatch import (
+    AICapExceeded,
+    AIDispatchError,
+    AIDispatchFailed,
+    NoRoutingConfigured,
+    call_llm_structured,
+)
+from app.services.ai_providers.base import (
+    NativeNotAvailable,
+    StructuredOutputError,
+)
+from app.services.scenario_engine import (
+    AnalyticEngine,
+    SimulationRequest,
+    WorldState,
+)
+
+
+logger = structlog.stdlib.get_logger()
+
+
+# Feature-gate key (see app/auth/feature_catalog.py). Gates AI-enhanced
+# plans behind an org-level entitlement so even an org with valid BYOK
+# credentials must opt in.
+AI_PLAN_FEATURE_KEY = "ai.smart_plan"
+
+# Routable feature name used by ai_routing_service / ai_dispatch.
+# Matches the entry in ``ROUTABLE_FEATURE_NAMES`` in
+# ``app/models/org_ai_routing.py`` ("smart_plan", since "ai." is the
+# entitlement-catalog prefix, not the routing key).
+ROUTING_FEATURE_KEY = "smart_plan"
+
+# Audit-event type for this slice. Single event-type emitted on every
+# AI invocation regardless of outcome; the ``outcome`` field
+# (success/failure) carries the disposition.
+AUDIT_EVENT_TYPE = "plans.scenario.ai_simulate"
+
+# Whitelist of params_json keys the wrapper is allowed to mutate. An
+# LLM-proposed adjustment to any field outside this set is logged as
+# "skipped" in provenance but never applied. Deliberately narrow —
+# the analytic baseline does the projection math; AI only nudges the
+# numeric assumptions a human user would have set manually.
+ASSUMPTION_FIELD_WHITELIST: frozenset[str] = frozenset(
+    {
+        "annual_return_pct",
+        "inflation_pct",
+        "monthly_contribution",
+    }
+)
+
+# JSON schema we hand to ``call_llm_structured``. The dispatcher's
+# structural validator only checks ``type``/``required`` (a deeper
+# validator is reserved for a future PR), so this is intentionally
+# the minimum the dispatcher needs to retry-on-mismatch. The strict
+# Pydantic re-validate below is the real tripwire.
+AI_ASSUMPTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["adjustments"],
+    "properties": {
+        "adjustments": {"type": "array"},
+        "summary": {"type": "string"},
+    },
+}
+
+
+# ── Pydantic models for the LLM contract ───────────────────────────────
+
+
+class AIAssumptionAdjustment(BaseModel):
+    """One assumption-level adjustment the LLM proposes.
+
+    ``field`` is the params_json key the LLM wants to change. The
+    wrapper enforces an allow-list (``ASSUMPTION_FIELD_WHITELIST``)
+    before applying; a non-whitelisted field is recorded in provenance
+    as ``applied=False`` and never mutates the scenario.
+
+    ``old_value`` and ``new_value`` are kept as strings so Decimal
+    quantization round-trips losslessly. The LLM is asked to format
+    them as decimal strings.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    old_value: str
+    new_value: str
+    reason: str
+
+
+class AIAssumptionDelta(BaseModel):
+    """Top-level Pydantic model for the LLM's structured response.
+
+    ``extra="forbid"`` is intentional — a model that wanders off the
+    schema is rejected so the wrapper falls back to analytic. We do
+    NOT want creative additions silently shaping the projection.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    adjustments: list[AIAssumptionAdjustment]
+    summary: str = ""
+
+
+# ── Public orchestrator ───────────────────────────────────────────────
+
+
+async def run_ai_simulation(
+    db: AsyncSession,
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+    org_id: int,
+    user_id: int,
+    actor_email: str,
+    scenario: Scenario,
+    state: WorldState,
+    horizon_months: int,
+    options: dict[str, Any],
+    smooth_with_regression: bool = False,
+    request_id: Optional[str] = None,
+    ip_address: Optional[str] = None,
+) -> dict[str, Any]:
+    """Run the AI-enhanced projection for ``scenario`` (or analytic
+    fallback if AI is gated off / unavailable / errored).
+
+    Output shape matches ``AnalyticEngine.simulate`` plus an optional
+    ``ai_assumptions`` provenance block. ``engine_name`` reflects which
+    path actually ran:
+
+    - ``"analytic_v1"`` — AI gate closed, routing missing, dispatch
+      error, schema mismatch, or zero whitelisted adjustments. The
+      result is bit-for-bit identical to what
+      ``AnalyticEngine.simulate`` would have produced.
+    - ``"analytic_v1+ai_assumptions_v1"`` — at least one whitelisted
+      adjustment was applied. The ``ai_assumptions`` block carries
+      provenance for every adjustment the LLM proposed (applied or
+      skipped) plus the model's ``summary``.
+
+    The caller (router) writes the result back onto the Scenario row.
+    This function never touches the row itself.
+    """
+    analytic = AnalyticEngine()
+    baseline_request = SimulationRequest(
+        scenario=scenario,
+        state=state,
+        horizon_months=horizon_months,
+        options=options,
+    )
+    baseline = analytic.simulate(
+        baseline_request, smooth_with_regression=smooth_with_regression
+    )
+
+    # 1. Gate check. AI Tier off → return the baseline unchanged. No
+    #    LLM call, no audit row (audit fires only when the AI path
+    #    was at least attempted).
+    try:
+        gate_open = await feature_service.has_feature(
+            db, org_id, AI_PLAN_FEATURE_KEY
+        )
+    except Exception as exc:  # noqa: BLE001 - defensive
+        logger.warning(
+            "plans.ai.gate_check.failed",
+            org_id=org_id,
+            scenario_id=scenario.id,
+            error_class=type(exc).__name__,
+        )
+        return baseline
+    if not gate_open:
+        logger.info(
+            "plans.ai.gate.closed",
+            org_id=org_id,
+            scenario_id=scenario.id,
+        )
+        return baseline
+
+    # 2. Build the prompt and call the dispatcher. The dispatcher
+    #    handles routing, cap enforcement, ledger writes, and retries
+    #    on schema mismatch — we just consume its result.
+    prompt_messages = _build_prompt_messages(scenario, state, horizon_months)
+    fallback_reason: Optional[str] = None
+    delta: Optional[AIAssumptionDelta] = None
+
+    try:
+        dispatch_result = await call_llm_structured(
+            db,
+            org_id=org_id,
+            feature_key=ROUTING_FEATURE_KEY,
+            messages=prompt_messages,
+            response_schema=AI_ASSUMPTION_SCHEMA,
+        )
+    except NoRoutingConfigured:
+        fallback_reason = "no_routing"
+    except AICapExceeded:
+        fallback_reason = "cap_exceeded"
+    except NativeNotAvailable:
+        fallback_reason = "native_unavailable"
+    except StructuredOutputError:
+        fallback_reason = "structured_output_exhausted"
+    except AIDispatchFailed as exc:
+        fallback_reason = f"dispatch_failed:{exc.code}"
+    except AIDispatchError as exc:
+        # Catch-all for any future typed dispatch error not enumerated
+        # above. Keeping this LAST ensures the more specific handlers
+        # win for the cases we care about, and a new error type
+        # doesn't slip past unnoticed (the structured log surfaces it).
+        fallback_reason = f"dispatch_error:{exc.code}"
+    except Exception as exc:  # noqa: BLE001 - defensive fallback
+        # Truly unexpected — the dispatcher should map known failure
+        # modes to typed errors. Log loudly and degrade gracefully.
+        logger.warning(
+            "plans.ai.dispatch.unexpected_error",
+            org_id=org_id,
+            scenario_id=scenario.id,
+            error_class=type(exc).__name__,
+        )
+        fallback_reason = f"unexpected:{type(exc).__name__}"
+    else:
+        # Parse strictly via Pydantic. The dispatcher's structural
+        # validator only checks top-level required keys; the Pydantic
+        # model rejects malformed adjustment objects (the real
+        # tripwire). On parse failure we fall back to analytic — the
+        # operator sees the schema error in the audit row's detail.
+        try:
+            delta = AIAssumptionDelta.model_validate(
+                dispatch_result.response.parsed
+            )
+        except ValidationError as exc:
+            logger.warning(
+                "plans.ai.schema.invalid",
+                org_id=org_id,
+                scenario_id=scenario.id,
+                error_count=len(exc.errors()),
+            )
+            fallback_reason = "schema_invalid"
+
+    # 3. If anything went wrong, return baseline + audit the fallback.
+    if delta is None:
+        await _record_audit(
+            session_factory,
+            org_id=org_id,
+            user_id=user_id,
+            actor_email=actor_email,
+            scenario=scenario,
+            outcome="failure",
+            detail={
+                "scenario_id": scenario.id,
+                "reason": fallback_reason or "unknown",
+                "applied_adjustments": 0,
+            },
+            request_id=request_id,
+            ip_address=ip_address,
+        )
+        return baseline
+
+    # 4. Apply whitelisted adjustments to a deep-copied params blob and
+    #    re-run the analytic engine. Track every adjustment in
+    #    provenance with an ``applied`` flag so operators see what
+    #    the LLM proposed even when the wrapper guarded against it.
+    new_params = deepcopy(scenario.params_json or {})
+    provenance_adjustments: list[dict[str, Any]] = []
+    applied_count = 0
+    for adj in delta.adjustments:
+        is_whitelisted = adj.field in ASSUMPTION_FIELD_WHITELIST
+        is_numeric = _is_numeric_decimal(adj.new_value)
+        applied = is_whitelisted and is_numeric
+        if applied:
+            new_params[adj.field] = adj.new_value
+            applied_count += 1
+        provenance_adjustments.append(
+            {
+                "field": adj.field,
+                "old_value": adj.old_value,
+                "new_value": adj.new_value,
+                "reason": adj.reason,
+                "applied": applied,
+            }
+        )
+
+    if applied_count == 0:
+        # Nothing actually changed. Surface this as a fallback in the
+        # audit row but return the baseline — the engine_name should
+        # honestly reflect that AI didn't move the numbers.
+        await _record_audit(
+            session_factory,
+            org_id=org_id,
+            user_id=user_id,
+            actor_email=actor_email,
+            scenario=scenario,
+            outcome="success",
+            detail={
+                "scenario_id": scenario.id,
+                "reason": "no_applicable_adjustments",
+                "proposed": len(provenance_adjustments),
+                "applied_adjustments": 0,
+            },
+            request_id=request_id,
+            ip_address=ip_address,
+        )
+        return baseline
+
+    # 5. Re-run analytic engine with the adjusted params. The scenario
+    #    object's params_json is mutated in-place for the duration of
+    #    this call — but since SQLAlchemy hasn't committed, and the
+    #    router writes back the projection separately, this DOES NOT
+    #    persist to the DB.
+    #
+    # Use a shallow override technique: temporarily swap params_json,
+    # simulate, then restore. This avoids constructing a new Scenario
+    # instance (which would risk losing FK/state semantics).
+    original_params = scenario.params_json
+    scenario.params_json = new_params
+    try:
+        adjusted_result = analytic.simulate(
+            SimulationRequest(
+                scenario=scenario,
+                state=state,
+                horizon_months=horizon_months,
+                options=options,
+            ),
+            smooth_with_regression=smooth_with_regression,
+        )
+    finally:
+        scenario.params_json = original_params
+
+    adjusted_result["engine_name"] = "analytic_v1+ai_assumptions_v1"
+    adjusted_result["ai_assumptions"] = {
+        "summary": delta.summary,
+        "adjustments": provenance_adjustments,
+        "applied_count": applied_count,
+        "proposed_count": len(provenance_adjustments),
+    }
+
+    await _record_audit(
+        session_factory,
+        org_id=org_id,
+        user_id=user_id,
+        actor_email=actor_email,
+        scenario=scenario,
+        outcome="success",
+        detail={
+            "scenario_id": scenario.id,
+            "applied_adjustments": applied_count,
+            "proposed_adjustments": len(provenance_adjustments),
+        },
+        request_id=request_id,
+        ip_address=ip_address,
+    )
+    logger.info(
+        "plans.ai.success",
+        org_id=org_id,
+        scenario_id=scenario.id,
+        applied=applied_count,
+        proposed=len(provenance_adjustments),
+    )
+    return adjusted_result
+
+
+# ── Internal helpers ───────────────────────────────────────────────────
+
+
+def _build_prompt_messages(
+    scenario: Scenario, state: WorldState, horizon_months: int
+) -> list[dict[str, str]]:
+    """Build the LLM messages for the assumption-adjustment call.
+
+    Privacy notes:
+
+    - We send aggregated cashflow trend data (12-month per-account
+      net) but NEVER individual transaction descriptions, merchant
+      names, counterparty info, or account labels. The LLM only sees
+      numeric trends + the current assumptions on the scenario.
+    - Account IDs are sent as ordinal indices, not the real DB ids,
+      to keep the prompt portable across re-runs.
+
+    The LLM is constrained to return a strict JSON object via the
+    structured-output capability (dispatcher applies the schema and
+    retries on parse failure).
+    """
+    stype = (
+        scenario.scenario_type.value
+        if hasattr(scenario.scenario_type, "value")
+        else str(scenario.scenario_type)
+    )
+    params = scenario.params_json or {}
+    current_assumptions = {
+        k: params.get(k)
+        for k in ASSUMPTION_FIELD_WHITELIST
+        if params.get(k) is not None
+    }
+
+    # Aggregate the 12-month history into a per-account net-monthly
+    # trend (sum, mean, count). Avoid raw monthly data so the prompt
+    # stays compact and doesn't leak per-month patterns that could
+    # be reverse-engineered to a single transaction.
+    history_by_acc: dict[int, list[str]] = {}
+    for pt in state.history:
+        history_by_acc.setdefault(pt.account_id, []).append(str(pt.net))
+    trend_summary = []
+    for idx, (_acc_id, nets) in enumerate(sorted(history_by_acc.items())):
+        # Compact summary; the LLM does not need account IDs.
+        try:
+            decs = [Decimal(n) for n in nets]
+            avg = sum(decs, Decimal("0")) / Decimal(len(decs)) if decs else Decimal("0")
+            trend_summary.append(
+                {
+                    "account_ordinal": idx,
+                    "months_observed": len(decs),
+                    "avg_net": str(avg.quantize(Decimal("0.01"))),
+                }
+            )
+        except InvalidOperation:
+            continue
+
+    system_msg = (
+        "You are a careful financial-planning assistant. Given a "
+        "scenario's current numeric assumptions and a short aggregated "
+        "view of an organization's recent monthly cashflow, propose at "
+        "most three adjustments to the assumption fields listed. Only "
+        "propose values you can justify from the cashflow trend. Each "
+        "adjustment must include the field name, the old value, the "
+        "new value, and a brief reason. Output strict JSON matching "
+        "the schema. Do not propose changes to fields outside the "
+        "provided list."
+    )
+    user_msg = {
+        "scenario_type": stype,
+        "horizon_months": horizon_months,
+        "current_assumptions": current_assumptions,
+        "allowed_fields": sorted(ASSUMPTION_FIELD_WHITELIST),
+        "cashflow_trend": trend_summary,
+    }
+    import json as _json
+    return [
+        {"role": "system", "content": system_msg},
+        {"role": "user", "content": _json.dumps(user_msg)},
+    ]
+
+
+def _is_numeric_decimal(value: str) -> bool:
+    """True if ``value`` parses as a finite Decimal. Used to defensively
+    reject non-numeric LLM outputs (e.g. "high") before they reach
+    Decimal math in ``AnalyticEngine``.
+    """
+    try:
+        d = Decimal(value)
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+    return d.is_finite()
+
+
+async def _record_audit(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    org_id: int,
+    user_id: int,
+    actor_email: str,
+    scenario: Scenario,
+    outcome: str,
+    detail: dict[str, Any],
+    request_id: Optional[str],
+    ip_address: Optional[str],
+) -> None:
+    """Best-effort audit-event recording for this AI invocation."""
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type=AUDIT_EVENT_TYPE,
+        actor_user_id=user_id,
+        actor_email=actor_email,
+        target_org_id=org_id,
+        target_org_name=None,
+        request_id=request_id,
+        ip_address=ip_address,
+        outcome=outcome,  # type: ignore[arg-type]
+        detail=detail,
+    )

--- a/backend/tests/services/test_scenario_engine.py
+++ b/backend/tests/services/test_scenario_engine.py
@@ -445,10 +445,14 @@ async def test_verdict_red_when_severe_dip(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_ai_engine_raises_not_implemented():
-    """PR4 stub: invoking the AIEngine MUST raise NotImplementedError
-    with the message "PR4" so a misconfigured request surfaces a
-    deliberate error, not a silent analytic fallback.
+async def test_ai_engine_sync_simulate_returns_analytic_baseline():
+    """PR4: the sync ``AIEngine.simulate`` now delegates to the analytic
+    baseline. The real AI orchestration is async and lives in
+    ``scenario_engine_ai.run_ai_simulation``; this sync method is the
+    safe fallback for callers without a DB context (e.g. compare).
+
+    The result must be shape-identical to ``AnalyticEngine.simulate``
+    on the same inputs.
     """
     state = WorldState(accounts=[], recurring=[])
     scenario = Scenario(
@@ -457,13 +461,16 @@ async def test_ai_engine_raises_not_implemented():
         params_json={},
         horizon_months=6,
     )
-    with pytest.raises(NotImplementedError) as exc_info:
-        AIEngine().simulate(
-            SimulationRequest(
-                scenario=scenario, state=state, horizon_months=6, options={}
-            )
-        )
-    assert "PR4" in str(exc_info.value)
+    req = SimulationRequest(
+        scenario=scenario, state=state, horizon_months=6, options={}
+    )
+    ai_result = AIEngine().simulate(req)
+    analytic_result = AnalyticEngine().simulate(req)
+    # Engine names diverge by design (AIEngine's sync fallback still
+    # carries the analytic engine name because that's what actually
+    # ran). Otherwise the shape is identical.
+    assert ai_result["engine_name"] == analytic_result["engine_name"]
+    assert ai_result.get("ai_assumptions") is None
 
 
 def test_get_engine_returns_analytic_by_default():

--- a/backend/tests/services/test_scenario_engine_ai.py
+++ b/backend/tests/services/test_scenario_engine_ai.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -181,6 +181,23 @@ async def _count_audit_rows(session_factory, event_type: str) -> int:
                 .where(AuditEvent.event_type == event_type)
             )
         ).scalar_one()
+
+
+async def _first_audit_detail(session_factory, event_type: str) -> dict | None:
+    """Return the `detail` JSON blob of the first audit row for the
+    given event_type, or None if no row exists.
+    """
+    from sqlalchemy import select
+    async with session_factory() as db:
+        row = (
+            await db.execute(
+                select(AuditEvent)
+                .where(AuditEvent.event_type == event_type)
+                .order_by(AuditEvent.id)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        return row.detail if row is not None else None
 
 
 # ── tests ───────────────────────────────────────────────────────────────
@@ -570,6 +587,19 @@ async def test_ai_simulation_falls_back_on_schema_mismatch(
     assert result.get("ai_assumptions") is None
     n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
     assert n == 1, "schema-mismatch fallback must emit one audit row"
+
+    # The audit detail must include a compact validation-error summary
+    # so an operator can tell at-a-glance why the LLM was rejected.
+    detail = await _first_audit_detail(
+        session_factory, "plans.scenario.ai_simulate"
+    )
+    assert detail is not None
+    assert detail["reason"] == "schema_invalid"
+    assert "validation_errors" in detail, (
+        "schema_invalid audit row must include a validation_errors summary"
+    )
+    assert detail["validation_errors"]["count"] >= 1
+    assert detail["validation_errors"]["first_type"] is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_scenario_engine_ai.py
+++ b/backend/tests/services/test_scenario_engine_ai.py
@@ -18,6 +18,7 @@ Architect-locked invariants pinned here:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from copy import deepcopy
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any
@@ -47,6 +48,7 @@ from app.services.ai_dispatch import (
 from app.services.ai_providers.base import StructuredOutputError, StructuredResponse
 from app.services.scenario_engine import (
     AccountSnapshot,
+    AnalyticEngine,
     SimulationRequest,
     WorldState,
 )
@@ -225,13 +227,16 @@ async def test_ai_simulation_falls_back_when_gate_closed(
 
 @pytest.mark.asyncio
 async def test_ai_simulation_falls_back_when_no_routing(
-    db, session_factory
+    db, session_factory, seed_org_user
 ):
     """When AI gate is open but the org has no routing for smart_plan
     (raises NoRoutingConfigured at dispatch), the wrapper returns the
-    analytic baseline. No exception leaks to the caller.
+    analytic baseline AND emits a failure audit row with
+    reason="no_routing". No exception leaks to the caller.
     """
-    scenario = _make_retirement_scenario()
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
     req = _make_request(scenario)
 
     with patch(
@@ -244,9 +249,9 @@ async def test_ai_simulation_falls_back_when_no_routing(
         result = await run_ai_simulation(
             db,
             session_factory=session_factory,
-            org_id=1,
-            user_id=1,
-            actor_email="test@example.com",
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
             scenario=scenario,
             state=req.state,
             horizon_months=req.horizon_months,
@@ -256,22 +261,40 @@ async def test_ai_simulation_falls_back_when_no_routing(
 
     assert result["engine_name"] == "analytic_v1"
     assert result.get("ai_assumptions") is None
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1, "no_routing fallback must emit one audit row"
 
 
 @pytest.mark.asyncio
 async def test_ai_simulation_happy_path_applies_deltas(
-    db, session_factory
+    db, session_factory, seed_org_user
 ):
     """LLM returns valid deltas → wrapper re-runs analytic with adjusted
     assumptions. Output carries ``engine_name = "analytic_v1+ai_assumptions_v1"``
     and an ``ai_assumptions`` provenance block describing what changed.
 
-    The baseline projection (without deltas) and the AI-adjusted
-    projection have measurably different ending balances when the
-    LLM bumps ``annual_return_pct``.
+    Crucially, the baseline projection (without deltas) and the
+    AI-adjusted projection have measurably different projection
+    numbers when the LLM bumps ``annual_return_pct``. The numeric
+    diff is the load-bearing assertion — a wrapper that built the
+    provenance block but forgot to re-run the analytic engine must
+    fail this test.
     """
-    scenario = _make_retirement_scenario()
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
     req = _make_request(scenario)
+
+    # Compute baseline independently so we can prove the AI path
+    # actually moved the projection numbers.
+    baseline_only = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+        )
+    )
 
     delta_payload = {
         "adjustments": [
@@ -313,9 +336,9 @@ async def test_ai_simulation_happy_path_applies_deltas(
         result = await run_ai_simulation(
             db,
             session_factory=session_factory,
-            org_id=1,
-            user_id=1,
-            actor_email="test@example.com",
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
             scenario=scenario,
             state=req.state,
             horizon_months=req.horizon_months,
@@ -330,6 +353,23 @@ async def test_ai_simulation_happy_path_applies_deltas(
     assert len(provenance["adjustments"]) == 2
     fields_changed = {a["field"] for a in provenance["adjustments"]}
     assert fields_changed == {"annual_return_pct", "inflation_pct"}
+
+    # Load-bearing: the analytic engine actually ran with the new
+    # assumptions. Comparing the projection content (after stripping
+    # provenance / engine-name / timestamps that differ by design)
+    # asserts the numbers changed.
+    def _projection_content(r: dict) -> dict:
+        return {
+            k: v for k, v in r.items()
+            if k not in ("engine_name", "ai_assumptions", "computed_at")
+        }
+    assert _projection_content(result) != _projection_content(baseline_only), (
+        "AI-adjusted projection numbers must differ from baseline when "
+        "annual_return_pct and inflation_pct were applied"
+    )
+
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1, "successful AI invocation must emit one audit row"
 
 
 @pytest.mark.asyncio
@@ -433,12 +473,15 @@ async def test_ai_simulation_writes_audit_on_fallback(
 
 @pytest.mark.asyncio
 async def test_ai_simulation_falls_back_on_dispatch_failed(
-    db, session_factory
+    db, session_factory, seed_org_user
 ):
     """Adapter/provider errors surface as ``AIDispatchFailed`` from the
-    dispatcher. The wrapper swallows them and returns analytic.
+    dispatcher. The wrapper swallows them, returns analytic, AND
+    writes a failure audit row.
     """
-    scenario = _make_retirement_scenario()
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
     req = _make_request(scenario)
 
     with patch(
@@ -451,9 +494,9 @@ async def test_ai_simulation_falls_back_on_dispatch_failed(
         result = await run_ai_simulation(
             db,
             session_factory=session_factory,
-            org_id=1,
-            user_id=1,
-            actor_email="actor@example.com",
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
             scenario=scenario,
             state=req.state,
             horizon_months=req.horizon_months,
@@ -463,20 +506,24 @@ async def test_ai_simulation_falls_back_on_dispatch_failed(
 
     assert result["engine_name"] == "analytic_v1"
     assert result.get("ai_assumptions") is None
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1, "dispatch-failure fallback must emit one audit row"
 
 
 @pytest.mark.asyncio
 async def test_ai_simulation_falls_back_on_schema_mismatch(
-    db, session_factory
+    db, session_factory, seed_org_user
 ):
     """An LLM that returns a JSON object that DOESN'T match
     ``AIAssumptionDelta`` (e.g. wrong field types, missing required
     keys) is rejected by the wrapper's Pydantic re-validation and the
     analytic baseline is returned. The dispatcher's response_schema
     catches structural mismatch up-front, but the Pydantic re-validate
-    is the strict tripwire.
+    is the strict tripwire. A failure audit row is written.
     """
-    scenario = _make_retirement_scenario()
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
     req = _make_request(scenario)
 
     # Provide a payload that passes the dispatcher's loose schema check
@@ -509,9 +556,9 @@ async def test_ai_simulation_falls_back_on_schema_mismatch(
         result = await run_ai_simulation(
             db,
             session_factory=session_factory,
-            org_id=1,
-            user_id=1,
-            actor_email="actor@example.com",
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
             scenario=scenario,
             state=req.state,
             horizon_months=req.horizon_months,
@@ -521,11 +568,13 @@ async def test_ai_simulation_falls_back_on_schema_mismatch(
 
     assert result["engine_name"] == "analytic_v1"
     assert result.get("ai_assumptions") is None
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1, "schema-mismatch fallback must emit one audit row"
 
 
 @pytest.mark.asyncio
 async def test_ai_simulation_unknown_field_is_skipped(
-    db, session_factory
+    db, session_factory, seed_org_user
 ):
     """The Pydantic model accepts the LLM's payload, but the wrapper
     only applies adjustments to a whitelist of known assumption fields
@@ -533,10 +582,22 @@ async def test_ai_simulation_unknown_field_is_skipped(
     adjustment naming a non-whitelisted field is dropped before the
     re-simulate; the result still flags this in provenance so an
     operator can see the LLM tried but the wrapper guarded against
-    arbitrary param mutation.
+    arbitrary param mutation. The whitelisted adjustment that
+    survives must actually change the projection numbers (proves the
+    re-simulate ran with the new value).
     """
-    scenario = _make_retirement_scenario()
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
     req = _make_request(scenario)
+    baseline_only = AnalyticEngine().simulate(
+        SimulationRequest(
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+        )
+    )
 
     delta_payload = {
         "adjustments": [
@@ -577,9 +638,9 @@ async def test_ai_simulation_unknown_field_is_skipped(
         result = await run_ai_simulation(
             db,
             session_factory=session_factory,
-            org_id=1,
-            user_id=1,
-            actor_email="actor@example.com",
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
             scenario=scenario,
             state=req.state,
             horizon_months=req.horizon_months,
@@ -600,6 +661,281 @@ async def test_ai_simulation_unknown_field_is_skipped(
     }
     assert "annual_return_pct" in applied_fields
     assert "evil_field" in skipped_fields
+
+    # The whitelisted adjustment actually changed the projection.
+    def _projection_content(r: dict) -> dict:
+        return {
+            k: v for k, v in r.items()
+            if k not in ("engine_name", "ai_assumptions", "computed_at")
+        }
+    assert _projection_content(result) != _projection_content(baseline_only), (
+        "applied=True on annual_return_pct must move the projection numbers"
+    )
+
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_falls_back_when_gate_check_raises(
+    db, session_factory, seed_org_user
+):
+    """A transient error while reading the feature gate (e.g. DB blip)
+    must degrade to the analytic baseline WITHOUT writing an audit row
+    — the audit pipeline only fires after the gate check passes
+    (\"audit fires only when the AI path was at least attempted\").
+    Pins the asymmetry so a future refactor of the bare-except can't
+    silently start emitting audits or 500s on gate-check failure.
+    """
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
+    req = _make_request(scenario)
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(side_effect=RuntimeError("db blip")),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(),
+    ) as mock_llm:
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+    mock_llm.assert_not_awaited()
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 0, "gate-check failure must NOT write an audit row"
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_applied_count_zero_returns_baseline_with_audit(
+    db, session_factory, seed_org_user
+):
+    """If the LLM responds successfully but every proposed adjustment
+    is non-applicable (all non-whitelisted, all out-of-range, etc.),
+    the wrapper returns the analytic baseline AND writes an audit
+    row recording ``reason=\"no_applicable_adjustments\"``. Pins the
+    branch that's otherwise easy to skip past.
+    """
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
+    req = _make_request(scenario)
+
+    # All adjustments target non-whitelisted fields → applied_count == 0.
+    delta_payload = {
+        "adjustments": [
+            {
+                "field": "totally_not_a_real_field",
+                "old_value": "x",
+                "new_value": "y",
+                "reason": "off-list",
+            },
+            {
+                "field": "another_bad_field",
+                "old_value": "x",
+                "new_value": "y",
+                "reason": "off-list",
+            },
+        ],
+        "summary": "the LLM had nothing useful to say",
+    }
+    fake_resp = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=delta_payload,
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(return_value=fake_resp),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    # engine_name reflects baseline (no AI provenance attached).
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1, "no_applicable_adjustments must still emit one audit row"
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_does_not_mutate_input_scenario_params(
+    db, session_factory, seed_org_user
+):
+    """The wrapper temporarily swaps ``scenario.params_json`` to feed
+    the adjusted assumptions through the analytic engine, then
+    restores in a ``finally`` block. This test pins that the input
+    Scenario object's ``params_json`` is unchanged after the call —
+    a regression that bypassed the restore would leak LLM
+    mutations back into the caller's session.
+    """
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
+    req = _make_request(scenario)
+    original_params = deepcopy(scenario.params_json)
+
+    delta_payload = {
+        "adjustments": [
+            {
+                "field": "annual_return_pct",
+                "old_value": "6.0",
+                "new_value": "7.5",
+                "reason": "headroom",
+            }
+        ],
+        "summary": "bump return",
+    }
+    fake_resp = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=delta_payload,
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(return_value=fake_resp),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    # Sanity: the adjustment was actually applied (otherwise the
+    # restore test is vacuous — there'd be nothing to restore).
+    assert result["engine_name"] == "analytic_v1+ai_assumptions_v1"
+    # Load-bearing: the caller's scenario object is unmutated.
+    assert scenario.params_json == original_params, (
+        "wrapper must restore scenario.params_json before returning; the "
+        "finally block at scenario_engine_ai.py:362-363 is load-bearing"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_out_of_bounds_value_is_skipped(
+    db, session_factory, seed_org_user
+):
+    """Per-field numeric bounds reject out-of-range LLM proposals
+    (e.g. ``annual_return_pct: \"500.0\"``, ``monthly_contribution:
+    \"-1000.0\"``). Whitelisted but out-of-range adjustments land
+    in provenance with ``applied=False`` and never reach the analytic
+    engine.
+    """
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
+    req = _make_request(scenario)
+
+    delta_payload = {
+        "adjustments": [
+            {
+                "field": "annual_return_pct",
+                "old_value": "6.0",
+                "new_value": "500.0",  # > 50 upper bound
+                "reason": "hallucinated outsized return",
+            },
+            {
+                "field": "monthly_contribution",
+                "old_value": "500.00",
+                "new_value": "-1000.00",  # < 0 lower bound
+                "reason": "negative contribution",
+            },
+            {
+                "field": "inflation_pct",
+                "old_value": "2.5",
+                "new_value": "not_a_number",  # non-numeric
+                "reason": "garbage",
+            },
+        ],
+        "summary": "everything out of range",
+    }
+    fake_resp = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=delta_payload,
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(return_value=fake_resp),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    # All three were rejected → applied_count == 0 → analytic baseline.
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1, "bounds-rejected-all must emit one audit row"
 
 
 def test_ai_assumption_delta_schema_has_required_keys():

--- a/backend/tests/services/test_scenario_engine_ai.py
+++ b/backend/tests/services/test_scenario_engine_ai.py
@@ -1,0 +1,626 @@
+"""Service tests for the AI-enhanced scenario engine wrapper (PR4).
+
+Architect-locked invariants pinned here:
+
+- The wrapper engages ONLY when the ``ai.smart_plan`` feature gate is
+  open AND ``smart_plan`` routing is configured. Otherwise the
+  analytic baseline is returned unchanged.
+- LLM responses are parsed via a strict Pydantic schema. Schema
+  mismatch -> fall back to analytic, never propagate.
+- Any LLM transport failure (StructuredOutputError, AIDispatchFailed,
+  NoRoutingConfigured) -> fall back to analytic. The frontend never
+  crashes because AI couldn't deliver.
+- On every AI invocation (success OR fallback), an audit event is
+  emitted via ``audit_service.record_audit_event``.
+- The wrapper still respects the sandboxing guarantee: it only reads
+  the world state; the analytic engine math does the projection.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.scenario import Scenario, ScenarioType
+from app.models.user import Organization, Role, User
+from app.security import hash_password
+from app.services.ai_dispatch import (
+    AIDispatchFailed,
+    NoRoutingConfigured,
+    StructuredDispatchResult,
+)
+from app.services.ai_providers.base import StructuredOutputError, StructuredResponse
+from app.services.scenario_engine import (
+    AccountSnapshot,
+    SimulationRequest,
+    WorldState,
+)
+from app.services.scenario_engine_ai import (
+    AI_ASSUMPTION_SCHEMA,
+    AIAssumptionDelta,
+    run_ai_simulation,
+)
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def seed_org_user(session_factory) -> dict:
+    """Seed minimal org + user so audit-event FK constraints pass.
+
+    The audit_events table FKs to organizations(id) and users(id); without
+    these rows the SQLite ON-FK-violation aborts the audit row write and
+    structurally invalidates the "did the wrapper audit?" assertion.
+    """
+    async with session_factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+        user = User(
+            org_id=org.id,
+            username="actor",
+            email="actor@example.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=False,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(user)
+        await db.commit()
+        return {"org_id": org.id, "user_id": user.id, "email": user.email}
+
+
+def _make_retirement_scenario(
+    *, horizon_months: int = 360, org_id: int = 1, user_id: int = 1
+) -> Scenario:
+    """Minimal retirement scenario the wrapper can run against."""
+    return Scenario(
+        org_id=org_id,
+        user_id=user_id,
+        name="Retirement",
+        scenario_type=ScenarioType.RETIREMENT,
+        params_json={
+            "scenario_type": "retirement",
+            "target_retirement_date": (
+                date.today().replace(day=1) + timedelta(days=horizon_months * 30)
+            ).isoformat(),
+            "currency": "EUR",
+            "monthly_contribution": "500.00",
+            "contribution_account_id": 1,
+            "target_balance": "100000.00",
+            "annual_return_pct": "6.0",
+            "inflation_pct": "2.5",
+            "contribution_curve": [],
+        },
+        horizon_months=horizon_months,
+    )
+
+
+def _make_world_state() -> WorldState:
+    return WorldState(
+        accounts=[
+            AccountSnapshot(
+                account_id=1,
+                account_name="Retirement Fund",
+                currency="EUR",
+                starting_balance=Decimal("0"),
+            )
+        ],
+        recurring=[],
+        history=[],
+    )
+
+
+def _make_request(scenario: Scenario) -> SimulationRequest:
+    return SimulationRequest(
+        scenario=scenario,
+        state=_make_world_state(),
+        horizon_months=scenario.horizon_months,
+        options={},
+    )
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+async def _count_audit_rows(session_factory, event_type: str) -> int:
+    from sqlalchemy import func, select
+    async with session_factory() as db:
+        return (
+            await db.execute(
+                select(func.count())
+                .select_from(AuditEvent)
+                .where(AuditEvent.event_type == event_type)
+            )
+        ).scalar_one()
+
+
+# ── tests ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_falls_back_when_gate_closed(
+    db, session_factory
+):
+    """When the ai.smart_plan feature gate is closed for the org,
+    ``run_ai_simulation`` returns the analytic baseline unchanged.
+
+    The engine_name on the response reflects the analytic baseline
+    (no AI provenance block), and call_llm_structured is never
+    invoked.
+    """
+    scenario = _make_retirement_scenario()
+    req = _make_request(scenario)
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=False),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(),
+    ) as mock_llm:
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=1,
+            user_id=1,
+            actor_email="test@example.com",
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+    mock_llm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_falls_back_when_no_routing(
+    db, session_factory
+):
+    """When AI gate is open but the org has no routing for smart_plan
+    (raises NoRoutingConfigured at dispatch), the wrapper returns the
+    analytic baseline. No exception leaks to the caller.
+    """
+    scenario = _make_retirement_scenario()
+    req = _make_request(scenario)
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(side_effect=NoRoutingConfigured()),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=1,
+            user_id=1,
+            actor_email="test@example.com",
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_happy_path_applies_deltas(
+    db, session_factory
+):
+    """LLM returns valid deltas → wrapper re-runs analytic with adjusted
+    assumptions. Output carries ``engine_name = "analytic_v1+ai_assumptions_v1"``
+    and an ``ai_assumptions`` provenance block describing what changed.
+
+    The baseline projection (without deltas) and the AI-adjusted
+    projection have measurably different ending balances when the
+    LLM bumps ``annual_return_pct``.
+    """
+    scenario = _make_retirement_scenario()
+    req = _make_request(scenario)
+
+    delta_payload = {
+        "adjustments": [
+            {
+                "field": "annual_return_pct",
+                "old_value": "6.0",
+                "new_value": "7.5",
+                "reason": "Recent recurring income growth suggests headroom",
+            },
+            {
+                "field": "inflation_pct",
+                "old_value": "2.5",
+                "new_value": "3.0",
+                "reason": "Recurring expense growth above prior assumption",
+            },
+        ],
+        "summary": "Adjusted retirement assumptions based on org cashflow.",
+    }
+
+    fake_resp = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=delta_payload,
+            raw_text="{}",
+            prompt_tokens=10,
+            completion_tokens=10,
+            model="gpt-4o-mini",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(return_value=fake_resp),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=1,
+            user_id=1,
+            actor_email="test@example.com",
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    assert result["engine_name"] == "analytic_v1+ai_assumptions_v1"
+    assert "ai_assumptions" in result
+    provenance = result["ai_assumptions"]
+    assert provenance["summary"] == delta_payload["summary"]
+    assert len(provenance["adjustments"]) == 2
+    fields_changed = {a["field"] for a in provenance["adjustments"]}
+    assert fields_changed == {"annual_return_pct", "inflation_pct"}
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_writes_audit_on_success(
+    db, session_factory, seed_org_user
+):
+    """Successful AI invocation emits an ``plans.scenario.ai_simulate``
+    audit row with outcome="success" and the delta count in detail.
+    """
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
+    req = _make_request(scenario)
+
+    delta_payload = {
+        "adjustments": [
+            {
+                "field": "annual_return_pct",
+                "old_value": "6.0",
+                "new_value": "7.5",
+                "reason": "test",
+            }
+        ],
+        "summary": "test summary",
+    }
+    fake_resp = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=delta_payload,
+            raw_text="{}",
+            prompt_tokens=10,
+            completion_tokens=10,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=42,
+    )
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(return_value=fake_resp),
+    ):
+        await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_writes_audit_on_fallback(
+    db, session_factory, seed_org_user
+):
+    """Fallback paths (StructuredOutputError, AIDispatchFailed) ALSO emit
+    an audit row with outcome="failure" so an operator can see how
+    often the AI path degrades. The frontend still gets a clean
+    analytic projection.
+    """
+    scenario = _make_retirement_scenario(
+        org_id=seed_org_user["org_id"], user_id=seed_org_user["user_id"]
+    )
+    req = _make_request(scenario)
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(side_effect=StructuredOutputError("STATUS_ERROR_STRUCTURED_OUTPUT")),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=seed_org_user["org_id"],
+            user_id=seed_org_user["user_id"],
+            actor_email=seed_org_user["email"],
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+    n = await _count_audit_rows(session_factory, "plans.scenario.ai_simulate")
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_falls_back_on_dispatch_failed(
+    db, session_factory
+):
+    """Adapter/provider errors surface as ``AIDispatchFailed`` from the
+    dispatcher. The wrapper swallows them and returns analytic.
+    """
+    scenario = _make_retirement_scenario()
+    req = _make_request(scenario)
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(side_effect=AIDispatchFailed("connection_error")),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=1,
+            user_id=1,
+            actor_email="actor@example.com",
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_falls_back_on_schema_mismatch(
+    db, session_factory
+):
+    """An LLM that returns a JSON object that DOESN'T match
+    ``AIAssumptionDelta`` (e.g. wrong field types, missing required
+    keys) is rejected by the wrapper's Pydantic re-validation and the
+    analytic baseline is returned. The dispatcher's response_schema
+    catches structural mismatch up-front, but the Pydantic re-validate
+    is the strict tripwire.
+    """
+    scenario = _make_retirement_scenario()
+    req = _make_request(scenario)
+
+    # Provide a payload that passes the dispatcher's loose schema check
+    # (has "adjustments" key) but fails the strict Pydantic model
+    # (each adjustment must have field/old_value/new_value/reason —
+    # here we ship a malformed adjustment).
+    bad_payload = {
+        "adjustments": [{"oops": "this is not valid"}],
+        "summary": "x",
+    }
+    fake_resp = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=bad_payload,
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(return_value=fake_resp),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=1,
+            user_id=1,
+            actor_email="actor@example.com",
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    assert result["engine_name"] == "analytic_v1"
+    assert result.get("ai_assumptions") is None
+
+
+@pytest.mark.asyncio
+async def test_ai_simulation_unknown_field_is_skipped(
+    db, session_factory
+):
+    """The Pydantic model accepts the LLM's payload, but the wrapper
+    only applies adjustments to a whitelist of known assumption fields
+    (annual_return_pct, inflation_pct, monthly_contribution). An
+    adjustment naming a non-whitelisted field is dropped before the
+    re-simulate; the result still flags this in provenance so an
+    operator can see the LLM tried but the wrapper guarded against
+    arbitrary param mutation.
+    """
+    scenario = _make_retirement_scenario()
+    req = _make_request(scenario)
+
+    delta_payload = {
+        "adjustments": [
+            {
+                "field": "evil_field",
+                "old_value": "any",
+                "new_value": "any",
+                "reason": "try to inject",
+            },
+            {
+                "field": "annual_return_pct",
+                "old_value": "6.0",
+                "new_value": "8.0",
+                "reason": "ok",
+            },
+        ],
+        "summary": "mixed",
+    }
+    fake_resp = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=delta_payload,
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    with patch(
+        "app.services.scenario_engine_ai.feature_service.has_feature",
+        AsyncMock(return_value=True),
+    ), patch(
+        "app.services.scenario_engine_ai.call_llm_structured",
+        AsyncMock(return_value=fake_resp),
+    ):
+        result = await run_ai_simulation(
+            db,
+            session_factory=session_factory,
+            org_id=1,
+            user_id=1,
+            actor_email="actor@example.com",
+            scenario=scenario,
+            state=req.state,
+            horizon_months=req.horizon_months,
+            options=req.options,
+            smooth_with_regression=False,
+        )
+
+    # The AI path engaged (engine name reflects it) and only the
+    # whitelisted field made it through.
+    assert result["engine_name"] == "analytic_v1+ai_assumptions_v1"
+    applied_fields = {
+        a["field"] for a in result["ai_assumptions"]["adjustments"]
+        if a.get("applied") is True
+    }
+    skipped_fields = {
+        a["field"] for a in result["ai_assumptions"]["adjustments"]
+        if a.get("applied") is False
+    }
+    assert "annual_return_pct" in applied_fields
+    assert "evil_field" in skipped_fields
+
+
+def test_ai_assumption_delta_schema_has_required_keys():
+    """Sanity: the schema we hand to the dispatcher must list the keys
+    the dispatcher's structural validator requires."""
+    assert AI_ASSUMPTION_SCHEMA["type"] == "object"
+    assert "adjustments" in AI_ASSUMPTION_SCHEMA.get("required", [])
+
+
+def test_ai_assumption_delta_model_round_trips():
+    payload = {
+        "adjustments": [
+            {
+                "field": "annual_return_pct",
+                "old_value": "6.0",
+                "new_value": "7.5",
+                "reason": "test",
+            }
+        ],
+        "summary": "ok",
+    }
+    model = AIAssumptionDelta.model_validate(payload)
+    assert model.summary == "ok"
+    assert model.adjustments[0].field == "annual_return_pct"


### PR DESCRIPTION
## Summary

- New `AIEngine` wrapper around `AnalyticEngine`. The wrapper calls the LLM via `call_llm_structured` to propose numeric-assumption deltas (annual_return_pct, inflation_pct, monthly_contribution) based on aggregated org cashflow, re-runs the analytic engine with adjusted params, and annotates the result with provenance.
- Engages only when the `ai.smart_plan` feature gate is open AND `smart_plan` routing is configured. Otherwise the analytic baseline is returned unchanged.
- Every failure mode (gate off, no routing, cap exceeded, dispatch error, structured-output exhaustion, schema mismatch, non-whitelisted field) falls back to the analytic baseline so the frontend never crashes. LLM responses are re-validated via a strict Pydantic model.
- `plans.scenario.ai_simulate` audit row written on every AI invocation (success or fallback) so an operator can see how often the path engages and how often it degrades.