### PR TITLE
feat(cc-cycle): slice 1 — per-CC cycle substrate (resolver + columns + validation)

### DIFF
--- a/backend/alembic/versions/061_cc_payment_day_columns.py
+++ b/backend/alembic/versions/061_cc_payment_day_columns.py
@@ -9,11 +9,11 @@ D3 / D7).
 
 Two new columns on ``accounts``:
 
-- ``payment_day TINYINT NULL``          — the day-of-month the payment
+- ``payment_day INTEGER NULL``          — the day-of-month the payment
   is due. NULL means "use resolver default" (day 1). User-settable;
   the resolver clamps 31 → Feb 28/29, Apr 30, etc. at compute time.
 
-- ``payment_day_relative_month TINYINT NULL``  — how many calendar
+- ``payment_day_relative_month INTEGER NULL``  — how many calendar
   months after the close month the payment falls. NULL means "use
   resolver default" (1 = next calendar month after close). 0 = same
   month as close; 1 = one month later, etc.

--- a/backend/alembic/versions/061_cc_payment_day_columns.py
+++ b/backend/alembic/versions/061_cc_payment_day_columns.py
@@ -1,0 +1,58 @@
+"""Add payment_day and payment_day_relative_month to accounts (Slice 1).
+
+Revision ID: 061_cc_payment_day_columns
+Revises: 060_rate_limit_overrides
+Create Date: 2026-05-28
+
+Per-CC cycle substrate (spec 2026-05-28-cc-billing-cycle.md, Slice 1 /
+D3 / D7).
+
+Two new columns on ``accounts``:
+
+- ``payment_day TINYINT NULL``          — the day-of-month the payment
+  is due. NULL means "use resolver default" (day 1). User-settable;
+  the resolver clamps 31 → Feb 28/29, Apr 30, etc. at compute time.
+
+- ``payment_day_relative_month TINYINT NULL``  — how many calendar
+  months after the close month the payment falls. NULL means "use
+  resolver default" (1 = next calendar month after close). 0 = same
+  month as close; 1 = one month later, etc.
+
+Both columns are intentionally **nullable with NO DB-level default**.
+A server default of 1 / 1 would silently fill those values on insert
+and break the "NULL = use resolver default" invariant D3 relies on:
+existing rows get NULL and the resolver treats NULL as default at
+compute time. The validation layer (account_type_change_service) is the
+single write surface; it enforces the CC-only invariant (both columns
+must be NULL on non-CC accounts, mirrors close_day).
+
+Shape mirrors ``close_day`` (migration 007, sa.Integer(), nullable=True,
+no server_default). Downgrade drops both columns with no data loss
+concern (Slice 1 adds columns; no stored data depends on them yet).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "061_cc_payment_day_columns"
+down_revision = "060_rate_limit_overrides"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "accounts",
+        sa.Column("payment_day", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "accounts",
+        sa.Column("payment_day_relative_month", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("accounts", "payment_day_relative_month")
+    op.drop_column("accounts", "payment_day")

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -60,6 +60,8 @@ class Account(Base):
     currency: Mapped[str] = mapped_column(String(3), nullable=False, default="EUR")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     close_day: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    payment_day: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    payment_day_relative_month: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     # User-stated opening balance for the account. Migration 041 sets
     # this to 0 for every existing account (canonical backfill, see

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -203,14 +203,14 @@ async def update_account(
     req_id = _request_id()
     ip = get_client_ip(request)
 
-    touches_type_or_close_day = (
+    touches_type_or_cc_columns = (
         body.account_type_id is not None
         or "close_day" in body.model_fields_set
         or "payment_day" in body.model_fields_set
         or "payment_day_relative_month" in body.model_fields_set
     )
 
-    if touches_type_or_close_day:
+    if touches_type_or_cc_columns:
         return await _update_account_atomic(
             account_id=account_id,
             body=body,
@@ -222,7 +222,7 @@ async def update_account(
             session_factory=session_factory,
         )
 
-    # ── Fast path: no type/close_day touch, stay on the request session.
+    # ── Fast path: no type/cc-column touch, stay on the request session.
     result = await db.execute(
         select(Account)
         .options(selectinload(Account.account_type))

--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -23,6 +23,7 @@ from app.services import audit_service
 from app.services.account_type_change_service import (
     apply_type_change_in_session,
     validate_create_close_day,
+    validate_create_payment_day,
 )
 from app.services.exceptions import ConflictError, ValidationError
 from app.services.transaction_service import (
@@ -56,6 +57,8 @@ def _to_response(account: Account) -> AccountResponse:
         currency=account.currency,
         is_active=account.is_active,
         close_day=account.close_day,
+        payment_day=account.payment_day,
+        payment_day_relative_month=account.payment_day_relative_month,
         is_default=account.is_default,
         opening_balance=account.opening_balance,
         opening_balance_date=account.opening_balance_date,
@@ -99,6 +102,13 @@ async def create_account(
     validate_create_close_day(
         target_slug=target_type.slug, close_day_value=body.close_day
     )
+    # CC billing cycle Slice 1: payment_day / payment_day_relative_month
+    # are CC-only optional columns. Both must be NULL on non-CC accounts.
+    validate_create_payment_day(
+        target_slug=target_type.slug,
+        payment_day_value=body.payment_day,
+        payment_day_relative_month_value=body.payment_day_relative_month,
+    )
 
     # opening_balance_date: caller may omit (and ride the DB default of
     # CURRENT_DATE) or supply an explicit date. We pass it through only
@@ -117,6 +127,8 @@ async def create_account(
         balance=body.opening_balance,
         currency=body.currency,
         close_day=body.close_day,
+        payment_day=body.payment_day,
+        payment_day_relative_month=body.payment_day_relative_month,
         opening_balance=body.opening_balance,
     )
     if body.opening_balance_date is not None:
@@ -192,7 +204,10 @@ async def update_account(
     ip = get_client_ip(request)
 
     touches_type_or_close_day = (
-        body.account_type_id is not None or "close_day" in body.model_fields_set
+        body.account_type_id is not None
+        or "close_day" in body.model_fields_set
+        or "payment_day" in body.model_fields_set
+        or "payment_day_relative_month" in body.model_fields_set
     )
 
     if touches_type_or_close_day:
@@ -380,6 +395,10 @@ async def _update_account_atomic(
                 target_type_id=target_type_id,
                 close_day_in_payload="close_day" in body.model_fields_set,
                 close_day_value=body.close_day,
+                payment_day_in_payload="payment_day" in body.model_fields_set,
+                payment_day_value=body.payment_day,
+                payment_day_relative_month_in_payload="payment_day_relative_month" in body.model_fields_set,
+                payment_day_relative_month_value=body.payment_day_relative_month,
             )
 
             old_opening_balance = account.opening_balance

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -34,6 +34,8 @@ class AccountCreate(BaseModel):
     account_type_id: int
     currency: str = "EUR"
     close_day: Optional[int] = Field(default=None, ge=1, le=28)
+    payment_day: Optional[int] = Field(default=None, ge=1, le=31)
+    payment_day_relative_month: Optional[int] = Field(default=None, ge=0, le=12)
     # Opening balance (L3.2 Wave 2A). User-stated starting amount and
     # the sole entry point for a non-zero starting balance: the live
     # ``Account.balance`` field is initialised from this value server-
@@ -55,6 +57,8 @@ class AccountUpdate(BaseModel):
     account_type_id: Optional[int] = None
     is_active: Optional[bool] = None
     close_day: Optional[int] = Field(default=None, ge=1, le=28)
+    payment_day: Optional[int] = Field(default=None, ge=1, le=31)
+    payment_day_relative_month: Optional[int] = Field(default=None, ge=0, le=12)
     is_default: Optional[bool] = None
     # Both opening fields are editable post-create. Audit-logged on
     # change (see ``accounts.update_account``).
@@ -78,6 +82,8 @@ class AccountResponse(BaseModel):
     currency: str
     is_active: bool
     close_day: Optional[int] = None
+    payment_day: Optional[int] = None
+    payment_day_relative_month: Optional[int] = None
     is_default: bool = False
     opening_balance: Decimal = Decimal("0.00")
     opening_balance_date: Optional[date] = None

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -33,7 +33,7 @@ class AccountCreate(BaseModel):
     name: str
     account_type_id: int
     currency: str = "EUR"
-    close_day: Optional[int] = Field(default=None, ge=1, le=28)
+    close_day: Optional[int] = Field(default=None, ge=1, le=31)
     payment_day: Optional[int] = Field(default=None, ge=1, le=31)
     payment_day_relative_month: Optional[int] = Field(default=None, ge=0, le=12)
     # Opening balance (L3.2 Wave 2A). User-stated starting amount and
@@ -56,7 +56,7 @@ class AccountUpdate(BaseModel):
     name: Optional[str] = None
     account_type_id: Optional[int] = None
     is_active: Optional[bool] = None
-    close_day: Optional[int] = Field(default=None, ge=1, le=28)
+    close_day: Optional[int] = Field(default=None, ge=1, le=31)
     payment_day: Optional[int] = Field(default=None, ge=1, le=31)
     payment_day_relative_month: Optional[int] = Field(default=None, ge=0, le=12)
     is_default: Optional[bool] = None

--- a/backend/app/services/account_type_change_service.py
+++ b/backend/app/services/account_type_change_service.py
@@ -21,8 +21,19 @@ Cascade rules (§ 3.1):
    this also covers the "no type change, only close_day on non-CC" hole the
    PUT path silently accepted before this spec.
 
+CC payment day columns (spec 2026-05-28-cc-billing-cycle.md, Slice 1):
+
+- ``payment_day`` and ``payment_day_relative_month`` mirror the close_day
+  invariant: NULL on non-CC accounts, optional on CC accounts (NULL means
+  "use resolver default"). Cascade is independent of close_day:
+  - (not CC -> CC): payload MAY carry either or both; both are optional.
+  - (CC -> not CC): server clears both to NULL regardless of payload.
+  - (CC -> CC): payload MAY update either or both; explicit NULL on a CC
+    account is permitted (unlike close_day) because NULL means "use default".
+  - (not CC -> not CC): payload MUST NOT carry non-null values (400).
+
 Cross-org target type ID resolves to 422 (entity-not-for-you semantics)
-to leave 400 reserved for cascade violations. Out-of-range close_day is
+to leave 400 reserved for cascade violations. Out-of-range values are
 caught by Pydantic before this service runs (422).
 """
 from __future__ import annotations
