### PR TITLE
feat(ai): LAI.3 smart budget rebalance — suggestion-only diff modal

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_budget, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -485,6 +485,7 @@ app.include_router(notifications.router)
 app.include_router(reports.router)
 app.include_router(scenarios.router)
 app.include_router(ai_providers.router)
+app.include_router(ai_budget.router)
 app.include_router(admin_ai_usage.router)
 app.include_router(admin_rate_limit_overrides.router)
 

--- a/backend/app/routers/ai_budget.py
+++ b/backend/app/routers/ai_budget.py
@@ -1,0 +1,83 @@
+"""LAI.3 — Smart Budget Rebalance router.
+
+Endpoint: ``POST /api/v1/ai/budget/rebalance``.
+
+Asks the LLM for category-level budget deltas via
+``budget_rebalance_service.suggest_rebalance``. The response is a
+SUGGESTION only — the frontend collects user accept/skip per row and
+re-uses the existing ``PUT /api/v1/budgets/{id}`` endpoints to apply
+the change.
+
+Feature gate: ``ai.budget`` (user-facing 403). The dispatch substrate
+also re-checks routing + caps internally; LLM failures are surfaced as
+``status=llm_unavailable`` (HTTP 200) so the UI shows an empty state
+instead of crashing.
+"""
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.auth.feature_deps import require_feature
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models.user import User
+from app.rate_limit import get_client_ip
+from app.schemas.budget_rebalance import BudgetRebalanceResponse
+from app.services import audit_service, budget_rebalance_service
+
+
+logger = structlog.stdlib.get_logger()
+
+
+router = APIRouter(prefix="/api/v1/ai/budget", tags=["ai-budget"])
+
+
+@router.post(
+    "/rebalance",
+    response_model=BudgetRebalanceResponse,
+    dependencies=[Depends(require_feature("ai.budget"))],
+)
+async def rebalance(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(
+        get_session_factory
+    ),
+) -> BudgetRebalanceResponse:
+    """Ask the AI for budget-rebalance suggestions for the current period.
+
+    Always returns 200 with a typed ``status``:
+      - ``ok`` + non-empty suggestions: render the diff modal.
+      - ``ok`` + empty suggestions: LLM declined to suggest changes.
+      - ``empty_no_budgets``: org has no current-period budgets.
+      - ``empty_no_history``: no settled expense history in last 3mo.
+      - ``llm_unavailable``: routing missing, cap exceeded, dispatch
+        failed, or structured-output retry budget exhausted.
+
+    Audit-logged with the structural outcome + suggestion count only;
+    no prompt / completion content, no category names.
+    """
+    response = await budget_rebalance_service.suggest_rebalance(
+        db, org_id=current_user.org_id
+    )
+
+    await audit_service.record_audit_event(
+        session_factory,
+        event_type="ai.budget.rebalance.requested",
+        actor_user_id=current_user.id,
+        actor_email=current_user.email,
+        target_org_id=current_user.org_id,
+        target_org_name=None,
+        request_id=structlog.contextvars.get_contextvars().get("request_id"),
+        ip_address=get_client_ip(request) if request is not None else None,
+        outcome="success" if response.status == "ok" else "failure",
+        detail={
+            "status": response.status,
+            "suggestion_count": len(response.suggestions),
+        },
+    )
+
+    return response

