### PR TITLE
feat(ai): relax api_key requirement for Ollama (LAN-only mode)

### DIFF
--- a/backend/alembic/versions/062_ollama_nullable_api_key.py
+++ b/backend/alembic/versions/062_ollama_nullable_api_key.py
@@ -1,0 +1,45 @@
+"""Make org_ai_credentials.encrypted_api_key nullable (Ollama LAN-only mode).
+
+Revision ID: 062_ollama_nullable_api_key
+Revises: 061_cc_payment_day_columns
+Create Date: 2026-05-29
+
+Spec: specs/2026-05-22-ai-tier-byo-and-native-providers.md line 37 + ~L219
+declares Ollama-no-key (LAN-only homelab mode) as a supported configuration.
+Implementation never caught up: ``encrypted_api_key`` was NOT NULL so a POST
+without an api_key would 422 at the schema layer.
+
+Single change: loosen ``encrypted_api_key`` from NOT NULL to nullable.
+
+Downgrade re-adds NOT NULL. No backfill needed — pre-launch state, zero real
+Ollama-no-key rows exist.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "062_ollama_nullable_api_key"
+down_revision = "061_cc_payment_day_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "org_ai_credentials",
+        "encrypted_api_key",
+        existing_type=sa.Text(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Pre-launch: no real Ollama-no-key rows expected; safe to re-add NOT NULL.
+    op.alter_column(
+        "org_ai_credentials",
+        "encrypted_api_key",
+        existing_type=sa.Text(),
+        nullable=False,
+    )

--- a/backend/alembic/versions/062_ollama_nullable_api_key.py
+++ b/backend/alembic/versions/062_ollama_nullable_api_key.py
@@ -1,5 +1,8 @@
 """Make org_ai_credentials.encrypted_api_key nullable (Ollama LAN-only mode).
 
+Also makes last_four and key_fingerprint nullable so Ollama-no-key rows
+can store NULL there instead of a misleading empty string.
+
 Revision ID: 062_ollama_nullable_api_key
 Revises: 061_cc_payment_day_columns
 Create Date: 2026-05-29
@@ -9,7 +12,8 @@ declares Ollama-no-key (LAN-only homelab mode) as a supported configuration.
 Implementation never caught up: ``encrypted_api_key`` was NOT NULL so a POST
 without an api_key would 422 at the schema layer.
 
-Single change: loosen ``encrypted_api_key`` from NOT NULL to nullable.
+Changes: loosen ``encrypted_api_key``, ``last_four``, and ``key_fingerprint``
+from NOT NULL to nullable.
 
 Downgrade re-adds NOT NULL. No backfill needed — pre-launch state, zero real
 Ollama-no-key rows exist.
@@ -33,6 +37,18 @@ def upgrade() -> None:
         existing_type=sa.Text(),
         nullable=True,
     )
+    op.alter_column(
+        "org_ai_credentials",
+        "last_four",
+        existing_type=sa.String(length=8),
+        nullable=True,
+    )
+    op.alter_column(
+        "org_ai_credentials",
+        "key_fingerprint",
+        existing_type=sa.String(length=64),
+        nullable=True,
+    )
 
 
 def downgrade() -> None:
@@ -41,5 +57,17 @@ def downgrade() -> None:
         "org_ai_credentials",
         "encrypted_api_key",
         existing_type=sa.Text(),
+        nullable=False,
+    )
+    op.alter_column(
+        "org_ai_credentials",
+        "last_four",
+        existing_type=sa.String(length=8),
+        nullable=False,
+    )
+    op.alter_column(
+        "org_ai_credentials",
+        "key_fingerprint",
+        existing_type=sa.String(length=64),
         nullable=False,
     )

--- a/backend/app/models/org_ai_credential.py
+++ b/backend/app/models/org_ai_credential.py
@@ -59,7 +59,7 @@ class OrgAICredential(Base):
         ),
         nullable=False,
     )
-    encrypted_api_key: Mapped[str] = mapped_column(Text, nullable=False)
+    encrypted_api_key: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     encrypted_bearer_token: Mapped[Optional[str]] = mapped_column(
         Text, nullable=True
     )

--- a/backend/app/models/org_ai_credential.py
+++ b/backend/app/models/org_ai_credential.py
@@ -66,8 +66,8 @@ class OrgAICredential(Base):
     base_url: Mapped[Optional[str]] = mapped_column(
         String(512), nullable=True
     )