@@ -56,6 +67,10 @@ class TypeChangeResult:
         "new_type_slug",
         "old_close_day",
         "new_close_day",
+        "old_payment_day",
+        "new_payment_day",
+        "old_payment_day_relative_month",
+        "new_payment_day_relative_month",
         "type_changed",
     )
 
@@ -69,6 +84,10 @@ class TypeChangeResult:
         new_type_slug: Optional[str],
         old_close_day: Optional[int],
         new_close_day: Optional[int],
+        old_payment_day: Optional[int],
+        new_payment_day: Optional[int],
+        old_payment_day_relative_month: Optional[int],
+        new_payment_day_relative_month: Optional[int],
         type_changed: bool,
     ) -> None:
         self.account_id = account_id
@@ -78,6 +97,10 @@ class TypeChangeResult:
         self.new_type_slug = new_type_slug
         self.old_close_day = old_close_day
         self.new_close_day = new_close_day
+        self.old_payment_day = old_payment_day
+        self.new_payment_day = new_payment_day
+        self.old_payment_day_relative_month = old_payment_day_relative_month
+        self.new_payment_day_relative_month = new_payment_day_relative_month
         self.type_changed = type_changed
 
 
@@ -162,6 +185,78 @@ def validate_create_close_day(
         )
 
 
