### PR TITLE
feat(ai): LAI.2 Smart Forecast refinement (AI seasonality + anomaly flags)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,7 @@ from app import redis_client
 from app.database import engine
 from app.logging import setup_logging
 from app.rate_limit import limiter
-from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
+from app.routers import account_types, accounts, admin, admin_ai_usage, admin_analytics, admin_announcements, admin_audit, admin_orgs, admin_rate_limit_overrides, admin_roles, admin_subscriptions, admin_users, ai_forecast, ai_providers, announcements, auth, budgets, categories, feedback, forecast, forecast_plans, import_router, notifications, onboarding, org_data, org_members, orgs, plans, recurring, reports, scenarios, settings, subscriptions, tags, transactions, users
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
 
 # Setup JSON logging early so uvicorn's loggers are captured
@@ -485,6 +485,7 @@ app.include_router(notifications.router)
 app.include_router(reports.router)
 app.include_router(scenarios.router)
 app.include_router(ai_providers.router)
+app.include_router(ai_forecast.router)
 app.include_router(admin_ai_usage.router)
 app.include_router(admin_rate_limit_overrides.router)
 

--- a/backend/app/routers/ai_forecast.py
+++ b/backend/app/routers/ai_forecast.py
@@ -22,7 +22,6 @@ the provenance reason. We deliberately do not log the LLM's free-text
 from __future__ import annotations
 
 import datetime
-import uuid
 from typing import Optional
 
 import structlog
@@ -76,14 +75,39 @@ async def refine_forecast_endpoint(
             )
 
     refined = await refine_forecast(
-        db, org_id=current_user.org_id, period_start=period_start_date
+        db,
+        org_id=current_user.org_id,
+        session_factory=session_factory,
+        period_start=period_start_date,
     )
 
     # Audit AFTER the business operation. The audit row carries the
     # outcome (was AI applied? was it a fallback?) but never carries
     # the LLM's summary text, because that could echo user-typed
     # category names back through audit storage.
-    outcome = "success" if refined.provenance.ai_applied else "failure"
+    #
+    # Audit-outcome semantics: only real system failures map to
+    # "failure". User-state preconditions (no routing configured, cap
+    # exceeded, insufficient history, provider lacks structured
+    # output) are clean "success" outcomes — the user got a usable
+    # baseline back. The full fallback_reason is in `detail` for
+    # forensic filtering. Same shape we landed on #370.
+    fallback_reason = refined.provenance.fallback_reason or ""
+    SYSTEM_FAILURE_REASONS = {
+        "history_build_failed",
+        "ai_structured_output_failed",
+        "ai_response_invalid_schema",
+    }
+    if refined.provenance.ai_applied:
+        outcome = "success"
+    elif (
+        fallback_reason in SYSTEM_FAILURE_REASONS
+        or fallback_reason.startswith("ai_dispatch_failed")
+    ):
+        outcome = "failure"
+    else:
+        outcome = "success"
+
     detail = {
         "ai_applied": refined.provenance.ai_applied,
         "fallback_reason": refined.provenance.fallback_reason,
@@ -102,7 +126,10 @@ async def refine_forecast_endpoint(
             actor_email=current_user.email,
             target_org_id=current_user.org_id,
             target_org_name=None,
-            request_id=uuid.uuid4().hex,
+            # Read the request_id from structlog's contextvars so the
+            # audit row correlates with the access log for this HTTP
+            # call. Generating a fresh UUID here would orphan the row.
+            request_id=structlog.contextvars.get_contextvars().get("request_id"),
             ip_address=get_client_ip(request),
             outcome=outcome,
             detail=detail,

--- a/backend/app/routers/ai_forecast.py
+++ b/backend/app/routers/ai_forecast.py
@@ -1,0 +1,117 @@
+"""LAI.2 — AI-refined Smart Forecast endpoint.
+
+Surface: ``POST /api/v1/ai/forecast/refine``. Opt-in refinement that
+layers AI-detected seasonality + anomaly flags on top of the
+deterministic forecast. Falls back to the baseline on any LLM failure
+so the UI always renders something useful.
+
+Gating:
+- ``require_feature("ai.forecast")``, the same feature gate the AI
+  tier catalog defines. Closed gate returns 403 ``feature_not_enabled``.
+- BYO routing + cap enforcement happen inside
+  ``ai_dispatch.call_llm_structured``. Missing routing /
+  cap-exceeded surface as "fallback to baseline" with a typed reason
+  in ``provenance.fallback_reason``, NOT as a hard error, so the user
+  still gets a usable forecast.
+
+Audit: every call writes an ``ai.forecast.refine.invoked`` event with
+the outcome (``success`` for AI-applied, ``failure`` for fallback) and
+the provenance reason. We deliberately do not log the LLM's free-text
+``summary`` because that could echo PII back through the audit log.
+"""
+from __future__ import annotations
+
+import datetime
+import uuid
+from typing import Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.auth.feature_deps import require_feature
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models.user import User
+from app.rate_limit import get_client_ip
+from app.schemas.ai_forecast import (
+    RefineForecastRequest,
+    RefinedForecastResponse,
+)
+from app.services import audit_service
+from app.services.ai_forecast_refine_service import refine_forecast
+
+
+logger = structlog.stdlib.get_logger()
+
+
+router = APIRouter(prefix="/api/v1/ai/forecast", tags=["ai", "forecast"])
+
+
+@router.post("/refine", response_model=RefinedForecastResponse)
+async def refine_forecast_endpoint(
+    request: Request,
+    body: RefineForecastRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(
+        get_session_factory
+    ),
+    _gate: dict = Depends(require_feature("ai.forecast")),
+):
+    period_start_date: Optional[datetime.date] = None
+    if body.period_start:
+        try:
+            period_start_date = datetime.date.fromisoformat(body.period_start)
+        except ValueError:
+            # Pydantic keeps period_start as a string for shape stability;
+            # surface bad input as a 400 rather than letting the service
+            # blow up on a malformed ISO date.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "invalid_period_start",
+                    "message": "period_start must be ISO date YYYY-MM-DD",
+                },
+            )
+
+    refined = await refine_forecast(
+        db, org_id=current_user.org_id, period_start=period_start_date
+    )
+
+    # Audit AFTER the business operation. The audit row carries the
+    # outcome (was AI applied? was it a fallback?) but never carries
+    # the LLM's summary text, because that could echo user-typed
+    # category names back through audit storage.
+    outcome = "success" if refined.provenance.ai_applied else "failure"
+    detail = {
+        "ai_applied": refined.provenance.ai_applied,
+        "fallback_reason": refined.provenance.fallback_reason,
+        "model": refined.provenance.model,
+        "categories_adjusted": sum(
+            1 for c in refined.categories if c.multiplier != 1.0
+        ),
+        "anomalies_flagged": len(refined.anomalies),
+        "period_start": refined.period_start,
+    }
+    try:
+        await audit_service.record_audit_event(
+            session_factory,
+            event_type="ai.forecast.refine.invoked",
+            actor_user_id=current_user.id,
+            actor_email=current_user.email,
+            target_org_id=current_user.org_id,
+            target_org_name=None,
+            request_id=uuid.uuid4().hex,
+            ip_address=get_client_ip(request),
+            outcome=outcome,
+            detail=detail,
+        )
+    except Exception as exc:  # pragma: no cover - audit failure must not break user flow
+        logger.warning(
+            "ai.forecast.refine.audit_failed",
+            org_id=current_user.org_id,
+            error_class=type(exc).__name__,
+        )
+
+    return refined

