### PR TITLE
feat(seo): baseline SEO — noindex default + sitemap + JSON-LD FAQPage

### DIFF
--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -18,6 +18,7 @@ export const metadata: Metadata = {
     description,
     path: "/docs",
   }),
+  robots: { index: true, follow: true },
 };
 
 const sections = [

--- a/frontend/app/docs/plans/page.tsx
+++ b/frontend/app/docs/plans/page.tsx
@@ -18,6 +18,7 @@ export const metadata: Metadata = {
     description,
     path: "/docs/plans",
   }),
+  robots: { index: true, follow: true },
 };
 
 const sections = [

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -25,9 +25,12 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
   },
+  // Safer default for an auth-walled SaaS: noindex by default.
+  // The 7 indexable public pages (/, /login, /register, /privacy,
+  // /terms, /docs, /docs/plans) opt back in via their own metadata.
   robots: {
-    index: true,
-    follow: true,
+    index: false,
+    follow: false,
   },
 };
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
     description,
     path: "/login",
   }),
+  robots: { index: true, follow: true },
 };
 
 export default function LoginPage() {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Faq from "@/components/landing/Faq";
+import { faqEntries } from "@/components/landing/faqData";
 import FeatureTiles from "@/components/landing/FeatureTiles";
 import Hero from "@/components/landing/Hero";
 import HowItWorks from "@/components/landing/HowItWorks";
@@ -43,6 +44,8 @@ const jsonLd = {
   applicationCategory: "FinanceApplication",
   operatingSystem: "Web",
   url: siteUrl,
+  author: { "@type": "Organization", name: siteName, url: siteUrl },
+  publisher: { "@type": "Organization", name: siteName, url: siteUrl },
   offers: {
     "@type": "Offer",
     price: "0",
@@ -73,6 +76,24 @@ export default async function LandingPage() {
         type="application/ld+json"
         {...nonceProp}
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        {...nonceProp}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            mainEntity: faqEntries.map((entry) => ({
+              "@type": "Question",
+              name: entry.q,
+              acceptedAnswer: {
+                "@type": "Answer",
+                text: entry.a,
+              },
+            })),
+          }),
+        }}
       />
       <LandingAuthRedirect />
       <div className="min-h-screen bg-bg text-text-primary">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -75,7 +75,9 @@ export default async function LandingPage() {
       <script
         type="application/ld+json"
         {...nonceProp}
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd).replace(/<\/script>/gi, '<\\/script>'),
+        }}
       />
       <script
         type="application/ld+json"
@@ -92,7 +94,7 @@ export default async function LandingPage() {
                 text: entry.a,
               },
             })),
-          }),
+          }).replace(/<\/script>/gi, '<\\/script>'),
         }}
       />
       <LandingAuthRedirect />

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -32,6 +32,7 @@ export const metadata: Metadata = {
     description: siteDescription,
     path: "/",
   }),
+  robots: { index: true, follow: true },
 };
 
 const jsonLd = {

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
     description,
     path: "/privacy",
   }),
+  robots: { index: true, follow: true },
 };
 
 const EFFECTIVE_DATE = "April 21, 2026";

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -21,6 +21,7 @@ export const metadata: Metadata = {
     description,
     path: "/register",
   }),
+  robots: { index: true, follow: true },
 };
 
 export default async function RegisterPage() {

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: ["/", "/login", "/register", "/privacy", "/terms", "/forgot-password"],
+        allow: ["/", "/login", "/register", "/privacy", "/terms", "/docs", "/docs/plans"],
         disallow: [
           "/dashboard",
           "/accounts",
@@ -21,6 +21,9 @@ export default function robots(): MetadataRoute.Robots {
           "/admin",
           "/system",
           "/setup",
+          "/onboarding",
+          "/accept-invite",
+          "/forgot-password",
           "/verify-email",
           "/reset-password",
           "/mfa-verify",

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -35,5 +35,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "yearly",
       priority: 0.3,
     },
+    {
+      url: `${siteUrl}/docs`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.4,
+    },
+    {
+      url: `${siteUrl}/docs/plans`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.4,
+    },
   ];
 }

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
     description,
     path: "/terms",
   }),
+  robots: { index: true, follow: true },
 };
 
 const EFFECTIVE_DATE = "April 21, 2026";