+def validate_payment_day_cascade(
+    *,
+    source_slug: Optional[str],
+    target_slug: Optional[str],
+    payment_day_in_payload: bool,
+    payment_day_value: Optional[int],
+    payment_day_relative_month_in_payload: bool,
+    payment_day_relative_month_value: Optional[int],
+) -> None:
+    """Validate payment_day / payment_day_relative_month cascade rules.
+
+    Mirrors the shape of ``validate_close_day_cascade`` but with relaxed
+    CC-target rules: on CC accounts both new columns are OPTIONAL (NULL
+    is valid — it means "use resolver default"). Only non-CC payloads
+    carrying non-null values are rejected.
+
+    Cascade matrix (spec D3 / Slice 1):
+    - (not CC -> CC): payload MAY carry either column; NULL/omitted is fine.
+    - (CC -> not CC): server clears both to NULL; payload carrying non-null
+      value(s) is rejected (400).
+    - (CC -> CC): payload MAY update either column; NULL is allowed.
+    - (not CC -> not CC): payload MUST NOT carry non-null values (400).
+    """
+    target_is_cc = target_slug == _CC
+
+    if target_is_cc:
+        # CC target: any value (including NULL) is fine. The range check
+        # is Pydantic's job (ge/le constraints on the schema field). Nothing
+        # to reject here.
+        return
+
+    # Target != CC. Non-null values are forbidden on non-CC accounts.
+    if payment_day_in_payload and payment_day_value is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="payment_day is only allowed on credit_card accounts",
+        )
+    if (
+        payment_day_relative_month_in_payload
+        and payment_day_relative_month_value is not None
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="payment_day_relative_month is only allowed on credit_card accounts",
+        )
+
+
+def validate_create_payment_day(
+    *,
+    target_slug: Optional[str],
+    payment_day_value: Optional[int],
+    payment_day_relative_month_value: Optional[int],
+) -> None:
+    """Create-path validation for payment_day / payment_day_relative_month.
+
+    Mirrors ``validate_create_close_day`` but with relaxed CC rules:
+    both new columns are optional on CC accounts (NULL = resolver default).
+    Non-CC accounts must not carry non-null values.
+    """
+    if target_slug != _CC:
+        if payment_day_value is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="payment_day is only allowed on credit_card accounts",
+            )
+        if payment_day_relative_month_value is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="payment_day_relative_month is only allowed on credit_card accounts",
+            )
+
+
 async def apply_type_change_in_session(
     svc_db: AsyncSession,
     *,
@@ -170,6 +265,10 @@ async def apply_type_change_in_session(
     target_type_id: int,
     close_day_in_payload: bool,
     close_day_value: Optional[int],
+    payment_day_in_payload: bool = False,
+    payment_day_value: Optional[int] = None,
+    payment_day_relative_month_in_payload: bool = False,
+    payment_day_relative_month_value: Optional[int] = None,
 ) -> tuple[Account, TypeChangeResult]:
     """Lock the row, validate the cascade, stage the type change.
 
@@ -206,6 +305,8 @@ async def apply_type_change_in_session(
         account.account_type.slug if account.account_type else None
     )
     old_close_day = account.close_day
+    old_payment_day = account.payment_day
+    old_payment_day_relative_month = account.payment_day_relative_month
 
     # Target-type existence + cross-org check. 422 (entity-not-for-you)
     # rather than 400, to leave 400 reserved for cascade violations
@@ -230,6 +331,14 @@ async def apply_type_change_in_session(
         close_day_in_payload=close_day_in_payload,
         close_day_value=close_day_value,
     )
+    validate_payment_day_cascade(
+        source_slug=old_type_slug,
+        target_slug=target_slug,
+        payment_day_in_payload=payment_day_in_payload,
+        payment_day_value=payment_day_value,
+        payment_day_relative_month_in_payload=payment_day_relative_month_in_payload,
+        payment_day_relative_month_value=payment_day_relative_month_value,
+    )
 
     # Apply: type first, then cascade the close_day column.
     account.account_type_id = target_type_id
@@ -243,10 +352,19 @@ async def apply_type_change_in_session(
         #     untouched (spec § 3.1 row 3, PR #246 second-review P1 fix).
         if close_day_in_payload:
             account.close_day = close_day_value
+        # Payment columns: write only when the payload carried them.
+        # NULL is a valid value (means "use resolver default") so we use
+        # the ``_in_payload`` sentinel rather than null-checking.
+        if payment_day_in_payload:
+            account.payment_day = payment_day_value
+        if payment_day_relative_month_in_payload:
+            account.payment_day_relative_month = payment_day_relative_month_value
     else:
         # Server-side clear when leaving CC, regardless of whether the
-        # payload carried close_day. Idempotent for non-CC -> non-CC.
+        # payload carried these columns. Idempotent for non-CC -> non-CC.
         account.close_day = None
+        account.payment_day = None
+        account.payment_day_relative_month = None
 
     result = TypeChangeResult(
         account_id=account_id,
@@ -256,6 +374,10 @@ async def apply_type_change_in_session(
         new_type_slug=target_slug,
         old_close_day=old_close_day,
         new_close_day=account.close_day,
+        old_payment_day=old_payment_day,
+        new_payment_day=account.payment_day,
+        old_payment_day_relative_month=old_payment_day_relative_month,
+        new_payment_day_relative_month=account.payment_day_relative_month,
         type_changed=type_changed,
     )
     return account, result
@@ -269,6 +391,10 @@ async def change_account_type(
     target_type_id: int,
     close_day_in_payload: bool,
     close_day_value: Optional[int],
+    payment_day_in_payload: bool = False,
+    payment_day_value: Optional[int] = None,
+    payment_day_relative_month_in_payload: bool = False,
+    payment_day_relative_month_value: Optional[int] = None,
 ) -> TypeChangeResult:
     """Thin owning-transaction wrapper for callers that only want to
     flip the type and have no other fields to mutate.
@@ -291,6 +417,10 @@ async def change_account_type(
                 target_type_id=target_type_id,
                 close_day_in_payload=close_day_in_payload,
                 close_day_value=close_day_value,
+                payment_day_in_payload=payment_day_in_payload,
+                payment_day_value=payment_day_value,
+                payment_day_relative_month_in_payload=payment_day_relative_month_in_payload,
+                payment_day_relative_month_value=payment_day_relative_month_value,
             )
             # Context manager commits on clean exit. Do NOT call
             # await svc_db.commit() here -- spec § 4.3 warning.

--- a/backend/app/services/account_type_change_service.py
+++ b/backend/app/services/account_type_change_service.py
@@ -146,8 +146,9 @@ def validate_close_day_cascade(
                 status_code=400,
                 detail="close_day is required when changing to credit_card",
             )
-        # Range check is enforced by Pydantic (Field(ge=1, le=28)) so
-        # by the time we reach this branch close_day is in [1, 28].
+        # Range check is enforced by Pydantic (Field(ge=1, le=31)) so
+        # by the time we reach this branch close_day is in [1, 31]. The
+        # cc_cycle_service resolver clamps 29-31 in short months.
         return
 
     # Target != credit_card. Payload must NOT carry a non-null close_day.
@@ -270,6 +271,14 @@ async def apply_type_change_in_session(
     payment_day_relative_month_value: Optional[int] = None,
 ) -> tuple[Account, TypeChangeResult]:
     """Lock the row, validate the cascade, stage the type change.
+
+    The four payment_day_* params default to "omitted" so existing call
+    sites that only flip the account type (no payment-day touch) keep
+    working unchanged. PR #374 review noted this is a silent gap if a
+    future caller forgets to thread payment-day through — guarded today
+    by the router's ``touches_type_or_cc_columns`` gate, which routes
+    any payment-day-touching PUT through this function with the params
+    set.
 
     Caller owns the transaction and the commit. This is the form the
     PUT route uses (PR #246 review feedback) so it can chain other

--- a/backend/app/services/account_type_change_service.py
+++ b/backend/app/services/account_type_change_service.py
@@ -187,7 +187,6 @@ def validate_create_close_day(
 
 def validate_payment_day_cascade(
     *,
-    source_slug: Optional[str],
     target_slug: Optional[str],
     payment_day_in_payload: bool,
     payment_day_value: Optional[int],
@@ -332,7 +331,6 @@ async def apply_type_change_in_session(
         close_day_value=close_day_value,
     )
     validate_payment_day_cascade(
-        source_slug=old_type_slug,
         target_slug=target_slug,
         payment_day_in_payload=payment_day_in_payload,
         payment_day_value=payment_day_value,

--- a/backend/app/services/cc_cycle_service.py
+++ b/backend/app/services/cc_cycle_service.py
@@ -111,8 +111,11 @@ def resolve_cycle(
     """
     if close_day is None:
         raise ValueError(
-            "resolve_cycle called on a non-credit-card account (close_day is None). "
-            "Callers should check account type before calling the CC cycle resolver."
+            "resolve_cycle requires a non-null close_day. "
+            "On this codebase that invariant only holds for credit_card accounts "
+            "(non-CC rows always carry close_day=NULL per the schema), so the "
+            "typical caller bug is invoking the resolver on a non-CC account. "
+            "Callers should branch on account_type.slug before calling."
         )
 
     # Apply defaults for NULL stored values (D3).

--- a/backend/app/services/cc_cycle_service.py
+++ b/backend/app/services/cc_cycle_service.py
@@ -1,0 +1,192 @@
+"""Per-CC cycle resolver (spec 2026-05-28-cc-billing-cycle.md, Slice 1).
+
+Single responsibility (D8): given the raw cycle fields from an Account
+row — ``close_day``, ``payment_day``, ``payment_day_relative_month`` —
+and a target date, return the ``CreditCardCycle`` the target date falls
+in, along with the payment date for that cycle.
+
+Slice 1 scope:
+- ``source`` is always ``"default"``; override lookup arrives in Slice 3.
+- The resolver is a pure function — no DB access, no async. Callers
+  pass the three column values directly (or an Account object via the
+  convenience wrapper ``resolve_cycle_for_account``).
+
+Architecture decisions honoured here:
+  D2 — Inclusive close day (tx on close day belongs to closing cycle).
+  D3 — Default payment: day 1, next calendar month after close month.
+  D8 — All cycle math lives in this service; callers must not re-derive.
+"""
+from __future__ import annotations
+
+import calendar
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal, Optional
+
+# Sentinel defaults applied when the stored columns are NULL.
+_DEFAULT_PAYMENT_DAY = 1
+_DEFAULT_PAYMENT_DAY_RELATIVE_MONTH = 1  # 1 = next calendar month
+
+
+@dataclass(frozen=True)
+class CreditCardCycle:
+    """Immutable triple returned by the resolver.
+
+    ``source`` is always ``"default"`` in Slice 1; Slice 3 adds
+    ``"override"`` when a ``cc_cycle_overrides`` row wins.
+    """
+
+    period_start: date
+    period_end_inclusive: date
+    payment_date: date
+    source: Literal["default", "override"]
+
+
+def _clamp_day(year: int, month: int, day: int) -> date:
+    """Return ``date(year, month, min(day, last_day_of_month))``.
+
+    Mirrors the clamp PFV already uses for ``Organization.billing_cycle_day``
+    in ``lib/date_utils.py``. Prevents ValueError on Feb 29/30/31, Apr 31, etc.
+    """
+    last_day = calendar.monthrange(year, month)[1]
+    return date(year, month, min(day, last_day))
+
+
+def _resolve_payment_date(close: date, payment_day: int, payment_day_relative_month: int) -> date:
+    """Compute the payment date from the cycle's effective close date.
+
+    Exactly mirrors the D3 pseudocode in the spec (the fixed version using
+    ``calendar.monthrange`` for the clamp):
+
+        months_offset = close.month - 1 + payment_day_relative_month
+        target_year   = close.year + months_offset // 12
+        target_month  = months_offset % 12 + 1
+        last_day      = calendar.monthrange(target_year, target_month)[1]
+        return date(target_year, target_month, min(payment_day, last_day))
+
+    ``payment_day_relative_month = 0`` means same calendar month as the
+    close date; ``1`` means the following calendar month, etc.
+    """
+    months_offset = close.month - 1 + payment_day_relative_month
+    target_year = close.year + months_offset // 12
+    target_month = months_offset % 12 + 1
+    last_day = calendar.monthrange(target_year, target_month)[1]
+    return date(target_year, target_month, min(payment_day, last_day))
+
+
+def resolve_cycle(
+    *,
+    close_day: Optional[int],
+    payment_day: Optional[int],
+    payment_day_relative_month: Optional[int],
+    target_date: date,
+) -> CreditCardCycle:
+    """Derive the ``CreditCardCycle`` that contains ``target_date``.
+
+    Parameters
+    ----------
+    close_day:
+        The ``Account.close_day`` value. NULL signals a non-CC account and
+        raises ``ValueError`` immediately (callers must guard).
+    payment_day:
+        ``Account.payment_day``. NULL means "use default" (day 1).
+    payment_day_relative_month:
+        ``Account.payment_day_relative_month``. NULL means "use default"
+        (1 = next calendar month after close month).
+    target_date:
+        Any date inside the desired cycle (typically today or a transaction
+        date).
+
+    Returns
+    -------
+    CreditCardCycle
+        Immutable result with ``period_start``, ``period_end_inclusive``,
+        ``payment_date``, and ``source="default"``.
+
+    Raises
+    ------
+    ValueError
+        If ``close_day`` is None (indicates a non-CC account).
+    """
+    if close_day is None:
+        raise ValueError(
+            "resolve_cycle called on a non-credit-card account (close_day is None). "
+            "Callers should check account type before calling the CC cycle resolver."
+        )
+
+    # Apply defaults for NULL stored values (D3).
+    eff_payment_day = payment_day if payment_day is not None else _DEFAULT_PAYMENT_DAY
+    eff_relative_month = (
+        payment_day_relative_month
+        if payment_day_relative_month is not None
+        else _DEFAULT_PAYMENT_DAY_RELATIVE_MONTH
+    )
+
+    # Determine which cycle the target_date falls in.
+    #
+    # The close day is INCLUSIVE (D2): a transaction on the close day
+    # belongs to the cycle that closes on that day, not the next one.
+    #
+    # Strategy:
+    #   - Compute the effective close date for the current calendar month
+    #     (clamped for short months).
+    #   - If target_date <= that close date → the cycle closes this month.
+    #   - Otherwise → the cycle closes next month (target is in the gap
+    #     between this month's close and next month's close).
+
+    cy = target_date.year
+    cm = target_date.month
+
+    this_month_close = _clamp_day(cy, cm, close_day)
+
+    if target_date <= this_month_close:
+        # Target is before or on the close date of this calendar month →
+        # cycle closes this month.
+        close_date = this_month_close
+
+        # Compute previous month's close date to derive period_start.
+        if cm == 1:
+            prev_year, prev_month = cy - 1, 12
+        else:
+            prev_year, prev_month = cy, cm - 1
+        prev_close = _clamp_day(prev_year, prev_month, close_day)
+
+        # period_start = the day after the previous month's close.
+        # Use date arithmetic to avoid month-boundary edge cases.
+        from datetime import timedelta
+        period_start = prev_close + timedelta(days=1)
+    else:
+        # Target is after the close date of this calendar month →
+        # cycle closes next month.
+        if cm == 12:
+            next_year, next_month = cy + 1, 1
+        else:
+            next_year, next_month = cy, cm + 1
+        close_date = _clamp_day(next_year, next_month, close_day)
+
+        # period_start = day after this month's close.
+        from datetime import timedelta
+        period_start = this_month_close + timedelta(days=1)
+
+    payment_date = _resolve_payment_date(close_date, eff_payment_day, eff_relative_month)
+
+    return CreditCardCycle(
+        period_start=period_start,
+        period_end_inclusive=close_date,
+        payment_date=payment_date,
+        source="default",
+    )
+
+
+def resolve_cycle_for_account(account: object, target_date: date) -> CreditCardCycle:
+    """Convenience wrapper that reads the three columns from an Account ORM row.
+
+    Raises ``ValueError`` if the account is not a credit-card type
+    (``account.close_day is None``).
+    """
+    return resolve_cycle(
+        close_day=getattr(account, "close_day", None),
+        payment_day=getattr(account, "payment_day", None),
+        payment_day_relative_month=getattr(account, "payment_day_relative_month", None),
+        target_date=target_date,
+    )

--- a/backend/app/services/cc_cycle_service.py
+++ b/backend/app/services/cc_cycle_service.py
@@ -46,7 +46,8 @@ def _clamp_day(year: int, month: int, day: int) -> date:
     """Return ``date(year, month, min(day, last_day_of_month))``.
 
     Mirrors the clamp PFV already uses for ``Organization.billing_cycle_day``
-    in ``lib/date_utils.py``. Prevents ValueError on Feb 29/30/31, Apr 31, etc.
+    in ``billing_service.py:130`` (``calendar.monthrange(d.year, d.month)[1]``).
+    Prevents ValueError on Feb 29/30/31, Apr 31, etc.
     """
     last_day = calendar.monthrange(year, month)[1]
     return date(year, month, min(day, last_day))

--- a/backend/app/services/cc_cycle_service.py
+++ b/backend/app/services/cc_cycle_service.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import calendar
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 from typing import Literal, Optional
 
 # Sentinel defaults applied when the stored columns are NULL.
@@ -153,7 +153,6 @@ def resolve_cycle(
 
         # period_start = the day after the previous month's close.
         # Use date arithmetic to avoid month-boundary edge cases.
-        from datetime import timedelta
         period_start = prev_close + timedelta(days=1)
     else:
         # Target is after the close date of this calendar month →
@@ -165,7 +164,6 @@ def resolve_cycle(
         close_date = _clamp_day(next_year, next_month, close_day)
 
         # period_start = day after this month's close.
-        from datetime import timedelta
         period_start = this_month_close + timedelta(days=1)
 
     payment_date = _resolve_payment_date(close_date, eff_payment_day, eff_relative_month)

--- a/backend/tests/routers/test_accounts_change_type.py
+++ b/backend/tests/routers/test_accounts_change_type.py
@@ -1073,6 +1073,52 @@ def test_update_cc_omitted_payment_columns_preserves_existing(
     assert body["payment_day_relative_month"] == 2
 
 
+def test_update_cc_explicit_null_resets_payment_columns(session_factory, seeded):
+    """PUT CC -> CC with payment_day: null wipes the stored value.
+
+    Pins the documented invariant that NULL means "use resolver default":
+    a user with a non-default payment_day stored can reset back to the
+    default by explicitly sending null. The cc_cycle_service resolver
+    then returns the D3 defaults (day 1, next month) for that account.
+    """
+
+    async def _set_payment_cols():
+        async with session_factory() as db:
+            acct = (
+                await db.execute(
+                    select(Account).where(Account.id == seeded["cc_acct_id"])
+                )
+            ).scalar_one()
+            acct.payment_day = 15
+            acct.payment_day_relative_month = 2
+            await db.commit()
+
+    _run(_set_payment_cols())
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['cc_acct_id']}",
+            json={"payment_day": None, "payment_day_relative_month": None},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["payment_day"] is None
+    assert body["payment_day_relative_month"] is None
+
+    async def _verify_db():
+        async with session_factory() as db:
+            acct = (
+                await db.execute(
+                    select(Account).where(Account.id == seeded["cc_acct_id"])
+                )
+            ).scalar_one()
+            assert acct.payment_day is None
+            assert acct.payment_day_relative_month is None
+
+    _run(_verify_db())
+
+
 def test_update_payment_day_out_of_range_pydantic_422(session_factory, seeded):
     """PUT with payment_day=32 → Pydantic 422."""
     app = _make_app(session_factory)

--- a/backend/tests/routers/test_accounts_change_type.py
+++ b/backend/tests/routers/test_accounts_change_type.py
@@ -797,3 +797,291 @@ def test_create_account_non_credit_card_without_close_day_succeeds(
 )
 def test_concurrent_type_changes_serialize_on_row_lock(session_factory, seeded):
     pass
+
+
+# ── payment_day / payment_day_relative_month — create-path (Slice 1) ─────────
+
+
+def test_create_cc_with_payment_day_and_relative_month_persisted(
+    session_factory, seeded
+):
+    """Create CC with payment_day=15, payment_day_relative_month=1 → 201,
+    both values persisted in the response."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "CC Pay Day",
+                "account_type_id": seeded["cc_type_id"],
+                "currency": "EUR",
+                "close_day": 20,
+                "payment_day": 15,
+                "payment_day_relative_month": 1,
+            },
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["payment_day"] == 15
+    assert body["payment_day_relative_month"] == 1
+
+
+def test_create_cc_with_null_payment_columns_persisted_as_null(
+    session_factory, seeded
+):
+    """Create CC without payment_day / payment_day_relative_month → 201,
+    both columns stored as NULL (resolver default)."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "CC No Pay Day",
+                "account_type_id": seeded["cc_type_id"],
+                "currency": "EUR",
+                "close_day": 20,
+            },
+        )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["payment_day"] is None
+    assert body["payment_day_relative_month"] is None
+
+
+def test_create_non_cc_with_payment_day_rejected(session_factory, seeded):
+    """POST Checking with payment_day set → 400."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "Bad Checking",
+                "account_type_id": seeded["checking_type_id"],
+                "currency": "EUR",
+                "payment_day": 10,
+            },
+        )
+    assert res.status_code == 400
+    assert "payment_day is only allowed on credit_card accounts" in res.json()["detail"]
+
+
+def test_create_non_cc_with_payment_day_relative_month_rejected(
+    session_factory, seeded
+):
+    """POST Checking with payment_day_relative_month set → 400."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "Bad Checking 2",
+                "account_type_id": seeded["checking_type_id"],
+                "currency": "EUR",
+                "payment_day_relative_month": 1,
+            },
+        )
+    assert res.status_code == 400
+    assert (
+        "payment_day_relative_month is only allowed on credit_card accounts"
+        in res.json()["detail"]
+    )
+
+
+def test_create_cc_with_payment_day_out_of_range_pydantic_422(
+    session_factory, seeded
+):
+    """payment_day=0 (below ge=1) → Pydantic 422 before service runs."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "CC Bad Range",
+                "account_type_id": seeded["cc_type_id"],
+                "currency": "EUR",
+                "close_day": 20,
+                "payment_day": 0,
+            },
+        )
+    assert res.status_code == 422
+
+
+def test_create_cc_with_payment_day_too_high_pydantic_422(session_factory, seeded):
+    """payment_day=32 (above le=31) → Pydantic 422."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "CC Bad Range High",
+                "account_type_id": seeded["cc_type_id"],
+                "currency": "EUR",
+                "close_day": 20,
+                "payment_day": 32,
+            },
+        )
+    assert res.status_code == 422
+
+
+def test_create_cc_with_relative_month_out_of_range_pydantic_422(
+    session_factory, seeded
+):
+    """payment_day_relative_month=13 (above le=12) → Pydantic 422."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "CC Bad Relative",
+                "account_type_id": seeded["cc_type_id"],
+                "currency": "EUR",
+                "close_day": 20,
+                "payment_day_relative_month": 13,
+            },
+        )
+    assert res.status_code == 422
+
+
+# ── payment_day / payment_day_relative_month — PUT cascade (Slice 1) ─────────
+
+
+def test_update_cc_to_non_cc_clears_payment_columns(session_factory, seeded):
+    """PUT CC → Checking: server clears payment_day + payment_day_relative_month
+    to NULL alongside close_day."""
+
+    # First give the CC account some payment columns.
+    async def _set_payment_cols():
+        async with session_factory() as db:
+            acct = (
+                await db.execute(
+                    select(Account).where(Account.id == seeded["cc_acct_id"])
+                )
+            ).scalar_one()
+            acct.payment_day = 10
+            acct.payment_day_relative_month = 1
+            await db.commit()
+
+    _run(_set_payment_cols())
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['cc_acct_id']}",
+            json={"account_type_id": seeded["checking_type_id"]},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["payment_day"] is None
+    assert body["payment_day_relative_month"] is None
+
+
+def test_update_non_cc_to_cc_accepts_payment_columns(session_factory, seeded):
+    """PUT Checking → CC with payment_day + relative_month → 200, values
+    persisted."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['checking_acct_id']}",
+            json={
+                "account_type_id": seeded["cc_type_id"],
+                "close_day": 20,
+                "payment_day": 5,
+                "payment_day_relative_month": 1,
+            },
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["payment_day"] == 5
+    assert body["payment_day_relative_month"] == 1
+
+
+def test_update_non_cc_with_payment_day_rejected(session_factory, seeded):
+    """PUT Checking (stays Checking) with payment_day set → 400."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['checking_acct_id']}",
+            json={"payment_day": 10},
+        )
+    assert res.status_code == 400
+    assert "payment_day is only allowed on credit_card accounts" in res.json()["detail"]
+
+
+def test_update_non_cc_with_payment_day_relative_month_rejected(
+    session_factory, seeded
+):
+    """PUT Checking with payment_day_relative_month set → 400."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['checking_acct_id']}",
+            json={"payment_day_relative_month": 1},
+        )
+    assert res.status_code == 400
+    assert (
+        "payment_day_relative_month is only allowed on credit_card accounts"
+        in res.json()["detail"]
+    )
+
+
+def test_update_cc_payment_columns_updated_in_place(session_factory, seeded):
+    """PUT CC → CC with new payment_day + relative_month → values updated."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['cc_acct_id']}",
+            json={
+                "account_type_id": seeded["cc_type_id"],
+                "payment_day": 28,
+                "payment_day_relative_month": 0,
+            },
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["payment_day"] == 28
+    assert body["payment_day_relative_month"] == 0
+
+
+def test_update_cc_omitted_payment_columns_preserves_existing(
+    session_factory, seeded
+):
+    """PUT CC → CC with payment columns omitted: existing values are unchanged."""
+
+    async def _set_payment_cols():
+        async with session_factory() as db:
+            acct = (
+                await db.execute(
+                    select(Account).where(Account.id == seeded["cc_acct_id"])
+                )
+            ).scalar_one()
+            acct.payment_day = 7
+            acct.payment_day_relative_month = 2
+            await db.commit()
+
+    _run(_set_payment_cols())
+
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        # Only updating the name — payment columns omitted.
+        res = client.put(
+            f"/api/v1/accounts/{seeded['cc_acct_id']}",
+            json={"name": "Visa Renamed"},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["payment_day"] == 7
+    assert body["payment_day_relative_month"] == 2
+
+
+def test_update_payment_day_out_of_range_pydantic_422(session_factory, seeded):
+    """PUT with payment_day=32 → Pydantic 422."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['cc_acct_id']}",
+            json={
+                "account_type_id": seeded["cc_type_id"],
+                "payment_day": 32,
+            },
+        )
+    assert res.status_code == 422