-    key_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
-    last_four: Mapped[str] = mapped_column(String(8), nullable=False)
+    key_fingerprint: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    last_four: Mapped[Optional[str]] = mapped_column(String(8), nullable=True)
     discovered_capabilities: Mapped[Optional[list[str]]] = mapped_column(
         JSON, nullable=True
     )

--- a/backend/app/schemas/org_ai_credential.py
+++ b/backend/app/schemas/org_ai_credential.py
@@ -141,6 +141,9 @@ class OrgAICredentialUpdate(BaseModel):
 class OrgAICredentialRotate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    # Rotate is symmetric with Create EXCEPT that api_key is non-optional and
+    # min_length=4: rotation is "swap to a new key", never "remove the key".
+    # Users who want to clear an Ollama credential's key delete + recreate.
     api_key: str = Field(
         min_length=API_KEY_MIN_LENGTH, max_length=API_KEY_MAX_LENGTH
     )
@@ -162,8 +165,8 @@ class OrgAICredentialResponse(BaseModel):
     id: int
     org_id: int
     provider: AiProvider
-    last_four: str
-    key_fingerprint: str
+    last_four: Optional[str]
+    key_fingerprint: Optional[str]
     base_url: Optional[str]
     label: Optional[str]
     discovered_capabilities: Optional[list[str]] = None

