### PR TITLE
fix(ai): allow RFC1918 + loopback for Ollama base_url

### DIFF
--- a/backend/app/schemas/org_ai_credential.py
+++ b/backend/app/schemas/org_ai_credential.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ipaddress
 from datetime import datetime
+from ipaddress import IPv4Address, IPv6Address
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -26,64 +27,88 @@ BASE_URL_MAX_LENGTH = 512
 _METADATA_IPS = frozenset({"169.254.169.254", "fd00:ec2::254"})
 
 
-def _reject_private_ip_literal(host: str) -> None:
-    """Raise ValueError if ``host`` is a literal IP in a blocked range.
-
-    Blocks loopback, RFC1918 private, link-local (covers IMDS 169.254/16),
-    multicast, unspecified, reserved, and cloud-metadata IPs. Also catches
-    IPv4-mapped IPv6 of any of the above (``::ffff:127.0.0.1`` etc.).
-
-    DNS names pass through this check — DNS rebinding is a residual risk
-    for v1; the operator is responsible for not pointing ``base_url`` at
-    a private DNS name that resolves to a metadata IP. A future iteration
-    can add a custom httpx transport that re-checks the resolved address
-    before connect.
-    """
+def _ip_or_none(host: str) -> IPv4Address | IPv6Address | None:
+    """Return the parsed IP if ``host`` is a literal address (with IPv4-mapped
+    IPv6 unwrapped to its IPv4 form), or None if it's a DNS name."""
     if not host:
-        return
-    # Strip surrounding brackets used by RFC3986 for IPv6 literals.
+        return None
     candidate = host.strip("[]")
     try:
         ip = ipaddress.ip_address(candidate)
     except ValueError:
-        # Not a literal IP — DNS name, fall through (see docstring).
-        return
-    # Cloud-metadata catch (also caught by is_link_local, but explicit so
-    # the error message tells the operator exactly what was rejected).
-    if str(ip) in _METADATA_IPS:
-        raise ValueError("base_url cannot point at a cloud metadata endpoint")
-    # IPv4-mapped IPv6 — unwrap and re-check on the IPv4 side.
+        return None
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
         ip = ip.ipv4_mapped
+    return ip
+
+
+def _reject_metadata_or_unsafe(host: str) -> None:
+    """Always-blocked classes (safe for all providers including Ollama):
+    cloud-metadata IPs, link-local (covers the rest of 169.254/16 beyond
+    the metadata constant), multicast, unspecified, and IETF-reserved IPs
+    (240/4, 255.255.255.255, etc.).
+
+    Loopback (127/8, ::1) is intentionally excluded here — it is handled
+    by _reject_private_or_loopback, which Ollama bypasses. Python 3.12
+    marks ::1 as is_reserved=True, so we must check is_loopback first to
+    avoid accidentally blocking it in this always-blocked layer.
+
+    RFC1918 private addresses (is_private) are intentionally absent — they
+    are the whole point of the provider-conditional layer; non-Ollama
+    providers hit them in _reject_private_or_loopback.
+
+    DNS names pass through (see _validate_base_url docstring for the DNS
+    rebinding note)."""
+    ip = _ip_or_none(host)
+    if ip is None:
+        return
+    if str(ip) in _METADATA_IPS:
+        raise ValueError("base_url cannot point at a cloud metadata endpoint")
+    # Loopback is provider-conditional (allowed for Ollama); skip it here.
+    if ip.is_loopback:
+        return
     if (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
+        ip.is_link_local
         or ip.is_multicast
         or ip.is_unspecified
         or ip.is_reserved
     ):
         raise ValueError(
-            "base_url cannot point at a private, loopback, link-local, "
-            "multicast, or reserved IP"
+            "base_url cannot point at a link-local, multicast, "
+            "unspecified, or reserved IP"
+        )
+
+
+def _reject_private_or_loopback(host: str) -> None:
+    """RFC1918 (10/8, 172.16/12, 192.168/16) and loopback (127.0.0.0/8, ::1).
+    Blocked for hosted providers; allowed for Ollama (operator's own LAN /
+    homelab — see spec 2026-05-29 section 3)."""
+    ip = _ip_or_none(host)
+    if ip is None:
+        return
+    if ip.is_private or ip.is_loopback:
+        raise ValueError(
+            "base_url cannot point at a private (RFC1918) or loopback IP"
         )
 
 
 def _validate_base_url(value: str) -> str:
-    """Reject base_url values that open an SSRF surface.
+    """Reject base_url values that open an SSRF surface, regardless of
+    provider. Provider-conditional checks (RFC1918 / loopback) run in
+    the model validator where ``provider`` is known.
 
     Allowed: http/https scheme + public hostname/IP. Private DNS names