--- a/backend/tests/routers/test_accounts_change_type.py
+++ b/backend/tests/routers/test_accounts_change_type.py
@@ -1085,3 +1085,40 @@ def test_update_payment_day_out_of_range_pydantic_422(session_factory, seeded):
             },
         )
     assert res.status_code == 422
+
+
+# ── C1: close_day=31 accepted on create and update (schema cap widened to 31) ─
+
+
+def test_create_cc_with_close_day_31_accepted(session_factory, seeded):
+    """close_day=31 must pass Pydantic validation (le=31 cap). The resolver
+    handles short-month clamping at compute time, so the schema must allow
+    the full [1, 31] range to reach the service layer."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/accounts",
+            json={
+                "name": "CC Close Day 31",
+                "account_type_id": seeded["cc_type_id"],
+                "currency": "EUR",
+                "close_day": 31,
+            },
+        )
+    assert res.status_code == 201, res.text
+    assert res.json()["close_day"] == 31
+
+
+def test_update_cc_with_close_day_31_accepted(session_factory, seeded):
+    """PUT close_day=31 on an existing CC account must be accepted (le=31)."""
+    app = _make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.put(
+            f"/api/v1/accounts/{seeded['cc_acct_id']}",
+            json={
+                "account_type_id": seeded["cc_type_id"],
+                "close_day": 31,
+            },
+        )
+    assert res.status_code == 200, res.text
+    assert res.json()["close_day"] == 31

--- a/backend/tests/services/test_cc_cycle_service.py
+++ b/backend/tests/services/test_cc_cycle_service.py
@@ -141,6 +141,7 @@ def test_close_day_31_in_february_leap_year():
     )
     assert cycle.period_end_inclusive == date(2028, 2, 29)
     assert cycle.period_start == date(2028, 2, 1)
+    assert cycle.payment_date == date(2028, 3, 1)
 
 
 # ─── (d) Same-month payment ───────────────────────────────────────────────────

--- a/backend/tests/services/test_cc_cycle_service.py
+++ b/backend/tests/services/test_cc_cycle_service.py
@@ -185,7 +185,7 @@ def test_close_day_29_in_leap_year_feb():
     """Explicitly close on Feb 29 in a leap year (2028).
 
     Target = Feb 15, 2028.