--- a/backend/app/routers/ai_budget.py
+++ b/backend/app/routers/ai_budget.py
@@ -61,7 +61,18 @@ async def rebalance(
     no prompt / completion content, no category names.
     """
     response = await budget_rebalance_service.suggest_rebalance(
-        db, org_id=current_user.org_id
+        db,
+        org_id=current_user.org_id,
+        session_factory=session_factory,
+    )
+
+    # Audit outcome distinguishes system failures from user-state
+    # preconditions. ``empty_no_budgets`` and ``empty_no_history`` are
+    # clean preconditions (the user just hasn't set up budgets / has
+    # no recent expenses) — they shouldn't show up as failures in the
+    # ops dashboard. Only ``llm_unavailable`` is a real failure.
+    audit_outcome = (
+        "failure" if response.status == "llm_unavailable" else "success"
     )
 
     await audit_service.record_audit_event(
@@ -72,8 +83,8 @@ async def rebalance(
         target_org_id=current_user.org_id,
         target_org_name=None,
         request_id=structlog.contextvars.get_contextvars().get("request_id"),
-        ip_address=get_client_ip(request) if request is not None else None,
-        outcome="success" if response.status == "ok" else "failure",
+        ip_address=get_client_ip(request),
+        outcome=audit_outcome,
         detail={
             "status": response.status,
             "suggestion_count": len(response.suggestions),

--- a/backend/app/schemas/budget_rebalance.py
+++ b/backend/app/schemas/budget_rebalance.py
@@ -1,0 +1,49 @@
+"""Pydantic schemas for LAI.3 — Smart Budget Rebalance."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BudgetDeltaSuggestion(BaseModel):
+    """One suggested change to an existing budget row.
+
+    ``category_id`` MUST reference an existing master category that
+    already has a budget in the current period for the requesting org.
+    The service rejects responses whose ``category_id`` set drifts from
+    the input budget set (defense-in-depth against prompt injection or
+    a misbehaving LLM).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    category_id: int
+    category_name: str = ""
+    current_amount: Decimal = Field(ge=0)
+    suggested_amount: Decimal = Field(ge=0)
+    delta_amount: Decimal  # may be negative
+    reasoning: str = Field(max_length=400)
+
+
+class BudgetRebalanceResponse(BaseModel):
+    """Top-level rebalance response.
+
+    ``status`` is the structural outcome. Frontend renders the modal
+    only when ``status == "ok"`` AND ``suggestions`` is non-empty;
+    every other status maps to a friendly empty state.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal[
+        "ok",
+        "empty_no_budgets",
+        "empty_no_history",
+        "llm_unavailable",
+    ]
+    period_start: Optional[str] = None
+    suggestions: list[BudgetDeltaSuggestion] = Field(default_factory=list)
+    summary: str = ""
+    request_id: Optional[str] = None

--- a/backend/app/services/budget_rebalance_service.py
+++ b/backend/app/services/budget_rebalance_service.py
@@ -38,7 +38,8 @@ from typing import Optional
 import structlog
 from dateutil.relativedelta import relativedelta
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload
 
 from app.models.budget import Budget
 from app.models.category import Category
@@ -119,6 +120,9 @@ async def _gather_facts(
     months' total + average + this month's running actual. Aggregates
     only — no transaction-level data leaves this function.
     """
+    # Eager-load the master category so we don't fire N+1 refreshes
+    # row-by-row below. selectinload issues one extra IN-query for all
+    # categories at once.
     budget_rows = (
         await db.execute(
             select(Budget)
@@ -127,15 +131,14 @@ async def _gather_facts(
                 Budget.period_start == period_start,
             )
             .order_by(Budget.category_id)
+            .options(selectinload(Budget.category))
         )
     ).scalars().all()
     if not budget_rows:
         return []
 
-    for b in budget_rows:
-        await db.refresh(b, ["category"])
-
     cat_ids = [b.category_id for b in budget_rows]
+    budgeted_cat_ids = set(cat_ids)
 
     sub_rows = (
         await db.execute(
@@ -147,27 +150,39 @@ async def _gather_facts(
     ).all()
     parent_to_subs: dict[int, list[int]] = {cid: [] for cid in cat_ids}
     for sub_id, parent_id in sub_rows:
+        # Skip children that have their own budget row — otherwise
+        # the child's transactions are counted twice (once via the
+        # parent's rollup, once via the child's own facts row).
+        if sub_id in budgeted_cat_ids:
+            continue
         parent_to_subs.setdefault(parent_id, []).append(sub_id)
 
     today = datetime.date.today()
-    three_months_ago = today - relativedelta(months=3)
     current_month_start = today.replace(day=1)
+
+    # The 3-month window must be (a) exactly 3 calendar months wide so
+    # the divisor of 3 is honest, AND (b) strictly disjoint from the
+    # current-period filter below — otherwise transactions in the
+    # overlap are counted in both totals. Pick whichever cutoff comes
+    # first (current calendar month vs. the period start) as the
+    # upper bound, then take a clean 3-month window ending there.
+    three_mo_upper = min(current_month_start, period_start)
+    three_mo_lower = three_mo_upper - relativedelta(months=3)
 
     facts: list[_CategoryFact] = []
     for b in budget_rows:
         all_cat_ids = [b.category_id] + parent_to_subs.get(b.category_id, [])
 
-        # Last 3 calendar months of settled expenses (rolling, not
-        # period-aligned) — gives a stable rate-of-spend signal even when
-        # billing periods are non-monthly.
+        # Last 3 calendar months of settled expenses, strictly before
+        # the current period and the current calendar month.
         three_mo_sum = await db.scalar(
             select(func.coalesce(func.sum(Transaction.amount), 0)).where(
                 Transaction.org_id == org_id,
                 Transaction.category_id.in_(all_cat_ids),
                 Transaction.type == TransactionType.EXPENSE,
                 Transaction.status == TransactionStatus.SETTLED,
-                Transaction.settled_date >= three_months_ago,
-                Transaction.settled_date < current_month_start,
+                Transaction.settled_date >= three_mo_lower,
+                Transaction.settled_date < three_mo_upper,
                 reportable_transaction_filter(),
             )
         )
@@ -313,7 +328,10 @@ def _validate_and_shape(
 
 
 async def suggest_rebalance(
-    db: AsyncSession, *, org_id: int
+    db: AsyncSession,
+    *,
+    org_id: int,
+    session_factory: Optional[async_sessionmaker[AsyncSession]] = None,
 ) -> BudgetRebalanceResponse:
     """Compute the AI rebalance suggestion for an org's current period.
 
@@ -321,6 +339,11 @@ async def suggest_rebalance(
     maps this to HTTP 200 regardless of internal failure mode. The
     feature gate is enforced at the router layer before this service
     runs.
+
+    ``session_factory`` is optional only because some legacy tests
+    call this without one; the router always passes it. When provided,
+    the LLM dispatch runs in its own session so the dispatcher's
+    ledger commit can't bleed into the request transaction.
     """
     period = await get_current_period(db, org_id)
     facts = await _gather_facts(
@@ -352,14 +375,28 @@ async def suggest_rebalance(
 
     messages = _build_messages(facts, period.start_date)
 
+    # ``call_llm_structured`` commits the session it's given (via
+    # ``_write_ledger_row`` in ai_dispatch.py). Use a dedicated session
+    # when one is available so the dispatcher's commit can't bleed
+    # into the request transaction. Same pattern as #368/#369.
     try:
-        result = await call_llm_structured(
-            db,
-            org_id=org_id,
-            feature_key=FEATURE_KEY,
-            messages=messages,
-            response_schema=LLM_RESPONSE_SCHEMA,
-        )
+        if session_factory is not None:
+            async with session_factory() as dispatch_db:
+                result = await call_llm_structured(
+                    dispatch_db,
+                    org_id=org_id,
+                    feature_key=FEATURE_KEY,
+                    messages=messages,
+                    response_schema=LLM_RESPONSE_SCHEMA,
+                )
+        else:
+            result = await call_llm_structured(
+                db,
+                org_id=org_id,
+                feature_key=FEATURE_KEY,
+                messages=messages,
+                response_schema=LLM_RESPONSE_SCHEMA,
+            )
     except (
         NoRoutingConfigured,
         AICapExceeded,

--- a/backend/app/services/budget_rebalance_service.py
+++ b/backend/app/services/budget_rebalance_service.py
@@ -1,0 +1,410 @@
+"""LAI.3 — Smart Budget Rebalance service.
+
+The service inspects the org's CURRENT period budgets and the prior 3
+months of actual settled expenses per master category. It builds a
+**redacted, aggregated** prompt (per-category monthly totals — never raw
+transaction rows) and asks the LLM via
+``ai_dispatch.call_llm_structured`` for a set of per-category budget
+deltas with reasoning.
+
+Hard rules baked into this layer:
+
+1. **Suggestion only.** This service never mutates the budget table.
+   The router returns deltas; the frontend collects user accept / skip
+   per row and re-uses the existing ``PUT /api/v1/budgets/{id}`` to
+   apply changes.
+
+2. **Category whitelist.** The LLM is told the closed set of
+   ``category_id`` values from the org's current-period budgets. Any
+   response containing a ``category_id`` outside that set is rejected
+   (defense-in-depth against prompt injection / LLM drift).
+
+3. **Aggregates only.** The prompt carries
+   ``{category_name, budget_amount, last_3mo_avg_actual, current_mo_actual}``
+   per category. No transaction descriptions, no merchant names, no
+   account ids, no user ids leave this layer.
+
+4. **Friendly empty states.** No budgets, no actuals, or LLM
+   unavailable all map to a typed ``status`` in the response so the UI
+   can show an empty-state message instead of crashing.
+"""
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional
+
+import structlog
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import Budget
+from app.models.category import Category
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.schemas.budget_rebalance import (
+    BudgetDeltaSuggestion,
+    BudgetRebalanceResponse,
+)
+from app.services.ai_dispatch import (
+    AICapabilityNotSupported,
+    AICapExceeded,
+    AIDispatchFailed,
+    NoRoutingConfigured,
+    call_llm_structured,
+)
+from app.services.ai_providers import (
+    NativeNotAvailable,
+    StructuredOutputError,
+)
+from app.services.billing_service import get_current_period
+from app.services.transaction_filters import reportable_transaction_filter
+
+
+logger = structlog.stdlib.get_logger()
+
+
+FEATURE_KEY = "ai.budget"
+
+
+# The structured-output schema the LLM must satisfy. ``call_llm_structured``
+# validates ``type=object`` + required keys; we additionally validate
+# the final payload in ``_validate_and_shape`` for type + bounds.
+LLM_RESPONSE_SCHEMA: dict = {
+    "type": "object",
+    "required": ["suggestions", "summary"],
+    "properties": {
+        "summary": {"type": "string"},
+        "suggestions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "category_id",
+                    "suggested_amount",
+                    "reasoning",
+                ],
+                "properties": {
+                    "category_id": {"type": "integer"},
+                    "suggested_amount": {"type": "number"},
+                    "reasoning": {"type": "string"},
+                },
+            },
+        },
+    },
+}
+
+
+@dataclass(frozen=True)
+class _CategoryFact:
+    category_id: int
+    category_name: str
+    budget_amount: Decimal
+    last_3mo_total: Decimal
+    last_3mo_avg: Decimal
+    current_mo_actual: Decimal
+
+
+async def _gather_facts(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    period_start: datetime.date,
+    period_end: Optional[datetime.date],
+) -> list[_CategoryFact]:
+    """Aggregate per-master-category facts for the prompt.
+
+    Returns one row per current-period budget. Includes the prior 3
+    months' total + average + this month's running actual. Aggregates
+    only — no transaction-level data leaves this function.
+    """
+    budget_rows = (
+        await db.execute(
+            select(Budget)
+            .where(
+                Budget.org_id == org_id,
+                Budget.period_start == period_start,
+            )
+            .order_by(Budget.category_id)
+        )
+    ).scalars().all()
+    if not budget_rows:
+        return []
+
+    for b in budget_rows:
+        await db.refresh(b, ["category"])
+
+    cat_ids = [b.category_id for b in budget_rows]
+
+    sub_rows = (
+        await db.execute(
+            select(Category.id, Category.parent_id).where(
+                Category.org_id == org_id,
+                Category.parent_id.in_(cat_ids),
+            )
+        )
+    ).all()
+    parent_to_subs: dict[int, list[int]] = {cid: [] for cid in cat_ids}
+    for sub_id, parent_id in sub_rows:
+        parent_to_subs.setdefault(parent_id, []).append(sub_id)
+
+    today = datetime.date.today()
+    three_months_ago = today - relativedelta(months=3)
+    current_month_start = today.replace(day=1)
+
+    facts: list[_CategoryFact] = []
+    for b in budget_rows:
+        all_cat_ids = [b.category_id] + parent_to_subs.get(b.category_id, [])
+
+        # Last 3 calendar months of settled expenses (rolling, not
+        # period-aligned) — gives a stable rate-of-spend signal even when
+        # billing periods are non-monthly.
+        three_mo_sum = await db.scalar(
+            select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+                Transaction.org_id == org_id,
+                Transaction.category_id.in_(all_cat_ids),
+                Transaction.type == TransactionType.EXPENSE,
+                Transaction.status == TransactionStatus.SETTLED,
+                Transaction.settled_date >= three_months_ago,
+                Transaction.settled_date < current_month_start,
+                reportable_transaction_filter(),
+            )
+        )
+        three_mo_total = Decimal(str(three_mo_sum or 0))
+        three_mo_avg = (three_mo_total / Decimal(3)).quantize(Decimal("0.01"))
+
+        # Current period's running spend.
+        q = select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+            Transaction.org_id == org_id,
+            Transaction.category_id.in_(all_cat_ids),
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.settled_date >= period_start,
+            reportable_transaction_filter(),
+        )
+        if period_end is not None:
+            q = q.where(Transaction.settled_date <= period_end)
+        current_sum = await db.scalar(q)
+        current_actual = Decimal(str(current_sum or 0))
+
+        facts.append(
+            _CategoryFact(
+                category_id=b.category_id,
+                category_name=b.category.name if b.category else "",
+                budget_amount=b.amount,
+                last_3mo_total=three_mo_total,
+                last_3mo_avg=three_mo_avg,
+                current_mo_actual=current_actual,
+            )
+        )
+
+    return facts
+
+
+def _build_messages(
+    facts: list[_CategoryFact], period_start: datetime.date
+) -> list[dict]:
+    """Build the LLM chat messages from aggregated facts.
+
+    The system prompt establishes the closed-set category contract +
+    the JSON output shape. The user message carries ONLY the aggregated
+    per-category numbers. No transaction descriptions, no PII.
+    """
+    closed_set_ids = sorted(f.category_id for f in facts)
+    system = (
+        "You are a budgeting assistant. Suggest small budget shifts based "
+        "on actual versus planned spending trends for ONE billing period.\n\n"
+        "RULES (must be followed):\n"
+        "1. Output ONLY a JSON object matching the schema; no prose, no markdown.\n"
+        "2. Every suggestion MUST reference a category_id from this exact set: "
+        f"{closed_set_ids}. Reject any other id.\n"
+        "3. ``suggested_amount`` MUST be a non-negative number representing the "
+        "new monthly budget for that category. Do not return deltas; return the "
+        "new absolute amount.\n"
+        "4. Limit reasoning to 2 short sentences per category. No personal "
+        "advice, no investment guidance.\n"
+        "5. Suggestions are ADVISORY ONLY — they are NOT auto-applied.\n"
+        "6. The sum of ``suggested_amount`` across all categories should "
+        "stay close to the sum of current budgets (within 10%). Reallocate, "
+        "do not inflate.\n"
+        "7. If no meaningful change is warranted, return an empty "
+        "``suggestions`` array with a short ``summary`` saying so.\n"
+    )
+
+    aggregates = [
+        {
+            "category_id": f.category_id,
+            "category_name": f.category_name,
+            "current_budget": float(f.budget_amount),
+            "last_3mo_avg_actual": float(f.last_3mo_avg),
+            "current_period_actual_so_far": float(f.current_mo_actual),
+        }
+        for f in facts
+    ]
+    user_payload = {
+        "period_start": period_start.isoformat(),
+        "categories": aggregates,
+    }
+    user = (
+        "Given the per-category aggregates below, suggest budget shifts.\n\n"
+        f"AGGREGATES:\n{user_payload}"
+    )
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+def _validate_and_shape(
+    raw: dict, facts: list[_CategoryFact]
+) -> list[BudgetDeltaSuggestion]:
+    """Convert raw LLM JSON into typed suggestions, rejecting drift.
+
+    Raises ``ValueError`` if the response contains category ids not in
+    the org's current-period budget set, or if numeric coercion fails.
+    """
+    allowed = {f.category_id: f for f in facts}
+    suggestions = raw.get("suggestions") or []
+    if not isinstance(suggestions, list):
+        raise ValueError("suggestions is not a list")
+
+    shaped: list[BudgetDeltaSuggestion] = []
+    seen: set[int] = set()
+    for item in suggestions:
+        if not isinstance(item, dict):
+            raise ValueError("suggestion item is not an object")
+        cid = item.get("category_id")
+        if not isinstance(cid, int) or cid not in allowed:
+            raise ValueError(f"category_id {cid!r} is not in the allowed set")
+        if cid in seen:
+            # Drop duplicate suggestions for the same category (LLM noise).
+            continue
+        seen.add(cid)
+        suggested = item.get("suggested_amount")
+        try:
+            suggested_amount = Decimal(str(suggested)).quantize(Decimal("0.01"))
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(
+                f"suggested_amount not numeric: {suggested!r}"
+            ) from exc
+        if suggested_amount < 0:
+            raise ValueError(
+                f"suggested_amount must be >= 0 (got {suggested_amount})"
+            )
+        reasoning = item.get("reasoning") or ""
+        if not isinstance(reasoning, str):
+            raise ValueError("reasoning must be a string")
+        reasoning = reasoning.strip()[:400]
+
+        fact = allowed[cid]
+        shaped.append(
+            BudgetDeltaSuggestion(
+                category_id=cid,
+                category_name=fact.category_name,
+                current_amount=fact.budget_amount,
+                suggested_amount=suggested_amount,
+                delta_amount=suggested_amount - fact.budget_amount,
+                reasoning=reasoning,
+            )
+        )
+
+    return shaped
+
+
+async def suggest_rebalance(
+    db: AsyncSession, *, org_id: int
+) -> BudgetRebalanceResponse:
+    """Compute the AI rebalance suggestion for an org's current period.
+
+    Always returns a typed ``BudgetRebalanceResponse`` — the router
+    maps this to HTTP 200 regardless of internal failure mode. The
+    feature gate is enforced at the router layer before this service
+    runs.
+    """
+    period = await get_current_period(db, org_id)
+    facts = await _gather_facts(
+        db,
+        org_id=org_id,
+        period_start=period.start_date,
+        period_end=period.end_date,
+    )
+    if not facts:
+        return BudgetRebalanceResponse(
+            status="empty_no_budgets",
+            period_start=period.start_date.isoformat(),
+            summary=(
+                "No budgets are set for the current period. Add a few "
+                "budgets first, then come back for a rebalance suggestion."
+            ),
+        )
+
+    if all(f.last_3mo_total <= 0 for f in facts):
+        return BudgetRebalanceResponse(
+            status="empty_no_history",
+            period_start=period.start_date.isoformat(),
+            summary=(
+                "Not enough recent spending history to suggest a "
+                "rebalance. Come back once you have a few months of "
+                "categorized transactions."
+            ),
+        )
+
+    messages = _build_messages(facts, period.start_date)
+
+    try:
+        result = await call_llm_structured(
+            db,
+            org_id=org_id,
+            feature_key=FEATURE_KEY,
+            messages=messages,
+            response_schema=LLM_RESPONSE_SCHEMA,
+        )
+    except (
+        NoRoutingConfigured,
+        AICapExceeded,
+        AICapabilityNotSupported,
+        NativeNotAvailable,
+        StructuredOutputError,
+        AIDispatchFailed,
+    ) as exc:
+        logger.info(
+            "ai.budget.rebalance.unavailable",
+            org_id=org_id,
+            error_class=type(exc).__name__,
+        )
+        return BudgetRebalanceResponse(
+            status="llm_unavailable",
+            period_start=period.start_date.isoformat(),
+            summary=(
+                "AI rebalance is temporarily unavailable. Set up an AI "
+                "provider in Settings or try again later."
+            ),
+        )
+
+    try:
+        shaped = _validate_and_shape(result.response.parsed, facts)
+    except ValueError as exc:
+        logger.info(
+            "ai.budget.rebalance.response_invalid",
+            org_id=org_id,
+            error=str(exc),
+        )
+        return BudgetRebalanceResponse(
+            status="llm_unavailable",
+            period_start=period.start_date.isoformat(),
+            summary=(
+                "AI returned an unexpected response. Try again, or set "
+                "up a different model in Settings."
+            ),
+        )
+
+    summary_raw = (result.response.parsed.get("summary") or "").strip()
+    summary = summary_raw[:400]
+
+    return BudgetRebalanceResponse(
+        status="ok",
+        period_start=period.start_date.isoformat(),
+        suggestions=shaped,
+        summary=summary,
+    )

--- a/backend/tests/routers/test_ai_budget_router.py
+++ b/backend/tests/routers/test_ai_budget_router.py
@@ -1,0 +1,256 @@
+"""LAI.3 — router tests for ``POST /api/v1/ai/budget/rebalance``.
+
+Pins:
+- Feature gate ``ai.budget=False`` → 403 ``feature_not_enabled``.
+- Gate True + service returns ``ok`` → 200 with typed payload.
+- Gate True + service returns ``llm_unavailable`` → 200 + empty-state
+  status (UI shouldn't crash).
+- Audit row is written with the structural outcome + count.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import os
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.auth.feature_deps import get_current_org_features
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.audit_event import AuditEvent
+from app.models.user import Organization, Role, User
+from app.routers.ai_budget import router as ai_budget_router
+from app.schemas.budget_rebalance import BudgetRebalanceResponse
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _set_ai_key(monkeypatch):
+    monkeypatch.setattr(
+        app_settings,
+        "ai_credential_encryption_key",
+        base64.urlsafe_b64encode(os.urandom(32)).decode("ascii"),
+    )
+    monkeypatch.setattr(
+        app_settings, "ai_credential_encryption_key_prev", ""
+    )
+
+
+def _make_app(session_factory, *, features: dict[str, bool], user: User):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return user
+
+    def override_get_session_factory():
+        return session_factory
+
+    async def override_features() -> dict[str, bool]:
+        return features
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_get_session_factory
+    app.dependency_overrides[get_current_org_features] = override_features
+    app.include_router(ai_budget_router)
+    return app
+
+
+@pytest_asyncio.fixture
+async def org_and_user(session_factory) -> tuple[Organization, User]:
+    async with session_factory() as session:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        session.add(org)
+        await session.commit()
+        user = User(
+            id=1,
+            org_id=org.id,
+            username="owner",
+            email="owner@example.com",
+            password_hash="x" * 64,
+            role=Role.OWNER,
+        )
+        session.add(user)
+        await session.commit()
+        return org, user
+
+
+def test_feature_gate_closed_returns_403(session_factory, org_and_user):
+    _, user = org_and_user
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": False,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+    client = TestClient(app)
+    res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 403
+    body = res.json()
+    assert body["detail"]["code"] == "feature_not_enabled"
+
+
+def test_feature_gate_open_returns_typed_response(
+    session_factory, org_and_user
+):
+    org, user = org_and_user
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+    fake = BudgetRebalanceResponse(
+        status="ok",
+        period_start=str(datetime.date.today().replace(day=1)),
+        summary="trim a little",
+        suggestions=[],
+    )
+    with patch(
+        "app.services.budget_rebalance_service.suggest_rebalance",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = TestClient(app)
+        res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["status"] == "ok"
+    assert body["summary"] == "trim a little"
+    assert body["suggestions"] == []
+
+
+def test_llm_unavailable_response_still_returns_200(
+    session_factory, org_and_user
+):
+    org, user = org_and_user
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+    fake = BudgetRebalanceResponse(
+        status="llm_unavailable",
+        period_start=str(datetime.date.today().replace(day=1)),
+        summary="AI rebalance is temporarily unavailable.",
+    )
+    with patch(
+        "app.services.budget_rebalance_service.suggest_rebalance",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = TestClient(app)
+        res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 200
+    assert res.json()["status"] == "llm_unavailable"
+
+
+def test_audit_row_written_with_outcome_and_count(
+    session_factory, org_and_user
+):
+    """Each rebalance request must produce an audit row.
+
+    The audit detail carries the structural outcome (success/failure)
+    AND the suggestion count — never prompt or completion content.
+    """
+    org, user = org_and_user
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+    fake = BudgetRebalanceResponse(
+        status="ok",
+        period_start=str(datetime.date.today().replace(day=1)),
+        summary="x",
+        suggestions=[],  # empty but ok status is success outcome
+    )
+    with patch(
+        "app.services.budget_rebalance_service.suggest_rebalance",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = TestClient(app)
+        res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 200
+
+    import asyncio
+
+    async def _read_audit():
+        async with session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.event_type
+                        == "ai.budget.rebalance.requested"
+                    )
+                )
+            ).scalars().all()
+            return rows
+
+    rows = asyncio.get_event_loop().run_until_complete(_read_audit())
+    assert len(rows) == 1
+    detail = rows[0].detail or {}
+    assert detail.get("status") == "ok"
+    assert detail.get("suggestion_count") == 0
+    assert rows[0].outcome.value == "success"

--- a/backend/tests/routers/test_ai_budget_router.py
+++ b/backend/tests/routers/test_ai_budget_router.py
@@ -451,4 +451,3 @@ def test_endpoint_never_mutates_budgets_table(
         "POST /rebalance must NEVER mutate the budgets table; "
         f"before={before}, after={after}"
     )
-    assert rows[0].outcome.value == "success"

--- a/backend/tests/routers/test_ai_budget_router.py
+++ b/backend/tests/routers/test_ai_budget_router.py
@@ -253,4 +253,202 @@ def test_audit_row_written_with_outcome_and_count(
     detail = rows[0].detail or {}
     assert detail.get("status") == "ok"
     assert detail.get("suggestion_count") == 0
+
+
+def test_audit_row_on_llm_unavailable_is_failure(
+    session_factory, org_and_user
+):
+    """When the service returns ``llm_unavailable``, the audit row
+    must land with ``outcome='failure'`` so ops can count real LLM
+    outages without noise from user-state preconditions."""
+    org, user = org_and_user
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+    fake = BudgetRebalanceResponse(
+        status="llm_unavailable",
+        period_start=str(datetime.date.today().replace(day=1)),
+        summary="AI temporarily unavailable.",
+    )
+    with patch(
+        "app.services.budget_rebalance_service.suggest_rebalance",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = TestClient(app)
+        res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 200
+
+    import asyncio
+
+    async def _read_audit():
+        async with session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.event_type
+                        == "ai.budget.rebalance.requested"
+                    )
+                )
+            ).scalars().all()
+            return rows
+
+    rows = asyncio.get_event_loop().run_until_complete(_read_audit())
+    assert len(rows) == 1
+    assert rows[0].outcome.value == "failure"
+    detail = rows[0].detail or {}
+    assert detail.get("status") == "llm_unavailable"
+
+
+def test_audit_row_on_empty_no_budgets_is_success(
+    session_factory, org_and_user
+):
+    """``empty_no_budgets`` is a user-state precondition, NOT a system
+    failure — audit outcome must reflect that so ops dashboards don't
+    treat \"user hasn't set up budgets\" as a real outage."""
+    org, user = org_and_user
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+    fake = BudgetRebalanceResponse(
+        status="empty_no_budgets",
+        period_start=str(datetime.date.today().replace(day=1)),
+        summary="No budgets are set.",
+    )
+    with patch(
+        "app.services.budget_rebalance_service.suggest_rebalance",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = TestClient(app)
+        res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 200
+
+    import asyncio
+
+    async def _read_audit():
+        async with session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(AuditEvent).where(
+                        AuditEvent.event_type
+                        == "ai.budget.rebalance.requested"
+                    )
+                )
+            ).scalars().all()
+            return rows
+
+    rows = asyncio.get_event_loop().run_until_complete(_read_audit())
+    assert len(rows) == 1
+    assert rows[0].outcome.value == "success"
+    detail = rows[0].detail or {}
+    assert detail.get("status") == "empty_no_budgets"
+
+
+def test_endpoint_never_mutates_budgets_table(
+    session_factory, org_and_user
+):
+    """Architectural invariant: POST /rebalance is suggestion-only.
+    The budgets table must be byte-identical before and after the
+    request, regardless of how the service responded. Pinning at the
+    router level guards against a future regression that auto-applies
+    even one row.
+    """
+    import asyncio
+    from decimal import Decimal
+
+    from app.models.budget import Budget
+    from app.models.category import Category, CategoryType
+
+    org, user = org_and_user
+
+    async def _seed_budgets():
+        async with session_factory() as session:
+            cat = Category(
+                org_id=org.id,
+                name="Groceries",
+                slug="groceries",
+                type=CategoryType.EXPENSE,
+                is_system=False,
+            )
+            session.add(cat)
+            await session.commit()
+            b = Budget(
+                org_id=org.id,
+                category_id=cat.id,
+                amount=Decimal("400.00"),
+                period_start=datetime.date.today().replace(day=1),
+                period_end=None,
+            )
+            session.add(b)
+            await session.commit()
+            return [(b.id, b.category_id, b.amount)]
+
+    before = asyncio.get_event_loop().run_until_complete(_seed_budgets())
+
+    app = _make_app(
+        session_factory,
+        features={
+            "ai.budget": True,
+            "ai.forecast": False,
+            "ai.smart_plan": False,
+            "ai.autocategorize": False,
+        },
+        user=user,
+    )
+
+    # Use the actual ok-status response shape with a non-empty
+    # suggestion list — the regression we want to catch is "service
+    # returned a suggestion AND the router secretly applied it".
+    from app.schemas.budget_rebalance import BudgetDeltaSuggestion
+
+    fake = BudgetRebalanceResponse(
+        status="ok",
+        period_start=str(datetime.date.today().replace(day=1)),
+        summary="trim a little",
+        suggestions=[
+            BudgetDeltaSuggestion(
+                category_id=before[0][1],
+                category_name="Groceries",
+                current_amount=Decimal("400.00"),
+                suggested_amount=Decimal("450.00"),
+                delta_amount=Decimal("50.00"),
+                reasoning="bump",
+            )
+        ],
+    )
+    with patch(
+        "app.services.budget_rebalance_service.suggest_rebalance",
+        new=AsyncMock(return_value=fake),
+    ):
+        client = TestClient(app)
+        res = client.post("/api/v1/ai/budget/rebalance")
+    assert res.status_code == 200, res.text
+
+    async def _read_budgets():
+        async with session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(Budget).where(Budget.org_id == org.id)
+                )
+            ).scalars().all()
+            return [(b.id, b.category_id, b.amount) for b in rows]
+
+    after = asyncio.get_event_loop().run_until_complete(_read_budgets())
+    assert before == after, (
+        "POST /rebalance must NEVER mutate the budgets table; "
+        f"before={before}, after={after}"
+    )
     assert rows[0].outcome.value == "success"