--- a/backend/app/schemas/ai_forecast.py
+++ b/backend/app/schemas/ai_forecast.py
@@ -1,0 +1,117 @@
+"""Pydantic shapes for LAI.2 — Smart Forecast refinement.
+
+The refinement endpoint layers AI-detected seasonality + anomaly flags
+on top of the deterministic forecast from ``forecast_service``. The
+LLM's output is validated against ``AIForecastAdjustments`` BEFORE we
+apply anything to the baseline; malformed responses are rejected and
+the endpoint falls back to the unmodified baseline (with a flag so the
+UI can surface the fallback).
+
+The exposed response carries both the baseline AND the refined view so
+the frontend can render a side-by-side delta or the toggle's
+``before/after`` tooltip without a second request.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+
+
+class SeasonalAdjustment(BaseModel):
+    """A single seasonal multiplier applied to a category for the period.
+
+    ``multiplier`` is a float in [0.5, 1.5] — we cap the range so a
+    misbehaving model cannot wipe out (multiplier=0) or 10x
+    (multiplier=10) a forecast line. Anything outside the band is
+    rejected at validate time and a fallback to the baseline is
+    served.
+    """
+
+    category_id: StrictInt
+    category_name: StrictStr
+    multiplier: StrictFloat = Field(..., ge=0.5, le=1.5)
+    rationale: StrictStr = Field(..., max_length=240)
+
+
+class AnomalyFlag(BaseModel):
+    """An anomaly the model spotted in the recent actuals.
+
+    Anomalies are aggregate patterns (category-level spikes, recurring
+    misses) — we never echo raw transaction text back to the user.
+    """
+
+    category_id: Optional[StrictInt] = None
+    category_name: StrictStr
+    description: StrictStr = Field(..., max_length=240)
+    severity: StrictStr = Field(..., pattern=r"^(info|warning|alert)$")
+
+
+class AIForecastAdjustments(BaseModel):
+    """Validated LLM response shape.
+
+    Rejecting malformed adjustments here is the primary safety control;
+    we never pass an LLM dict straight through to the baseline math.
+    """
+
+    seasonal: list[SeasonalAdjustment] = Field(default_factory=list, max_length=40)
+    anomalies: list[AnomalyFlag] = Field(default_factory=list, max_length=20)
+    confidence: StrictFloat = Field(..., ge=0.0, le=1.0)
+    summary: StrictStr = Field(..., max_length=480)
+
+
+class RefinedCategoryRow(BaseModel):
+    """One category row in the refined forecast output.
+
+    Mirrors the baseline category row but adds the multiplier that was
+    applied and the resulting refined-forecast amount. The original
+    baseline values stay populated so the UI can render a "was, now"
+    delta inline.
+    """
+
+    category_id: StrictInt
+    category_name: StrictStr
+    baseline_forecast: Decimal
+    multiplier: StrictFloat
+    refined_forecast: Decimal
+
+
+class RefinedForecastProvenance(BaseModel):
+    """Where the refined numbers came from. Surfaces in the UI tooltip.
+
+    ``ai_applied`` is False when we fell back (LLM failure, feature gate,
+    invalid response). When False the refined_* values equal the
+    baseline_* values and ``adjustments`` is empty.
+    """
+
+    ai_applied: StrictBool
+    fallback_reason: Optional[StrictStr] = None
+    model: Optional[StrictStr] = None
+    confidence: Optional[StrictFloat] = None
+    summary: Optional[StrictStr] = None
+    notes: list[StrictStr] = Field(default_factory=list)
+
+
+class RefinedForecastResponse(BaseModel):
+    """Response shape for POST /api/v1/ai/forecast/refine."""
+
+    period_start: StrictStr
+    period_end: StrictStr
+    baseline_forecast_expense: Decimal
+    refined_forecast_expense: Decimal
+    baseline_forecast_income: Decimal
+    refined_forecast_income: Decimal
+    categories: list[RefinedCategoryRow]
+    anomalies: list[AnomalyFlag]
+    provenance: RefinedForecastProvenance
+
+
+class RefineForecastRequest(BaseModel):
+    """Request body for the refine endpoint.
+
+    ``period_start`` is optional. When omitted the service uses the
+    current billing period (same convention as GET /api/v1/forecast).
+    """
+
+    period_start: Optional[StrictStr] = None

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -1,0 +1,460 @@
+"""LAI.2 — Smart Forecast refinement service.
+
+Layers AI-detected seasonality + anomaly flags on top of the
+deterministic forecast from ``forecast_service``. The flow is:
+
+1. Compute the baseline via ``forecast_service.compute_forecast``.
+2. Build an aggregated transaction summary (LAST 6 BILLING PERIODS,
+   per-category, monthly totals only, no raw transaction text, no
+   merchant names, no descriptions). This is the prompt-builder's
+   privacy boundary: we send aggregates, not rows.
+3. Build the Prompt with the baseline + summary.
+4. Dispatch via ``ai_dispatch.call_llm_structured`` with feature key
+   ``"ai.forecast"`` and the ``AIForecastAdjustments`` JSON schema.
+5. Validate the response via Pydantic. Malformed values fall back to
+   baseline.
+6. Apply per-category multipliers (already range-checked by Pydantic)
+   and emit provenance.
+
+Fallback contract: on ANY exception (gate closed, no routing, cap
+exceeded, structured-output exhausted, validation failure) the service
+returns the baseline forecast with ``provenance.ai_applied=False`` and
+``fallback_reason`` set. The router never 5xxs because refinement is
+purely additive.
+
+Data sent to the LLM (privacy boundary documented here):
+- Baseline forecast totals (income / expense Decimal aggregates).
+- Per-category history: ``{name, period_label, total_expense}``.
+  We DO NOT send: transaction memos, merchant names, individual
+  amounts, account names, dates beyond period labels, user / account
+  IDs.
+- The org_id is not sent. Category names are user-typed, so an org
+  could leak intent via "Pat's secret therapy fund". The caller is
+  responsible for any further redaction at the category level.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Optional
+
+import structlog
+from pydantic import ValidationError as PydanticValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.category import Category
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.schemas.ai_forecast import (
+    AIForecastAdjustments,
+    RefinedCategoryRow,
+    RefinedForecastProvenance,
+    RefinedForecastResponse,
+)
+from app.services import ai_dispatch, forecast_service
+from app.services.ai_providers.base import StructuredOutputError
+from app.services.transaction_filters import reportable_transaction_filter
+
+logger = structlog.stdlib.get_logger()
+
+
+# LAI.2 feature key, matches the AI tier feature catalog.
+FEATURE_KEY = "ai.forecast"
+
+# Pull 6 months of history, enough seasonality signal without flooding
+# the prompt. Categories with zero spend in the window are omitted.
+HISTORY_MONTHS = 6
+
+
+SYSTEM_INSTRUCTIONS = (
+    "You are a personal-finance forecasting assistant. The user has "
+    "provided their baseline monthly forecast (computed deterministically "
+    "from settled + pending + recurring transactions) and a 6-month "
+    "history of aggregate spend per category. Detect seasonal patterns "
+    "and flag anomalies. Return ONLY a JSON object matching the "
+    "AIForecastAdjustments schema. Multipliers MUST be between 0.5 "
+    "and 1.5. Confidence MUST be between 0.0 and 1.0. Treat category "
+    "names as opaque labels. Do not invent categories that aren't in "
+    "the input."
+)
+
+
+# JSON schema passed to call_llm_structured. We keep this in sync with
+# the Pydantic model. The dispatcher's structured-output retry check
+# only validates required keys + top-level type, so the Pydantic
+# re-validation in this service is what catches subtle shape drift.
+RESPONSE_JSON_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["seasonal", "anomalies", "confidence", "summary"],
+    "properties": {
+        "seasonal": {"type": "array"},
+        "anomalies": {"type": "array"},
+        "confidence": {"type": "number"},
+        "summary": {"type": "string"},
+    },
+}
+
+
+@dataclass(frozen=True)
+class _RefinementContext:
+    """Internal helper carrying the baseline + history into prompt build."""
+
+    baseline: dict
+    history: list[dict]
+    category_index: dict[int, str]
+
+
+def _month_start_n_back(end: datetime.date, n: int) -> datetime.date:
+    """Return the first-of-month n months before ``end``'s month."""
+    year = end.year
+    month = end.month - n
+    while month <= 0:
+        month += 12
+        year -= 1
+    return datetime.date(year, month, 1)
+
+
+async def _build_category_history(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    period_end: datetime.date,
+) -> list[dict]:
+    """Build a 6-month per-category expense history.
+
+    Returns one row per (category, month) with the total expense. Used
+    inside the LLM prompt as aggregates only, no transaction-level
+    detail. Settled-only (status=SETTLED) because pending rows are
+    speculative and would conflate noise with seasonality.
+
+    Month bucketing is done in Python so the query stays portable
+    between SQLite (tests) and MySQL (production), where the
+    ``YYYY-MM`` truncation functions diverge (``strftime`` vs.
+    ``date_format``).
+    """
+    history_start = _month_start_n_back(period_end, HISTORY_MONTHS - 1)
+
+    result = await db.execute(
+        select(
+            Transaction.category_id,
+            Transaction.settled_date,
+            Transaction.amount,
+        )
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.status == TransactionStatus.SETTLED,
+            Transaction.settled_date >= history_start,
+            Transaction.settled_date <= period_end,
+            reportable_transaction_filter(),
+        )
+    )
+
+    buckets: dict[tuple[Optional[int], str], Decimal] = {}
+    for row in result.all():
+        cat_id = int(row[0]) if row[0] is not None else None
+        settled = row[1]
+        amount = Decimal(str(row[2]))
+        if settled is None:
+            continue
+        month_label = f"{settled.year:04d}-{settled.month:02d}"
+        key = (cat_id, month_label)
+        buckets[key] = buckets.get(key, Decimal("0")) + amount
+
+    rows: list[dict] = []
+    for (cat_id, month_label), total in sorted(
+        buckets.items(), key=lambda kv: (kv[0][1], kv[0][0] or 0)
+    ):
+        rows.append(
+            {
+                "category_id": cat_id,
+                "month": month_label,
+                "total_expense": str(total),
+            }
+        )
+    return rows
+
+
+async def _category_index(db: AsyncSession, *, org_id: int) -> dict[int, str]:
+    """Return ``{category_id: name}`` for the org. Used to label history
+    rows in the prompt AND to label refined output rows.
+    """
+    result = await db.execute(
+        select(Category.id, Category.name).where(Category.org_id == org_id)
+    )
+    return {int(row[0]): str(row[1]) for row in result.all()}
+
+
+def _build_messages(ctx: _RefinementContext) -> list[dict]:
+    """Build the messages array for the structured-output dispatch.
+
+    Privacy note: ``ctx.baseline`` is the typed forecast dict from
+    ``forecast_service.compute_forecast`` (string-serialized Decimals,
+    category names, period labels). ``ctx.history`` is monthly
+    aggregates only, see ``_build_category_history``. Nothing else
+    leaves this function.
+    """
+    history_with_names = [
+        {
+            "category_id": row["category_id"],
+            "category_name": ctx.category_index.get(
+                row["category_id"] or -1, "Unknown"
+            ),
+            "month": row["month"],
+            "total_expense": row["total_expense"],
+        }
+        for row in ctx.history
+    ]
+
+    user_payload = {
+        "baseline_forecast": {
+            "period_start": ctx.baseline["period_start"],
+            "period_end": ctx.baseline["period_end"],
+            "forecast_income": ctx.baseline["forecast_income"],
+            "forecast_expense": ctx.baseline["forecast_expense"],
+            "categories": ctx.baseline["categories"],
+        },
+        "history": history_with_names,
+    }
+
+    return [
+        {"role": "system", "content": SYSTEM_INSTRUCTIONS},
+        {
+            "role": "user",
+            "content": json.dumps(user_payload, default=str),
+        },
+    ]
+
+
+def _apply_adjustments(
+    *, baseline: dict, adjustments: AIForecastAdjustments
+) -> tuple[list[RefinedCategoryRow], Decimal, list[str]]:
+    """Apply seasonal multipliers to the baseline categories.
+
+    Returns (rows, refined_expense_total, notes).
+
+    Notes capture any adjustments the model returned for categories
+    that don't exist in the baseline (hallucinated category_id). Those
+    adjustments are ignored, not applied; the note surfaces in the UI
+    tooltip so the user can see what was skipped.
+    """
+    by_id: dict[int, "object"] = {adj.category_id: adj for adj in adjustments.seasonal}
+
+    notes: list[str] = []
+    rows: list[RefinedCategoryRow] = []
+    refined_total = Decimal("0")
+
+    for cat in baseline.get("categories", []):
+        cat_id = int(cat["category_id"])
+        baseline_amount = Decimal(str(cat["forecast"]))
+        adj = by_id.get(cat_id)
+        if adj is None:
+            multiplier = 1.0
+            refined_amount = baseline_amount
+        else:
+            multiplier = float(adj.multiplier)
+            # Decimal * float via str round-trip to keep the quantization
+            # deterministic and avoid float-binary representation drift.
+            refined_amount = (
+                baseline_amount * Decimal(str(multiplier))
+            ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+        rows.append(
+            RefinedCategoryRow(
+                category_id=cat_id,
+                category_name=cat["category_name"],
+                baseline_forecast=baseline_amount,
+                multiplier=multiplier,
+                refined_forecast=refined_amount,
+            )
+        )
+        refined_total += refined_amount
+
+    # Surface any adjustments that referenced categories not present in
+    # the baseline (e.g. model hallucinated a category) so the UI can
+    # flag them. We don't apply those, they contribute 0 to refined.
+    baseline_ids = {int(c["category_id"]) for c in baseline.get("categories", [])}
+    for adj in adjustments.seasonal:
+        if adj.category_id not in baseline_ids:
+            notes.append(
+                f"Ignored adjustment for unknown category_id={adj.category_id} "
+                f"({adj.category_name!r})"
+            )
+
+    return rows, refined_total, notes
+
+
+def _baseline_response(
+    *, baseline: dict, fallback_reason: str
+) -> RefinedForecastResponse:
+    """Build a refined-response that mirrors the baseline with no AI applied."""
+    rows = [
+        RefinedCategoryRow(
+            category_id=int(cat["category_id"]),
+            category_name=cat["category_name"],
+            baseline_forecast=Decimal(str(cat["forecast"])),
+            multiplier=1.0,
+            refined_forecast=Decimal(str(cat["forecast"])),
+        )
+        for cat in baseline.get("categories", [])
+    ]
+    return RefinedForecastResponse(
+        period_start=baseline["period_start"],
+        period_end=baseline["period_end"],
+        baseline_forecast_expense=Decimal(baseline["forecast_expense"]),
+        refined_forecast_expense=Decimal(baseline["forecast_expense"]),
+        baseline_forecast_income=Decimal(baseline["forecast_income"]),
+        refined_forecast_income=Decimal(baseline["forecast_income"]),
+        categories=rows,
+        anomalies=[],
+        provenance=RefinedForecastProvenance(
+            ai_applied=False,
+            fallback_reason=fallback_reason,
+            model=None,
+            confidence=None,
+            summary=None,
+            notes=[],
+        ),
+    )
+
+
+async def refine_forecast(
+    db: AsyncSession,
+    *,
+    org_id: int,
+    period_start: Optional[datetime.date] = None,
+) -> RefinedForecastResponse:
+    """Public entry point. Always returns a usable response, falling
+    back to baseline on any LLM-side failure.
+
+    All LLM/dispatch failures are swallowed and surfaced via
+    ``provenance.ai_applied=False``.
+    """
+    baseline = await forecast_service.compute_forecast(
+        db, org_id, period_start=period_start
+    )
+
+    # Build the history + index for the prompt.
+    p_end = datetime.date.fromisoformat(baseline["period_end"])
+    try:
+        history = await _build_category_history(
+            db, org_id=org_id, period_end=p_end
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "ai.forecast.refine.history_failed",
+            org_id=org_id,
+            error_class=type(exc).__name__,
+        )
+        return _baseline_response(
+            baseline=baseline, fallback_reason="history_build_failed"
+        )
+
+    if not history:
+        # No actuals to detect seasonality from. Return baseline with
+        # an explanatory fallback reason instead of paying for a call
+        # that has no signal to learn from.
+        return _baseline_response(
+            baseline=baseline, fallback_reason="insufficient_history"
+        )
+
+    category_index = await _category_index(db, org_id=org_id)
+    ctx = _RefinementContext(
+        baseline=baseline,
+        history=history,
+        category_index=category_index,
+    )
+    messages = _build_messages(ctx)
+
+    # Dispatch through the cap + ledger chokepoint. Any failure here
+    # (no routing, hard cap exceeded, adapter network error, retry
+    # budget exhausted) becomes a fallback rather than a 5xx.
+    try:
+        result = await ai_dispatch.call_llm_structured(
+            db,
+            org_id=org_id,
+            feature_key=FEATURE_KEY,
+            messages=messages,
+            response_schema=RESPONSE_JSON_SCHEMA,
+        )
+    except ai_dispatch.NoRoutingConfigured:
+        return _baseline_response(
+            baseline=baseline, fallback_reason="ai_routing_not_configured"
+        )
+    except ai_dispatch.AICapExceeded:
+        logger.info(
+            "ai.forecast.refine.cap_exceeded",
+            org_id=org_id,
+        )
+        return _baseline_response(
+            baseline=baseline, fallback_reason="ai_cap_exceeded"
+        )
+    except ai_dispatch.AICapabilityNotSupported:
+        return _baseline_response(
+            baseline=baseline,
+            fallback_reason="ai_capability_not_supported",
+        )
+    except StructuredOutputError:
+        logger.warning(
+            "ai.forecast.refine.structured_exhausted",
+            org_id=org_id,
+        )
+        return _baseline_response(
+            baseline=baseline,
+            fallback_reason="ai_structured_output_failed",
+        )
+    except ai_dispatch.AIDispatchFailed as exc:
+        logger.warning(
+            "ai.forecast.refine.dispatch_failed",
+            org_id=org_id,
+            error_class=exc.code,
+        )
+        return _baseline_response(
+            baseline=baseline, fallback_reason=f"ai_dispatch_failed:{exc.code}"
+        )
+
+    # Validate the parsed JSON against the strict Pydantic shape.
+    # Pydantic rejects out-of-band multipliers (>1.5, <0.5), negative
+    # confidence, missing fields. We never apply an unvalidated dict
+    # to the baseline math.
+    try:
+        adjustments = AIForecastAdjustments.model_validate(result.response.parsed)
+    except PydanticValidationError as exc:
+        logger.warning(
+            "ai.forecast.refine.invalid_schema",
+            org_id=org_id,
+            error_count=len(exc.errors()),
+        )
+        return _baseline_response(
+            baseline=baseline,
+            fallback_reason="ai_response_invalid_schema",
+        )
+
+    rows, refined_expense, notes = _apply_adjustments(
+        baseline=baseline, adjustments=adjustments
+    )
+
+    return RefinedForecastResponse(
+        period_start=baseline["period_start"],
+        period_end=baseline["period_end"],
+        baseline_forecast_expense=Decimal(baseline["forecast_expense"]),
+        refined_forecast_expense=refined_expense,
+        baseline_forecast_income=Decimal(baseline["forecast_income"]),
+        # Income side stays unmodified in this PR. The model's seasonal
+        # multipliers target expense categories only. Income forecasts
+        # come from recurring + executed which is a deterministic
+        # signal already.
+        refined_forecast_income=Decimal(baseline["forecast_income"]),
+        categories=rows,
+        anomalies=adjustments.anomalies,
+        provenance=RefinedForecastProvenance(
+            ai_applied=True,
+            fallback_reason=None,
+            model=result.response.model,
+            confidence=adjustments.confidence,
+            summary=adjustments.summary,
+            notes=notes,
+        ),
+    )

--- a/backend/app/services/ai_forecast_refine_service.py
+++ b/backend/app/services/ai_forecast_refine_service.py
@@ -43,7 +43,7 @@ from typing import Any, Optional
 import structlog
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.category import Category
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
@@ -54,14 +54,22 @@ from app.schemas.ai_forecast import (
     RefinedForecastResponse,
 )
 from app.services import ai_dispatch, forecast_service
-from app.services.ai_providers.base import StructuredOutputError
+from app.services.ai_providers.base import NativeNotAvailable, StructuredOutputError
 from app.services.transaction_filters import reportable_transaction_filter
 
 logger = structlog.stdlib.get_logger()
 
 
-# LAI.2 feature key, matches the AI tier feature catalog.
-FEATURE_KEY = "ai.forecast"
+# Two distinct keys for the same surface:
+# - GATE_KEY is the entitlement-catalog key the router checks via
+#   require_feature(); the value matches the AI tier flag the org pays for.
+# - ROUTING_KEY is the routable feature name the dispatcher uses to look
+#   up a per-feature routing row in ORG_AI_DEFAULT_ROUTING. It MUST be a
+#   member of ROUTABLE_FEATURE_NAMES in app/models/org_ai_routing.py.
+#   If you pass the gate key here, feature-specific routing rows are
+#   silently missed and the dispatcher falls through to the default.
+GATE_KEY = "ai.forecast"
+ROUTING_KEY = "smart_forecast"
 
 # Pull 6 months of history, enough seasonality signal without flooding
 # the prompt. Categories with zero spend in the window are omitted.
@@ -120,7 +128,7 @@ async def _build_category_history(
     db: AsyncSession,
     *,
     org_id: int,
-    period_end: datetime.date,
+    period_start: datetime.date,
 ) -> list[dict]:
     """Build a 6-month per-category expense history.
 
@@ -129,12 +137,20 @@ async def _build_category_history(
     detail. Settled-only (status=SETTLED) because pending rows are
     speculative and would conflate noise with seasonality.
 
+    The window ends STRICTLY before ``period_start`` — we don't want
+    actuals from the forecast period itself bleeding into the
+    seasonality signal, because the LLM's multiplier is supposed to
+    *modify* the forecast, not learn from it. The window is the 6
+    calendar months ending on the last day before period_start.
+
     Month bucketing is done in Python so the query stays portable
     between SQLite (tests) and MySQL (production), where the
     ``YYYY-MM`` truncation functions diverge (``strftime`` vs.
     ``date_format``).
     """
-    history_start = _month_start_n_back(period_end, HISTORY_MONTHS - 1)
+    # End of the history window = the last full calendar month before
+    # period_start. Start = 6 months back from that, on the 1st.
+    history_start = _month_start_n_back(period_start, HISTORY_MONTHS)
 
     result = await db.execute(
         select(
@@ -147,7 +163,7 @@ async def _build_category_history(
             Transaction.type == TransactionType.EXPENSE,
             Transaction.status == TransactionStatus.SETTLED,
             Transaction.settled_date >= history_start,
-            Transaction.settled_date <= period_end,
+            Transaction.settled_date < period_start,
             reportable_transaction_filter(),
         )
     )
@@ -324,6 +340,7 @@ async def refine_forecast(
     db: AsyncSession,
     *,
     org_id: int,
+    session_factory: Optional[async_sessionmaker[AsyncSession]] = None,
     period_start: Optional[datetime.date] = None,
 ) -> RefinedForecastResponse:
     """Public entry point. Always returns a usable response, falling
@@ -331,16 +348,24 @@ async def refine_forecast(
 
     All LLM/dispatch failures are swallowed and surfaced via
     ``provenance.ai_applied=False``.
+
+    ``session_factory`` is optional only because some existing tests
+    call this without one; the router always passes it. When provided,
+    the LLM dispatch runs in its own session so the dispatcher's
+    ledger commit can't bleed into the request transaction (same
+    pattern as the categorize + budget services).
     """
     baseline = await forecast_service.compute_forecast(
         db, org_id, period_start=period_start
     )
 
-    # Build the history + index for the prompt.
-    p_end = datetime.date.fromisoformat(baseline["period_end"])
+    # Build the history + index for the prompt. The history window
+    # ends STRICTLY before period_start so the forecast period's own
+    # actuals don't leak into the seasonality signal.
+    p_start = datetime.date.fromisoformat(baseline["period_start"])
     try:
         history = await _build_category_history(
-            db, org_id=org_id, period_end=p_end
+            db, org_id=org_id, period_start=p_start
         )
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning(
@@ -371,14 +396,29 @@ async def refine_forecast(
     # Dispatch through the cap + ledger chokepoint. Any failure here
     # (no routing, hard cap exceeded, adapter network error, retry
     # budget exhausted) becomes a fallback rather than a 5xx.
+    #
+    # The dispatcher commits the session it's given (via
+    # _write_ledger_row); use a dedicated session when one is
+    # available so the commit can't bleed into the request transaction.
+    # Same pattern as categorize + budget services.
     try:
-        result = await ai_dispatch.call_llm_structured(
-            db,
-            org_id=org_id,
-            feature_key=FEATURE_KEY,
-            messages=messages,
-            response_schema=RESPONSE_JSON_SCHEMA,
-        )
+        if session_factory is not None:
+            async with session_factory() as dispatch_db:
+                result = await ai_dispatch.call_llm_structured(
+                    dispatch_db,
+                    org_id=org_id,
+                    feature_key=ROUTING_KEY,
+                    messages=messages,
+                    response_schema=RESPONSE_JSON_SCHEMA,
+                )
+        else:
+            result = await ai_dispatch.call_llm_structured(
+                db,
+                org_id=org_id,
+                feature_key=ROUTING_KEY,
+                messages=messages,
+                response_schema=RESPONSE_JSON_SCHEMA,
+            )
     except ai_dispatch.NoRoutingConfigured:
         return _baseline_response(
             baseline=baseline, fallback_reason="ai_routing_not_configured"
@@ -395,6 +435,19 @@ async def refine_forecast(
         return _baseline_response(
             baseline=baseline,
             fallback_reason="ai_capability_not_supported",
+        )
+    except NativeNotAvailable:
+        # Provider doesn't natively support structured output. Per
+        # ai_dispatch this is re-raised directly (NOT wrapped); the
+        # other LAI services catch it in their fallback tuple, so we
+        # do the same here. Without this the endpoint 5xxs.
+        logger.info(
+            "ai.forecast.refine.native_not_available",
+            org_id=org_id,
+        )
+        return _baseline_response(
+            baseline=baseline,
+            fallback_reason="ai_native_not_available",
         )
     except StructuredOutputError:
         logger.warning(

--- a/backend/tests/routers/test_ai_forecast_refine.py
+++ b/backend/tests/routers/test_ai_forecast_refine.py
@@ -479,23 +479,22 @@ async def test_invalid_period_start_returns_400(session_factory):
 # ---------- audit emission (success + user-state + system failure) ----
 
 
-def _audit_rows(session_factory):
-    """Sync helper that fetches all ai.forecast.refine.invoked rows."""
-    import asyncio
+async def _audit_rows(session_factory):
+    """Fetch all ai.forecast.refine.invoked rows. Must be awaited from
+    within the pytest-asyncio event loop — the prior sync wrapper that
+    called run_until_complete raised 'event loop already running'.
+    """
     from sqlalchemy import select as _select
 
-    async def _read():
-        async with session_factory() as s:
-            from app.models.audit_event import AuditEvent
-            return (
-                await s.execute(
-                    _select(AuditEvent).where(
-                        AuditEvent.event_type == "ai.forecast.refine.invoked"
-                    )
+    async with session_factory() as s:
+        from app.models.audit_event import AuditEvent
+        return (
+            await s.execute(
+                _select(AuditEvent).where(
+                    AuditEvent.event_type == "ai.forecast.refine.invoked"
                 )
-            ).scalars().all()
-
-    return asyncio.get_event_loop().run_until_complete(_read())
+            )
+        ).scalars().all()
 
 
 @pytest.mark.asyncio
@@ -546,7 +545,7 @@ async def test_audit_row_written_on_success(session_factory):
         )
     assert resp.status_code == 200
 
-    rows = _audit_rows(session_factory)
+    rows = await _audit_rows(session_factory)
     assert len(rows) == 1, "exactly one audit row per refine call"
     row = rows[0]
     assert row.outcome.value == "success"
@@ -579,7 +578,7 @@ async def test_audit_row_user_state_preconditions_are_success(session_factory):
     assert resp.status_code == 200
     assert resp.json()["provenance"]["fallback_reason"] == "ai_routing_not_configured"
 
-    rows = _audit_rows(session_factory)
+    rows = await _audit_rows(session_factory)
     assert len(rows) == 1
     assert rows[0].outcome.value == "success", (
         "ai_routing_not_configured is a user-state precondition, not a system failure"
@@ -608,7 +607,7 @@ async def test_audit_row_system_failure_marks_failure(session_factory):
         )
     assert resp.status_code == 200
 
-    rows = _audit_rows(session_factory)
+    rows = await _audit_rows(session_factory)
     assert len(rows) == 1
     assert rows[0].outcome.value == "failure"
     assert (rows[0].detail or {}).get("fallback_reason") == "ai_structured_output_failed"

--- a/backend/tests/routers/test_ai_forecast_refine.py
+++ b/backend/tests/routers/test_ai_forecast_refine.py
@@ -474,3 +474,335 @@ async def test_invalid_period_start_returns_400(session_factory):
     )
     assert resp.status_code == 400
     assert resp.json()["detail"]["code"] == "invalid_period_start"
+
+
+# ---------- audit emission (success + user-state + system failure) ----
+
+
+def _audit_rows(session_factory):
+    """Sync helper that fetches all ai.forecast.refine.invoked rows."""
+    import asyncio
+    from sqlalchemy import select as _select
+
+    async def _read():
+        async with session_factory() as s:
+            from app.models.audit_event import AuditEvent
+            return (
+                await s.execute(
+                    _select(AuditEvent).where(
+                        AuditEvent.event_type == "ai.forecast.refine.invoked"
+                    )
+                )
+            ).scalars().all()
+
+    return asyncio.get_event_loop().run_until_complete(_read())
+
+
+@pytest.mark.asyncio
+async def test_audit_row_written_on_success(session_factory):
+    """Happy path writes one audit row with outcome='success' and the
+    correct provenance detail (no LLM summary leaked into the row)."""
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    from app.services.ai_providers.base import StructuredResponse
+    from app.services.ai_dispatch import StructuredDispatchResult
+
+    fake_response = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed={
+                "seasonal": [
+                    {
+                        "category_id": seed["category_id"],
+                        "category_name": "Groceries",
+                        "multiplier": 1.1,
+                        "rationale": "ok",
+                    }
+                ],
+                "anomalies": [],
+                "confidence": 0.9,
+                "summary": "this string MUST NOT appear in the audit row",
+            },
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        return_value=fake_response,
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200
+
+    rows = _audit_rows(session_factory)
+    assert len(rows) == 1, "exactly one audit row per refine call"
+    row = rows[0]
+    assert row.outcome.value == "success"
+    detail = row.detail or {}
+    assert detail["ai_applied"] is True
+    assert detail["categories_adjusted"] == 1
+    # Summary text must never reach the audit row (PII / category-name
+    # leak surface).
+    assert "MUST NOT appear" not in repr(detail)
+
+
+@pytest.mark.asyncio
+async def test_audit_row_user_state_preconditions_are_success(session_factory):
+    """No-routing / cap-exceeded / insufficient-history are clean
+    preconditions, not system failures. The audit outcome must be
+    'success' for those so ops dashboards aren't polluted with noise."""
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    # No routing configured by default in the seed → service returns
+    # 'ai_routing_not_configured', a precondition.
+    resp = client.post(
+        "/api/v1/ai/forecast/refine",
+        json={"period_start": seed["period_start"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["provenance"]["fallback_reason"] == "ai_routing_not_configured"
+
+    rows = _audit_rows(session_factory)
+    assert len(rows) == 1
+    assert rows[0].outcome.value == "success", (
+        "ai_routing_not_configured is a user-state precondition, not a system failure"
+    )
+    assert (rows[0].detail or {}).get("fallback_reason") == "ai_routing_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_audit_row_system_failure_marks_failure(session_factory):
+    """Real system failures (StructuredOutputError, dispatch errors)
+    DO record outcome='failure'."""
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        side_effect=StructuredOutputError(),
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200
+
+    rows = _audit_rows(session_factory)
+    assert len(rows) == 1
+    assert rows[0].outcome.value == "failure"
+    assert (rows[0].detail or {}).get("fallback_reason") == "ai_structured_output_failed"
+
+
+# ---------- additional fallback paths --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_native_not_available_falls_back_to_baseline(session_factory):
+    """Provider can't do structured output natively → ai_native_not_available
+    fallback. Previously uncaught, would 5xx the endpoint."""
+    from app.services.ai_providers.base import NativeNotAvailable
+
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        side_effect=NativeNotAvailable(),
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"]["ai_applied"] is False
+    assert body["provenance"]["fallback_reason"] == "ai_native_not_available"
+
+
+@pytest.mark.asyncio
+async def test_cap_exceeded_falls_back_to_baseline(session_factory):
+    """AICapExceeded → ai_cap_exceeded fallback (user-state)."""
+    from app.services.ai_dispatch import AICapExceeded
+
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        side_effect=AICapExceeded(),
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["provenance"]["fallback_reason"] == "ai_cap_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failed_falls_back_with_code(session_factory):
+    """AIDispatchFailed → ai_dispatch_failed:{code} fallback."""
+    from app.services.ai_dispatch import AIDispatchFailed
+
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        side_effect=AIDispatchFailed("connection_error"),
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["provenance"]["fallback_reason"] == "ai_dispatch_failed:connection_error"
+
+
+@pytest.mark.asyncio
+async def test_capability_not_supported_falls_back(session_factory):
+    """AICapabilityNotSupported → ai_capability_not_supported fallback."""
+    from app.services.ai_dispatch import AICapabilityNotSupported
+
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        side_effect=AICapabilityNotSupported(
+            capability="structured_output",
+            feature_key="smart_forecast",
+        ),
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["provenance"]["fallback_reason"] == "ai_capability_not_supported"
+
+
+# ---------- architectural invariants ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_endpoint_never_mutates_user_data_tables(session_factory):
+    """The /refine endpoint must NEVER write to Transaction, Category,
+    or Budget. Pinning the suggestion-only invariant at the router
+    level — a future regression that auto-applied a multiplier (e.g.
+    by writing a new Transaction adjustment row) would slip past
+    every other test in this file because they all check the response
+    shape, not the DB state.
+    """
+    from sqlalchemy import select as _select
+
+    from app.models.budget import Budget
+    from app.models.category import Category as _Category
+    from app.models.transaction import Transaction as _Transaction
+    from app.services.ai_providers.base import StructuredResponse
+    from app.services.ai_dispatch import StructuredDispatchResult
+
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def _snapshot():
+        async with session_factory() as s:
+            tx = (
+                await s.execute(_select(_Transaction))
+            ).scalars().all()
+            cat = (
+                await s.execute(_select(_Category))
+            ).scalars().all()
+            bud = (
+                await s.execute(_select(Budget))
+            ).scalars().all()
+            return (
+                {(r.id, r.amount, r.category_id) for r in tx},
+                {(r.id, r.name) for r in cat},
+                {(r.id, r.amount, r.category_id) for r in bud},
+            )
+
+    before = await _snapshot()
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    fake_response = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed={
+                "seasonal": [
+                    {
+                        "category_id": seed["category_id"],
+                        "category_name": "Groceries",
+                        "multiplier": 1.3,
+                        "rationale": "test",
+                    }
+                ],
+                "anomalies": [],
+                "confidence": 0.9,
+                "summary": "test",
+            },
+            raw_text="{}",
+            prompt_tokens=1,
+            completion_tokens=1,
+            model="m",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        return_value=fake_response,
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200, resp.text
+    # Sanity: refinement actually fired so we're testing the meaningful path.
+    assert resp.json()["provenance"]["ai_applied"] is True
+
+    after = await _snapshot()
+    assert before == after, (
+        "POST /refine must NOT mutate Transaction / Category / Budget rows; "
+        "this feature is suggestion-only by contract."
+    )

--- a/backend/tests/routers/test_ai_forecast_refine.py
+++ b/backend/tests/routers/test_ai_forecast_refine.py
@@ -1,0 +1,476 @@
+"""LAI.2 — Smart Forecast refinement router tests.
+
+Pins:
+- Feature gate closed -> 403.
+- Feature gate open + no routing -> 200 with ``ai_applied=False`` and
+  ``fallback_reason="ai_routing_not_configured"`` (still serves the
+  baseline, never 5xx).
+- Feature gate open + happy LLM path -> 200 with ``ai_applied=True``,
+  multiplier applied to the baseline category, anomalies surfaced.
+- Out-of-band LLM response (multiplier=5.0) -> Pydantic rejects ->
+  fallback to baseline with ``ai_response_invalid_schema``.
+- Cross-org isolation: an org with a closed gate gets 403 even if
+  another org has the gate open.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import os
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings as app_settings
+from app.database import get_db
+from app.deps import get_current_user, get_session_factory
+from app.models import Base
+from app.models.account import Account, AccountType
+from app.models.billing import BillingPeriod
+from app.models.category import Category
+from app.models.feature_override import OrgFeatureOverride
+from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization, Role, User
+from app.routers.ai_forecast import router as ai_forecast_router
+from app.security import hash_password
+from app.services.ai_providers.base import StructuredOutputError
+
+
+# ---------- fixtures -------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _set_ai_key(monkeypatch):
+    """The AI dispatch path peeks at the credential encryption key on
+    import; even though we mock the dispatch call itself, defaulting
+    the setting here keeps the test surface minimal for any future
+    code path that touches the encryption module at import time.
+    """
+    monkeypatch.setattr(
+        app_settings,
+        "ai_credential_encryption_key",
+        base64.urlsafe_b64encode(os.urandom(32)).decode("ascii"),
+    )
+    monkeypatch.setattr(
+        app_settings, "ai_credential_encryption_key_prev", ""
+    )
+
+
+def _make_app(session_factory, user_resolver):
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        return await user_resolver(session_factory)
+
+    def override_get_session_factory():
+        return session_factory
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_session_factory] = override_get_session_factory
+    app.include_router(ai_forecast_router)
+    return app
+
+
+async def _seed_org_with_data(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    enable_ai_forecast: bool,
+) -> dict:
+    """Seed an org with one account, one category, one settled history
+    transaction, and one in-period settled transaction. The settled
+    history row is what gives the refinement service something to
+    feed into the prompt; the in-period one anchors a baseline forecast
+    category row that the multiplier can act on.
+    """
+    today = datetime.date.today()
+    period_start = today.replace(day=1)
+    # End of current month-ish; the baseline computation walks 30d if
+    # the period has no end_date.
+    period_end = period_start + datetime.timedelta(days=27)
+    history_date = period_start - datetime.timedelta(days=45)
+
+    async with factory() as db:
+        org = Organization(name="Acme", billing_cycle_day=1)
+        db.add(org)
+        await db.commit()
+
+        owner = User(
+            org_id=org.id,
+            username="owner",
+            email="owner@acme.io",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(owner)
+        await db.commit()
+
+        if enable_ai_forecast:
+            db.add(
+                OrgFeatureOverride(
+                    org_id=org.id,
+                    feature_key="ai.forecast",
+                    value=True,
+                    set_by=owner.id,
+                )
+            )
+            await db.commit()
+
+        # Billing period: compute_forecast falls back to
+        # get_current_period which auto-creates if missing, but we
+        # pre-seed an explicit one so the test pins the date math.
+        period = BillingPeriod(
+            org_id=org.id,
+            start_date=period_start,
+            end_date=period_end,
+        )
+        db.add(period)
+        await db.flush()
+
+        at = AccountType(
+            org_id=org.id,
+            name="Checking",
+            slug="checking",
+            is_system=True,
+        )
+        db.add(at)
+        await db.flush()
+        account = Account(
+            org_id=org.id,
+            name="Main",
+            account_type_id=at.id,
+            balance=Decimal("1000.00"),
+            currency="EUR",
+            is_default=True,
+        )
+        db.add(account)
+        category = Category(
+            org_id=org.id,
+            name="Groceries",
+            type="expense",
+        )
+        db.add(category)
+        await db.commit()
+
+        # Settled transaction in the current period -> appears in the
+        # baseline categories breakdown so the multiplier has something
+        # to act on.
+        db.add(
+            Transaction(
+                org_id=org.id,
+                account_id=account.id,
+                category_id=category.id,
+                date=period_start + datetime.timedelta(days=5),
+                settled_date=period_start + datetime.timedelta(days=5),
+                amount=Decimal("100.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.SETTLED,
+                description="seed",
+            )
+        )
+        # Historical row from a month ago -> contributes to the
+        # 6-month history aggregate the refinement service builds.
+        db.add(
+            Transaction(
+                org_id=org.id,
+                account_id=account.id,
+                category_id=category.id,
+                date=history_date,
+                settled_date=history_date,
+                amount=Decimal("120.00"),
+                type=TransactionType.EXPENSE,
+                status=TransactionStatus.SETTLED,
+                description="seed-history",
+            )
+        )
+        await db.commit()
+
+        return {
+            "org_id": org.id,
+            "owner_id": owner.id,
+            "period_start": period_start.isoformat(),
+            "category_id": category.id,
+        }
+
+
+async def _get_user(factory, user_id: int) -> User:
+    from sqlalchemy import select
+
+    async with factory() as db:
+        result = await db.execute(select(User).where(User.id == user_id))
+        return result.scalar_one()
+
+
+# ---------- tests ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_feature_gate_closed_returns_403(session_factory):
+    """No override row -> ai.forecast default-false -> 403.
+
+    Pins the defense-in-depth gate. The router MUST refuse before
+    calling into the service, so no audit row, no dispatch, no
+    baseline computation.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=False)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/ai/forecast/refine",
+        json={"period_start": seed["period_start"]},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["detail"]["code"] == "feature_not_enabled"
+    assert body["detail"]["feature_key"] == "ai.forecast"
+
+
+@pytest.mark.asyncio
+async def test_no_routing_falls_back_to_baseline(session_factory):
+    """Feature gate open + no AI routing -> baseline with typed reason.
+
+    The service must NOT 5xx when routing is missing; it must return
+    the baseline forecast with provenance.ai_applied=False so the UI
+    keeps rendering something useful.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/ai/forecast/refine",
+        json={"period_start": seed["period_start"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"]["ai_applied"] is False
+    assert body["provenance"]["fallback_reason"] == "ai_routing_not_configured"
+    # Baseline still computed correctly.
+    assert body["baseline_forecast_expense"] == body["refined_forecast_expense"]
+    # The seeded category appears in the response with multiplier=1.0.
+    assert any(c["category_id"] == seed["category_id"] for c in body["categories"])
+
+
+@pytest.mark.asyncio
+async def test_happy_path_applies_multiplier(session_factory):
+    """Mocked dispatch returns valid adjustments -> multipliers applied.
+
+    Verifies the LLM->Pydantic->baseline-math chain.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    # Build a fake StructuredResponse-bearing DispatchResult. The
+    # ``parsed`` dict matches the schema the service expects from
+    # call_llm_structured -> AIForecastAdjustments.
+    from app.services.ai_providers.base import StructuredResponse
+    from app.services.ai_dispatch import StructuredDispatchResult
+
+    fake_response = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed={
+                "seasonal": [
+                    {
+                        "category_id": seed["category_id"],
+                        "category_name": "Groceries",
+                        "multiplier": 1.2,
+                        "rationale": "Historical Nov uptick.",
+                    }
+                ],
+                "anomalies": [
+                    {
+                        "category_id": seed["category_id"],
+                        "category_name": "Groceries",
+                        "description": "120 USD month-over-month vs 100 baseline.",
+                        "severity": "info",
+                    }
+                ],
+                "confidence": 0.78,
+                "summary": "One small seasonal uptick in groceries.",
+            },
+            raw_text="{}",
+            prompt_tokens=10,
+            completion_tokens=10,
+            model="mock-model",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        return_value=fake_response,
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"]["ai_applied"] is True
+    assert body["provenance"]["confidence"] == 0.78
+    assert body["provenance"]["model"] == "mock-model"
+    # The seeded category had a baseline forecast of 100.00 (one settled
+    # transaction in the period). 1.2x -> 120.00.
+    cat = next(c for c in body["categories"] if c["category_id"] == seed["category_id"])
+    assert Decimal(cat["baseline_forecast"]) == Decimal("100.00")
+    assert Decimal(cat["refined_forecast"]) == Decimal("120.00")
+    assert cat["multiplier"] == 1.2
+    # Anomaly surfaced.
+    assert len(body["anomalies"]) == 1
+    assert body["anomalies"][0]["severity"] == "info"
+
+
+@pytest.mark.asyncio
+async def test_out_of_band_multiplier_falls_back_to_baseline(session_factory):
+    """LLM returns multiplier=5.0 -> Pydantic rejects -> baseline served.
+
+    This is the primary safety control: a misbehaving model cannot
+    blow up a forecast line. Out-of-band response triggers a fallback
+    with ``ai_response_invalid_schema``.
+    """
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    from app.services.ai_providers.base import StructuredResponse
+    from app.services.ai_dispatch import StructuredDispatchResult
+
+    fake_response = StructuredDispatchResult(
+        response=StructuredResponse(
+            parsed={
+                "seasonal": [
+                    {
+                        "category_id": seed["category_id"],
+                        "category_name": "Groceries",
+                        "multiplier": 5.0,  # out of [0.5, 1.5]
+                        "rationale": "Bad model.",
+                    }
+                ],
+                "anomalies": [],
+                "confidence": 0.5,
+                "summary": "Bad output.",
+            },
+            raw_text="{}",
+            prompt_tokens=10,
+            completion_tokens=10,
+            model="mock-model",
+            retries_used=0,
+        ),
+        ledger_id=1,
+    )
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        return_value=fake_response,
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"]["ai_applied"] is False
+    assert body["provenance"]["fallback_reason"] == "ai_response_invalid_schema"
+    # Refined equals baseline because no multiplier was applied.
+    assert body["refined_forecast_expense"] == body["baseline_forecast_expense"]
+
+
+@pytest.mark.asyncio
+async def test_structured_output_exhausted_falls_back(session_factory):
+    """Dispatch raises StructuredOutputError -> baseline + typed reason."""
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    with patch(
+        "app.services.ai_forecast_refine_service.ai_dispatch.call_llm_structured",
+        side_effect=StructuredOutputError(),
+    ):
+        resp = client.post(
+            "/api/v1/ai/forecast/refine",
+            json={"period_start": seed["period_start"]},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provenance"]["ai_applied"] is False
+    assert body["provenance"]["fallback_reason"] == "ai_structured_output_failed"
+
+
+@pytest.mark.asyncio
+async def test_invalid_period_start_returns_400(session_factory):
+    """Malformed period_start string -> 400, not a 500."""
+    seed = await _seed_org_with_data(session_factory, enable_ai_forecast=True)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, seed["owner_id"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/v1/ai/forecast/refine",
+        json={"period_start": "not-a-date"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "invalid_period_start"

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ import { PieChart, Pie, BarChart, Bar, XAxis, YAxis, Cell, Tooltip, ResponsiveCo
 import { chartColor } from "@/lib/chart-colors";
 import { BudgetSpentBarShape, type BudgetSpentBarShapeProps } from "@/lib/chart-shapes";
 import OnTrackTile from "@/components/dashboard/OnTrackTile";
+import AIForecastRefineToggle from "@/components/dashboard/AIForecastRefineToggle";
 import AccountMonthEndForecast, {
   type AccountMonthEndForecastResponse,
 } from "@/components/dashboard/AccountMonthEndForecast";
@@ -745,6 +746,14 @@ export default function DashboardPage() {
                   triggerLabel="What does On Track mean?"
                 />
               </div>
+              {/* LAI.2: opt-in AI refinement. Hides itself on 403
+                  (feature gate closed) so users without the AI tier
+                  never see the toggle. Only surfaces in the current
+                  period — past/future-period forecasts are
+                  deterministic + locked, refinement would mislead. */}
+              {!isPastSelectedPeriod && !isFutureSelectedPeriod && (
+                <AIForecastRefineToggle periodStart={realPeriodStart} />
+              )}
             </div>
           </TourAnchor>
 

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles, AlertTriangle, Loader2 } from "lucide-react";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { card } from "@/lib/styles";
+
+// Mirrors backend/app/schemas/ai_forecast.RefinedForecastResponse.
+export interface RefinedCategoryRow {
+  category_id: number;
+  category_name: string;
+  baseline_forecast: string;
+  multiplier: number;
+  refined_forecast: string;
+}
+
+export interface AnomalyFlag {
+  category_id: number | null;
+  category_name: string;
+  description: string;
+  severity: "info" | "warning" | "alert";
+}
+
+export interface RefinedForecastProvenance {
+  ai_applied: boolean;
+  fallback_reason: string | null;
+  model: string | null;
+  confidence: number | null;
+  summary: string | null;
+  notes: string[];
+}
+
+export interface RefinedForecastResponse {
+  period_start: string;
+  period_end: string;
+  baseline_forecast_expense: string;
+  refined_forecast_expense: string;
+  baseline_forecast_income: string;
+  refined_forecast_income: string;
+  categories: RefinedCategoryRow[];
+  anomalies: AnomalyFlag[];
+  provenance: RefinedForecastProvenance;
+}
+
+export interface AIForecastRefineToggleProps {
+  periodStart: string | null;
+  // Render-only render-prop: parent decides whether to surface the
+  // toggle (e.g. only when the OnTrackTile has a plan). Default true.
+  visible?: boolean;
+}
+
+/**
+ * AI-refined forecast toggle + badge.
+ *
+ * Opt-in: clicking "Apply AI refinement" hits
+ * `POST /api/v1/ai/forecast/refine` and surfaces a small badge with
+ * the delta vs. the baseline. If the feature gate is closed (403), the
+ * toggle hides itself silently — the user never sees a permission
+ * error, they just never see the AI option.
+ *
+ * On any other failure (no routing, cap exceeded, structured output
+ * exhausted) the backend falls back to the baseline; the UI surfaces
+ * the typed `fallback_reason` in the tooltip so the user understands
+ * why no adjustments were applied.
+ */
+export default function AIForecastRefineToggle({
+  periodStart,
+  visible = true,
+}: AIForecastRefineToggleProps) {
+  const [refined, setRefined] = useState<RefinedForecastResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [gateBlocked, setGateBlocked] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  if (!visible || gateBlocked) return null;
+
+  const handleClick = async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const body = await apiFetch<RefinedForecastResponse>(
+        "/api/v1/ai/forecast/refine",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ period_start: periodStart ?? null }),
+        },
+      );
+      setRefined(body);
+    } catch (err) {
+      if (err instanceof ApiResponseError && err.status === 403) {
+        // Feature gate closed. Hide the toggle entirely.
+        setGateBlocked(true);
+        return;
+      }
+      setErrorMessage(
+        err instanceof Error ? err.message : "Failed to refine forecast",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Idle state — invite the user to opt in.
+  if (refined === null) {
+    return (
+      <div className={`${card} mt-3 flex items-center gap-3 p-3 md:p-4`}>
+        <Sparkles className="h-4 w-4 text-text-secondary" aria-hidden="true" />
+        <div className="flex-1 text-sm text-text-secondary">
+          Layer AI-detected seasonality on this forecast.
+        </div>
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={loading}
+          data-testid="ai-forecast-refine-toggle"
+          className="rounded border border-border bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-primary hover:bg-bg-tertiary disabled:opacity-50"
+        >
+          {loading ? (
+            <span className="inline-flex items-center gap-1">
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+              Refining,
+            </span>
+          ) : (
+            "Apply AI refinement"
+          )}
+        </button>
+        {errorMessage && (
+          <span className="text-xs text-danger" role="status">
+            {errorMessage}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // Refined state — show badge + delta.
+  const aiApplied = refined.provenance.ai_applied;
+  const baseline = Number(refined.baseline_forecast_expense);
+  const refinedAmt = Number(refined.refined_forecast_expense);
+  const delta = refinedAmt - baseline;
+  const adjustments = refined.categories.filter((c) => c.multiplier !== 1);
+
+  return (
+    <div className={`${card} mt-3 p-3 md:p-4`} data-testid="ai-forecast-refined-panel">
+      <div className="flex items-center gap-3">
+        {aiApplied ? (
+          <span
+            data-testid="ai-refined-badge"
+            className="inline-flex items-center gap-1 rounded-full bg-bg-tertiary px-2 py-0.5 text-xs font-medium text-text-primary"
+          >
+            <Sparkles className="h-3 w-3" aria-hidden="true" />
+            AI-refined
+          </span>
+        ) : (
+          <span
+            data-testid="ai-fallback-badge"
+            className="inline-flex items-center gap-1 rounded-full bg-bg-tertiary px-2 py-0.5 text-xs font-medium text-text-muted"
+          >
+            <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+            Baseline (AI unavailable)
+          </span>
+        )}
+        <div className="flex-1 text-sm text-text-secondary">
+          {aiApplied ? (
+            <>
+              {delta >= 0 ? "+" : ""}
+              {delta.toFixed(2)} vs. baseline
+              {adjustments.length > 0 && (
+                <span className="ml-2 text-xs text-text-muted">
+                  ({adjustments.length} categor
+                  {adjustments.length === 1 ? "y" : "ies"} adjusted)
+                </span>
+              )}
+            </>
+          ) : (
+            <span data-testid="ai-fallback-reason" className="text-xs">
+              {refined.provenance.fallback_reason ?? "Falling back to baseline"}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setTooltipOpen((open) => !open)}
+          aria-expanded={tooltipOpen}
+          aria-controls="ai-forecast-refine-tooltip"
+          className="text-xs text-text-secondary underline underline-offset-2 hover:text-text-primary"
+        >
+          {tooltipOpen ? "Hide details" : "What changed?"}
+        </button>
+      </div>
+      {tooltipOpen && (
+        <div
+          id="ai-forecast-refine-tooltip"
+          role="region"
+          aria-label="AI refinement details"
+          className="mt-3 border-t border-border pt-3 text-xs text-text-secondary"
+        >
+          {aiApplied && refined.provenance.summary && (
+            <p className="mb-2 italic">{refined.provenance.summary}</p>
+          )}
+          {adjustments.length > 0 && (
+            <ul className="mb-2 list-disc space-y-1 pl-4" data-testid="ai-adjustments-list">
+              {adjustments.map((adj) => (
+                <li key={adj.category_id}>
+                  <span className="font-medium text-text-primary">
+                    {adj.category_name}
+                  </span>
+                  : {Number(adj.baseline_forecast).toFixed(2)} -&gt;{" "}
+                  {Number(adj.refined_forecast).toFixed(2)} (x
+                  {adj.multiplier.toFixed(2)})
+                </li>
+              ))}
+            </ul>
+          )}
+          {refined.anomalies.length > 0 && (
+            <div className="mb-2">
+              <p className="font-medium text-text-primary">Anomalies</p>
+              <ul className="mt-1 list-disc space-y-1 pl-4">
+                {refined.anomalies.map((anom, idx) => (
+                  <li key={`${anom.category_id ?? "general"}-${idx}`}>
+                    <span className="font-medium text-text-primary">
+                      {anom.category_name}
+                    </span>
+                    : {anom.description}{" "}
+                    <span className="text-text-muted">[{anom.severity}]</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {refined.provenance.notes.length > 0 && (
+            <ul className="mb-2 list-disc space-y-1 pl-4 text-text-muted">
+              {refined.provenance.notes.map((note, idx) => (
+                <li key={idx}>{note}</li>
+              ))}
+            </ul>
+          )}
+          {refined.provenance.model && (
+            <p className="text-text-muted">
+              Model: {refined.provenance.model}
+              {refined.provenance.confidence !== null &&
+                refined.provenance.confidence !== undefined && (
+                  <>
+                    {" , confidence "}
+                    {(refined.provenance.confidence * 100).toFixed(0)}%
+                  </>
+                )}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              setRefined(null);
+              setTooltipOpen(false);
+            }}
+            className="mt-3 text-xs text-text-secondary underline underline-offset-2 hover:text-text-primary"
+          >
+            Revert to baseline
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/AIForecastRefineToggle.tsx
+++ b/frontend/components/dashboard/AIForecastRefineToggle.tsx
@@ -120,7 +120,7 @@ export default function AIForecastRefineToggle({
           {loading ? (
             <span className="inline-flex items-center gap-1">
               <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
-              Refining,
+              Refining…
             </span>
           ) : (
             "Apply AI refinement"
@@ -243,7 +243,7 @@ export default function AIForecastRefineToggle({
               {refined.provenance.confidence !== null &&
                 refined.provenance.confidence !== undefined && (
                   <>
-                    {" , confidence "}
+                    {", confidence "}
                     {(refined.provenance.confidence * 100).toFixed(0)}%
                   </>
                 )}

--- a/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
+++ b/frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx
@@ -1,0 +1,198 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AIForecastRefineToggle, {
+  type RefinedForecastResponse,
+} from "@/components/dashboard/AIForecastRefineToggle";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+import { apiFetch, ApiResponseError } from "@/lib/api";
+
+const mockedFetch = apiFetch as unknown as ReturnType<typeof vi.fn>;
+
+function refinedFixture(
+  overrides?: Partial<RefinedForecastResponse>,
+): RefinedForecastResponse {
+  return {
+    period_start: "2026-05-01",
+    period_end: "2026-05-31",
+    baseline_forecast_expense: "100.00",
+    refined_forecast_expense: "120.00",
+    baseline_forecast_income: "1000.00",
+    refined_forecast_income: "1000.00",
+    categories: [
+      {
+        category_id: 1,
+        category_name: "Groceries",
+        baseline_forecast: "100.00",
+        multiplier: 1.2,
+        refined_forecast: "120.00",
+      },
+    ],
+    anomalies: [
+      {
+        category_id: 1,
+        category_name: "Groceries",
+        description: "Spike vs. trailing average.",
+        severity: "warning",
+      },
+    ],
+    provenance: {
+      ai_applied: true,
+      fallback_reason: null,
+      model: "gpt-4o-mini",
+      confidence: 0.75,
+      summary: "Detected one mild seasonal uptick.",
+      notes: [],
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AIForecastRefineToggle - idle and apply flow", () => {
+  it("renders the apply CTA when idle and triggers POST on click", async () => {
+    mockedFetch.mockResolvedValueOnce(refinedFixture());
+
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+    const button = screen.getByTestId("ai-forecast-refine-toggle");
+    expect(button).toBeInTheDocument();
+    expect(button.textContent).toContain("Apply AI refinement");
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument();
+    });
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "/api/v1/ai/forecast/refine",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ period_start: "2026-05-01" }),
+      }),
+    );
+  });
+
+  it("shows the AI-refined badge when the backend applies adjustments", async () => {
+    mockedFetch.mockResolvedValueOnce(refinedFixture());
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+
+    fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ai-refined-badge")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("ai-fallback-badge")).toBeNull();
+    // Delta vs. baseline surfaced.
+    expect(screen.getByText(/\+20\.00 vs\. baseline/)).toBeInTheDocument();
+    expect(screen.getByText(/1 category adjusted/)).toBeInTheDocument();
+  });
+});
+
+describe("AIForecastRefineToggle - tooltip details", () => {
+  it("toggles the detail panel and lists adjustments + anomalies", async () => {
+    mockedFetch.mockResolvedValueOnce(refinedFixture());
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+
+    fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-forecast-refined-panel")).toBeInTheDocument(),
+    );
+
+    // Closed by default.
+    expect(screen.queryByTestId("ai-adjustments-list")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /What changed/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-adjustments-list")).toBeInTheDocument(),
+    );
+    // Summary shown in the tooltip.
+    expect(
+      screen.getByText("Detected one mild seasonal uptick."),
+    ).toBeInTheDocument();
+    // Adjustment row lists the multiplier as x1.20.
+    const list = screen.getByTestId("ai-adjustments-list");
+    expect(list.textContent).toContain("Groceries");
+    expect(list.textContent).toContain("x1.20");
+    // Anomaly listed — match the description via a text-content includes
+    // check because the severity tag renders as a sibling span.
+    expect(screen.getByText(/Spike vs\. trailing average/i)).toBeInTheDocument();
+  });
+});
+
+describe("AIForecastRefineToggle - fallback handling", () => {
+  it("shows fallback badge + reason when backend returns ai_applied=false", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      refinedFixture({
+        refined_forecast_expense: "100.00",
+        provenance: {
+          ai_applied: false,
+          fallback_reason: "ai_routing_not_configured",
+          model: null,
+          confidence: null,
+          summary: null,
+          notes: [],
+        },
+        categories: [
+          {
+            category_id: 1,
+            category_name: "Groceries",
+            baseline_forecast: "100.00",
+            multiplier: 1.0,
+            refined_forecast: "100.00",
+          },
+        ],
+        anomalies: [],
+      }),
+    );
+
+    render(<AIForecastRefineToggle periodStart="2026-05-01" />);
+    fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("ai-fallback-badge")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("ai-refined-badge")).toBeNull();
+    expect(screen.getByTestId("ai-fallback-reason").textContent).toContain(
+      "ai_routing_not_configured",
+    );
+  });
+
+  it("hides itself entirely on a 403 (feature gate closed)", async () => {
+    mockedFetch.mockRejectedValueOnce(
+      new ApiResponseError(403, "feature_not_enabled", "feature_not_enabled"),
+    );
+
+    const { container } = render(
+      <AIForecastRefineToggle periodStart="2026-05-01" />,
+    );
+    fireEvent.click(screen.getByTestId("ai-forecast-refine-toggle"));
+
+    await waitFor(() => {
+      // After 403 the toggle removes itself from the DOM.
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});
+
+describe("AIForecastRefineToggle - visibility prop", () => {
+  it("renders nothing when visible=false", () => {
+    const { container } = render(
+      <AIForecastRefineToggle periodStart="2026-05-01" visible={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Layers AI-detected seasonality + anomaly flags on top of the deterministic forecast. Opt-in via a small toggle next to the dashboard's OnTrackTile; falls back to the baseline on any LLM failure so the UI always renders something useful.

### Backend

- `POST /api/v1/ai/forecast/refine` gated by the `ai.forecast` feature catalog key.
- `ai_forecast_refine_service` builds a 6-month per-category aggregate summary and dispatches via `ai_dispatch.call_llm_structured`. No raw transactions, merchant names, or descriptions leave the service; only aggregated category totals.
- `AIForecastAdjustments` Pydantic schema clamps multipliers to `[0.5, 1.5]`. Out-of-band LLM responses are rejected and the baseline is served with `provenance.fallback_reason=ai_response_invalid_schema`.
- Every call writes an `ai.forecast.refine.invoked` audit event with the outcome + provenance. Free-text summary is intentionally **not** audited (would echo user-typed category names).
- Fallback is purely additive: `NoRoutingConfigured`, `AICapExceeded`, `StructuredOutputError`, `AIDispatchFailed`, validation errors all return 200 with `provenance.ai_applied=false`.

### Frontend

- `AIForecastRefineToggle` component: idle CTA, "AI-refined" badge, expandable details (multipliers per category, anomalies, model + confidence, "Revert to baseline").
- Self-hides on 403 (closed feature gate) so users without the AI tier never see the toggle.
- Mounted on `/dashboard` in the current period only; past + future periods are deterministic by design.

### Files (8)

- `backend/app/routers/ai_forecast.py` (new)
- `backend/app/schemas/ai_forecast.py` (new)
- `backend/app/services/ai_forecast_refine_service.py` (new)
- `backend/app/main.py` (router registration)
- `backend/tests/routers/test_ai_forecast_refine.py` (new, 6 tests)
- `frontend/components/dashboard/AIForecastRefineToggle.tsx` (new)
- `frontend/app/dashboard/page.tsx` (mount the toggle)
- `frontend/tests/components/dashboard/ai-forecast-refine-toggle.test.tsx` (new, 6 tests)