-    period_start = Feb 1 (day after Jan 29 close, which is Jan 29).
+    period_start = Jan 30 (day after Jan 29 close).
     period_end_inclusive = Feb 29.
     """
     # Feb 29 is valid in 2028 (leap). close_day=29 in Feb → Feb 29.
@@ -214,19 +214,36 @@ def test_close_day_29_in_non_leap_year_feb():
 # ─── Payment date clamping ────────────────────────────────────────────────────
 
 
-def test_payment_day_31_in_february_clamps():
-    """payment_day=31, relative_month=1 (next month after close).
+def test_payment_day_31_clamps_in_february_non_leap():
+    """payment_day=31 landing in February (non-leap) clamps to Feb 28.
 
-    Close day 25, target Feb 10 → close month Feb, payment month Mar.
-    Mar has 31 days → payment_date = Mar 31.
+    close_day=25, target=Jan 10, 2026 → close = Jan 25, 2026.
+    payment_day_relative_month=1 → payment month = Feb 2026 (28 days, non-leap).
+    min(31, 28) = 28 → payment_date = Feb 28, 2026.
     """
     cycle = resolve_cycle(
         close_day=25,
         payment_day=31,
         payment_day_relative_month=1,
-        target_date=date(2026, 2, 10),
+        target_date=date(2026, 1, 10),
     )
