### PR TITLE
feat(help): cross-page tour + per-field tooltip map (L5.3)

### DIFF
--- a/frontend/app/accounts/page.tsx
+++ b/frontend/app/accounts/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import HelpTooltip from "@/components/help/HelpTooltip";
 import Tooltip from "@/components/Tooltip";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -309,7 +310,10 @@ export default function AccountsPage() {
 
   return (
     <AppShell>
-      <div className="mb-8 flex items-start gap-1">
+      <div
+        className="mb-8 flex items-start gap-1"
+        data-tour-id="accounts.title"
+      >
         <h1 className={`${pageTitle} mb-0`}>Accounts</h1>
         <HelpAnchor section="accounts" label="Accounts" />
       </div>
@@ -455,7 +459,10 @@ export default function AccountsPage() {
                       simply count from 0. */}
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
                     <div className="w-full sm:flex-1">
-                      <label htmlFor="acct-opening-balance" className={label}>Opening balance</label>
+                      <span className="mb-1.5 flex items-center gap-1">
+                        <label htmlFor="acct-opening-balance" className={`${label} mb-0`}>Opening balance</label>
+                        <HelpTooltip k="account.opening-balance" />
+                      </span>
                       <input
                         id="acct-opening-balance"
                         type="number"

--- a/frontend/app/budgets/page.tsx
+++ b/frontend/app/budgets/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
+import HelpTooltip from "@/components/help/HelpTooltip";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -206,7 +207,7 @@ export default function BudgetsPage() {
   return (
     <AppShell>
       <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-start gap-1">
+        <div className="flex items-start gap-1" data-tour-id="budgets.title">
           <h1 className={`${pageTitle} mb-0`}>Budgets</h1>
           <HelpAnchor section="budgets" label="Budgets" />
         </div>
@@ -298,7 +299,10 @@ export default function BudgetsPage() {
               </select>
             </div>
             <div className="w-full sm:w-40">
-              <label htmlFor="b-amount" className={label}>Monthly limit</label>
+              <span className="mb-1.5 flex items-center gap-1">
+                <label htmlFor="b-amount" className={`${label} mb-0`}>Monthly limit</label>
+                <HelpTooltip k="budget.monthly-limit" />
+              </span>
               <input id="b-amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value={formAmount} onChange={(e) => setFormAmount(e.target.value)} className={input} />
             </div>
             <button type="submit" className={`${btnPrimary} sm:min-h-0`}>Add</button>

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -406,7 +406,7 @@ export default function CategoriesPage() {
   return (
     <AppShell>
       <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-start gap-1">
+        <div className="flex items-start gap-1" data-tour-id="categories.title">
           <h1 className={`${pageTitle} mb-0`}>Categories</h1>
           <HelpAnchor section="categories" label="Categories" />
         </div>

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -286,7 +286,7 @@ export default function PlansPage() {
   return (
     <AppShell>
       <header className="mb-4 flex items-center justify-between gap-3">
-        <div>
+        <div data-tour-id="plans.title">
           <h1 className={`${pageTitle} mb-0`}>Plans</h1>
           <p className="mt-1 text-sm text-text-muted">
             Plan one-off life events. Nothing here touches your real transactions.{" "}

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -86,7 +86,7 @@ export default function ReportsListPage() {
   return (
     <AppShell>
       <header className="mb-6 flex items-center justify-between">
-        <div>
+        <div data-tour-id="reports.title">
           <h1 className="text-2xl font-semibold text-text-primary">Reports</h1>
           <p className="text-sm text-text-muted">
             Build a layout of KPIs and charts over your transactions.

--- a/frontend/app/transactions/page.tsx
+++ b/frontend/app/transactions/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import AppShell from "@/components/AppShell";
 import HelpAnchor from "@/components/HelpAnchor";
 import Tooltip from "@/components/Tooltip";
+import HelpTooltip from "@/components/help/HelpTooltip";
 import Spinner from "@/components/ui/Spinner";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
@@ -975,7 +976,7 @@ function TransactionsPageContent() {
         </div>
       )}
       <div className="mb-8 flex items-center justify-between">
-        <div className="flex items-start gap-1">
+        <div className="flex items-start gap-1" data-tour-id="transactions.title">
           <h1 className={`${pageTitle} mb-0`}>Transactions</h1>
           <HelpAnchor section="transactions" label="Transactions" />
         </div>
@@ -1028,7 +1029,10 @@ function TransactionsPageContent() {
           </div>
           <form onSubmit={handleAdd} className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div>
-              <label htmlFor="tx-account" className={label}>{formMode === "transfer" ? "From Account" : "Account"}</label>
+              <span className="mb-1.5 flex items-center gap-1">
+                <label htmlFor="tx-account" className={`${label} mb-0`}>{formMode === "transfer" ? "From Account" : "Account"}</label>
+                {formMode === "transaction" ? <HelpTooltip k="tx.account" /> : null}
+              </span>
               <select id="tx-account" required value={formAccountId} onChange={(e) => handleAccountChange(e.target.value === "" ? "" : Number(e.target.value))} className={input}>
                 <option value="">Select account</option>
                 {activeAccounts.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
@@ -1044,7 +1048,10 @@ function TransactionsPageContent() {
               </div>
             ) : (
               <div>
-                <label htmlFor="tx-type" className={label}>Type</label>
+                <span className="mb-1.5 flex items-center gap-1">
+                  <label htmlFor="tx-type" className={`${label} mb-0`}>Type</label>
+                  <HelpTooltip k="tx.type" />
+                </span>
                 <select id="tx-type" value={formType} onChange={(e) => handleTypeChange(e.target.value as "income" | "expense")} className={input}>
                   <option value="expense">Expense</option>
                   <option value="income">Income</option>
@@ -1059,7 +1066,10 @@ function TransactionsPageContent() {
             )}
             {formMode === "transfer" && (
               <div>
-                <label htmlFor="tx-transfer-cat" className={label}>Transfer category</label>
+                <span className="mb-1.5 flex items-center gap-1">
+                  <label htmlFor="tx-transfer-cat" className={`${label} mb-0`}>Transfer category</label>
+                  <HelpTooltip k="transfer.category" />
+                </span>
                 <CategorySelect id="tx-transfer-cat" categories={categories} value={formTransferCatId} onChange={setFormTransferCatId} typeFilter="BOTH" className={input} onCategoryCreated={(cat) => setCategories((prev) => [...prev, cat])} />
                 <p className="mt-1 text-[10px] text-text-muted">Transfers use one category shared by both legs. Pick Transfer, Credit Card Payment, or another transfer-compatible category you create. Leave empty to use the default Transfer category.</p>
               </div>
@@ -1097,7 +1107,10 @@ function TransactionsPageContent() {
             </div>
             {formMode === "transaction" && (
               <div>
-                <label htmlFor="tx-tags" className={label}>Tags</label>
+                <span className="mb-1.5 flex items-center gap-1">
+                  <label htmlFor="tx-tags" className={`${label} mb-0`}>Tags</label>
+                  <HelpTooltip k="tx.tags" />
+                </span>
                 <TagChipInput
                   id="tx-tags"
                   value={formTags}
@@ -1107,7 +1120,10 @@ function TransactionsPageContent() {
               </div>
             )}
             <div>
-              <label htmlFor="tx-amount" className={label}>Amount</label>
+              <span className="mb-1.5 flex items-center gap-1">
+                <label htmlFor="tx-amount" className={`${label} mb-0`}>Amount</label>
+                <HelpTooltip k="tx.amount" />
+              </span>
               <input id="tx-amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value={formAmount} onChange={(e) => setFormAmount(e.target.value)} className={input} />
             </div>
             <div>
@@ -1154,7 +1170,7 @@ function TransactionsPageContent() {
                 </label>
                 {formRecurring && (
                   <>
-                    <div>
+                    <div className="flex items-center gap-1">
                       <label htmlFor="tx-freq" className="sr-only">Frequency</label>
                       <select id="tx-freq" value={formFrequency} onChange={(e) => setFormFrequency(e.target.value)} className={input}>
                         <option value="weekly">Weekly</option>
@@ -1163,10 +1179,12 @@ function TransactionsPageContent() {
                         <option value="quarterly">Quarterly</option>
                         <option value="yearly">Yearly</option>
                       </select>
+                      <HelpTooltip k="tx.frequency" />
                     </div>
                     <label className="flex items-center gap-2 text-xs text-text-muted">
                       <input type="checkbox" checked={formAutoSettle} onChange={(e) => setFormAutoSettle(e.target.checked)} className="rounded border-border" />
                       Auto-settle
+                      <HelpTooltip k="tx.auto-settle" />
                     </label>
                   </>
                 )}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -9,6 +9,7 @@ import {
   Building2,
   CalendarClock,
   ChevronUp,
+  Compass,
   CreditCard,
   FileText,
   Gauge,
@@ -27,6 +28,10 @@ import {
   X,
 } from "lucide-react";
 import { useAuth } from "@/components/auth/AuthProvider";
+import {
+  TOUR_FLAG_KEY,
+  TOUR_FLAG_VALUE_EXTENDED,
+} from "@/lib/help/tour";
 import AppShellAddTransactionCta, {
   shouldShowAddTransactionCta,
 } from "@/components/AppShellAddTransactionCta";
@@ -488,6 +493,28 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
           {userExpanded && (
             <div className="absolute bottom-full left-3 right-3 mb-1.5 rounded-lg border border-sidebar-border bg-sidebar-bg py-1 shadow-xl">
+              <button
+                onClick={() => {
+                  try {
+                    window.sessionStorage.setItem(
+                      TOUR_FLAG_KEY,
+                      TOUR_FLAG_VALUE_EXTENDED,
+                    );
+                  } catch {
+                    // Storage disabled. The button remains functional
+                    // through Settings → Profile → Replay tour as a
+                    // fallback (audit-logged path).
+                  }
+                  setUserExpanded(false);
+                  setSidebarOpen(false);
+                  router.push("/dashboard");
+                }}
+                data-testid="user-menu-replay-tour"
+                className="flex w-full items-center gap-2.5 px-3.5 py-2 text-[13px] text-sidebar-text hover:bg-sidebar-hover hover:text-sidebar-text-bright"
+              >
+                <Compass aria-hidden="true" className="h-4 w-4" strokeWidth={1.5} />
+                Replay product tour
+              </button>
               <Link
                 href="/settings"
                 onClick={() => setSidebarOpen(false)}

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -501,9 +501,15 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                       TOUR_FLAG_VALUE_EXTENDED,
                     );
                   } catch {
-                    // Storage disabled. The button remains functional
-                    // through Settings → Profile → Replay tour as a
-                    // fallback (audit-logged path).
+                    // sessionStorage unavailable (Safari private mode,
+                    // disabled storage). The replay-tour flow depends
+                    // on this flag — `DashboardTourAutoStart` and
+                    // `RestartTourCard` both read it on mount, so the
+                    // tour won't auto-start in this branch. We still
+                    // navigate to /dashboard so the user sees their
+                    // home; restart-tour from the Settings card has
+                    // the same limitation. TODO: lift the start path
+                    // onto the TourContext so it's storage-independent.
                   }
                   setUserExpanded(false);
                   setSidebarOpen(false);

--- a/frontend/components/accounts/AdjustBalanceModal.tsx
+++ b/frontend/components/accounts/AdjustBalanceModal.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
+import HelpTooltip from "@/components/help/HelpTooltip";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import {
   btnPrimary,
@@ -137,9 +138,12 @@ export default function AdjustBalanceModal({ account, onClose, onAdjusted }: Pro
           </div>
 
           <div>
-            <label className={label} htmlFor="adjust-balance-target">
-              Target balance
-            </label>
+            <span className="mb-1.5 flex items-center gap-1">
+              <label className={`${label} mb-0`} htmlFor="adjust-balance-target">
+                Target balance
+              </label>
+              <HelpTooltip k="account.adjust-balance" />
+            </span>
             <input
               id="adjust-balance-target"
               ref={inputRef}

--- a/frontend/components/floating/TransactionForm.tsx
+++ b/frontend/components/floating/TransactionForm.tsx
@@ -5,6 +5,7 @@ import { FormEvent, MouseEvent, useEffect, useRef, useState } from "react";
 import DescriptionAutocomplete from "@/components/transactions/DescriptionAutocomplete";
 import TagChipInput from "@/components/transactions/TagChipInput";
 import CategorySelect from "@/components/ui/CategorySelect";
+import HelpTooltip from "@/components/help/HelpTooltip";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { todayISO } from "@/lib/format";
 import {
@@ -286,9 +287,12 @@ export default function TransactionForm({
       {errMsg && <div className={errorCls}>{errMsg}</div>}
 
       <div>
-        <label htmlFor="fab-tx-account" className={label}>
-          Account
-        </label>
+        <span className="mb-1.5 flex items-center gap-1">
+          <label htmlFor="fab-tx-account" className={`${label} mb-0`}>
+            Account
+          </label>
+          <HelpTooltip k="tx.account" />
+        </span>
         <select
           id="fab-tx-account"
           required
@@ -308,9 +312,12 @@ export default function TransactionForm({
       </div>
 
       <div>
-        <label htmlFor="fab-tx-type" className={label}>
-          Type
-        </label>
+        <span className="mb-1.5 flex items-center gap-1">
+          <label htmlFor="fab-tx-type" className={`${label} mb-0`}>
+            Type
+          </label>
+          <HelpTooltip k="tx.type" />
+        </span>
         <select
           id="fab-tx-type"
           value={type}
@@ -376,9 +383,12 @@ export default function TransactionForm({
       </div>
 
       <div>
-        <label htmlFor="fab-tx-amount" className={label}>
-          Amount
-        </label>
+        <span className="mb-1.5 flex items-center gap-1">
+          <label htmlFor="fab-tx-amount" className={`${label} mb-0`}>
+            Amount
+          </label>
+          <HelpTooltip k="tx.amount" />
+        </span>
         <input
           id="fab-tx-amount"
           type="number"

--- a/frontend/components/help/HelpTooltip.tsx
+++ b/frontend/components/help/HelpTooltip.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * HelpTooltip — content-map-driven wrapper around the base Tooltip
+ * primitive (L5.3 — help residuals).
+ *
+ * Use this for every frequently confused field. Define the copy once
+ * in ``frontend/lib/help/tooltips.ts`` keyed by a stable id, then drop
+ * ``<HelpTooltip k="tx.frequency" />`` next to the matching label. The
+ * underlying ``<Tooltip>`` owns the portal, accessibility wiring
+ * (aria-describedby), reduced-motion, and viewport clamping.
+ *
+ * The single-letter ``k`` prop name keeps call sites tight when many
+ * tooltips share a row, e.g.
+ *
+ *   <label>Amount <HelpTooltip k="tx.amount" /></label>
+ *
+ * Callers that need to override the trigger label can pass it
+ * directly; everything else comes from the content map.
+ */
+import Tooltip from "@/components/Tooltip";
+import {
+  getHelpTooltip,
+  type HelpTooltipKey,
+} from "@/lib/help/tooltips";
+
+export interface HelpTooltipProps {
+  /** Content-map key. See ``HELP_TOOLTIPS`` in ``lib/help/tooltips.ts``. */
+  k: HelpTooltipKey;
+  /** Override the trigger ARIA label (rarely needed). */
+  triggerLabel?: string;
+  /** Optional class overrides forwarded to the default trigger. */
+  className?: string;
+}
+
+export default function HelpTooltip({
+  k,
+  triggerLabel,
+  className,
+}: HelpTooltipProps) {
+  const entry = getHelpTooltip(k);
+  return (
+    <Tooltip
+      content={entry.content}
+      learnMoreSection={entry.learnMoreSection}
+      triggerLabel={triggerLabel ?? entry.triggerLabel ?? "More info"}
+      className={className}
+      id={`help-${k.replace(/\./g, "-")}`}
+    />
+  );
+}

--- a/frontend/components/help/HelpTooltip.tsx
+++ b/frontend/components/help/HelpTooltip.tsx
@@ -18,6 +18,8 @@
  * Callers that need to override the trigger label can pass it
  * directly; everything else comes from the content map.
  */
+import { useId } from "react";
+
 import Tooltip from "@/components/Tooltip";
 import {
   getHelpTooltip,
@@ -39,13 +41,19 @@ export default function HelpTooltip({
   className,
 }: HelpTooltipProps) {
   const entry = getHelpTooltip(k);
+  // Per-instance suffix so the same key can be rendered multiple
+  // times on the same page (e.g. the inline transactions edit row
+  // AND the floating quick-add form both render `tx.amount`) without
+  // generating duplicate DOM ids — which would break aria-describedby.
+  // The stable key prefix keeps the id greppable in dev tools.
+  const instanceId = useId().replace(/:/g, "");
   return (
     <Tooltip
       content={entry.content}
       learnMoreSection={entry.learnMoreSection}
       triggerLabel={triggerLabel ?? entry.triggerLabel ?? "More info"}
       className={className}
-      id={`help-${k.replace(/\./g, "-")}`}
+      id={`help-${k.replace(/\./g, "-")}-${instanceId}`}
     />
   );
 }

--- a/frontend/components/onboarding/OnboardingPageBody.tsx
+++ b/frontend/components/onboarding/OnboardingPageBody.tsx
@@ -40,15 +40,11 @@ import { apiFetch } from "@/lib/api";
 import { btnPrimary, btnSecondary, card, input, label } from "@/lib/styles";
 import type { AccountType } from "@/lib/types";
 
-const DASHBOARD_TOUR_STEPS = [
-  "dashboard.header",
-  "dashboard.import-cta",
-  "dashboard.period-nav",
-  "dashboard.on-track-tile",
-  "dashboard.account-forecast",
-];
-
-const TOUR_FLAG_KEY = "tbd-pending-dashboard-tour";
+import {
+  DASHBOARD_TOUR_STEPS,
+  TOUR_FLAG_KEY,
+  TOUR_FLAG_VALUE_DASHBOARD,
+} from "@/lib/help/tour";
 
 // sessionStorage flag the Google SSO callback page sets when a new
 // local user has just been created. Reading it here inserts a
@@ -167,7 +163,7 @@ export default function OnboardingPageBody() {
         // tour.start() from here directly. Stash a flag in
         // sessionStorage and the dashboard reads it on mount.
         try {
-          window.sessionStorage.setItem(TOUR_FLAG_KEY, "1");
+          window.sessionStorage.setItem(TOUR_FLAG_KEY, TOUR_FLAG_VALUE_DASHBOARD);
         } catch {
           // sessionStorage may be unavailable in private mode. The
           // tour just will not start automatically — non-fatal.
@@ -562,4 +558,3 @@ export default function OnboardingPageBody() {
   );
 }
 
-export { TOUR_FLAG_KEY, DASHBOARD_TOUR_STEPS };

--- a/frontend/components/settings/RestartTourCard.tsx
+++ b/frontend/components/settings/RestartTourCard.tsx
@@ -22,10 +22,10 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import { btnSecondary, card, cardHeader, cardTitle } from "@/lib/styles";
 
-// Mirrors the constant in OnboardingPageBody. Duplicated rather than
-// imported so the wizard module is not pulled into the Settings page
-// bundle just for one string.
-const TOUR_FLAG_KEY = "tbd-pending-dashboard-tour";
+import {
+  TOUR_FLAG_KEY,
+  TOUR_FLAG_VALUE_DASHBOARD,
+} from "@/lib/help/tour";
 
 export default function RestartTourCard() {
   const router = useRouter();
@@ -46,7 +46,7 @@ export default function RestartTourCard() {
       // so AppShell will NOT redirect us to /onboarding after this call.
       await refreshMe();
       try {
-        window.sessionStorage.setItem(TOUR_FLAG_KEY, "1");
+        window.sessionStorage.setItem(TOUR_FLAG_KEY, TOUR_FLAG_VALUE_DASHBOARD);
       } catch {
         // Private mode or storage disabled. The dashboard tour will
         // not auto-start; the user can re-click the button from

--- a/frontend/components/tour/TourProvider.tsx
+++ b/frontend/components/tour/TourProvider.tsx
@@ -27,27 +27,24 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+
+import {
+  DASHBOARD_TOUR_STEPS,
+  EXTENDED_TOUR_STEPS,
+  STEP_COPY,
+  TOUR_FLAG_KEY,
+  TOUR_FLAG_VALUE_DASHBOARD,
+  TOUR_FLAG_VALUE_EXTENDED,
+  pagePrefix,
+  routeForPrefix,
+} from "@/lib/help/tour";
 
 import {
   TourContext,
   useTourEngine,
   type TourApi,
 } from "./useTour";
-
-// Same sessionStorage key the onboarding wizard writes when the user
-// opts into the post-wizard tour. We auto-start the dashboard tour
-// when this is set AND the user lands on /dashboard. The flag is
-// cleared on start so a reload does not re-trigger.
-const TOUR_FLAG_KEY = "tbd-pending-dashboard-tour";
-
-const DASHBOARD_TOUR_STEPS = [
-  "dashboard.header",
-  "dashboard.import-cta",
-  "dashboard.period-nav",
-  "dashboard.on-track-tile",
-  "dashboard.account-forecast",
-];
 
 function DashboardTourAutoStart({ api }: { api: TourApi }) {
   const pathname = usePathname();
@@ -59,19 +56,49 @@ function DashboardTourAutoStart({ api }: { api: TourApi }) {
     } catch {
       return;
     }
-    if (flag !== "1") return;
+    if (
+      flag !== TOUR_FLAG_VALUE_DASHBOARD &&
+      flag !== TOUR_FLAG_VALUE_EXTENDED
+    ) {
+      return;
+    }
     try {
       window.sessionStorage.removeItem(TOUR_FLAG_KEY);
     } catch {
       // best-effort
     }
+    const steps =
+      flag === TOUR_FLAG_VALUE_EXTENDED
+        ? EXTENDED_TOUR_STEPS
+        : DASHBOARD_TOUR_STEPS;
     // Defer one tick so the dashboard's TourAnchor DOM is mounted
     // before the engine measures positions.
     const t = window.setTimeout(() => {
-      api.start(DASHBOARD_TOUR_STEPS);
+      api.start(steps);
     }, 100);
     return () => window.clearTimeout(t);
   }, [pathname, api]);
+  return null;
+}
+
+/**
+ * Watches the active step's page prefix and pushes the router when
+ * the user is on a different surface. The overlay's anchor-missing
+ * fallback would otherwise auto-skip past every off-route step.
+ * Only fires while the tour is active.
+ */
+function TourRouter({ api }: { api: TourApi }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentStep = api.currentStep;
+  useEffect(() => {
+    if (!api.isActive) return;
+    if (!currentStep) return;
+    const route = routeForPrefix(pagePrefix(currentStep));
+    if (!route) return;
+    if (pathname === route) return;
+    router.push(route);
+  }, [api.isActive, currentStep, pathname, router]);
   return null;
 }
 
@@ -104,37 +131,6 @@ function usePrefersReducedMotion(): boolean {
   }, []);
   return reduced;
 }
-
-interface TourStepCopy {
-  title: string;
-  body: string;
-}
-
-// Step copy in one place so the wizard team can tweak voice without
-// chasing JSX. Keys match the dot-namespaced anchor ids the dashboard
-// already wired through PR #226.
-const STEP_COPY: Record<string, TourStepCopy> = {
-  "dashboard.header": {
-    title: "Welcome to your dashboard",
-    body: "This is where you will see how the month is going at a glance. Net cashflow, balances, and what is coming up.",
-  },
-  "dashboard.import-cta": {
-    title: "Bring in your transactions",
-    body: "Import a bank export here, or add transactions one by one. The Better Decision works with whatever you have.",
-  },
-  "dashboard.period-nav": {
-    title: "Move through periods",
-    body: "Each month is its own billing period. Use these arrows to look back at history or peek ahead.",
-  },
-  "dashboard.on-track-tile": {
-    title: "How the month is shaping up",
-    body: "On Track tells you if your spending plan and your reality agree. Green means you are on it. Yellow means it is worth a look.",
-  },
-  "dashboard.account-forecast": {
-    title: "Account forecast",
-    body: "We project each account out to the end of the period using your recurring transactions and budgets.",
-  },
-};
 
 function TourOverlay({ api }: { api: TourApi }) {
   const reducedMotion = usePrefersReducedMotion();
@@ -176,13 +172,30 @@ function TourOverlay({ api }: { api: TourApi }) {
     return () => window.clearTimeout(t);
   }, [api, rect]);
 
-  // Escape closes the tour. The overlay is informative
-  // (aria-modal="false") so we do not trap focus, but a keyboard
-  // user should still be able to dismiss it without grabbing a mouse.
+  // Keyboard nav. The overlay is informative (aria-modal="false") so
+  // we don't trap focus, but the tour itself has to be fully usable
+  // from the keyboard:
+  //   - Escape closes
+  //   - ArrowRight advances (matches "Next" button)
+  //   - ArrowLeft goes back (matches "Back" button)
+  // We deliberately leave Tab/Enter/Space to the browser's default
+  // button focus handling so the card's own buttons keep their
+  // standard semantics.
   useEffect(() => {
     if (!api.isActive) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") api.close();
+      if (e.key === "Escape") {
+        api.close();
+        return;
+      }
+      if (e.key === "ArrowRight") {
+        api.next();
+        return;
+      }
+      if (e.key === "ArrowLeft") {
+        api.prev();
+        return;
+      }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
@@ -313,6 +326,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     <TourContext.Provider value={api}>
       {children}
       <DashboardTourAutoStart api={api} />
+      <TourRouter api={api} />
       <TourOverlay api={api} />
     </TourContext.Provider>
   );

--- a/frontend/components/tour/TourProvider.tsx
+++ b/frontend/components/tour/TourProvider.tsx
@@ -217,7 +217,12 @@ function TourOverlay({ api }: { api: TourApi }) {
       // Escape stays global; arrow advance/back only fires when focus is
       // outside an editable element.
       if (!(target instanceof HTMLElement)) return false;
+      // Real browsers compute isContentEditable from the attribute, but
+      // jsdom does not — so also check the raw attribute as a fallback
+      // so tests stay honest.
       if (target.isContentEditable) return true;
+      const ce = target.getAttribute("contenteditable");
+      if (ce === "" || ce === "true" || ce === "plaintext-only") return true;
       const tag = target.tagName;
       return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
     };

--- a/frontend/components/tour/TourProvider.tsx
+++ b/frontend/components/tour/TourProvider.tsx
@@ -95,7 +95,19 @@ function TourRouter({ api }: { api: TourApi }) {
     if (!api.isActive) return;
     if (!currentStep) return;
     const route = routeForPrefix(pagePrefix(currentStep));
-    if (!route) return;
+    if (!route) {
+      // Unknown prefix means the tour authoring drifted from the
+      // route map. The overlay will auto-skip when the anchor isn't
+      // found, but surfacing it as a console warning makes the
+      // missing entry visible in CI smoke runs / E2E logs instead of
+      // silently no-opping.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[tour] no route mapped for step prefix "${pagePrefix(currentStep)}" ` +
+          `(step="${currentStep}"). Add an entry to routeForPrefix() in lib/help/tour.ts.`,
+      );
+      return;
+    }
     if (pathname === route) return;
     router.push(route);
   }, [api.isActive, currentStep, pathname, router]);
@@ -134,6 +146,7 @@ function usePrefersReducedMotion(): boolean {
 
 function TourOverlay({ api }: { api: TourApi }) {
   const reducedMotion = usePrefersReducedMotion();
+  const pathname = usePathname();
   const [rect, setRect] = useState<AnchorRect | null>(null);
   const [mounted, setMounted] = useState(false);
 
@@ -161,16 +174,30 @@ function TourOverlay({ api }: { api: TourApi }) {
 
   // If the active step has no anchor in the DOM (route changed,
   // element removed), advance after a short grace so flicker does
-  // not stall the user. 200ms is enough for a Next.js client nav.
+  // not stall the user.
+  //
+  // BUT: when a cross-page step is in flight, TourRouter has just
+  // pushed the new route and we're waiting for the destination page
+  // to mount its `data-tour-id` anchors. Auto-skipping during that
+  // window would silently advance past every step on a slow page.
+  // Suspend auto-skip until the pathname matches the step's expected
+  // route, then poll on a longer grace (800ms) to absorb the
+  // hydration + data-fetch tail.
   useEffect(() => {
     if (!api.isActive) return;
     if (rect) return;
+    if (!api.currentStep) return;
+    const expectedRoute = routeForPrefix(pagePrefix(api.currentStep));
+    // If we know the step belongs to a different route than we're on,
+    // don't auto-skip — TourRouter will move us there and the anchor
+    // will appear shortly.
+    if (expectedRoute && pathname !== expectedRoute) return;
     const t = window.setTimeout(() => {
       const fresh = getAnchorRect(api.currentStep);
       if (!fresh) api.next();
-    }, 200);
+    }, 800);
     return () => window.clearTimeout(t);
-  }, [api, rect]);
+  }, [api, rect, pathname]);
 
   // Keyboard nav. The overlay is informative (aria-modal="false") so
   // we don't trap focus, but the tour itself has to be fully usable
@@ -183,11 +210,23 @@ function TourOverlay({ api }: { api: TourApi }) {
   // standard semantics.
   useEffect(() => {
     if (!api.isActive) return;
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+      // Arrow keys belong to inputs, textareas, selects, contenteditables
+      // — for cursor movement, radio/listbox navigation, etc. Hijacking
+      // them while the user is mid-keystroke breaks the underlying page.
+      // Escape stays global; arrow advance/back only fires when focus is
+      // outside an editable element.
+      if (!(target instanceof HTMLElement)) return false;
+      if (target.isContentEditable) return true;
+      const tag = target.tagName;
+      return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+    };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         api.close();
         return;
       }
+      if (isEditableTarget(e.target)) return;
       if (e.key === "ArrowRight") {
         api.next();
         return;

--- a/frontend/components/ui/AddCategoryModal.tsx
+++ b/frontend/components/ui/AddCategoryModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import HelpTooltip from "@/components/help/HelpTooltip";
 import { apiFetch, extractErrorMessage } from "@/lib/api";
 import {
   btnPrimary,
@@ -206,7 +207,10 @@ export default function AddCategoryModal({
             </div>
           ) : (
             <fieldset>
-              <legend className={labelCls}>Type</legend>
+              <legend className="mb-1.5 flex items-center gap-1">
+                <span className={`${labelCls} mb-0`}>Type</span>
+                <HelpTooltip k="cat.type" />
+              </legend>
               <div className="flex gap-4 text-sm text-text-primary">
                 {(["expense", "income", "both"] as const).map((t) => (
                   <label key={t} className="flex items-center gap-1.5">
@@ -235,6 +239,7 @@ export default function AddCategoryModal({
               }}
             />
             <label htmlFor="add-cat-issub">Subcategory</label>
+            <HelpTooltip k="cat.subcategory" />
           </div>
 
           {isSub && (

--- a/frontend/lib/help/tooltips.ts
+++ b/frontend/lib/help/tooltips.ts
@@ -1,0 +1,151 @@
+/**
+ * Tooltip content map (L5.3 — help residuals).
+ *
+ * One row per frequently confused field, looked up by string key. The
+ * ``<HelpTooltip>`` wrapper consumes this map so future additions are
+ * a one-line edit instead of an inline-JSX shuffle. Pair this with the
+ * existing ``<Tooltip>`` primitive (``frontend/components/Tooltip.tsx``)
+ * which owns the trigger, portal, accessibility, and reduced-motion
+ * behavior.
+ *
+ * House style: one short sentence, no em-dashes (use commas/periods
+ * or parentheses instead), plain language. Each entry can optionally
+ * point at a /docs anchor via ``learnMoreSection`` so power users get
+ * the full manual in a new tab.
+ *
+ * Keys are dot-namespaced "<feature>.<field>" so a future tooltip
+ * audit can grep for every site that uses ``HelpTooltip key="tx.X"``.
+ */
+
+export interface HelpTooltipEntry {
+  /** One short sentence. No em-dashes. */
+  content: string;
+  /** Optional /docs anchor for "Learn more" deep link. */
+  learnMoreSection?: string;
+  /** Optional ARIA label override for the trigger button. */
+  triggerLabel?: string;
+}
+
+export const HELP_TOOLTIPS = {
+  // Transactions
+  "tx.account": {
+    content:
+      "Which account this transaction belongs to. Pick the account the money actually moved through, not the one it pays for.",
+    learnMoreSection: "transactions",
+    triggerLabel: "What does Account mean here?",
+  },
+  "tx.type": {
+    content:
+      "Expense means money going out, Income means money coming in. The Better Decision stores all amounts as positives and uses Type to set the sign.",
+    learnMoreSection: "transactions",
+    triggerLabel: "What is the difference between Expense and Income?",
+  },
+  "tx.amount": {
+    content:
+      "Always a positive number. The Type field above controls whether it counts as money in or money out.",
+    learnMoreSection: "transactions",
+    triggerLabel: "Why is Amount always positive?",
+  },
+  "tx.frequency": {
+    content:
+      "How often this transaction repeats. Weekly fires every 7 days, Monthly fires on the same day each month, Yearly fires on the same day each year.",
+    learnMoreSection: "transactions",
+    triggerLabel: "What does Frequency mean?",
+  },
+  "tx.auto-settle": {
+    content:
+      "When on, recurring instances flip from Pending to Settled on their scheduled date with no extra clicks. Leave off if you want to confirm each one yourself.",
+    learnMoreSection: "transactions",
+    triggerLabel: "What does Auto settle do?",
+  },
+  "tx.tags": {
+    content:
+      "Free form labels you can attach to a transaction. Tags do not replace categories, they live alongside them so you can group across categories (work, vacation, etc).",
+    learnMoreSection: "transactions",
+    triggerLabel: "What are Tags?",
+  },
+
+  // Transfers
+  "transfer.category": {
+    content:
+      "Transfers use one shared category for both legs. Pick Transfer, Credit Card Payment, or another both type category. Leave empty to use the default Transfer category.",
+    learnMoreSection: "transactions",
+    triggerLabel: "Which category should a transfer use?",
+  },
+
+  // Categories
+  "cat.type": {
+    content:
+      "Income, Expense, or Both. Both is for transfer style categories like Credit Card Payment that can carry either direction.",
+    learnMoreSection: "categories",
+    triggerLabel: "What does category Type mean?",
+  },
+  "cat.subcategory": {
+    content:
+      "Subcategories nest under a master. A master like Food can have child rows Groceries, Dining, and Coffee, so you can drill in without losing the parent total.",
+    learnMoreSection: "categories",
+    triggerLabel: "Explain category nesting",
+  },
+
+  // Budgets
+  "budget.monthly-limit": {
+    content:
+      "The cap for this category in one billing period. Budgets reset every period and never roll over.",
+    learnMoreSection: "budgets",
+    triggerLabel: "What does Monthly limit mean?",
+  },
+
+  // Accounts
+  "account.opening-balance": {
+    content:
+      "What the account held on the day you start tracking it. The Better Decision uses this as a starting point and adds your transactions on top.",
+    learnMoreSection: "accounts",
+    triggerLabel: "What is Opening balance?",
+  },
+  "account.adjust-balance": {
+    content:
+      "Use this when your real bank balance differs from the one The Better Decision is showing. We record a single Adjustment transaction so the difference is auditable.",
+    learnMoreSection: "accounts",
+    triggerLabel: "Why is there an Adjustment transaction?",
+  },
+
+  // Plans
+  "plans.sandbox": {
+    content:
+      "Plans is a sandbox. Whatever you do here, including big life events and salary changes, never modifies your real transactions or budgets.",
+    learnMoreSection: "plans",
+    triggerLabel: "Does Plans change my real data?",
+  },
+
+  // Reports
+  "reports.kpi": {
+    content:
+      "Drop in KPIs (Net Cashflow, Total Spent, Savings Rate) and charts over any date range. Layouts are saved per user.",
+    learnMoreSection: "reports",
+    triggerLabel: "What can I put in a report?",
+  },
+
+  // Dashboard
+  "dashboard.on-track": {
+    content:
+      "On Track compares your budgeted spend to your actual spend. Green is within plan, yellow is close to the cap, red is over.",
+    learnMoreSection: "dashboard",
+    triggerLabel: "What do the On Track colors mean?",
+  },
+} as const satisfies Record<string, HelpTooltipEntry>;
+
+export type HelpTooltipKey = keyof typeof HELP_TOOLTIPS;
+
+/**
+ * Returns the entry for a key. Throws in dev when the key is missing
+ * so typos surface during local work; returns a soft fallback in
+ * production so a single bad key never breaks a page.
+ */
+export function getHelpTooltip(key: HelpTooltipKey): HelpTooltipEntry {
+  const entry = HELP_TOOLTIPS[key];
+  if (entry) return entry;
+  if (process.env.NODE_ENV !== "production") {
+    throw new Error(`[HelpTooltip] unknown key: ${String(key)}`);
+  }
+  return { content: "" };
+}

--- a/frontend/lib/help/tooltips.ts
+++ b/frontend/lib/help/tooltips.ts
@@ -14,7 +14,8 @@
  * the full manual in a new tab.
  *
  * Keys are dot-namespaced "<feature>.<field>" so a future tooltip
- * audit can grep for every site that uses ``HelpTooltip key="tx.X"``.
+ * audit can grep for every site that uses ``HelpTooltip k="tx.X"``
+ * (the prop is `k`, not `key` — `key` is React-reserved).
  */
 
 export interface HelpTooltipEntry {

--- a/frontend/lib/help/tour.ts
+++ b/frontend/lib/help/tour.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared tour constants (L5.3 — help residuals).
+ *
+ * Single source of truth for the dot-namespaced tour step ids and the
+ * sessionStorage flag the dashboard auto-start watcher consumes. Pages
+ * decorate elements with ``<TourAnchor id="<step-id>">`` and the
+ * provider matches them against this list at runtime.
+ *
+ * Two preset step lists:
+ *
+ *   - ``DASHBOARD_TOUR_STEPS`` — the short, dashboard-only tour the
+ *     first-run wizard offers right after signup. Stays inside one
+ *     page, no routing.
+ *
+ *   - ``EXTENDED_TOUR_STEPS`` — the multi-surface replay tour exposed
+ *     via the user menu's "Replay product tour" action. Walks through
+ *     the dashboard plus six feature pages (transactions, accounts,
+ *     categories, budgets, reports, plans). The provider auto-pushes
+ *     the router when the next step's prefix differs from the current
+ *     route.
+ *
+ * Step copy is co-located in ``STEP_COPY`` below so the wizard team
+ * can tweak voice without chasing JSX. House style: short sentences,
+ * commas/periods over em-dashes, plain words ("see", "shows", "moves"
+ * etc.). No AI-isms ("delve", "leverage", "robust").
+ */
+
+export const TOUR_FLAG_KEY = "tbd-pending-dashboard-tour";
+
+/** Value written to ``TOUR_FLAG_KEY`` to request the extended replay. */
+export const TOUR_FLAG_VALUE_EXTENDED = "extended";
+/** Value written for the original first-run dashboard tour. */
+export const TOUR_FLAG_VALUE_DASHBOARD = "1";
+
+export const DASHBOARD_TOUR_STEPS = [
+  "dashboard.header",
+  "dashboard.import-cta",
+  "dashboard.period-nav",
+  "dashboard.on-track-tile",
+  "dashboard.account-forecast",
+];
+
+/**
+ * Extended replay tour. One stop per top-level page so a curious user
+ * can revisit the whole product without being overwhelmed. The
+ * provider matches the page prefix ("dashboard", "transactions", ...)
+ * against the current pathname and routes between steps when the
+ * prefix changes.
+ */
+export const EXTENDED_TOUR_STEPS = [
+  "dashboard.header",
+  "transactions.title",
+  "accounts.title",
+  "categories.title",
+  "budgets.title",
+  "reports.title",
+  "plans.title",
+];
+
+export interface TourStepCopy {
+  title: string;
+  body: string;
+}
+
+/**
+ * Copy for every supported tour step. Used by the overlay card. Keys
+ * must match the ``data-tour-id`` attributes the pages set via
+ * ``<TourAnchor>``.
+ */
+export const STEP_COPY: Record<string, TourStepCopy> = {
+  "dashboard.header": {
+    title: "Welcome to your dashboard",
+    body: "This is where you will see how the month is going at a glance. Net cashflow, balances, and what is coming up.",
+  },
+  "dashboard.import-cta": {
+    title: "Bring in your transactions",
+    body: "Import a bank export here, or add transactions one by one. The Better Decision works with whatever you have.",
+  },
+  "dashboard.period-nav": {
+    title: "Move through periods",
+    body: "Each month is its own billing period. Use these arrows to look back at history or peek ahead.",
+  },
+  "dashboard.on-track-tile": {
+    title: "How the month is shaping up",
+    body: "On Track tells you if your spending plan and your reality agree. Green means you are on it. Yellow means it is worth a look.",
+  },
+  "dashboard.account-forecast": {
+    title: "Account forecast",
+    body: "We project each account out to the end of the period using your recurring transactions and budgets.",
+  },
+  "transactions.title": {
+    title: "Transactions",
+    body: "Every account entry lives here. Add or import them, filter by date or category, and mark transfers so the totals stay clean.",
+  },
+  "accounts.title": {
+    title: "Accounts",
+    body: "Track each account you own. Pending entries are kept separate from settled, and the forecast uses both to show where you land.",
+  },
+  "categories.title": {
+    title: "Categories",
+    body: "Categories shape your budgets and reports. Masters group spending, subcategories sit underneath, and Edit mode lets you reorder them.",
+  },
+  "budgets.title": {
+    title: "Budgets",
+    body: "Set a monthly limit per category. The dashboard tile tells you whether your actual spending is on track or drifting.",
+  },
+  "reports.title": {
+    title: "Reports",
+    body: "Build a layout of KPIs and charts over your transactions. Save it, name it, share it across your org.",
+  },
+  "plans.title": {
+    title: "Plans",
+    body: "Plans is the sandbox for big one off decisions. House move, career change, sabbatical. Nothing here touches your real transactions.",
+  },
+};
+
+/**
+ * Returns the page-prefix portion of a dot-namespaced step id
+ * (e.g. ``"transactions"`` from ``"transactions.title"``). Used by the
+ * provider's router effect to decide whether the next step is on a
+ * different surface.
+ */
+export function pagePrefix(stepId: string): string {
+  const dot = stepId.indexOf(".");
+  return dot >= 0 ? stepId.slice(0, dot) : stepId;
+}
+
+/**
+ * Maps a step's page prefix to the route the provider should push to
+ * before the overlay measures the anchor. Kept tight to the prefixes
+ * EXTENDED_TOUR_STEPS uses; unknown prefixes return null and the
+ * provider falls back to the current route (the overlay's auto-skip
+ * will then advance past missing anchors).
+ */
+export function routeForPrefix(prefix: string): string | null {
+  switch (prefix) {
+    case "dashboard":
+      return "/dashboard";
+    case "transactions":
+      return "/transactions";
+    case "accounts":
+      return "/accounts";
+    case "categories":
+      return "/categories";
+    case "budgets":
+      return "/budgets";
+    case "reports":
+      return "/reports";
+    case "plans":
+      return "/plans";
+    default:
+      return null;
+  }
+}

--- a/frontend/tests/components/HelpTooltip.test.tsx
+++ b/frontend/tests/components/HelpTooltip.test.tsx
@@ -54,4 +54,33 @@ describe("HelpTooltip", () => {
       HELP_TOOLTIPS["cat.subcategory"].learnMoreSection!,
     );
   });
+
+  it("generates unique DOM ids when the same key is rendered twice on the page", async () => {
+    // The transactions page (edit row) and the floating quick-add
+    // form both render <HelpTooltip k="tx.amount" />. If HelpTooltip
+    // hashed the id from the key alone, the second mount would
+    // collide with the first and break aria-describedby wiring.
+    render(
+      <div>
+        <HelpTooltip k="tx.amount" />
+        <HelpTooltip k="tx.amount" />
+      </div>,
+    );
+    const triggers = screen.getAllByTestId("tooltip-trigger");
+    expect(triggers).toHaveLength(2);
+    // Open the first tooltip and capture its id, then the second.
+    // The base Tooltip wires aria-describedby imperatively on focus.
+    act(() => fireEvent.focus(triggers[0]));
+    const id0 = triggers[0].getAttribute("aria-describedby");
+    act(() => fireEvent.blur(triggers[0]));
+    act(() => fireEvent.focus(triggers[1]));
+    const id1 = triggers[1].getAttribute("aria-describedby");
+    expect(id0).toBeTruthy();
+    expect(id1).toBeTruthy();
+    expect(id0).not.toBe(id1);
+    // The stable key prefix still appears in both ids so dev tools
+    // and audits can grep for the field name.
+    expect(id0).toContain("help-tx-amount");
+    expect(id1).toContain("help-tx-amount");
+  });
 });

--- a/frontend/tests/components/HelpTooltip.test.tsx
+++ b/frontend/tests/components/HelpTooltip.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * HelpTooltip render tests (L5.3).
+ *
+ * The wrapper delegates to the base Tooltip, so we only verify:
+ *   - It looks up content from the map by key.
+ *   - It forwards triggerLabel + learnMoreSection through.
+ *   - It renders a trigger element (the underlying button).
+ */
+import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import HelpTooltip from "@/components/help/HelpTooltip";
+import { HELP_TOOLTIPS } from "@/lib/help/tooltips";
+
+describe("HelpTooltip", () => {
+  it("renders a trigger button by default", () => {
+    render(<HelpTooltip k="tx.type" />);
+    const trigger = screen.getByTestId("tooltip-trigger");
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.tagName).toBe("BUTTON");
+  });
+
+  it("uses the content map entry on open", async () => {
+    render(<HelpTooltip k="tx.amount" />);
+    const trigger = screen.getByTestId("tooltip-trigger");
+    act(() => {
+      fireEvent.focus(trigger);
+    });
+    const bubble = await screen.findByRole("tooltip");
+    // Match against the actual map entry so a copy edit there does
+    // not break this test as long as it stays non-empty.
+    expect(bubble).toHaveTextContent(HELP_TOOLTIPS["tx.amount"].content);
+  });
+
+  it("uses the per-entry triggerLabel as the ARIA label", () => {
+    render(<HelpTooltip k="tx.type" />);
+    const trigger = screen.getByTestId("tooltip-trigger");
+    expect(trigger).toHaveAttribute(
+      "aria-label",
+      HELP_TOOLTIPS["tx.type"].triggerLabel,
+    );
+  });
+
+  it("renders a Learn more link when the entry sets learnMoreSection", async () => {
+    render(<HelpTooltip k="cat.subcategory" />);
+    const trigger = screen.getByTestId("tooltip-trigger");
+    act(() => {
+      fireEvent.focus(trigger);
+    });
+    await screen.findByRole("tooltip");
+    const link = screen.getByTestId("tooltip-learn-more");
+    expect(link).toHaveAttribute(
+      "data-section",
+      HELP_TOOLTIPS["cat.subcategory"].learnMoreSection!,
+    );
+  });
+});

--- a/frontend/tests/components/tour/tour-provider-keys-and-skip.test.tsx
+++ b/frontend/tests/components/tour/tour-provider-keys-and-skip.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * TourProvider integration tests (L5.3).
+ *
+ * Pins three Copilot-flagged behaviors that the unit-level constants
+ * tests cannot reach:
+ *
+ *   - ArrowLeft / ArrowRight do NOT hijack the cursor when focus is
+ *     inside an input/textarea/select/contenteditable element. Without
+ *     this, a user typing in a form during the tour would lose normal
+ *     keyboard navigation.
+ *
+ *   - ArrowRight DOES advance the step when focus is outside any
+ *     editable element. Escape DOES close.
+ *
+ *   - The missing-anchor auto-skip suspends while the pathname doesn't
+ *     match the step's expected route. Without this, slow cross-page
+ *     navigation would silently skip past steps before their anchors
+ *     mount.
+ */
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TourProvider } from "@/components/tour/TourProvider";
+import { useTour } from "@/components/tour/useTour";
+
+let mockPathname = "/transactions";
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({
+    push: (route: string) => {
+      mockPush(route);
+      // Simulate the route having committed for tests that need it.
+      mockPathname = route;
+    },
+  }),
+}));
+
+function StartButton({ steps }: { steps: string[] }) {
+  const api = useTour();
+  return (
+    <button data-testid="start" onClick={() => api.start(steps)}>
+      start
+    </button>
+  );
+}
+
+beforeEach(() => {
+  mockPathname = "/transactions";
+  mockPush.mockReset();
+  // Provide an anchor for the on-route step so the tour doesn't
+  // immediately enter the auto-skip path during the keyboard tests.
+  const anchor = document.createElement("div");
+  anchor.setAttribute("data-tour-id", "transactions.title");
+  document.body.appendChild(anchor);
+});
+
+afterEach(() => {
+  document.querySelectorAll("[data-tour-id]").forEach((el) => el.remove());
+  vi.useRealTimers();
+});
+
+describe("TourProvider keyboard handling", () => {
+  it("ArrowRight ignored when focus is inside an INPUT", async () => {
+    render(
+      <TourProvider>
+        <input data-testid="page-input" />
+        <StartButton steps={["transactions.title"]} />
+      </TourProvider>,
+    );
+    fireEvent.click(screen.getByTestId("start"));
+    await waitFor(() => screen.getByTestId("tour-card"));
+    const card = screen.getByTestId("tour-card");
+    const labelBefore = card.querySelector(".uppercase")?.textContent;
+    expect(labelBefore).toMatch(/Step 1 of 1/);
+
+    const input = screen.getByTestId("page-input") as HTMLInputElement;
+    input.focus();
+    fireEvent.keyDown(input, { key: "ArrowRight" });
+
+    // The tour MUST still be active on the same single step — pressing
+    // ArrowRight in an input cannot advance/finish the tour.
+    const labelAfter = card.querySelector(".uppercase")?.textContent;
+    expect(labelAfter).toMatch(/Step 1 of 1/);
+  });
+
+  it("ArrowRight ignored when focus is in a contenteditable", async () => {
+    render(
+      <TourProvider>
+        <div data-testid="rich-text" contentEditable suppressContentEditableWarning>
+          hello
+        </div>
+        <StartButton steps={["transactions.title", "transactions.title"]} />
+      </TourProvider>,
+    );
+    fireEvent.click(screen.getByTestId("start"));
+    await waitFor(() => screen.getByTestId("tour-card"));
+
+    const rt = screen.getByTestId("rich-text") as HTMLDivElement;
+    rt.focus();
+    fireEvent.keyDown(rt, { key: "ArrowRight" });
+
+    const label = screen.getByTestId("tour-card").querySelector(".uppercase")
+      ?.textContent;
+    expect(label).toMatch(/Step 1 of 2/);
+  });
+
+  it("ArrowRight advances when focus is NOT on an editable element", async () => {
+    render(
+      <TourProvider>
+        <StartButton steps={["transactions.title", "transactions.title"]} />
+      </TourProvider>,
+    );
+    fireEvent.click(screen.getByTestId("start"));
+    await waitFor(() => screen.getByTestId("tour-card"));
+
+    fireEvent.keyDown(document.body, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      const label = screen.getByTestId("tour-card").querySelector(".uppercase")
+        ?.textContent;
+      expect(label).toMatch(/Step 2 of 2/);
+    });
+  });
+
+  it("Escape closes the tour even from an editable element", async () => {
+    render(
+      <TourProvider>
+        <input data-testid="page-input" />
+        <StartButton steps={["transactions.title"]} />
+      </TourProvider>,
+    );
+    fireEvent.click(screen.getByTestId("start"));
+    await waitFor(() => screen.getByTestId("tour-card"));
+
+    const input = screen.getByTestId("page-input") as HTMLInputElement;
+    input.focus();
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("tour-card")).toBeNull();
+    });
+  });
+});
+
+describe("TourProvider missing-anchor auto-skip", () => {
+  it("does NOT auto-skip while the pathname doesn't match the step's expected route", async () => {
+    vi.useFakeTimers();
+    // Start on /transactions but the first step targets the
+    // categories surface — TourRouter will push, but on a slow page
+    // the anchor isn't there yet. The provider must suspend
+    // auto-skip until the route settles.
+    mockPathname = "/transactions";
+    render(
+      <TourProvider>
+        <StartButton
+          steps={["categories.title", "transactions.title"]}
+        />
+      </TourProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByTestId("start"));
+    });
+    await act(async () => {
+      // Past the old 200ms auto-skip + new 800ms grace.
+      vi.advanceTimersByTime(1500);
+    });
+    // We never planted a `categories.title` anchor, but the pathname
+    // also hasn't matched `/categories` yet (router push is mocked to
+    // be synchronous on this test, but pathname is recomputed AFTER
+    // the next render — assert the engine is STILL on step 1, not
+    // auto-skipped to step 2).
+    //
+    // (The actual product behavior is that TourRouter will push and
+    // the destination page will eventually mount its anchor. This
+    // test only checks that the auto-skip doesn't fire while we're
+    // still on /transactions.)
+    const label = screen.queryByTestId("tour-card")
+      ?.querySelector(".uppercase")?.textContent;
+    // Either still on step 1, or the overlay rendered briefly in
+    // centred-no-anchor mode — both are acceptable. The forbidden
+    // state is "step 2 of 2" which would mean an auto-skip past
+    // step 1 happened.
+    if (label) {
+      expect(label).not.toMatch(/Step 2 of 2/);
+    }
+  });
+});

--- a/frontend/tests/lib/help-tooltips.test.ts
+++ b/frontend/tests/lib/help-tooltips.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Content-map sanity tests (L5.3).
+ *
+ * The tooltip content map ships customer-facing copy in a typed
+ * record so future edits are one-liners. These tests lock the
+ * invariants the codebase relies on:
+ *   - No em-dashes anywhere (house style, user-locked).
+ *   - Every entry has non-empty content.
+ *   - getHelpTooltip throws in dev when a key is unknown.
+ *   - The full set covers the ~15 frequently-confused fields the spec
+ *     calls out (sanity floor, not exact count).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  HELP_TOOLTIPS,
+  getHelpTooltip,
+  type HelpTooltipKey,
+} from "@/lib/help/tooltips";
+
+describe("HELP_TOOLTIPS", () => {
+  const entries = Object.entries(HELP_TOOLTIPS) as [
+    HelpTooltipKey,
+    (typeof HELP_TOOLTIPS)[HelpTooltipKey],
+  ][];
+
+  it("contains at least 15 entries (L5.3 floor)", () => {
+    expect(entries.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it("every entry has non-empty content", () => {
+    for (const [key, entry] of entries) {
+      expect(entry.content, `key=${key}`).toBeTruthy();
+      expect(entry.content.length, `key=${key}`).toBeGreaterThan(5);
+    }
+  });
+
+  it("no entry uses an em-dash (house style)", () => {
+    for (const [key, entry] of entries) {
+      expect(entry.content, `key=${key}`).not.toMatch(/—/);
+      if (entry.triggerLabel) {
+        expect(entry.triggerLabel, `key=${key}`).not.toMatch(/—/);
+      }
+    }
+  });
+
+  it("no entry uses an en-dash inside a sentence (house style)", () => {
+    // En-dashes between words ("X – Y") read like em-dashes; allow
+    // them only when they border digits (date/number ranges).
+    for (const [key, entry] of entries) {
+      const offending = entry.content.match(/\D\s–\s\D/);
+      expect(offending, `key=${key}`).toBeNull();
+    }
+  });
+
+  it("getHelpTooltip returns the matching entry", () => {
+    const first = entries[0];
+    if (!first) throw new Error("HELP_TOOLTIPS is empty");
+    const [key, entry] = first;
+    expect(getHelpTooltip(key)).toEqual(entry);
+  });
+
+  it("getHelpTooltip throws in dev when key is unknown", () => {
+    // @ts-expect-error -- testing the runtime guard
+    expect(() => getHelpTooltip("definitely-not-a-key")).toThrow(
+      /unknown key/,
+    );
+  });
+
+  it("covers the surfaces the L5.3 spec calls out", () => {
+    // Per the L5.3 ticket: transactions (sign convention, frequency),
+    // categories (type), budgets (recurrence). Lock those keys here
+    // so accidentally dropping one shows up as a test failure rather
+    // than a silent regression.
+    const required: HelpTooltipKey[] = [
+      "tx.type",
+      "tx.frequency",
+      "cat.type",
+      "budget.monthly-limit",
+    ];
+    for (const k of required) {
+      expect(HELP_TOOLTIPS[k]).toBeTruthy();
+    }
+  });
+});

--- a/frontend/tests/lib/help-tour.test.ts
+++ b/frontend/tests/lib/help-tour.test.ts
@@ -83,4 +83,48 @@ describe("tour constants", () => {
   it("routeForPrefix returns null for unknown prefixes", () => {
     expect(routeForPrefix("nonsense")).toBeNull();
   });
+
+  it("every tour step has at least one matching anchor in the source tree", async () => {
+    // The whole tour silently no-ops at the overlay layer if a step's
+    // anchor element isn't in the DOM. Scan the frontend source for
+    // each step id appearing either as `data-tour-id="X"` or
+    // `<TourAnchor id="X">`. Catches authoring drift (renamed step,
+    // missing wiring) before it ships.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const ROOT = path.resolve(__dirname, "../..");
+
+    // Walk app/ and components/ collecting every .tsx file. Skip
+    // node_modules and the tests directory itself.
+    function walk(dir: string, acc: string[]): string[] {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === "node_modules") continue;
+        if (entry.name === "tests") continue;
+        if (entry.name.startsWith(".")) continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, acc);
+        else if (entry.name.endsWith(".tsx")) acc.push(full);
+      }
+      return acc;
+    }
+    const files = walk(path.join(ROOT, "app"), []);
+    walk(path.join(ROOT, "components"), files);
+    const haystack = files
+      .map((f) => fs.readFileSync(f, "utf8"))
+      .join("\n");
+
+    const allSteps = new Set<string>([
+      ...DASHBOARD_TOUR_STEPS,
+      ...EXTENDED_TOUR_STEPS,
+    ]);
+    for (const id of allSteps) {
+      // Either pattern is acceptable. The first is the direct
+      // attribute; the second is the TourAnchor wrapper that
+      // synthesizes it.
+      const direct = `data-tour-id="${id}"`;
+      const anchor = `<TourAnchor id="${id}"`;
+      const found = haystack.includes(direct) || haystack.includes(anchor);
+      expect(found, `step "${id}" has no matching data-tour-id or <TourAnchor id="${id}"> in frontend/app or frontend/components`).toBe(true);
+    }
+  });
 });

--- a/frontend/tests/lib/help-tour.test.ts
+++ b/frontend/tests/lib/help-tour.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tour constants tests (L5.3).
+ *
+ * Locks the shape of the cross-page tour: every extended step has
+ * matching copy in STEP_COPY, every prefix in EXTENDED_TOUR_STEPS
+ * routes to a known surface, and the sessionStorage flag values stay
+ * distinct so the dashboard auto-start can tell which tour to launch.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DASHBOARD_TOUR_STEPS,
+  EXTENDED_TOUR_STEPS,
+  STEP_COPY,
+  TOUR_FLAG_KEY,
+  TOUR_FLAG_VALUE_DASHBOARD,
+  TOUR_FLAG_VALUE_EXTENDED,
+  pagePrefix,
+  routeForPrefix,
+} from "@/lib/help/tour";
+
+describe("tour constants", () => {
+  it("the sessionStorage key matches the legacy literal exactly", () => {
+    // The wizard auto-start guard reads this key. Renaming it would
+    // strand any partially-onboarded user with a flag they no longer
+    // satisfy. Lock the value.
+    expect(TOUR_FLAG_KEY).toBe("tbd-pending-dashboard-tour");
+  });
+
+  it("the dashboard and extended flag values are distinct", () => {
+    expect(TOUR_FLAG_VALUE_DASHBOARD).not.toBe(TOUR_FLAG_VALUE_EXTENDED);
+    expect(TOUR_FLAG_VALUE_DASHBOARD.length).toBeGreaterThan(0);
+    expect(TOUR_FLAG_VALUE_EXTENDED.length).toBeGreaterThan(0);
+  });
+
+  it("dashboard tour has at least 5 steps and stays in /dashboard", () => {
+    expect(DASHBOARD_TOUR_STEPS.length).toBeGreaterThanOrEqual(5);
+    for (const id of DASHBOARD_TOUR_STEPS) {
+      expect(pagePrefix(id)).toBe("dashboard");
+    }
+  });
+
+  it("extended tour covers 5-7 surfaces (spec requirement)", () => {
+    expect(EXTENDED_TOUR_STEPS.length).toBeGreaterThanOrEqual(5);
+    expect(EXTENDED_TOUR_STEPS.length).toBeLessThanOrEqual(7);
+  });
+
+  it("every extended step has copy in STEP_COPY", () => {
+    for (const id of EXTENDED_TOUR_STEPS) {
+      expect(STEP_COPY[id], `missing copy for ${id}`).toBeTruthy();
+      expect(STEP_COPY[id]?.title).toBeTruthy();
+      expect(STEP_COPY[id]?.body).toBeTruthy();
+    }
+  });
+
+  it("every dashboard step has copy in STEP_COPY", () => {
+    for (const id of DASHBOARD_TOUR_STEPS) {
+      expect(STEP_COPY[id], `missing copy for ${id}`).toBeTruthy();
+    }
+  });
+
+  it("every extended step routes to a known surface", () => {
+    for (const id of EXTENDED_TOUR_STEPS) {
+      const route = routeForPrefix(pagePrefix(id));
+      expect(route, `no route for ${id}`).toBeTruthy();
+      expect(route).toMatch(/^\//);
+    }
+  });
+
+  it("no copy uses an em-dash (house style)", () => {
+    for (const [id, copy] of Object.entries(STEP_COPY)) {
+      expect(copy.title, `id=${id}`).not.toMatch(/—/);
+      expect(copy.body, `id=${id}`).not.toMatch(/—/);
+    }
+  });
+
+  it("pagePrefix returns the dot-prefix portion", () => {
+    expect(pagePrefix("transactions.title")).toBe("transactions");
+    expect(pagePrefix("dashboard.header")).toBe("dashboard");
+    expect(pagePrefix("noprefix")).toBe("noprefix");
+  });
+
+  it("routeForPrefix returns null for unknown prefixes", () => {
+    expect(routeForPrefix("nonsense")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

L5.3 help residuals — finishes the in-app tour and tooltip coverage so users can replay the product walk-through and get inline copy on confusing fields.

### Tour

- New shared module `frontend/lib/help/tour.ts` owns the dot-namespaced step ids, sessionStorage flag, copy map (`STEP_COPY`), and route lookup. `OnboardingPageBody`, `RestartTourCard`, and `TourProvider` all consume from one place now (no more duplicated string literals).
- New 7-stop replay tour covers dashboard, transactions, accounts, categories, budgets, reports, plans. `TourProvider` ships a `TourRouter` watcher that auto-navigates between surfaces as the step prefix changes; the existing dashboard auto-start still triggers the original 5-step first-run tour for new users.
- "Replay product tour" item added to the user-menu dropdown in `AppShell` (the Settings → Profile card stays as a fallback). Distinct sessionStorage value (`extended`) keeps the two tours from getting crossed.
- Keyboard nav: Esc closes, ArrowLeft / ArrowRight step. Reduced-motion already honored via the original overlay.
- Anchors planted on each surface page via `data-tour-id` (no new visual change).

### Tooltips

- New typed content map `frontend/lib/help/tooltips.ts` with 15 entries (transactions Account / Type / Amount / Tags / Frequency / Auto-settle, Transfer category, Category Type / Subcategory, Budget monthly limit, Account opening balance, Adjust balance, Plans sandbox, Reports KPI, Dashboard On Track). Future additions are one-line edits.
- Thin `<HelpTooltip k="..." />` wrapper around the existing `<Tooltip>` primitive (portal, aria-describedby, reduced-motion, viewport clamp all reused). Default trigger is the same `?` button.
- Wired into the page-level transactions form, the floating quick-add form, the category modal, the budgets form, the accounts page, and the adjust-balance modal.

### Tests

- 21 new tests across the tour constants, tooltip map (em-dash + en-dash linter), and `<HelpTooltip>` render. All existing tour + tooltip + page tests still green (96-test regression slice run from the worktree, all 171 tests pass on the broader run that includes pages I edited).
- Em-dash audit test in `help-tooltips.test.ts` will fail the build if a customer-copy entry ever picks one up.