### PR TITLE
fix(do): sync rotated AI_CREDENTIAL_ENCRYPTION_KEY EV blobs

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -138,11 +138,11 @@ services:
       - key: AI_CREDENTIAL_ENCRYPTION_KEY
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:sn7ynZMy38Z7o0sDzFldMwA6Q7yxB8S3:RoTRbtfu3PKUZLCKBqqr/w==]
+        value: EV[1:Nysd1FwUmJSXbnetxU9r4N3A/2g8UsUj:d+gKpNSU/amIC1dHSEigq5D3jMkXQDmwT+uAqAs+S9khODsKnVZZ94AsUKtE+QX64s7qNkySZhfrHfyq]
       - key: AI_CREDENTIAL_ENCRYPTION_KEY_PREV
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:Hlvi5JFq2Bydn2BCirJVEv+CbGSOz/aF:nKZqg6GmYwhaCNeJvp5ubg==]
+        value: EV[1:fXl3Y39U5+b7Z+W/1sgSyN+Upqp5aNbr:sDEMJveK356wpnloAbmK3e+OMKCIW/Lo3Wo4JcWLQHHzxR4YFpQzKEcfiVcWS8L23cik0TT1MnoeAkEZ]
       - key: AI_NATIVE_ENABLED
         scope: RUN_AND_BUILD_TIME
         value: "false"


### PR DESCRIPTION
## Summary
Production KEK rotated 2026-05-29 ~17:25 GMT+2 to unbreak Anthropic / OpenAI credential creation.

The on-disk `.do/app.yaml` EV[] blobs were stale post-repo-migration — the 12:07 commit (3f42eea) restored them from a live spec that DO could no longer decrypt, surfacing as empty SECRETs at runtime and `AiCredentialCryptoError: AI_CREDENTIAL_ENCRYPTION_KEY is not configured` on every credential save (logs confirmed at 14:55 GMT+2). The KEK lifespan guard treats an empty key as "first use" and allows boot, so the app was up but encryption was broken at request time.

This PR syncs the fresh EV[] blobs from the now-live spec into the repo so the next push doesn't blank them again (the `reference_do_spec_sync.md` trap).

## Verification
- `org_ai_credentials` COUNT(*) before rotation: 0 (zero data to migrate)
- New EV[] blobs pulled via `doctl apps spec get`
- Diff is 2 lines exactly: the two value: EV[...] entries for the AI KEK and its _PREV slot
- Anthropic credential add should now succeed (operator to retry post-merge — though the prod runtime already has the new keys; this PR just stops the next CI deploy from rolling them back)