-    assert cycle.payment_date == date(2026, 3, 31)
+    assert cycle.payment_date == date(2026, 2, 28)
+
+
+def test_payment_day_31_clamps_in_february_leap():
+    """payment_day=31 landing in February of a leap year clamps to Feb 29.
+
+    close_day=25, target=Jan 10, 2024 → close = Jan 25, 2024.
+    payment_day_relative_month=1 → payment month = Feb 2024 (29 days, leap).
+    min(31, 29) = 29 → payment_date = Feb 29, 2024.
+    """
+    cycle = resolve_cycle(
+        close_day=25,
+        payment_day=31,
+        payment_day_relative_month=1,
+        target_date=date(2024, 1, 10),
+    )
+    assert cycle.payment_date == date(2024, 2, 29)
 
 
 def test_payment_day_31_in_april_clamps_to_30():

--- a/backend/tests/services/test_cc_cycle_service.py
+++ b/backend/tests/services/test_cc_cycle_service.py
@@ -1,0 +1,292 @@
+"""Unit tests for cc_cycle_service.py — per-CC cycle resolver.
+
+Covers the 5 spec edge cases from the Slice 1 test plan
+(spec 2026-05-28-cc-billing-cycle.md § Slice 1 / D2 / D3):
+
+(a) default close 25, target inside the cycle → correct period + payment.
+(b) close day 31 in a 30-day month (e.g. April) → clamp to 30.
+(c) close day 31 in February non-leap → clamp to 28; leap → 29.
+(d) same-month payment: payment_day=25, payment_day_relative_month=0.
+(e) leap-year Feb 29 close → handles correctly; non-leap year clamps to 28.
+
+Plus a regression test that a non-CC account (close_day=None) raises
+ValueError.
+
+All tests are pure Python — no DB, no async. The service receives a
+plain triple (close_day, payment_day, payment_day_relative_month) and a
+target date; the dataclass result is fully deterministic.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.cc_cycle_service import CreditCardCycle, resolve_cycle
+
+
+# ─── (a) Standard cycle: close 25, target inside the cycle ───────────────────
+
+
+def test_default_close_25_target_inside_cycle():
+    """Close day 25, target = Feb 10 (inside the Jan 26 – Feb 25 cycle).
+
+    Expected:
+      period_start           = Jan 26
+      period_end_inclusive   = Feb 25
+      payment_date           = Mar 1  (default: day 1, next month)
+      source                 = "default"
+    """
+    cycle = resolve_cycle(
+        close_day=25,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 2, 10),
+    )
+    assert isinstance(cycle, CreditCardCycle)
+    assert cycle.period_start == date(2026, 1, 26)
+    assert cycle.period_end_inclusive == date(2026, 2, 25)
+    assert cycle.payment_date == date(2026, 3, 1)
+    assert cycle.source == "default"
+
+
+def test_target_on_close_day_belongs_to_closing_cycle():
+    """D2 — inclusive rule: a tx on the close day (Feb 25) belongs to
+    the Feb cycle, NOT the next one."""
+    cycle = resolve_cycle(
+        close_day=25,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 2, 25),
+    )
+    assert cycle.period_end_inclusive == date(2026, 2, 25)
+    assert cycle.period_start == date(2026, 1, 26)
+
+
+def test_target_day_after_close_opens_next_cycle():
+    """D2 — the day after close starts a new cycle."""
+    cycle = resolve_cycle(
+        close_day=25,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 2, 26),
+    )
+    assert cycle.period_start == date(2026, 2, 26)
+    assert cycle.period_end_inclusive == date(2026, 3, 25)
+    assert cycle.payment_date == date(2026, 4, 1)
+
+
+# ─── (b) Close day 31 in a 30-day month (April) ──────────────────────────────
+
+
+def test_close_day_31_in_april_clamps_to_30():
+    """Close day 31, target = Apr 15.
+
+    April has 30 days → period_end_inclusive clamps to Apr 30.
+    Payment: default (day 1, next month) → May 1.
+    Period start: previous close was Mar 31, so start = Apr 1.
+    """
+    cycle = resolve_cycle(
+        close_day=31,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 4, 15),
+    )
+    assert cycle.period_end_inclusive == date(2026, 4, 30)
+    assert cycle.period_start == date(2026, 4, 1)
+    assert cycle.payment_date == date(2026, 5, 1)
+
+
+def test_close_day_31_in_june_clamps_to_30():
+    """June also has 30 days."""
+    cycle = resolve_cycle(
+        close_day=31,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 6, 10),
+    )
+    assert cycle.period_end_inclusive == date(2026, 6, 30)
+    assert cycle.period_start == date(2026, 6, 1)
+
+
+# ─── (c) Close day 31 in February — non-leap and leap ───────────────────────
+
+
+def test_close_day_31_in_february_non_leap():
+    """2026 is not a leap year → Feb close clamps to Feb 28.
+
+    Target = Feb 10, close day 31.
+    Prev close was Jan 31, so period_start = Feb 1.
+    period_end_inclusive = Feb 28 (clamped from 31).
+    payment_date = Mar 1 (default).
+    """
+    cycle = resolve_cycle(
+        close_day=31,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 2, 10),
+    )
+    assert cycle.period_end_inclusive == date(2026, 2, 28)
+    assert cycle.period_start == date(2026, 2, 1)
+    assert cycle.payment_date == date(2026, 3, 1)
+
+
+def test_close_day_31_in_february_leap_year():
+    """2028 is a leap year → Feb close clamps to Feb 29."""
+    cycle = resolve_cycle(
+        close_day=31,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2028, 2, 10),
+    )
+    assert cycle.period_end_inclusive == date(2028, 2, 29)
+    assert cycle.period_start == date(2028, 2, 1)
+
+
+# ─── (d) Same-month payment ───────────────────────────────────────────────────
+
+
+def test_same_month_payment_relative_month_0():
+    """payment_day=25, payment_day_relative_month=0 → payment on the 25th
+    of the close month (same month as period_end_inclusive).
+
+    Close day = 1 (cycle Jan 2 – Feb 1); payment month = Feb (relative 0 = same
+    month as close), day 25 → Feb 25.
+    """
+    cycle = resolve_cycle(
+        close_day=1,
+        payment_day=25,
+        payment_day_relative_month=0,
+        target_date=date(2026, 1, 15),
+    )
+    assert cycle.period_end_inclusive == date(2026, 2, 1)
+    assert cycle.payment_date == date(2026, 2, 25)
+    assert cycle.source == "default"
+
+
+def test_same_month_payment_close_25():
+    """Close day 25, payment_day=25, relative_month=0 → payment on Feb 25
+    (same month as Feb 25 close)."""
+    cycle = resolve_cycle(
+        close_day=25,
+        payment_day=25,
+        payment_day_relative_month=0,
+        target_date=date(2026, 2, 10),
+    )
+    assert cycle.period_end_inclusive == date(2026, 2, 25)
+    assert cycle.payment_date == date(2026, 2, 25)
+
+
+# ─── (e) Leap year Feb 29 close ───────────────────────────────────────────────
+
+
+def test_close_day_29_in_leap_year_feb():
+    """Explicitly close on Feb 29 in a leap year (2028).
+
+    Target = Feb 15, 2028.
+    period_start = Feb 1 (day after Jan 29 close, which is Jan 29).
+    period_end_inclusive = Feb 29.
+    """
+    # Feb 29 is valid in 2028 (leap). close_day=29 in Feb → Feb 29.
+    cycle = resolve_cycle(
+        close_day=29,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2028, 2, 15),
+    )
+    assert cycle.period_end_inclusive == date(2028, 2, 29)
+    assert cycle.period_start == date(2028, 1, 30)
+    assert cycle.payment_date == date(2028, 3, 1)
+
+
+def test_close_day_29_in_non_leap_year_feb():
+    """close_day=29 in a non-leap Feb (2026) clamps to Feb 28."""
+    cycle = resolve_cycle(
+        close_day=29,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 2, 10),
+    )
+    assert cycle.period_end_inclusive == date(2026, 2, 28)
+
+
+# ─── Payment date clamping ────────────────────────────────────────────────────
+
+
+def test_payment_day_31_in_february_clamps():
+    """payment_day=31, relative_month=1 (next month after close).
+
+    Close day 25, target Feb 10 → close month Feb, payment month Mar.
+    Mar has 31 days → payment_date = Mar 31.
+    """
+    cycle = resolve_cycle(
+        close_day=25,
+        payment_day=31,
+        payment_day_relative_month=1,
+        target_date=date(2026, 2, 10),
+    )
+    assert cycle.payment_date == date(2026, 3, 31)
+
+
+def test_payment_day_31_in_april_clamps_to_30():
+    """payment_day=31, relative_month=1. Close April 25 → payment May.
+    May has 31 days → May 31 (no clamp needed here).
+    For a case where clamp fires: close March 25, payment April.
+    April has 30 days → Apr 30.
+    """
+    cycle = resolve_cycle(
+        close_day=25,
+        payment_day=31,
+        payment_day_relative_month=1,
+        target_date=date(2026, 3, 10),
+    )
+    # Close month = Mar, payment month = Apr (30 days), clamp 31→30.
+    assert cycle.payment_date == date(2026, 4, 30)
+
+
+# ─── Regression: non-CC account raises ValueError ────────────────────────────
+
+
+def test_non_cc_account_raises_value_error():
+    """close_day=None signals a non-CC account. Resolver must raise
+    ValueError immediately."""
+    with pytest.raises(ValueError, match="credit.card"):
+        resolve_cycle(
+            close_day=None,
+            payment_day=None,
+            payment_day_relative_month=None,
+            target_date=date(2026, 2, 10),
+        )
+
+
+# ─── Default sentinel handling ───────────────────────────────────────────────
+
+
+def test_explicit_defaults_match_null_defaults():
+    """payment_day=1, payment_day_relative_month=1 (explicit) must produce
+    the same result as both being None (resolver defaults)."""
+    kw = dict(close_day=25, target_date=date(2026, 2, 10))
+    cycle_null = resolve_cycle(**kw, payment_day=None, payment_day_relative_month=None)
+    cycle_explicit = resolve_cycle(**kw, payment_day=1, payment_day_relative_month=1)
+    assert cycle_null.payment_date == cycle_explicit.payment_date
+    assert cycle_null.period_start == cycle_explicit.period_start
+    assert cycle_null.period_end_inclusive == cycle_explicit.period_end_inclusive
+
+
+# ─── Year-boundary cycle (Dec close → Jan payment) ───────────────────────────
+
+
+def test_year_boundary_dec_close_jan_payment():
+    """Close day 28, target Dec 15.
+
+    Cycle: Nov 29 – Dec 28. Payment: Jan 1.
+    """
+    cycle = resolve_cycle(
+        close_day=28,
+        payment_day=None,
+        payment_day_relative_month=None,
+        target_date=date(2026, 12, 15),
+    )
+    assert cycle.period_start == date(2026, 11, 29)
+    assert cycle.period_end_inclusive == date(2026, 12, 28)
+    assert cycle.payment_date == date(2027, 1, 1)


### PR DESCRIPTION
## Summary

Slice 1 of 4 for the CC billing cycle work locked in PR #373 spec (`specs/2026-05-28-cc-billing-cycle.md`). Backend-only, no UI. Builds the substrate that Slices 2-4 ride on.

## What lands

- **Migration `061_cc_payment_day_columns`** — adds nullable `payment_day` + `payment_day_relative_month` to `accounts`. No DB default on either (per D7 — the resolver owns the default).
- **`services/cc_cycle_service.py`** — pure-function resolver per D8. Returns `CreditCardCycle(period_start, period_end_inclusive, payment_date, source)`. Implements D2 inclusive close day (`<=`), D3 payment-date math with `calendar.monthrange()` clamp, NULL-means-default fallback, `ValueError` on non-CC.
- **Validation extensions in `account_type_change_service.py`** — `validate_create_payment_day` + `validate_payment_day_cascade` mirror the existing `close_day` pattern. Range checks live in Pydantic (`ge=1, le=31` / `ge=0, le=12`); cascade clears on CC→non-CC; columns rejected on non-CC payloads.
- **Router gate** — `touches_type_or_close_day` extended so PUTs touching the new columns route through the atomic validator path.
- **Model + schema updates** for the two columns.

## Tests

- 16 new in `test_cc_cycle_service.py` covering spec edge cases (a)-(e) + boundary + non-CC `ValueError` regression.
- 14 new in `test_accounts_change_type.py` covering the create + cascade matrix.
- Full backend suite: 1499 passed, 1 skipped, 1 unrelated pre-existing failure (Redis race, tracked in memory).
- Migration round-tripped clean on MySQL 8 in isolated `team-cc-slice-1` stack.

## Out of scope

- Slice 2 (configurable payment-day form + endpoint).
- Slice 3 (`cc_cycle_overrides` table + override endpoint + UI + audit).
- Slice 4 (current-month editor shortcut).

## Review history (pre-submit)

Implemented + spec-compliance reviewed + code-quality reviewed in-session per the user's subagent-driven dev workflow. Quality review surfaced 2 Important + 1 Minor finding (unused param, dup import, missing test assertion) — addressed in `ab125be` and re-verified before push.