--- a/backend/app/schemas/org_ai_credential.py
+++ b/backend/app/schemas/org_ai_credential.py
@@ -91,8 +91,8 @@ class OrgAICredentialCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     provider: AiProvider
-    api_key: str = Field(
-        min_length=API_KEY_MIN_LENGTH, max_length=API_KEY_MAX_LENGTH
+    api_key: Optional[str] = Field(
+        default=None, max_length=API_KEY_MAX_LENGTH
     )
     bearer_token: Optional[str] = Field(
         default=None, max_length=API_KEY_MAX_LENGTH
@@ -118,6 +118,15 @@ class OrgAICredentialCreate(BaseModel):
             raise ValueError(
                 "bearer_token is only valid for the ollama provider"
             )
+        # Ollama: api_key is optional (LAN-only homelab mode, spec line 37).
+        # All other providers: api_key is required and must meet min length.
+        if self.provider != AiProvider.OLLAMA:
+            stripped = (self.api_key or "").strip()
+            if len(stripped) < API_KEY_MIN_LENGTH:
+                raise ValueError(
+                    f"api_key is required (min {API_KEY_MIN_LENGTH} characters)"
+                    f" for provider '{self.provider.value}'"
+                )
         return self
 
 

--- a/backend/app/services/ai_credential_service.py
+++ b/backend/app/services/ai_credential_service.py
@@ -44,7 +44,7 @@ def _credential_validation_failure(error: str) -> HTTPException:
 async def _run_validate(
     *,
     provider: AiProvider,
-    api_key: str,
+    api_key: Optional[str],
     bearer_token: Optional[str],
     base_url: Optional[str],
 ) -> ValidateResult:
@@ -122,13 +122,13 @@ async def create_credential(
     row = OrgAICredential(
         org_id=org_id,
         provider=payload.provider,
-        encrypted_api_key=encrypt(payload.api_key),
+        encrypted_api_key=encrypt(payload.api_key) if payload.api_key else None,
         encrypted_bearer_token=(
             encrypt(payload.bearer_token) if payload.bearer_token else None
         ),
         base_url=payload.base_url,
-        key_fingerprint=fingerprint(payload.api_key),
-        last_four=last_four(payload.api_key),
+        key_fingerprint=fingerprint(payload.api_key) if payload.api_key else "",
+        last_four=last_four(payload.api_key) if payload.api_key else "",
         discovered_capabilities=result.discovered_capabilities,
         discovered_models=result.discovered_models,
         label=payload.label,
@@ -237,7 +237,11 @@ async def validate_credential(
     request_id: Optional[str],
     ip_address: Optional[str],
 ) -> OrgAICredential:
-    api_key = decrypt(credential.encrypted_api_key)
+    api_key = (
+        decrypt(credential.encrypted_api_key)
+        if credential.encrypted_api_key
+        else None
+    )
     bearer_token = (
         decrypt(credential.encrypted_bearer_token)
         if credential.encrypted_bearer_token

--- a/backend/app/services/ai_credential_service.py
+++ b/backend/app/services/ai_credential_service.py
@@ -127,8 +127,8 @@ async def create_credential(
             encrypt(payload.bearer_token) if payload.bearer_token else None
         ),
         base_url=payload.base_url,
-        key_fingerprint=fingerprint(payload.api_key) if payload.api_key else "",
-        last_four=last_four(payload.api_key) if payload.api_key else "",
+        key_fingerprint=fingerprint(payload.api_key) if payload.api_key else None,
+        last_four=last_four(payload.api_key) if payload.api_key else None,
         discovered_capabilities=result.discovered_capabilities,
         discovered_models=result.discovered_models,
         label=payload.label,

--- a/backend/app/services/ai_dispatch.py
+++ b/backend/app/services/ai_dispatch.py
@@ -627,7 +627,9 @@ async def call_llm(
     )
 
     # 4. Build adapter.
-    api_key = decrypt(cred.encrypted_api_key)
+    api_key = (
+        decrypt(cred.encrypted_api_key) if cred.encrypted_api_key else None
+    )
     bearer = (
         decrypt(cred.encrypted_bearer_token)
         if cred.encrypted_bearer_token
@@ -908,7 +910,9 @@ async def _prepare_dispatch(
         period=_current_period(),
     )
 
-    api_key = decrypt(cred.encrypted_api_key)
+    api_key = (
+        decrypt(cred.encrypted_api_key) if cred.encrypted_api_key else None
+    )
     bearer = (
         decrypt(cred.encrypted_bearer_token)
         if cred.encrypted_bearer_token

--- a/backend/tests/routers/test_ai_providers.py
+++ b/backend/tests/routers/test_ai_providers.py
@@ -467,6 +467,45 @@ async def test_validate_different_credentials_independent(session_factory):
     assert acquire_mock.call_args_list[1].kwargs["credential_id"] == b_id
 
 
+async def test_ollama_no_key_creates_credential_with_null_encrypted_api_key(
+    session_factory,
+):
+    """POST Ollama credential without api_key must return 201 and store
+    encrypted_api_key as NULL (spec line 37: LAN-only homelab mode)."""
+    from sqlalchemy import select
+    from app.models.org_ai_credential import OrgAICredential
+
+    ids = await _seed(session_factory)
+
+    async def resolver(_factory):
+        return await _get_user(session_factory, ids["owner_a"])
+
+    app = _make_app(session_factory, resolver)
+    client = TestClient(app)
+
+    with _patch_adapter(_ok_validate(["llama3"])):
+        resp = client.post(
+            "/api/v1/settings/ai-providers",
+            json={
+                "provider": "ollama",
+                "base_url": "http://ollama.internal:11434",
+            },
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["provider"] == "ollama"
+    assert "encrypted_api_key" not in body
+
+    # Confirm the DB row has encrypted_api_key IS NULL.
+    cred_id = body["id"]
+    async with session_factory() as db:
+        result = await db.execute(
+            select(OrgAICredential).where(OrgAICredential.id == cred_id)
+        )
+        row = result.scalar_one()
+    assert row.encrypted_api_key is None
+
+
 async def test_validate_falls_open_when_redis_unavailable(
     session_factory, caplog
 ):

--- a/backend/tests/schemas/test_org_ai_credential_ssrf.py
+++ b/backend/tests/schemas/test_org_ai_credential_ssrf.py
@@ -123,13 +123,20 @@ def test_ollama_credential_accepts_null_api_key() -> None:
 
 def test_non_ollama_credential_still_rejects_missing_api_key() -> None:
     """Non-Ollama providers require api_key; omitting it must raise."""
-    for provider in (AiProvider.OPENAI, AiProvider.ANTHROPIC):
+    for provider in (AiProvider.OPENAI, AiProvider.ANTHROPIC, AiProvider.OPENAI_COMPATIBLE):
         with pytest.raises(ValidationError):
-            OrgAICredentialCreate(provider=provider)
+            OrgAICredentialCreate(
+                provider=provider,
+                **({"base_url": "https://localhost:11434/v1"} if provider == AiProvider.OPENAI_COMPATIBLE else {}),
+            )
 
 
 def test_non_ollama_credential_still_rejects_short_api_key() -> None:
     """Non-Ollama providers reject api_key shorter than API_KEY_MIN_LENGTH."""
-    for provider in (AiProvider.OPENAI, AiProvider.ANTHROPIC):
+    for provider in (AiProvider.OPENAI, AiProvider.ANTHROPIC, AiProvider.OPENAI_COMPATIBLE):
         with pytest.raises(ValidationError):
-            OrgAICredentialCreate(provider=provider, api_key="abc")
+            OrgAICredentialCreate(
+                provider=provider,
+                api_key="abc",
+                **({"base_url": "https://localhost:11434/v1"} if provider == AiProvider.OPENAI_COMPATIBLE else {}),
+            )

--- a/backend/tests/schemas/test_org_ai_credential_ssrf.py
+++ b/backend/tests/schemas/test_org_ai_credential_ssrf.py
@@ -95,3 +95,41 @@ def test_base_url_required_for_ollama_and_compatible() -> None:
             api_key="sk-test-1234",
             base_url=None,
         )
+
+
+# ---------------------------------------------------------------------------
+# Ollama no-key (LAN-only homelab mode) — spec line 37 + ~L219
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_credential_accepts_missing_api_key() -> None:
+    """Ollama POST without api_key must validate successfully."""
+    cred = OrgAICredentialCreate(
+        provider=AiProvider.OLLAMA,
+        base_url="http://ollama.internal:11434",
+    )
+    assert cred.api_key is None
+
+
+def test_ollama_credential_accepts_null_api_key() -> None:
+    """Ollama POST with api_key=None must validate successfully."""
+    cred = OrgAICredentialCreate(
+        provider=AiProvider.OLLAMA,
+        api_key=None,
+        base_url="http://ollama.internal:11434",
+    )
+    assert cred.api_key is None
+
+
+def test_non_ollama_credential_still_rejects_missing_api_key() -> None:
+    """Non-Ollama providers require api_key; omitting it must raise."""
+    for provider in (AiProvider.OPENAI, AiProvider.ANTHROPIC):
+        with pytest.raises(ValidationError):
+            OrgAICredentialCreate(provider=provider)
+
+
+def test_non_ollama_credential_still_rejects_short_api_key() -> None:
+    """Non-Ollama providers reject api_key shorter than API_KEY_MIN_LENGTH."""
+    for provider in (AiProvider.OPENAI, AiProvider.ANTHROPIC):
+        with pytest.raises(ValidationError):
+            OrgAICredentialCreate(provider=provider, api_key="abc")

--- a/frontend/app/settings/ai-providers/page.tsx
+++ b/frontend/app/settings/ai-providers/page.tsx
@@ -28,8 +28,8 @@ interface Credential {
   id: number;
   org_id: number;
   provider: Provider;
-  last_four: string;
-  key_fingerprint: string;
+  last_four: string | null;
+  key_fingerprint: string | null;
   base_url: string | null;
   label: string | null;
   discovered_capabilities: string[] | null;
@@ -284,7 +284,7 @@ export default function AiProvidersPage() {
                     <td className="px-4 py-2">{PROVIDER_LABELS[c.provider]}</td>
                     <td className="px-4 py-2">{c.label ?? "-"}</td>
                     <td className="px-4 py-2 font-mono text-xs">
-                      ***{c.last_four}
+                      {c.last_four ? `***${c.last_four}` : "-"}
                     </td>
                     <td className="px-4 py-2">
                       {c.validation_error ? (
@@ -631,7 +631,7 @@ function RoutingSection({
                 <option value="">(choose)</option>
                 {credentials.map((c) => (
                   <option key={c.id} value={c.id}>
-                    {PROVIDER_LABELS[c.provider]} ***{c.last_four}
+                    {PROVIDER_LABELS[c.provider]}{c.last_four ? ` ***${c.last_four}` : ""}
                     {c.label ? ` (${c.label})` : ""}
                   </option>
                 ))}
@@ -802,7 +802,7 @@ function FeatureRoutingTable({
                       <option value="">(use default)</option>
                       {credentials.map((c) => (
                         <option key={c.id} value={c.id}>
-                          {PROVIDER_LABELS[c.provider]} ***{c.last_four}
+                          {PROVIDER_LABELS[c.provider]}{c.last_four ? ` ***${c.last_four}` : ""}
                           {c.label ? ` (${c.label})` : ""}
                         </option>
                       ))}

--- a/frontend/app/settings/ai-providers/page.tsx
+++ b/frontend/app/settings/ai-providers/page.tsx
@@ -376,17 +376,16 @@ function AddCredentialModal({
 
   const needsBaseUrl = NEEDS_BASE_URL.includes(provider);
   const allowsBearer = ALLOWS_BEARER.includes(provider);
+  const apiKeyOptional = provider === "ollama";
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!apiKey.trim()) return;
+    if (!apiKeyOptional && !apiKey.trim()) return;
     setSubmitting(true);
     setErrorText(null);
     try {
-      const body: Record<string, unknown> = {
-        provider,
-        api_key: apiKey,
-      };
+      const body: Record<string, unknown> = { provider };
+      if (apiKey.trim()) body.api_key = apiKey.trim();
       if (labelText.trim()) body.label = labelText.trim();
       if (needsBaseUrl) body.base_url = baseUrl.trim();
       if (allowsBearer && bearerToken.trim()) body.bearer_token = bearerToken.trim();
@@ -477,7 +476,7 @@ function AddCredentialModal({
           </div>
           <div>
             <label className={labelCls} htmlFor="ai-api-key">
-              API key
+              API key{apiKeyOptional ? " (optional)" : ""}
             </label>
             <input
               id="ai-api-key"
@@ -487,8 +486,13 @@ function AddCredentialModal({
               onChange={(e) => setApiKey(e.target.value)}
               disabled={submitting}
               autoComplete="off"
-              required
+              required={!apiKeyOptional}
             />
+            {apiKeyOptional && (
+              <p className="mt-1 text-xs text-text-muted">
+                Optional for self-hosted Ollama (LAN-only).
+              </p>
+            )}
           </div>
           {allowsBearer && (
             <div>
@@ -538,7 +542,7 @@ function AddCredentialModal({
               className={btnPrimary}
               disabled={
                 submitting ||
-                !apiKey.trim() ||
+                (!apiKeyOptional && !apiKey.trim()) ||
                 (needsBaseUrl && !baseUrl.trim()) ||
                 provider === "native"
               }


### PR DESCRIPTION
## Summary

Implementation catches up to the locked spec at \`specs/2026-05-22-ai-tier-byo-and-native-providers.md\` line 37: "Ollama with no bearer is also valid (LAN-only)." Until now the \`OrgAICredentialCreate.api_key\` Field enforced \`min_length=4\` for every provider, which 422'd any homelab Ollama POST without a key.

## What changes

- **Migration 062**: \`org_ai_credentials.encrypted_api_key\`, \`last_four\`, \`key_fingerprint\` all NOT NULL → nullable. Downgrade reverses (no backfill — pre-launch).
- **Schema**: \`OrgAICredentialCreate.api_key: Optional[str]\` (no \`min_length\` on the Field). \`_check_provider_requirements\` now enforces the \`>= 4\` rule for every provider except Ollama. \`OrgAICredentialResponse.last_four\` and \`.key_fingerprint\` typed \`Optional[str]\`.
- **Service**: \`create_credential\` stores \`None\` (not empty string) when payload omits \`api_key\`; encrypt/decrypt/fingerprint/last_four callsites guarded against \`None\`.
- **\`OrgAICredentialRotate\` unchanged**: comment added explaining the deliberate Create/Rotate asymmetry — rotation is "swap to a new key, never remove."
- **Frontend** (\`/settings/ai-providers\`): \`api_key\` input \`required\` conditional on \`provider !== "ollama"\`; submit guard mirrors; "Optional for self-hosted Ollama (LAN-only)." hint added. Response type narrowed to \`string | null\`; all three render sites branch on null so no "Key ending in ..." with nothing after it.

## Out of scope (sibling candidates)

- \`OPENAI_COMPATIBLE\` (LocalAI, vLLM, etc.) shares the same homelab use case but is intentionally NOT bundled. Validator still requires \`api_key\` for it. If you want the same relaxation for OPENAI_COMPATIBLE, it's a one-line condition flip in the validator plus the equivalent frontend toggle — happy to ship in a follow-up.

## Tests

40 schema + router tests pass (5 new); 9 adapter tests pass; 0 failures. Schema tests now cover OPENAI_COMPATIBLE in the non-Ollama rejection loop. Router test reads the raw DB row and asserts \`encrypted_api_key IS NULL\` after a no-key Ollama POST — not a response-shape shortcut.

## Review history (pre-submit)

In-session subagent-driven dev: implementer + spec-compliance review (✅ clean) + code-quality review (3 Important, 2 Minor) → fix round (3 valid items addressed; Imp 2 downgrade-backfill pushed back per \`feedback_pre_launch_state.md\`) → re-review (✅ approved).