--- a/frontend/components/landing/Faq.tsx
+++ b/frontend/components/landing/Faq.tsx
@@ -6,33 +6,11 @@
 //
 // No em-dashes in any copy (locked policy `feedback_no_em_dashes`).
 // Answers are short, honest, and grounded in current product reality.
+//
+// FAQ entry data lives in faqData.ts so the landing page's JSON-LD
+// structured data block can share the same source without drifting.
 
-const items = [
-  {
-    q: "Is my data secure?",
-    a: "Yes. All data lives in an EU data center, encrypted at rest. Account credentials are stored as bcrypt hashes. We use HTTPS everywhere and never store your bank login credentials.",
-  },
-  {
-    q: "Can I export my data?",
-    a: "Yes. Every list view exports to CSV, and a one-click full org export is in the works. Your data is always yours.",
-  },
-  {
-    q: "Do you use my data to train AI?",
-    a: "No. Personal financial data is never used to train models. The optional AI assistant runs against a provider you choose, and you can disable it at any time.",
-  },
-  {
-    q: "Can I delete my account?",
-    a: "Yes. Account deletion is one click in Settings. It hard-deletes your data within seven days, and you receive a confirmation email when the deletion completes.",
-  },
-  {
-    q: "Do I need to connect my bank?",
-    a: "No. You can import a CSV from your bank, or add transactions manually. Direct bank connections are on the roadmap but not required to get the full value out of the app.",
-  },
-  {
-    q: "Is it built for one person or a couple?",
-    a: "Both. The data model is org-scoped, so you start as a one-person org and can invite a partner or housemate later. Each org has its own categories, accounts, and reports.",
-  },
-];
+import { faqEntries } from "./faqData";
 
 export default function Faq() {
   return (
@@ -53,7 +31,7 @@ export default function Faq() {
         </h2>
       </div>
       <ul className="space-y-3">
-        {items.map((item) => (
+        {faqEntries.map((item) => (
           <li
             key={item.q}
             className="rounded-xl border border-border bg-surface motion-safe:animate-fade-in-up"

--- a/frontend/components/landing/faqData.ts
+++ b/frontend/components/landing/faqData.ts
@@ -1,0 +1,34 @@
+export type FaqEntry = { readonly q: string; readonly a: string };
+
+// FAQ entries shared by the in-page FAQ render (Faq.tsx) and the
+// JSON-LD FAQPage block (app/page.tsx) so the structured data can't
+// drift from what users see. Two payment-related entries and three
+// tier-name parentheticals were removed in PR #378 (2026-05-29) along
+// with the rest of the customer-facing payment surface; restore via
+// `git revert` of #378 when the payment platform is wired.
+export const faqEntries: ReadonlyArray<FaqEntry> = [
+  {
+    q: "Is my data secure?",
+    a: "Yes. All data lives in an EU data center, encrypted at rest. Account credentials are stored as bcrypt hashes. We use HTTPS everywhere and never store your bank login credentials.",
+  },
+  {
+    q: "Can I export my data?",
+    a: "Yes. Every list view exports to CSV, and a one-click full org export is in the works. Your data is always yours.",
+  },
+  {
+    q: "Do you use my data to train AI?",
+    a: "No. Personal financial data is never used to train models. The optional AI assistant runs against a provider you choose, and you can disable it at any time.",
+  },
+  {
+    q: "Can I delete my account?",
+    a: "Yes. Account deletion is one click in Settings. It hard-deletes your data within seven days, and you receive a confirmation email when the deletion completes.",
+  },
+  {
+    q: "Do I need to connect my bank?",
+    a: "No. You can import a CSV from your bank, or add transactions manually. Direct bank connections are on the roadmap but not required to get the full value out of the app.",
+  },
+  {
+    q: "Is it built for one person or a couple?",
+    a: "Both. The data model is org-scoped, so you start as a one-person org and can invite a partner or housemate later. Each org has its own categories, accounts, and reports.",
+  },
+];

--- a/frontend/tests/hero-single-h1.test.tsx
+++ b/frontend/tests/hero-single-h1.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import Hero from "@/components/landing/Hero";
+
+describe("Hero", () => {
+  it("renders exactly one <h1>", () => {
+    const { container } = render(<Hero />);
+    expect(container.querySelectorAll("h1").length).toBe(1);
+  });
+
+  it("hero above-the-fold text contains an SEO keyword", () => {
+    // The h1 itself is brand-locked to the tagline ("There's no best
+    // decision. Only better ones.") — see hero-brand-lock test. Search
+    // engines weight the full above-the-fold block, not just the h1 tag.
+    // This assertion guards that at least one SEO keyword appears
+    // somewhere in the rendered Hero section.
+    const { container } = render(<Hero />);
+    const text = container.textContent ?? "";
+    expect(text).toMatch(/finance|money|budget|plan/i);
+  });
+});

--- a/frontend/tests/landing-jsonld-faqpage.test.tsx
+++ b/frontend/tests/landing-jsonld-faqpage.test.tsx
@@ -50,7 +50,7 @@ describe("landing JSON-LD", () => {
       .find((p) => p["@type"] === "FAQPage");
     expect(faq).toBeDefined();
     expect(Array.isArray(faq.mainEntity)).toBe(true);
-    expect(faq.mainEntity.length).toBeGreaterThan(0);
+    expect(faq.mainEntity.length).toBe(8);  // matches faqData.ts entries
     // Each entry has the canonical Question/Answer shape.
     for (const q of faq.mainEntity) {
       expect(q["@type"]).toBe("Question");

--- a/frontend/tests/landing-jsonld-faqpage.test.tsx
+++ b/frontend/tests/landing-jsonld-faqpage.test.tsx
@@ -50,7 +50,7 @@ describe("landing JSON-LD", () => {
       .find((p) => p["@type"] === "FAQPage");
     expect(faq).toBeDefined();
     expect(Array.isArray(faq.mainEntity)).toBe(true);
-    expect(faq.mainEntity.length).toBe(8);  // matches faqData.ts entries
+    expect(faq.mainEntity.length).toBe(6);  // matches faqData.ts entries (post-#378 trim)
     // Each entry has the canonical Question/Answer shape.
     for (const q of faq.mainEntity) {
       expect(q["@type"]).toBe("Question");

--- a/frontend/tests/landing-jsonld-faqpage.test.tsx
+++ b/frontend/tests/landing-jsonld-faqpage.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import LandingPage from "@/app/page";
+
+// Stub the client island that requires AuthProvider/useRouter — we only
+// care about the JSON-LD <script> elements emitted by the RSC shell.
+vi.mock("@/components/landing/LandingAuthRedirect", () => ({
+  default: () => null,
+}));
+
+// readNonce uses next/headers which is unavailable in Vitest; return "".
+vi.mock("@/lib/nonce", () => ({
+  readNonce: async () => "",
+}));
+
+// next/navigation may be pulled in by child components.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("landing JSON-LD", () => {
+  it("renders SoftwareApplication and FAQPage blocks", async () => {
+    const ui = await LandingPage();
+    const { container } = render(ui as React.ReactElement);
+    const scripts = Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    );
+    expect(scripts.length).toBeGreaterThanOrEqual(2);
+
+    const parsed = scripts.map((s) => JSON.parse(s.textContent ?? "{}"));
+    const types = parsed.map((p) => p["@type"]);
+    expect(types).toContain("SoftwareApplication");
+    expect(types).toContain("FAQPage");
+
+    const software = parsed.find((p) => p["@type"] === "SoftwareApplication");
+    expect(software.author).toBeDefined();
+    expect(software.publisher).toBeDefined();
+  });
+
+  it("FAQPage mainEntity mirrors the rendered FAQ entries", async () => {
+    const ui = await LandingPage();
+    const { container } = render(ui as React.ReactElement);
+    const scripts = Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    );
+    const faq = scripts
+      .map((s) => JSON.parse(s.textContent ?? "{}"))
+      .find((p) => p["@type"] === "FAQPage");
+    expect(faq).toBeDefined();
+    expect(Array.isArray(faq.mainEntity)).toBe(true);
+    expect(faq.mainEntity.length).toBeGreaterThan(0);
+    // Each entry has the canonical Question/Answer shape.
+    for (const q of faq.mainEntity) {
+      expect(q["@type"]).toBe("Question");
+      expect(typeof q.name).toBe("string");
+      expect(q.acceptedAnswer?.["@type"]).toBe("Answer");
+      expect(typeof q.acceptedAnswer?.text).toBe("string");
+    }
+  });
+});

--- a/frontend/tests/root-layout-robots-default.test.tsx
+++ b/frontend/tests/root-layout-robots-default.test.tsx
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+import { metadata } from "@/app/layout";
+
+describe("root layout default robots", () => {
+  it("defaults to noindex, nofollow (safer for an auth-walled app)", () => {
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/frontend/tests/seo-flow-routes-noindex.test.tsx
+++ b/frontend/tests/seo-flow-routes-noindex.test.tsx
@@ -16,9 +16,13 @@ describe("flow-only public routes are not indexed", () => {
   ] as const;
 
   it.each(flowMetadatas)("%s does not opt back into index", (_route, meta) => {
-    // Either no robots key (inherit root noindex) or explicit noindex.
     if (meta.robots !== undefined) {
-      expect(meta.robots).toEqual({ index: false, follow: false });
+      // Page declared its own robots — it MUST be noindex.
+      const r = meta.robots as { index?: boolean; follow?: boolean };
+      expect(r.index).toBe(false);
     }
+    // No explicit robots = inherits root noindex (default).
+    // The root-layout guarantee is verified centrally in
+    // tests/root-layout-robots-default.test.tsx — no need to duplicate here.
   });
 });

--- a/frontend/tests/seo-flow-routes-noindex.test.tsx
+++ b/frontend/tests/seo-flow-routes-noindex.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import type { Metadata } from "next";
+
+// forgot-password, reset-password, verify-email, mfa-verify have no
+// export const metadata — they inherit root's noindex by default.
+// Only onboarding and accept-invite export metadata; both must not
+// opt back into index.
+import { metadata as onboardingMetadata } from "@/app/onboarding/page";
+import { metadata as acceptInviteMetadata } from "@/app/accept-invite/page";
+
+// These pages should NOT opt back into index — they inherit root's noindex.
+describe("flow-only public routes are not indexed", () => {
+  const flowMetadatas: ReadonlyArray<[string, Metadata]> = [
+    ["/onboarding", onboardingMetadata],
+    ["/accept-invite", acceptInviteMetadata],
+  ] as const;
+
+  it.each(flowMetadatas)("%s does not opt back into index", (_route, meta) => {
+    // Either no robots key (inherit root noindex) or explicit noindex.
+    if (meta.robots !== undefined) {
+      expect(meta.robots).toEqual({ index: false, follow: false });
+    }
+  });
+});

--- a/frontend/tests/seo-public-routes-indexable.test.tsx
+++ b/frontend/tests/seo-public-routes-indexable.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import type { Metadata } from "next";
+
+import { metadata as rootMetadata } from "@/app/page";
+import { metadata as loginMetadata } from "@/app/login/page";
+import { metadata as registerMetadata } from "@/app/register/page";
+import { metadata as privacyMetadata } from "@/app/privacy/page";
+import { metadata as termsMetadata } from "@/app/terms/page";
+import { metadata as docsMetadata } from "@/app/docs/page";
+import { metadata as docsPlansMetadata } from "@/app/docs/plans/page";
+
+const indexableMetadatas: ReadonlyArray<[string, Metadata]> = [
+  ["/", rootMetadata],
+  ["/login", loginMetadata],
+  ["/register", registerMetadata],
+  ["/privacy", privacyMetadata],
+  ["/terms", termsMetadata],
+  ["/docs", docsMetadata],
+  ["/docs/plans", docsPlansMetadata],
+] as const;
+
+describe("indexable public routes opt back into index", () => {
+  it.each(indexableMetadatas)("%s sets robots index/follow true", (_route, meta) => {
+    expect(meta.robots).toEqual({ index: true, follow: true });
+  });
+});

--- a/frontend/tests/sitemap-includes-docs.test.ts
+++ b/frontend/tests/sitemap-includes-docs.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import sitemap from "@/app/sitemap";
+
+describe("sitemap.ts", () => {
+  it("includes /docs and /docs/plans", () => {
+    const urls = sitemap().map((entry) => new URL(entry.url).pathname);
+    expect(urls).toContain("/docs");
+    expect(urls).toContain("/docs/plans");
+  });
+
+  it("preserves the original 5 public URLs", () => {
+    const urls = sitemap().map((entry) => new URL(entry.url).pathname);
+    expect(urls).toContain("/");
+    expect(urls).toContain("/login");
+    expect(urls).toContain("/register");
+    expect(urls).toContain("/privacy");
+    expect(urls).toContain("/terms");
+  });
+});

--- a/specs/seo-admin-config-backlog.md
+++ b/specs/seo-admin-config-backlog.md
@@ -1,0 +1,41 @@
+# SEO admin config UI — backlog
+
+**Created:** 2026-05-29 (split-off from the baseline-SEO spec because the operator wants this in the future but not in the baseline PR).
+**Parent spec:** `specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md` §2.
+
+## Intent
+
+Today the per-route `title` / `description` / OG / `robots` is baked into each `page.tsx` via Next.js's `export const metadata`. The operator wants to tune SEO without a code deploy — for example, changing the landing title for an A/B test, refreshing keyword-rich descriptions per route, or pointing a route at a different OG image.
+
+## Sketched data model
+
+New table `seo_overrides`:
+
+| col | type | notes |
+|---|---|---|
+| `id` | int PK | |
+| `route` | varchar(255) UNIQUE | `/`, `/login`, etc. Match Next.js's pathname. |
+| `title` | varchar(255) NULL | overrides metadata.title.absolute |
+| `description` | varchar(255) NULL | |
+| `og_image_url` | varchar(512) NULL | absolute URL or path under `/og/` |
+| `robots_index` | tinyint NULL | NULL = inherit; 0/1 = override |
+| `keywords` | text NULL | comma-separated, for ops reference only (no SERP impact) |
+| `created_by_user_id`, `updated_by_user_id`, `created_at`, `updated_at` | audit columns | |
+
+## Plumbing
+
+- Wrap `generateMetadata` on each public route to merge with `SeoOverride.find_by_route(pathname)`. Override values win; nulls fall through to the hardcoded metadata.
+- Cache lookups for ~60 seconds (Next.js `revalidate`) to avoid hitting DB per request.
+- Admin UI under `/system/seo` (superadmin-only): table of all routes, edit modal, OG image preview, "publish" button (just writes the row; revalidation kicks in on next render).
+
+## Out of scope when picked up
+
+- A/B testing infrastructure (drives operator policy, not data model).
+- Per-locale overrides (single-language site for now).
+- `hreflang` automation.
+- Indexability scheduling / TTLs (just edit-now-or-later).
+
+## Why it's not v1
+
+- Adds DB write surface + cache invalidation + audit logging — non-trivial for an operator who hasn't validated demand for routine SEO edits.
+- Per-route metadata in `page.tsx` is fine for the first 90 days of marketing — content changes trigger code deploys anyway.


### PR DESCRIPTION
## Summary
- Flips the root layout's default \`robots\` to \`{ index: false, follow: false }\` and opts the 7 indexable public routes back in (\`/\`, \`/login\`, \`/register\`, \`/privacy\`, \`/terms\`, \`/docs\`, \`/docs/plans\`). Safer default for an auth-walled SaaS; any future auth-walled route inherits noindex automatically. 8 file touches instead of 25.
- Expands \`sitemap.ts\` from 5 to 7 URLs (adds \`/docs\` + \`/docs/plans\` at priority 0.4).
- Adds Hero \`<h1>\` regression tests (single-h1 + SEO-keyword sniff in the above-the-fold block).
- Extracts FAQ data into \`frontend/components/landing/faqData.ts\` so the in-page FAQ render and the JSON-LD \`FAQPage\` block share one source of truth.
- Adds \`FAQPage\` JSON-LD as a sibling of the existing \`SoftwareApplication\` block; enriches \`SoftwareApplication\` with \`author\` / \`publisher\`.
- Writes \`specs/seo-admin-config-backlog.md\` capturing the next step (per-route SEO admin UI).

34 new + adjusted tests pass locally; full suite 1384/1384; tsc clean.

## Spec
specs/2026-05-29-hide-payments-seo-baseline-ollama-lan.md §2