--- a/backend/tests/services/test_budget_rebalance.py
+++ b/backend/tests/services/test_budget_rebalance.py
@@ -1,0 +1,532 @@
+"""LAI.3 — Smart Budget Rebalance service tests.
+
+Covers the public ``suggest_rebalance`` entry point in
+``budget_rebalance_service``. The dispatch substrate
+(``call_llm_structured``) is patched at the module boundary so these
+tests are completely offline.
+
+Cases:
+- No current-period budgets → ``empty_no_budgets``.
+- Budgets exist but no settled history → ``empty_no_history``.
+- Happy path: LLM returns valid suggestions → ``ok`` + shaped deltas.
+- LLM returns an unknown ``category_id`` → ``llm_unavailable`` (the
+  cross-org / hallucination guard).
+- ``NoRoutingConfigured`` from the dispatch layer → ``llm_unavailable``.
+- ``StructuredOutputError`` (retry budget exhausted) → ``llm_unavailable``.
+- Inputs to the prompt are aggregates only — no raw transaction data
+  leaks into the message payload.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import os
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.models import Base
+from app.models.billing import BillingPeriod
+from app.models.budget import Budget
+from app.models.category import Category, CategoryType
+from app.models.transaction import (
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+from app.models.user import Organization, Role, User
+from app.services import budget_rebalance_service
+from app.services.ai_dispatch import (
+    NoRoutingConfigured,
+    StructuredDispatchResult,
+)
+from app.services.ai_providers.base import (
+    StructuredOutputError,
+    StructuredResponse,
+)
+
+
+# ---------- fixtures --------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture(autouse=True)
+def _set_ai_key(monkeypatch):
+    monkeypatch.setattr(
+        app_settings,
+        "ai_credential_encryption_key",
+        base64.urlsafe_b64encode(os.urandom(32)).decode("ascii"),
+    )
+    monkeypatch.setattr(
+        app_settings, "ai_credential_encryption_key_prev", ""
+    )
+
+
+@pytest_asyncio.fixture
+async def org(db: AsyncSession) -> Organization:
+    o = Organization(name="Acme", billing_cycle_day=1)
+    db.add(o)
+    await db.commit()
+    return o
+
+
+@pytest_asyncio.fixture
+async def user(db: AsyncSession, org: Organization) -> User:
+    u = User(
+        org_id=org.id,
+        username="owner",
+        email="owner@example.com",
+        password_hash="x" * 64,
+        role=Role.OWNER,
+    )
+    db.add(u)
+    await db.commit()
+    return u
+
+
+@pytest_asyncio.fixture
+async def period(db: AsyncSession, org: Organization) -> BillingPeriod:
+    today = datetime.date.today()
+    p = BillingPeriod(org_id=org.id, start_date=today.replace(day=1))
+    db.add(p)
+    await db.commit()
+    return p
+
+
+@pytest_asyncio.fixture
+async def categories(
+    db: AsyncSession, org: Organization
+) -> dict[str, Category]:
+    groceries = Category(
+        org_id=org.id,
+        name="Groceries",
+        type=CategoryType.EXPENSE,
+        parent_id=None,
+    )
+    dining = Category(
+        org_id=org.id,
+        name="Dining",
+        type=CategoryType.EXPENSE,
+        parent_id=None,
+    )
+    db.add_all([groceries, dining])
+    await db.commit()
+    return {"groceries": groceries, "dining": dining}
+
+
+@pytest_asyncio.fixture
+async def budgets(
+    db: AsyncSession,
+    org: Organization,
+    period: BillingPeriod,
+    categories: dict[str, Category],
+) -> dict[str, Budget]:
+    g = Budget(
+        org_id=org.id,
+        category_id=categories["groceries"].id,
+        amount=Decimal("400.00"),
+        period_start=period.start_date,
+        period_end=period.end_date,
+    )
+    d = Budget(
+        org_id=org.id,
+        category_id=categories["dining"].id,
+        amount=Decimal("200.00"),
+        period_start=period.start_date,
+        period_end=period.end_date,
+    )
+    db.add_all([g, d])
+    await db.commit()
+    return {"groceries": g, "dining": d}
+
+
+async def _seed_account(db: AsyncSession, org: Organization, user: User):
+    """Minimal account row so we can insert transactions."""
+    from app.models.account import Account, AccountType
+
+    at = AccountType(org_id=org.id, name="Checking", slug="checking")
+    db.add(at)
+    await db.flush()
+    acct = Account(
+        org_id=org.id,
+        account_type_id=at.id,
+        name="checking",
+        balance=Decimal("1000.00"),
+        currency="USD",
+    )
+    db.add(acct)
+    await db.commit()
+    return acct
+
+
+async def _seed_history(
+    db: AsyncSession,
+    *,
+    org: Organization,
+    user: User,
+    category: Category,
+    amount: Decimal,
+    settled: datetime.date,
+):
+    acct = await _seed_account(db, org, user)
+    tx = Transaction(
+        org_id=org.id,
+        account_id=acct.id,
+        category_id=category.id,
+        description="x",
+        amount=amount,
+        type=TransactionType.EXPENSE,
+        status=TransactionStatus.SETTLED,
+        settled_date=settled,
+        date=settled,
+    )
+    db.add(tx)
+    await db.commit()
+
+
+# ---------- empty paths ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_budgets_returns_empty_no_budgets(
+    db: AsyncSession, org: Organization, user: User, period: BillingPeriod
+):
+    out = await budget_rebalance_service.suggest_rebalance(db, org_id=org.id)
+    assert out.status == "empty_no_budgets"
+    assert out.suggestions == []
+
+
+@pytest.mark.asyncio
+async def test_budgets_but_no_history_returns_empty_no_history(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+    budgets,
+):
+    out = await budget_rebalance_service.suggest_rebalance(db, org_id=org.id)
+    assert out.status == "empty_no_history"
+    assert out.suggestions == []
+
+
+# ---------- happy path ------------------------------------------------
+
+
+def _make_structured_result(parsed: dict) -> StructuredDispatchResult:
+    return StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed=parsed,
+            raw_text="{}",
+            prompt_tokens=10,
+            completion_tokens=20,
+            model="gpt-4o-mini",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_shaped_suggestions(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+    categories,
+    budgets,
+):
+    """LLM returns valid suggestions for known category_ids → ok."""
+    today = datetime.date.today()
+    last_month = (today.replace(day=1) - datetime.timedelta(days=1))
+    await _seed_history(
+        db,
+        org=org,
+        user=user,
+        category=categories["groceries"],
+        amount=Decimal("450.00"),
+        settled=last_month,
+    )
+
+    captured_messages: list[list[dict]] = []
+
+    async def fake_call(
+        *args, messages, response_schema, feature_key, org_id, **kw
+    ):
+        captured_messages.append(messages)
+        return _make_structured_result(
+            {
+                "summary": "Move money to groceries; you consistently overspend.",
+                "suggestions": [
+                    {
+                        "category_id": categories["groceries"].id,
+                        "suggested_amount": 450.0,
+                        "reasoning": "Trailing 3-month spend is well above the current limit.",
+                    },
+                    {
+                        "category_id": categories["dining"].id,
+                        "suggested_amount": 150.0,
+                        "reasoning": "You've been under budget here for months.",
+                    },
+                ],
+            }
+        )
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        out = await budget_rebalance_service.suggest_rebalance(
+            db, org_id=org.id
+        )
+
+    assert out.status == "ok"
+    assert out.summary.startswith("Move money to groceries")
+    assert len(out.suggestions) == 2
+    g_sugg = next(
+        s for s in out.suggestions
+        if s.category_id == categories["groceries"].id
+    )
+    assert g_sugg.suggested_amount == Decimal("450.00")
+    assert g_sugg.current_amount == Decimal("400.00")
+    assert g_sugg.delta_amount == Decimal("50.00")
+    d_sugg = next(
+        s for s in out.suggestions
+        if s.category_id == categories["dining"].id
+    )
+    assert d_sugg.delta_amount == Decimal("-50.00")
+
+    # Aggregates-only: prompt must NOT carry raw transaction text. The
+    # _seed_history call above set description="x"; that string must
+    # not appear anywhere in the message payload.
+    flat = " ".join(
+        m.get("content", "") for ms in captured_messages for m in ms
+    )
+    assert "description" not in flat.lower()
+    # The trailing-spend aggregate (last_3mo_avg) for groceries is
+    # $450 / 3 = $150. The aggregate MUST be in the prompt.
+    assert "150.0" in flat or "150" in flat
+
+
+# ---------- defense-in-depth: unknown category_id --------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_category_id_in_response_returns_llm_unavailable(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+    categories,
+    budgets,
+):
+    """LLM returns a category_id that is NOT in the org's budget set.
+
+    The service refuses to surface partial/hallucinated data and
+    returns the friendly empty state.
+    """
+    today = datetime.date.today()
+    last_month = today.replace(day=1) - datetime.timedelta(days=1)
+    await _seed_history(
+        db,
+        org=org,
+        user=user,
+        category=categories["groceries"],
+        amount=Decimal("100.00"),
+        settled=last_month,
+    )
+
+    async def fake_call(*args, **kw):
+        return _make_structured_result(
+            {
+                "summary": "drift",
+                "suggestions": [
+                    {
+                        # 99999 is NOT a real category for this org.
+                        "category_id": 99999,
+                        "suggested_amount": 250.0,
+                        "reasoning": "I am hallucinating.",
+                    }
+                ],
+            }
+        )
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        out = await budget_rebalance_service.suggest_rebalance(
+            db, org_id=org.id
+        )
+
+    assert out.status == "llm_unavailable"
+    assert out.suggestions == []
+
+
+# ---------- LLM unavailable paths ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_routing_returns_llm_unavailable(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+    categories,
+    budgets,
+):
+    today = datetime.date.today()
+    last_month = today.replace(day=1) - datetime.timedelta(days=1)
+    await _seed_history(
+        db,
+        org=org,
+        user=user,
+        category=categories["groceries"],
+        amount=Decimal("100.00"),
+        settled=last_month,
+    )
+
+    async def fake_call(*args, **kw):
+        raise NoRoutingConfigured()
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        out = await budget_rebalance_service.suggest_rebalance(
+            db, org_id=org.id
+        )
+
+    assert out.status == "llm_unavailable"
+    assert "AI rebalance is temporarily unavailable" in out.summary
+
+
+@pytest.mark.asyncio
+async def test_structured_output_exhausted_returns_llm_unavailable(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+    categories,
+    budgets,
+):
+    today = datetime.date.today()
+    last_month = today.replace(day=1) - datetime.timedelta(days=1)
+    await _seed_history(
+        db,
+        org=org,
+        user=user,
+        category=categories["groceries"],
+        amount=Decimal("100.00"),
+        settled=last_month,
+    )
+
+    async def fake_call(*args, **kw):
+        raise StructuredOutputError("STATUS_ERROR_STRUCTURED_OUTPUT")
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        out = await budget_rebalance_service.suggest_rebalance(
+            db, org_id=org.id
+        )
+
+    assert out.status == "llm_unavailable"
+
+
+# ---------- contract: no auto-apply -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_never_mutates_budgets(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+    categories,
+    budgets,
+):
+    """The service is read-only: even on the ``ok`` path, the budget
+    rows must not be mutated. Application is the frontend's job, via
+    the existing budget update endpoints.
+    """
+    today = datetime.date.today()
+    last_month = today.replace(day=1) - datetime.timedelta(days=1)
+    await _seed_history(
+        db,
+        org=org,
+        user=user,
+        category=categories["groceries"],
+        amount=Decimal("100.00"),
+        settled=last_month,
+    )
+
+    before_groceries = budgets["groceries"].amount
+    before_dining = budgets["dining"].amount
+
+    async def fake_call(*args, **kw):
+        return _make_structured_result(
+            {
+                "summary": "shift",
+                "suggestions": [
+                    {
+                        "category_id": categories["groceries"].id,
+                        "suggested_amount": 999.0,
+                        "reasoning": "test",
+                    }
+                ],
+            }
+        )
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        await budget_rebalance_service.suggest_rebalance(db, org_id=org.id)
+
+    await db.refresh(budgets["groceries"])
+    await db.refresh(budgets["dining"])
+    assert budgets["groceries"].amount == before_groceries
+    assert budgets["dining"].amount == before_dining

--- a/backend/tests/services/test_budget_rebalance.py
+++ b/backend/tests/services/test_budget_rebalance.py
@@ -530,3 +530,164 @@ async def test_service_never_mutates_budgets(
     await db.refresh(budgets["dining"])
     assert budgets["groceries"].amount == before_groceries
     assert budgets["dining"].amount == before_dining
+
+
+# ---------- parent/child rollup correctness --------------------------
+
+
+@pytest.mark.asyncio
+async def test_child_with_own_budget_is_not_double_counted_via_parent(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+):
+    """When a parent category AND its child BOTH have budgets, the
+    child's transactions must NOT roll up into the parent's facts row
+    (otherwise the same dollars are counted in both rows).
+
+    Seeds: Housing (parent, $2000 budget), Rent (child of Housing,
+    $1500 budget). $1000 of expenses settled on Rent last month.
+
+    Expected: in the prompt, Rent's avg appears in Rent's facts row
+    (~333/mo); Housing's facts row sees $0 (Housing itself has no
+    transactions and Rent's are absorbed into Rent's own row).
+    """
+    today = datetime.date.today()
+    last_month = today.replace(day=1) - datetime.timedelta(days=1)
+
+    housing = Category(
+        org_id=org.id, name="Housing", type=CategoryType.EXPENSE, parent_id=None,
+    )
+    db.add(housing)
+    await db.commit()
+    rent = Category(
+        org_id=org.id, name="Rent", type=CategoryType.EXPENSE, parent_id=housing.id,
+    )
+    db.add(rent)
+    await db.commit()
+
+    db.add_all([
+        Budget(
+            org_id=org.id, category_id=housing.id,
+            amount=Decimal("2000.00"),
+            period_start=period.start_date, period_end=period.end_date,
+        ),
+        Budget(
+            org_id=org.id, category_id=rent.id,
+            amount=Decimal("1500.00"),
+            period_start=period.start_date, period_end=period.end_date,
+        ),
+    ])
+    await db.commit()
+
+    await _seed_history(
+        db, org=org, user=user, category=rent,
+        amount=Decimal("1000.00"), settled=last_month,
+    )
+
+    captured_payloads: list[dict] = []
+
+    async def fake_call(*args, messages, **kw):
+        # The user-content message has the aggregates dict embedded as
+        # its content. Extract by finding the categories list in the
+        # JSON-ish payload.
+        for m in messages:
+            content = m.get("content", "")
+            if "categories" in content and "category_id" in content:
+                # Eval the payload — _build_messages writes it via repr(),
+                # so it's a Python literal, NOT JSON.
+                import ast, re
+                match = re.search(r"\{.*\}", content, re.DOTALL)
+                if match:
+                    captured_payloads.append(ast.literal_eval(match.group()))
+        return _make_structured_result(
+            {"summary": "ok", "suggestions": []}
+        )
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        await budget_rebalance_service.suggest_rebalance(db, org_id=org.id)
+
+    assert captured_payloads, "expected the prompt to carry an aggregates payload"
+    cats = captured_payloads[0]["categories"]
+    by_id = {c["category_id"]: c for c in cats}
+    assert housing.id in by_id and rent.id in by_id
+    # Rent's 3mo avg should reflect the $1000 settled last month.
+    assert by_id[rent.id]["last_3mo_avg_actual"] > 0
+    # Housing's 3mo avg must be ZERO — its only would-be source is
+    # Rent's transactions, which now belong to Rent's own row.
+    assert by_id[housing.id]["last_3mo_avg_actual"] == 0.0, (
+        f"Housing row should not double-count Rent's transactions; "
+        f"got {by_id[housing.id]['last_3mo_avg_actual']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unbudgeted_child_still_rolls_up_into_parent(
+    db: AsyncSession,
+    org: Organization,
+    user: User,
+    period: BillingPeriod,
+):
+    """When the child has NO budget of its own, the parent's facts
+    row should include the child's transactions. This pins the
+    rollup-for-unbudgeted-children behavior that the duplicate-skip
+    guard must not break.
+    """
+    today = datetime.date.today()
+    last_month = today.replace(day=1) - datetime.timedelta(days=1)
+
+    housing = Category(
+        org_id=org.id, name="Housing", type=CategoryType.EXPENSE, parent_id=None,
+    )
+    db.add(housing)
+    await db.commit()
+    rent = Category(
+        org_id=org.id, name="Rent", type=CategoryType.EXPENSE, parent_id=housing.id,
+    )
+    db.add(rent)
+    await db.commit()
+
+    # Parent ONLY has a budget; child does not.
+    db.add(Budget(
+        org_id=org.id, category_id=housing.id,
+        amount=Decimal("2000.00"),
+        period_start=period.start_date, period_end=period.end_date,
+    ))
+    await db.commit()
+
+    await _seed_history(
+        db, org=org, user=user, category=rent,
+        amount=Decimal("900.00"), settled=last_month,
+    )
+
+    captured_payloads: list[dict] = []
+
+    async def fake_call(*args, messages, **kw):
+        for m in messages:
+            content = m.get("content", "")
+            if "categories" in content and "category_id" in content:
+                import ast, re
+                match = re.search(r"\{.*\}", content, re.DOTALL)
+                if match:
+                    captured_payloads.append(ast.literal_eval(match.group()))
+        return _make_structured_result(
+            {"summary": "ok", "suggestions": []}
+        )
+
+    with patch(
+        "app.services.budget_rebalance_service.call_llm_structured",
+        side_effect=fake_call,
+    ):
+        await budget_rebalance_service.suggest_rebalance(db, org_id=org.id)
+
+    cats = captured_payloads[0]["categories"]
+    by_id = {c["category_id"]: c for c in cats}
+    assert housing.id in by_id
+    # Rent has no own facts row (no budget on Rent).
+    assert rent.id not in by_id
+    # Housing's facts row picks up Rent's $900 last month.
+    assert by_id[housing.id]["last_3mo_avg_actual"] > 0

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -16,6 +16,7 @@ import ConfirmModal from "@/components/ui/ConfirmModal";
 import { chartColor } from "@/lib/chart-colors";
 import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import { useTransactionAddedListener } from "@/lib/hooks/use-transaction-added";
+import BudgetRebalanceModal from "@/components/budgets/BudgetRebalanceModal";
 
 export default function BudgetsPage() {
   const { user, loading } = useAuth();
@@ -44,6 +45,11 @@ export default function BudgetsPage() {
   const [transferCategoryId, setTransferCategoryId] = useState<number | "">("");
   const [transferAmount, setTransferAmount] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+
+  // LAI.3 — Smart Budget Rebalance. The modal lazy-fetches when opened
+  // and never auto-applies; user accept/skip per row, then Apply
+  // writes via existing PUT /budgets/{id}.
+  const [rebalanceOpen, setRebalanceOpen] = useState(false);
 
   const selectedPeriod = periods.length > 0 ? periods[periodIdx] : null;
   const periodStart = selectedPeriod?.start_date ?? "";
@@ -217,6 +223,15 @@ export default function BudgetsPage() {
               className="min-h-[44px] sm:min-h-0 rounded-md border border-border-subtle bg-surface-raised px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-overlay"
             >
               From Forecast
+            </button>
+          )}
+          {isCurrentPeriod && budgets.length > 0 && (
+            <button
+              onClick={() => setRebalanceOpen(true)}
+              className="min-h-[44px] sm:min-h-0 rounded-md border border-border-subtle bg-surface-raised px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-overlay"
+              data-testid="suggest-rebalance-btn"
+            >
+              Suggest rebalance
             </button>
           )}
           {isCurrentPeriod && availableCategories.length > 0 && (
@@ -482,6 +497,18 @@ export default function BudgetsPage() {
         variant="danger"
         onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
         onCancel={() => setConfirmDeleteId(null)}
+      />
+      <BudgetRebalanceModal
+        open={rebalanceOpen}
+        budgets={budgets.map((b) => ({
+          id: b.id,
+          category_id: b.category_id,
+          amount: b.amount,
+        }))}
+        onApplied={() => {
+          void loadBudgets();
+        }}
+        onClose={() => setRebalanceOpen(false)}
       />
     </AppShell>
   );

--- a/frontend/components/budgets/BudgetRebalanceModal.tsx
+++ b/frontend/components/budgets/BudgetRebalanceModal.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import Spinner from "@/components/ui/Spinner";
+import { apiFetch, extractErrorMessage } from "@/lib/api";
+import { formatAmount } from "@/lib/format";
+import { btnPrimary, btnSecondary, card, error as errorCls } from "@/lib/styles";
+
+export type RebalanceStatus =
+  | "ok"
+  | "empty_no_budgets"
+  | "empty_no_history"
+  | "llm_unavailable";
+
+export interface RebalanceSuggestion {
+  category_id: number;
+  category_name: string;
+  current_amount: string | number;
+  suggested_amount: string | number;
+  delta_amount: string | number;
+  reasoning: string;
+}
+
+export interface RebalanceResponse {
+  status: RebalanceStatus;
+  period_start: string | null;
+  suggestions: RebalanceSuggestion[];
+  summary: string;
+}
+
+interface Budget {
+  id: number;
+  category_id: number;
+  amount: string | number;
+}
+
+interface Props {
+  open: boolean;
+  budgets: Budget[];
+  /** Called after the user clicks Apply and the writes succeed.
+   *  Lets the parent reload its budgets list. */
+  onApplied: () => void;
+  onClose: () => void;
+}
+
+function toNumber(value: string | number): number {
+  return typeof value === "string" ? Number(value) : value;
+}
+
+export default function BudgetRebalanceModal({
+  open,
+  budgets,
+  onApplied,
+  onClose,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  const [response, setResponse] = useState<RebalanceResponse | null>(null);
+  const [acceptedIds, setAcceptedIds] = useState<Set<number>>(new Set());
+  const [fetchError, setFetchError] = useState<string>("");
+  const [applyError, setApplyError] = useState<string>("");
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setResponse(null);
+    setFetchError("");
+    setApplyError("");
+    setAcceptedIds(new Set());
+    apiFetch<RebalanceResponse>("/api/v1/ai/budget/rebalance", {
+      method: "POST",
+    })
+      .then((res) => {
+        if (cancelled) return;
+        if (res) {
+          setResponse(res);
+          // Accept-by-default: each suggestion is opt-out, mirroring
+          // the diff-review UX. The user can skip individual rows
+          // before clicking Apply.
+          setAcceptedIds(
+            new Set((res.suggestions ?? []).map((s) => s.category_id)),
+          );
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setFetchError(extractErrorMessage(err));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const budgetIdByCategory = useMemo(() => {
+    const m = new Map<number, number>();
+    for (const b of budgets) m.set(b.category_id, b.id);
+    return m;
+  }, [budgets]);
+
+  function toggleRow(categoryId: number) {
+    setAcceptedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(categoryId)) next.delete(categoryId);
+      else next.add(categoryId);
+      return next;
+    });
+  }
+
+  async function handleApply() {
+    if (!response) return;
+    setApplyError("");
+    setApplying(true);
+    try {
+      const accepted = response.suggestions.filter((s) =>
+        acceptedIds.has(s.category_id),
+      );
+      for (const s of accepted) {
+        const budgetId = budgetIdByCategory.get(s.category_id);
+        if (!budgetId) continue;
+        await apiFetch(`/api/v1/budgets/${budgetId}`, {
+          method: "PUT",
+          body: JSON.stringify({ amount: toNumber(s.suggested_amount) }),
+        });
+      }
+      onApplied();
+      onClose();
+    } catch (err) {
+      setApplyError(extractErrorMessage(err));
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  if (!open) return null;
+
+  const hasOkSuggestions =
+    response?.status === "ok" && (response.suggestions?.length ?? 0) > 0;
+
+  const acceptedCount = acceptedIds.size;
+  const acceptedSum = response
+    ? response.suggestions
+        .filter((s) => acceptedIds.has(s.category_id))
+        .reduce((acc, s) => acc + toNumber(s.delta_amount), 0)
+    : 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="rebalance-title"
+    >
+      <div
+        className={`${card} relative w-full max-w-3xl max-h-[90vh] overflow-y-auto`}
+      >
+        <div className="flex items-start justify-between border-b border-border-subtle px-6 py-4">
+          <div>
+            <h2
+              id="rebalance-title"
+              className="text-base font-semibold text-text-primary"
+            >
+              AI budget rebalance
+            </h2>
+            <p className="mt-1 text-xs text-text-muted">
+              Suggestions only. Nothing is applied until you click Apply.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-text-muted hover:text-text-primary"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          {loading && (
+            <div className="flex justify-center py-12">
+              <Spinner />
+            </div>
+          )}
+
+          {!loading && fetchError && (
+            <div className={`mb-4 ${errorCls}`} role="alert">
+              {fetchError}
+            </div>
+          )}
+
+          {!loading && response && response.status !== "ok" && (
+            <EmptyState status={response.status} message={response.summary} />
+          )}
+
+          {!loading && response && response.status === "ok" && !hasOkSuggestions && (
+            <EmptyState
+              status="ok_no_changes"
+              message={
+                response.summary ||
+                "AI looked at your budgets and didn't recommend any changes."
+              }
+            />
+          )}
+
+          {!loading && response && hasOkSuggestions && (
+            <>
+              {response.summary && (
+                <p className="mb-4 text-sm text-text-secondary">
+                  {response.summary}
+                </p>
+              )}
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm" data-testid="rebalance-diff-table">
+                  <thead>
+                    <tr className="border-b border-border-subtle text-left">
+                      <th className="py-2 pr-3 text-xs font-medium text-text-muted">
+                        Apply
+                      </th>
+                      <th className="py-2 pr-3 text-xs font-medium text-text-muted">
+                        Category
+                      </th>
+                      <th className="py-2 pr-3 text-right text-xs font-medium text-text-muted">
+                        Current
+                      </th>
+                      <th className="py-2 pr-3 text-right text-xs font-medium text-text-muted">
+                        Suggested
+                      </th>
+                      <th className="py-2 pr-3 text-right text-xs font-medium text-text-muted">
+                        Delta
+                      </th>
+                      <th className="py-2 pr-3 text-xs font-medium text-text-muted">
+                        Reasoning
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {response.suggestions.map((s) => {
+                      const delta = toNumber(s.delta_amount);
+                      const accepted = acceptedIds.has(s.category_id);
+                      return (
+                        <tr
+                          key={s.category_id}
+                          className="border-b border-border-subtle/60 align-top"
+                          data-testid={`rebalance-row-${s.category_id}`}
+                        >
+                          <td className="py-2 pr-3">
+                            <input
+                              type="checkbox"
+                              aria-label={`Apply suggestion for ${s.category_name}`}
+                              checked={accepted}
+                              onChange={() => toggleRow(s.category_id)}
+                              className="h-4 w-4 accent-accent"
+                            />
+                          </td>
+                          <td className="py-2 pr-3 text-text-primary">
+                            {s.category_name}
+                          </td>
+                          <td className="py-2 pr-3 text-right tabular-nums text-text-secondary">
+                            {formatAmount(toNumber(s.current_amount))}
+                          </td>
+                          <td className="py-2 pr-3 text-right tabular-nums text-text-primary">
+                            {formatAmount(toNumber(s.suggested_amount))}
+                          </td>
+                          <td
+                            className={`py-2 pr-3 text-right tabular-nums ${
+                              delta > 0
+                                ? "text-success"
+                                : delta < 0
+                                  ? "text-danger"
+                                  : "text-text-muted"
+                            }`}
+                          >
+                            {delta > 0 ? "+" : ""}
+                            {formatAmount(delta)}
+                          </td>
+                          <td className="py-2 pr-3 text-xs text-text-muted">
+                            {s.reasoning}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-3 text-xs text-text-muted">
+                {acceptedCount} of {response.suggestions.length} changes
+                selected. Net change: {acceptedSum > 0 ? "+" : ""}
+                {formatAmount(acceptedSum)}.
+              </p>
+            </>
+          )}
+
+          {applyError && (
+            <div className={`mt-4 ${errorCls}`} role="alert">
+              {applyError}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-border-subtle bg-surface-raised/30 px-6 py-3">
+          <button type="button" onClick={onClose} className={btnSecondary}>
+            Cancel
+          </button>
+          {hasOkSuggestions && (
+            <button
+              type="button"
+              onClick={handleApply}
+              disabled={applying || acceptedCount === 0}
+              className={btnPrimary}
+            >
+              {applying ? "Applying..." : `Apply ${acceptedCount} change${acceptedCount === 1 ? "" : "s"}`}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({
+  status,
+  message,
+}: {
+  status: RebalanceStatus | "ok_no_changes";
+  message: string;
+}) {
+  const title =
+    status === "empty_no_budgets"
+      ? "No budgets yet"
+      : status === "empty_no_history"
+        ? "Not enough history yet"
+        : status === "llm_unavailable"
+          ? "AI is unavailable"
+          : "Nothing to rebalance";
+  return (
+    <div className="py-10 text-center" data-testid="rebalance-empty-state">
+      <p className="text-sm font-medium text-text-primary">{title}</p>
+      <p className="mt-2 text-xs text-text-muted">{message}</p>
+    </div>
+  );
+}

--- a/frontend/components/budgets/BudgetRebalanceModal.tsx
+++ b/frontend/components/budgets/BudgetRebalanceModal.tsx
@@ -60,6 +60,12 @@ export default function BudgetRebalanceModal({
   const [fetchError, setFetchError] = useState<string>("");
   const [applyError, setApplyError] = useState<string>("");
   const [applying, setApplying] = useState(false);
+  // Per-row apply state: which suggestions have been written successfully
+  // this apply attempt, and which (if any) failed. Lets the user see
+  // exactly what landed when a mid-loop failure cuts the loop short.
+  const [appliedIds, setAppliedIds] = useState<Set<number>>(new Set());
+  const [failedIds, setFailedIds] = useState<Set<number>>(new Set());
+  const [skippedIds, setSkippedIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     if (!open) return;
@@ -69,6 +75,9 @@ export default function BudgetRebalanceModal({
     setFetchError("");
     setApplyError("");
     setAcceptedIds(new Set());
+    setAppliedIds(new Set());
+    setFailedIds(new Set());
+    setSkippedIds(new Set());
     apiFetch<RebalanceResponse>("/api/v1/ai/budget/rebalance", {
       method: "POST",
     })
@@ -116,24 +125,60 @@ export default function BudgetRebalanceModal({
     if (!response) return;
     setApplyError("");
     setApplying(true);
-    try {
-      const accepted = response.suggestions.filter((s) =>
-        acceptedIds.has(s.category_id),
-      );
-      for (const s of accepted) {
-        const budgetId = budgetIdByCategory.get(s.category_id);
-        if (!budgetId) continue;
+    // Reset per-row state for this apply attempt.
+    const justApplied = new Set<number>();
+    const justFailed = new Set<number>();
+    const justSkipped = new Set<number>();
+    const accepted = response.suggestions.filter((s) =>
+      acceptedIds.has(s.category_id),
+    );
+    let firstError: unknown = null;
+    for (const s of accepted) {
+      const budgetId = budgetIdByCategory.get(s.category_id);
+      if (!budgetId) {
+        // The user's budgets prop drifted (a budget was deleted between
+        // open and apply). Surface it instead of silently dropping.
+        justSkipped.add(s.category_id);
+        continue;
+      }
+      try {
         await apiFetch(`/api/v1/budgets/${budgetId}`, {
           method: "PUT",
           body: JSON.stringify({ amount: toNumber(s.suggested_amount) }),
         });
+        justApplied.add(s.category_id);
+      } catch (err) {
+        justFailed.add(s.category_id);
+        if (firstError === null) firstError = err;
+        // Stop on first failure — applying further rows after a
+        // server-side rejection would mask the failure and make it
+        // harder for the user to recover.
+        break;
       }
+    }
+    setAppliedIds(justApplied);
+    setFailedIds(justFailed);
+    setSkippedIds(justSkipped);
+    if (firstError !== null) {
+      setApplyError(extractErrorMessage(firstError));
+    } else if (justSkipped.size > 0 && justApplied.size === 0) {
+      setApplyError(
+        "No budget rows could be applied. Refresh and try again.",
+      );
+    }
+    setApplying(false);
+    // Notify the parent so it reloads budgets only if anything landed.
+    if (justApplied.size > 0) {
       onApplied();
+    }
+    // Auto-close only when everything succeeded — otherwise leave the
+    // modal open so the user can see per-row status.
+    if (
+      justFailed.size === 0 &&
+      justSkipped.size === 0 &&
+      justApplied.size === accepted.length
+    ) {
       onClose();
-    } catch (err) {
-      setApplyError(extractErrorMessage(err));
-    } finally {
-      setApplying(false);
     }
   }
 
@@ -243,11 +288,22 @@ export default function BudgetRebalanceModal({
                     {response.suggestions.map((s) => {
                       const delta = toNumber(s.delta_amount);
                       const accepted = acceptedIds.has(s.category_id);
+                      const wasApplied = appliedIds.has(s.category_id);
+                      const wasFailed = failedIds.has(s.category_id);
+                      const wasSkipped = skippedIds.has(s.category_id);
+                      const rowStatus = wasApplied
+                        ? "applied"
+                        : wasFailed
+                          ? "failed"
+                          : wasSkipped
+                            ? "skipped"
+                            : null;
                       return (
                         <tr
                           key={s.category_id}
                           className="border-b border-border-subtle/60 align-top"
                           data-testid={`rebalance-row-${s.category_id}`}
+                          data-row-status={rowStatus ?? "pending"}
                         >
                           <td className="py-2 pr-3">
                             <input
@@ -255,11 +311,26 @@ export default function BudgetRebalanceModal({
                               aria-label={`Apply suggestion for ${s.category_name}`}
                               checked={accepted}
                               onChange={() => toggleRow(s.category_id)}
+                              disabled={wasApplied}
                               className="h-4 w-4 accent-accent"
                             />
                           </td>
                           <td className="py-2 pr-3 text-text-primary">
                             {s.category_name}
+                            {rowStatus && (
+                              <span
+                                className={`ml-2 text-[10px] uppercase tracking-wide ${
+                                  wasApplied
+                                    ? "text-success"
+                                    : wasFailed
+                                      ? "text-danger"
+                                      : "text-text-muted"
+                                }`}
+                                data-testid={`rebalance-row-${s.category_id}-status`}
+                              >
+                                {rowStatus}
+                              </span>
+                            )}
                           </td>
                           <td className="py-2 pr-3 text-right tabular-nums text-text-secondary">
                             {formatAmount(toNumber(s.current_amount))}

--- a/frontend/tests/components/budgets/BudgetRebalanceModal.test.tsx
+++ b/frontend/tests/components/budgets/BudgetRebalanceModal.test.tsx
@@ -1,0 +1,198 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import BudgetRebalanceModal, {
+  type RebalanceResponse,
+} from "@/components/budgets/BudgetRebalanceModal";
+import { apiFetch } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const apiFetchMock = vi.mocked(apiFetch);
+
+const budgets = [
+  { id: 10, category_id: 1, amount: 400 },
+  { id: 11, category_id: 2, amount: 200 },
+];
+
+const okResponse: RebalanceResponse = {
+  status: "ok",
+  period_start: "2026-05-01",
+  summary: "Move money from dining to groceries.",
+  suggestions: [
+    {
+      category_id: 1,
+      category_name: "Groceries",
+      current_amount: 400,
+      suggested_amount: 450,
+      delta_amount: 50,
+      reasoning: "You consistently overspend on groceries.",
+    },
+    {
+      category_id: 2,
+      category_name: "Dining",
+      current_amount: 200,
+      suggested_amount: 150,
+      delta_amount: -50,
+      reasoning: "You under-spend here every month.",
+    },
+  ],
+};
+
+describe("BudgetRebalanceModal", () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+  });
+
+  it("does not render when open=false", () => {
+    render(
+      <BudgetRebalanceModal
+        open={false}
+        budgets={budgets}
+        onApplied={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders the diff table on ok response", async () => {
+    apiFetchMock.mockResolvedValueOnce(okResponse);
+    render(
+      <BudgetRebalanceModal
+        open
+        budgets={budgets}
+        onApplied={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("rebalance-diff-table")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Groceries")).toBeInTheDocument();
+    expect(screen.getByText("Dining")).toBeInTheDocument();
+    // Suggestion only — nothing was applied. The endpoint that was
+    // called must be the rebalance endpoint, never a PUT.
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/v1/ai/budget/rebalance",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("renders empty state for llm_unavailable without crashing", async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      status: "llm_unavailable",
+      period_start: "2026-05-01",
+      summary: "AI is unavailable.",
+      suggestions: [],
+    } satisfies RebalanceResponse);
+
+    render(
+      <BudgetRebalanceModal
+        open
+        budgets={budgets}
+        onApplied={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("rebalance-empty-state")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("rebalance-diff-table")).not.toBeInTheDocument();
+    // Apply button must not render in an empty state.
+    expect(
+      screen.queryByRole("button", { name: /Apply/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies only accepted rows via PUT /budgets/{id}", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(okResponse) // initial fetch
+      .mockResolvedValue({}); // PUT writes
+    const onApplied = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <BudgetRebalanceModal
+        open
+        budgets={budgets}
+        onApplied={onApplied}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("rebalance-diff-table")).toBeInTheDocument(),
+    );
+
+    // Skip the Dining row (uncheck its checkbox).
+    const diningCheckbox = screen.getByLabelText(
+      /Apply suggestion for Dining/i,
+    ) as HTMLInputElement;
+    expect(diningCheckbox.checked).toBe(true);
+    await act(async () => {
+      fireEvent.click(diningCheckbox);
+    });
+    expect(diningCheckbox.checked).toBe(false);
+
+    // Click Apply.
+    const applyBtn = screen.getByRole("button", { name: /Apply 1 change/i });
+    await act(async () => {
+      fireEvent.click(applyBtn);
+    });
+
+    await waitFor(() => expect(onApplied).toHaveBeenCalled());
+    expect(onClose).toHaveBeenCalled();
+
+    // First call is the rebalance fetch; subsequent calls are PUTs.
+    // We accepted Groceries (category_id=1) which maps to budget id 10,
+    // and skipped Dining. Therefore exactly one PUT must fire, to /10.
+    const putCalls = apiFetchMock.mock.calls.filter((c) => {
+      const init = c[1] as RequestInit | undefined;
+      return init?.method === "PUT";
+    });
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0][0]).toBe("/api/v1/budgets/10");
+    expect(putCalls[0][1]).toMatchObject({
+      method: "PUT",
+      body: JSON.stringify({ amount: 450 }),
+    });
+  });
+
+  it("does not call any PUT when the user clicks Cancel", async () => {
+    apiFetchMock.mockResolvedValueOnce(okResponse);
+    const onApplied = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <BudgetRebalanceModal
+        open
+        budgets={budgets}
+        onApplied={onApplied}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("rebalance-diff-table")).toBeInTheDocument(),
+    );
+
+    const cancel = screen.getByRole("button", { name: /Cancel/i });
+    await act(async () => {
+      fireEvent.click(cancel);
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onApplied).not.toHaveBeenCalled();
+    const putCalls = apiFetchMock.mock.calls.filter((c) => {
+      const init = c[1] as RequestInit | undefined;
+      return init?.method === "PUT";
+    });
+    expect(putCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Backend**: `POST /api/v1/ai/budget/rebalance` aggregates the current period's budgets + last 3 months of actuals per master category and asks the LLM (via `call_llm_structured`) for advisory delta suggestions. Hard category-id whitelist rejects hallucinated / cross-org ids. Aggregates-only prompt (per-category monthly totals — never raw transaction text).
- **Safety**: feature-gated on `ai.budget`; empty / LLM-unavailable states map to a typed `status` so the UI shows an empty state instead of crashing. Audit row written with structural outcome + suggestion count only (no prompt / completion content).
- **Frontend**: Budgets page gets a "Suggest rebalance" button that opens a diff modal showing current vs suggested per row with per-row Accept/Skip toggles. Apply re-uses the existing `PUT /api/v1/budgets/{id}` — no new mutation endpoint. Nothing is ever auto-applied.
- **Tests**: 12 new tests total — 7 service (sqlite, mocked adapter), 4 router (TestClient with dependency overrides), 5 frontend (vitest + RTL).