### PR TITLE
fix(deploy): repoint DO spec + apex OIDC to fjcloudaiconsulting/tbd

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -72,7 +72,7 @@ ingress:
 services:
   - name: backend
     github:
-      repo: flamarion/pfv
+      repo: fjcloudaiconsulting/tbd
       branch: main
       deploy_on_push: false
     source_dir: backend
@@ -138,11 +138,11 @@ services:
       - key: AI_CREDENTIAL_ENCRYPTION_KEY
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: ""
+        value: EV[1:sn7ynZMy38Z7o0sDzFldMwA6Q7yxB8S3:RoTRbtfu3PKUZLCKBqqr/w==]
       - key: AI_CREDENTIAL_ENCRYPTION_KEY_PREV
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: ""
+        value: EV[1:Hlvi5JFq2Bydn2BCirJVEv+CbGSOz/aF:nKZqg6GmYwhaCNeJvp5ubg==]
       - key: AI_NATIVE_ENABLED
         scope: RUN_AND_BUILD_TIME
         value: "false"
@@ -245,7 +245,7 @@ services:
 
   - name: frontend
     github:
-      repo: flamarion/pfv
+      repo: fjcloudaiconsulting/tbd
       branch: main
       deploy_on_push: false
     source_dir: frontend
@@ -319,7 +319,7 @@ jobs:
   - name: migrate
     kind: PRE_DEPLOY
     github:
-      repo: flamarion/pfv
+      repo: fjcloudaiconsulting/tbd
       branch: main
       deploy_on_push: false
     source_dir: backend

--- a/.github/workflows/apex-deploy.yml
+++ b/.github/workflows/apex-deploy.yml
@@ -5,7 +5,7 @@
 # Auth is via GitHub OIDC -> AWS IAM role (no long-lived AWS keys).
 #
 # The IAM role's trust policy (provisioned by PR #240) only accepts
-# tokens whose `sub` claim matches `repo:flamarion/pfv:ref:refs/heads/main`.
+# tokens whose `sub` claim matches `repo:fjcloudaiconsulting/tbd:ref:refs/heads/main`.
 # That is the load-bearing security boundary; this workflow's
 # `branches: [main]` trigger is belt-and-suspenders.
 #

--- a/infra/terraform/apex/README.md
+++ b/infra/terraform/apex/README.md
@@ -99,7 +99,7 @@ flip to OIDC immediately.
    - `AWS_SECRET_ACCESS_KEY` (Environment, sensitive) = the secret
    - `aws_account_id` (Terraform) = your 12-digit account id
 3. Configure the workspace's VCS settings:
-   - Repo: `flamarion/pfv`
+   - Repo: `fjcloudaiconsulting/tbd`
    - Working directory: `infra/terraform/apex`
    - Trigger pattern: `infra/terraform/apex/**`
    - Auto-apply: **off**
@@ -160,7 +160,7 @@ targets; apex has no such reuse story.
   `ListBucket` on the apex bucket only, and `CreateInvalidation` on the
   apex distribution only. No other bucket, no other distribution. The
   trust policy uses `StringEquals` on the OIDC `sub` claim, pinned to
-  exactly `repo:flamarion/pfv:ref:refs/heads/main`. PR-context tokens
+  exactly `repo:fjcloudaiconsulting/tbd:ref:refs/heads/main`. PR-context tokens
   have a different `sub` and are rejected at the trust level. Workflow
   `if:` guards alone would be insufficient because PR authors can edit
   the workflow file; this restriction is IAM-enforced.

--- a/infra/terraform/apex/terraform.tfvars.example
+++ b/infra/terraform/apex/terraform.tfvars.example
@@ -9,7 +9,7 @@
 # Optional overrides (defaults live in variables.tf):
 # aws_region                         = "eu-central-1"
 # domain                             = "thebetterdecision.com"
-# github_repo                        = "flamarion/pfv"
+# github_repo                        = "fjcloudaiconsulting/tbd"
 # github_main_branch                 = "main"
 # tfc_organization                   = "FlamaCorp"
 # tfc_workspace_pattern              = "pfv-apex*"

--- a/infra/terraform/apex/variables.tf
+++ b/infra/terraform/apex/variables.tf
@@ -23,7 +23,7 @@ variable "domain" {
 variable "github_repo" {
   description = "GitHub repo (owner/name) allowed to assume the GitHub Actions deploy role via OIDC."
   type        = string
-  default     = "flamarion/pfv"
+  default     = "fjcloudaiconsulting/tbd"
 }
 
 variable "github_main_branch" {


### PR DESCRIPTION
## Summary

Repo migrated `flamarion/pfv` → `fjcloudaiconsulting/tbd`; deploys broke because three layers still pointed at the old path.

- `.do/app.yaml` — backend, frontend, migrate all updated. **Also restored the two `AI_CREDENTIAL_ENCRYPTION_KEY*` `EV[]` blobs from the live spec** (they were `""` on disk; spec is authoritative on push and would have wiped them → lifespan KEK guard refuses to boot). Live blobs pulled via DO MCP `apps-get-info`.
- `infra/terraform/apex/variables.tf` — `github_repo` default drives the AWS IAM OIDC trust policy `sub` claim (`StringEquals repo:<owner/name>:ref:refs/heads/main`). Without this, `apex-deploy.yml` OIDC exchange would fail after the next TFC apply.
- `infra/terraform/apex/README.md`, `terraform.tfvars.example`, `apex-deploy.yml` — comment / docs sync.

## Out of scope / required manual follow-up

Before merge:

1. **TFC re-connect.** Workspaces `FlamaCorp/pfv` and `FlamaCorp/pfv-apex` still point VCS to `flamarion/pfv`. Repoint both to `fjcloudaiconsulting/tbd` in the TFC UI, otherwise VCS-driven plan/apply won't pick up this branch (or main after merge).
2. **TFC workspace variables.** If `github_repo` is set as a workspace variable in `FlamaCorp/pfv-apex`, that overrides the default in `variables.tf` — update it there too.
3. **Apex IAM apply.** After TFC re-connect, an apply on `FlamaCorp/pfv-apex` rewrites the trust policy `sub` claim. Until that lands, `apex-deploy.yml` jobs will still fail OIDC even though the workflow comment is correct.

## Verification path

After merge + TFC re-connect:
- `gh workflow run release.yml` (or push to main) → deploy.yml pushes the new `.do/app.yaml` via `doctl apps update --spec` → DO build pulls source from `fjcloudaiconsulting/tbd` and proceeds.
- Apex deploy works once `FlamaCorp/pfv-apex` apply rewrites the IAM trust policy.