-    (``ollama.internal``, ``my-llm.local``) ARE allowed in v1 — operators
-    fronting Ollama in their VPC need them. Literal private/loopback IPs
-    are rejected so a malicious org admin can't pivot through the backend
-    onto 127.0.0.1 or the cloud metadata service.
+    (``ollama.internal``, ``my-llm.local``) ARE allowed — operators
+    fronting Ollama in their VPC need them. DNS rebinding remains a
+    residual v1 risk; a future iteration can add a custom httpx
+    transport that re-checks the resolved address before connect.
     """
     parsed = urlparse(value)
     if parsed.scheme not in ("http", "https"):
         raise ValueError("base_url must use http or https scheme")
     if not parsed.hostname:
         raise ValueError("base_url must include a hostname")
-    _reject_private_ip_literal(parsed.hostname)
+    _reject_metadata_or_unsafe(parsed.hostname)
     return value
 
 
@@ -114,6 +139,13 @@ class OrgAICredentialCreate(BaseModel):
                 raise ValueError(
                     "base_url is required for ollama and openai_compatible providers"
                 )
+        # Provider-conditional SSRF policy:
+        # - Ollama: operator's own LAN/homelab, allow RFC1918 + loopback.
+        # - All other providers: strict block per the v1 SSRF guard.
+        if self.base_url and self.provider != AiProvider.OLLAMA:
+            parsed = urlparse(self.base_url)
+            if parsed.hostname:
+                _reject_private_or_loopback(parsed.hostname)
         if self.provider != AiProvider.OLLAMA and self.bearer_token:
             raise ValueError(
                 "bearer_token is only valid for the ollama provider"

--- a/backend/tests/schemas/test_org_ai_credential_ssrf.py
+++ b/backend/tests/schemas/test_org_ai_credential_ssrf.py
@@ -140,3 +140,67 @@ def test_non_ollama_credential_still_rejects_short_api_key() -> None:
                 api_key="abc",
                 **({"base_url": "https://localhost:11434/v1"} if provider == AiProvider.OPENAI_COMPATIBLE else {}),
             )
+
+
+# --- 2026-05-29: Ollama LAN/loopback policy ---
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://192.168.1.163:11434/",   # RFC1918 192.168/16
+        "http://10.0.0.5:11434/",        # RFC1918 10/8
+        "http://172.16.5.5:11434/",      # RFC1918 172.16/12
+        "http://127.0.0.1:11434/",       # loopback IPv4
+        "http://[::1]:11434/",           # loopback IPv6
+        "http://[::ffff:192.168.1.1]/",  # IPv4-mapped IPv6 LAN
+    ],
+)
+def test_ollama_accepts_lan_and_loopback_ip(base_url: str) -> None:
+    cred = OrgAICredentialCreate(
+        provider=AiProvider.OLLAMA,
+        base_url=base_url,
+    )
+    assert cred.base_url == base_url
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://169.254.169.254/",                   # AWS/GCP/DO IMDS
+        "http://[fd00:ec2::254]/",                   # AWS IPv6 IMDS
+        "http://[::ffff:169.254.169.254]/",          # mapped IPv6 metadata
+        "http://169.254.1.1/",                       # link-local non-metadata
+        "http://224.0.0.1/",                         # multicast
+    ],
+)
+def test_ollama_still_rejects_metadata_and_unsafe(base_url: str) -> None:
+    with pytest.raises(ValidationError):
+        OrgAICredentialCreate(
+            provider=AiProvider.OLLAMA,
+            base_url=base_url,
+        )
+
+
+def test_openai_compatible_still_rejects_lan_ip() -> None:
+    """Strict SSRF block unchanged for non-Ollama providers."""
+    with pytest.raises(ValidationError):
+        OrgAICredentialCreate(
+            provider=AiProvider.OPENAI_COMPATIBLE,
+            api_key="sk-test-key-1234",
+            base_url="http://192.168.1.163/",
+        )
+
+
+def test_public_ip_still_accepted_for_any_provider() -> None:
+    cred_ollama = OrgAICredentialCreate(
+        provider=AiProvider.OLLAMA,
+        base_url="https://ollama.example.com/",
+    )
+    cred_openai = OrgAICredentialCreate(
+        provider=AiProvider.OPENAI_COMPATIBLE,
+        api_key="sk-test-key-1234",
+        base_url="https://api.example.com/",
+    )
+    assert cred_ollama.base_url.endswith(".example.com/")
+    assert cred_openai.base_url.endswith(".example.com/")

--- a/specs/2026-05-29-hide-payments-seo-baseline-ollama-lan-plan.md
+++ b/specs/2026-05-29-hide-payments-seo-baseline-ollama-lan-plan.md
@@ -1,0 +1,1608 @@
+# Hide Payments + Baseline SEO + Ollama LAN Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship three independent PRs that (A) unblock LAN/loopback IPs for Ollama credentials, (B) hide all remaining payment/billing/upgrade surfaces, and (C) ship baseline SEO so the marketing site is indexable and the rest of the app is not.
+
+**Architecture:** Three phases, one PR per phase, no inter-PR dependency — implementer can ship in any order. PR A includes the design spec commit. PR B extends the existing `billing_ui_enabled` flag (shipped 2026-05-21) to its remaining gaps without introducing new infrastructure. PR C flips the default `robots` directive in the root layout from `index` to `noindex` and opts in the 7 indexable public routes — fewer file touches and a safer default than opt-out-per-page.
+
+**Tech Stack:** FastAPI / SQLAlchemy 2.0 / Pydantic v2 (backend), Next.js 15 App Router / React 19 / Vitest (frontend), Docker Compose (test runner per CLAUDE.md).
+
+**Spec:** `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md` — read it first; this plan implements that spec exactly.
+
+---
+
+## File Structure (across all three PRs)
+
+### PR A — Ollama validator
+- **Modify** `backend/app/schemas/org_ai_credential.py:29-130` — split IP guard into two helpers, move provider-conditional check into model validator.
+- **Modify** `backend/tests/schemas/test_org_ai_credential_ssrf.py` — extend with the 9-case test matrix.
+- **Commit** `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md` (the design spec, hitching a ride on the smallest PR).
+- **Commit** `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan-plan.md` (this plan).
+
+### PR B — Hide remaining payment surfaces
+- **Delete** `frontend/components/landing/PricingPreview.tsx`
+- **Modify** `frontend/app/page.tsx` — remove `PricingPreview` import + render.
+- **Modify** `frontend/components/landing/Faq.tsx` — delete 2 payment entries, strip "(Pro tier)".
+- **Modify** `frontend/components/landing/Hero.tsx` — add "Free while in beta" line near CTA.
+- **Modify** `frontend/components/AppShell.tsx` — gate Subscriptions + Plan Catalog admin nav entries on `billingUiEnabled`.
+- **Modify** `backend/app/services/subscription_service.py:86` — gate `_send_trial_email_safe` call on `app_settings.billing_ui_enabled`.
+- **Modify** `backend/tests/services/test_email_templates.py` (or new file) — add gating tests.
+- **Create** `frontend/tests/landing-payments-hidden.test.tsx` — render assertions for the deleted surfaces.
+- **Create** `frontend/tests/appshell-admin-nav-billing-gate.test.tsx` — admin nav assertions for both flag states.
+
+### PR C — Baseline SEO
+- **Modify** `frontend/app/layout.tsx:28-31` — flip default `robots` to `{ index: false, follow: false }`.
+- **Modify** the 7 indexable pages (`/`, `/login`, `/register`, `/privacy`, `/terms`, `/docs`, `/docs/plans`) — add `robots: { index: true, follow: true }` to each page's existing `metadata` export.
+- **Modify** `frontend/app/sitemap.ts` — append `/docs` and `/docs/plans`.
+- **Modify** `frontend/components/landing/Hero.tsx` — `<h1>` audit + tune.
+- **Modify** `frontend/app/page.tsx` — extend JSON-LD with `author` / `publisher` and add a sibling `FAQPage` block.
+- **Verify** per-page metadata distinctness on the 7 indexable routes (small fixes if any inherit the root template).
+- **Create** `specs/seo-admin-config-backlog.md` — backlog doc for the future per-route SEO admin UI.
+- **Create** `frontend/tests/root-layout-robots-default.test.tsx` — root layout default is noindex.
+- **Create** `frontend/tests/seo-public-routes-indexable.test.tsx` — opt-in pages override to index.
+- **Create** `frontend/tests/seo-flow-routes-noindex.test.tsx` — inheritance check on a flow-only route.
+- **Create** `frontend/tests/landing-jsonld-faqpage.test.tsx` — FAQPage block + author/publisher presence.
+- **Create** `frontend/tests/sitemap-includes-docs.test.ts` — sitemap.ts contains /docs.
+
+---
+
+## Conventions for all phases
+
+**Test runner (per CLAUDE.md):**
+- Backend tests: `docker compose exec backend pytest <path>`
+- Frontend tests: `docker compose exec frontend npm test -- <path>`
+- TypeScript check: `docker compose exec frontend npx tsc --noEmit`
+
+**This is the user's local stack** (not a parallel agent session), so plain `docker compose exec` without `-p team-<name>` is correct. If executing as a subagent dispatched in parallel, the implementer MUST follow `~/.claude/projects/-Users-flamarion-src-tbd/memory/reference_shared_mysql_volume_trap.md` and isolate the compose project with `-p team-<name>`.
+
+**Branch naming:** `fix/ollama-lan-ip-allow`, `feat/hide-remaining-payment-surfaces`, `feat/baseline-seo-noindex-default`.
+
+**PR style (per [[feedback_pr_format]] + [[feedback_no_ai_attribution]]):** Concise description, no test-plan section, no Co-Authored-By.
+
+**Commit style:** Frequent, small, with `feat`/`fix`/`test`/`chore` prefix. Never push to main. Always PR.
+
+---
+
+# PHASE A — PR A: Ollama validator allows LAN/loopback IPs
+
+**Goal:** Backend Pydantic schema accepts `http://192.168.1.163:11434/` and `http://127.0.0.1:11434/` (and IPv6 loopback `[::1]`) when `provider=ollama`, while still rejecting cloud metadata IPs and link-local. Other providers retain the strict block.
+
+**Branch:** `fix/ollama-lan-ip-allow`
+
+---
+
+### Task A.1: Create branch off main
+
+**Files:** none yet.
+
+- [ ] **Step 1: Confirm main is clean and current**
+
+```bash
+git fetch origin
+git status
+```
+Expected: clean working tree, on any branch.
+
+- [ ] **Step 2: Branch off origin/main**
+
+```bash
+git checkout -b fix/ollama-lan-ip-allow origin/main
+```
+Expected: `Switched to a new branch 'fix/ollama-lan-ip-allow'`.
+
+---
+
+### Task A.2: Commit the design spec + plan (PR A carries these)
+
+**Files:**
+- Add: `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md` (already on disk, untracked)
+- Add: `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan-plan.md` (this plan, already on disk, untracked)
+
+- [ ] **Step 1: Verify both files are present**
+
+```bash
+ls specs/2026-05-29-hide-payments-seo-baseline-ollama-lan*.md
+```
+Expected: both files listed.
+
+- [ ] **Step 2: Stage and commit**
+
+```bash
+git add specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md specs/2026-05-29-hide-payments-seo-baseline-ollama-lan-plan.md
+git commit -m "spec: hide payments + baseline SEO + Ollama LAN allow"
+```
+
+---
+
+### Task A.3: Write failing test for Ollama LAN IP acceptance
+
+**Files:**
+- Test: `backend/tests/schemas/test_org_ai_credential_ssrf.py`
+
+- [ ] **Step 1: Inspect existing test file structure**
+
+```bash
+docker compose exec backend cat backend/tests/schemas/test_org_ai_credential_ssrf.py | head -60
+```
+Expected output: shows the existing import block, fixtures, and test naming convention. Use the same style and helpers below.
+
+- [ ] **Step 2: Append the new test cases at the end of the file**
+
+```python
+# --- 2026-05-29: Ollama LAN/loopback policy ---
+
+import pytest
+from pydantic import ValidationError
+from app.schemas.org_ai_credential import OrgAICredentialCreate
+from app.models.org_ai_credential import AiProvider
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://192.168.1.163:11434/",   # RFC1918 192.168/16
+        "http://10.0.0.5:11434/",        # RFC1918 10/8
+        "http://172.16.5.5:11434/",      # RFC1918 172.16/12
+        "http://127.0.0.1:11434/",       # loopback IPv4
+        "http://[::1]:11434/",           # loopback IPv6
+        "http://[::ffff:192.168.1.1]/",  # IPv4-mapped IPv6 LAN
+    ],
+)
+def test_ollama_accepts_lan_and_loopback_ip(base_url):
+    cred = OrgAICredentialCreate(
+        provider=AiProvider.OLLAMA,
+        base_url=base_url,
+    )
+    assert cred.base_url == base_url
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://169.254.169.254/",                   # AWS/GCP/DO IMDS
+        "http://[fd00:ec2::254]/",                   # AWS IPv6 IMDS
+        "http://[::ffff:169.254.169.254]/",          # mapped IPv6 metadata
+        "http://169.254.1.1/",                       # link-local non-metadata
+        "http://224.0.0.1/",                         # multicast
+    ],
+)
+def test_ollama_still_rejects_metadata_and_unsafe(base_url):
+    with pytest.raises(ValidationError):
+        OrgAICredentialCreate(
+            provider=AiProvider.OLLAMA,
+            base_url=base_url,
+        )
+
+
+def test_openai_compatible_still_rejects_lan_ip():
+    """Strict SSRF block unchanged for non-Ollama providers."""
+    with pytest.raises(ValidationError):
+        OrgAICredentialCreate(
+            provider=AiProvider.OPENAI_COMPATIBLE,
+            api_key="sk-test-key-1234",
+            base_url="http://192.168.1.163/",
+        )
+
+
+def test_public_ip_still_accepted_for_any_provider():
+    cred_ollama = OrgAICredentialCreate(
+        provider=AiProvider.OLLAMA,
+        base_url="https://ollama.example.com/",
+    )
+    cred_openai = OrgAICredentialCreate(
+        provider=AiProvider.OPENAI_COMPATIBLE,
+        api_key="sk-test-key-1234",
+        base_url="https://api.example.com/",
+    )
+    assert cred_ollama.base_url.endswith(".example.com/")
+    assert cred_openai.base_url.endswith(".example.com/")
+```
+
+- [ ] **Step 3: Run new tests to confirm they fail (current schema rejects LAN for Ollama)**
+
+```bash
+docker compose exec backend pytest backend/tests/schemas/test_org_ai_credential_ssrf.py -v -k "lan_and_loopback or still_rejects_metadata or openai_compatible_still or public_ip"
+```
+Expected: `test_ollama_accepts_lan_and_loopback_ip[…]` FAIL with ValidationError; the "rejects" tests likely PASS already (current strict block); `test_openai_compatible_still_rejects_lan_ip` PASS; `test_public_ip_still_accepted_for_any_provider` PASS.
+
+---
+
+### Task A.4: Refactor `_reject_private_ip_literal` into two helpers
+
+**Files:**
+- Modify: `backend/app/schemas/org_ai_credential.py:29-87`
+
+- [ ] **Step 1: Replace the single helper with two split helpers**
+
+Replace lines 29-69 (`_reject_private_ip_literal`) with:
+
+```python
+def _ip_or_none(host: str) -> "ipaddress._BaseAddress | None":
+    """Return the parsed IP if ``host`` is a literal address (with IPv4-mapped
+    IPv6 unwrapped to its IPv4 form), or None if it's a DNS name."""
+    if not host:
+        return None
+    candidate = host.strip("[]")
+    try:
+        ip = ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip
+
+
+def _reject_metadata_or_unsafe(host: str) -> None:
+    """Always-blocked classes (safe for all providers including Ollama):
+    cloud-metadata IPs, link-local (covers the rest of 169.254/16 beyond
+    the metadata constant), multicast, unspecified, and reserved.
+
+    DNS names pass through (see module docstring for the DNS rebinding
+    note)."""
+    ip = _ip_or_none(host)
+    if ip is None:
+        return
+    if str(ip) in _METADATA_IPS:
+        raise ValueError("base_url cannot point at a cloud metadata endpoint")
+    if (
+        ip.is_link_local
+        or ip.is_multicast
+        or ip.is_unspecified
+        or ip.is_reserved
+    ):
+        raise ValueError(
+            "base_url cannot point at a link-local, multicast, "
+            "unspecified, or reserved IP"
+        )
+
+
+def _reject_private_or_loopback(host: str) -> None:
+    """RFC1918 (10/8, 172.16/12, 192.168/16) and loopback (127.0.0.0/8, ::1).
+    Blocked for hosted providers; allowed for Ollama (operator's own LAN /
+    homelab — see spec 2026-05-29 section 3)."""
+    ip = _ip_or_none(host)
+    if ip is None:
+        return
+    if ip.is_private or ip.is_loopback:
+        raise ValueError(
+            "base_url cannot point at a private (RFC1918) or loopback IP"
+        )
+```
+
+- [ ] **Step 2: Update `_validate_base_url` to only call the always-blocked helper**
+
+Replace lines 72-87 with:
+
+```python
+def _validate_base_url(value: str) -> str:
+    """Reject base_url values that open an SSRF surface, regardless of
+    provider. Provider-conditional checks (RFC1918 / loopback) run in
+    the model validator where ``provider`` is known.
+
+    Allowed: http/https scheme + public hostname/IP. Private DNS names
+    (``ollama.internal``, ``my-llm.local``) ARE allowed — operators
+    fronting Ollama in their VPC need them. DNS rebinding remains a
+    residual v1 risk; a future iteration can add a custom httpx
+    transport that re-checks the resolved address before connect.
+    """
+    parsed = urlparse(value)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("base_url must use http or https scheme")
+    if not parsed.hostname:
+        raise ValueError("base_url must include a hostname")
+    _reject_metadata_or_unsafe(parsed.hostname)
+    return value
+```
+
+- [ ] **Step 3: Add the provider-conditional block to `_check_provider_requirements`**
+
+Inside the model validator at line ~110, immediately after the existing `base_url is required for ollama and openai_compatible providers` check, add:
+
+```python
+        # Provider-conditional SSRF policy:
+        # - Ollama: operator's own LAN/homelab, allow RFC1918 + loopback.
+        # - All other providers: strict block per the v1 SSRF guard.
+        if self.base_url and self.provider != AiProvider.OLLAMA:
+            parsed = urlparse(self.base_url)
+            if parsed.hostname:
+                _reject_private_or_loopback(parsed.hostname)
+```
+
+This belongs **after** the `base_url is required` check (so the missing-base_url ValueError fires first) and **before** the bearer_token / api_key checks.
+
+- [ ] **Step 4: Run the new tests to confirm they pass**
+
+```bash
+docker compose exec backend pytest backend/tests/schemas/test_org_ai_credential_ssrf.py -v
+```
+Expected: all tests in the file PASS, including the new ones from Task A.3.
+
+- [ ] **Step 5: Run the full schemas test suite to confirm no regressions**
+
+```bash
+docker compose exec backend pytest backend/tests/schemas/ -v
+```
+Expected: every test PASSES.
+
+- [ ] **Step 6: Run the AI credential service + crypto tests too (touch-test)**
+
+```bash
+docker compose exec backend pytest backend/tests/services/test_ai_credential_service.py backend/tests/services/test_ai_credential_crypto.py -v
+```
+Expected: all PASS.
+
+---
+
+### Task A.5: Commit and push the branch
+
+- [ ] **Step 1: Verify diff**
+
+```bash
+git diff --stat
+```
+Expected: 2 files changed — `backend/app/schemas/org_ai_credential.py` and `backend/tests/schemas/test_org_ai_credential_ssrf.py`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/schemas/org_ai_credential.py backend/tests/schemas/test_org_ai_credential_ssrf.py
+git commit -m "$(cat <<'EOF'
+fix(ai): allow RFC1918 + loopback for Ollama base_url
+
+Spec: specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md §3
+
+The 2026-05-22 BYO credentials SSRF guard rejects all literal private
+IPs unconditionally. PR #375 shipped LAN-only Ollama (no api_key) but
+left the IP literal guard intact, so the most natural LAN URL
+(http://192.168.1.163:11434/) hits a Pydantic ValidationError.
+
+Split _reject_private_ip_literal into two helpers:
+- _reject_metadata_or_unsafe — always blocked (metadata, link-local,
+  multicast, unspecified, reserved). Runs in the field validator.
+- _reject_private_or_loopback — RFC1918 + loopback. Runs in the
+  model validator only for non-Ollama providers.
+
+Behavior change is one-directional: previously rejected Ollama LAN
+URLs now accept. Previously accepted URLs continue to accept. Strict
+SSRF block for openai_compatible / anthropic / openai unchanged.
+EOF
+)"
+```
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin fix/ollama-lan-ip-allow
+gh pr create --title "fix(ai): allow RFC1918 + loopback for Ollama base_url" --body "$(cat <<'EOF'
+## Summary
+- Splits the SSRF IP guard into always-blocked vs provider-conditional helpers.
+- Ollama credentials now accept RFC1918 LAN + loopback (incl. `[::1]` and IPv4-mapped IPv6) — unblocks the LAN-only homelab mode shipped in PR #375.
+- Cloud metadata IPs (`169.254.169.254`, `fd00:ec2::254`) and link-local remain hard-blocked for ALL providers, including Ollama.
+- Strict block for `openai_compatible` / `anthropic` / `openai` is unchanged.
+
+## Spec
+specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md §3
+EOF
+)"
+```
+Expected: PR URL printed.
+
+---
+
+# PHASE B — PR B: Hide remaining payment surfaces
+
+**Goal:** With `BILLING_UI_ENABLED=false` (prod default), zero user-visible payment references anywhere. Landing surfaces hardcode-deleted (apex is static); in-app + backend surfaces flag-gated.
+
+**Branch:** `feat/hide-remaining-payment-surfaces`
+
+---
+
+### Task B.1: Create branch off main
+
+- [ ] **Step 1:**
+
+```bash
+git fetch origin && git checkout -b feat/hide-remaining-payment-surfaces origin/main
+```
+
+---
+
+### Task B.2: Write failing test for landing page payment-string absence
+
+**Files:**
+- Create: `frontend/tests/landing-payments-hidden.test.tsx`
+
+- [ ] **Step 1: Identify the existing landing-page test pattern**
+
+```bash
+docker compose exec frontend ls tests/ | grep -i landing
+```
+Expected: lists any existing landing tests, e.g., `landing-hero.test.tsx`. Mimic the import + render style.
+
+- [ ] **Step 2: Create the new test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import LandingPage from "@/app/page";
+
+describe("landing page after payment hide", () => {
+  it("has zero references to pricing/plans/payment", async () => {
+    const ui = await LandingPage();
+    const { container } = render(ui as React.ReactElement);
+    const text = container.textContent ?? "";
+
+    const forbidden = [
+      "Pro",
+      "Team",
+      "€9",
+      "€19",
+      "Coming soon",
+      "Join the waitlist",
+      "Pricing",
+      "payment methods",
+      "free plan",
+    ];
+
+    for (const needle of forbidden) {
+      expect(text.toLowerCase()).not.toContain(needle.toLowerCase());
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run to confirm it fails**
+
+```bash
+docker compose exec frontend npm test -- tests/landing-payments-hidden.test.tsx
+```
+Expected: FAIL — at least "Pro", "Team", "€9", "Coming soon", "Join the waitlist" still appear (from PricingPreview).
+
+---
+
+### Task B.3: Delete `PricingPreview.tsx` and remove the import
+
+**Files:**
+- Delete: `frontend/components/landing/PricingPreview.tsx`
+- Modify: `frontend/app/page.tsx`
+
+- [ ] **Step 1: Find the import + render site in page.tsx**
+
+```bash
+grep -n "PricingPreview" /Users/flamarion/src/tbd/frontend/app/page.tsx
+```
+Expected: two matches — one import line near the top, one `<PricingPreview />` tag in the JSX.
+
+- [ ] **Step 2: Delete the file**
+
+```bash
+git rm frontend/components/landing/PricingPreview.tsx
+```
+
+- [ ] **Step 3: Remove import + render from `page.tsx`**
+
+Use Edit to remove the import line and the `<PricingPreview />` JSX tag. The component sits between other landing sections — leave the surrounding sections untouched.
+
+- [ ] **Step 4: Re-run the landing test**
+
+```bash
+docker compose exec frontend npm test -- tests/landing-payments-hidden.test.tsx
+```
+Expected: most forbidden strings are now gone; "free plan" + "payment methods" may still fail (from `Faq.tsx`).
+
+---
+
+### Task B.4: Delete payment FAQ entries and strip "(Pro tier)"
+
+**Files:**
+- Modify: `frontend/components/landing/Faq.tsx`
+
+- [ ] **Step 1: Inspect the FAQ data structure**
+
+```bash
+sed -n '1,80p' /Users/flamarion/src/tbd/frontend/components/landing/Faq.tsx
+```
+Expected: shows the FAQ array. Locate:
+- The entry with question containing "payment methods".
+- The entry with question containing "free plan" (in the "Is there a free plan?" sense — NOT the free-tier reference inside the AI assistant line).
+- The line referring to "AI assistant (Pro tier)".
+
+- [ ] **Step 2: Delete the two entries from the array**
+
+Use Edit on `Faq.tsx` to remove the two objects (`{ q: "What payment methods...", a: "..." }` and `{ q: "Is there a free plan?", a: "..." }`). Preserve the trailing comma discipline of the array (no dangling commas, no missing ones).
+
+- [ ] **Step 3: Strip "(Pro tier)" from the AI-assistant line**
+
+In the AI-assistant feature description, change `optional AI assistant (Pro tier)` → `optional AI assistant`. Keep the rest of the sentence intact.
+
+- [ ] **Step 4: Re-run the landing test**
+
+```bash
+docker compose exec frontend npm test -- tests/landing-payments-hidden.test.tsx
+```
+Expected: PASS (all forbidden strings absent).
+
+- [ ] **Step 5: Quick visual sanity (TypeScript + tsc)**
+
+```bash
+docker compose exec frontend npx tsc --noEmit
+```
+Expected: no type errors.
+
+---
+
+### Task B.5: Add "Free while in beta" line near the Hero CTA
+
+**Files:**
+- Modify: `frontend/components/landing/Hero.tsx`
+
+- [ ] **Step 1: Find the primary CTA in the hero**
+
+```bash
+grep -n "Get started\|Create your\|signup\|sign up\|register\|Try" /Users/flamarion/src/tbd/frontend/components/landing/Hero.tsx
+```
+Expected: shows the CTA `<Link>` or `<a>` element and surrounding markup.
+
+- [ ] **Step 2: Add the line immediately below the CTA**
+
+The exact JSX depends on Hero's structure. Add a paragraph or span with these EXACT classes if Tailwind is used (match siblings) and this EXACT copy:
+
+```tsx
+<p className="mt-3 text-sm text-foreground/70">
+  Free while in beta. No credit card required.
+</p>
+```
+
+If a different classname pattern is already used (e.g., `text-muted-foreground`, `text-slate-500`), follow that pattern. Keep the copy verbatim.
+
+- [ ] **Step 3: Render-check the landing**
+
+```bash
+docker compose exec frontend npm test -- tests/landing-payments-hidden.test.tsx
+```
+Expected: still PASS (the new line doesn't contain any forbidden strings).
+
+---
+
+### Task B.6: Commit the landing changes
+
+- [ ] **Step 1:**
+
+```bash
+git add -u frontend/components/landing/PricingPreview.tsx frontend/app/page.tsx frontend/components/landing/Faq.tsx frontend/components/landing/Hero.tsx frontend/tests/landing-payments-hidden.test.tsx
+git commit -m "feat(landing): hide pricing + payment FAQs, add beta notice"
+```
+
+---
+
+### Task B.7: Write failing test for AppShell admin nav gating
+
+**Files:**
+- Create: `frontend/tests/appshell-admin-nav-billing-gate.test.tsx`
+
+- [ ] **Step 1: Find how AppShell is tested today**
+
+```bash
+docker compose exec frontend ls tests/ | grep -i appshell
+```
+Expected: lists existing AppShell tests. Borrow the auth-context mock pattern.
+
+- [ ] **Step 2: Create the test**
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AppShell from "@/components/AppShell";
+
+const makeSuperadminAuth = (billingUiEnabled: boolean) => ({
+  user: {
+    id: 1,
+    email: "a@b",
+    is_superadmin: true,
+    org_role: "owner",
+  },
+  billingUiEnabled,
+  // … fill in other required AuthContext fields with sensible defaults
+});
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from "@/components/auth/AuthProvider";
+
+describe("AppShell admin nav billing gate", () => {
+  it("hides Subscriptions and Plan Catalog when billingUiEnabled=false", () => {
+    (useAuth as any).mockReturnValue(makeSuperadminAuth(false));
+    render(<AppShell><div /></AppShell>);
+    expect(screen.queryByText("Subscriptions")).toBeNull();
+    expect(screen.queryByText("Plan Catalog")).toBeNull();
+  });
+
+  it("shows Subscriptions and Plan Catalog when billingUiEnabled=true", () => {
+    (useAuth as any).mockReturnValue(makeSuperadminAuth(true));
+    render(<AppShell><div /></AppShell>);
+    expect(screen.getByText("Subscriptions")).toBeInTheDocument();
+    expect(screen.getByText("Plan Catalog")).toBeInTheDocument();
+  });
+});
+```
+
+NOTE: the `makeSuperadminAuth` helper needs the full shape of `AuthContextValue`. Open `frontend/components/auth/AuthProvider.tsx`, copy the value type, and fill in defaults for any required field not shown above. Don't ship a `TODO: fill in fields` comment.
+
+- [ ] **Step 3: Run to confirm failure**
+
+```bash
+docker compose exec frontend npm test -- tests/appshell-admin-nav-billing-gate.test.tsx
+```
+Expected: the first test FAILS (Subscriptions/Plan Catalog visible when flag is off); the second test PASSES.
+
+---
+
+### Task B.8: Gate the two admin nav entries in `AppShell.tsx`
+
+**Files:**
+- Modify: `frontend/components/AppShell.tsx:170-200` (the admin nav array)
+
+- [ ] **Step 1: Locate the admin nav declaration**
+
+```bash
+sed -n '160,210p' /Users/flamarion/src/tbd/frontend/components/AppShell.tsx
+```
+Expected: shows the array literal containing Subscriptions and Plan Catalog entries (lines ~178 and ~184-188 per the inventory).
+
+- [ ] **Step 2: Confirm `billingUiEnabled` is already destructured from `useAuth()`**
+
+If not, add it. Pattern (mirrors how SettingsLayout does it):
+
+```tsx
+const { user, billingUiEnabled } = useAuth();
+```
+
+- [ ] **Step 3: Filter the two entries**
+
+Two equivalent edits — pick whichever matches the local style:
+
+**Option 1 (inline conditional spread):**
+
+```tsx
+const adminNav = [
+  // … other admin entries unchanged
+  ...(billingUiEnabled
+    ? [
+        { label: "Subscriptions", href: "/admin/subscriptions", icon: CreditCard },
+        { label: "Plan Catalog", href: "/system/plans", icon: CreditCard },
+      ]
+    : []),
+  // … other admin entries unchanged
+];
+```
+
+**Option 2 (post-build filter):**
+
+```tsx
+const adminNav = [
+  // … all entries including Subscriptions + Plan Catalog
+].filter(item => {
+  if (!billingUiEnabled && (item.href === "/admin/subscriptions" || item.href === "/system/plans")) {
+    return false;
+  }
+  return true;
+});
+```
+
+Match the codebase style — if `SettingsLayout` uses Option 2 (post-build filter), use Option 2 here too for consistency. Check first:
+
+```bash
+grep -A6 "billingUiEnabled" /Users/flamarion/src/tbd/frontend/components/SettingsLayout.tsx
+```
+
+- [ ] **Step 4: Re-run the test**
+
+```bash
+docker compose exec frontend npm test -- tests/appshell-admin-nav-billing-gate.test.tsx
+```
+Expected: both tests PASS.
+
+- [ ] **Step 5: TS check**
+
+```bash
+docker compose exec frontend npx tsc --noEmit
+```
+Expected: clean.
+
+---
+
+### Task B.9: Commit the AppShell changes
+
+```bash
+git add frontend/components/AppShell.tsx frontend/tests/appshell-admin-nav-billing-gate.test.tsx
+git commit -m "feat(appshell): gate Subscriptions + Plan Catalog admin nav on billingUiEnabled"
+```
+
+---
+
+### Task B.10: Write failing test for trial-email gating
+
+**Files:**
+- Modify: `backend/tests/services/test_email_templates.py` (extend) OR create `backend/tests/services/test_subscription_service_trial_email_gate.py`.
+
+Choose **extend** if `test_email_templates.py` already imports `app_settings`; otherwise create a new file to keep the email-template-formatting tests separate from gating logic tests. Per the inventory it's likely cleaner to create a new file.
+
+- [ ] **Step 1: Create the new test file**
+
+```python
+"""Test that send_trial_expiring_email is gated by billing_ui_enabled."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import subscription_service
+
+
+@pytest.mark.asyncio
+async def test_send_trial_email_safe_no_op_when_flag_off(monkeypatch):
+    """When BILLING_UI_ENABLED=false, the trial reminder email is not sent."""
+    monkeypatch.setattr(
+        "app.services.subscription_service.app_settings.billing_ui_enabled",
+        False,
+    )
+    sent = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.subscription_service.send_trial_expiring_email",
+        sent,
+    )
+    await subscription_service._send_trial_email_safe(
+        email="u@x.com",
+        days_left=3,
+        org_name="Doe Household",
+    )
+    sent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_trial_email_safe_sends_when_flag_on(monkeypatch):
+    """When BILLING_UI_ENABLED=true, the trial reminder email IS sent."""
+    monkeypatch.setattr(
+        "app.services.subscription_service.app_settings.billing_ui_enabled",
+        True,
+    )
+    sent = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.subscription_service.send_trial_expiring_email",
+        sent,
+    )
+    await subscription_service._send_trial_email_safe(
+        email="u@x.com",
+        days_left=3,
+        org_name="Doe Household",
+    )
+    sent.assert_called_once_with("u@x.com", 3, "Doe Household")
+```
+
+- [ ] **Step 2: Confirm `app_settings` is imported in subscription_service.py**
+
+```bash
+grep -n "app_settings\|from app.config" /Users/flamarion/src/tbd/backend/app/services/subscription_service.py | head
+```
+If `app_settings` is not yet imported, the next step's edit will add the import.
+
+- [ ] **Step 3: Run the new tests to confirm they fail**
+
+```bash
+docker compose exec backend pytest backend/tests/services/test_subscription_service_trial_email_gate.py -v
+```
+Expected: `test_send_trial_email_safe_no_op_when_flag_off` FAILS (send IS called); `test_send_trial_email_safe_sends_when_flag_on` PASSES.
+
+---
+
+### Task B.11: Gate `_send_trial_email_safe` on `app_settings.billing_ui_enabled`
+
+**Files:**
+- Modify: `backend/app/services/subscription_service.py:82-90`
+
+- [ ] **Step 1: Add the import if absent**
+
+If `app_settings` is not already imported at the top of the file, add:
+
+```python
+from app.config import settings as app_settings
+```
+
+(Use the same alias name `app_settings` so the test's monkeypatch path matches.)
+
+- [ ] **Step 2: Add the gate inside `_send_trial_email_safe`**
+
+Replace the existing function body with:
+
+```python
+async def _send_trial_email_safe(email: str, days_left: int, org_name: str) -> None:
+    """Send trial reminder in background; swallow errors to avoid unhandled task exceptions.
+
+    No-op when billing UI is disabled (the user never sees a way to act
+    on the email; sending it would be confusing during the pre-payment
+    beta window).
+    """
+    if not app_settings.billing_ui_enabled:
+        return
+    try:
+        await send_trial_expiring_email(email, days_left, org_name)
+    except Exception:
+        await logger.awarning("trial_reminder_email_failed", email=email, days_left=days_left)
+```
+
+- [ ] **Step 3: Run the gating tests**
+
+```bash
+docker compose exec backend pytest backend/tests/services/test_subscription_service_trial_email_gate.py -v
+```
+Expected: both PASS.
+
+- [ ] **Step 4: Run the existing email-template tests (touch-test for regressions)**
+
+```bash
+docker compose exec backend pytest backend/tests/services/test_email_templates.py -v
+```
+Expected: all PASS (template formatting is unaffected; we only gated the caller).
+
+- [ ] **Step 5: Run the subscription_service test suite**
+
+```bash
+docker compose exec backend pytest backend/tests/services/ -v -k "subscription"
+```
+Expected: all PASS.
+
+---
+
+### Task B.12: Commit the backend changes
+
+```bash
+git add backend/app/services/subscription_service.py backend/tests/services/test_subscription_service_trial_email_gate.py
+git commit -m "feat(billing): gate _send_trial_email_safe on billing_ui_enabled"
+```
+
+---
+
+### Task B.13: Push and open PR
+
+```bash
+git push -u origin feat/hide-remaining-payment-surfaces
+gh pr create --title "feat: hide remaining payment surfaces (landing + admin nav + trial email)" --body "$(cat <<'EOF'
+## Summary
+- Deletes the landing pricing section and the two payment-related FAQ entries; adds a "Free while in beta" notice to the hero.
+- Gates the admin-nav "Subscriptions" and "Plan Catalog" entries on the existing `billingUiEnabled` flag (same pattern as `SettingsLayout`'s Billing tab).
+- Gates `_send_trial_email_safe` on `app_settings.billing_ui_enabled` so we stop sending trial-expiring emails while the customer-facing billing surface is hidden.
+- Landing-surface edits are hardcoded (apex landing is a static export and can't read the runtime flag) — revert via `git revert` when payment is wired.
+
+## Spec
+specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md §1
+EOF
+)"
+```
+
+---
+
+# PHASE C — PR C: Baseline SEO
+
+**Goal:** Marketing landing + 6 other public pages are indexable with distinct meta; everything else (auth-walled + flow-only public routes) is `noindex` by default. Sitemap covers public docs. Landing emits two JSON-LD blocks (`SoftwareApplication` + `FAQPage`).
+
+**Branch:** `feat/baseline-seo-noindex-default`
+
+**Strategy note:** No `(app)` route group exists; flipping the root layout to `noindex` default and opting-in 7 pages is fewer files (8) and a safer default than adding noindex to 25 individual routes.
+
+---
+
+### Task C.1: Create branch off main
+
+```bash
+git fetch origin && git checkout -b feat/baseline-seo-noindex-default origin/main
+```
+
+---
+
+### Task C.2: Write failing test — root layout default is noindex
+
+**Files:**
+- Create: `frontend/tests/root-layout-robots-default.test.tsx`
+
+- [ ] **Step 1: Create the test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { metadata } from "@/app/layout";
+
+describe("root layout default robots", () => {
+  it("defaults to noindex, nofollow (safer for an auth-walled app)", () => {
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+docker compose exec frontend npm test -- tests/root-layout-robots-default.test.tsx
+```
+Expected: FAIL — current root metadata.robots is `{ index: true, follow: true }`.
+
+---
+
+### Task C.3: Flip root layout default
+
+**Files:**
+- Modify: `frontend/app/layout.tsx:28-31`
+
+- [ ] **Step 1: Replace the robots block**
+
+Change
+
+```typescript
+  robots: {
+    index: true,
+    follow: true,
+  },
+```
+
+to
+
+```typescript
+  // Safer default for an auth-walled SaaS: noindex by default.
+  // The 7 indexable public pages (/, /login, /register, /privacy,
+  // /terms, /docs, /docs/plans) opt back in via their own metadata.
+  robots: {
+    index: false,
+    follow: false,
+  },
+```
+
+- [ ] **Step 2: Re-run the test**
+
+```bash
+docker compose exec frontend npm test -- tests/root-layout-robots-default.test.tsx
+```
+Expected: PASS.
+
+---
+
+### Task C.4: Write failing test — indexable pages opt back in
+
+**Files:**
+- Create: `frontend/tests/seo-public-routes-indexable.test.tsx`
+
+- [ ] **Step 1: Create the test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { metadata as rootMetadata } from "@/app/page";
+import { metadata as loginMetadata } from "@/app/login/page";
+import { metadata as registerMetadata } from "@/app/register/page";
+import { metadata as privacyMetadata } from "@/app/privacy/page";
+import { metadata as termsMetadata } from "@/app/terms/page";
+import { metadata as docsMetadata } from "@/app/docs/page";
+import { metadata as docsPlansMetadata } from "@/app/docs/plans/page";
+
+const indexableMetadatas = [
+  ["/", rootMetadata],
+  ["/login", loginMetadata],
+  ["/register", registerMetadata],
+  ["/privacy", privacyMetadata],
+  ["/terms", termsMetadata],
+  ["/docs", docsMetadata],
+  ["/docs/plans", docsPlansMetadata],
+] as const;
+
+describe("indexable public routes opt back into index", () => {
+  it.each(indexableMetadatas)("%s sets robots index/follow true", (_route, meta) => {
+    expect(meta.robots).toEqual({ index: true, follow: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+docker compose exec frontend npm test -- tests/seo-public-routes-indexable.test.tsx
+```
+Expected: FAIL — none of the pages explicitly set `robots: { index: true }`.
+
+---
+
+### Task C.5: Add `robots: { index: true, follow: true }` to the 7 indexable pages
+
+**Files:**
+- Modify each of:
+  - `frontend/app/page.tsx`
+  - `frontend/app/login/page.tsx`
+  - `frontend/app/register/page.tsx`
+  - `frontend/app/privacy/page.tsx`
+  - `frontend/app/terms/page.tsx`
+  - `frontend/app/docs/page.tsx`
+  - `frontend/app/docs/plans/page.tsx`
+
+- [ ] **Step 1: For each page, locate the existing `export const metadata` block**
+
+```bash
+for f in frontend/app/page.tsx frontend/app/login/page.tsx frontend/app/register/page.tsx frontend/app/privacy/page.tsx frontend/app/terms/page.tsx frontend/app/docs/page.tsx frontend/app/docs/plans/page.tsx; do
+  echo "=== $f ==="
+  grep -n "export const metadata\|robots:" /Users/flamarion/src/tbd/$f
+done
+```
+Expected: each page shows an `export const metadata = { ... }` line. None should currently have a `robots:` key.
+
+- [ ] **Step 2: Add the robots key to each page's metadata object**
+
+For each file, use Edit to add (preserving surrounding properties):
+
+```typescript
+  robots: { index: true, follow: true },
+```
+
+Place it adjacent to other top-level meta keys (e.g., after `title` / `description`). If the page uses a helper like `pageSocialMeta()` that spreads its return value, add the `robots` key OUTSIDE the spread (so it's not overridden):
+
+```typescript
+export const metadata: Metadata = {
+  ...pageSocialMeta({ /* … */ }),
+  robots: { index: true, follow: true },
+};
+```
+
+- [ ] **Step 3: Re-run the test**
+
+```bash
+docker compose exec frontend npm test -- tests/seo-public-routes-indexable.test.tsx
+```
+Expected: all 7 cases PASS.
+
+---
+
+### Task C.6: Write failing test — flow-only routes inherit noindex
+
+**Files:**
+- Create: `frontend/tests/seo-flow-routes-noindex.test.tsx`
+
+- [ ] **Step 1: Create the test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { metadata as forgotMetadata } from "@/app/forgot-password/page";
+import { metadata as resetMetadata } from "@/app/reset-password/page";
+import { metadata as verifyMetadata } from "@/app/verify-email/page";
+import { metadata as mfaMetadata } from "@/app/mfa-verify/page";
+import { metadata as onboardingMetadata } from "@/app/onboarding/page";
+import { metadata as acceptInviteMetadata } from "@/app/accept-invite/page";
+
+// These pages should NOT opt back into index — they inherit root's noindex.
+describe("flow-only public routes are not indexed", () => {
+  const flowMetadatas = [
+    ["/forgot-password", forgotMetadata],
+    ["/reset-password", resetMetadata],
+    ["/verify-email", verifyMetadata],
+    ["/mfa-verify", mfaMetadata],
+    ["/onboarding", onboardingMetadata],
+    ["/accept-invite", acceptInviteMetadata],
+  ] as const;
+
+  it.each(flowMetadatas)("%s does not opt back into index", (_route, meta) => {
+    // Either no robots key (inherit root noindex) or explicit noindex.
+    if (meta.robots !== undefined) {
+      expect(meta.robots).toEqual({ index: false, follow: false });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+docker compose exec frontend npm test -- tests/seo-flow-routes-noindex.test.tsx
+```
+Expected: PASS (these pages don't currently set `robots`, so they inherit the now-noindex root). If any page does set `robots: { index: true }`, the test FAILS and you must remove or correct that override.
+
+---
+
+### Task C.7: Commit Tasks C.2–C.6
+
+```bash
+git add frontend/app/layout.tsx frontend/app/page.tsx frontend/app/login/page.tsx frontend/app/register/page.tsx frontend/app/privacy/page.tsx frontend/app/terms/page.tsx frontend/app/docs/page.tsx frontend/app/docs/plans/page.tsx frontend/tests/root-layout-robots-default.test.tsx frontend/tests/seo-public-routes-indexable.test.tsx frontend/tests/seo-flow-routes-noindex.test.tsx
+git commit -m "feat(seo): default to noindex, opt 7 public routes back into index"
+```
+
+---
+
+### Task C.8: Write failing test — sitemap includes `/docs` and `/docs/plans`
+
+**Files:**
+- Create: `frontend/tests/sitemap-includes-docs.test.ts`
+
+- [ ] **Step 1: Create the test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import sitemap from "@/app/sitemap";
+
+describe("sitemap.ts", () => {
+  it("includes /docs and /docs/plans", () => {
+    const urls = sitemap().map(entry => new URL(entry.url).pathname);
+    expect(urls).toContain("/docs");
+    expect(urls).toContain("/docs/plans");
+  });
+
+  it("preserves the original 5 public URLs", () => {
+    const urls = sitemap().map(entry => new URL(entry.url).pathname);
+    expect(urls).toContain("/");
+    expect(urls).toContain("/login");
+    expect(urls).toContain("/register");
+    expect(urls).toContain("/privacy");
+    expect(urls).toContain("/terms");
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+docker compose exec frontend npm test -- tests/sitemap-includes-docs.test.ts
+```
+Expected: first test FAILS (sitemap currently has 5 URLs, none of them /docs); second PASSES.
+
+---
+
+### Task C.9: Append docs URLs to `sitemap.ts`
+
+**Files:**
+- Modify: `frontend/app/sitemap.ts`
+
+- [ ] **Step 1: Inspect current sitemap**
+
+```bash
+cat /Users/flamarion/src/tbd/frontend/app/sitemap.ts
+```
+
+- [ ] **Step 2: Add the two new entries**
+
+Append two entries with priority 0.4 (support content, not conversion):
+
+```typescript
+  {
+    url: `${siteUrl}/docs`,
+    lastModified: new Date(),
+    changeFrequency: "monthly",
+    priority: 0.4,
+  },
+  {
+    url: `${siteUrl}/docs/plans`,
+    lastModified: new Date(),
+    changeFrequency: "monthly",
+    priority: 0.4,
+  },
+```
+
+Match the existing import + `siteUrl` helper used by the file. Field names (`changeFrequency` casing, etc.) must match Next.js's `MetadataRoute.Sitemap` type — copy from the existing entries above.
+
+- [ ] **Step 3: Re-run**
+
+```bash
+docker compose exec frontend npm test -- tests/sitemap-includes-docs.test.ts
+```
+Expected: both PASS.
+
+---
+
+### Task C.10: Write failing test — Hero has exactly one `<h1>`
+
+**Files:**
+- Create: `frontend/tests/hero-single-h1.test.tsx`
+
+- [ ] **Step 1: Create the test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import Hero from "@/components/landing/Hero";
+
+describe("Hero", () => {
+  it("renders exactly one <h1>", () => {
+    const { container } = render(<Hero />);
+    expect(container.querySelectorAll("h1").length).toBe(1);
+  });
+
+  it("h1 contains keyword-friendly copy", () => {
+    const { container } = render(<Hero />);
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent ?? "").toMatch(/finance|money|budget|plan/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+docker compose exec frontend npm test -- tests/hero-single-h1.test.tsx
+```
+Expected: either PASS already (if Hero has one h1 with keyword content) or FAIL (audit-and-fix in next task).
+
+---
+
+### Task C.11: Hero `<h1>` audit + tune
+
+**Files:**
+- Modify: `frontend/components/landing/Hero.tsx` (only if needed)
+
+- [ ] **Step 1: Open Hero.tsx and count `<h1>` elements**
+
+```bash
+grep -c "<h1" /Users/flamarion/src/tbd/frontend/components/landing/Hero.tsx
+```
+
+- [ ] **Step 2: Apply fixes based on Step 1**
+
+- If count == 0: add an `<h1>` containing the starter copy `"Personal finance, planned not panicked"` (operator may finalize the exact phrase before merge).
+- If count == 1 and the test from Task C.10 passes: no change.
+- If count > 1: demote extras to `<h2>` while keeping their styling. Re-run the test.
+
+- [ ] **Step 3: Re-run**
+
+```bash
+docker compose exec frontend npm test -- tests/hero-single-h1.test.tsx
+```
+Expected: both tests PASS.
+
+---
+
+### Task C.12: Verify per-page metadata distinctness (audit + small fixes)
+
+**Files:**
+- Read: each of the 7 indexable pages' `metadata` block.
+- Modify: only those that just inherit the root template (no own `title` / `description`).
+
+- [ ] **Step 1: Print each page's title + description**
+
+```bash
+for f in frontend/app/page.tsx frontend/app/login/page.tsx frontend/app/register/page.tsx frontend/app/privacy/page.tsx frontend/app/terms/page.tsx frontend/app/docs/page.tsx frontend/app/docs/plans/page.tsx; do
+  echo "=== $f ==="
+  sed -n '/export const metadata/,/^};/p' /Users/flamarion/src/tbd/$f
+done
+```
+
+- [ ] **Step 2: Confirm each page has distinct, keyword-relevant `title` + `description`**
+
+For each page, the title should be unique (not just the root template's default) and reflect the page's intent. The description should be 130-160 chars, mention the page's topic, and include search-relevant terms.
+
+If a page is missing distinct metadata, add it. Example for `/login`:
+
+```typescript
+export const metadata: Metadata = {
+  title: "Sign in",  // becomes "Sign in · The Better Decision" via root template
+  description: "Sign in to The Better Decision to manage your accounts, budgets, and financial plans.",
+  robots: { index: true, follow: true },
+};
+```
+
+NOTE: do NOT replicate the root description on every page — that triggers duplicate-description warnings in Search Console.
+
+- [ ] **Step 3: Commit Tasks C.8–C.12 (sitemap + Hero + metadata audit)**
+
+```bash
+git add frontend/app/sitemap.ts frontend/components/landing/Hero.tsx \
+  frontend/app/page.tsx frontend/app/login/page.tsx frontend/app/register/page.tsx \
+  frontend/app/privacy/page.tsx frontend/app/terms/page.tsx \
+  frontend/app/docs/page.tsx frontend/app/docs/plans/page.tsx \
+  frontend/tests/sitemap-includes-docs.test.ts \
+  frontend/tests/hero-single-h1.test.tsx
+git commit -m "feat(seo): expand sitemap with docs, audit Hero h1, distinct per-page meta"
+```
+
+---
+
+### Task C.13: Write failing test — landing JSON-LD has SoftwareApplication + FAQPage
+
+**Files:**
+- Create: `frontend/tests/landing-jsonld-faqpage.test.tsx`
+
+- [ ] **Step 1: Create the test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import LandingPage from "@/app/page";
+
+describe("landing JSON-LD", () => {
+  it("renders SoftwareApplication and FAQPage blocks", async () => {
+    const ui = await LandingPage();
+    const { container } = render(ui as React.ReactElement);
+    const scripts = Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    );
+    expect(scripts.length).toBeGreaterThanOrEqual(2);
+
+    const parsed = scripts.map(s => JSON.parse(s.textContent ?? "{}"));
+    const types = parsed.map(p => p["@type"]);
+    expect(types).toContain("SoftwareApplication");
+    expect(types).toContain("FAQPage");
+
+    const software = parsed.find(p => p["@type"] === "SoftwareApplication");
+    expect(software.author).toBeDefined();
+    expect(software.publisher).toBeDefined();
+  });
+
+  it("FAQPage excludes the deleted payment FAQs", async () => {
+    const ui = await LandingPage();
+    const { container } = render(ui as React.ReactElement);
+    const scripts = Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    );
+    const faq = scripts
+      .map(s => JSON.parse(s.textContent ?? "{}"))
+      .find(p => p["@type"] === "FAQPage");
+    const text = JSON.stringify(faq);
+    expect(text.toLowerCase()).not.toContain("payment methods");
+    expect(text.toLowerCase()).not.toContain("free plan");
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+docker compose exec frontend npm test -- tests/landing-jsonld-faqpage.test.tsx
+```
+Expected: FAIL — only one JSON-LD block exists (SoftwareApplication), and it lacks author/publisher.
+
+---
+
+### Task C.14: Extend landing JSON-LD in `page.tsx`
+
+**Files:**
+- Modify: `frontend/app/page.tsx`
+
+- [ ] **Step 1: Locate the existing `application/ld+json` script tag**
+
+```bash
+grep -n "application/ld+json\|SoftwareApplication" /Users/flamarion/src/tbd/frontend/app/page.tsx
+```
+
+- [ ] **Step 2: Add `author` + `publisher` to the SoftwareApplication block**
+
+In the JSON object passed to the existing script tag, add:
+
+```typescript
+author: { "@type": "Organization", name: siteName, url: siteUrl },
+publisher: { "@type": "Organization", name: siteName, url: siteUrl },
+```
+
+Use the existing `siteName` / `siteUrl` imports — don't hardcode.
+
+- [ ] **Step 3: Build the FAQ data shared with both `Faq.tsx` and the JSON-LD block**
+
+If the FAQ entries live solely inside `Faq.tsx`, extract them into `frontend/components/landing/faqData.ts` (or wherever existing landing data co-locates):
+
+```typescript
+// frontend/components/landing/faqData.ts
+export type FaqEntry = { q: string; a: string };
+
+export const faqEntries: ReadonlyArray<FaqEntry> = [
+  // … paste the surviving entries from Faq.tsx (post PR B) here
+];
+```
+
+Update `Faq.tsx` to import from this shared file. Then `page.tsx` imports the same array and renders the JSON-LD.
+
+If extraction is too invasive, an acceptable v1 alternative is to manually duplicate the entries in `page.tsx` — but flag this as a small follow-up. (Recommendation: do the extraction; it's a 10-minute task and avoids drift.)
+
+- [ ] **Step 4: Add a second JSON-LD script for FAQPage**
+
+In the same head block as the existing SoftwareApplication script, render:
+
+```tsx
+<script
+  type="application/ld+json"
+  nonce={nonce ?? undefined}
+  dangerouslySetInnerHTML={{
+    __html: JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: faqEntries.map(entry => ({
+        "@type": "Question",
+        name: entry.q,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: entry.a,
+        },
+      })),
+    }),
+  }}
+/>
+```
+
+Use the same nonce handling pattern as the existing JSON-LD script (so CSP is satisfied).
+
+- [ ] **Step 5: Re-run**
+
+```bash
+docker compose exec frontend npm test -- tests/landing-jsonld-faqpage.test.tsx
+```
+Expected: both tests PASS.
+
+---
+
+### Task C.15: Write the SEO admin-UI backlog file
+
+**Files:**
+- Create: `specs/seo-admin-config-backlog.md`
+
+- [ ] **Step 1: Create the file**
+
+Write the following content verbatim:
+
+```markdown
+# SEO admin config UI — backlog
+
+**Created:** 2026-05-29 (split-off from the baseline-SEO spec because the operator wants this in the future but not in the baseline PR).
+**Parent spec:** `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md` §2.
+
+## Intent
+
+Today the per-route `title` / `description` / OG / `robots` is baked into each `page.tsx` via Next.js's `export const metadata`. The operator wants to be able to tune SEO without a code deploy — for example, changing the landing title for an A/B test, refreshing keyword-rich descriptions per route, or pointing a route at a different OG image.
+
+## Sketched data model
+
+New table `seo_overrides`:
+
+| col | type | notes |
+|---|---|---|
+| `id` | int PK | |
+| `route` | varchar(255) UNIQUE | `/`, `/login`, etc. Match Next.js's pathname. |
+| `title` | varchar(255) NULL | overrides metadata.title.absolute |
+| `description` | varchar(255) NULL | |
+| `og_image_url` | varchar(512) NULL | absolute URL or path under `/og/` |
+| `robots_index` | tinyint NULL | NULL = inherit; 0/1 = override |
+| `keywords` | text NULL | comma-separated, for ops reference only (no impact on SERPs) |
+| `created_by_user_id`, `updated_by_user_id`, `created_at`, `updated_at` | audit columns | |
+
+## Plumbing
+
+- Wrap `generateMetadata` on each public route to merge with `SeoOverride.find_by_route(pathname)`. Override values win; nulls fall through to the hardcoded metadata.
+- Cache lookups for ~60 seconds (Next.js `revalidate`) to avoid hitting DB per request.
+- Admin UI under `/system/seo` (superadmin-only): table of all routes, edit modal, OG image preview, "publish" button (just writes the row; revalidation kicks in on next render).
+
+## Out of scope when picked up
+
+- A/B testing infrastructure (drives operator policy, not data model).
+- Per-locale overrides (single-language site for now).
+- `hreflang` automation.
+- Indexability scheduling / TTLs (just edit-now-or-later).
+
+## Why it's not v1
+
+- Adds DB write surface + cache invalidation + audit logging — non-trivial for an operator who hasn't validated demand for routine SEO edits.
+- Per-route metadata in `page.tsx` is fine for the first 90 days of marketing — content changes will trigger code deploys anyway as the landing copy evolves.
+```
+
+- [ ] **Step 2: Stage it**
+
+```bash
+git add specs/seo-admin-config-backlog.md
+```
+
+---
+
+### Task C.16: Commit Tasks C.13–C.15
+
+```bash
+git add frontend/app/page.tsx frontend/components/landing/Faq.tsx \
+  frontend/components/landing/faqData.ts \
+  frontend/tests/landing-jsonld-faqpage.test.tsx \
+  specs/seo-admin-config-backlog.md
+git commit -m "feat(seo): JSON-LD FAQPage + SoftwareApplication author/publisher; backlog SEO admin"
+```
+
+(If you skipped the `faqData.ts` extraction in Task C.14 Step 3, omit it from `git add`.)
+
+---
+
+### Task C.17: Final integration test — robots.txt + sitemap.xml served correctly
+
+**Files:** none new; this is a fetch-based smoke test through the local stack.
+
+- [ ] **Step 1: Boot the stack if it isn't running**
+
+```bash
+./pfv status
+# If down: ./pfv start
+```
+
+- [ ] **Step 2: Fetch and inspect**
+
+```bash
+curl -s http://localhost/robots.txt | head -20
+curl -s http://localhost/sitemap.xml | head -40
+```
+Expected:
+- `robots.txt` allows `/`, `/login`, `/register`, `/privacy`, `/terms`, `/forgot-password`; disallows `/dashboard/*`, `/auth/*`, `/api/*`; references the sitemap URL.
+- `sitemap.xml` lists 7 URLs: the original 5 plus `/docs` and `/docs/plans`.
+
+- [ ] **Step 3: Spot-check the noindex meta on an auth-walled page**
+
+```bash
+curl -s http://localhost/login | grep -o '<meta[^>]*robots[^>]*>'
+```
+Expected: `<meta name="robots" content="index, follow"/>` (because `/login` opted in).
+
+```bash
+# Auth-walled page returns the login redirect, so curl /dashboard isn't useful.
+# Spot-check a flow page instead:
+curl -s http://localhost/forgot-password | grep -o '<meta[^>]*robots[^>]*>'
+```
+Expected: `<meta name="robots" content="noindex, nofollow"/>` (inherits root).
+
+If steps 2 or 3 disagree with expectations, do NOT proceed to PR — diagnose the cascade (Next.js sometimes silently merges robots flags) and fix.
+
+---
+
+### Task C.18: Push and open PR
+
+```bash
+git push -u origin feat/baseline-seo-noindex-default
+gh pr create --title "feat(seo): baseline SEO — noindex default + sitemap + JSON-LD FAQPage" --body "$(cat <<'EOF'
+## Summary
+- Flips the root layout's default `robots` to `{ index: false, follow: false }` and opts the 7 indexable public routes back in (`/`, `/login`, `/register`, `/privacy`, `/terms`, `/docs`, `/docs/plans`).
+- Expands `sitemap.ts` to include `/docs` and `/docs/plans`.
+- Adds a JSON-LD `FAQPage` block to the landing page and enriches `SoftwareApplication` with `author` / `publisher`. FAQ data extracted to a shared module so the in-page FAQ render and the structured data can't drift.
+- Audits Hero `<h1>` and per-page meta distinctness.
+- Adds `specs/seo-admin-config-backlog.md` as the next step toward a runtime SEO admin UI.
+
+## Spec
+specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md §2
+EOF
+)"
+```
+
+---
+
+## Self-review (writing-plans skill checklist)
+
+**1. Spec coverage** — every spec requirement maps to a task:
+
+| Spec section | Tasks |
+|---|---|
+| §1 landing hardcode (PricingPreview, FAQs, "(Pro tier)", Hero notice) | B.3, B.4, B.5 |
+| §1 admin nav flag-gate | B.7, B.8 |
+| §1 trial-email backend gate | B.10, B.11 |
+| §2 root layout default → noindex | C.2, C.3 |
+| §2 7 indexable opt-ins | C.4, C.5 |
+| §2 flow-only inherit noindex | C.6 (test only — no code change needed because we flipped the default) |
+| §2 sitemap expansion | C.8, C.9 |
+| §2 Hero `<h1>` audit | C.10, C.11 |
+| §2 per-page meta distinctness | C.12 |
+| §2 JSON-LD enhancement | C.13, C.14 |
+| §2 backlog file | C.15 |
+| §3 split helpers + provider-conditional check | A.4 |
+| §3 test matrix (9 cases) | A.3 (includes both IPv4 + IPv6 loopback per spec amendment) |
+| Spec + plan commits | A.2 |
+
+No spec section is uncovered.
+
+**2. Placeholder scan** — searched for `TBD`, `TODO`, `fill in`, `as appropriate`, `etc.`, vague verbs:
+- "fill in" appears once in B.7 referring to the `AuthContextValue` fields the implementer must paste from the actual type — this is mechanical (open the type, copy fields) not a design decision. Acceptable.
+- No "TODO", no "implement later", no "see above". Each task shows the actual code.
+
+**3. Type consistency** —
+- `_reject_metadata_or_unsafe` and `_reject_private_or_loopback` names match between the spec, the test file references, and the implementation file references.
+- `app_settings` import alias is consistent across the gate test and the implementation.
+- `billingUiEnabled` (camelCase) on the frontend, `billing_ui_enabled` (snake) on the backend — matches the established convention from the 2026-05-21 spec.
+- `faqEntries` / `FaqEntry` names used in C.14 Step 3 are consistently referenced in C.14 Step 4 and C.16's git add.
+
+No drift found.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan-plan.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks; matches the user's [[feedback_subagent_driven]] + [[feedback_subagent_execution_guardrails]] rules.
+
+**2. Inline Execution** — execute tasks in this session with batch checkpoints.
+
+Per the user's earlier choice ("Brainstorm → plan → stop"), the recommended next step is **STOP here for plan review** before either execution mode kicks off.

--- a/specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md
+++ b/specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md
@@ -1,0 +1,254 @@
+# Hide remaining payment surfaces, ship baseline SEO, allow Ollama LAN IPs — design
+
+**Status:** approved by operator 2026-05-29 (sections 1–3 + packaging).
+**Date:** 2026-05-29.
+**Source:** operator request 2026-05-29 — "I won't charge anything for now, given the complexity of this integration for a system that is not being fully used and validated by people other than me. Hide completely any payment references from the system and landing page." Plus baseline SEO request and the Ollama LAN IP rejection in the BYO credential form (screenshot 2026-05-29 13:26 GMT+2).
+
+## Why one spec, three PRs
+
+The three chunks are independent and ship separately. They are bundled in one spec because they were brainstormed together as a single session intent ("park monetization, draw users in, unblock my own LAN Ollama"). Each chunk has its own _Files_ + _Tests_ + _Rollout_ block; `writing-plans` should produce one phased plan with three independent phases (one PR per phase).
+
+Packaging order (no dependency between PRs):
+
+1. **PR A** — Ollama validator LAN fix (smallest, unblocks the screenshot scenario).
+2. **PR B** — Extend `billing_ui_enabled` to the remaining payment surfaces.
+3. **PR C** — Baseline SEO + admin-UI backlog file.
+
+---
+
+## Section 1 — Extend `billing_ui_enabled` to all remaining payment surfaces
+
+### Goal
+
+After this PR, with `BILLING_UI_ENABLED=false` (the production default since 2026-05-21), there must be zero user-visible reference to pricing, billing, plans, subscriptions, trials, or upgrades anywhere the operator points a non-superadmin user.
+
+### Substrate (already exists from 2026-05-21)
+
+The earlier spec [`2026-05-21-hide-billing-ui-until-payment.md`](2026-05-21-hide-billing-ui-until-payment.md) shipped:
+
+- `BILLING_UI_ENABLED` env var, `app_settings.billing_ui_enabled: bool = False`.
+- `/api/v1/auth/status` returns `billing_ui_enabled`.
+- `AuthProvider` exposes `billingUiEnabled` via `useAuth()`.
+- Already gates: `TrialBanner`, Settings/Billing tab in `SettingsLayout`, `/settings/billing` page, the `/app/page.tsx` trial-copy line.
+
+This PR is a **coverage extension** of that same flag — no new flag, no rename. Same default (`false`), same `/auth/status` shape.
+
+### Customer-facing surface (gap inventory, 2026-05-29 code survey)
+
+Two categories of action, by render context:
+
+**Hardcoded edits (landing surfaces — apex static export, flag is theatre)**
+
+The apex deploy (`thebetterdecision.com`) is a **static export** that cannot read `/auth/status` at runtime. The 2026-05-21 spec set this precedent with Option A — hardcode the copy edit, revert via PR when payment is wired. This PR follows the same Option A for the remaining landing surfaces; the `billingUiEnabled` flag does not gate them because the static export can't read it.
+
+| File | What's still visible | Action |
+|---|---|---|
+| `frontend/components/landing/PricingPreview.tsx` | Whole pricing section (Free / Pro / Team tiers, "Coming soon" badges, "Join the waitlist" CTAs, footer disclaimer about VAT). | **Delete** the file. Re-add via `git revert` when payment is wired. |
+| `frontend/app/page.tsx` | `<PricingPreview />` import + render. | Remove the import and the `<PricingPreview />` tag from the page. |
+| `frontend/components/landing/Faq.tsx` (item for "What payment methods will you accept?") | FAQ Q&A about payment methods. | **Delete** the entry from the FAQ array. |
+| `frontend/components/landing/Faq.tsx` (item for "Is there a free plan?") | FAQ Q&A about the free plan. | **Delete** the entry from the FAQ array. |
+| `frontend/components/landing/Faq.tsx` (line referring to "AI assistant (Pro tier)") | Inline "(Pro tier)" qualifier in a feature description. | **Edit** the line to strip "(Pro tier)" so it reads "optional AI assistant". |
+| `frontend/components/landing/Hero.tsx` (or wherever the hero CTA lives — confirm at implementation) | No payment-clarity line near CTA. | **Add** a single line: _"Free while in beta. No credit card required."_ Hardcoded; revert separately if/when payment is wired and we want different copy. |
+
+**Flag-gated edits (in-app + backend — read `billing_ui_enabled` at runtime)**
+
+| File | What's still visible when flag is off | Action |
+|---|---|---|
+| `frontend/components/AppShell.tsx:178` | Admin nav item "Subscriptions" → `/admin/subscriptions` (CreditCard icon). | Filter from admin nav array when `!billingUiEnabled`. Same pattern as `SettingsLayout`'s existing tab filter. |
+| `frontend/components/AppShell.tsx:184-188` | Admin nav item "Plan Catalog" → `/system/plans` (CreditCard icon). | Filter from admin nav array when `!billingUiEnabled`. |
+| `backend/app/services/email_service.py:341-371` | `send_trial_expiring_email()` — periodic notification. | Wrap the **call site** (not the function) with `if app_settings.billing_ui_enabled:`. Keep the function intact so re-enabling is a config flip + the call-site guard removal. |
+
+These three are runtime-flag-gated because they execute inside the FastAPI/Next.js runtime where `/auth/status` (frontend) or `app_settings` (backend) is available. Flipping `BILLING_UI_ENABLED=true` restores them without a code change.
+
+### Files to touch
+
+#### Frontend (hardcoded edits — landing)
+- `frontend/components/landing/PricingPreview.tsx` — **delete file**.
+- `frontend/app/page.tsx` — remove `PricingPreview` import + `<PricingPreview />` tag.
+- `frontend/components/landing/Faq.tsx` — delete the two payment FAQ entries; strip "(Pro tier)" from the AI-assistant line.
+- `frontend/components/landing/Hero.tsx` (confirm path during implementation) — add the "Free while in beta. No credit card required." line near the CTA.
+
+#### Frontend (flag-gated — in-app)
+- `frontend/components/AppShell.tsx` — wrap the two admin nav entries (Subscriptions, Plan Catalog) in a `billingUiEnabled &&` filter when assembling the admin nav array. Same pattern as `SettingsLayout`'s existing tab filter.
+
+#### Backend (flag-gated)
+- Wherever `send_trial_expiring_email` is invoked (likely a scheduled-task entrypoint such as `backend/app/services/notifications_scheduler.py` — confirm during implementation; the service module itself stays unchanged) — wrap the call site with `if app_settings.billing_ui_enabled:`.
+
+### Tests
+
+- **Frontend Vitest:** render test of landing page (`/`) asserting no "Pro" / "Team" / "€9" / "Coming soon" / "Join the waitlist" / "payment methods" strings appear. (Landing surfaces are deleted, not flag-gated — single-state test.) Render test of `AppShell` admin nav with `billingUiEnabled=false` (Subscriptions + Plan Catalog absent) and `billingUiEnabled=true` (both present).
+- **Backend pytest:** test that the trial-expiring-email scheduled-task entrypoint does NOT invoke `send_trial_expiring_email` when `app_settings.billing_ui_enabled=False`. Mock the email transport and assert zero send attempts. Also test the inverse with the setting flipped.
+- **No e2e.** Existing billing-page tests from 2026-05-21 cover the in-page render path.
+
+### Rollout
+
+This PR ships with `BILLING_UI_ENABLED=false` (already the prod default). Customer-facing payment surface disappears completely on merge.
+
+To re-enable when payment is wired:
+
+1. `git revert` the landing-page deletions/edits (PricingPreview file, page.tsx import, FAQ entries, hero copy line) — or rewrite the copy if the messaging has evolved.
+2. Flip `BILLING_UI_ENABLED=true` in `.do/app.yaml` and any other environment surfaces (see `ENVIRONMENT.md`).
+3. Remove the `if app_settings.billing_ui_enabled:` guard around `send_trial_expiring_email` call site (or leave it — it's permissive when the flag flips true).
+4. Deploy. Admin nav links and the trial email come back automatically when the flag is true.
+
+Rollback is symmetric: flip flag back to `false`.
+
+### Out of scope
+
+- Backend API gating of `/api/v1/subscriptions`, `/api/v1/plans`, `/api/v1/admin/subscriptions/*`. Same reasoning as 2026-05-21: owner-only auth, no UI calls them with flag off. Defense-in-depth not worth the rollback complexity.
+- `OnboardingPageBody.tsx:373` "billing" mention — confirmed in 2026-05-21 review as transaction-billing, not subscription-billing.
+- Removing Paddle backend integration, billing models, plan-catalog service, etc. All dormant when no UI consumes them.
+
+---
+
+## Section 2 — Baseline SEO + admin-UI backlog file
+
+### Goal
+
+Make the marketing landing page and the public auth pages indexable and discoverable for terms like "personal finance app", "budget planner", "self-hosted finance", etc. Avoid leaking auth-walled routes into search results. Defer the per-route admin SEO config UI to a follow-up backlog item.
+
+### Substrate (already exists, 2026-05-29 inventory)
+
+- `frontend/app/layout.tsx:12` — root metadata: title template `%s · The Better Decision`, default title + description, robots stub, OG/Twitter stubs.
+- `frontend/app/page.tsx:23` — landing page already calls `pageSocialMeta()` for OG + Twitter cards + canonical.
+- `frontend/app/robots.ts` — allow `/`, `/login`, `/register`, `/privacy`, `/terms`, `/forgot-password`; disallow `/dashboard/*`, `/auth/*`, `/api/*`; references sitemap.
+- `frontend/app/sitemap.ts` — 5 URLs (`/`, `/register`, `/login`, `/privacy`, `/terms`) with priorities + lastModified.
+- `frontend/app/opengraph-image.tsx` — dynamic 1200×630 OG image generator.
+- `frontend/app/icon.svg` — favicon.
+- Landing page already renders one `application/ld+json` block with `@type: SoftwareApplication` (CSP-nonced).
+
+### Indexability matrix
+
+Crawler should see (`index, follow`): `/`, `/login`, `/register`, `/privacy`, `/terms`, `/docs`, `/docs/plans`.
+
+Crawler should NOT see (`noindex, nofollow`): all auth-walled routes under the app shell **plus** the public-but-not-useful pages `onboarding`, `accept-invite`, `forgot-password`, `reset-password`, `verify-email`, `mfa-verify`. These are flow pages tied to a session or a per-org token — there's no SEO value in indexing them, and indexed reset-password URLs are a footgun.
+
+### Gaps to close
+
+1. **`noindex` on auth-walled routes.** 19 routes under the app shell have no per-page `robots` directive. `robots.ts` already disallows them at the crawler level, but engines occasionally index discovered URLs without a per-page directive. Add one `export const metadata = { robots: { index: false, follow: false } }` at the **shallowest shared layout** of the authenticated app (likely `frontend/app/(app)/layout.tsx` or whatever route group wraps the auth-walled pages — confirm at implementation). One file, not nineteen.
+2. **`noindex` on flow-only public routes.** Add the same `metadata.robots` directive to `onboarding`, `accept-invite`, `forgot-password`, `reset-password`, `verify-email`, `mfa-verify`. Per-route (no shared layout to lean on).
+3. **Sitemap expansion.** Add `/docs` and `/docs/plans` to `frontend/app/sitemap.ts`. Keep priorities low (0.4) — support content, not conversion. Do NOT add the flow pages to the sitemap.
+4. **Landing `<h1>`.** Verify the Hero component has exactly one `<h1>`. If absent or generic, replace with a keyword-rich phrase. Starter copy (operator finalizes at implementation): _"Personal finance, planned not panicked."_ If multiple `<h1>`s exist on the page, demote extras to `<h2>`.
+5. **Per-page meta on indexable public pages.** Each of `/`, `/login`, `/register`, `/privacy`, `/terms`, `/docs`, `/docs/plans` should have a distinct, keyword-relevant `title` + `description`. The inventory confirmed each has *some* metadata — verify each is distinct (not just inheriting the root template) and tuned for the page's intent. Fill in any that just inherit.
+6. **JSON-LD enhancement on landing.** Extend the existing `SoftwareApplication` block in `frontend/app/page.tsx` to include `author` and `publisher` properties. Add a sibling `FAQPage` block that mirrors the (post-Section-1) FAQ section — only non-payment FAQs end up in the structured data. Skip `aggregateRating` until real reviews exist (Google penalizes fake review markup).
+7. **Backlog file.** Write `specs/seo-admin-config-backlog.md` (one screen, ≤200 words) describing the future admin UI: per-route DB-stored title/description/keywords/OG-image override, superadmin-only, fed via a new `SeoOverride` model that takes precedence over hardcoded `metadata` exports. No code, just intent + sketched data model — starting point for when the operator picks this up.
+
+### Out of scope this PR
+
+- Admin UI for SEO config (deferred via backlog file).
+- `hreflang` (single-language site for now).
+- Custom OG image per route (single shared dynamic OG is fine for v1).
+- Schema.org `Review` / `aggregateRating` (no real reviews to cite).
+- Backend-served sitemap (Next.js `sitemap.ts` is enough; not enough URLs to justify a DB-backed sitemap yet).
+- Performance/Core Web Vitals work (separate concern, not SEO baseline).
+
+### Files to touch
+
+- `frontend/app/(app)/layout.tsx` (or equivalent shared layout for the auth-walled group — confirm at implementation; create one if none exists) — `export const metadata = { robots: { index: false, follow: false } }`.
+- `frontend/app/onboarding/layout.tsx` (or `page.tsx`), `frontend/app/accept-invite/...`, `frontend/app/forgot-password/...`, `frontend/app/reset-password/...`, `frontend/app/verify-email/...`, `frontend/app/mfa-verify/...` — same `metadata.robots` noindex directive on each.
+- `frontend/app/sitemap.ts` — append `/docs` and `/docs/plans` URLs.
+- `frontend/components/landing/Hero.tsx` (confirm path at implementation) — `<h1>` audit + tune.
+- Per-page `metadata` exports for the 7 indexable public pages — verify + fill where needed.
+- `frontend/app/page.tsx` — extend the existing JSON-LD render to include `author`/`publisher` on `SoftwareApplication` and to add a `FAQPage` block.
+- `specs/seo-admin-config-backlog.md` — new file, see Gap #7.
+
+### Tests
+
+- Fetch-based test: `GET /robots.txt` returns 200 with the expected allow/disallow rules; `GET /sitemap.xml` returns 200 and includes `/docs` and `/docs/plans` plus the original 5 URLs.
+- Vitest render test on `/`: assert exactly one `<h1>`; assert two `<script type="application/ld+json">` blocks (SoftwareApplication + FAQPage); assert `FAQPage` JSON includes the post-Section-1 surviving FAQ entries (and excludes the two deleted payment ones).
+- Vitest render-head test on `/dashboard` (or any auth-walled route): assert `<meta name="robots" content="noindex, nofollow">` is present.
+- Vitest render-head test on `/forgot-password` (sample of the flow-only public list): assert `<meta name="robots" content="noindex, nofollow">` is present.
+- Vitest render-head test on `/login` (sample of the indexable list): assert `noindex` is **absent**.
+
+### Rollout
+
+Ship. SEO baseline is invisible to current users; only crawlers notice. Verify post-deploy with `curl https://thebetterdecision.com/robots.txt` and `…/sitemap.xml`, and check Google Search Console once indexed.
+
+---
+
+## Section 3 — Ollama validator: allow private/LAN IPs
+
+### Goal
+
+When the operator configures an Ollama credential, allow `base_url` to be a literal RFC1918 LAN IP (e.g., `http://192.168.1.163:11434/`) or loopback (`http://127.0.0.1:11434/`) without breaking the SSRF guard against cloud metadata + link-local addresses, and without weakening the guard for other providers.
+
+### Substrate
+
+- `backend/app/schemas/org_ai_credential.py:29-69` — `_reject_private_ip_literal(host)` blocks loopback, RFC1918, link-local, multicast, unspecified, reserved, IPv4-mapped IPv6, and cloud metadata IPs.
+- `_validate_base_url(value)` at L72-87 runs `_reject_private_ip_literal` unconditionally inside a Pydantic `@field_validator`, which doesn't have access to the `provider` field.
+- The `@model_validator(mode="after")` block at L110-130 already runs provider-aware checks (api_key requirements, bearer_token validity per provider). This is where the provider-conditional IP policy belongs.
+
+### Behavior change
+
+For **`provider == OLLAMA`**: allow RFC1918 (`10/8`, `172.16/12`, `192.168/16`) and loopback (`127.0.0.0/8`, `::1`). Continue blocking:
+
+- Cloud metadata: `169.254.169.254`, `fd00:ec2::254` (and IPv4-mapped IPv6 variants).
+- Link-local (the rest of `169.254/16` beyond the metadata constant — IMDS bypass surface).
+- Multicast / unspecified / reserved.
+
+For **all other providers**: behavior unchanged. Full strict block per the current `_reject_private_ip_literal`.
+
+### Code shape
+
+Refactor the IP guard into two functions:
+
+```python
+def _reject_metadata_or_unsafe(host: str) -> None:
+    """Always-blocked classes: metadata IPs, link-local, multicast,
+    unspecified, reserved. Safe for all providers including Ollama."""
+
+def _reject_private_or_loopback(host: str) -> None:
+    """RFC1918 + loopback. Blocked for hosted providers, allowed for
+    Ollama (operator's own LAN/homelab)."""
+```
+
+Move BOTH calls out of `_validate_base_url` and into a new model-validator helper invoked from `_check_provider_requirements`:
+
+- Field validator `_check_base_url` keeps the scheme + hostname-presence checks and unconditionally runs `_reject_metadata_or_unsafe(host)`.
+- Model validator (post-validation, when `provider` is known) runs `_reject_private_or_loopback(host)` only for non-Ollama providers.
+
+The `OrgAICredentialRotate` schema does not include `base_url`, so it needs no change.
+
+### Files to touch
+
+- `backend/app/schemas/org_ai_credential.py` — refactor as above; update the `_validate_base_url` docstring to reflect the provider-conditional policy.
+
+### Tests
+
+`backend/tests/test_org_ai_credential_schema.py` (extend the existing tests; the file already covers happy paths from the 2026-05-22 BYO credentials work):
+
+| Case | Provider | base_url | Expected |
+|---|---|---|---|
+| LAN IP for Ollama | `ollama` | `http://192.168.1.163:11434/` | accept |
+| Loopback IPv4 for Ollama | `ollama` | `http://127.0.0.1:11434/` | accept |
+| Loopback IPv6 for Ollama | `ollama` | `http://[::1]:11434/` | accept |
+| Metadata IP for Ollama | `ollama` | `http://169.254.169.254/` | reject (metadata) |
+| Link-local for Ollama (non-metadata) | `ollama` | `http://169.254.1.1/` | reject (link-local) |
+| Multicast for Ollama | `ollama` | `http://224.0.0.1/` | reject |
+| LAN IP for openai_compatible | `openai_compatible` | `http://192.168.1.163/` | reject (unchanged) |
+| IPv4-mapped IPv6 LAN for Ollama | `ollama` | `http://[::ffff:192.168.1.1]/` | accept |
+| IPv4-mapped IPv6 metadata for Ollama | `ollama` | `http://[::ffff:169.254.169.254]/` | reject (metadata via mapped) |
+| Public IP for any provider | `ollama` / `anthropic` | `https://api.example.com/` | accept (unchanged) |
+
+### Frontend
+
+No change. The error from the backend is already surfaced inline in the form (the screenshot proves it). With the validator fix, the user's exact scenario passes silently.
+
+### Rollout
+
+Ship in its own PR. Backwards-compatible (the only behavior change is *accepting* previously-rejected inputs, never rejecting previously-accepted ones). No env var, no migration, no flag.
+
+### Out of scope
+
+- DNS-rebinding protection (custom httpx transport that re-resolves at connect time). Already noted as a residual v1 risk in the existing docstring (L36-40). Not regressed by this change.
+- A future opt-in "trust-the-operator" mode that allows private IPs for `openai_compatible` too. The model-validator structure makes this trivial to add later by widening the conditional from `provider == OLLAMA` to `provider in {OLLAMA, OPENAI_COMPATIBLE} and app_settings.ai_trust_local_endpoints`.
+
+---
+
+## Cross-cutting notes
+
+- **No new env vars.** Section 1 reuses `BILLING_UI_ENABLED`. Sections 2 + 3 introduce none.
+- **No DB migrations.** All three sections.
+- **No new dependencies.**
+- **Memory links:** [[reference_do_spec_sync]] — not invoked here (no new env vars), but the rule still governs any future flag flip. [[feedback_pr_format]] — PRs land without test-plan sections. [[feedback_no_push_main]] — three branches + three PRs.
+- **No backwards-compat shims** (per [[feedback_pre_launch_state]]) — Section 1's PricingPreview deletion is hard-remove; revert via `git revert` when payment is wired.


### PR DESCRIPTION
## Summary
- Splits the SSRF IP guard into always-blocked vs provider-conditional helpers.
- Ollama credentials now accept RFC1918 LAN + loopback (incl. `[::1]` and IPv4-mapped IPv6) — unblocks the LAN-only homelab mode shipped in PR #375.
- Cloud metadata IPs (`169.254.169.254`, `fd00:ec2::254`) and link-local remain hard-blocked for ALL providers, including Ollama.
- Strict block for `openai_compatible` / `anthropic` / `openai` is unchanged.

## Spec
specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md §3