### PR TITLE
feat(reports): make Reports v2 usable — templates, versioning, editor controls, chart/table improvements

### DIFF
--- a/backend/alembic/versions/063_reports_original_snapshot.py
+++ b/backend/alembic/versions/063_reports_original_snapshot.py
@@ -1,0 +1,26 @@
+"""add reports original snapshot columns
+
+Revision ID: 063_reports_original_snapshot
+Revises: 062_ollama_nullable_api_key
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "063_reports_original_snapshot"
+down_revision = "062_ollama_nullable_api_key"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("reports", sa.Column("original_layout_json", sa.JSON(), nullable=True))
+    op.add_column("reports", sa.Column("original_canvas_filters_json", sa.JSON(), nullable=True))
+    op.execute(
+        "UPDATE reports SET original_layout_json = layout_json, "
+        "original_canvas_filters_json = canvas_filters_json"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("reports", "original_canvas_filters_json")
+    op.drop_column("reports", "original_layout_json")

--- a/backend/alembic/versions/064_report_versions.py
+++ b/backend/alembic/versions/064_report_versions.py
@@ -1,0 +1,87 @@
+"""report version history (max 5, original pinned)
+
+Replaces the single ``reports.original_*`` snapshot columns with a
+bounded ``report_versions`` history table. Backfills one
+``is_original=True`` version per existing report (from the original
+snapshot columns, falling back to live state), then drops the snapshot
+columns.
+
+Revision ID: 064_report_versions
+Revises: 063_reports_original_snapshot
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "064_report_versions"
+down_revision = "063_reports_original_snapshot"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "report_versions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("report_id", sa.Integer(), nullable=False),
+        sa.Column("is_original", sa.Boolean(), nullable=False),
+        sa.Column("layout_json", sa.JSON(), nullable=True),
+        sa.Column("canvas_filters_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["report_id"],
+            ["reports.id"],
+            name="fk_report_versions_report",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_report_versions_report", "report_versions", ["report_id"]
+    )
+
+    # Backfill one original version per existing report. Prefer the
+    # snapshot columns; fall back to live layout/filters when NULL.
+    op.execute(
+        "INSERT INTO report_versions "
+        "(report_id, is_original, layout_json, canvas_filters_json, created_at) "
+        "SELECT id, TRUE, "
+        "COALESCE(original_layout_json, layout_json), "
+        "COALESCE(original_canvas_filters_json, canvas_filters_json), "
+        "created_at "
+        "FROM reports"
+    )
+
+    op.drop_column("reports", "original_canvas_filters_json")
+    op.drop_column("reports", "original_layout_json")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "reports",
+        sa.Column("original_layout_json", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "reports",
+        sa.Column("original_canvas_filters_json", sa.JSON(), nullable=True),
+    )
+    # Best-effort: copy the is_original version back into the columns.
+    op.execute(
+        "UPDATE reports SET "
+        "original_layout_json = ("
+        "  SELECT rv.layout_json FROM report_versions rv "
+        "  WHERE rv.report_id = reports.id AND rv.is_original = TRUE "
+        "  LIMIT 1"
+        "), "
+        "original_canvas_filters_json = ("
+        "  SELECT rv.canvas_filters_json FROM report_versions rv "
+        "  WHERE rv.report_id = reports.id AND rv.is_original = TRUE "
+        "  LIMIT 1"
+        ")"
+    )
+    op.drop_index("ix_report_versions_report", table_name="report_versions")
+    op.drop_table("report_versions")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -38,7 +38,7 @@ from app.models.notification import (  # noqa: F401
     NotificationCategory,
     UserNotificationPreferences,
 )
-from app.models.report import Report, ReportVisibility  # noqa: F401
+from app.models.report import Report, ReportVersion, ReportVisibility  # noqa: F401
 from app.models.scenario import Scenario, ScenarioType  # noqa: F401
 from app.models.org_ai_credential import (  # noqa: F401
     AiProvider,
@@ -117,6 +117,7 @@ __all__ = [
     "NotificationCategory",
     "UserNotificationPreferences",
     "Report",
+    "ReportVersion",
     "ReportVisibility",
     "Scenario",
     "ScenarioType",

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -31,6 +31,7 @@ from typing import Any, Optional
 
 from sqlalchemy import (
     JSON,
+    Boolean,
     DateTime,
     Enum,
     ForeignKey,
@@ -39,7 +40,7 @@ from sqlalchemy import (
     String,
     func,
 )
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
 
@@ -77,8 +78,6 @@ class Report(Base):
     description: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
     layout_json: Mapped[Any] = mapped_column(JSON, nullable=False)
     canvas_filters_json: Mapped[Any] = mapped_column(JSON, nullable=False)
-    original_layout_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
-    original_canvas_filters_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
     schema_version: Mapped[int] = mapped_column(
         Integer, nullable=False, default=1, server_default="1"
     )
@@ -94,6 +93,13 @@ class Report(Base):
         nullable=False,
     )
 
+    versions: Mapped[list["ReportVersion"]] = relationship(
+        "ReportVersion",
+        back_populates="report",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
     __table_args__ = (
         # "Shared by your org" + "Yours" reads.
         Index(
@@ -102,4 +108,37 @@ class Report(Base):
             "visibility",
         ),
         Index("ix_reports_owner", "owner_user_id"),
+    )
+
+
+class ReportVersion(Base):
+    """A point-in-time snapshot of a report's layout + canvas filters.
+
+    Replaces the single ``reports.original_*`` snapshot columns with a
+    small bounded history (max 5 per report). Exactly one row per report
+    has ``is_original=True`` (captured at create, never evicted); the
+    remaining up to 4 rows are the most recent saves.
+    """
+
+    __tablename__ = "report_versions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    report_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("reports.id", name="fk_report_versions_report", ondelete="CASCADE"),
+        nullable=False,
+    )
+    is_original: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    layout_json: Mapped[Any] = mapped_column(JSON, nullable=True)
+    canvas_filters_json: Mapped[Any] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    report: Mapped["Report"] = relationship("Report", back_populates="versions")
+
+    __table_args__ = (
+        Index("ix_report_versions_report", "report_id"),
     )

--- a/backend/app/models/report.py
+++ b/backend/app/models/report.py
@@ -77,6 +77,8 @@ class Report(Base):
     description: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
     layout_json: Mapped[Any] = mapped_column(JSON, nullable=False)
     canvas_filters_json: Mapped[Any] = mapped_column(JSON, nullable=False)
+    original_layout_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    original_canvas_filters_json: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
     schema_version: Mapped[int] = mapped_column(
         Integer, nullable=False, default=1, server_default="1"
     )

--- a/backend/app/reports/templates.py
+++ b/backend/app/reports/templates.py
@@ -74,12 +74,21 @@ def _last_12_months_range(today: date) -> dict:
     return {"start": _iso(start), "end": _iso(today)}
 
 
-_TODAY = date.today()
-_THIS_MONTH = _this_month_range(_TODAY)
-_LAST_12_MONTHS = _last_12_months_range(_TODAY)
+def get_report_templates() -> list[dict]:
+    """Build the starter report templates with fresh date windows.
 
+    The ``canvas_filters_json.date_range`` windows are computed from
+    ``date.today()`` at CALL TIME (not module import) so a long-running
+    backend always serves a window relative to the current date. The
+    endpoint calls this per request; "this month" / "trailing 12 months"
+    therefore roll over with the calendar instead of staying frozen to
+    the date the process booted.
+    """
+    today = date.today()
+    this_month = _this_month_range(today)
+    last_12_months = _last_12_months_range(today)
 
-REPORT_TEMPLATES: list[dict] = [
+    return [
     {
         "key": "monthly_review",
         "name": "Monthly review",
@@ -87,7 +96,7 @@ REPORT_TEMPLATES: list[dict] = [
             "Net, income, and expense at a glance for the current month, "
             "plus spend by category and a daily income-vs-expense trend."
         ),
-        "canvas_filters_json": {"date_range": _THIS_MONTH},
+        "canvas_filters_json": {"date_range": this_month},
         "layout_json": {
             "version": 1,
             "widgets": [
@@ -162,7 +171,7 @@ REPORT_TEMPLATES: list[dict] = [
         "description": (
             "Average monthly net over the trailing year and net by month."
         ),
-        "canvas_filters_json": {"date_range": _LAST_12_MONTHS},
+        "canvas_filters_json": {"date_range": last_12_months},
         "layout_json": {
             "version": 1,
             "widgets": [
@@ -199,7 +208,7 @@ REPORT_TEMPLATES: list[dict] = [
             "Category share of spend, the top transactions table, and a "
             "stacked category-by-month breakdown."
         ),
-        "canvas_filters_json": {"date_range": _THIS_MONTH},
+        "canvas_filters_json": {"date_range": this_month},
         "layout_json": {
             "version": 1,
             "widgets": [

--- a/backend/app/reports/templates.py
+++ b/backend/app/reports/templates.py
@@ -1,0 +1,248 @@
+"""Reports v2 — starter report templates (code fixtures).
+
+Architect-locked decision (Reports v2 "Slice 1"): the three starter
+templates are Python code fixtures, NOT DB seed rows. ``GET
+/api/v1/reports/templates`` returns them; the frontend "Use template"
+action POSTs the chosen ``layout_json`` / ``canvas_filters_json`` to the
+existing ``POST /api/v1/reports`` create endpoint.
+
+CRITICAL — shape contract:
+
+The ``layout_json`` widgets and ``canvas_filters_json`` MUST match the
+*implemented* frontend widget-config shapes in
+``frontend/lib/reports/types.ts``, because the canvas renders these dicts
+directly. A shape mismatch renders a blank widget. The shapes used here:
+
+- Single-measure widgets (kpi, bar, pie, sparkline) carry
+  ``config.measure`` (a ``Measure`` = ``{agg, field}``).
+- Multi-series widgets (line, area, stacked_bar, table) carry
+  ``config.measures`` (a list of ``{measure: {agg, field}, label?}``).
+- Per-widget filters use the ``WidgetFilters`` shape (e.g.
+  ``{"txn_type": "expense"}``), NOT the raw AST ``{field, op, value}``
+  primitive.
+- Dimensions are drawn from the closed ``Dimension`` union: only
+  ``category`` / ``month`` / ``day`` are used below.
+- ``canvas_filters_json.date_range`` is a ``CanvasDateRange`` =
+  ``{start, end}`` of ABSOLUTE ISO dates. The implemented frontend does
+  NOT store relative preset strings: ``DatePresetChips`` resolves a
+  preset to an absolute window at click time ("the backend AST doesn't
+  model relative ranges; freezing the absolute window at click time").
+  We mirror that here, computing the windows relative to the current
+  date so the starter range is sensible when the template is cloned.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+
+def _measure(agg: str, field: str = "amount") -> dict:
+    """A single ``Measure`` (``agg(field)``)."""
+    return {"agg": agg, "field": field}
+
+
+def _series(agg: str, label: str, field: str = "amount") -> dict:
+    """A single ``SeriesConfig`` entry for multi-series widgets."""
+    return {"measure": _measure(agg, field), "label": label}
+
+
+def _iso(d: date) -> str:
+    return d.isoformat()
+
+
+def _this_month_range(today: date) -> dict:
+    """``{start, end}`` for the calendar month containing ``today``.
+
+    Mirrors ``DatePresetChips.buildPresetRanges`` ``this_month``.
+    """
+    start = today.replace(day=1)
+    # First day of next month, minus one day, is the last day of this month.
+    if today.month == 12:
+        first_next = date(today.year + 1, 1, 1)
+    else:
+        first_next = date(today.year, today.month + 1, 1)
+    last = first_next - timedelta(days=1)
+    return {"start": _iso(start), "end": _iso(last)}
+
+
+def _last_12_months_range(today: date) -> dict:
+    """``{start, end}`` for the trailing 12 months.
+
+    Mirrors ``DatePresetChips.buildPresetRanges`` ``last_12_months``:
+    start = first day of the same month one year ago, end = today.
+    """
+    start = date(today.year - 1, today.month, 1)
+    return {"start": _iso(start), "end": _iso(today)}
+
+
+_TODAY = date.today()
+_THIS_MONTH = _this_month_range(_TODAY)
+_LAST_12_MONTHS = _last_12_months_range(_TODAY)
+
+
+REPORT_TEMPLATES: list[dict] = [
+    {
+        "key": "monthly_review",
+        "name": "Monthly review",
+        "description": (
+            "Net, income, and expense at a glance for the current month, "
+            "plus spend by category and a daily income-vs-expense trend."
+        ),
+        "canvas_filters_json": {"date_range": _THIS_MONTH},
+        "layout_json": {
+            "version": 1,
+            "widgets": [
+                {
+                    "id": "mr-kpi-net",
+                    "type": "kpi",
+                    "title": "Net",
+                    "grid": {"x": 0, "y": 0, "w": 4, "h": 2},
+                    "config": {
+                        "dataset": "transactions",
+                        "measure": _measure("sum"),
+                        "format": "currency",
+                    },
+                },
+                {
+                    "id": "mr-kpi-income",
+                    "type": "kpi",
+                    "title": "Income",
+                    "grid": {"x": 4, "y": 0, "w": 4, "h": 2},
+                    "config": {
+                        "dataset": "transactions",
+                        "measure": _measure("sum"),
+                        "filters": {"txn_type": "income"},
+                        "format": "currency",
+                    },
+                },
+                {
+                    "id": "mr-kpi-expense",
+                    "type": "kpi",
+                    "title": "Expense",
+                    "grid": {"x": 8, "y": 0, "w": 4, "h": 2},
+                    "config": {
+                        "dataset": "transactions",
+                        "measure": _measure("sum"),
+                        "filters": {"txn_type": "expense"},
+                        "format": "currency",
+                    },
+                },
+                {
+                    "id": "mr-bar-category",
+                    "type": "bar",
+                    "title": "Spend by category",
+                    "grid": {"x": 0, "y": 2, "w": 6, "h": 4},
+                    "config": {
+                        "dataset": "transactions",
+                        "measure": _measure("sum"),
+                        "dimensions": ["category"],
+                        "filters": {"txn_type": "expense"},
+                        "sort": {"by": "value", "dir": "desc"},
+                        "limit": 10,
+                        "format": "currency",
+                    },
+                },
+                {
+                    "id": "mr-line-income-expense",
+                    "type": "line",
+                    "title": "Income vs expense",
+                    "grid": {"x": 6, "y": 2, "w": 6, "h": 4},
+                    "config": {
+                        "dataset": "transactions",
+                        "measures": [_series("sum", "Net")],
+                        "dimensions": ["day"],
+                        "format": "currency",
+                    },
+                },
+            ],
+        },
+    },
+    {
+        "key": "cash_flow_trend",
+        "name": "Cash flow trend",
+        "description": (
+            "Average monthly net over the trailing year and net by month."
+        ),
+        "canvas_filters_json": {"date_range": _LAST_12_MONTHS},
+        "layout_json": {
+            "version": 1,
+            "widgets": [
+                {
+                    "id": "cft-kpi-avg-net",
+                    "type": "kpi",
+                    "title": "Avg monthly net (12mo)",
+                    "grid": {"x": 0, "y": 0, "w": 4, "h": 2},
+                    "config": {
+                        "dataset": "transactions",
+                        "measure": _measure("avg"),
+                        "format": "currency",
+                    },
+                },
+                {
+                    "id": "cft-line-net-by-month",
+                    "type": "line",
+                    "title": "Net by month",
+                    "grid": {"x": 0, "y": 2, "w": 12, "h": 4},
+                    "config": {
+                        "dataset": "transactions",
+                        "measures": [_series("sum", "Net")],
+                        "dimensions": ["month"],
+                        "format": "currency",
+                    },
+                },
+            ],
+        },
+    },
+    {
+        "key": "category_deep_dive",
+        "name": "Category deep-dive",
+        "description": (
+            "Category share of spend, the top transactions table, and a "
+            "stacked category-by-month breakdown."
+        ),
+        "canvas_filters_json": {"date_range": _THIS_MONTH},
+        "layout_json": {
+            "version": 1,
+            "widgets": [
+                {
+                    "id": "cdd-pie-share",
+                    "type": "pie",
+                    "title": "Category share",
+                    "grid": {"x": 0, "y": 0, "w": 6, "h": 4},
+                    "config": {
+                        "dataset": "transactions",
+                        "measure": _measure("sum"),
+                        "dimensions": ["category"],
+                        "filters": {"txn_type": "expense"},
+                    },
+                },
+                {
+                    "id": "cdd-table-top",
+                    "type": "table",
+                    "title": "Top transactions",
+                    "grid": {"x": 6, "y": 0, "w": 6, "h": 4},
+                    "config": {
+                        "dataset": "transactions",
+                        "measures": [_series("sum", "Amount")],
+                        "dimensions": ["category"],
+                        "sort": {"by": "value", "dir": "desc"},
+                        "limit": 20,
+                        "format": "currency",
+                    },
+                },
+                {
+                    "id": "cdd-stacked-by-month",
+                    "type": "stacked_bar",
+                    "title": "Category by month",
+                    "grid": {"x": 0, "y": 4, "w": 12, "h": 4},
+                    "config": {
+                        "dataset": "transactions",
+                        "measures": [_series("sum", "Spend")],
+                        "dimensions": ["month", "category"],
+                        "filters": {"txn_type": "expense"},
+                        "format": "currency",
+                    },
+                },
+            ],
+        },
+    },
+]

--- a/backend/app/reports/templates.py
+++ b/backend/app/reports/templates.py
@@ -94,7 +94,7 @@ def get_report_templates() -> list[dict]:
         "name": "Monthly review",
         "description": (
             "Net, income, and expense at a glance for the current month, "
-            "plus spend by category and a daily income-vs-expense trend."
+            "plus spend by category and a daily net trend."
         ),
         "canvas_filters_json": {"date_range": this_month},
         "layout_json": {
@@ -151,9 +151,9 @@ def get_report_templates() -> list[dict]:
                     },
                 },
                 {
-                    "id": "mr-line-income-expense",
+                    "id": "mr-line-net-trend",
                     "type": "line",
-                    "title": "Income vs expense",
+                    "title": "Net trend (daily)",
                     "grid": {"x": 6, "y": 2, "w": 6, "h": 4},
                     "config": {
                         "dataset": "transactions",
@@ -205,7 +205,7 @@ def get_report_templates() -> list[dict]:
         "key": "category_deep_dive",
         "name": "Category deep-dive",
         "description": (
-            "Category share of spend, the top transactions table, and a "
+            "Category share of spend, a top-categories table, and a "
             "stacked category-by-month breakdown."
         ),
         "canvas_filters_json": {"date_range": this_month},
@@ -227,7 +227,7 @@ def get_report_templates() -> list[dict]:
                 {
                     "id": "cdd-table-top",
                     "type": "table",
-                    "title": "Top transactions",
+                    "title": "Top categories",
                     "grid": {"x": 6, "y": 0, "w": 6, "h": 4},
                     "config": {
                         "dataset": "transactions",

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -271,7 +271,23 @@ async def update_report(
         )
     patch = body.model_dump(exclude_unset=True)
     versioned_keys = {"layout_json", "canvas_filters_json"}
-    layout_changed = any(k in patch for k in versioned_keys)
+    # ``layout_json`` / ``canvas_filters_json`` are NOT-NULL columns.
+    # ``exclude_unset`` keeps an absent key out of the patch, but an
+    # explicit ``{"layout_json": null}`` lands here and would assign None,
+    # tripping an IntegrityError (500). Reject it up-front with a 422.
+    for k in versioned_keys:
+        if k in patch and patch[k] is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"{k} may not be null",
+            )
+    # Only snapshot when the canvas content actually changes. An explicit
+    # value identical to the current live state (or a rename / visibility-
+    # only edit) must NOT add a no-op version that prematurely evicts
+    # meaningful history under the bounded-retention cap.
+    layout_changed = any(
+        k in patch and patch[k] != getattr(row, k) for k in versioned_keys
+    )
     for k, v in patch.items():
         setattr(row, k, v)
     if layout_changed:

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -48,7 +48,13 @@ from app.deps import get_current_user
 from app.models.report import Report, ReportVisibility
 from app.models.user import Role, User
 from app.rate_limit import limiter
-from app.schemas.report import ReportCreate, ReportResponse, ReportUpdate
+from app.reports.templates import REPORT_TEMPLATES
+from app.schemas.report import (
+    ReportCreate,
+    ReportResponse,
+    ReportTemplate,
+    ReportUpdate,
+)
 from app.schemas.reports_query import ReportsQuery, ReportsQueryResponse
 from app.services.reports_query_service import execute_query
 
@@ -169,6 +175,16 @@ async def create_report(
     await db.commit()
     await db.refresh(row)
     return row
+
+
+@router.get("/templates", response_model=list[ReportTemplate])
+async def list_templates(current_user: User = Depends(get_current_user)):
+    """Return the starter report templates (code fixtures).
+
+    Registered ABOVE ``GET /{report_id}`` so the literal ``/templates``
+    path is not captured by the ``{report_id}`` integer matcher.
+    """
+    return [ReportTemplate(**t) for t in REPORT_TEMPLATES]
 
 
 @router.get("/{report_id}", response_model=ReportResponse)

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -45,7 +45,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings as app_settings
 from app.database import get_db
 from app.deps import get_current_user
-from app.models.report import Report, ReportVisibility
+from app.models.report import Report, ReportVersion, ReportVisibility
 from app.models.user import Role, User
 from app.rate_limit import limiter
 from app.reports.templates import get_report_templates
@@ -54,6 +54,7 @@ from app.schemas.report import (
     ReportResponse,
     ReportTemplate,
     ReportUpdate,
+    ReportVersionSummary,
 )
 from app.schemas.reports_query import ReportsQuery, ReportsQueryResponse
 from app.services.reports_query_service import execute_query
@@ -107,6 +108,48 @@ def _can_edit(user: User, report: Report) -> bool:
     ):
         return True
     return False
+
+
+# Retention: keep the original (never evicted) + this many most-recent
+# non-original versions. Max 5 total per report.
+MAX_NON_ORIGINAL_VERSIONS = 4
+
+
+async def _snapshot_version(
+    db: AsyncSession, report: Report, *, is_original: bool
+) -> None:
+    """Append a version row capturing the report's current live state.
+
+    For non-original snapshots, enforces retention afterwards: the
+    ``is_original`` row is never evicted; only the oldest non-original
+    rows beyond ``MAX_NON_ORIGINAL_VERSIONS`` are deleted (ordered by
+    ``created_at, id`` ascending). The caller is responsible for the
+    surrounding ``commit``.
+    """
+    db.add(
+        ReportVersion(
+            report_id=report.id,
+            is_original=is_original,
+            layout_json=report.layout_json,
+            canvas_filters_json=report.canvas_filters_json,
+        )
+    )
+    if is_original:
+        return
+
+    await db.flush()
+    stmt = (
+        select(ReportVersion)
+        .where(
+            ReportVersion.report_id == report.id,
+            ReportVersion.is_original.is_(False),
+        )
+        .order_by(ReportVersion.created_at.asc(), ReportVersion.id.asc())
+    )
+    non_original = list((await db.execute(stmt)).scalars().all())
+    excess = len(non_original) - MAX_NON_ORIGINAL_VERSIONS
+    for stale in non_original[:max(excess, 0)]:
+        await db.delete(stale)
 
 
 @router.post(
@@ -168,10 +211,10 @@ async def create_report(
         description=body.description,
         layout_json=body.layout_json,
         canvas_filters_json=body.canvas_filters_json,
-        original_layout_json=body.layout_json,
-        original_canvas_filters_json=body.canvas_filters_json,
     )
     db.add(row)
+    await db.flush()
+    await _snapshot_version(db, row, is_original=True)
     await db.commit()
     await db.refresh(row)
     return row
@@ -227,32 +270,81 @@ async def update_report(
             detail="Forbidden",
         )
     patch = body.model_dump(exclude_unset=True)
+    versioned_keys = {"layout_json", "canvas_filters_json"}
+    layout_changed = any(k in patch for k in versioned_keys)
     for k, v in patch.items():
         setattr(row, k, v)
+    if layout_changed:
+        # Capture the NEW live state as a non-original version (with
+        # retention) only when the canvas itself changed. A rename /
+        # visibility-only edit does not add to the history.
+        await _snapshot_version(db, row, is_original=False)
     await db.commit()
     await db.refresh(row)
     return row
 
 
-@router.post("/{report_id}/reset", response_model=ReportResponse)
-async def reset_report(
+@router.get(
+    "/{report_id}/versions",
+    response_model=list[ReportVersionSummary],
+)
+async def list_report_versions(
     report_id: int,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Revert a report's live state to its as-created snapshot.
+    """List a report's version history, newest-first.
 
-    Copies ``original_layout_json`` / ``original_canvas_filters_json``
-    back into the live ``layout_json`` / ``canvas_filters_json`` columns.
-    The snapshot columns are set once at create and never touched by
-    edits, so this is a pure restore.
+    Each entry is a lightweight summary (``id`` / ``is_original`` /
+    ``created_at``); the full layout payload is not returned in the list.
+    404 when the report is missing or invisible (mirrors GET).
+    """
+    row = await db.get(Report, report_id)
+    if row is None or not _can_view(current_user, row):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Report not found",
+        )
+    stmt = (
+        select(ReportVersion)
+        .where(ReportVersion.report_id == report_id)
+        .order_by(ReportVersion.created_at.desc(), ReportVersion.id.desc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
 
-    Visibility / edit gating mirrors PATCH + DELETE: 404 when the row is
-    missing or invisible, 403 when the caller lacks edit rights.
 
-    Task-1 backfilled existing rows, so ``original_*`` should never be
-    NULL; the coalesce-to-current guard keeps a legacy NULL row from
-    blanking its live state.
+async def _restore_version(
+    db: AsyncSession,
+    report: Report,
+    version: ReportVersion,
+) -> Report:
+    """Copy a version's layout/filters into the live report and commit.
+
+    Restoring does NOT itself create a new version; the next Save does.
+    """
+    report.layout_json = version.layout_json
+    report.canvas_filters_json = version.canvas_filters_json
+    await db.commit()
+    await db.refresh(report)
+    return report
+
+
+@router.post(
+    "/{report_id}/versions/{version_id}/restore",
+    response_model=ReportResponse,
+)
+async def restore_report_version(
+    report_id: int,
+    version_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Restore a specific version into the report's live state.
+
+    404 when the report is missing/invisible, 403 when the caller lacks
+    edit rights, 404 when the version does not belong to this report.
+    Does NOT create a new version.
     """
     row = await db.get(Report, report_id)
     if row is None or not _can_view(current_user, row):
@@ -265,13 +357,55 @@ async def reset_report(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Forbidden",
         )
-    if row.original_layout_json is not None:
-        row.layout_json = row.original_layout_json
-    if row.original_canvas_filters_json is not None:
-        row.canvas_filters_json = row.original_canvas_filters_json
-    await db.commit()
-    await db.refresh(row)
-    return row
+    version = await db.get(ReportVersion, version_id)
+    if version is None or version.report_id != report_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Version not found",
+        )
+    return await _restore_version(db, row, version)
+
+
+@router.post("/{report_id}/reset", response_model=ReportResponse)
+async def reset_report(
+    report_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Revert a report's live state to its as-created (original) version.
+
+    Sugar over the version-restore path: finds this report's
+    ``is_original=True`` version and restores it, so the existing
+    "Revert to original" button keeps working.
+
+    Visibility / edit gating mirrors PATCH + DELETE: 404 when the row is
+    missing or invisible, 403 when the caller lacks edit rights.
+    """
+    row = await db.get(Report, report_id)
+    if row is None or not _can_view(current_user, row):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Report not found",
+        )
+    if not _can_edit(current_user, row):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )
+    stmt = (
+        select(ReportVersion)
+        .where(
+            ReportVersion.report_id == report_id,
+            ReportVersion.is_original.is_(True),
+        )
+        .order_by(ReportVersion.id.asc())
+    )
+    original = (await db.execute(stmt)).scalars().first()
+    if original is None:
+        # No original version recorded (legacy / seeded row without
+        # backfill). Nothing to restore; return the live state unchanged.
+        return row
+    return await _restore_version(db, row, original)
 
 
 @router.delete(

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -234,6 +234,46 @@ async def update_report(
     return row
 
 
+@router.post("/{report_id}/reset", response_model=ReportResponse)
+async def reset_report(
+    report_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Revert a report's live state to its as-created snapshot.
+
+    Copies ``original_layout_json`` / ``original_canvas_filters_json``
+    back into the live ``layout_json`` / ``canvas_filters_json`` columns.
+    The snapshot columns are set once at create and never touched by
+    edits, so this is a pure restore.
+
+    Visibility / edit gating mirrors PATCH + DELETE: 404 when the row is
+    missing or invisible, 403 when the caller lacks edit rights.
+
+    Task-1 backfilled existing rows, so ``original_*`` should never be
+    NULL; the coalesce-to-current guard keeps a legacy NULL row from
+    blanking its live state.
+    """
+    row = await db.get(Report, report_id)
+    if row is None or not _can_view(current_user, row):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Report not found",
+        )
+    if not _can_edit(current_user, row):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden",
+        )
+    if row.original_layout_json is not None:
+        row.layout_json = row.original_layout_json
+    if row.original_canvas_filters_json is not None:
+        row.canvas_filters_json = row.original_canvas_filters_json
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
 @router.delete(
     "/{report_id}",
     status_code=status.HTTP_204_NO_CONTENT,

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -408,6 +408,47 @@ async def reset_report(
     return await _restore_version(db, row, original)
 
 
+@router.post(
+    "/{report_id}/duplicate",
+    response_model=ReportResponse,
+    status_code=201,
+)
+async def duplicate_report(
+    report_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a private copy of a visible report, owned by the caller.
+
+    404 when the source is missing or invisible (mirrors GET). The copy
+    is always ``private`` regardless of the source's visibility, carries
+    the source name with a " (copy)" suffix, and reuses the same
+    creation path as ``create_report`` so it gets its own
+    ``is_original`` version snapshot.
+    """
+    source = await db.get(Report, report_id)
+    if source is None or not _can_view(current_user, source):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Report not found",
+        )
+    row = Report(
+        owner_user_id=current_user.id,
+        org_id=current_user.org_id,
+        visibility=ReportVisibility.PRIVATE,
+        name=f"{source.name} (copy)",
+        description=source.description,
+        layout_json=source.layout_json,
+        canvas_filters_json=source.canvas_filters_json,
+    )
+    db.add(row)
+    await db.flush()
+    await _snapshot_version(db, row, is_original=True)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
 @router.delete(
     "/{report_id}",
     status_code=status.HTTP_204_NO_CONTENT,

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -48,7 +48,7 @@ from app.deps import get_current_user
 from app.models.report import Report, ReportVisibility
 from app.models.user import Role, User
 from app.rate_limit import limiter
-from app.reports.templates import REPORT_TEMPLATES
+from app.reports.templates import get_report_templates
 from app.schemas.report import (
     ReportCreate,
     ReportResponse,
@@ -183,8 +183,12 @@ async def list_templates(current_user: User = Depends(get_current_user)):
 
     Registered ABOVE ``GET /{report_id}`` so the literal ``/templates``
     path is not captured by the ``{report_id}`` integer matcher.
+
+    Calls ``get_report_templates()`` per request so the date windows are
+    recomputed from ``date.today()`` and never go stale on a long-running
+    backend.
     """
-    return [ReportTemplate(**t) for t in REPORT_TEMPLATES]
+    return [ReportTemplate(**t) for t in get_report_templates()]
 
 
 @router.get("/{report_id}", response_model=ReportResponse)

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -162,6 +162,8 @@ async def create_report(
         description=body.description,
         layout_json=body.layout_json,
         canvas_filters_json=body.canvas_filters_json,
+        original_layout_json=body.layout_json,
+        original_canvas_filters_json=body.canvas_filters_json,
     )
     db.add(row)
     await db.commit()

--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -57,6 +57,19 @@ class ReportUpdate(BaseModel):
     canvas_filters_json: Optional[dict[str, Any]] = None
 
 
+class ReportTemplate(BaseModel):
+    """A starter report template returned by
+    ``GET /api/v1/reports/templates``. The frontend "Use template" action
+    POSTs ``layout_json`` / ``canvas_filters_json`` to the create endpoint.
+    """
+
+    key: str
+    name: str
+    description: str
+    layout_json: dict[str, Any]
+    canvas_filters_json: dict[str, Any]
+
+
 class ReportResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -84,3 +84,17 @@ class ReportResponse(BaseModel):
     schema_version: int
     created_at: datetime
     updated_at: datetime
+
+
+class ReportVersionSummary(BaseModel):
+    """Lightweight version-history row for the version list endpoint.
+
+    Intentionally omits the full ``layout_json`` / ``canvas_filters_json``
+    payload; the list only needs to render selectable history entries.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    is_original: bool
+    created_at: datetime

--- a/backend/app/services/admin_users_service.py
+++ b/backend/app/services/admin_users_service.py
@@ -55,7 +55,13 @@ delete handler walks them explicitly so we never rely on implicit
      remain on the org (the FK from transactions.import_batch_id
      to import_batches.id has ON DELETE SET NULL).
 
-The 6 + 7 explicit deletes mirror the FK-ordered delete pattern
+  8. ``reports.owner_user_id`` — ``ON DELETE RESTRICT``. Reports are
+     handled in-band before the user delete: org-shared reports are
+     transferred to the org's active OWNER, private reports are
+     hard-deleted (their ``report_versions`` cascade). A bare delete
+     would otherwise trip the RESTRICT FK for any report author.
+
+The 6 + 7 + 8 explicit handlers mirror the FK-ordered delete pattern
 ``org_data_service.wipe_org_data`` established for the org-wipe
 path. See ``reference_truncate_org_scoped.md`` for the broader
 "don't leave orphaned rows" rule.
@@ -70,12 +76,13 @@ the audit row is self-explanatory.
 from __future__ import annotations
 
 import structlog
-from sqlalchemy import delete
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.import_batch import ImportBatch
 from app.models.invitation import Invitation
-from app.models.user import User
+from app.models.report import Report, ReportVisibility
+from app.models.user import Role, User
 from app.services.exceptions import ConflictError, NotFoundError
 
 
@@ -160,9 +167,72 @@ async def delete_user(
         )
     )
 
+    # ── reports.owner_user_id (ON DELETE RESTRICT) ───────────────────
+    #
+    # The FK is RESTRICT, so a bare DELETE FROM users raises if the
+    # target authored any report. Handle their reports in the same
+    # transaction:
+    #
+    #   - ORG-shared reports → transfer to the org's active OWNER so the
+    #     team keeps its shared report.
+    #   - PRIVATE reports → hard-delete (report_versions cascade via the
+    #     ON DELETE CASCADE FK on report_versions.report_id).
+    #
+    # Edge case: ``delete_user`` requires ``is_active=False``, so a
+    # *deactivated* org owner is reachable here. The last-active-owner
+    # guard lives on the deactivate path, not this endpoint, so there is
+    # no in-process owner to transfer to when the only owner is the
+    # (now inactive) target. If no other active OWNER exists, fall back
+    # to deleting the org-shared reports too rather than leaving an
+    # un-transferable RESTRICT FK.
+    new_owner_id = (
+        await db.execute(
+            select(User.id)
+            .where(
+                User.org_id == snapshot["org_id"],
+                User.role == Role.OWNER,
+                User.is_active.is_(True),
+                User.id != target_user_id,
+            )
+            .order_by(User.id.asc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    private_delete = await db.execute(
+        delete(Report).where(
+            Report.owner_user_id == target_user_id,
+            Report.visibility == ReportVisibility.PRIVATE,
+        )
+    )
+
+    if new_owner_id is not None:
+        shared_result = await db.execute(
+            update(Report)
+            .where(
+                Report.owner_user_id == target_user_id,
+                Report.visibility == ReportVisibility.ORG,
+            )
+            .values(owner_user_id=new_owner_id)
+        )
+        reports_transferred = shared_result.rowcount or 0
+        reports_deleted_shared = 0
+    else:
+        shared_result = await db.execute(
+            delete(Report).where(
+                Report.owner_user_id == target_user_id,
+                Report.visibility == ReportVisibility.ORG,
+            )
+        )
+        reports_transferred = 0
+        reports_deleted_shared = shared_result.rowcount or 0
+
     fk_cleanup_counts = {
         "invitations": inv_result.rowcount or 0,
         "import_batches": batches_result.rowcount or 0,
+        "reports_deleted_private": private_delete.rowcount or 0,
+        "reports_deleted_shared": reports_deleted_shared,
+        "reports_transferred": reports_transferred,
     }
 
     # Finally, the user row itself. SET NULL FKs (audit_events,

--- a/backend/tests/routers/test_reports_templates.py
+++ b/backend/tests/routers/test_reports_templates.py
@@ -20,7 +20,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 from app.config import settings as app_settings
-from app.models.report import Report
+from app.models.report import Report, ReportVisibility
 
 from tests.routers.test_reports import (  # noqa: F401 — reuse fixtures
     _enable_flag,
@@ -144,4 +144,103 @@ async def test_templates_endpoint_404_when_flag_off(session_factory, monkeypatch
     app = _make_app(session_factory, _resolver("user_a"))
     with TestClient(app) as client:
         res = client.get("/api/v1/reports/templates")
+    assert res.status_code == 404
+
+
+# ─── POST /api/v1/reports/{id}/reset ────────────────────────────────
+
+
+_LAYOUT_A = {"version": 1, "widgets": [{"id": "w1", "type": "kpi"}]}
+_FILTERS_X = {"date_range": {"kind": "relative", "preset": "last_30_days"}}
+_LAYOUT_B = {"version": 1, "widgets": []}
+_FILTERS_Y = {"date_range": {"kind": "relative", "preset": "last_7_days"}}
+
+
+@pytest.mark.asyncio
+async def test_reset_restores_original(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "Reset Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT_A,
+            "canvas_filters_json": _FILTERS_X,
+        })
+        assert res.status_code == 201, res.text
+        report_id = res.json()["id"]
+
+        # Edit the live state away from the original snapshot.
+        patched = client.patch(f"/api/v1/reports/{report_id}", json={
+            "layout_json": _LAYOUT_B,
+            "canvas_filters_json": _FILTERS_Y,
+        })
+        assert patched.status_code == 200, patched.text
+        assert patched.json()["layout_json"] == _LAYOUT_B
+        assert patched.json()["canvas_filters_json"] == _FILTERS_Y
+
+        # Reset back to the as-created snapshot.
+        reset = client.post(f"/api/v1/reports/{report_id}/reset")
+        assert reset.status_code == 200, reset.text
+        body = reset.json()
+        assert body["layout_json"] == _LAYOUT_A
+        assert body["canvas_filters_json"] == _FILTERS_X
+
+    # DB re-read confirms the live columns now match the original.
+    async with session_factory() as db:
+        row = (
+            await db.execute(select(Report).where(Report.id == report_id))
+        ).scalar_one()
+        assert row.layout_json == _LAYOUT_A
+        assert row.canvas_filters_json == _FILTERS_X
+        # snapshot untouched
+        assert row.original_layout_json == _LAYOUT_A
+        assert row.original_canvas_filters_json == _FILTERS_X
+
+
+@pytest.mark.asyncio
+async def test_reset_forbidden_for_non_editor(session_factory):
+    """A same-org MEMBER who is not the owner can VIEW an org-shared
+    report but cannot reset it (mirrors the PATCH/DELETE edit gate).
+    """
+    seeds = await _seed(session_factory)
+    async with session_factory() as db:
+        report = Report(
+            owner_user_id=seeds["user_a_id"],  # OWNER role authored it
+            org_id=seeds["org_a_id"],
+            visibility=ReportVisibility.ORG,
+            name="org-shared",
+            layout_json=_LAYOUT_B,
+            canvas_filters_json=_FILTERS_Y,
+            original_layout_json=_LAYOUT_A,
+            original_canvas_filters_json=_FILTERS_X,
+        )
+        db.add(report)
+        await db.commit()
+        await db.refresh(report)
+        rid = report.id
+
+    # member_a is MEMBER role — can view but not edit.
+    app = _make_app(session_factory, _resolver("member_a"))
+    with TestClient(app) as client:
+        res = client.post(f"/api/v1/reports/{rid}/reset")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reset_404_when_not_found(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports/999999/reset")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reset_404_when_flag_off(session_factory, monkeypatch):
+    monkeypatch.setattr(app_settings, "feature_reports_v2", False)
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports/1/reset")
     assert res.status_code == 404

--- a/backend/tests/routers/test_reports_templates.py
+++ b/backend/tests/routers/test_reports_templates.py
@@ -17,6 +17,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
+from app.config import settings as app_settings
 from app.models.report import Report
 
 from tests.routers.test_reports import (  # noqa: F401 — reuse fixtures
@@ -81,3 +82,33 @@ async def test_patch_does_not_touch_original_snapshot(session_factory):
         assert row.layout_json == {"version": 1, "widgets": []}
         assert row.original_layout_json == _LAYOUT
         assert row.original_canvas_filters_json == _FILTERS
+
+
+# ─── GET /api/v1/reports/templates ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_templates_endpoint_returns_three(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/reports/templates")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert len(body) == 3
+    keys = {t["key"] for t in body}
+    assert keys == {"monthly_review", "cash_flow_trend", "category_deep_dive"}
+    for t in body:
+        assert t["layout_json"]["widgets"], t["key"]
+
+
+@pytest.mark.asyncio
+async def test_templates_endpoint_404_when_flag_off(session_factory, monkeypatch):
+    # The autouse ``_enable_flag`` fixture force-enables the flag; flip
+    # it back off here so the router-level dep fires its 404.
+    monkeypatch.setattr(app_settings, "feature_reports_v2", False)
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/reports/templates")
+    assert res.status_code == 404

--- a/backend/tests/routers/test_reports_templates.py
+++ b/backend/tests/routers/test_reports_templates.py
@@ -13,6 +13,8 @@ Fixtures (``session_factory``, ``_make_app``, ``_seed``, ``_resolver``,
 """
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
@@ -100,6 +102,37 @@ async def test_templates_endpoint_returns_three(session_factory):
     assert keys == {"monthly_review", "cash_flow_trend", "category_deep_dive"}
     for t in body:
         assert t["layout_json"]["widgets"], t["key"]
+
+
+@pytest.mark.asyncio
+async def test_templates_date_windows_reflect_current_month(session_factory):
+    # The date windows must be computed per request from date.today(),
+    # not frozen at module import. Assert the monthly_review window starts
+    # on the first day of the current month and ends on the last day.
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/reports/templates")
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    today = date.today()
+    first_of_month = today.replace(day=1)
+
+    by_key = {t["key"]: t for t in body}
+    monthly = by_key["monthly_review"]
+    date_range = monthly["canvas_filters_json"]["date_range"]
+    assert date_range["start"] == first_of_month.isoformat()
+    # end is the last day of the current month (>= today, same month)
+    end = date.fromisoformat(date_range["end"])
+    assert end >= today
+    assert end.year == today.year and end.month == today.month
+
+    # trailing-12-months template ends at today
+    cash_flow = by_key["cash_flow_trend"]
+    cf_range = cash_flow["canvas_filters_json"]["date_range"]
+    assert cf_range["end"] == today.isoformat()
+    assert cf_range["start"] == date(today.year - 1, today.month, 1).isoformat()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_reports_templates.py
+++ b/backend/tests/routers/test_reports_templates.py
@@ -1,0 +1,83 @@
+"""Router tests for Reports v2 "Revert to original" snapshot columns.
+
+create_report must populate ``original_layout_json`` +
+``original_canvas_filters_json`` from the create-time layout/filters so a
+future "Revert to original" can restore them. PATCH must NOT touch the
+snapshot.
+
+The snapshot columns are not exposed in the API response, so assertions
+read the ``Report`` row back from the DB via the test ``session_factory``.
+
+Fixtures (``session_factory``, ``_make_app``, ``_seed``, ``_resolver``,
+``_enable_flag``) are reused from ``test_reports.py``.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.models.report import Report
+
+from tests.routers.test_reports import (  # noqa: F401 — reuse fixtures
+    _enable_flag,
+    _make_app,
+    _resolver,
+    _seed,
+    session_factory,
+)
+
+
+_LAYOUT = {"version": 1, "widgets": [{"id": "w1", "type": "kpi"}]}
+_FILTERS = {"date_range": {"kind": "relative", "preset": "last_30_days"}}
+
+
+@pytest.mark.asyncio
+async def test_create_snapshots_original_layout_and_filters(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "Snapshot Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        assert res.status_code == 201, res.text
+        report_id = res.json()["id"]
+
+    async with session_factory() as db:
+        row = (
+            await db.execute(select(Report).where(Report.id == report_id))
+        ).scalar_one()
+        assert row.original_layout_json == _LAYOUT
+        assert row.original_canvas_filters_json == _FILTERS
+
+
+@pytest.mark.asyncio
+async def test_patch_does_not_touch_original_snapshot(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "Snapshot Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        assert res.status_code == 201, res.text
+        report_id = res.json()["id"]
+
+        patched = client.patch(f"/api/v1/reports/{report_id}", json={
+            "layout_json": {"version": 1, "widgets": []},
+        })
+        assert patched.status_code == 200, patched.text
+
+    async with session_factory() as db:
+        row = (
+            await db.execute(select(Report).where(Report.id == report_id))
+        ).scalar_one()
+        # live layout changed, snapshot must be untouched
+        assert row.layout_json == {"version": 1, "widgets": []}
+        assert row.original_layout_json == _LAYOUT
+        assert row.original_canvas_filters_json == _FILTERS

--- a/backend/tests/routers/test_reports_templates.py
+++ b/backend/tests/routers/test_reports_templates.py
@@ -133,6 +133,65 @@ async def test_patch_without_layout_change_does_not_version(session_factory):
 
 
 @pytest.mark.asyncio
+async def test_patch_identical_layout_does_not_version(session_factory):
+    """Re-sending the current layout/filters verbatim must not snapshot.
+
+    A no-op save would otherwise burn one of the 4 non-original slots and
+    prematurely evict meaningful history under the bounded cap.
+    """
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "Idempotent Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        assert res.status_code == 201, res.text
+        report_id = res.json()["id"]
+
+        # PATCH with values identical to the live state.
+        patched = client.patch(f"/api/v1/reports/{report_id}", json={
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        assert patched.status_code == 200, patched.text
+
+    versions = await _versions_for(session_factory, report_id)
+    # Still just the create-time original; the no-op save added nothing.
+    assert len(versions) == 1
+    assert versions[0].is_original is True
+
+
+@pytest.mark.asyncio
+async def test_patch_null_layout_rejected_with_422(session_factory):
+    """Explicit null for the NOT-NULL JSON columns must 422, not 500."""
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "Null Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        assert res.status_code == 201, res.text
+        report_id = res.json()["id"]
+
+        for field in ("layout_json", "canvas_filters_json"):
+            patched = client.patch(
+                f"/api/v1/reports/{report_id}", json={field: None}
+            )
+            assert patched.status_code == 422, patched.text
+
+    # No version churn from the rejected writes; only the original remains.
+    versions = await _versions_for(session_factory, report_id)
+    assert len(versions) == 1
+    assert versions[0].is_original is True
+
+
+@pytest.mark.asyncio
 async def test_list_versions(session_factory):
     await _seed(session_factory)
     app = _make_app(session_factory, _resolver("user_a"))

--- a/backend/tests/routers/test_reports_templates.py
+++ b/backend/tests/routers/test_reports_templates.py
@@ -1,12 +1,13 @@
-"""Router tests for Reports v2 "Revert to original" snapshot columns.
+"""Router tests for Reports v2 version history + "Revert to original".
 
-create_report must populate ``original_layout_json`` +
-``original_canvas_filters_json`` from the create-time layout/filters so a
-future "Revert to original" can restore them. PATCH must NOT touch the
-snapshot.
+create_report records one ``is_original=True`` ``report_versions`` row
+from the create-time layout/filters. Save (PATCH) records a new
+non-original version ONLY when ``layout_json`` / ``canvas_filters_json``
+change, capped at 5 total (original pinned + 4 most-recent). Restore /
+reset copy a version back into the live report without adding a version.
 
-The snapshot columns are not exposed in the API response, so assertions
-read the ``Report`` row back from the DB via the test ``session_factory``.
+The version rows are read back from the DB via the test
+``session_factory``.
 
 Fixtures (``session_factory``, ``_make_app``, ``_seed``, ``_resolver``,
 ``_enable_flag``) are reused from ``test_reports.py``.
@@ -20,7 +21,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 from app.config import settings as app_settings
-from app.models.report import Report, ReportVisibility
+from app.models.report import Report, ReportVersion, ReportVisibility
 
 from tests.routers.test_reports import (  # noqa: F401 — reuse fixtures
     _enable_flag,
@@ -33,6 +34,18 @@ from tests.routers.test_reports import (  # noqa: F401 — reuse fixtures
 
 _LAYOUT = {"version": 1, "widgets": [{"id": "w1", "type": "kpi"}]}
 _FILTERS = {"date_range": {"kind": "relative", "preset": "last_30_days"}}
+
+
+async def _versions_for(session_factory, report_id):
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                select(ReportVersion)
+                .where(ReportVersion.report_id == report_id)
+                .order_by(ReportVersion.created_at.asc(), ReportVersion.id.asc())
+            )
+        ).scalars().all()
+        return list(rows)
 
 
 @pytest.mark.asyncio
@@ -49,21 +62,57 @@ async def test_create_snapshots_original_layout_and_filters(session_factory):
         assert res.status_code == 201, res.text
         report_id = res.json()["id"]
 
-    async with session_factory() as db:
-        row = (
-            await db.execute(select(Report).where(Report.id == report_id))
-        ).scalar_one()
-        assert row.original_layout_json == _LAYOUT
-        assert row.original_canvas_filters_json == _FILTERS
+    versions = await _versions_for(session_factory, report_id)
+    assert len(versions) == 1
+    original = versions[0]
+    assert original.is_original is True
+    assert original.layout_json == _LAYOUT
+    assert original.canvas_filters_json == _FILTERS
 
 
 @pytest.mark.asyncio
-async def test_patch_does_not_touch_original_snapshot(session_factory):
+async def test_save_creates_version_and_caps_at_five(session_factory):
     await _seed(session_factory)
     app = _make_app(session_factory, _resolver("user_a"))
     with TestClient(app) as client:
         res = client.post("/api/v1/reports", json={
-            "name": "Snapshot Report",
+            "name": "Capped Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        assert res.status_code == 201, res.text
+        report_id = res.json()["id"]
+
+        # 6 distinct saves; only the 4 most recent non-originals survive.
+        saved_layouts = []
+        for i in range(6):
+            layout = {"version": 1, "widgets": [{"id": f"w{i}", "type": "kpi"}]}
+            saved_layouts.append(layout)
+            patched = client.patch(f"/api/v1/reports/{report_id}", json={
+                "layout_json": layout,
+            })
+            assert patched.status_code == 200, patched.text
+
+    versions = await _versions_for(session_factory, report_id)
+    assert len(versions) == 5
+    originals = [v for v in versions if v.is_original]
+    non_originals = [v for v in versions if not v.is_original]
+    assert len(originals) == 1
+    assert originals[0].layout_json == _LAYOUT  # creation layout pinned
+    assert len(non_originals) == 4
+    # The 4 most recent saves (saves 2..5, zero-indexed) survive in order.
+    survived = [v.layout_json for v in non_originals]
+    assert survived == saved_layouts[2:]
+
+
+@pytest.mark.asyncio
+async def test_patch_without_layout_change_does_not_version(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "Meta Report",
             "visibility": "private",
             "layout_json": _LAYOUT,
             "canvas_filters_json": _FILTERS,
@@ -72,18 +121,176 @@ async def test_patch_does_not_touch_original_snapshot(session_factory):
         report_id = res.json()["id"]
 
         patched = client.patch(f"/api/v1/reports/{report_id}", json={
-            "layout_json": {"version": 1, "widgets": []},
+            "name": "Renamed",
+            "visibility": "org",
         })
         assert patched.status_code == 200, patched.text
+
+    versions = await _versions_for(session_factory, report_id)
+    # Only the create-time original; the metadata-only PATCH added nothing.
+    assert len(versions) == 1
+    assert versions[0].is_original is True
+
+
+@pytest.mark.asyncio
+async def test_list_versions(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "List Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        assert res.status_code == 201, res.text
+        report_id = res.json()["id"]
+
+        for i in range(2):
+            patched = client.patch(f"/api/v1/reports/{report_id}", json={
+                "layout_json": {"version": 1, "widgets": [{"id": f"s{i}"}]},
+            })
+            assert patched.status_code == 200, patched.text
+
+        listed = client.get(f"/api/v1/reports/{report_id}/versions")
+        assert listed.status_code == 200, listed.text
+        body = listed.json()
+
+    assert len(body) == 3
+    # Newest-first ordering.
+    ids = [v["id"] for v in body]
+    assert ids == sorted(ids, reverse=True)
+    # The original is the oldest entry (last in newest-first list).
+    assert body[-1]["is_original"] is True
+    assert [v["is_original"] for v in body[:-1]] == [False, False]
+    # Summary shape only.
+    assert set(body[0].keys()) == {"id", "is_original", "created_at"}
+
+
+@pytest.mark.asyncio
+async def test_restore_version_sets_live_and_does_not_add_version(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    layout_v2 = {"version": 1, "widgets": [{"id": "v2"}]}
+    layout_v3 = {"version": 1, "widgets": [{"id": "v3"}]}
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports", json={
+            "name": "Restore Report",
+            "visibility": "private",
+            "layout_json": _LAYOUT,
+            "canvas_filters_json": _FILTERS,
+        })
+        report_id = res.json()["id"]
+
+        client.patch(f"/api/v1/reports/{report_id}", json={"layout_json": layout_v2})
+        client.patch(f"/api/v1/reports/{report_id}", json={"layout_json": layout_v3})
+
+        listed = client.get(f"/api/v1/reports/{report_id}/versions").json()
+        count_before = len(listed)
+        # Pick the v2 (older non-original) entry to restore.
+        target = None
+        async with session_factory() as db:
+            rows = (
+                await db.execute(
+                    select(ReportVersion).where(
+                        ReportVersion.report_id == report_id,
+                        ReportVersion.layout_json == layout_v2,
+                    )
+                )
+            ).scalars().all()
+            target = rows[0].id
+
+        restored = client.post(
+            f"/api/v1/reports/{report_id}/versions/{target}/restore"
+        )
+        assert restored.status_code == 200, restored.text
+        assert restored.json()["layout_json"] == layout_v2
+
+        listed_after = client.get(f"/api/v1/reports/{report_id}/versions").json()
+
+    assert len(listed_after) == count_before  # restore added no version
 
     async with session_factory() as db:
         row = (
             await db.execute(select(Report).where(Report.id == report_id))
         ).scalar_one()
-        # live layout changed, snapshot must be untouched
-        assert row.layout_json == {"version": 1, "widgets": []}
-        assert row.original_layout_json == _LAYOUT
-        assert row.original_canvas_filters_json == _FILTERS
+        assert row.layout_json == layout_v2
+
+
+@pytest.mark.asyncio
+async def test_restore_404_for_version_of_other_report(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        a = client.post("/api/v1/reports", json={
+            "name": "A", "visibility": "private",
+            "layout_json": _LAYOUT, "canvas_filters_json": _FILTERS,
+        }).json()
+        b = client.post("/api/v1/reports", json={
+            "name": "B", "visibility": "private",
+            "layout_json": _LAYOUT, "canvas_filters_json": _FILTERS,
+        }).json()
+
+        b_versions = client.get(f"/api/v1/reports/{b['id']}/versions").json()
+        b_version_id = b_versions[0]["id"]
+
+        # Try to restore B's version onto report A → 404 (wrong report).
+        res = client.post(
+            f"/api/v1/reports/{a['id']}/versions/{b_version_id}/restore"
+        )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_restore_forbidden_for_non_editor(session_factory):
+    seeds = await _seed(session_factory)
+    async with session_factory() as db:
+        report = Report(
+            owner_user_id=seeds["user_a_id"],
+            org_id=seeds["org_a_id"],
+            visibility=ReportVisibility.ORG,
+            name="org-shared",
+            layout_json=_LAYOUT,
+            canvas_filters_json=_FILTERS,
+        )
+        db.add(report)
+        await db.commit()
+        await db.refresh(report)
+        rid = report.id
+        ver = ReportVersion(
+            report_id=rid,
+            is_original=True,
+            layout_json=_LAYOUT,
+            canvas_filters_json=_FILTERS,
+        )
+        db.add(ver)
+        await db.commit()
+        await db.refresh(ver)
+        vid = ver.id
+
+    app = _make_app(session_factory, _resolver("member_a"))
+    with TestClient(app) as client:
+        res = client.post(f"/api/v1/reports/{rid}/versions/{vid}/restore")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_versions_404_when_not_found(session_factory):
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/reports/999999/versions")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_versions_404_when_flag_off(session_factory, monkeypatch):
+    monkeypatch.setattr(app_settings, "feature_reports_v2", False)
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.get("/api/v1/reports/1/versions")
+    assert res.status_code == 404
 
 
 # ─── GET /api/v1/reports/templates ──────────────────────────────────
@@ -179,7 +386,7 @@ async def test_reset_restores_original(session_factory):
         assert patched.json()["layout_json"] == _LAYOUT_B
         assert patched.json()["canvas_filters_json"] == _FILTERS_Y
 
-        # Reset back to the as-created snapshot.
+        # Reset back to the as-created (original) version.
         reset = client.post(f"/api/v1/reports/{report_id}/reset")
         assert reset.status_code == 200, reset.text
         body = reset.json()
@@ -193,9 +400,11 @@ async def test_reset_restores_original(session_factory):
         ).scalar_one()
         assert row.layout_json == _LAYOUT_A
         assert row.canvas_filters_json == _FILTERS_X
-        # snapshot untouched
-        assert row.original_layout_json == _LAYOUT_A
-        assert row.original_canvas_filters_json == _FILTERS_X
+
+    # Reset (a restore) does not itself add a version: original + 1 save.
+    versions = await _versions_for(session_factory, report_id)
+    assert len(versions) == 2
+    assert sum(1 for v in versions if v.is_original) == 1
 
 
 @pytest.mark.asyncio
@@ -212,8 +421,6 @@ async def test_reset_forbidden_for_non_editor(session_factory):
             name="org-shared",
             layout_json=_LAYOUT_B,
             canvas_filters_json=_FILTERS_Y,
-            original_layout_json=_LAYOUT_A,
-            original_canvas_filters_json=_FILTERS_X,
         )
         db.add(report)
         await db.commit()

--- a/backend/tests/routers/test_reports_templates.py
+++ b/backend/tests/routers/test_reports_templates.py
@@ -451,3 +451,115 @@ async def test_reset_404_when_flag_off(session_factory, monkeypatch):
     with TestClient(app) as client:
         res = client.post("/api/v1/reports/1/reset")
     assert res.status_code == 404
+
+
+# ─── POST /api/v1/reports/{id}/duplicate ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_creates_private_copy_for_caller(session_factory):
+    seeds = await _seed(session_factory)
+    # An ORG-shared report owned by user_a; user_a duplicates it.
+    async with session_factory() as db:
+        report = Report(
+            owner_user_id=seeds["user_a_id"],
+            org_id=seeds["org_a_id"],
+            visibility=ReportVisibility.ORG,
+            name="Quarterly",
+            layout_json=_LAYOUT,
+            canvas_filters_json=_FILTERS,
+        )
+        db.add(report)
+        await db.commit()
+        await db.refresh(report)
+        rid = report.id
+
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post(f"/api/v1/reports/{rid}/duplicate")
+        assert res.status_code == 201, res.text
+        body = res.json()
+
+    assert body["id"] != rid
+    assert body["owner_user_id"] == seeds["user_a_id"]
+    assert body["org_id"] == seeds["org_a_id"]
+    assert body["visibility"] == "private"
+    assert body["name"] == "Quarterly (copy)"
+    assert body["layout_json"] == _LAYOUT
+    assert body["canvas_filters_json"] == _FILTERS
+
+    # The copy gets exactly one is_original version snapshot.
+    versions = await _versions_for(session_factory, body["id"])
+    assert len(versions) == 1
+    assert versions[0].is_original is True
+    assert versions[0].layout_json == _LAYOUT
+    assert versions[0].canvas_filters_json == _FILTERS
+
+
+@pytest.mark.asyncio
+async def test_duplicate_by_org_member_owns_the_copy(session_factory):
+    """A same-org member who can VIEW an org-shared report can duplicate
+    it; the copy is private and owned by that member, not the original
+    author.
+    """
+    seeds = await _seed(session_factory)
+    async with session_factory() as db:
+        report = Report(
+            owner_user_id=seeds["user_a_id"],
+            org_id=seeds["org_a_id"],
+            visibility=ReportVisibility.ORG,
+            name="Shared",
+            layout_json=_LAYOUT,
+            canvas_filters_json=_FILTERS,
+        )
+        db.add(report)
+        await db.commit()
+        await db.refresh(report)
+        rid = report.id
+
+    app = _make_app(session_factory, _resolver("member_a"))
+    with TestClient(app) as client:
+        res = client.post(f"/api/v1/reports/{rid}/duplicate")
+        assert res.status_code == 201, res.text
+        body = res.json()
+
+    assert body["owner_user_id"] == seeds["member_a_id"]
+    assert body["visibility"] == "private"
+    assert body["name"] == "Shared (copy)"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_404_for_non_viewer(session_factory):
+    """A user in a different org cannot see (and thus cannot duplicate)
+    a private report — 404, never leaking existence.
+    """
+    seeds = await _seed(session_factory)
+    async with session_factory() as db:
+        report = Report(
+            owner_user_id=seeds["user_a_id"],
+            org_id=seeds["org_a_id"],
+            visibility=ReportVisibility.PRIVATE,
+            name="Private A",
+            layout_json=_LAYOUT,
+            canvas_filters_json=_FILTERS,
+        )
+        db.add(report)
+        await db.commit()
+        await db.refresh(report)
+        rid = report.id
+
+    # user_b is in org B.
+    app = _make_app(session_factory, _resolver("user_b"))
+    with TestClient(app) as client:
+        res = client.post(f"/api/v1/reports/{rid}/duplicate")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_duplicate_404_when_flag_off(session_factory, monkeypatch):
+    monkeypatch.setattr(app_settings, "feature_reports_v2", False)
+    await _seed(session_factory)
+    app = _make_app(session_factory, _resolver("user_a"))
+    with TestClient(app) as client:
+        res = client.post("/api/v1/reports/1/duplicate")
+    assert res.status_code == 404

--- a/backend/tests/services/test_admin_users_service.py
+++ b/backend/tests/services/test_admin_users_service.py
@@ -28,6 +28,7 @@ from app.models.audit_event import AuditEvent, AuditOutcome
 from app.models.category import Category, CategoryType
 from app.models.import_batch import ImportBatch, ImportBatchStatus, ImportSourceFormat
 from app.models.invitation import Invitation
+from app.models.report import Report, ReportVersion, ReportVisibility
 from app.models.tag import Tag
 from app.models.transaction import Transaction, TransactionType
 from app.models.user import Organization, Role, User
@@ -272,6 +273,89 @@ async def test_delete_user_cleans_import_batches_and_nulls_transactions(
         # The other transaction columns are untouched.
         assert txn_after.amount == Decimal("12.34")
         assert txn_after.description == "Imported row"
+
+
+@pytest.mark.asyncio
+async def test_delete_user_handles_owned_reports(session_factory):
+    """Deleting a user who owns reports must not trip the
+    ``reports.owner_user_id`` ON DELETE RESTRICT FK.
+
+    - A PRIVATE report authored by the deleted user (with its
+      ``report_versions``) is hard-deleted (the version rows cascade).
+    - An ORG-shared report authored by the deleted user is transferred
+      to the org's active OWNER (the actor here).
+    """
+    seed = await _seed(session_factory)
+
+    _LAYOUT = {"version": 1, "widgets": [{"id": "w1"}]}
+    _FILTERS = {"date_range": {"kind": "relative", "preset": "last_30_days"}}
+
+    async with session_factory() as db:
+        private = Report(
+            owner_user_id=seed["inactive_id"],
+            org_id=seed["org_id"],
+            visibility=ReportVisibility.PRIVATE,
+            name="my private",
+            layout_json=_LAYOUT,
+            canvas_filters_json=_FILTERS,
+        )
+        shared = Report(
+            owner_user_id=seed["inactive_id"],
+            org_id=seed["org_id"],
+            visibility=ReportVisibility.ORG,
+            name="team shared",
+            layout_json=_LAYOUT,
+            canvas_filters_json=_FILTERS,
+        )
+        db.add_all([private, shared])
+        await db.flush()
+        # Each gets an is_original version + a non-original to prove the
+        # cascade reaches the version rows for the deleted private report.
+        db.add_all([
+            ReportVersion(
+                report_id=private.id, is_original=True,
+                layout_json=_LAYOUT, canvas_filters_json=_FILTERS,
+            ),
+            ReportVersion(
+                report_id=private.id, is_original=False,
+                layout_json=_LAYOUT, canvas_filters_json=_FILTERS,
+            ),
+            ReportVersion(
+                report_id=shared.id, is_original=True,
+                layout_json=_LAYOUT, canvas_filters_json=_FILTERS,
+            ),
+        ])
+        await db.commit()
+        private_id = private.id
+        shared_id = shared.id
+
+    async with session_factory() as db:
+        await admin_users_service.delete_user(
+            db,
+            target_user_id=seed["inactive_id"],
+            actor_user_id=seed["actor_id"],
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        # The user delete succeeded — no RESTRICT FK error.
+        assert await db.get(User, seed["inactive_id"]) is None
+
+        # Private report and ALL its versions are gone.
+        assert await db.get(Report, private_id) is None
+        private_versions = (
+            await db.execute(
+                select(ReportVersion).where(
+                    ReportVersion.report_id == private_id
+                )
+            )
+        ).scalars().all()
+        assert private_versions == []
+
+        # Org-shared report survives, reassigned to the org's active owner.
+        shared_after = await db.get(Report, shared_id)
+        assert shared_after is not None
+        assert shared_after.owner_user_id == seed["actor_id"]
 
 
 @pytest.mark.asyncio

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -27,7 +27,7 @@ import Link from "next/link";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { getReport, saveLayout } from "@/lib/reports/api";
+import { deleteReport, getReport, resetReport, saveLayout } from "@/lib/reports/api";
 import type {
   BarConfig,
   CanvasFilters,
@@ -36,6 +36,7 @@ import type {
   ReportSummary,
   Widget,
 } from "@/lib/reports/types";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import Canvas from "@/components/reports/Canvas";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import ConfigRail from "@/components/reports/ConfigRail";
@@ -231,6 +232,32 @@ export default function ReportEditorPage({ params }: PageProps) {
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [reverting, setReverting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmRevert, setConfirmRevert] = useState(false);
+
+  // Hydrate the canvas state (report snapshot + layout + filters) from
+  // a server ``ReportSummary``. Reused by the initial load, Cancel
+  // (restore the last-saved snapshot), and Revert (rolled-back
+  // snapshot).
+  function hydrateFromReport(r: ReportSummary) {
+    setReport(r);
+    const lj = (r.layout_json ?? {}) as Partial<LayoutJson>;
+    setLayout(
+      lj && Array.isArray(lj.widgets)
+        ? { version: 1, widgets: lj.widgets as Widget[] }
+        : DEFAULT_LAYOUT,
+    );
+    setCanvasFilters((r.canvas_filters_json as CanvasFilters) ?? {});
+    setSelectedWidgetId(null);
+    setDirty(false);
+  }
+
+  // Owner-only affordances. The backend enforces this regardless, but
+  // hiding Delete/Revert for non-owners keeps the header honest when
+  // the page already knows the viewer isn't the owner.
+  const canEdit = !!user && !!report && report.owner_user_id === user.id;
 
   useEffect(() => {
     if (authLoading) return;
@@ -246,14 +273,7 @@ export default function ReportEditorPage({ params }: PageProps) {
     getReport(Number(id))
       .then((r) => {
         if (cancelled) return;
-        setReport(r);
-        const lj = (r.layout_json ?? {}) as Partial<LayoutJson>;
-        setLayout(
-          lj && Array.isArray(lj.widgets)
-            ? { version: 1, widgets: lj.widgets as Widget[] }
-            : DEFAULT_LAYOUT,
-        );
-        setCanvasFilters((r.canvas_filters_json as CanvasFilters) ?? {});
+        hydrateFromReport(r);
       })
       .catch((err: Error) => {
         if (!cancelled) setLoadError(err.message || "Couldn't load report");
@@ -330,6 +350,48 @@ export default function ReportEditorPage({ params }: PageProps) {
       setSaveError(e.message || "Couldn't save layout");
     } finally {
       setSaving(false);
+    }
+  }
+
+  // Cancel editing — discard unsaved local changes by restoring the
+  // last-saved server snapshot the page already holds in ``report``,
+  // then drop back to view mode. No network call: ``report`` always
+  // reflects the most recent successful load/save.
+  function handleCancelEdit() {
+    if (report) hydrateFromReport(report);
+    setEditMode(false);
+    setSaveError(null);
+  }
+
+  async function handleDelete() {
+    if (!report || deleting) return;
+    setConfirmDelete(false);
+    setDeleting(true);
+    setSaveError(null);
+    try {
+      await deleteReport(report.id);
+      router.push("/reports");
+    } catch (err) {
+      const e = err as Error;
+      setSaveError(e.message || "Couldn't delete report");
+      setDeleting(false);
+    }
+  }
+
+  async function handleRevert() {
+    if (!report || reverting) return;
+    setConfirmRevert(false);
+    setReverting(true);
+    setSaveError(null);
+    try {
+      const reverted = await resetReport(report.id);
+      hydrateFromReport(reverted);
+      setEditMode(false);
+    } catch (err) {
+      const e = err as Error;
+      setSaveError(e.message || "Couldn't revert report");
+    } finally {
+      setReverting(false);
     }
   }
 
@@ -413,6 +475,38 @@ export default function ReportEditorPage({ params }: PageProps) {
               Add widget
             </button>
           )}
+          {editMode && (
+            <button
+              type="button"
+              onClick={handleCancelEdit}
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              data-testid="report-editor-cancel"
+            >
+              Cancel
+            </button>
+          )}
+          {canEdit && (
+            <button
+              type="button"
+              onClick={() => setConfirmRevert(true)}
+              disabled={reverting}
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="report-editor-revert"
+            >
+              {reverting ? "Reverting..." : "Revert to original"}
+            </button>
+          )}
+          {canEdit && (
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(true)}
+              disabled={deleting}
+              className="rounded-md border border-danger px-3 py-1.5 text-sm text-danger hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="report-editor-delete"
+            >
+              {deleting ? "Deleting..." : "Delete"}
+            </button>
+          )}
           <button
             type="button"
             onClick={handleSave}
@@ -482,6 +576,25 @@ export default function ReportEditorPage({ params }: PageProps) {
           onPick={addWidget}
         />
       </div>
+
+      <ConfirmModal
+        open={confirmDelete}
+        title="Delete report"
+        message="Delete this report? This can't be undone."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setConfirmDelete(false)}
+      />
+      <ConfirmModal
+        open={confirmRevert}
+        title="Revert to original"
+        message="Revert to the original version? Your changes since creation will be lost."
+        confirmLabel="Revert"
+        variant="warning"
+        onConfirm={handleRevert}
+        onCancel={() => setConfirmRevert(false)}
+      />
     </AppShell>
   );
 }

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -390,12 +390,15 @@ export default function ReportEditorPage({ params }: PageProps) {
     [layout.widgets, selectedWidgetId],
   );
 
-  // Editing is desktop-only. On small screens (< sm) we force VIEW mode
-  // regardless of the user's ``editMode`` toggle: the report renders as a
-  // read-only single-column stack with no drag/resize and no edit
-  // toolbar. ``editMode`` is preserved in state so resizing back up to
-  // desktop restores whatever the user had open.
-  const editModeActive = editMode && !isSmallScreen;
+  // Editing is desktop-only AND owner-only. On small screens (< sm) we
+  // force VIEW mode regardless of the user's ``editMode`` toggle: the
+  // report renders as a read-only single-column stack with no drag/resize
+  // and no edit toolbar. Non-owners (e.g. viewers of an org-shared
+  // report) never enter edit mode either — the backend 403s their
+  // PATCH/DELETE/restore, so surfacing edit chrome would only let them
+  // build unsavable local changes. ``editMode`` is preserved in state so
+  // resizing back up to desktop (as an owner) restores what they had open.
+  const editModeActive = editMode && !isSmallScreen && canEdit;
 
   function updateLayout(next: LayoutJson) {
     setLayout(next);
@@ -695,8 +698,10 @@ export default function ReportEditorPage({ params }: PageProps) {
           )}
 
           {/* Mode toggle: View mode shows "Edit", edit mode shows "Done".
-              Hidden on small screens, where editing is unavailable. */}
-          {!isSmallScreen && (
+              Hidden on small screens (editing is desktop-only) and for
+              non-owners (editing is owner-only; the backend 403s their
+              writes, so an "edit" state would only mislead). */}
+          {!isSmallScreen && canEdit && (
             <button
               type="button"
               onClick={() => setEditMode((v) => !v)}
@@ -752,14 +757,19 @@ export default function ReportEditorPage({ params }: PageProps) {
                 with no widgets shows nothing.
               </p>
               <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => setPickerOpen(true)}
-                  className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
-                  data-testid="report-editor-empty-add-widget"
-                >
-                  Add widget
-                </button>
+                {/* "Add widget" is owner-only: a non-owner viewing a shared
+                    report can't save, so the picker would only let them
+                    build unsavable local changes (backend 403s the PATCH). */}
+                {canEdit && (
+                  <button
+                    type="button"
+                    onClick={() => setPickerOpen(true)}
+                    className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
+                    data-testid="report-editor-empty-add-widget"
+                  >
+                    Add widget
+                  </button>
+                )}
                 <Link
                   href="/reports"
                   className="rounded-md border border-border px-4 py-2 text-sm text-text-primary hover:bg-bg-elevated"

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -189,24 +189,56 @@ function emptyWidget(type: WidgetType, id: string): Widget {
   }
 }
 
-function renderWidgetByType(w: Widget, canvasFilters: CanvasFilters) {
+function renderWidgetByType(
+  w: Widget,
+  canvasFilters: CanvasFilters,
+  editMode: boolean,
+) {
   switch (w.type) {
     case "kpi":
-      return <KPIWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <KPIWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
     case "bar":
-      return <BarWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <BarWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
     case "line":
-      return <LineWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <LineWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
     case "area":
-      return <AreaWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <AreaWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
     case "pie":
-      return <PieWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <PieWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
     case "sparkline":
-      return <SparklineWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <SparklineWidget
+          widget={w}
+          canvasFilters={canvasFilters}
+          editMode={editMode}
+        />
+      );
     case "stacked_bar":
-      return <StackedBarWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <StackedBarWidget
+          widget={w}
+          canvasFilters={canvasFilters}
+          editMode={editMode}
+        />
+      );
     case "table":
-      return <TableWidget widget={w} canvasFilters={canvasFilters} />;
+      return (
+        <TableWidget
+          widget={w}
+          canvasFilters={canvasFilters}
+          editMode={editMode}
+        />
+      );
   }
 }
 
@@ -676,7 +708,7 @@ export default function ReportEditorPage({ params }: PageProps) {
                   onSelect={() => setSelectedWidgetId(w.id)}
                   onRemove={() => removeWidget(w.id)}
                 >
-                  {renderWidgetByType(w, canvasFilters)}
+                  {renderWidgetByType(w, canvasFilters, editMode)}
                 </WidgetShell>
               )}
             />

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -562,9 +562,33 @@ export default function ReportEditorPage({ params }: PageProps) {
           {layout.widgets.length === 0 ? (
             <div
               data-testid="report-editor-empty"
-              className="rounded-md border border-dashed border-border bg-surface px-6 py-10 text-center text-sm text-text-muted"
+              className="rounded-md border border-dashed border-border bg-surface px-6 py-10 text-center"
             >
-              No widgets yet. Click &quot;Add widget&quot; to start.
+              <p className="text-sm font-medium text-text-primary">
+                This report has no widgets yet
+              </p>
+              <p className="mx-auto mt-1 max-w-md text-sm text-text-muted">
+                Add a widget to see your data. Canvas filters (date,
+                accounts, categories) apply to every widget, so a report
+                with no widgets shows nothing.
+              </p>
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPickerOpen(true)}
+                  className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
+                  data-testid="report-editor-empty-add-widget"
+                >
+                  Add widget
+                </button>
+                <Link
+                  href="/reports"
+                  className="rounded-md border border-border px-4 py-2 text-sm text-text-primary hover:bg-bg-elevated"
+                  data-testid="report-editor-empty-templates"
+                >
+                  Start from a template
+                </Link>
+              </div>
             </div>
           ) : (
             <Canvas

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -29,9 +29,11 @@ import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
 import {
   deleteReport,
+  duplicateReport,
   getReport,
   restoreVersion,
   saveLayout,
+  updateReport,
 } from "@/lib/reports/api";
 import type {
   BarConfig,
@@ -241,6 +243,8 @@ export default function ReportEditorPage({ params }: PageProps) {
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [restoring, setRestoring] = useState(false);
+  const [duplicating, setDuplicating] = useState(false);
+  const [togglingVisibility, setTogglingVisibility] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [pendingRestore, setPendingRestore] =
@@ -393,6 +397,42 @@ export default function ReportEditorPage({ params }: PageProps) {
     }
   }
 
+  // Duplicate the report into a fresh private copy owned by the
+  // viewer, then navigate to the copy's editor. Anyone who can view
+  // the report (i.e. is on this page) can duplicate it.
+  async function handleDuplicate() {
+    if (!report || duplicating) return;
+    setDuplicating(true);
+    setSaveError(null);
+    try {
+      const copy = await duplicateReport(report.id);
+      router.push(`/reports/${copy.id}`);
+    } catch (err) {
+      const e = err as Error;
+      setSaveError(e.message || "Couldn't duplicate report");
+      setDuplicating(false);
+    }
+  }
+
+  // Flip the report between private and org-shared visibility. Gated
+  // on edit rights (``canEdit``); the backend enforces this regardless.
+  async function handleToggleVisibility() {
+    if (!report || togglingVisibility) return;
+    const next: ReportSummary["visibility"] =
+      report.visibility === "org" ? "private" : "org";
+    setTogglingVisibility(true);
+    setSaveError(null);
+    try {
+      const updated = await updateReport(report.id, { visibility: next });
+      setReport(updated);
+    } catch (err) {
+      const e = err as Error;
+      setSaveError(e.message || "Couldn't update sharing");
+    } finally {
+      setTogglingVisibility(false);
+    }
+  }
+
   // Restore a chosen version into the live report. Confirmed via the
   // ConfirmModal before this fires. Re-hydrates the canvas from the
   // server's restored snapshot, closes the History panel, and drops
@@ -511,7 +551,40 @@ export default function ReportEditorPage({ params }: PageProps) {
             </button>
           )}
 
-          {/* Both modes: History + Delete. */}
+          {/* Both modes: Sharing state, Duplicate, History + Delete. */}
+          {/* Visibility: editors get a toggle; non-editors see it read-only. */}
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={handleToggleVisibility}
+              disabled={togglingVisibility}
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="report-editor-visibility-toggle"
+              aria-label="Toggle report sharing"
+            >
+              <span data-testid="report-editor-visibility">
+                {report.visibility === "org" ? "Shared with org" : "Private"}
+              </span>
+            </button>
+          ) : (
+            <span
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-muted"
+              data-testid="report-editor-visibility"
+            >
+              {report.visibility === "org" ? "Shared with org" : "Private"}
+            </span>
+          )}
+
+          <button
+            type="button"
+            onClick={handleDuplicate}
+            disabled={duplicating}
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid="report-editor-duplicate"
+          >
+            {duplicating ? "Duplicating..." : "Duplicate"}
+          </button>
+
           <button
             type="button"
             onClick={() => setHistoryOpen(true)}

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -249,6 +249,44 @@ function newWidgetId(): string {
   return `w_${Math.random().toString(36).slice(2, 10)}`;
 }
 
+// Tailwind's ``sm`` breakpoint. Below this we render the report as a
+// read-only single-column stack and force VIEW mode (no drag/resize, no
+// edit toolbar) — editing stays a desktop affordance.
+const SMALL_SCREEN_QUERY = "(max-width: 639px)";
+
+/**
+ * Order widgets for the mobile single-column stack: top-to-bottom by
+ * grid ``y``, then left-to-right by grid ``x`` so the vertical reading
+ * order matches what the desktop grid shows. Exported for unit testing
+ * the ordering independently of viewport mocking.
+ */
+export function orderWidgetsForStack(widgets: Widget[]): Widget[] {
+  return [...widgets].sort((a, b) => {
+    if (a.grid.y !== b.grid.y) return a.grid.y - b.grid.y;
+    return a.grid.x - b.grid.x;
+  });
+}
+
+/**
+ * True when the viewport is below Tailwind's ``sm`` breakpoint. SSR-safe
+ * (returns false until mounted) and listens for breakpoint crossings so
+ * rotating a phone or resizing a window flips the read-only stack on/off.
+ */
+function useIsSmallScreen(): boolean {
+  const [small, setSmall] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mq = window.matchMedia(SMALL_SCREEN_QUERY);
+    const update = () => setSmall(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  return small;
+}
+
 export default function ReportEditorPage({ params }: PageProps) {
   // Next 15 makes ``params`` a promise; ``use()`` unwraps it on the
   // client without awaiting at the top level. In test harnesses we
@@ -261,6 +299,7 @@ export default function ReportEditorPage({ params }: PageProps) {
   const { id } = resolvedParams;
   const router = useRouter();
   const { user, loading: authLoading, featureReportsV2 } = useAuth();
+  const isSmallScreen = useIsSmallScreen();
 
   const [report, setReport] = useState<ReportSummary | null>(null);
   const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
@@ -273,6 +312,7 @@ export default function ReportEditorPage({ params }: PageProps) {
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [showSavedToast, setShowSavedToast] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [restoring, setRestoring] = useState(false);
   const [duplicating, setDuplicating] = useState(false);
@@ -338,10 +378,24 @@ export default function ReportEditorPage({ params }: PageProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, user, authLoading, featureReportsV2]);
 
+  // Auto-dismiss the "Report saved" toast ~2s after it appears.
+  useEffect(() => {
+    if (!showSavedToast) return;
+    const t = setTimeout(() => setShowSavedToast(false), 2000);
+    return () => clearTimeout(t);
+  }, [showSavedToast]);
+
   const selectedWidget = useMemo(
     () => layout.widgets.find((w) => w.id === selectedWidgetId) ?? null,
     [layout.widgets, selectedWidgetId],
   );
+
+  // Editing is desktop-only. On small screens (< sm) we force VIEW mode
+  // regardless of the user's ``editMode`` toggle: the report renders as a
+  // read-only single-column stack with no drag/resize and no edit
+  // toolbar. ``editMode`` is preserved in state so resizing back up to
+  // desktop restores whatever the user had open.
+  const editModeActive = editMode && !isSmallScreen;
 
   function updateLayout(next: LayoutJson) {
     setLayout(next);
@@ -396,6 +450,7 @@ export default function ReportEditorPage({ params }: PageProps) {
       setReport(saved);
       setDirty(false);
       setLastSavedAt(new Date());
+      setShowSavedToast(true);
     } catch (err) {
       const e = err as Error;
       setSaveError(e.message || "Couldn't save layout");
@@ -550,8 +605,10 @@ export default function ReportEditorPage({ params }: PageProps) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          {/* Edit-mode-only: Add widget + Save (+ Cancel when dirty). */}
-          {editMode && (
+          {/* Edit-mode-only: Add widget + Save (+ Cancel when dirty).
+              All gated on ``editModeActive`` so small screens (< sm)
+              never show edit affordances. */}
+          {editModeActive && (
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
@@ -561,7 +618,7 @@ export default function ReportEditorPage({ params }: PageProps) {
               Add widget
             </button>
           )}
-          {editMode && (
+          {editModeActive && (
             <button
               type="button"
               onClick={handleSave}
@@ -572,7 +629,7 @@ export default function ReportEditorPage({ params }: PageProps) {
               {saving ? "Saving..." : "Save"}
             </button>
           )}
-          {editMode && dirty && (
+          {editModeActive && dirty && (
             <button
               type="button"
               onClick={handleCancelEdit}
@@ -637,17 +694,34 @@ export default function ReportEditorPage({ params }: PageProps) {
             </button>
           )}
 
-          {/* Mode toggle: View mode shows "Edit", edit mode shows "Done". */}
-          <button
-            type="button"
-            onClick={() => setEditMode((v) => !v)}
-            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
-            data-testid="report-editor-toggle-edit"
-          >
-            {editMode ? "Done" : "Edit"}
-          </button>
+          {/* Mode toggle: View mode shows "Edit", edit mode shows "Done".
+              Hidden on small screens, where editing is unavailable. */}
+          {!isSmallScreen && (
+            <button
+              type="button"
+              onClick={() => setEditMode((v) => !v)}
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              data-testid="report-editor-toggle-edit"
+            >
+              {editMode ? "Done" : "Edit"}
+            </button>
+          )}
         </div>
       </header>
+
+      {/* Transient success toast. ``role="status"`` (polite live region)
+          announces the save to assistive tech; auto-dismisses after ~2s
+          via the effect above. Pointer-events-none so it never blocks
+          the UI underneath. */}
+      {showSavedToast && (
+        <div
+          role="status"
+          data-testid="report-editor-saved-toast"
+          className="pointer-events-none fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-md bg-text-primary px-4 py-2 text-sm font-medium text-surface shadow-lg"
+        >
+          Report saved
+        </div>
+      )}
 
       {saveError && (
         <div
@@ -695,26 +769,40 @@ export default function ReportEditorPage({ params }: PageProps) {
                 </Link>
               </div>
             </div>
+          ) : isSmallScreen ? (
+            // Mobile (< sm): read-only single-column stack ordered by
+            // grid (y, then x). No grid, no drag/resize, no select/edit
+            // chrome — editing is desktop-only.
+            <div
+              data-testid="reports-canvas-stack"
+              className="flex flex-col gap-3"
+            >
+              {orderWidgetsForStack(layout.widgets).map((w) => (
+                <div key={w.id}>
+                  {renderWidgetByType(w, canvasFilters, false)}
+                </div>
+              ))}
+            </div>
           ) : (
             <Canvas
               layout={layout}
-              editMode={editMode}
+              editMode={editModeActive}
               onLayoutChange={updateLayout}
               renderWidget={(w) => (
                 <WidgetShell
                   widgetId={w.id}
                   selected={selectedWidgetId === w.id}
-                  editMode={editMode}
+                  editMode={editModeActive}
                   onSelect={() => setSelectedWidgetId(w.id)}
                   onRemove={() => removeWidget(w.id)}
                 >
-                  {renderWidgetByType(w, canvasFilters, editMode)}
+                  {renderWidgetByType(w, canvasFilters, editModeActive)}
                 </WidgetShell>
               )}
             />
           )}
         </div>
-        {editMode && selectedWidget && (
+        {editModeActive && selectedWidget && (
           <ConfigRail
             widget={selectedWidget}
             canvasFilters={canvasFilters}

--- a/frontend/app/reports/[id]/page.tsx
+++ b/frontend/app/reports/[id]/page.tsx
@@ -27,17 +27,24 @@ import Link from "next/link";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { deleteReport, getReport, resetReport, saveLayout } from "@/lib/reports/api";
+import {
+  deleteReport,
+  getReport,
+  restoreVersion,
+  saveLayout,
+} from "@/lib/reports/api";
 import type {
   BarConfig,
   CanvasFilters,
   KPIConfig,
   LayoutJson,
   ReportSummary,
+  ReportVersionSummary,
   Widget,
 } from "@/lib/reports/types";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import Canvas from "@/components/reports/Canvas";
+import HistoryPanel from "@/components/reports/HistoryPanel";
 import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
 import ConfigRail from "@/components/reports/ConfigRail";
 import WidgetPicker from "@/components/reports/WidgetPicker";
@@ -225,7 +232,7 @@ export default function ReportEditorPage({ params }: PageProps) {
   const [layout, setLayout] = useState<LayoutJson>(DEFAULT_LAYOUT);
   const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
   const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
-  const [editMode, setEditMode] = useState(true);
+  const [editMode, setEditMode] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -233,9 +240,11 @@ export default function ReportEditorPage({ params }: PageProps) {
   const [dirty, setDirty] = useState(false);
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
   const [deleting, setDeleting] = useState(false);
-  const [reverting, setReverting] = useState(false);
+  const [restoring, setRestoring] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [confirmRevert, setConfirmRevert] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [pendingRestore, setPendingRestore] =
+    useState<ReportVersionSummary | null>(null);
 
   // Hydrate the canvas state (report snapshot + layout + filters) from
   // a server ``ReportSummary``. Reused by the initial load, Cancel
@@ -274,6 +283,12 @@ export default function ReportEditorPage({ params }: PageProps) {
       .then((r) => {
         if (cancelled) return;
         hydrateFromReport(r);
+        // Default to view mode for reports that already have content; a
+        // blank (0-widget) report opens in edit mode so the user has an
+        // obvious starting point.
+        const lj = (r.layout_json ?? {}) as Partial<LayoutJson>;
+        const widgetCount = Array.isArray(lj.widgets) ? lj.widgets.length : 0;
+        setEditMode(widgetCount === 0);
       })
       .catch((err: Error) => {
         if (!cancelled) setLoadError(err.message || "Couldn't load report");
@@ -378,20 +393,26 @@ export default function ReportEditorPage({ params }: PageProps) {
     }
   }
 
-  async function handleRevert() {
-    if (!report || reverting) return;
-    setConfirmRevert(false);
-    setReverting(true);
+  // Restore a chosen version into the live report. Confirmed via the
+  // ConfirmModal before this fires. Re-hydrates the canvas from the
+  // server's restored snapshot, closes the History panel, and drops
+  // back to view mode.
+  async function handleRestore() {
+    if (!report || !pendingRestore || restoring) return;
+    const versionId = pendingRestore.id;
+    setRestoring(true);
     setSaveError(null);
     try {
-      const reverted = await resetReport(report.id);
-      hydrateFromReport(reverted);
+      const restored = await restoreVersion(report.id, versionId);
+      hydrateFromReport(restored);
       setEditMode(false);
+      setHistoryOpen(false);
+      setPendingRestore(null);
     } catch (err) {
       const e = err as Error;
-      setSaveError(e.message || "Couldn't revert report");
+      setSaveError(e.message || "Couldn't restore version");
     } finally {
-      setReverting(false);
+      setRestoring(false);
     }
   }
 
@@ -457,14 +478,7 @@ export default function ReportEditorPage({ params }: PageProps) {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setEditMode((v) => !v)}
-            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
-            data-testid="report-editor-toggle-edit"
-          >
-            {editMode ? "View" : "Edit"}
-          </button>
+          {/* Edit-mode-only: Add widget + Save (+ Cancel when dirty). */}
           {editMode && (
             <button
               type="button"
@@ -478,6 +492,17 @@ export default function ReportEditorPage({ params }: PageProps) {
           {editMode && (
             <button
               type="button"
+              onClick={handleSave}
+              disabled={saving || !dirty}
+              className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="report-editor-save"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+          )}
+          {editMode && dirty && (
+            <button
+              type="button"
               onClick={handleCancelEdit}
               className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
               data-testid="report-editor-cancel"
@@ -485,17 +510,16 @@ export default function ReportEditorPage({ params }: PageProps) {
               Cancel
             </button>
           )}
-          {canEdit && (
-            <button
-              type="button"
-              onClick={() => setConfirmRevert(true)}
-              disabled={reverting}
-              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
-              data-testid="report-editor-revert"
-            >
-              {reverting ? "Reverting..." : "Revert to original"}
-            </button>
-          )}
+
+          {/* Both modes: History + Delete. */}
+          <button
+            type="button"
+            onClick={() => setHistoryOpen(true)}
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+            data-testid="report-editor-history"
+          >
+            History
+          </button>
           {canEdit && (
             <button
               type="button"
@@ -507,14 +531,15 @@ export default function ReportEditorPage({ params }: PageProps) {
               {deleting ? "Deleting..." : "Delete"}
             </button>
           )}
+
+          {/* Mode toggle: View mode shows "Edit", edit mode shows "Done". */}
           <button
             type="button"
-            onClick={handleSave}
-            disabled={saving || !dirty}
-            className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
-            data-testid="report-editor-save"
+            onClick={() => setEditMode((v) => !v)}
+            className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+            data-testid="report-editor-toggle-edit"
           >
-            {saving ? "Saving..." : "Save"}
+            {editMode ? "Done" : "Edit"}
           </button>
         </div>
       </header>
@@ -586,14 +611,20 @@ export default function ReportEditorPage({ params }: PageProps) {
         onConfirm={handleDelete}
         onCancel={() => setConfirmDelete(false)}
       />
+      <HistoryPanel
+        open={historyOpen}
+        reportId={report.id}
+        onClose={() => setHistoryOpen(false)}
+        onRestore={(v) => setPendingRestore(v)}
+      />
       <ConfirmModal
-        open={confirmRevert}
-        title="Revert to original"
-        message="Revert to the original version? Your changes since creation will be lost."
-        confirmLabel="Revert"
+        open={pendingRestore !== null}
+        title="Restore version"
+        message="Restore this version? Current unsaved changes will be lost."
+        confirmLabel="Restore"
         variant="warning"
-        onConfirm={handleRevert}
-        onCancel={() => setConfirmRevert(false)}
+        onConfirm={handleRestore}
+        onCancel={() => setPendingRestore(null)}
       />
     </AppShell>
   );

--- a/frontend/app/reports/new/page.tsx
+++ b/frontend/app/reports/new/page.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+/**
+ * Reports v2 — unsaved draft editor (`/reports/new`).
+ *
+ * A report must NOT exist in the DB until the user explicitly Saves
+ * it, even when started from a template. This page opens an in-memory
+ * draft (blank starter content, or a template's layout when
+ * ``?template=<key>`` is present) and lets the user build it with the
+ * same canvas pieces the saved-report editor uses. Save is the ONLY
+ * persistence: it POSTs a new report and replaces the URL with the
+ * real id so the back button never returns to the throwaway draft.
+ *
+ * History / Delete / Revert / Duplicate are intentionally absent —
+ * there is nothing saved to act on yet. Those live on the saved-report
+ * editor at `/reports/[id]`.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+
+import AppShell from "@/components/AppShell";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { createReport, listTemplates } from "@/lib/reports/api";
+import { blankDraftSeed } from "@/lib/reports/draft";
+import type {
+  CanvasFilters,
+  LayoutJson,
+  Widget,
+  WidgetType,
+} from "@/lib/reports/types";
+import Canvas from "@/components/reports/Canvas";
+import CanvasFiltersBar from "@/components/reports/CanvasFiltersBar";
+import ConfigRail from "@/components/reports/ConfigRail";
+import WidgetPicker from "@/components/reports/WidgetPicker";
+import WidgetShell from "@/components/reports/WidgetShell";
+import {
+  emptyWidget,
+  newWidgetId,
+  renderWidgetByType,
+} from "@/components/reports/widgetKit";
+
+export default function ReportDraftPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const templateKey = searchParams.get("template");
+  const { user, loading: authLoading, featureReportsV2 } = useAuth();
+
+  const [name, setName] = useState("Untitled report");
+  const [layout, setLayout] = useState<LayoutJson | null>(null);
+  const [canvasFilters, setCanvasFilters] = useState<CanvasFilters>({});
+  const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  // Guards the one-time draft seed so re-renders don't clobber edits.
+  const seeded = useRef(false);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) {
+      router.replace("/login");
+      return;
+    }
+    if (!featureReportsV2) {
+      router.replace("/dashboard");
+      return;
+    }
+    if (seeded.current) return;
+
+    // Seed the in-memory draft. NO DB write happens here — the draft
+    // lives in component state until the user clicks Save.
+    function seedBlank() {
+      const seed = blankDraftSeed();
+      setLayout(seed.layout);
+      setCanvasFilters(seed.canvasFilters);
+      seeded.current = true;
+    }
+
+    if (!templateKey) {
+      seedBlank();
+      return;
+    }
+
+    let cancelled = false;
+    listTemplates()
+      .then((templates) => {
+        if (cancelled || seeded.current) return;
+        const t = templates.find((x) => x.key === templateKey);
+        if (t) {
+          setName(t.name);
+          setLayout(t.layout_json);
+          setCanvasFilters(t.canvas_filters_json ?? {});
+          seeded.current = true;
+        } else {
+          // Unknown/invalid key — fall back to the blank draft.
+          seedBlank();
+        }
+      })
+      .catch(() => {
+        if (!cancelled && !seeded.current) seedBlank();
+      });
+    return () => {
+      cancelled = true;
+    };
+    // ``router`` omitted intentionally — useRouter() identity isn't
+    // guaranteed stable and refiring would reseed over edits (the
+    // ``seeded`` ref also guards that).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, authLoading, featureReportsV2, templateKey]);
+
+  const selectedWidget = useMemo(
+    () => layout?.widgets.find((w) => w.id === selectedWidgetId) ?? null,
+    [layout, selectedWidgetId],
+  );
+
+  function updateLayout(next: LayoutJson) {
+    setLayout(next);
+  }
+
+  function updateWidget(nextWidget: Widget) {
+    setLayout((prev) =>
+      prev
+        ? {
+            ...prev,
+            widgets: prev.widgets.map((w) =>
+              w.id === nextWidget.id ? nextWidget : w,
+            ),
+          }
+        : prev,
+    );
+  }
+
+  function addWidget(type: WidgetType) {
+    const id = newWidgetId();
+    const widget = emptyWidget(type, id);
+    setLayout((prev) => {
+      const widgets = prev?.widgets ?? [];
+      const maxY = widgets.reduce(
+        (max, w) => Math.max(max, w.grid.y + w.grid.h),
+        0,
+      );
+      widget.grid = { ...widget.grid, x: 0, y: maxY };
+      return { version: 1, widgets: [...widgets, widget] };
+    });
+    setSelectedWidgetId(id);
+    setPickerOpen(false);
+  }
+
+  function removeWidget(widgetId: string) {
+    setLayout((prev) =>
+      prev
+        ? { ...prev, widgets: prev.widgets.filter((w) => w.id !== widgetId) }
+        : prev,
+    );
+    if (selectedWidgetId === widgetId) setSelectedWidgetId(null);
+  }
+
+  async function handleSave() {
+    if (!layout || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const created = await createReport({
+        name: name.trim() || "Untitled report",
+        visibility: "private",
+        layout_json: layout,
+        canvas_filters_json: canvasFilters,
+      });
+      // Replace (not push) so the back button skips the throwaway draft.
+      router.replace(`/reports/${created.id}`);
+    } catch (err) {
+      const e = err as Error;
+      setSaveError(e.message || "Couldn't save report");
+      setSaving(false);
+    }
+  }
+
+  function handleCancel() {
+    // Discard the in-memory draft — nothing was persisted.
+    router.push("/reports");
+  }
+
+  if (authLoading || !layout) {
+    return (
+      <AppShell>
+        <div className="flex h-full items-center justify-center">
+          <div
+            data-testid="report-draft-loading"
+            className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-accent"
+          />
+        </div>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="flex h-full flex-col" data-testid="report-draft">
+        <header className="flex items-center justify-between border-b border-border bg-surface px-4 py-3">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/reports"
+              className="text-sm text-text-muted hover:text-text-primary"
+            >
+              Reports
+            </Link>
+            <span className="text-text-muted">/</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              aria-label="Report name"
+              data-testid="report-draft-name"
+              className="rounded-md border border-border bg-bg px-2 py-1 text-sm font-semibold text-text-primary"
+            />
+            <span
+              data-testid="report-draft-unsaved"
+              className="text-xs text-text-muted"
+            >
+              Draft (not saved)
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              data-testid="report-draft-add-widget"
+            >
+              Add widget
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+              data-testid="report-draft-save"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="rounded-md border border-border px-3 py-1.5 text-sm text-text-primary hover:bg-bg-elevated"
+              data-testid="report-draft-cancel"
+            >
+              Cancel
+            </button>
+          </div>
+        </header>
+
+        {saveError && (
+          <div
+            role="alert"
+            className="border-b border-danger/30 bg-danger/10 px-4 py-2 text-sm text-danger"
+          >
+            {saveError}
+          </div>
+        )}
+
+        <div className="border-b border-border bg-bg px-4 py-3">
+          <CanvasFiltersBar value={canvasFilters} onChange={setCanvasFilters} />
+        </div>
+
+        <div className="flex flex-1 overflow-hidden">
+          <div className="flex-1 overflow-y-auto px-4 py-4">
+            {layout.widgets.length === 0 ? (
+              <div
+                data-testid="report-draft-empty"
+                className="rounded-md border border-dashed border-border bg-surface px-6 py-10 text-center"
+              >
+                <p className="text-sm font-medium text-text-primary">
+                  This draft has no widgets yet
+                </p>
+                <p className="mx-auto mt-1 max-w-md text-sm text-text-muted">
+                  Add a widget to see your data. Canvas filters (date,
+                  accounts, categories) apply to every widget.
+                </p>
+                <div className="mt-4 flex items-center justify-center">
+                  <button
+                    type="button"
+                    onClick={() => setPickerOpen(true)}
+                    className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
+                    data-testid="report-draft-empty-add-widget"
+                  >
+                    Add widget
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <Canvas
+                layout={layout}
+                editMode
+                onLayoutChange={updateLayout}
+                renderWidget={(w) => (
+                  <WidgetShell
+                    widgetId={w.id}
+                    selected={selectedWidgetId === w.id}
+                    editMode
+                    onSelect={() => setSelectedWidgetId(w.id)}
+                    onRemove={() => removeWidget(w.id)}
+                  >
+                    {renderWidgetByType(w, canvasFilters, true)}
+                  </WidgetShell>
+                )}
+              />
+            )}
+          </div>
+          {selectedWidget && (
+            <ConfigRail
+              widget={selectedWidget}
+              canvasFilters={canvasFilters}
+              onUpdate={updateWidget}
+              onClose={() => setSelectedWidgetId(null)}
+            />
+          )}
+        </div>
+
+        <WidgetPicker
+          open={pickerOpen}
+          onClose={() => setPickerOpen(false)}
+          onPick={addWidget}
+        />
+      </div>
+    </AppShell>
+  );
+}

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -18,15 +18,22 @@ import Link from "next/link";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { createReport, listReports } from "@/lib/reports/api";
-import type { ReportSummary } from "@/lib/reports/types";
+import {
+  createFromTemplate,
+  createReport,
+  listReports,
+  listTemplates,
+} from "@/lib/reports/api";
+import type { ReportSummary, ReportTemplate } from "@/lib/reports/types";
 
 export default function ReportsListPage() {
   const router = useRouter();
   const { user, loading: authLoading, featureReportsV2 } = useAuth();
   const [reports, setReports] = useState<ReportSummary[] | null>(null);
+  const [templates, setTemplates] = useState<ReportTemplate[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+  const [usingTemplate, setUsingTemplate] = useState<string | null>(null);
 
   useEffect(() => {
     if (authLoading) return;
@@ -45,6 +52,15 @@ export default function ReportsListPage() {
       })
       .catch((err: Error) => {
         if (!cancelled) setError(err.message || "Couldn't load reports");
+      });
+    // Templates load independently — a failure here must not block the
+    // reports list, so it swallows its own error (falls back to []).
+    listTemplates()
+      .then((data) => {
+        if (!cancelled) setTemplates(data);
+      })
+      .catch(() => {
+        if (!cancelled) setTemplates([]);
       });
     return () => {
       cancelled = true;
@@ -70,6 +86,19 @@ export default function ReportsListPage() {
       const e = err as Error;
       setError(e.message || "Couldn't create report");
       setCreating(false);
+    }
+  }
+
+  async function handleUseTemplate(t: ReportTemplate) {
+    if (usingTemplate) return;
+    setUsingTemplate(t.key);
+    try {
+      const created = await createFromTemplate(t);
+      router.push(`/reports/${created.id}`);
+    } catch (err) {
+      const e = err as Error;
+      setError(e.message || "Couldn't create report from template");
+      setUsingTemplate(null);
     }
   }
 
@@ -111,6 +140,36 @@ export default function ReportsListPage() {
         </div>
       )}
 
+      {templates && templates.length > 0 && (
+        <section className="mb-8" data-testid="reports-templates">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-text-muted">
+            Start from a template
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {templates.map((t) => (
+              <div
+                key={t.key}
+                data-testid={`report-template-${t.key}`}
+                className="flex flex-col rounded-md border border-border bg-surface p-4"
+              >
+                <div className="font-medium text-text-primary">{t.name}</div>
+                <p className="mt-1 flex-1 text-sm text-text-muted">
+                  {t.description}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => handleUseTemplate(t)}
+                  disabled={usingTemplate !== null}
+                  className="mt-3 inline-flex items-center justify-center gap-2 self-start rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {usingTemplate === t.key ? "Creating..." : "Use template"}
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       {reports === null && !error ? (
         <div className="rounded-md border border-border bg-surface px-4 py-6 text-sm text-text-muted">
           Loading...
@@ -124,7 +183,7 @@ export default function ReportsListPage() {
             No reports yet
           </p>
           <p className="mt-1 text-sm text-text-muted">
-            Start a blank canvas to build your first one.
+            Start from a template above, or create a blank report.
           </p>
         </div>
       ) : (

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -4,9 +4,10 @@
  * Reports v2 — list page.
  *
  * Shows reports visible to the caller (own + org-shared) and a
- * "New report" button that creates an empty private report and
- * navigates to the editor. Templates tab + visibility toggle are
- * PR4 work; this page keeps the substrate ready for them.
+ * "New report" button that opens an unsaved draft at /reports/new.
+ * Neither "New report" nor "Use template" persists a row here: a
+ * report exists in the DB only after the user explicitly Saves the
+ * draft. Templates seed the draft via /reports/new?template=<key>.
  *
  * The page guards the ``feature_reports_v2`` signal client-side; if
  * the operator hasn't flipped the flag, the user shouldn't be here.
@@ -20,14 +21,11 @@ import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
 import ConfirmModal from "@/components/ui/ConfirmModal";
 import {
-  createFromTemplate,
-  createReport,
   deleteReport,
   duplicateReport,
   listReports,
   listTemplates,
 } from "@/lib/reports/api";
-import { buildPresetRanges } from "@/components/reports/filters/DatePresetChips";
 import type { ReportSummary, ReportTemplate } from "@/lib/reports/types";
 
 export default function ReportsListPage() {
@@ -36,8 +34,6 @@ export default function ReportsListPage() {
   const [reports, setReports] = useState<ReportSummary[] | null>(null);
   const [templates, setTemplates] = useState<ReportTemplate[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [usingTemplate, setUsingTemplate] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<ReportSummary | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [duplicatingId, setDuplicatingId] = useState<number | null>(null);
@@ -78,61 +74,17 @@ export default function ReportsListPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, authLoading, featureReportsV2]);
 
-  async function handleNewReport() {
-    if (creating) return;
-    setCreating(true);
-    try {
-      // A truly blank report renders nothing (canvas filters cascade
-      // INTO widgets, and there are no widgets), so seed one sensible
-      // starter widget plus a this-month canvas date so the new report
-      // opens in view mode already showing data. The widget shape must
-      // match what the editor's ``addWidget`` factory mints for a bar
-      // (single-measure ``config.measure``) so it renders identically.
-      const ranges = buildPresetRanges(new Date());
-      const created = await createReport({
-        name: "Untitled report",
-        visibility: "private",
-        canvas_filters_json: { date_range: ranges.this_month },
-        layout_json: {
-          version: 1,
-          widgets: [
-            {
-              id: "w_start",
-              type: "bar",
-              title: "Spend by category",
-              grid: { x: 0, y: 0, w: 6, h: 4 },
-              config: {
-                dataset: "transactions",
-                measure: { agg: "sum", field: "amount" },
-                dimensions: ["category"],
-                filters: { txn_type: "expense" },
-                sort: { by: "value", dir: "desc" },
-                limit: 10,
-                format: "currency",
-              },
-            },
-          ],
-        },
-      });
-      router.push(`/reports/${created.id}`);
-    } catch (err) {
-      const e = err as Error;
-      setError(e.message || "Couldn't create report");
-      setCreating(false);
-    }
+  // "New report" no longer persists anything. It opens the unsaved
+  // draft editor at /reports/new; the row is created only when the user
+  // explicitly Saves there.
+  function handleNewReport() {
+    router.push("/reports/new");
   }
 
-  async function handleUseTemplate(t: ReportTemplate) {
-    if (usingTemplate) return;
-    setUsingTemplate(t.key);
-    try {
-      const created = await createFromTemplate(t);
-      router.push(`/reports/${created.id}`);
-    } catch (err) {
-      const e = err as Error;
-      setError(e.message || "Couldn't create report from template");
-      setUsingTemplate(null);
-    }
+  // "Use template" likewise opens an unsaved draft, seeded from the
+  // template, via /reports/new?template=<key>. No DB write until Save.
+  function handleUseTemplate(t: ReportTemplate) {
+    router.push(`/reports/new?template=${encodeURIComponent(t.key)}`);
   }
 
   // Duplicate a report into a fresh private copy owned by the caller,
@@ -192,10 +144,9 @@ export default function ReportsListPage() {
         <button
           type="button"
           onClick={handleNewReport}
-          disabled={creating}
-          className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
         >
-          {creating ? "Creating..." : "New report"}
+          New report
         </button>
       </header>
 
@@ -227,10 +178,9 @@ export default function ReportsListPage() {
                 <button
                   type="button"
                   onClick={() => handleUseTemplate(t)}
-                  disabled={usingTemplate !== null}
-                  className="mt-3 inline-flex items-center justify-center gap-2 self-start rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+                  className="mt-3 inline-flex items-center justify-center gap-2 self-start rounded-md bg-accent px-3 py-1.5 text-sm font-semibold text-accent-foreground transition hover:bg-accent-hover"
                 >
-                  {usingTemplate === t.key ? "Creating..." : "Use template"}
+                  Use template
                 </button>
               </div>
             ))}

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -26,6 +26,7 @@ import {
   listReports,
   listTemplates,
 } from "@/lib/reports/api";
+import { buildPresetRanges } from "@/components/reports/filters/DatePresetChips";
 import type { ReportSummary, ReportTemplate } from "@/lib/reports/types";
 
 export default function ReportsListPage() {
@@ -79,11 +80,37 @@ export default function ReportsListPage() {
     if (creating) return;
     setCreating(true);
     try {
+      // A truly blank report renders nothing (canvas filters cascade
+      // INTO widgets, and there are no widgets), so seed one sensible
+      // starter widget plus a this-month canvas date so the new report
+      // opens in view mode already showing data. The widget shape must
+      // match what the editor's ``addWidget`` factory mints for a bar
+      // (single-measure ``config.measure``) so it renders identically.
+      const ranges = buildPresetRanges(new Date());
       const created = await createReport({
         name: "Untitled report",
         visibility: "private",
-        layout_json: { version: 1, widgets: [] },
-        canvas_filters_json: {},
+        canvas_filters_json: { date_range: ranges.this_month },
+        layout_json: {
+          version: 1,
+          widgets: [
+            {
+              id: "w_start",
+              type: "bar",
+              title: "Spend by category",
+              grid: { x: 0, y: 0, w: 6, h: 4 },
+              config: {
+                dataset: "transactions",
+                measure: { agg: "sum", field: "amount" },
+                dimensions: ["category"],
+                filters: { txn_type: "expense" },
+                sort: { by: "value", dir: "desc" },
+                limit: 10,
+                format: "currency",
+              },
+            },
+          ],
+        },
       });
       router.push(`/reports/${created.id}`);
     } catch (err) {

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -23,6 +23,7 @@ import {
   createFromTemplate,
   createReport,
   deleteReport,
+  duplicateReport,
   listReports,
   listTemplates,
 } from "@/lib/reports/api";
@@ -39,6 +40,7 @@ export default function ReportsListPage() {
   const [usingTemplate, setUsingTemplate] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<ReportSummary | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [duplicatingId, setDuplicatingId] = useState<number | null>(null);
 
   useEffect(() => {
     if (authLoading) return;
@@ -130,6 +132,23 @@ export default function ReportsListPage() {
       const e = err as Error;
       setError(e.message || "Couldn't create report from template");
       setUsingTemplate(null);
+    }
+  }
+
+  // Duplicate a report into a fresh private copy owned by the caller,
+  // then navigate to the copy's editor. Anyone who can view a report
+  // (own or org-shared) can duplicate it.
+  async function handleDuplicate(target: ReportSummary) {
+    if (duplicatingId !== null) return;
+    setDuplicatingId(target.id);
+    setError(null);
+    try {
+      const copy = await duplicateReport(target.id);
+      router.push(`/reports/${copy.id}`);
+    } catch (err) {
+      const e = err as Error;
+      setError(e.message || "Couldn't duplicate report");
+      setDuplicatingId(null);
     }
   }
 
@@ -256,6 +275,15 @@ export default function ReportsListPage() {
                   {r.visibility}
                 </span>
               </Link>
+              <button
+                type="button"
+                onClick={() => handleDuplicate(r)}
+                disabled={duplicatingId === r.id}
+                className="mr-2 rounded-md border border-border px-2.5 py-1 text-xs text-text-primary hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+                data-testid={`report-duplicate-${r.id}`}
+              >
+                {duplicatingId === r.id ? "Duplicating..." : "Duplicate"}
+              </button>
               {r.owner_user_id === user?.id && (
                 <button
                   type="button"

--- a/frontend/app/reports/page.tsx
+++ b/frontend/app/reports/page.tsx
@@ -18,9 +18,11 @@ import Link from "next/link";
 
 import AppShell from "@/components/AppShell";
 import { useAuth } from "@/components/auth/AuthProvider";
+import ConfirmModal from "@/components/ui/ConfirmModal";
 import {
   createFromTemplate,
   createReport,
+  deleteReport,
   listReports,
   listTemplates,
 } from "@/lib/reports/api";
@@ -34,6 +36,8 @@ export default function ReportsListPage() {
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [usingTemplate, setUsingTemplate] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<ReportSummary | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   useEffect(() => {
     if (authLoading) return;
@@ -99,6 +103,24 @@ export default function ReportsListPage() {
       const e = err as Error;
       setError(e.message || "Couldn't create report from template");
       setUsingTemplate(null);
+    }
+  }
+
+  async function handleDelete() {
+    const target = pendingDelete;
+    if (!target || deletingId !== null) return;
+    setPendingDelete(null);
+    setDeletingId(target.id);
+    try {
+      await deleteReport(target.id);
+      setReports((prev) =>
+        (prev ?? []).filter((r) => r.id !== target.id),
+      );
+    } catch (err) {
+      const e = err as Error;
+      setError(e.message || "Couldn't delete report");
+    } finally {
+      setDeletingId(null);
     }
   }
 
@@ -189,32 +211,49 @@ export default function ReportsListPage() {
       ) : (
         <ul className="divide-y divide-border rounded-md border border-border bg-surface">
           {(reports ?? []).map((r) => (
-            <li key={r.id}>
+            <li key={r.id} className="flex items-center hover:bg-bg-elevated">
               <Link
                 href={`/reports/${r.id}`}
-                className="block px-4 py-3 hover:bg-bg-elevated"
+                className="flex flex-1 items-center justify-between px-4 py-3"
                 data-testid={`report-row-${r.id}`}
               >
-                <div className="flex items-center justify-between">
-                  <div>
-                    <div className="font-medium text-text-primary">
-                      {r.name}
+                <div>
+                  <div className="font-medium text-text-primary">{r.name}</div>
+                  {r.description && (
+                    <div className="text-sm text-text-muted">
+                      {r.description}
                     </div>
-                    {r.description && (
-                      <div className="text-sm text-text-muted">
-                        {r.description}
-                      </div>
-                    )}
-                  </div>
-                  <span className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
-                    {r.visibility}
-                  </span>
+                  )}
                 </div>
+                <span className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+                  {r.visibility}
+                </span>
               </Link>
+              {r.owner_user_id === user?.id && (
+                <button
+                  type="button"
+                  onClick={() => setPendingDelete(r)}
+                  disabled={deletingId === r.id}
+                  className="mr-3 rounded-md border border-danger px-2.5 py-1 text-xs text-danger hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-60"
+                  data-testid={`report-delete-${r.id}`}
+                >
+                  {deletingId === r.id ? "Deleting..." : "Delete"}
+                </button>
+              )}
             </li>
           ))}
         </ul>
       )}
+
+      <ConfirmModal
+        open={pendingDelete !== null}
+        title="Delete report"
+        message="Delete this report? This can't be undone."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </AppShell>
   );
 }

--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -11,6 +11,7 @@ import {
   ChevronUp,
   Compass,
   CreditCard,
+  FileBarChart,
   FileText,
   Gauge,
   HelpCircle,
@@ -114,7 +115,7 @@ const baseNavItems = [
 const REPORTS_NAV_ITEM = {
   href: "/reports",
   label: "Reports",
-  icon: <BarChart3 {...NAV_ICON_PROPS} />,
+  icon: <FileBarChart {...NAV_ICON_PROPS} />,
 } as const;
 
 function buildNavItems(featureReportsV2: boolean) {

--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -27,6 +27,8 @@ import AccountFilter from "@/components/reports/filters/AccountFilter";
 import CategoryPicker from "@/components/reports/filters/CategoryPicker";
 import DatePresetChips from "@/components/reports/filters/DatePresetChips";
 import TagFilter from "@/components/reports/filters/TagFilter";
+import HelpTooltip from "@/components/help/HelpTooltip";
+import type { HelpTooltipKey } from "@/lib/help/tooltips";
 import type {
   AreaConfig,
   Aggregation,
@@ -61,6 +63,14 @@ const AGG_OPTIONS: Array<{ value: Aggregation; label: string }> = [
   { value: "avg", label: "Average" },
   { value: "distinct", label: "Distinct count" },
 ];
+
+/** Tooltip key for each aggregation type (plain-language explainer). */
+const AGG_HELP_KEY: Record<Aggregation, HelpTooltipKey> = {
+  sum: "reports.agg.sum",
+  count: "reports.agg.count",
+  avg: "reports.agg.avg",
+  distinct: "reports.agg.distinct",
+};
 
 const FIELD_OPTIONS: Array<{ value: MeasureField; label: string }> = [
   { value: "amount", label: "Amount" },
@@ -273,7 +283,7 @@ export default function ConfigRail({
       )}
 
       {widget.type !== "kpi" && (
-        <Section label="Primary dimension">
+        <Section label="Primary dimension" help="reports.master-category">
           <select
             value={
               ((widget.config as BarConfig).dimensions ?? [])[0] ?? "category"
@@ -304,6 +314,7 @@ export default function ConfigRail({
               ? "Break down by (optional)"
               : "Secondary dimension (optional)"
           }
+          help="reports.master-category"
         >
           <select
             value={
@@ -387,15 +398,19 @@ export default function ConfigRail({
 
 function Section({
   label,
+  help,
   children,
 }: {
   label: string;
+  /** Optional help-tooltip key rendered as an info icon next to the label. */
+  help?: HelpTooltipKey;
   children: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-1">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
-        {label}
+      <div className="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider text-text-muted">
+        <span>{label}</span>
+        {help && <HelpTooltip k={help} />}
       </div>
       {children}
     </div>
@@ -422,7 +437,7 @@ function SingleMeasureEditor({
 }) {
   return (
     <>
-      <Section label="Aggregation">
+      <Section label="Aggregation" help={AGG_HELP_KEY[measure.agg]}>
         <select
           value={measure.agg}
           onChange={(e) =>
@@ -526,7 +541,7 @@ function MeasuresEditor({
             aria-label={`Series ${idx + 1} label`}
             className="rounded-md border border-border bg-bg px-2 py-1 text-xs text-text-primary"
           />
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1">
             <select
               value={s.measure.agg}
               onChange={(e) =>
@@ -544,6 +559,7 @@ function MeasuresEditor({
                 </option>
               ))}
             </select>
+            <HelpTooltip k={AGG_HELP_KEY[s.measure.agg]} />
             <select
               value={s.measure.field}
               onChange={(e) =>

--- a/frontend/components/reports/ConfigRail.tsx
+++ b/frontend/components/reports/ConfigRail.tsx
@@ -291,21 +291,31 @@ export default function ConfigRail({
         </Section>
       )}
 
-      {/* Secondary dimension picker — Table-only in v1. Bar / line /
-          area / stacked widgets currently only consume ``dimensions[0]``,
-          so exposing a secondary picker for them would be a no-op UX
-          (architect-locked). Split-series rendering is a follow-up if
-          users ask for it. */}
-      {widget.type === "table" && (
-        <Section label="Secondary dimension (optional)">
+      {/* Secondary dimension picker. For a bar widget this "Break down
+          by" slices each total bar into stacked segments (one color per
+          secondary value, e.g. per account) with a legend. For a table
+          it adds a second grouping column. Both consume
+          ``dimensions[1]`` and the backend AST already supports two
+          dimensions, so no query-layer change is needed. */}
+      {(widget.type === "bar" || widget.type === "table") && (
+        <Section
+          label={
+            widget.type === "bar"
+              ? "Break down by (optional)"
+              : "Secondary dimension (optional)"
+          }
+        >
           <select
             value={
-              ((widget.config as TableConfig).dimensions ?? [])[1] ?? ""
+              ((widget.config as BarConfig | TableConfig).dimensions ?? [])[1] ??
+              ""
             }
             onChange={(e) =>
               setSecondaryDimension((e.target.value || "") as Dimension | "")
             }
-            aria-label="Secondary dimension"
+            aria-label={
+              widget.type === "bar" ? "Break down by" : "Secondary dimension"
+            }
             className="w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text-primary"
           >
             <option value="">None</option>

--- a/frontend/components/reports/HistoryPanel.tsx
+++ b/frontend/components/reports/HistoryPanel.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * Reports v2 — version History panel.
+ *
+ * Replaces the standalone "Revert to original" button. Lists the
+ * report's saved versions newest-first (from ``listVersions``). The
+ * original snapshot gets an "Original" badge; every other row shows
+ * its ``created_at`` timestamp. Each row offers a Restore action,
+ * which the parent confirms before calling ``restoreVersion``.
+ */
+import { useEffect, useState } from "react";
+
+import { listVersions } from "@/lib/reports/api";
+import type { ReportVersionSummary } from "@/lib/reports/types";
+import { btnSecondary } from "@/lib/styles";
+
+interface Props {
+  open: boolean;
+  reportId: number;
+  onClose: () => void;
+  onRestore: (version: ReportVersionSummary) => void;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function HistoryPanel({
+  open,
+  reportId,
+  onClose,
+  onRestore,
+}: Props) {
+  const [versions, setVersions] = useState<ReportVersionSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setVersions(null);
+    setError(null);
+    listVersions(reportId)
+      .then((vs) => {
+        if (!cancelled) setVersions(vs);
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message || "Couldn't load history");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, reportId]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="history-panel-title"
+        data-testid="report-history-panel"
+        className="w-full max-w-[min(32rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h3
+            id="history-panel-title"
+            className="text-lg font-semibold text-text-primary"
+          >
+            Version history
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-text-muted hover:text-text-primary"
+            data-testid="report-history-close"
+            aria-label="Close history"
+          >
+            Close
+          </button>
+        </div>
+
+        {error && (
+          <p
+            role="alert"
+            className="mt-4 rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger"
+          >
+            {error}
+          </p>
+        )}
+
+        {!error && versions === null && (
+          <p className="mt-4 text-sm text-text-muted">Loading history...</p>
+        )}
+
+        {!error && versions !== null && versions.length === 0 && (
+          <p className="mt-4 text-sm text-text-muted">No versions yet.</p>
+        )}
+
+        {!error && versions !== null && versions.length > 0 && (
+          <ul className="mt-4 divide-y divide-border">
+            {versions.map((v) => (
+              <li
+                key={v.id}
+                data-testid={`report-history-row-${v.id}`}
+                className="flex items-center justify-between gap-3 py-3"
+              >
+                <div className="flex items-center gap-2">
+                  {v.is_original ? (
+                    <span
+                      data-testid="report-history-original-badge"
+                      className="rounded-full bg-accent/15 px-2 py-0.5 text-xs font-medium text-accent"
+                    >
+                      Original
+                    </span>
+                  ) : (
+                    <span className="text-sm text-text-secondary">
+                      {formatTimestamp(v.created_at)}
+                    </span>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onRestore(v)}
+                  className={`${btnSecondary} min-h-[36px]`}
+                  data-testid={`report-history-restore-${v.id}`}
+                >
+                  Restore
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/reports/filters/AccountFilter.tsx
+++ b/frontend/components/reports/filters/AccountFilter.tsx
@@ -41,7 +41,10 @@ export default function AccountFilter({
     { revalidateOnFocus: false },
   );
 
-  const accounts = data ?? [];
+  // Deactivated accounts must not be selectable as report filters; the
+  // shared /api/v1/accounts endpoint returns active + inactive (the
+  // accounts management page needs the inactive ones to reactivate them).
+  const accounts = (data ?? []).filter((a) => a.is_active);
   const selectedSet = new Set(value);
 
   function toggle(id: number) {

--- a/frontend/components/reports/widgetKit.tsx
+++ b/frontend/components/reports/widgetKit.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+/**
+ * Reports v2 — shared widget kit.
+ *
+ * Holds the pieces that both the saved-report editor (`/reports/[id]`)
+ * and the unsaved-draft editor (`/reports/new`) need: the per-type
+ * "empty widget" factory, the type → component renderer, a widget-id
+ * minter, and the mobile stack ordering. Extracted so the draft editor
+ * can reuse them without duplicating the editor's body or threading a
+ * "no id" mode through the big saved-report page.
+ */
+import type { CanvasFilters, Widget, WidgetType } from "@/lib/reports/types";
+import type { BarConfig, KPIConfig } from "@/lib/reports/types";
+import KPIWidget from "@/components/reports/widgets/KPIWidget";
+import BarWidget from "@/components/reports/widgets/BarWidget";
+import LineWidget from "@/components/reports/widgets/LineWidget";
+import AreaWidget from "@/components/reports/widgets/AreaWidget";
+import PieWidget from "@/components/reports/widgets/PieWidget";
+import SparklineWidget from "@/components/reports/widgets/SparklineWidget";
+import StackedBarWidget from "@/components/reports/widgets/StackedBarWidget";
+import TableWidget from "@/components/reports/widgets/TableWidget";
+
+function emptyKPI(id: string): Widget {
+  const config: KPIConfig = {
+    dataset: "transactions",
+    measure: { agg: "sum", field: "amount" },
+    format: "currency",
+    compare_prior_period: false,
+  };
+  return {
+    id,
+    type: "kpi",
+    title: "New KPI",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config,
+  };
+}
+
+function emptyBar(id: string): Widget {
+  const config: BarConfig = {
+    dataset: "transactions",
+    measure: { agg: "sum", field: "amount" },
+    dimensions: ["category"],
+    sort: { by: "value", dir: "desc" },
+    limit: 10,
+    format: "currency",
+  };
+  return {
+    id,
+    type: "bar",
+    title: "New bar chart",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config,
+  };
+}
+
+function emptyMultiSeries(
+  id: string,
+  type: "line" | "area" | "stacked_bar" | "table",
+): Widget {
+  const baseConfig = {
+    dataset: "transactions" as const,
+    measures: [{ measure: { agg: "sum" as const, field: "amount" as const } }],
+    dimensions: [type === "table" ? ("category" as const) : ("month" as const)],
+    sort: { by: "value" as const, dir: "desc" as const },
+    limit: type === "table" ? 50 : 100,
+    format: "currency" as const,
+  };
+  const baseGrid =
+    type === "table" ? { x: 0, y: 0, w: 12, h: 6 } : { x: 0, y: 0, w: 6, h: 4 };
+  return {
+    id,
+    type,
+    title:
+      type === "line"
+        ? "New line chart"
+        : type === "area"
+          ? "New area chart"
+          : type === "stacked_bar"
+            ? "New stacked bar chart"
+            : "New table",
+    grid: baseGrid,
+    config: baseConfig,
+  } as Widget;
+}
+
+function emptyPie(id: string): Widget {
+  return {
+    id,
+    type: "pie",
+    title: "New pie chart",
+    grid: { x: 0, y: 0, w: 4, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+      sort: { by: "value", dir: "desc" },
+      limit: 50,
+      format: "currency",
+      top_n: 8,
+    },
+  };
+}
+
+function emptySparkline(id: string): Widget {
+  return {
+    id,
+    type: "sparkline",
+    title: "New sparkline",
+    grid: { x: 0, y: 0, w: 3, h: 2 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["month"],
+      sort: { by: "dimension", dir: "asc" },
+      limit: 50,
+      format: "number",
+    },
+  };
+}
+
+export function emptyWidget(type: WidgetType, id: string): Widget {
+  switch (type) {
+    case "kpi":
+      return emptyKPI(id);
+    case "bar":
+      return emptyBar(id);
+    case "line":
+      return emptyMultiSeries(id, "line");
+    case "area":
+      return emptyMultiSeries(id, "area");
+    case "stacked_bar":
+      return emptyMultiSeries(id, "stacked_bar");
+    case "table":
+      return emptyMultiSeries(id, "table");
+    case "pie":
+      return emptyPie(id);
+    case "sparkline":
+      return emptySparkline(id);
+  }
+}
+
+export function renderWidgetByType(
+  w: Widget,
+  canvasFilters: CanvasFilters,
+  editMode: boolean,
+) {
+  switch (w.type) {
+    case "kpi":
+      return (
+        <KPIWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
+    case "bar":
+      return (
+        <BarWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
+    case "line":
+      return (
+        <LineWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
+    case "area":
+      return (
+        <AreaWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
+    case "pie":
+      return (
+        <PieWidget widget={w} canvasFilters={canvasFilters} editMode={editMode} />
+      );
+    case "sparkline":
+      return (
+        <SparklineWidget
+          widget={w}
+          canvasFilters={canvasFilters}
+          editMode={editMode}
+        />
+      );
+    case "stacked_bar":
+      return (
+        <StackedBarWidget
+          widget={w}
+          canvasFilters={canvasFilters}
+          editMode={editMode}
+        />
+      );
+    case "table":
+      return (
+        <TableWidget
+          widget={w}
+          canvasFilters={canvasFilters}
+          editMode={editMode}
+        />
+      );
+  }
+}
+
+export function newWidgetId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `w_${crypto.randomUUID().slice(0, 8)}`;
+  }
+  return `w_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Order widgets for the mobile single-column stack: top-to-bottom by
+ * grid ``y``, then left-to-right by grid ``x`` so the vertical reading
+ * order matches what the desktop grid shows.
+ */
+export function orderWidgetsForStack(widgets: Widget[]): Widget[] {
+  return [...widgets].sort((a, b) => {
+    if (a.grid.y !== b.grid.y) return a.grid.y - b.grid.y;
+    return a.grid.x - b.grid.x;
+  });
+}

--- a/frontend/components/reports/widgets/AreaWidget.tsx
+++ b/frontend/components/reports/widgets/AreaWidget.tsx
@@ -24,10 +24,13 @@ import type {
   AreaWidget as AreaWidgetType,
   CanvasFilters,
 } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import { buildSeriesCsvDataset } from "./seriesCsv";
 
 interface Props {
   widget: AreaWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
 }
 
 const AREA_COLORS = [
@@ -38,7 +41,7 @@ const AREA_COLORS = [
   "var(--color-danger)",
 ];
 
-export default function AreaWidget({ widget, canvasFilters }: Props) {
+export default function AreaWidget({ widget, canvasFilters, editMode }: Props) {
   const measures = widget.config.measures.map((m) => m.measure);
   const { series, isLoading, error } = useSeriesQueries(
     widget,
@@ -53,6 +56,12 @@ export default function AreaWidget({ widget, canvasFilters }: Props) {
     seriesLabel(m, i, widget.config.measures.length),
   );
   const stackId = widget.config.stacked && seriesKeys.length > 1 ? "stack" : undefined;
+  const csvDataset = buildSeriesCsvDataset(
+    dimensionKey,
+    rows,
+    seriesKeys,
+    labels,
+  );
 
   return (
     <div
@@ -60,11 +69,18 @@ export default function AreaWidget({ widget, canvasFilters }: Props) {
       data-widget-id={widget.id}
       className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
     >
-      <div
-        className="mb-2 text-sm font-semibold text-text-primary"
-        aria-label={widget.title || "Area chart"}
-      >
-        {widget.title || "Area chart"}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div
+          className="text-sm font-semibold text-text-primary"
+          aria-label={widget.title || "Area chart"}
+        >
+          {widget.title || "Area chart"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "Area chart"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       <div className="flex-1">
         {isLoading ? (

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 /**
- * Bar widget — vertical bars over a single dimension. Pulls rows
- * through ``useReportQuery``; takes the first dimension key from
- * the widget config and treats ``value`` as the measure axis.
+ * Bar widget — vertical bars over a primary dimension. Pulls rows
+ * through ``useReportQuery``; treats the first dimension as the x-axis
+ * label and ``value`` as the measure axis.
+ *
+ * When a SECONDARY dimension is set (``config.dimensions[1]``, e.g.
+ * "account"), each total bar is sliced into stacked segments — one per
+ * distinct secondary value, each a distinct color from the categorical
+ * palette — with a legend mapping color → secondary value. The backend
+ * AST supports up to two dimensions, so this is a single query grouped
+ * by ``[primary, secondary]`` that we pivot client-side via
+ * ``pivotBySecondaryDimension`` (reusing the same merge/backfill idiom
+ * the multi-series widgets use). With no secondary dimension the widget
+ * keeps its original single-color behavior.
  *
  * Recharts is the canvas chart engine across the app (Dashboard,
  * Budgets, Forecast Plans); reusing it here keeps visual register
@@ -19,8 +29,9 @@ import {
   YAxis,
 } from "recharts";
 
-import { chartColor } from "@/lib/chart-colors";
+import { categoricalColor, chartColor } from "@/lib/chart-colors";
 import { useReportQuery } from "@/lib/reports/useReportQuery";
+import { pivotBySecondaryDimension } from "@/lib/reports/series";
 import type {
   BarWidget as BarWidgetType,
   CanvasFilters,
@@ -34,11 +45,26 @@ interface Props {
 export default function BarWidget({ widget, canvasFilters }: Props) {
   const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
 
-  const dimensionKey = widget.config.dimensions[0] ?? "dimension";
-  const rows = (data?.rows ?? []).map((r) => ({
-    label: String(r[dimensionKey] ?? "—"),
+  const primaryKey = widget.config.dimensions[0] ?? "dimension";
+  const secondaryKey = widget.config.dimensions[1];
+  const sliced = Boolean(secondaryKey);
+
+  const queryRows = data?.rows ?? [];
+
+  // Single-series shape (no break-down): one ``value`` per label.
+  const simpleRows = queryRows.map((r) => ({
+    label: String(r[primaryKey] ?? "—"),
     value: typeof r.value === "number" ? r.value : Number(r.value ?? 0),
   }));
+
+  // Sliced shape: pivot [primary, secondary] into one numeric field per
+  // distinct secondary value so each becomes a stacked Recharts series.
+  const { rows: stackedRows, secondaryValues } = sliced
+    ? pivotBySecondaryDimension(queryRows, primaryKey, secondaryKey!)
+    : { rows: [], secondaryValues: [] as string[] };
+
+  const rows = sliced ? stackedRows : simpleRows;
+  const hasRows = rows.length > 0;
 
   return (
     <div
@@ -63,7 +89,7 @@ export default function BarWidget({ widget, canvasFilters }: Props) {
           >
             Couldn&apos;t load
           </div>
-        ) : rows.length === 0 ? (
+        ) : !hasRows ? (
           <div
             data-testid="bar-widget-empty"
             className="flex h-full items-center justify-center text-sm text-text-muted"
@@ -81,16 +107,60 @@ export default function BarWidget({ widget, canvasFilters }: Props) {
               />
               <YAxis tick={{ fill: chartColor.axisTick, fontSize: 11 }} />
               <Tooltip cursor={{ fill: "var(--color-border)", opacity: 0.3 }} />
-              <Bar
-                dataKey="value"
-                fill={chartColor.spent}
-                radius={[4, 4, 0, 0]}
-                animationDuration={400}
-              />
+              {sliced ? (
+                secondaryValues.map((sv, i) => (
+                  <Bar
+                    key={sv}
+                    dataKey={sv}
+                    name={sv}
+                    stackId="stack"
+                    fill={categoricalColor(i)}
+                    radius={
+                      i === secondaryValues.length - 1 ? [4, 4, 0, 0] : 0
+                    }
+                    animationDuration={400}
+                  />
+                ))
+              ) : (
+                <Bar
+                  dataKey="value"
+                  fill={chartColor.spent}
+                  radius={[4, 4, 0, 0]}
+                  animationDuration={400}
+                />
+              )}
             </BarChart>
           </ResponsiveContainer>
         )}
       </div>
+
+      {/* DOM legend (outside the SVG) maps each color → secondary value.
+          Rendered ourselves rather than via Recharts ``<Legend>`` so it
+          stays visible in headless layouts (jsdom collapses the chart)
+          and so swatch colors stay theme-token driven. */}
+      {sliced && !isLoading && !error && hasRows && (
+        <ul
+          data-testid="bar-widget-legend"
+          className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-text-secondary"
+        >
+          {secondaryValues.map((sv, i) => (
+            <li
+              key={sv}
+              data-testid="bar-widget-legend-item"
+              className="flex items-center gap-1"
+            >
+              <span
+                data-testid="bar-widget-legend-swatch"
+                data-color={categoricalColor(i)}
+                aria-hidden="true"
+                className="inline-block h-2.5 w-2.5 rounded-sm"
+                style={{ backgroundColor: categoricalColor(i) }}
+              />
+              <span>{sv}</span>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -62,9 +62,9 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
 
   // Sliced shape: pivot [primary, secondary] into one numeric field per
   // distinct secondary value so each becomes a stacked Recharts series.
-  const { rows: stackedRows, secondaryValues } = sliced
+  const { rows: stackedRows, secondaryValues, seriesKeys } = sliced
     ? pivotBySecondaryDimension(queryRows, primaryKey, secondaryKey!)
-    : { rows: [], secondaryValues: [] as string[] };
+    : { rows: [], secondaryValues: [] as string[], seriesKeys: [] as string[] };
 
   const rows = sliced ? stackedRows : simpleRows;
   const hasRows = rows.length > 0;
@@ -78,8 +78,8 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
         headers: [dimensionHeader(primaryKey), ...secondaryValues],
         rows: stackedRows.map((r) => [
           String(r.label),
-          ...secondaryValues.map((sv) =>
-            typeof r[sv] === "number" ? (r[sv] as number) : 0,
+          ...seriesKeys.map((sk) =>
+            typeof r[sk] === "number" ? (r[sk] as number) : 0,
           ),
         ]) as CsvCell[][],
       }
@@ -139,8 +139,8 @@ export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
               {sliced ? (
                 secondaryValues.map((sv, i) => (
                   <Bar
-                    key={sv}
-                    dataKey={sv}
+                    key={seriesKeys[i]}
+                    dataKey={seriesKeys[i]}
                     name={sv}
                     stackId="stack"
                     fill={categoricalColor(i)}

--- a/frontend/components/reports/widgets/BarWidget.tsx
+++ b/frontend/components/reports/widgets/BarWidget.tsx
@@ -31,18 +31,21 @@ import {
 
 import { categoricalColor, chartColor } from "@/lib/chart-colors";
 import { useReportQuery } from "@/lib/reports/useReportQuery";
-import { pivotBySecondaryDimension } from "@/lib/reports/series";
+import { dimensionHeader, pivotBySecondaryDimension } from "@/lib/reports/series";
 import type {
   BarWidget as BarWidgetType,
   CanvasFilters,
 } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import type { CsvCell } from "@/lib/reports/csv";
 
 interface Props {
   widget: BarWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
 }
 
-export default function BarWidget({ widget, canvasFilters }: Props) {
+export default function BarWidget({ widget, canvasFilters, editMode }: Props) {
   const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
 
   const primaryKey = widget.config.dimensions[0] ?? "dimension";
@@ -66,14 +69,40 @@ export default function BarWidget({ widget, canvasFilters }: Props) {
   const rows = sliced ? stackedRows : simpleRows;
   const hasRows = rows.length > 0;
 
+  // CSV export. Single-series: [dimension, measure]. Sliced (break-down
+  // by a secondary dimension): [primary dimension, ...one column per
+  // secondary value], mirroring the stacked segments.
+  const measureLabel = widget.config.measure.field;
+  const csvDataset = sliced
+    ? {
+        headers: [dimensionHeader(primaryKey), ...secondaryValues],
+        rows: stackedRows.map((r) => [
+          String(r.label),
+          ...secondaryValues.map((sv) =>
+            typeof r[sv] === "number" ? (r[sv] as number) : 0,
+          ),
+        ]) as CsvCell[][],
+      }
+    : {
+        headers: [dimensionHeader(primaryKey), measureLabel],
+        rows: simpleRows.map((r) => [r.label, r.value]) as CsvCell[][],
+      };
+
   return (
     <div
       data-testid="bar-widget"
       data-widget-id={widget.id}
       className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
     >
-      <div className="mb-2 text-sm font-semibold text-text-primary">
-        {widget.title || "Bar chart"}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="text-sm font-semibold text-text-primary">
+          {widget.title || "Bar chart"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "Bar chart"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       <div className="flex-1">
         {isLoading ? (

--- a/frontend/components/reports/widgets/KPIWidget.tsx
+++ b/frontend/components/reports/widgets/KPIWidget.tsx
@@ -12,10 +12,13 @@
  */
 import { useReportQuery } from "@/lib/reports/useReportQuery";
 import type { CanvasFilters, KPIWidget as KPIWidgetType } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import type { CsvCell } from "@/lib/reports/csv";
 
 interface Props {
   widget: KPIWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
   /**
    * Optional injected prior-period value. Computed by the editor
    * page (which can resolve the prior-period date range from the
@@ -28,6 +31,7 @@ interface Props {
 export default function KPIWidget({
   widget,
   canvasFilters,
+  editMode,
   priorValue,
 }: Props) {
   const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
@@ -44,14 +48,31 @@ export default function KPIWidget({
       ? ((value - priorValue) / Math.abs(priorValue)) * 100
       : null;
 
+  // CSV export: a single label/value row (the KPI is one number).
+  const measureLabel = widget.config.measure.field;
+  const csvDataset = {
+    headers: [widget.title || "KPI", measureLabel],
+    rows:
+      value === null
+        ? ([] as CsvCell[][])
+        : ([[widget.title || "KPI", value]] as CsvCell[][]),
+  };
+
   return (
     <div
       data-testid="kpi-widget"
       data-widget-id={widget.id}
       className="flex h-full flex-col justify-center gap-1 rounded-lg border border-border bg-surface p-4"
     >
-      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
-        {widget.title || "KPI"}
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+          {widget.title || "KPI"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "KPI"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       {isLoading ? (
         <div

--- a/frontend/components/reports/widgets/LineWidget.tsx
+++ b/frontend/components/reports/widgets/LineWidget.tsx
@@ -28,10 +28,13 @@ import type {
   CanvasFilters,
   LineWidget as LineWidgetType,
 } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import { buildSeriesCsvDataset } from "./seriesCsv";
 
 interface Props {
   widget: LineWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
 }
 
 const LINE_COLORS = [
@@ -42,7 +45,7 @@ const LINE_COLORS = [
   "var(--color-danger)",
 ];
 
-export default function LineWidget({ widget, canvasFilters }: Props) {
+export default function LineWidget({ widget, canvasFilters, editMode }: Props) {
   const measures = widget.config.measures.map((m) => m.measure);
   const { series, isLoading, error } = useSeriesQueries(
     widget,
@@ -56,6 +59,12 @@ export default function LineWidget({ widget, canvasFilters }: Props) {
   const labels = widget.config.measures.map((m, i) =>
     seriesLabel(m, i, widget.config.measures.length),
   );
+  const csvDataset = buildSeriesCsvDataset(
+    dimensionKey,
+    rows,
+    seriesKeys,
+    labels,
+  );
 
   return (
     <div
@@ -63,11 +72,18 @@ export default function LineWidget({ widget, canvasFilters }: Props) {
       data-widget-id={widget.id}
       className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
     >
-      <div
-        className="mb-2 text-sm font-semibold text-text-primary"
-        aria-label={widget.title || "Line chart"}
-      >
-        {widget.title || "Line chart"}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div
+          className="text-sm font-semibold text-text-primary"
+          aria-label={widget.title || "Line chart"}
+        >
+          {widget.title || "Line chart"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "Line chart"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       <div className="flex-1">
         {isLoading ? (

--- a/frontend/components/reports/widgets/PieWidget.tsx
+++ b/frontend/components/reports/widgets/PieWidget.tsx
@@ -18,15 +18,18 @@ import {
 } from "recharts";
 
 import { useReportQuery } from "@/lib/reports/useReportQuery";
-import { topNWithOther } from "@/lib/reports/series";
+import { dimensionHeader, topNWithOther } from "@/lib/reports/series";
 import type {
   CanvasFilters,
   PieWidget as PieWidgetType,
 } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import type { CsvCell } from "@/lib/reports/csv";
 
 interface Props {
   widget: PieWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
 }
 
 const PIE_COLORS = [
@@ -41,7 +44,7 @@ const PIE_COLORS = [
   "var(--color-bg-elevated, var(--color-border))",
 ];
 
-export default function PieWidget({ widget, canvasFilters }: Props) {
+export default function PieWidget({ widget, canvasFilters, editMode }: Props) {
   const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
 
   const dimensionKey = widget.config.dimensions[0] ?? "dimension";
@@ -52,17 +55,32 @@ export default function PieWidget({ widget, canvasFilters }: Props) {
   }));
   const rows = topNWithOther(rawRows, topN);
 
+  // CSV export mirrors the displayed slices (after the top-N "Other"
+  // roll-up): [dimension, measure].
+  const measureLabel = widget.config.measure.field;
+  const csvDataset = {
+    headers: [dimensionHeader(dimensionKey), measureLabel],
+    rows: rows.map((r) => [r.label, r.value]) as CsvCell[][],
+  };
+
   return (
     <div
       data-testid="pie-widget"
       data-widget-id={widget.id}
       className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
     >
-      <div
-        className="mb-2 text-sm font-semibold text-text-primary"
-        aria-label={widget.title || "Pie chart"}
-      >
-        {widget.title || "Pie chart"}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div
+          className="text-sm font-semibold text-text-primary"
+          aria-label={widget.title || "Pie chart"}
+        >
+          {widget.title || "Pie chart"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "Pie chart"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       <div className="flex-1">
         {isLoading ? (

--- a/frontend/components/reports/widgets/SparklineWidget.tsx
+++ b/frontend/components/reports/widgets/SparklineWidget.tsx
@@ -18,17 +18,25 @@ import {
 } from "recharts";
 
 import { useReportQuery } from "@/lib/reports/useReportQuery";
+import { dimensionHeader } from "@/lib/reports/series";
 import type {
   CanvasFilters,
   SparklineWidget as SparklineWidgetType,
 } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import type { CsvCell } from "@/lib/reports/csv";
 
 interface Props {
   widget: SparklineWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
 }
 
-export default function SparklineWidget({ widget, canvasFilters }: Props) {
+export default function SparklineWidget({
+  widget,
+  canvasFilters,
+  editMode,
+}: Props) {
   const { data, error, isLoading } = useReportQuery(widget, canvasFilters);
 
   const dimensionKey = widget.config.dimensions[0] ?? "dimension";
@@ -39,6 +47,13 @@ export default function SparklineWidget({ widget, canvasFilters }: Props) {
   const lastValue = rows.length > 0 ? rows[rows.length - 1].value : null;
   const format = widget.config.format ?? "number";
 
+  // CSV export mirrors the underlying trend series: [dimension, measure].
+  const measureLabel = widget.config.measure.field;
+  const csvDataset = {
+    headers: [dimensionHeader(dimensionKey), measureLabel],
+    rows: rows.map((r) => [r.label, r.value]) as CsvCell[][],
+  };
+
   return (
     <div
       data-testid="sparkline-widget"
@@ -46,8 +61,15 @@ export default function SparklineWidget({ widget, canvasFilters }: Props) {
       className="flex h-full flex-col justify-center gap-1 rounded-lg border border-border bg-surface p-3"
       aria-label={widget.title || "Sparkline"}
     >
-      <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
-        {widget.title || "Sparkline"}
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted">
+          {widget.title || "Sparkline"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "Sparkline"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       {isLoading ? (
         <div

--- a/frontend/components/reports/widgets/StackedBarWidget.tsx
+++ b/frontend/components/reports/widgets/StackedBarWidget.tsx
@@ -28,10 +28,13 @@ import type {
   CanvasFilters,
   StackedBarWidget as StackedBarWidgetType,
 } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import { buildSeriesCsvDataset } from "./seriesCsv";
 
 interface Props {
   widget: StackedBarWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
 }
 
 const BAR_COLORS = [
@@ -42,7 +45,11 @@ const BAR_COLORS = [
   "var(--color-danger)",
 ];
 
-export default function StackedBarWidget({ widget, canvasFilters }: Props) {
+export default function StackedBarWidget({
+  widget,
+  canvasFilters,
+  editMode,
+}: Props) {
   const measures = widget.config.measures.map((m) => m.measure);
   const { series, isLoading, error } = useSeriesQueries(
     widget,
@@ -61,6 +68,12 @@ export default function StackedBarWidget({ widget, canvasFilters }: Props) {
     widget.config.stacked === false || seriesKeys.length < 2
       ? undefined
       : "stack";
+  const csvDataset = buildSeriesCsvDataset(
+    dimensionKey,
+    rows,
+    seriesKeys,
+    labels,
+  );
 
   return (
     <div
@@ -68,11 +81,18 @@ export default function StackedBarWidget({ widget, canvasFilters }: Props) {
       data-widget-id={widget.id}
       className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
     >
-      <div
-        className="mb-2 text-sm font-semibold text-text-primary"
-        aria-label={widget.title || "Stacked bar chart"}
-      >
-        {widget.title || "Stacked bar chart"}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div
+          className="text-sm font-semibold text-text-primary"
+          aria-label={widget.title || "Stacked bar chart"}
+        >
+          {widget.title || "Stacked bar chart"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "Stacked bar chart"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       <div className="flex-1">
         {isLoading ? (

--- a/frontend/components/reports/widgets/TableWidget.tsx
+++ b/frontend/components/reports/widgets/TableWidget.tsx
@@ -19,33 +19,27 @@
 import { useMemo, useState } from "react";
 
 import { useSeriesQueries } from "@/lib/reports/useReportQuery";
-import { mergeSeriesRowsForTable, seriesLabel } from "@/lib/reports/series";
+import {
+  DIMENSION_HEADERS,
+  mergeSeriesRowsForTable,
+  seriesLabel,
+} from "@/lib/reports/series";
 import type {
   CanvasFilters,
-  Dimension,
   TableWidget as TableWidgetType,
 } from "@/lib/reports/types";
+import WidgetCsvButton from "./WidgetCsvButton";
+import type { CsvCell } from "@/lib/reports/csv";
 
 interface Props {
   widget: TableWidgetType;
   canvasFilters?: CanvasFilters;
+  editMode?: boolean;
 }
 
 const PAGE_SIZE = 50;
 
-const DIMENSION_HEADERS: Record<Dimension, string> = {
-  category: "Category",
-  category_master: "Master category",
-  account: "Account",
-  tag: "Tag",
-  txn_type: "Type",
-  status: "Status",
-  month: "Month",
-  week: "Week",
-  day: "Day",
-};
-
-export default function TableWidget({ widget, canvasFilters }: Props) {
+export default function TableWidget({ widget, canvasFilters, editMode }: Props) {
   const measures = widget.config.measures.map((m) => m.measure);
   const { series, isLoading, error } = useSeriesQueries(
     widget,
@@ -124,17 +118,48 @@ export default function TableWidget({ widget, canvasFilters }: Props) {
     });
   }, [widget.config.measures, rows, seriesKeys]);
 
+  // CSV export mirrors the rendered table: dimension columns followed by
+  // one column per measure, every row the widget holds (in the current
+  // sort order), then a Total row matching the footer.
+  const csvDataset = useMemo(() => {
+    const headers = [
+      ...dimensions.map((d) => DIMENSION_HEADERS[d] ?? d),
+      ...seriesLabels,
+    ];
+    const dataRows: CsvCell[][] = sortedRows.map((row) => [
+      ...dimensions.map((d) => String(row[d] ?? "—")),
+      ...seriesKeys.map((key) =>
+        typeof row[key] === "number" ? (row[key] as number) : null,
+      ),
+    ]);
+    if (dataRows.length > 0) {
+      const totalRow: CsvCell[] = [
+        ...dimensions.map((_, di) => (di === 0 ? "Total" : "")),
+        ...columnTotals.map((t) => (t === null ? "" : t)),
+      ];
+      dataRows.push(totalRow);
+    }
+    return { headers, rows: dataRows };
+  }, [dimensions, seriesLabels, sortedRows, seriesKeys, columnTotals]);
+
   return (
     <div
       data-testid="table-widget"
       data-widget-id={widget.id}
       className="flex h-full flex-col rounded-lg border border-border bg-surface p-4"
     >
-      <div
-        className="mb-2 text-sm font-semibold text-text-primary"
-        aria-label={widget.title || "Table"}
-      >
-        {widget.title || "Table"}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div
+          className="text-sm font-semibold text-text-primary"
+          aria-label={widget.title || "Table"}
+        >
+          {widget.title || "Table"}
+        </div>
+        <WidgetCsvButton
+          title={widget.title || "Table"}
+          dataset={csvDataset}
+          editMode={editMode}
+        />
       </div>
       <div className="flex-1 overflow-auto">
         {isLoading ? (

--- a/frontend/components/reports/widgets/TableWidget.tsx
+++ b/frontend/components/reports/widgets/TableWidget.tsx
@@ -99,6 +99,31 @@ export default function TableWidget({ widget, canvasFilters }: Props) {
 
   const format = widget.config.format ?? "number";
 
+  // Total row: sum each measure column across the FULL result set
+  // (every row the widget holds in memory), not just the visible page.
+  // Only additive aggregations (sum/count) get a real total; for
+  // avg/distinct/min/max a column sum is meaningless, so we render a
+  // placeholder rather than fabricate a wrong number.
+  //
+  // Caveat: this totals the rows the query returned, which are subject
+  // to the widget's ``limit``. It is NOT a separate server-side grand
+  // total. Fine for v1.
+  const columnTotals = useMemo(() => {
+    return widget.config.measures.map((m, i) => {
+      const agg = m.measure.agg;
+      const additive = agg === "sum" || agg === "count";
+      if (!additive) return null;
+      const key = seriesKeys[i];
+      let sum = 0;
+      for (const row of rows) {
+        const v = row[key];
+        const n = typeof v === "number" ? v : Number(v);
+        if (Number.isFinite(n)) sum += n;
+      }
+      return sum;
+    });
+  }, [widget.config.measures, rows, seriesKeys]);
+
   return (
     <div
       data-testid="table-widget"
@@ -183,6 +208,25 @@ export default function TableWidget({ widget, canvasFilters }: Props) {
                 </tr>
               ))}
             </tbody>
+            <tfoot>
+              <tr
+                data-testid="table-widget-total-row"
+                className="border-t-2 border-border font-semibold text-text-primary"
+              >
+                {dimensions.map((d, di) => (
+                  <td key={d} className="py-1.5 pr-3">
+                    {di === 0 ? "Total" : ""}
+                  </td>
+                ))}
+                {seriesKeys.map((key, i) => (
+                  <td key={key} className="py-1.5 pr-3 text-right font-mono">
+                    {columnTotals[i] === null
+                      ? "—"
+                      : formatCell(columnTotals[i], format)}
+                  </td>
+                ))}
+              </tr>
+            </tfoot>
           </table>
         )}
       </div>

--- a/frontend/components/reports/widgets/WidgetCsvButton.tsx
+++ b/frontend/components/reports/widgets/WidgetCsvButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * Per-widget "Export CSV" affordance.
+ *
+ * Each widget already derives the exact rows it renders (single-measure
+ * widgets from ``useReportQuery``; multi-series / table widgets from the
+ * client-side merge of ``useSeriesQueries``). Rather than route a fresh
+ * backend export endpoint, the widget passes that in-memory display data
+ * down here as a ``{ headers, rows }`` dataset and this button serializes
+ * + downloads it client-side.
+ *
+ * Lives inside each widget's own header row (not in ``WidgetShell``)
+ * because the rows are computed inside the widget body from hooks that
+ * ``WidgetShell`` — which only wraps the rendered children — can't see.
+ * Keeping the button local to where the data is derived is the least
+ * invasive integration and stays consistent across all eight widgets.
+ *
+ * View-mode only: hidden in edit mode to keep the editing chrome (drag
+ * handle, remove, config rail) uncluttered.
+ */
+import { Download } from "lucide-react";
+
+import { csvFilename, downloadCsv, toCsv, type CsvDataset } from "@/lib/reports/csv";
+
+interface Props {
+  /** Widget title; slugified into the download filename. */
+  title: string;
+  /** The exact rows the widget is displaying. */
+  dataset: CsvDataset;
+  /** Hidden in edit mode. Defaults to view mode (false). */
+  editMode?: boolean;
+}
+
+export default function WidgetCsvButton({ title, dataset, editMode }: Props) {
+  if (editMode) return null;
+
+  const hasRows = dataset.rows.length > 0;
+
+  function handleExport() {
+    if (!hasRows) return;
+    const csv = toCsv(dataset.headers, dataset.rows);
+    downloadCsv(csvFilename(title), csv);
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="widget-csv-export"
+      onClick={(e) => {
+        // The widget shell selects the widget on click; exporting
+        // shouldn't change selection.
+        e.stopPropagation();
+        handleExport();
+      }}
+      disabled={!hasRows}
+      title="Export CSV"
+      aria-label={`Export ${title || "widget"} as CSV`}
+      className="rounded p-1 text-text-muted transition hover:bg-bg-elevated hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      <Download aria-hidden="true" className="h-3.5 w-3.5" />
+    </button>
+  );
+}

--- a/frontend/components/reports/widgets/seriesCsv.ts
+++ b/frontend/components/reports/widgets/seriesCsv.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared CSV export-dataset builder for the multi-series chart widgets
+ * (Line / Area / StackedBar). All three render the same merged shape:
+ * one row per dimension value with ``label`` plus one numeric field per
+ * series key (``s0..sN``). The CSV mirrors that: a dimension column
+ * followed by one column per series, using the human series labels as
+ * headers.
+ */
+import { dimensionHeader } from "@/lib/reports/series";
+import type { CsvCell, CsvDataset } from "@/lib/reports/csv";
+
+export function buildSeriesCsvDataset(
+  dimensionKey: string,
+  rows: Array<{ label: string } & Record<string, number | string>>,
+  seriesKeys: string[],
+  seriesLabels: string[],
+): CsvDataset {
+  return {
+    headers: [dimensionHeader(dimensionKey), ...seriesLabels],
+    rows: rows.map((r) => [
+      String(r.label),
+      ...seriesKeys.map((key) =>
+        typeof r[key] === "number" ? (r[key] as number) : 0,
+      ),
+    ]) as CsvCell[][],
+  };
+}

--- a/frontend/lib/chart-colors.ts
+++ b/frontend/lib/chart-colors.ts
@@ -21,3 +21,25 @@ export const chartColor = {
   remaining: "var(--color-border)",
   axisTick: "var(--color-text-secondary)",
 } as const;
+
+// Categorical palette for multi-series charts (e.g. a bar chart split
+// into one stacked segment per account). Each entry is a theme-aware CSS
+// variable so light/dark switches cascade; series index modulo the
+// length picks a color so we never run out. Ordered for adjacent-segment
+// contrast. The trailing fallbacks keep the list usable even if a theme
+// hasn't defined every optional token.
+export const categoricalColors: readonly string[] = [
+  "var(--color-accent)",
+  "var(--color-success)",
+  "var(--color-info, var(--color-accent))",
+  "var(--color-warning, var(--color-text-secondary))",
+  "var(--color-danger)",
+  "var(--color-text-secondary)",
+  "var(--color-accent-2, var(--color-success))",
+  "var(--color-text-muted)",
+] as const;
+
+/** Pick a distinct categorical color by series index (wraps around). */
+export function categoricalColor(index: number): string {
+  return categoricalColors[index % categoricalColors.length];
+}

--- a/frontend/lib/help/tooltips.ts
+++ b/frontend/lib/help/tooltips.ts
@@ -125,6 +125,32 @@ export const HELP_TOOLTIPS = {
     learnMoreSection: "reports",
     triggerLabel: "What can I put in a report?",
   },
+  "reports.agg.sum": {
+    content: "Adds up the field's values across every matching row.",
+    learnMoreSection: "reports",
+    triggerLabel: "What does Sum do?",
+  },
+  "reports.agg.count": {
+    content: "Counts how many rows match, ignoring the field's value.",
+    learnMoreSection: "reports",
+    triggerLabel: "What does Count do?",
+  },
+  "reports.agg.avg": {
+    content: "Averages the field's values across every matching row.",
+    learnMoreSection: "reports",
+    triggerLabel: "What does Average do?",
+  },
+  "reports.agg.distinct": {
+    content: "Counts unique values, so repeats are only counted once.",
+    learnMoreSection: "reports",
+    triggerLabel: "What does Distinct count do?",
+  },
+  "reports.master-category": {
+    content:
+      "Groups by the master (parent) category instead of each subcategory, so Food rolls up Groceries, Dining, and Coffee into one total.",
+    learnMoreSection: "reports",
+    triggerLabel: "What is a master category here?",
+  },
 
   // Dashboard
   "dashboard.on-track": {

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -14,6 +14,7 @@ import type {
   LayoutJson,
   ReportCreatePayload,
   ReportSummary,
+  ReportTemplate,
   ReportUpdatePayload,
   ReportsQuery,
   ReportsQueryResponse,
@@ -21,6 +22,10 @@ import type {
 
 export async function listReports(): Promise<ReportSummary[]> {
   return apiFetch<ReportSummary[]>("/api/v1/reports");
+}
+
+export async function listTemplates(): Promise<ReportTemplate[]> {
+  return apiFetch<ReportTemplate[]>("/api/v1/reports/templates");
 }
 
 export async function getReport(id: number): Promise<ReportSummary> {
@@ -34,6 +39,17 @@ export async function createReport(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
+  });
+}
+
+export async function createFromTemplate(
+  t: ReportTemplate,
+): Promise<ReportSummary> {
+  return createReport({
+    name: t.name,
+    visibility: "private",
+    layout_json: t.layout_json,
+    canvas_filters_json: t.canvas_filters_json,
   });
 }
 

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -70,6 +70,18 @@ export async function deleteReport(id: number): Promise<void> {
 }
 
 /**
+ * Duplicate a report. The backend creates a fresh private copy owned
+ * by the caller (regardless of who owns the source) and returns its
+ * ``ReportSummary`` with a 201. Anyone who can view a report can
+ * duplicate it.
+ */
+export async function duplicateReport(id: number): Promise<ReportSummary> {
+  return apiFetch<ReportSummary>(`/api/v1/reports/${id}/duplicate`, {
+    method: "POST",
+  });
+}
+
+/**
  * Revert a report's live layout + canvas filters back to the
  * as-created snapshot the backend captured at creation time. Returns
  * the updated ``ReportSummary`` so the editor can re-hydrate its

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -16,6 +16,7 @@ import type {
   ReportSummary,
   ReportTemplate,
   ReportUpdatePayload,
+  ReportVersionSummary,
   ReportsQuery,
   ReportsQueryResponse,
 } from "./types";
@@ -78,6 +79,32 @@ export async function resetReport(id: number): Promise<ReportSummary> {
   return apiFetch<ReportSummary>(`/api/v1/reports/${id}/reset`, {
     method: "POST",
   });
+}
+
+/**
+ * List the saved versions of a report, newest-first. The original
+ * snapshot carries ``is_original: true``; the editor's History panel
+ * badges it and offers a Restore action per row.
+ */
+export async function listVersions(
+  id: number,
+): Promise<ReportVersionSummary[]> {
+  return apiFetch<ReportVersionSummary[]>(`/api/v1/reports/${id}/versions`);
+}
+
+/**
+ * Restore a saved version into the report's live layout + canvas
+ * filters. Returns the updated ``ReportSummary`` so the editor can
+ * re-hydrate its canvas from the restored server state.
+ */
+export async function restoreVersion(
+  id: number,
+  versionId: number,
+): Promise<ReportSummary> {
+  return apiFetch<ReportSummary>(
+    `/api/v1/reports/${id}/versions/${versionId}/restore`,
+    { method: "POST" },
+  );
 }
 
 export async function runQuery(

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -68,6 +68,18 @@ export async function deleteReport(id: number): Promise<void> {
   await apiFetch<void>(`/api/v1/reports/${id}`, { method: "DELETE" });
 }
 
+/**
+ * Revert a report's live layout + canvas filters back to the
+ * as-created snapshot the backend captured at creation time. Returns
+ * the updated ``ReportSummary`` so the editor can re-hydrate its
+ * canvas from the rolled-back server state.
+ */
+export async function resetReport(id: number): Promise<ReportSummary> {
+  return apiFetch<ReportSummary>(`/api/v1/reports/${id}/reset`, {
+    method: "POST",
+  });
+}
+
 export async function runQuery(
   body: ReportsQuery,
 ): Promise<ReportsQueryResponse> {

--- a/frontend/lib/reports/csv.ts
+++ b/frontend/lib/reports/csv.ts
@@ -1,0 +1,78 @@
+/**
+ * Client-side CSV export for Reports v2 widgets.
+ *
+ * Each widget already holds the exact rows it rendered (from
+ * ``useReportQuery`` / ``useSeriesQueries`` merged client-side). Rather
+ * than round-trip a new backend endpoint, a widget builds a small
+ * ``{ headers, rows }`` export dataset from that in-memory data and
+ * hands it to ``downloadCsv`` to trigger a browser download.
+ */
+
+/** A field value in a CSV cell. ``null``/``undefined`` render empty. */
+export type CsvCell = string | number | null | undefined;
+
+export interface CsvDataset {
+  headers: string[];
+  rows: CsvCell[][];
+}
+
+/**
+ * Serialize headers + rows to an RFC4180-ish CSV string.
+ *
+ * Fields containing a comma, double-quote, CR or LF are wrapped in
+ * double quotes; interior double-quotes are doubled. Numbers render via
+ * ``String(n)``; ``null``/``undefined`` render as an empty field. Rows
+ * are joined with CRLF (the RFC4180 record separator); no trailing
+ * newline is appended.
+ */
+export function toCsv(headers: string[], rows: CsvCell[][]): string {
+  const lines = [headers.map(escapeField).join(",")];
+  for (const row of rows) {
+    lines.push(row.map(escapeField).join(","));
+  }
+  return lines.join("\r\n");
+}
+
+function escapeField(value: CsvCell): string {
+  if (value === null || value === undefined) return "";
+  const s = typeof value === "number" ? String(value) : String(value);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Trigger a browser download of ``csv`` as ``filename`` via a Blob +
+ * object URL and a synthesized anchor click. No-ops outside the browser
+ * (SSR / non-DOM environments).
+ */
+export function downloadCsv(filename: string, csv: string): void {
+  if (typeof document === "undefined" || typeof URL === "undefined") return;
+  // Prepend a UTF-8 BOM so Excel opens accented characters correctly.
+  const blob = new Blob(["﻿" + csv], {
+    type: "text/csv;charset=utf-8;",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = "none";
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Slugify a widget title into a safe CSV filename stem. Falls back to
+ * ``"report"`` when the title is empty after slugification.
+ */
+export function csvFilename(title: string): string {
+  const slug = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${slug || "report"}.csv`;
+}

--- a/frontend/lib/reports/draft.ts
+++ b/frontend/lib/reports/draft.ts
@@ -1,0 +1,44 @@
+/**
+ * Reports v2 — blank draft seed.
+ *
+ * A truly empty report renders nothing (canvas filters cascade INTO
+ * widgets, and there are no widgets), so a fresh draft seeds one
+ * sensible starter widget plus a this-month canvas date so the draft
+ * shows data immediately. This is the content the list page's "New
+ * report" button used to persist directly; it now lives only in the
+ * unsaved draft until the user Saves.
+ */
+import { buildPresetRanges } from "@/components/reports/filters/DatePresetChips";
+import type { CanvasFilters, LayoutJson } from "@/lib/reports/types";
+
+export interface DraftSeed {
+  layout: LayoutJson;
+  canvasFilters: CanvasFilters;
+}
+
+export function blankDraftSeed(now: Date = new Date()): DraftSeed {
+  const ranges = buildPresetRanges(now);
+  return {
+    canvasFilters: { date_range: ranges.this_month },
+    layout: {
+      version: 1,
+      widgets: [
+        {
+          id: "w_start",
+          type: "bar",
+          title: "Spend by category",
+          grid: { x: 0, y: 0, w: 6, h: 4 },
+          config: {
+            dataset: "transactions",
+            measure: { agg: "sum", field: "amount" },
+            dimensions: ["category"],
+            filters: { txn_type: "expense" },
+            sort: { by: "value", dir: "desc" },
+            limit: 10,
+            format: "currency",
+          },
+        },
+      ],
+    },
+  };
+}

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -148,10 +148,15 @@ export function mergeSeriesRowsForTable(
  * single total bar is sliced into one colored segment per secondary
  * value (e.g. per account).
  *
- * Returns both the pivoted rows and the ordered list of distinct
- * secondary values (first-seen order) so callers can map a stable color
- * + legend entry to each. Missing combinations are backfilled with 0 so
- * Recharts renders flat segments instead of gaps.
+ * Returns the pivoted rows, the ordered list of distinct secondary
+ * values (first-seen order, for legend labels), and a matching list of
+ * STABLE generated keys (``s0``, ``s1``, …). Numeric fields are keyed by
+ * the generated key, NOT the raw secondary value: a raw value used as a
+ * Recharts ``dataKey`` is fragile (a "." is parsed as a nested path, and
+ * special chars / collisions can stop bars from rendering). Callers pair
+ * ``seriesKeys[i]`` (the dataKey) with ``secondaryValues[i]`` (the
+ * display label). Missing combinations are backfilled with 0 so Recharts
+ * renders flat segments instead of gaps.
  */
 export function pivotBySecondaryDimension(
   rows: QueryRow[],
@@ -160,37 +165,51 @@ export function pivotBySecondaryDimension(
 ): {
   rows: Array<{ label: string } & Record<string, number | string>>;
   secondaryValues: string[];
+  seriesKeys: string[];
 } {
   const byLabel = new Map<string, Record<string, number | string>>();
   const order: string[] = [];
   const secondaryValues: string[] = [];
-  const seenSecondary = new Set<string>();
+  // Map each distinct secondary value to a stable generated key. Using a
+  // null-prototype Map key set + generated keys avoids prototype
+  // pollution from user-controlled values like ``__proto__``.
+  const keyForSecondary = new Map<string, string>();
 
   for (const row of rows) {
     const label = readLabel(row, primaryKey);
     const secondary = readLabel(row, secondaryKey);
-    if (!seenSecondary.has(secondary)) {
-      seenSecondary.add(secondary);
+    let seriesKey = keyForSecondary.get(secondary);
+    if (seriesKey === undefined) {
+      seriesKey = `s${secondaryValues.length}`;
+      keyForSecondary.set(secondary, seriesKey);
       secondaryValues.push(secondary);
     }
     let existing = byLabel.get(label);
     if (!existing) {
-      existing = { label };
+      // Null-prototype record: user-controlled secondary values become
+      // generated keys on a prototype-less object, so values like
+      // ``__proto__`` are plain data and can't pollute Object.prototype.
+      existing = Object.assign(
+        Object.create(null) as Record<string, number | string>,
+        { label },
+      );
       byLabel.set(label, existing);
       order.push(label);
     }
     // Same (primary, secondary) pair shouldn't repeat after GROUP BY,
     // but sum defensively in case it does.
-    const prior = typeof existing[secondary] === "number"
-      ? (existing[secondary] as number)
+    const prior = typeof existing[seriesKey] === "number"
+      ? (existing[seriesKey] as number)
       : 0;
-    existing[secondary] = prior + readNumber(row.value);
+    existing[seriesKey] = prior + readNumber(row.value);
   }
+
+  const seriesKeys = secondaryValues.map((sv) => keyForSecondary.get(sv)!);
 
   for (const label of order) {
     const r = byLabel.get(label)!;
-    for (const sv of secondaryValues) {
-      if (typeof r[sv] !== "number") r[sv] = 0;
+    for (const sk of seriesKeys) {
+      if (typeof r[sk] !== "number") r[sk] = 0;
     }
   }
 
@@ -199,6 +218,7 @@ export function pivotBySecondaryDimension(
       { label: string } & Record<string, number | string>
     >,
     secondaryValues,
+    seriesKeys,
   };
 }
 

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -6,6 +6,7 @@
  * shared dimension key.
  */
 import type {
+  Dimension,
   Measure,
   QueryRow,
   ReportsQueryResponse,
@@ -18,6 +19,28 @@ const HUMAN_AGG: Record<Measure["agg"], string> = {
   avg: "Average",
   distinct: "Distinct",
 };
+
+/**
+ * Human-readable column header per dimension. Shared by the table
+ * widget's header row and the CSV export of every dimension-bearing
+ * widget so the exported header matches what the user sees.
+ */
+export const DIMENSION_HEADERS: Record<Dimension, string> = {
+  category: "Category",
+  category_master: "Master category",
+  account: "Account",
+  tag: "Tag",
+  txn_type: "Type",
+  status: "Status",
+  month: "Month",
+  week: "Week",
+  day: "Day",
+};
+
+/** Header label for a dimension key, falling back to the raw key. */
+export function dimensionHeader(key: string): string {
+  return DIMENSION_HEADERS[key as Dimension] ?? key;
+}
 
 /**
  * Stable human label for a series. Uses the optional ``label`` if

--- a/frontend/lib/reports/series.ts
+++ b/frontend/lib/reports/series.ts
@@ -115,6 +115,70 @@ export function mergeSeriesRowsForTable(
   return order.map((k) => byKey.get(k)!);
 }
 
+/**
+ * Pivot a single two-dimension query result into stacked-bar rows.
+ *
+ * Given rows grouped by ``[primaryKey, secondaryKey]`` (e.g. category ×
+ * account), produce one row per primary value whose numeric fields are
+ * keyed by each distinct secondary value. Recharts then renders one
+ * ``<Bar dataKey={secondaryValue} stackId>`` per secondary value, so a
+ * single total bar is sliced into one colored segment per secondary
+ * value (e.g. per account).
+ *
+ * Returns both the pivoted rows and the ordered list of distinct
+ * secondary values (first-seen order) so callers can map a stable color
+ * + legend entry to each. Missing combinations are backfilled with 0 so
+ * Recharts renders flat segments instead of gaps.
+ */
+export function pivotBySecondaryDimension(
+  rows: QueryRow[],
+  primaryKey: string,
+  secondaryKey: string,
+): {
+  rows: Array<{ label: string } & Record<string, number | string>>;
+  secondaryValues: string[];
+} {
+  const byLabel = new Map<string, Record<string, number | string>>();
+  const order: string[] = [];
+  const secondaryValues: string[] = [];
+  const seenSecondary = new Set<string>();
+
+  for (const row of rows) {
+    const label = readLabel(row, primaryKey);
+    const secondary = readLabel(row, secondaryKey);
+    if (!seenSecondary.has(secondary)) {
+      seenSecondary.add(secondary);
+      secondaryValues.push(secondary);
+    }
+    let existing = byLabel.get(label);
+    if (!existing) {
+      existing = { label };
+      byLabel.set(label, existing);
+      order.push(label);
+    }
+    // Same (primary, secondary) pair shouldn't repeat after GROUP BY,
+    // but sum defensively in case it does.
+    const prior = typeof existing[secondary] === "number"
+      ? (existing[secondary] as number)
+      : 0;
+    existing[secondary] = prior + readNumber(row.value);
+  }
+
+  for (const label of order) {
+    const r = byLabel.get(label)!;
+    for (const sv of secondaryValues) {
+      if (typeof r[sv] !== "number") r[sv] = 0;
+    }
+  }
+
+  return {
+    rows: order.map((l) => byLabel.get(l)!) as Array<
+      { label: string } & Record<string, number | string>
+    >,
+    secondaryValues,
+  };
+}
+
 function readLabel(
   row: QueryRow,
   key: string,

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -287,6 +287,14 @@ export interface ReportSummary {
   updated_at: string;
 }
 
+export interface ReportTemplate {
+  key: string;
+  name: string;
+  description: string;
+  layout_json: LayoutJson;
+  canvas_filters_json: CanvasFilters;
+}
+
 export interface ReportCreatePayload {
   name: string;
   description?: string;

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -287,6 +287,12 @@ export interface ReportSummary {
   updated_at: string;
 }
 
+export interface ReportVersionSummary {
+  id: number;
+  is_original: boolean;
+  created_at: string;
+}
+
 export interface ReportTemplate {
   key: string;
   name: string;

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -62,9 +62,28 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/reports/10",
 }));
 
-import ReportEditorPage from "@/app/reports/[id]/page";
+import ReportEditorPage, {
+  orderWidgetsForStack,
+} from "@/app/reports/[id]/page";
 import { useAuth } from "@/components/auth/AuthProvider";
 import * as reportsApi from "@/lib/reports/api";
+import type { Widget } from "@/lib/reports/types";
+
+// Install a ``matchMedia`` stub that reports the given small-screen
+// state for the ``max-width`` query the page uses. jsdom ships no
+// matchMedia, so absent this the page treats every test as desktop.
+function mockMatchMedia(isSmall: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: /max-width/.test(query) ? isSmall : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
 
 const BASE_USER = {
   id: 1,
@@ -140,6 +159,10 @@ describe("ReportEditorPage", () => {
     });
     pushMock.mockReset();
     replaceMock.mockReset();
+    // Default every test to desktop (no matchMedia → page treats as
+    // desktop). Individual mobile tests opt into the small-screen stub.
+    // @ts-expect-error -- clear any stub a prior test installed
+    delete window.matchMedia;
   });
 
   it("renders the canvas for an empty report and opens the widget picker", async () => {
@@ -706,6 +729,137 @@ describe("ReportEditorPage", () => {
     await waitFor(() =>
       expect(pushMock).toHaveBeenCalledWith("/reports/77"),
     );
+  });
+
+  it("shows a 'Report saved' toast after a successful save", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+    saveLayoutMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:01",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    fireEvent.click(screen.getByTestId("report-editor-add-widget"));
+    fireEvent.click(screen.getByTestId("widget-picker-option-bar"));
+    await waitFor(() =>
+      expect(screen.getByTestId("bar-widget")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByTestId("report-editor-save"));
+
+    const toast = await screen.findByTestId("report-editor-saved-toast");
+    expect(toast).toHaveTextContent("Report saved");
+    // Accessible polite live region.
+    expect(toast).toHaveAttribute("role", "status");
+  });
+
+  it("on small screens renders a read-only widget stack with no edit affordances", async () => {
+    mockMatchMedia(true);
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      ...REPORT_WITH_WIDGET,
+      // Two widgets out of grid order to exercise the (y, x) sort.
+      layout_json: {
+        version: 1 as const,
+        widgets: [
+          {
+            id: "w_lower",
+            type: "kpi" as const,
+            title: "Lower",
+            grid: { x: 0, y: 4, w: 3, h: 2 },
+            config: {
+              dataset: "transactions" as const,
+              measure: { agg: "sum" as const, field: "amount" as const },
+              format: "currency" as const,
+            },
+          },
+          {
+            id: "w_upper",
+            type: "kpi" as const,
+            title: "Upper",
+            grid: { x: 0, y: 0, w: 3, h: 2 },
+            config: {
+              dataset: "transactions" as const,
+              measure: { agg: "sum" as const, field: "amount" as const },
+              format: "currency" as const,
+            },
+          },
+        ],
+      },
+    } as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    // Read-only stack renders (NOT the grid Canvas).
+    const stack = await screen.findByTestId("reports-canvas-stack");
+    expect(stack).toBeInTheDocument();
+    expect(screen.queryByTestId("reports-canvas")).toBeNull();
+    // Both widgets render their data.
+    expect(stack.querySelectorAll("[data-widget-id]").length).toBe(2);
+    expect(screen.getAllByTestId("kpi-widget").length).toBe(2);
+    // No edit affordances at all: no Edit toggle, Add, Save, Cancel.
+    expect(screen.queryByTestId("report-editor-toggle-edit")).toBeNull();
+    expect(screen.queryByTestId("report-editor-add-widget")).toBeNull();
+    expect(screen.queryByTestId("report-editor-save")).toBeNull();
+    expect(screen.queryByTestId("report-editor-cancel")).toBeNull();
+  });
+
+  it("orders widgets for the mobile stack by grid (y, then x)", () => {
+    const widgets: Widget[] = [
+      {
+        id: "c",
+        type: "kpi",
+        title: "c",
+        grid: { x: 6, y: 2, w: 3, h: 2 },
+        config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } },
+      },
+      {
+        id: "a",
+        type: "kpi",
+        title: "a",
+        grid: { x: 6, y: 0, w: 3, h: 2 },
+        config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } },
+      },
+      {
+        id: "b",
+        type: "kpi",
+        title: "b",
+        grid: { x: 0, y: 0, w: 3, h: 2 },
+        config: { dataset: "transactions", measure: { agg: "sum", field: "amount" } },
+      },
+    ];
+    expect(orderWidgetsForStack(widgets).map((w) => w.id)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+    // Pure function: does not mutate the input order.
+    expect(widgets.map((w) => w.id)).toEqual(["c", "a", "b"]);
   });
 
   it("redirects to /dashboard when feature_reports_v2 is false", async () => {

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -26,7 +26,8 @@ vi.mock("@/lib/reports/api", () => ({
   saveLayout: vi.fn(),
   runQuery: vi.fn(),
   deleteReport: vi.fn(),
-  resetReport: vi.fn(),
+  listVersions: vi.fn(),
+  restoreVersion: vi.fn(),
 }));
 
 vi.mock("@/components/AppShell", () => ({
@@ -117,14 +118,16 @@ describe("ReportEditorPage", () => {
   const saveLayoutMock = vi.mocked(reportsApi.saveLayout);
   const runQueryMock = vi.mocked(reportsApi.runQuery);
   const deleteReportMock = vi.mocked(reportsApi.deleteReport);
-  const resetReportMock = vi.mocked(reportsApi.resetReport);
+  const listVersionsMock = vi.mocked(reportsApi.listVersions);
+  const restoreVersionMock = vi.mocked(reportsApi.restoreVersion);
 
   beforeEach(() => {
     getReportMock.mockReset();
     saveLayoutMock.mockReset();
     runQueryMock.mockReset();
     deleteReportMock.mockReset();
-    resetReportMock.mockReset();
+    listVersionsMock.mockReset();
+    restoreVersionMock.mockReset();
     runQueryMock.mockResolvedValue({
       rows: [],
       meta: { row_count: 0, truncated: false, query_ms: 1 },
@@ -341,8 +344,13 @@ describe("ReportEditorPage", () => {
 
     renderIsolated(<ReportEditorPage params={makeParams()} />);
 
+    // Report has widgets → opens in view mode. Enter edit mode so the
+    // config rail can mount on widget selection.
+    await screen.findByTestId("kpi-widget");
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+
     // Click the widget shell to select it; config rail mounts.
-    const shell = await screen.findByTestId("kpi-widget");
+    const shell = screen.getByTestId("kpi-widget");
     fireEvent.click(shell);
 
     await waitFor(() =>
@@ -416,45 +424,156 @@ describe("ReportEditorPage", () => {
       expect(screen.queryByTestId("bar-widget")).toBeNull(),
     );
     expect(screen.queryByTestId("report-editor-dirty")).toBeNull();
-    // Exited edit mode: the toggle now reads "Edit", Add widget is gone.
+    // Exited edit mode: the toggle now reads "Edit", Add widget + Cancel
+    // are gone.
+    expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
+      "Edit",
+    );
     expect(screen.queryByTestId("report-editor-add-widget")).toBeNull();
+    expect(screen.queryByTestId("report-editor-cancel")).toBeNull();
     // No server save was issued by Cancel.
     expect(saveLayoutMock).not.toHaveBeenCalled();
   });
 
-  it("reverts to original: calls resetReport and re-hydrates from the response", async () => {
+  // A report carrying at least one widget. Used by the view-mode /
+  // toggle / history tests below.
+  const REPORT_WITH_WIDGET = {
+    id: 10,
+    owner_user_id: 1,
+    org_id: 1,
+    visibility: "private" as const,
+    name: "My report",
+    description: null,
+    layout_json: {
+      version: 1 as const,
+      widgets: [
+        {
+          id: "w_kpi",
+          type: "kpi" as const,
+          title: "Total",
+          grid: { x: 0, y: 0, w: 3, h: 2 },
+          config: {
+            dataset: "transactions" as const,
+            measure: { agg: "sum" as const, field: "amount" as const },
+            format: "currency" as const,
+          },
+        },
+      ],
+    },
+    canvas_filters_json: {},
+    schema_version: 1,
+    created_at: "2026-05-22T10:00:00",
+    updated_at: "2026-05-22T10:00:00",
+  };
+
+  it("opens a report with widgets in view mode (Edit/History/Delete, no edit affordances)", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    // View-mode toolbar.
+    expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
+      "Edit",
+    );
+    expect(screen.getByTestId("report-editor-history")).toBeInTheDocument();
+    expect(screen.getByTestId("report-editor-delete")).toBeInTheDocument();
+    // No edit-only affordances.
+    expect(screen.queryByTestId("report-editor-add-widget")).toBeNull();
+    expect(screen.queryByTestId("report-editor-save")).toBeNull();
+    expect(screen.queryByTestId("report-editor-cancel")).toBeNull();
+  });
+
+  it("Edit enters edit mode; Save is disabled until a change, which also reveals Cancel", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+
+    // Edit-mode toolbar: Add widget + Save + History + Delete + Done.
+    expect(screen.getByTestId("report-editor-add-widget")).toBeInTheDocument();
+    expect(screen.getByTestId("report-editor-history")).toBeInTheDocument();
+    expect(screen.getByTestId("report-editor-delete")).toBeInTheDocument();
+    expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
+      "Done",
+    );
+    // Save disabled initially (not dirty); Cancel hidden (not dirty).
+    expect(screen.getByTestId("report-editor-save")).toBeDisabled();
+    expect(screen.queryByTestId("report-editor-cancel")).toBeNull();
+
+    // Make a change → Save enables, Cancel appears.
+    fireEvent.click(screen.getByTestId("report-editor-add-widget"));
+    fireEvent.click(screen.getByTestId("widget-picker-option-bar"));
+    await waitFor(() =>
+      expect(screen.getByTestId("bar-widget")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("report-editor-save")).not.toBeDisabled();
+    expect(screen.getByTestId("report-editor-cancel")).toBeInTheDocument();
+  });
+
+  it("Done returns to view mode and Edit re-enters edit mode (toggle works)", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    // Enter edit.
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+    expect(screen.getByTestId("report-editor-add-widget")).toBeInTheDocument();
+    expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
+      "Done",
+    );
+    // Done → view mode.
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+    expect(screen.queryByTestId("report-editor-add-widget")).toBeNull();
+    expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
+      "Edit",
+    );
+    // Edit → back to edit mode.
+    fireEvent.click(screen.getByTestId("report-editor-toggle-edit"));
+    expect(screen.getByTestId("report-editor-add-widget")).toBeInTheDocument();
+  });
+
+  it("opens a 0-widget (blank) report in edit mode", async () => {
     mockUser(true);
     getReportMock.mockResolvedValue({
       id: 10,
       owner_user_id: 1,
       org_id: 1,
       visibility: "private",
-      name: "My report",
+      name: "Blank",
       description: null,
-      layout_json: {
-        version: 1,
-        widgets: [
-          {
-            id: "w_kpi",
-            type: "kpi",
-            title: "Total",
-            grid: { x: 0, y: 0, w: 3, h: 2 },
-            config: {
-              dataset: "transactions",
-              measure: { agg: "sum", field: "amount" },
-              format: "currency",
-            },
-          },
-        ],
-      },
+      layout_json: { version: 1, widgets: [] },
       canvas_filters_json: {},
       schema_version: 1,
       created_at: "2026-05-22T10:00:00",
       updated_at: "2026-05-22T10:00:00",
     });
-    // Reverted server snapshot returns an empty layout (the as-created
-    // state had no widgets).
-    resetReportMock.mockResolvedValue({
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    // Edit mode: Add widget present, toggle reads "Done".
+    expect(screen.getByTestId("report-editor-add-widget")).toBeInTheDocument();
+    expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
+      "Done",
+    );
+  });
+
+  it("History lists versions and Restore re-hydrates from the restored report", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+    listVersionsMock.mockResolvedValue([
+      { id: 99, is_original: false, created_at: "2026-05-23T09:30:00" },
+      { id: 1, is_original: true, created_at: "2026-05-22T10:00:00" },
+    ]);
+    // Restoring the original returns an empty layout.
+    restoreVersionMock.mockResolvedValue({
       id: 10,
       owner_user_id: 1,
       org_id: 1,
@@ -465,25 +584,43 @@ describe("ReportEditorPage", () => {
       canvas_filters_json: {},
       schema_version: 1,
       created_at: "2026-05-22T10:00:00",
-      updated_at: "2026-05-22T10:00:02",
+      updated_at: "2026-05-22T10:00:05",
     });
 
     renderIsolated(<ReportEditorPage params={makeParams()} />);
 
-    // Widget from the loaded report is present.
     await screen.findByTestId("kpi-widget");
+    fireEvent.click(screen.getByTestId("report-editor-history"));
 
-    fireEvent.click(screen.getByTestId("report-editor-revert"));
-    // Confirm modal → Revert (scope to the dialog).
-    const dialog = screen.getByRole("dialog");
-    fireEvent.click(within(dialog).getByRole("button", { name: "Revert" }));
+    // Panel opens and lists both versions; original badged.
+    await screen.findByTestId("report-history-panel");
+    await waitFor(() =>
+      expect(listVersionsMock).toHaveBeenCalledWith(10),
+    );
+    await screen.findByTestId("report-history-row-1");
+    expect(screen.getByTestId("report-history-row-99")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("report-history-original-badge"),
+    ).toBeInTheDocument();
 
-    await waitFor(() => expect(resetReportMock).toHaveBeenCalledWith(10));
-    // Page re-hydrates from the returned (empty) layout.
+    // Restore the original → confirm. Scope to the confirm dialog
+    // (the history panel is also a dialog).
+    fireEvent.click(screen.getByTestId("report-history-restore-1"));
+    const dialog = screen.getByRole("dialog", { name: "Restore version" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Restore" }));
+
+    await waitFor(() =>
+      expect(restoreVersionMock).toHaveBeenCalledWith(10, 1),
+    );
+    // Re-hydrated from the restored (empty) layout; panel closed; view mode.
     await waitFor(() =>
       expect(screen.queryByTestId("kpi-widget")).toBeNull(),
     );
+    expect(screen.queryByTestId("report-history-panel")).toBeNull();
     expect(screen.getByTestId("report-editor-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
+      "Edit",
+    );
   });
 
   it("redirects to /dashboard when feature_reports_v2 is false", async () => {

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -28,6 +28,8 @@ vi.mock("@/lib/reports/api", () => ({
   deleteReport: vi.fn(),
   listVersions: vi.fn(),
   restoreVersion: vi.fn(),
+  updateReport: vi.fn(),
+  duplicateReport: vi.fn(),
 }));
 
 vi.mock("@/components/AppShell", () => ({
@@ -120,6 +122,8 @@ describe("ReportEditorPage", () => {
   const deleteReportMock = vi.mocked(reportsApi.deleteReport);
   const listVersionsMock = vi.mocked(reportsApi.listVersions);
   const restoreVersionMock = vi.mocked(reportsApi.restoreVersion);
+  const updateReportMock = vi.mocked(reportsApi.updateReport);
+  const duplicateReportMock = vi.mocked(reportsApi.duplicateReport);
 
   beforeEach(() => {
     getReportMock.mockReset();
@@ -128,6 +132,8 @@ describe("ReportEditorPage", () => {
     deleteReportMock.mockReset();
     listVersionsMock.mockReset();
     restoreVersionMock.mockReset();
+    updateReportMock.mockReset();
+    duplicateReportMock.mockReset();
     runQueryMock.mockResolvedValue({
       rows: [],
       meta: { row_count: 0, truncated: false, query_ms: 1 },
@@ -628,6 +634,77 @@ describe("ReportEditorPage", () => {
     expect(screen.getByTestId("report-editor-empty")).toBeInTheDocument();
     expect(screen.getByTestId("report-editor-toggle-edit")).toHaveTextContent(
       "Edit",
+    );
+  });
+
+  it("toggles visibility to org as an editor and reflects the new state", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+    updateReportMock.mockResolvedValue({
+      ...REPORT_WITH_WIDGET,
+      visibility: "org",
+      updated_at: "2026-05-22T11:00:00",
+    } as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    const toggle = screen.getByTestId("report-editor-visibility-toggle");
+    expect(toggle).not.toBeDisabled();
+    // Starts private.
+    expect(screen.getByTestId("report-editor-visibility")).toHaveTextContent(
+      /private/i,
+    );
+
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(updateReportMock).toHaveBeenCalledWith(10, { visibility: "org" }),
+    );
+    // Local state reflects the shared visibility.
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("report-editor-visibility"),
+      ).toHaveTextContent(/org/i),
+    );
+  });
+
+  it("does not enable the visibility toggle for a non-editor (non-owner)", async () => {
+    mockUser(true);
+    // Report owned by someone else; viewer (user id 1) is not the owner.
+    getReportMock.mockResolvedValue({
+      ...REPORT_WITH_WIDGET,
+      owner_user_id: 999,
+      visibility: "org",
+    } as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    // No enabled toggle for a non-editor.
+    expect(
+      screen.queryByTestId("report-editor-visibility-toggle"),
+    ).toBeNull();
+  });
+
+  it("duplicates the report and navigates to the new copy", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);
+    duplicateReportMock.mockResolvedValue({
+      ...REPORT_WITH_WIDGET,
+      id: 77,
+    } as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    fireEvent.click(screen.getByTestId("report-editor-duplicate"));
+
+    await waitFor(() =>
+      expect(duplicateReportMock).toHaveBeenCalledWith(10),
+    );
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith("/reports/77"),
     );
   });
 

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { SWRConfig } from "swr";
 
 // Stub the canvas (react-grid-layout) — jsdom can't measure container
@@ -25,6 +25,8 @@ vi.mock("@/lib/reports/api", () => ({
   getReport: vi.fn(),
   saveLayout: vi.fn(),
   runQuery: vi.fn(),
+  deleteReport: vi.fn(),
+  resetReport: vi.fn(),
 }));
 
 vi.mock("@/components/AppShell", () => ({
@@ -114,11 +116,15 @@ describe("ReportEditorPage", () => {
   const getReportMock = vi.mocked(reportsApi.getReport);
   const saveLayoutMock = vi.mocked(reportsApi.saveLayout);
   const runQueryMock = vi.mocked(reportsApi.runQuery);
+  const deleteReportMock = vi.mocked(reportsApi.deleteReport);
+  const resetReportMock = vi.mocked(reportsApi.resetReport);
 
   beforeEach(() => {
     getReportMock.mockReset();
     saveLayoutMock.mockReset();
     runQueryMock.mockReset();
+    deleteReportMock.mockReset();
+    resetReportMock.mockReset();
     runQueryMock.mockResolvedValue({
       rows: [],
       meta: { row_count: 0, truncated: false, query_ms: 1 },
@@ -344,6 +350,140 @@ describe("ReportEditorPage", () => {
     );
     // Override pill appears on the overridden date field.
     expect(screen.getByTestId("override-pill")).toBeInTheDocument();
+  });
+
+  it("deletes the report via confirm and navigates back to /reports", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+    deleteReportMock.mockResolvedValue(undefined);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    fireEvent.click(screen.getByTestId("report-editor-delete"));
+    // Confirm modal appears; clicking its Confirm button fires the
+    // delete. Scope to the dialog so we don't match the header trigger.
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(deleteReportMock).toHaveBeenCalledWith(10));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports"));
+  });
+
+  it("cancels editing: discards unsaved changes and exits edit mode", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor");
+    // Make a dirty change.
+    fireEvent.click(screen.getByTestId("report-editor-add-widget"));
+    fireEvent.click(screen.getByTestId("widget-picker-option-bar"));
+    await waitFor(() =>
+      expect(screen.getByTestId("bar-widget")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("report-editor-dirty")).toBeInTheDocument();
+
+    // Cancel discards the unsaved widget and exits edit mode.
+    fireEvent.click(screen.getByTestId("report-editor-cancel"));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("bar-widget")).toBeNull(),
+    );
+    expect(screen.queryByTestId("report-editor-dirty")).toBeNull();
+    // Exited edit mode: the toggle now reads "Edit", Add widget is gone.
+    expect(screen.queryByTestId("report-editor-add-widget")).toBeNull();
+    // No server save was issued by Cancel.
+    expect(saveLayoutMock).not.toHaveBeenCalled();
+  });
+
+  it("reverts to original: calls resetReport and re-hydrates from the response", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: {
+        version: 1,
+        widgets: [
+          {
+            id: "w_kpi",
+            type: "kpi",
+            title: "Total",
+            grid: { x: 0, y: 0, w: 3, h: 2 },
+            config: {
+              dataset: "transactions",
+              measure: { agg: "sum", field: "amount" },
+              format: "currency",
+            },
+          },
+        ],
+      },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+    // Reverted server snapshot returns an empty layout (the as-created
+    // state had no widgets).
+    resetReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "My report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:02",
+    });
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    // Widget from the loaded report is present.
+    await screen.findByTestId("kpi-widget");
+
+    fireEvent.click(screen.getByTestId("report-editor-revert"));
+    // Confirm modal → Revert (scope to the dialog).
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Revert" }));
+
+    await waitFor(() => expect(resetReportMock).toHaveBeenCalledWith(10));
+    // Page re-hydrates from the returned (empty) layout.
+    await waitFor(() =>
+      expect(screen.queryByTestId("kpi-widget")).toBeNull(),
+    );
+    expect(screen.getByTestId("report-editor-empty")).toBeInTheDocument();
   });
 
   it("redirects to /dashboard when feature_reports_v2 is false", async () => {

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -159,6 +159,14 @@ describe("ReportEditorPage", () => {
     // sidebar/nav frame + shell-level surfaces.
     expect(screen.getByTestId("app-shell")).toBeInTheDocument();
     expect(screen.getByTestId("report-editor-empty")).toBeInTheDocument();
+    // Empty-state guidance explains that canvas filters cascade into
+    // every widget, so a 0-widget report shows nothing.
+    expect(
+      screen.getByText(/Add a widget to see your data/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/apply to every widget/i),
+    ).toBeInTheDocument();
 
     // Add widget opens the picker dialog.
     fireEvent.click(screen.getByTestId("report-editor-add-widget"));

--- a/frontend/tests/app/reports-editor-page.test.tsx
+++ b/frontend/tests/app/reports-editor-page.test.tsx
@@ -710,6 +710,52 @@ describe("ReportEditorPage", () => {
     ).toBeNull();
   });
 
+  it("hides edit affordances for a non-owner viewing a shared report", async () => {
+    mockUser(true);
+    // Report owned by someone else; viewer (user id 1) is not the owner.
+    getReportMock.mockResolvedValue({
+      ...REPORT_WITH_WIDGET,
+      owner_user_id: 999,
+      visibility: "org",
+    } as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("kpi-widget");
+    // The Edit/Done toggle is owner-only.
+    expect(screen.queryByTestId("report-editor-toggle-edit")).toBeNull();
+  });
+
+  it("hides the empty-state 'Add widget' CTA for a non-owner", async () => {
+    mockUser(true);
+    getReportMock.mockResolvedValue({
+      id: 10,
+      owner_user_id: 999, // viewer (id 1) is not the owner
+      org_id: 1,
+      visibility: "org",
+      name: "Shared empty report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    } as never);
+
+    renderIsolated(<ReportEditorPage params={makeParams()} />);
+
+    await screen.findByTestId("report-editor-empty");
+    // Owner-only CTA must not render for a view-only user; the backend
+    // 403s their PATCH, so the picker would only build unsavable changes.
+    expect(
+      screen.queryByTestId("report-editor-empty-add-widget"),
+    ).toBeNull();
+    // The "Start from a template" link still shows (it only navigates).
+    expect(
+      screen.getByTestId("report-editor-empty-templates"),
+    ).toBeInTheDocument();
+  });
+
   it("duplicates the report and navigates to the new copy", async () => {
     mockUser(true);
     getReportMock.mockResolvedValue(REPORT_WITH_WIDGET as never);

--- a/frontend/tests/app/reports-new-page.test.tsx
+++ b/frontend/tests/app/reports-new-page.test.tsx
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ReportDraftPage from "@/app/reports/new/page";
+import * as reportsApi from "@/lib/reports/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/reports/api", () => ({
+  createReport: vi.fn(),
+  listTemplates: vi.fn(),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+// The widget components fire SWR queries against the live API; stub
+// them out so the draft canvas renders without network. We assert on
+// the widget shell / title, not the rendered data.
+vi.mock("@/components/reports/widgets/BarWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="bar-widget">{widget.title}</div>
+  ),
+}));
+vi.mock("@/components/reports/widgets/KPIWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="kpi-widget">{widget.title}</div>
+  ),
+}));
+vi.mock("@/components/reports/widgets/LineWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="line-widget">{widget.title}</div>
+  ),
+}));
+vi.mock("@/components/reports/widgets/AreaWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="area-widget">{widget.title}</div>
+  ),
+}));
+vi.mock("@/components/reports/widgets/PieWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="pie-widget">{widget.title}</div>
+  ),
+}));
+vi.mock("@/components/reports/widgets/SparklineWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="sparkline-widget">{widget.title}</div>
+  ),
+}));
+vi.mock("@/components/reports/widgets/StackedBarWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="stacked-bar-widget">{widget.title}</div>
+  ),
+}));
+vi.mock("@/components/reports/widgets/TableWidget", () => ({
+  default: ({ widget }: { widget: { title: string } }) => (
+    <div data-testid="table-widget">{widget.title}</div>
+  ),
+}));
+
+// Canvas filters bar pulls accounts/categories from the API; stub it.
+vi.mock("@/components/reports/CanvasFiltersBar", () => ({
+  default: () => <div data-testid="canvas-filters-bar" />,
+}));
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/AuthProvider")
+  >("@/components/auth/AuthProvider");
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => "/reports/new",
+  useSearchParams: () => searchParams,
+}));
+
+function mockUser(featureReportsV2 = true) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: { id: 1 } as never,
+    loading: false,
+    needsSetup: false,
+    featureReportsV2,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+const TEMPLATE = {
+  key: "monthly_review",
+  name: "Monthly review",
+  description: "x",
+  layout_json: {
+    version: 1 as const,
+    widgets: [
+      {
+        id: "t_kpi",
+        type: "kpi" as const,
+        title: "Net income",
+        grid: { x: 0, y: 0, w: 3, h: 2 },
+        config: {
+          dataset: "transactions" as const,
+          measure: { agg: "sum" as const, field: "amount" as const },
+          format: "currency" as const,
+        },
+      },
+    ],
+  },
+  canvas_filters_json: {},
+};
+
+describe("ReportDraftPage (/reports/new)", () => {
+  const createMock = vi.mocked(reportsApi.createReport);
+  const listTemplatesMock = vi.mocked(reportsApi.listTemplates);
+
+  beforeEach(() => {
+    createMock.mockReset();
+    listTemplatesMock.mockReset();
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    searchParams = new URLSearchParams();
+    listTemplatesMock.mockResolvedValue([]);
+  });
+
+  it("renders a blank draft with the starter bar widget, no DB write", async () => {
+    mockUser(true);
+
+    render(<ReportDraftPage />);
+
+    await screen.findByText("Spend by category");
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("loads a template draft when ?template is present", async () => {
+    mockUser(true);
+    searchParams = new URLSearchParams("template=monthly_review");
+    listTemplatesMock.mockResolvedValue([TEMPLATE]);
+
+    render(<ReportDraftPage />);
+
+    await screen.findByText("Net income");
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the blank draft when ?template is unknown", async () => {
+    mockUser(true);
+    searchParams = new URLSearchParams("template=does_not_exist");
+    listTemplatesMock.mockResolvedValue([TEMPLATE]);
+
+    render(<ReportDraftPage />);
+
+    await screen.findByText("Spend by category");
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("persists only on Save, then navigates to the created report id", async () => {
+    mockUser(true);
+    createMock.mockResolvedValue({ id: 99 } as never);
+
+    render(<ReportDraftPage />);
+
+    await screen.findByText("Spend by category");
+    fireEvent.click(screen.getByTestId("report-draft-save"));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    const payload = createMock.mock.calls[0][0];
+    expect(payload.visibility).toBe("private");
+    const layout = payload.layout_json as { widgets: unknown[] };
+    expect(layout.widgets).toHaveLength(1);
+    expect(payload.canvas_filters_json).toBeTruthy();
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith("/reports/99"));
+  });
+
+  it("discards the draft on Cancel without any DB write", async () => {
+    mockUser(true);
+
+    render(<ReportDraftPage />);
+
+    await screen.findByText("Spend by category");
+    fireEvent.click(screen.getByTestId("report-draft-cancel"));
+
+    expect(createMock).not.toHaveBeenCalled();
+    expect(pushMock).toHaveBeenCalledWith("/reports");
+  });
+});

--- a/frontend/tests/app/reports-page.test.tsx
+++ b/frontend/tests/app/reports-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import ReportsListPage from "@/app/reports/page";
 import * as reportsApi from "@/lib/reports/api";
@@ -9,6 +9,7 @@ vi.mock("@/lib/reports/api", () => ({
   listTemplates: vi.fn(),
   createReport: vi.fn(),
   createFromTemplate: vi.fn(),
+  deleteReport: vi.fn(),
 }));
 
 vi.mock("@/components/AppShell", () => ({
@@ -76,11 +77,13 @@ describe("ReportsListPage", () => {
   const listMock = vi.mocked(reportsApi.listReports);
   const listTemplatesMock = vi.mocked(reportsApi.listTemplates);
   const createMock = vi.mocked(reportsApi.createReport);
+  const deleteMock = vi.mocked(reportsApi.deleteReport);
 
   beforeEach(() => {
     listMock.mockReset();
     listTemplatesMock.mockReset();
     createMock.mockReset();
+    deleteMock.mockReset();
     pushMock.mockReset();
     replaceMock.mockReset();
     // Templates load independently of the reports list; default to an
@@ -159,6 +162,39 @@ describe("ReportsListPage", () => {
 
     await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/42"));
+  });
+
+  it("deletes a report card via confirm and removes it from the list", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([
+      {
+        id: 10,
+        owner_user_id: 1,
+        org_id: 1,
+        visibility: "private",
+        name: "Monthly review",
+        description: null,
+        layout_json: {},
+        canvas_filters_json: {},
+        schema_version: 1,
+        created_at: "2026-05-21T10:00:00",
+        updated_at: "2026-05-22T10:00:00",
+      },
+    ]);
+    deleteMock.mockResolvedValue(undefined);
+
+    render(<ReportsListPage />);
+
+    await screen.findByText("Monthly review");
+    fireEvent.click(screen.getByTestId("report-delete-10"));
+    // Confirm modal → Delete.
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(deleteMock).toHaveBeenCalledWith(10));
+    await waitFor(() =>
+      expect(screen.queryByText("Monthly review")).toBeNull(),
+    );
   });
 
   it("redirects to /dashboard when feature_reports_v2 is false", async () => {

--- a/frontend/tests/app/reports-page.test.tsx
+++ b/frontend/tests/app/reports-page.test.tsx
@@ -164,6 +164,51 @@ describe("ReportsListPage", () => {
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/42"));
   });
 
+  it("seeds a starter bar widget and a date range on 'New report'", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([]);
+    createMock.mockResolvedValue({
+      id: 42,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "Untitled report",
+      description: null,
+      layout_json: { version: 1, widgets: [] },
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-22T10:00:00",
+      updated_at: "2026-05-22T10:00:00",
+    });
+
+    render(<ReportsListPage />);
+
+    await screen.findByTestId("reports-empty-state");
+    fireEvent.click(screen.getByRole("button", { name: /new report/i }));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    const payload = createMock.mock.calls[0][0];
+
+    // Exactly one bar widget seeded so the new report renders data
+    // immediately instead of a blank void.
+    expect(payload.layout_json).toBeTruthy();
+    const layout = payload.layout_json as { version: number; widgets: unknown[] };
+    expect(layout.widgets).toHaveLength(1);
+    const widget = layout.widgets[0] as { type: string; config: { measure: unknown } };
+    expect(widget.type).toBe("bar");
+    // Single-measure bar uses config.measure (not measures[]).
+    expect(widget.config.measure).toEqual({ agg: "sum", field: "amount" });
+
+    // Canvas date range is set (this-month window) so the widget shows
+    // current data the moment the report opens.
+    const filters = payload.canvas_filters_json as {
+      date_range?: { start?: string; end?: string };
+    };
+    expect(filters.date_range).toBeTruthy();
+    expect(filters.date_range?.start).toBeTruthy();
+    expect(filters.date_range?.end).toBeTruthy();
+  });
+
   it("deletes a report card via confirm and removes it from the list", async () => {
     mockUser(true);
     listMock.mockResolvedValue([

--- a/frontend/tests/app/reports-page.test.tsx
+++ b/frontend/tests/app/reports-page.test.tsx
@@ -141,75 +141,19 @@ describe("ReportsListPage", () => {
     expect(screen.getByText(/No reports yet/i)).toBeInTheDocument();
   });
 
-  it("creates a new report and navigates to its editor on 'New report'", async () => {
+  it("navigates to the draft editor on 'New report' without persisting", async () => {
     mockUser(true);
     listMock.mockResolvedValue([]);
-    createMock.mockResolvedValue({
-      id: 42,
-      owner_user_id: 1,
-      org_id: 1,
-      visibility: "private",
-      name: "Untitled report",
-      description: null,
-      layout_json: { version: 1, widgets: [] },
-      canvas_filters_json: {},
-      schema_version: 1,
-      created_at: "2026-05-22T10:00:00",
-      updated_at: "2026-05-22T10:00:00",
-    });
 
     render(<ReportsListPage />);
 
     await screen.findByTestId("reports-empty-state");
     fireEvent.click(screen.getByRole("button", { name: /new report/i }));
 
-    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/42"));
-  });
-
-  it("seeds a starter bar widget and a date range on 'New report'", async () => {
-    mockUser(true);
-    listMock.mockResolvedValue([]);
-    createMock.mockResolvedValue({
-      id: 42,
-      owner_user_id: 1,
-      org_id: 1,
-      visibility: "private",
-      name: "Untitled report",
-      description: null,
-      layout_json: { version: 1, widgets: [] },
-      canvas_filters_json: {},
-      schema_version: 1,
-      created_at: "2026-05-22T10:00:00",
-      updated_at: "2026-05-22T10:00:00",
-    });
-
-    render(<ReportsListPage />);
-
-    await screen.findByTestId("reports-empty-state");
-    fireEvent.click(screen.getByRole("button", { name: /new report/i }));
-
-    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
-    const payload = createMock.mock.calls[0][0];
-
-    // Exactly one bar widget seeded so the new report renders data
-    // immediately instead of a blank void.
-    expect(payload.layout_json).toBeTruthy();
-    const layout = payload.layout_json as { version: number; widgets: unknown[] };
-    expect(layout.widgets).toHaveLength(1);
-    const widget = layout.widgets[0] as { type: string; config: { measure: unknown } };
-    expect(widget.type).toBe("bar");
-    // Single-measure bar uses config.measure (not measures[]).
-    expect(widget.config.measure).toEqual({ agg: "sum", field: "amount" });
-
-    // Canvas date range is set (this-month window) so the widget shows
-    // current data the moment the report opens.
-    const filters = payload.canvas_filters_json as {
-      date_range?: { start?: string; end?: string };
-    };
-    expect(filters.date_range).toBeTruthy();
-    expect(filters.date_range?.start).toBeTruthy();
-    expect(filters.date_range?.end).toBeTruthy();
+    // No DB write happens on the list page anymore — the draft is
+    // created only when the user Saves it on /reports/new.
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/new"));
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   it("deletes a report card via confirm and removes it from the list", async () => {

--- a/frontend/tests/app/reports-page.test.tsx
+++ b/frontend/tests/app/reports-page.test.tsx
@@ -6,7 +6,9 @@ import { useAuth } from "@/components/auth/AuthProvider";
 
 vi.mock("@/lib/reports/api", () => ({
   listReports: vi.fn(),
+  listTemplates: vi.fn(),
   createReport: vi.fn(),
+  createFromTemplate: vi.fn(),
 }));
 
 vi.mock("@/components/AppShell", () => ({
@@ -72,13 +74,18 @@ function mockUser(featureReportsV2 = true) {
 
 describe("ReportsListPage", () => {
   const listMock = vi.mocked(reportsApi.listReports);
+  const listTemplatesMock = vi.mocked(reportsApi.listTemplates);
   const createMock = vi.mocked(reportsApi.createReport);
 
   beforeEach(() => {
     listMock.mockReset();
+    listTemplatesMock.mockReset();
     createMock.mockReset();
     pushMock.mockReset();
     replaceMock.mockReset();
+    // Templates load independently of the reports list; default to an
+    // empty set so these list-focused tests don't trip on undefined.
+    listTemplatesMock.mockResolvedValue([]);
   });
 
   it("renders inside AppShell so users see the sidebar/nav frame", async () => {

--- a/frontend/tests/app/reports-page.test.tsx
+++ b/frontend/tests/app/reports-page.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/lib/reports/api", () => ({
   createReport: vi.fn(),
   createFromTemplate: vi.fn(),
   deleteReport: vi.fn(),
+  duplicateReport: vi.fn(),
 }));
 
 vi.mock("@/components/AppShell", () => ({
@@ -78,12 +79,14 @@ describe("ReportsListPage", () => {
   const listTemplatesMock = vi.mocked(reportsApi.listTemplates);
   const createMock = vi.mocked(reportsApi.createReport);
   const deleteMock = vi.mocked(reportsApi.deleteReport);
+  const duplicateMock = vi.mocked(reportsApi.duplicateReport);
 
   beforeEach(() => {
     listMock.mockReset();
     listTemplatesMock.mockReset();
     createMock.mockReset();
     deleteMock.mockReset();
+    duplicateMock.mockReset();
     pushMock.mockReset();
     replaceMock.mockReset();
     // Templates load independently of the reports list; default to an
@@ -240,6 +243,46 @@ describe("ReportsListPage", () => {
     await waitFor(() =>
       expect(screen.queryByText("Monthly review")).toBeNull(),
     );
+  });
+
+  it("duplicates a report card and navigates to the new copy", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([
+      {
+        id: 10,
+        owner_user_id: 1,
+        org_id: 1,
+        visibility: "private",
+        name: "Monthly review",
+        description: null,
+        layout_json: {},
+        canvas_filters_json: {},
+        schema_version: 1,
+        created_at: "2026-05-21T10:00:00",
+        updated_at: "2026-05-22T10:00:00",
+      },
+    ]);
+    duplicateMock.mockResolvedValue({
+      id: 88,
+      owner_user_id: 1,
+      org_id: 1,
+      visibility: "private",
+      name: "Monthly review (copy)",
+      description: null,
+      layout_json: {},
+      canvas_filters_json: {},
+      schema_version: 1,
+      created_at: "2026-05-23T10:00:00",
+      updated_at: "2026-05-23T10:00:00",
+    });
+
+    render(<ReportsListPage />);
+
+    await screen.findByText("Monthly review");
+    fireEvent.click(screen.getByTestId("report-duplicate-10"));
+
+    await waitFor(() => expect(duplicateMock).toHaveBeenCalledWith(10));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/88"));
   });
 
   it("redirects to /dashboard when feature_reports_v2 is false", async () => {

--- a/frontend/tests/app/reports-templates.test.tsx
+++ b/frontend/tests/app/reports-templates.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ReportsListPage from "@/app/reports/page";
+import * as reportsApi from "@/lib/reports/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/reports/api", () => ({
+  listReports: vi.fn(),
+  listTemplates: vi.fn(),
+  createReport: vi.fn(),
+  createFromTemplate: vi.fn(),
+}));
+
+vi.mock("@/components/AppShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-shell">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/AuthProvider")
+  >("@/components/auth/AuthProvider");
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+  };
+});
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => "/reports",
+}));
+
+function mockUser(featureReportsV2 = true) {
+  vi.mocked(useAuth).mockReturnValue({
+    user: { id: 1 } as never,
+    loading: false,
+    needsSetup: false,
+    featureReportsV2,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  });
+}
+
+const TEMPLATE = {
+  key: "monthly_review",
+  name: "Monthly review",
+  description: "x",
+  layout_json: { version: 1 as const, widgets: [] },
+  canvas_filters_json: {},
+};
+
+describe("ReportsListPage — templates", () => {
+  const listMock = vi.mocked(reportsApi.listReports);
+  const listTemplatesMock = vi.mocked(reportsApi.listTemplates);
+  const createFromTemplateMock = vi.mocked(reportsApi.createFromTemplate);
+
+  beforeEach(() => {
+    listMock.mockReset();
+    listTemplatesMock.mockReset();
+    createFromTemplateMock.mockReset();
+    pushMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  it("renders the templates section from the API", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([]);
+    listTemplatesMock.mockResolvedValue([TEMPLATE]);
+
+    render(<ReportsListPage />);
+
+    await screen.findByText("Monthly review");
+    expect(screen.getByText("x")).toBeInTheDocument();
+  });
+
+  it("instantiates a template and navigates to its editor on 'Use template'", async () => {
+    mockUser(true);
+    listMock.mockResolvedValue([]);
+    listTemplatesMock.mockResolvedValue([TEMPLATE]);
+    createFromTemplateMock.mockResolvedValue({ id: 42 } as never);
+
+    render(<ReportsListPage />);
+
+    await screen.findByText("Monthly review");
+    fireEvent.click(screen.getByRole("button", { name: /use template/i }));
+
+    await waitFor(() =>
+      expect(createFromTemplateMock).toHaveBeenCalledTimes(1),
+    );
+    expect(createFromTemplateMock).toHaveBeenCalledWith(TEMPLATE);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/42"));
+  });
+});

--- a/frontend/tests/app/reports-templates.test.tsx
+++ b/frontend/tests/app/reports-templates.test.tsx
@@ -83,21 +83,23 @@ describe("ReportsListPage — templates", () => {
     expect(screen.getByText("x")).toBeInTheDocument();
   });
 
-  it("instantiates a template and navigates to its editor on 'Use template'", async () => {
+  it("navigates to the draft editor with the template key on 'Use template'", async () => {
     mockUser(true);
     listMock.mockResolvedValue([]);
     listTemplatesMock.mockResolvedValue([TEMPLATE]);
-    createFromTemplateMock.mockResolvedValue({ id: 42 } as never);
 
     render(<ReportsListPage />);
 
     await screen.findByText("Monthly review");
     fireEvent.click(screen.getByRole("button", { name: /use template/i }));
 
+    // Starting from a template no longer persists a row — it opens an
+    // unsaved draft seeded from the template.
     await waitFor(() =>
-      expect(createFromTemplateMock).toHaveBeenCalledTimes(1),
+      expect(pushMock).toHaveBeenCalledWith(
+        "/reports/new?template=monthly_review",
+      ),
     );
-    expect(createFromTemplateMock).toHaveBeenCalledWith(TEMPLATE);
-    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/reports/42"));
+    expect(createFromTemplateMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
+++ b/frontend/tests/components/reports/config-rail-secondary-dimension.test.tsx
@@ -1,11 +1,13 @@
 /**
- * Regression: the "Secondary dimension" picker is Table-only in v1.
- * Bar / line / area / stacked-bar / kpi / pie / sparkline widgets
- * only consume ``dimensions[0]``, so exposing the picker for them
- * would be a no-op UX. Architect-locked Option A — split-series
- * rendering is a follow-up if users ask for it.
+ * Secondary dimension picker visibility.
+ *
+ * The "Secondary dimension" picker is Table-only. The bar widget now
+ * exposes a "Break down by" picker that slices each total bar into
+ * stacked, per-secondary-value colored segments (e.g. per account).
+ * line / area / stacked-bar / kpi / pie / sparkline still only consume
+ * ``dimensions[0]``, so they expose no secondary picker.
  */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { SWRConfig } from "swr";
 
 import ConfigRail from "@/components/reports/ConfigRail";
@@ -153,7 +155,6 @@ function makeTable(): TableWidget {
 }
 
 const HIDDEN_CASES: Array<{ name: string; widget: Widget }> = [
-  { name: "bar", widget: makeBar() },
   { name: "line", widget: makeLine() },
   { name: "area", widget: makeArea() },
   { name: "stacked_bar", widget: makeStacked() },
@@ -191,5 +192,57 @@ describe("ConfigRail — secondary dimension picker visibility", () => {
     expect(
       screen.getByLabelText("Secondary dimension"),
     ).toBeInTheDocument();
+  });
+
+  it("DOES render the 'Break down by' picker for bar", () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeBar()}
+        canvasFilters={{}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Break down by")).toBeInTheDocument();
+    // The bar picker is NOT labeled "Secondary dimension" (table-only).
+    expect(
+      screen.queryByLabelText("Secondary dimension"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("sets dimensions[1] when a bar break-down is chosen, and clears it on None", () => {
+    const updates: Widget[] = [];
+    const bar = makeBar();
+    const { rerender } = renderIsolated(
+      <ConfigRail
+        widget={bar}
+        canvasFilters={{}}
+        onUpdate={(w) => updates.push(w)}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Break down by"), {
+      target: { value: "account" },
+    });
+    const afterSet = updates.at(-1) as BarWidget;
+    expect(afterSet.config.dimensions).toEqual(["category", "account"]);
+
+    rerender(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <ConfigRail
+          widget={afterSet}
+          canvasFilters={{}}
+          onUpdate={(w) => updates.push(w)}
+          onClose={() => {}}
+        />
+      </SWRConfig>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Break down by"), {
+      target: { value: "" },
+    });
+    const afterClear = updates.at(-1) as BarWidget;
+    expect(afterClear.config.dimensions).toEqual(["category"]);
   });
 });

--- a/frontend/tests/components/reports/config-rail-tooltips.test.tsx
+++ b/frontend/tests/components/reports/config-rail-tooltips.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * ConfigRail help tooltips (Reports v2 polish).
+ *
+ * Jargon in the widget config rail gets inline ``HelpTooltip`` info
+ * icons: the aggregation selector explains Sum / Count / Average /
+ * Distinct, and the dimension labels carry the master-category
+ * explainer. We assert the tooltip triggers render (by their ARIA
+ * label from the content map) rather than driving the portal open.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import ConfigRail from "@/components/reports/ConfigRail";
+import { apiFetch } from "@/lib/api";
+import { HELP_TOOLTIPS } from "@/lib/help/tooltips";
+import type { BarWidget, LineWidget } from "@/lib/reports/types";
+
+vi.mock("@/lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+function renderIsolated(ui: React.ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {ui}
+    </SWRConfig>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(apiFetch).mockReset();
+  vi.mocked(apiFetch).mockImplementation(
+    () => Promise.resolve([]) as Promise<unknown>,
+  );
+});
+
+function makeBar(): BarWidget {
+  return {
+    id: "w_bar",
+    type: "bar",
+    title: "Bar",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measure: { agg: "sum", field: "amount" },
+      dimensions: ["category"],
+    },
+  };
+}
+
+function makeLine(): LineWidget {
+  return {
+    id: "w_line",
+    type: "line",
+    title: "Line",
+    grid: { x: 0, y: 0, w: 6, h: 4 },
+    config: {
+      dataset: "transactions",
+      measures: [{ measure: { agg: "distinct", field: "amount" } }],
+      dimensions: ["month"],
+    },
+  };
+}
+
+describe("ConfigRail — help tooltips", () => {
+  it("renders the aggregation tooltip trigger for a single-measure widget", () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeBar()}
+        canvasFilters={{}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // Bar defaults to Sum → the Sum explainer trigger is present.
+    expect(
+      screen.getByRole("button", {
+        name: HELP_TOOLTIPS["reports.agg.sum"].triggerLabel,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("swaps the aggregation tooltip to match the selected aggregation", () => {
+    const updates: BarWidget[] = [];
+    renderIsolated(
+      <ConfigRail
+        widget={makeBar()}
+        canvasFilters={{}}
+        onUpdate={(w) => updates.push(w as BarWidget)}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Aggregation"), {
+      target: { value: "distinct" },
+    });
+    const next = updates.at(-1) as BarWidget;
+    expect(next.config.measure.agg).toBe("distinct");
+  });
+
+  it("renders the master-category explainer next to the dimension label", () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeBar()}
+        canvasFilters={{}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // Bar exposes both the Primary dimension and the Break-down (optional)
+    // labels, so the master-category explainer renders on each.
+    expect(
+      screen.getAllByRole("button", {
+        name: HELP_TOOLTIPS["reports.master-category"].triggerLabel,
+      }).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a per-series aggregation tooltip for multi-series widgets", () => {
+    renderIsolated(
+      <ConfigRail
+        widget={makeLine()}
+        canvasFilters={{}}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // The line series defaults to Distinct count → its explainer shows.
+    expect(
+      screen.getByRole("button", {
+        name: HELP_TOOLTIPS["reports.agg.distinct"].triggerLabel,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/reports/filters/account-filter.test.tsx
+++ b/frontend/tests/components/reports/filters/account-filter.test.tsx
@@ -82,6 +82,42 @@ describe("AccountFilter", () => {
     expect(onChange).toHaveBeenCalledWith([2]);
   });
 
+  it("excludes deactivated accounts from the chip list", async () => {
+    apiFetchMock.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: "Checking",
+        account_type_id: 1,
+        account_type_name: "Bank",
+        account_type_slug: "bank",
+        balance: 0,
+        currency: "USD",
+        is_active: true,
+        close_day: null,
+        is_default: true,
+      },
+      {
+        id: 11,
+        name: "Old Savings",
+        account_type_id: 1,
+        account_type_name: "Bank",
+        account_type_slug: "bank",
+        balance: 0,
+        currency: "USD",
+        is_active: false,
+        close_day: null,
+        is_default: false,
+      },
+    ]);
+
+    renderIsolated(<AccountFilter value={[]} onChange={() => {}} />);
+
+    expect(await screen.findByTestId("account-filter-chip-10")).toBeInTheDocument();
+    expect(screen.getByText("Checking")).toBeInTheDocument();
+    expect(screen.queryByTestId("account-filter-chip-11")).not.toBeInTheDocument();
+    expect(screen.queryByText("Old Savings")).not.toBeInTheDocument();
+  });
+
   it("renders an error state when the fetch fails", async () => {
     apiFetchMock.mockRejectedValueOnce(new Error("boom"));
 

--- a/frontend/tests/components/reports/widgets/bar-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/bar-widget.test.tsx
@@ -12,7 +12,8 @@ vi.mock("@/lib/reports/api", () => ({
 // Recharts renders SVG via ResponsiveContainer; jsdom doesn't compute
 // layout, so the ResponsiveContainer collapses to 0×0 and skips the
 // chart body. We assert on the data-binding path (chart container
-// present, no error / empty state) rather than the rendered bars.
+// present, no error / empty state) and on the DOM legend the widget
+// renders itself (outside the SVG) when a break-down dimension is set.
 function renderIsolated(ui: React.ReactElement) {
   return render(
     <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
@@ -21,7 +22,9 @@ function renderIsolated(ui: React.ReactElement) {
   );
 }
 
-function makeWidget(): BarWidgetType {
+function makeWidget(
+  overrides: Partial<BarWidgetType["config"]> = {},
+): BarWidgetType {
   return {
     id: `w_bar_${Math.random().toString(36).slice(2, 10)}`,
     type: "bar",
@@ -34,6 +37,7 @@ function makeWidget(): BarWidgetType {
       sort: { by: "value", dir: "desc" },
       limit: 10,
       format: "currency",
+      ...overrides,
     },
   };
 }
@@ -88,5 +92,62 @@ describe("BarWidget", () => {
     await waitFor(() =>
       expect(screen.getByTestId("bar-widget-error")).toBeInTheDocument(),
     );
+  });
+
+  it("renders single-series bars with no per-account legend when no break-down dimension is set", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 200 },
+        { category: "Transport", value: 80 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 4 },
+    });
+
+    renderIsolated(<BarWidget widget={makeWidget()} />);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("bar-widget-loading")).toBeNull(),
+    );
+    // No break-down → the per-series legend must be absent.
+    expect(screen.queryByTestId("bar-widget-legend")).toBeNull();
+  });
+
+  it("queries grouped by both dimensions and renders a per-account legend when broken down by account", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", account: "Checking", value: 120 },
+        { category: "Food", account: "Savings", value: 40 },
+        { category: "Transport", account: "Checking", value: 60 },
+        { category: "Transport", account: "Credit Card", value: 25 },
+      ],
+      meta: { row_count: 4, truncated: false, query_ms: 6 },
+    });
+
+    renderIsolated(
+      <BarWidget widget={makeWidget({ dimensions: ["category", "account"] })} />,
+    );
+
+    // One query, grouped by both dimensions.
+    await waitFor(() => expect(runQueryMock).toHaveBeenCalledTimes(1));
+    expect(runQueryMock.mock.calls[0][0].dimensions).toEqual([
+      "category",
+      "account",
+    ]);
+
+    // Legend lists every distinct account, each with its own swatch color.
+    const legend = await screen.findByTestId("bar-widget-legend");
+    expect(legend).toBeInTheDocument();
+
+    const items = screen.getAllByTestId("bar-widget-legend-item");
+    expect(items).toHaveLength(3);
+    expect(legend).toHaveTextContent("Checking");
+    expect(legend).toHaveTextContent("Savings");
+    expect(legend).toHaveTextContent("Credit Card");
+
+    // Each legend swatch carries a distinct color.
+    const swatches = screen
+      .getAllByTestId("bar-widget-legend-swatch")
+      .map((el) => el.getAttribute("data-color"));
+    expect(new Set(swatches).size).toBe(swatches.length);
   });
 });

--- a/frontend/tests/components/reports/widgets/bar-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/bar-widget.test.tsx
@@ -1,13 +1,21 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 
 import BarWidget from "@/components/reports/widgets/BarWidget";
 import type { BarWidget as BarWidgetType } from "@/lib/reports/types";
 import { runQuery } from "@/lib/reports/api";
+import { downloadCsv } from "@/lib/reports/csv";
 
 vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
+
+// Mock only the download side effect; keep the real toCsv / csvFilename
+// so the test asserts the actual serialized CSV string.
+vi.mock("@/lib/reports/csv", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/reports/csv")>();
+  return { ...actual, downloadCsv: vi.fn() };
+});
 
 // Recharts renders SVG via ResponsiveContainer; jsdom doesn't compute
 // layout, so the ResponsiveContainer collapses to 0×0 and skips the
@@ -44,9 +52,11 @@ function makeWidget(
 
 describe("BarWidget", () => {
   const runQueryMock = vi.mocked(runQuery);
+  const downloadMock = vi.mocked(downloadCsv);
 
   beforeEach(() => {
     runQueryMock.mockReset();
+    downloadMock.mockReset();
   });
 
   it("renders the chart surface and the title when rows are present", async () => {
@@ -149,5 +159,68 @@ describe("BarWidget", () => {
       .getAllByTestId("bar-widget-legend-swatch")
       .map((el) => el.getAttribute("data-color"));
     expect(new Set(swatches).size).toBe(swatches.length);
+  });
+
+  it("shows the Export CSV button in view mode and downloads the displayed single-series rows", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 200 },
+        { category: "Transport", value: 80 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 4 },
+    });
+
+    renderIsolated(<BarWidget widget={makeWidget()} />);
+
+    const exportBtn = await screen.findByTestId("widget-csv-export");
+    expect(exportBtn).toBeInTheDocument();
+    await waitFor(() => expect(exportBtn).not.toBeDisabled());
+
+    fireEvent.click(exportBtn);
+
+    expect(downloadMock).toHaveBeenCalledTimes(1);
+    const [filename, csv] = downloadMock.mock.calls[0];
+    expect(filename).toBe("spend-by-category.csv");
+    expect(csv).toBe("Category,amount\r\nFood,200\r\nTransport,80");
+  });
+
+  it("exports one column per account when broken down by a secondary dimension", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", account: "Checking", value: 120 },
+        { category: "Food", account: "Savings", value: 40 },
+        { category: "Transport", account: "Checking", value: 60 },
+      ],
+      meta: { row_count: 3, truncated: false, query_ms: 6 },
+    });
+
+    renderIsolated(
+      <BarWidget widget={makeWidget({ dimensions: ["category", "account"] })} />,
+    );
+
+    const exportBtn = await screen.findByTestId("widget-csv-export");
+    await waitFor(() => expect(exportBtn).not.toBeDisabled());
+    fireEvent.click(exportBtn);
+
+    const [, csv] = downloadMock.mock.calls[0];
+    // Primary dimension column + one column per distinct account; missing
+    // (Transport, Savings) backfilled with 0.
+    expect(csv).toBe(
+      "Category,Checking,Savings\r\nFood,120,40\r\nTransport,60,0",
+    );
+  });
+
+  it("hides the Export CSV button in edit mode", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [{ category: "Food", value: 200 }],
+      meta: { row_count: 1, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<BarWidget widget={makeWidget()} editMode />);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("bar-widget-loading")).toBeNull(),
+    );
+    expect(screen.queryByTestId("widget-csv-export")).toBeNull();
   });
 });

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -128,6 +128,115 @@ describe("TableWidget", () => {
     expect(screen.getByTestId("table-widget-next-page")).toBeInTheDocument();
   });
 
+  it("renders a Total row that sums all rows of a sum measure", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 200 },
+        { category: "Transport", value: 80 },
+        { category: "Books", value: 20 },
+      ],
+      meta: { row_count: 3, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    const totalRow = await screen.findByTestId("table-widget-total-row");
+    // Dimension cell reads "Total".
+    expect(totalRow).toHaveTextContent("Total");
+    // 200 + 80 + 20 = 300, formatted as currency.
+    expect(totalRow).toHaveTextContent("$300.00");
+  });
+
+  it("sums ALL rows in the total even across multiple pages", async () => {
+    // 75 rows, value = 1 each => grand total 75, even though only 50
+    // are visible on the first page.
+    const rows = Array.from({ length: 75 }, (_, i) => ({
+      category: `Cat ${i}`,
+      value: 1,
+    }));
+    runQueryMock.mockResolvedValueOnce({
+      rows,
+      meta: { row_count: 75, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget({ format: "number" })} />);
+
+    const totalRow = await screen.findByTestId("table-widget-total-row");
+    expect(totalRow).toHaveTextContent("Total");
+    expect(totalRow).toHaveTextContent("75");
+  });
+
+  it("shows a placeholder (no fabricated number) for an avg measure column", async () => {
+    runQueryMock.mockResolvedValue({
+      rows: [
+        { category: "Food", value: 50 },
+        { category: "Transport", value: 30 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(
+      <TableWidget
+        widget={makeWidget({
+          format: "number",
+          measures: [
+            { measure: { agg: "sum", field: "amount" }, label: "Total" },
+            { measure: { agg: "avg", field: "amount" }, label: "Avg" },
+          ],
+        })}
+      />,
+    );
+
+    const totalRow = await screen.findByTestId("table-widget-total-row");
+    const cells = Array.from(totalRow.querySelectorAll("td")).map(
+      (td) => td.textContent ?? "",
+    );
+    // cells: [dimension "Total", sum column "80", avg column placeholder]
+    expect(cells[0]).toBe("Total");
+    expect(cells[1]).toBe("80");
+    // avg column must NOT be a number; it's the placeholder.
+    expect(cells[2]).toBe("—");
+  });
+
+  it("totals each measure column independently (multi-measure)", async () => {
+    // Two series queries: sum-of-amount and count-of-id.
+    runQueryMock
+      .mockResolvedValueOnce({
+        rows: [
+          { category: "Food", value: 200 },
+          { category: "Transport", value: 100 },
+        ],
+        meta: { row_count: 2, truncated: false, query_ms: 1 },
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { category: "Food", value: 4 },
+          { category: "Transport", value: 6 },
+        ],
+        meta: { row_count: 2, truncated: false, query_ms: 1 },
+      });
+
+    renderIsolated(
+      <TableWidget
+        widget={makeWidget({
+          format: "number",
+          measures: [
+            { measure: { agg: "sum", field: "amount" }, label: "Amount" },
+            { measure: { agg: "count", field: "id" }, label: "Count" },
+          ],
+        })}
+      />,
+    );
+
+    const totalRow = await screen.findByTestId("table-widget-total-row");
+    const cells = Array.from(totalRow.querySelectorAll("td")).map(
+      (td) => td.textContent ?? "",
+    );
+    expect(cells[0]).toBe("Total");
+    expect(cells[1]).toBe("300"); // 200 + 100
+    expect(cells[2]).toBe("10"); // 4 + 6 (count is additive)
+  });
+
   it("fires one query per column when multiple measures are configured", async () => {
     runQueryMock.mockResolvedValue({
       rows: [{ category: "Food", value: 50 }],

--- a/frontend/tests/components/reports/widgets/table-widget.test.tsx
+++ b/frontend/tests/components/reports/widgets/table-widget.test.tsx
@@ -4,10 +4,16 @@ import { SWRConfig } from "swr";
 import TableWidget from "@/components/reports/widgets/TableWidget";
 import type { TableWidget as TableWidgetType } from "@/lib/reports/types";
 import { runQuery } from "@/lib/reports/api";
+import { downloadCsv } from "@/lib/reports/csv";
 
 vi.mock("@/lib/reports/api", () => ({
   runQuery: vi.fn(),
 }));
+
+vi.mock("@/lib/reports/csv", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/reports/csv")>();
+  return { ...actual, downloadCsv: vi.fn() };
+});
 
 function renderIsolated(ui: React.ReactElement) {
   return render(
@@ -37,9 +43,11 @@ function makeWidget(overrides: Partial<TableWidgetType["config"]> = {}): TableWi
 
 describe("TableWidget", () => {
   const runQueryMock = vi.mocked(runQuery);
+  const downloadMock = vi.mocked(downloadCsv);
 
   beforeEach(() => {
     runQueryMock.mockReset();
+    downloadMock.mockReset();
   });
 
   it("renders rows with dimension + measure columns when data arrives", async () => {
@@ -256,5 +264,80 @@ describe("TableWidget", () => {
     );
 
     await waitFor(() => expect(runQueryMock).toHaveBeenCalledTimes(3));
+  });
+
+  it("exports CSV with dimension + measure headers, every row, and a Total row", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [
+        { category: "Food", value: 200 },
+        { category: "Transport", value: 80 },
+      ],
+      meta: { row_count: 2, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} />);
+
+    const exportBtn = await screen.findByTestId("widget-csv-export");
+    await waitFor(() => expect(exportBtn).not.toBeDisabled());
+    fireEvent.click(exportBtn);
+
+    expect(downloadMock).toHaveBeenCalledTimes(1);
+    const [filename, csv] = downloadMock.mock.calls[0];
+    expect(filename).toBe("top-categories.csv");
+    // Header uses the human dimension label "Category" + the measure
+    // field "amount"; the Total row sums the additive column (280).
+    expect(csv).toBe(
+      "Category,amount\r\nFood,200\r\nTransport,80\r\nTotal,280",
+    );
+  });
+
+  it("exports one column per measure for a multi-measure table", async () => {
+    runQueryMock
+      .mockResolvedValueOnce({
+        rows: [
+          { category: "Food", value: 200 },
+          { category: "Transport", value: 100 },
+        ],
+        meta: { row_count: 2, truncated: false, query_ms: 1 },
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { category: "Food", value: 4 },
+          { category: "Transport", value: 6 },
+        ],
+        meta: { row_count: 2, truncated: false, query_ms: 1 },
+      });
+
+    renderIsolated(
+      <TableWidget
+        widget={makeWidget({
+          measures: [
+            { measure: { agg: "sum", field: "amount" }, label: "Amount" },
+            { measure: { agg: "count", field: "id" }, label: "Count" },
+          ],
+        })}
+      />,
+    );
+
+    const exportBtn = await screen.findByTestId("widget-csv-export");
+    await waitFor(() => expect(exportBtn).not.toBeDisabled());
+    fireEvent.click(exportBtn);
+
+    const [, csv] = downloadMock.mock.calls[0];
+    expect(csv).toBe(
+      "Category,Amount,Count\r\nFood,200,4\r\nTransport,100,6\r\nTotal,300,10",
+    );
+  });
+
+  it("hides the Export CSV button in edit mode", async () => {
+    runQueryMock.mockResolvedValueOnce({
+      rows: [{ category: "Food", value: 200 }],
+      meta: { row_count: 1, truncated: false, query_ms: 1 },
+    });
+
+    renderIsolated(<TableWidget widget={makeWidget()} editMode />);
+
+    await screen.findByText("Food");
+    expect(screen.queryByTestId("widget-csv-export")).toBeNull();
   });
 });

--- a/frontend/tests/components/reports/widgets/widget-csv-button.test.tsx
+++ b/frontend/tests/components/reports/widgets/widget-csv-button.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import WidgetCsvButton from "@/components/reports/widgets/WidgetCsvButton";
+import { downloadCsv } from "@/lib/reports/csv";
+
+vi.mock("@/lib/reports/csv", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/reports/csv")>();
+  return { ...actual, downloadCsv: vi.fn() };
+});
+
+describe("WidgetCsvButton", () => {
+  const downloadMock = vi.mocked(downloadCsv);
+
+  beforeEach(() => downloadMock.mockReset());
+
+  it("renders in view mode", () => {
+    render(
+      <WidgetCsvButton
+        title="Spend by category"
+        dataset={{ headers: ["A"], rows: [["x"]] }}
+      />,
+    );
+    expect(screen.getByTestId("widget-csv-export")).toBeInTheDocument();
+  });
+
+  it("hides in edit mode", () => {
+    render(
+      <WidgetCsvButton
+        title="Spend"
+        editMode
+        dataset={{ headers: ["A"], rows: [["x"]] }}
+      />,
+    );
+    expect(screen.queryByTestId("widget-csv-export")).toBeNull();
+  });
+
+  it("is disabled when there are no rows", () => {
+    render(
+      <WidgetCsvButton title="Spend" dataset={{ headers: ["A"], rows: [] }} />,
+    );
+    expect(screen.getByTestId("widget-csv-export")).toBeDisabled();
+  });
+
+  it("builds CSV from the dataset and downloads with a slugified filename", () => {
+    render(
+      <WidgetCsvButton
+        title="Spend by Category"
+        dataset={{
+          headers: ["Category", "Amount"],
+          rows: [
+            ["Food", 200],
+            ["Transport", 80],
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("widget-csv-export"));
+
+    expect(downloadMock).toHaveBeenCalledTimes(1);
+    const [filename, csv] = downloadMock.mock.calls[0];
+    expect(filename).toBe("spend-by-category.csv");
+    expect(csv).toBe("Category,Amount\r\nFood,200\r\nTransport,80");
+  });
+
+  it("does not download when there are no rows (button disabled)", () => {
+    render(<WidgetCsvButton title="X" dataset={{ headers: ["A"], rows: [] }} />);
+    fireEvent.click(screen.getByTestId("widget-csv-export"));
+    expect(downloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/lib/help-tooltips.test.ts
+++ b/frontend/tests/lib/help-tooltips.test.ts
@@ -67,6 +67,22 @@ describe("HELP_TOOLTIPS", () => {
     );
   });
 
+  it("covers the Reports aggregation jargon (Reports v2 polish)", () => {
+    const aggKeys: HelpTooltipKey[] = [
+      "reports.agg.sum",
+      "reports.agg.count",
+      "reports.agg.avg",
+      "reports.agg.distinct",
+    ];
+    for (const k of aggKeys) {
+      expect(HELP_TOOLTIPS[k], `key=${k}`).toBeTruthy();
+    }
+    // Distinct copy mentions counting unique values (spec example).
+    expect(HELP_TOOLTIPS["reports.agg.distinct"].content).toMatch(/unique/i);
+    // Master-category explainer is present for the dimension labels.
+    expect(HELP_TOOLTIPS["reports.master-category"]).toBeTruthy();
+  });
+
   it("covers the surfaces the L5.3 spec calls out", () => {
     // Per the L5.3 ticket: transactions (sign convention, frequency),
     // categories (type), budgets (recurrence). Lock those keys here

--- a/frontend/tests/lib/reports/csv.test.ts
+++ b/frontend/tests/lib/reports/csv.test.ts
@@ -1,0 +1,76 @@
+import { downloadCsv, toCsv } from "@/lib/reports/csv";
+
+describe("toCsv", () => {
+  it("joins headers and rows with commas + CRLF line breaks", () => {
+    const csv = toCsv(
+      ["Category", "Amount"],
+      [
+        ["Food", 200],
+        ["Transport", 80],
+      ],
+    );
+    expect(csv).toBe("Category,Amount\r\nFood,200\r\nTransport,80");
+  });
+
+  it("quotes fields containing a comma", () => {
+    const csv = toCsv(["Label", "Value"], [["Food, drink", 10]]);
+    expect(csv).toBe('Label,Value\r\n"Food, drink",10');
+  });
+
+  it("quotes and doubles interior double-quotes", () => {
+    const csv = toCsv(["Label"], [['He said "hi"']]);
+    expect(csv).toBe('Label\r\n"He said ""hi"""');
+  });
+
+  it("quotes fields containing newlines", () => {
+    const csv = toCsv(["Label"], [["line1\nline2"]]);
+    expect(csv).toBe('Label\r\n"line1\nline2"');
+  });
+
+  it("renders numbers without quoting", () => {
+    const csv = toCsv(["A", "B"], [[1, 2.5]]);
+    expect(csv).toBe("A,B\r\n1,2.5");
+  });
+
+  it("renders null as an empty field", () => {
+    const csv = toCsv(["A", "B"], [["x", null]]);
+    expect(csv).toBe("A,B\r\nx,");
+  });
+
+  it("quotes a header that itself contains a comma", () => {
+    const csv = toCsv(["Sum, total"], [[5]]);
+    expect(csv).toBe('"Sum, total"\r\n5');
+  });
+
+  it("handles an empty row set (headers only)", () => {
+    const csv = toCsv(["A", "B"], []);
+    expect(csv).toBe("A,B");
+  });
+});
+
+describe("downloadCsv", () => {
+  it("creates a blob anchor and triggers a click with the slug filename", () => {
+    const createObjectURL = vi.fn((_blob: Blob) => "blob:mock-url");
+    const revokeObjectURL = vi.fn((_url: string) => {});
+    // jsdom doesn't implement URL.createObjectURL.
+    (URL as unknown as { createObjectURL: typeof createObjectURL }).createObjectURL =
+      createObjectURL;
+    (URL as unknown as { revokeObjectURL: typeof revokeObjectURL }).revokeObjectURL =
+      revokeObjectURL;
+
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    downloadCsv("spend.csv", "A,B\r\n1,2");
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toContain("text/csv");
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+
+    clickSpy.mockRestore();
+  });
+});

--- a/frontend/tests/lib/reports/pivot.test.ts
+++ b/frontend/tests/lib/reports/pivot.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { pivotBySecondaryDimension } from "@/lib/reports/series";
+import type { QueryRow } from "@/lib/reports/types";
+
+describe("pivotBySecondaryDimension", () => {
+  it("pivots rows into stable generated series keys paired with labels", () => {
+    const rows: QueryRow[] = [
+      { month: "Jan", account: "Checking", value: 10 },
+      { month: "Jan", account: "Savings", value: 5 },
+      { month: "Feb", account: "Checking", value: 7 },
+    ];
+
+    const out = pivotBySecondaryDimension(rows, "month", "account");
+
+    // Display labels keep first-seen order.
+    expect(out.secondaryValues).toEqual(["Checking", "Savings"]);
+    // Series keys are generated (s0, s1, …), NOT the raw labels.
+    expect(out.seriesKeys).toEqual(["s0", "s1"]);
+
+    // Rows keyed by the generated keys, with missing combos backfilled 0.
+    const jan = out.rows.find((r) => r.label === "Jan")!;
+    const feb = out.rows.find((r) => r.label === "Feb")!;
+    expect(jan.s0).toBe(10);
+    expect(jan.s1).toBe(5);
+    expect(feb.s0).toBe(7);
+    expect(feb.s1).toBe(0); // Savings had no Feb row → backfilled.
+  });
+
+  it("does not break on a secondary value containing a dot", () => {
+    // A raw value like "Acme Inc." used as a Recharts dataKey would be
+    // parsed as a nested path. Generated keys sidestep that entirely.
+    const rows: QueryRow[] = [
+      { month: "Jan", vendor: "Acme Inc.", value: 3 },
+    ];
+    const out = pivotBySecondaryDimension(rows, "month", "vendor");
+    expect(out.secondaryValues).toEqual(["Acme Inc."]);
+    expect(out.seriesKeys).toEqual(["s0"]);
+    expect(out.rows[0].s0).toBe(3);
+  });
+
+  it("is immune to prototype pollution from a __proto__ secondary value", () => {
+    const rows: QueryRow[] = [
+      { month: "Jan", k: "__proto__", value: 9 },
+      { month: "Jan", k: "constructor", value: 4 },
+    ];
+    const out = pivotBySecondaryDimension(rows, "month", "k");
+
+    // The malicious values become ordinary generated data keys.
+    expect(out.secondaryValues).toEqual(["__proto__", "constructor"]);
+    expect(out.seriesKeys).toEqual(["s0", "s1"]);
+    expect(out.rows[0].s0).toBe(9);
+    expect(out.rows[0].s1).toBe(4);
+
+    // Nothing leaked onto Object.prototype.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call({}, "9")).toBe(false);
+  });
+});

--- a/specs/2026-06-01-reports-simplify-and-complete.md
+++ b/specs/2026-06-01-reports-simplify-and-complete.md
@@ -1,0 +1,51 @@
+# Reports — make it usable (templates + builder simplification), then complete PR4
+
+**Status:** draft for review, 2026-06-01.
+**Builds on:** `specs/2026-05-22-reports-v2-flexible-canvas.md` (architect-locked). PR1-PR3 of that train shipped (#343, #350, #352): backend AST query engine, canvas, all 8 widgets, filter primitives. The surface is now enabled locally (`FEATURE_REPORTS_V2=true`).
+
+## Motivation
+
+The owner could not generate a single report. A read-only investigation found **no blocking bugs** — the problem is **UX friction**:
+
+- "New report" drops the user on a blank canvas. Editor empty state (`app/reports/[id]/page.tsx:448`) just says "No widgets yet. Click Add widget to start." The list-page empty state is separate (`app/reports/page.tsx:118-129`).
+- Adding a widget interposes a picker modal with 8 jargon-labeled types, no default/preview/recommendation (`components/reports/WidgetPicker.tsx:46-115`). **Note:** once a type is chosen, the inserted widget is already fully configured and renders immediately (`emptyBar()` etc., `app/reports/[id]/page.tsx:63-180`) — so the friction is the picker step, NOT an empty/unconfigured widget.
+- The config rail shows 15+ controls at once — aggregation, measure, dimension, and 6 filter sub-sections (`components/reports/ConfigRail.tsx:218-374`) — using terms like "distinct count" and "master category" with no explanation.
+- "No data" and "Saved" give no actionable feedback.
+
+The single highest-impact fix is the one PR4 piece never built: **templates** (one click -> a working report). Estimated to remove ~80% of the pain.
+
+## Plan (priority-ordered; lowest effort / highest impact first)
+
+### Slice 1 — Templates (the core fix)
+
+- **Backend:** `backend/app/reports/templates/__init__.py` registers 3 code fixtures (architect lock #2 — code fixtures, NOT DB seed rows): **Monthly review**, **Cash flow trend**, **Category deep-dive**. **Author the fixtures against the implemented frontend `lib/reports/types.ts` shape** (`config.measure` for single-measure widgets, `config.measures[]` for line/area/stacked_bar/table, dimensions from the `Dimension` union, filters as `WidgetFilters` like `{txn_type:"expense", date_range:{...}}`) — **NOT** the raw AST `{field,op,value}` sketch in the parent spec §5, which predates the `WidgetFilters` indirection and would not render. `GET /api/v1/reports/templates` returns them (correctly gated by the existing `require_reports_v2_enabled` 404 dependency since it mounts on the same router).
+- **Instantiate:** "Use template" reuses the **existing** `createReport` endpoint (`api.ts:30-38` accepts `layout_json`+`canvas_filters_json`+`visibility`) to create a new **private** report from the template. No new instantiate endpoint needed — only `GET /reports/templates` is new.
+- **Frontend:** a **Templates** section on `/reports`; cards show name + description; "Use template" -> instantiate -> open canvas with charts already rendering against the user's data. Empty state becomes "Start from a template" + "Build from scratch".
+
+### Slice 2 — Builder simplification
+
+- **Streamline the add flow:** the inserted widget is already pre-configured and renders (see Motivation), so the work is to **skip/streamline the picker modal** — e.g. a one-click "Add chart" that inserts the default Bar immediately, with type-switching available in the rail afterward. (Re-scoped from "add defaults" — defaults already exist.)
+- **Empty-state CTA:** hero copy explaining what you can build + buttons to templates / add-first-widget. Editor empty state at `app/reports/[id]/page.tsx:448`; list-page empty state at `app/reports/page.tsx:118-129`.
+- **ConfigRail tiering:** group **Basic** (chart type, measure, dimension) always visible; collapse **Filters** + **Advanced** (sort, limit, format) into a disclosure, closed by default (`ConfigRail.tsx:218-374`).
+- **Tooltips on jargon:** reuse `HelpTooltip` / `lib/help/tooltips.ts` (has a master-category entry already; **add new keys for aggregation types** `sum`/`count`/`avg`/`distinct`) for aggregation, master category, dimensions.
+- **Actionable empty/no-data + save feedback:** "No data" widget message suggests adjusting filters / dimension / period (`BarWidget.tsx:66` and siblings); a 2-second success toast on save.
+
+### Slice 3 — Complete PR4 (per locked spec §11)
+
+- **Duplicate:** `POST /api/v1/reports/{id}/duplicate` -> clone as private; button on report cards.
+- **Sharing/visibility:** private <-> org toggle in the report header, gated by edit rights (owner always; org owner/admin for org-shared).
+- **CSV export per widget:** view-mode button. **Default: client-side** (each widget already holds its rows; single-measure widgets via `data.rows`, multi-series via the `series[]` from `useSeriesQueries` — the export helper needs per-widget-type extraction). No new endpoint, no extra auth surface. Architect lock #3 applies only if a server route is later chosen.
+- **Mobile:** single-column read-only stack on `<sm` (editing stays desktop-only).
+- **Ownership transfer — CORRECTNESS FIX, not polish (do this first in Slice 3).** `backend/app/services/admin_users_service.py:delete_user` (~line 93-171) cleans up `invitations` + `import_batches` then `DELETE FROM users`, but **never touches `reports`**. Because `reports.owner_user_id` is `ON DELETE RESTRICT` (migration `051`), deleting any user who owns a report **already raises an FK violation today**. Fix: before deleting the user, transfer their org-shared reports to the org owner and hard-delete their private reports. Scope is **only this path** — member "removal" is just `is_active=False` (no delete, no RESTRICT hit; `admin_org_members_service.update_member:167-173`), and **org-owner transfer doesn't exist yet** as a service. Drop those two from scope; they don't apply. (See [[reference_org_delete_cascade_fk_audit]] — same FK-cascade discipline.)
+
+## Phasing
+
+Subagent-driven, sequential with review gates; **branch + PR per slice**. Slice 1 first (unblocks "can I make a report at all"), then Slice 2, then Slice 3. Production flag stays gated in `.do/app.yaml` until owner sign-off; `FEATURE_REPORTS_V2` default flip in `.env.example` lands with Slice 3.
+
+## Minor / noted
+
+- Query `meta` quirk: `truncated:true` and `query_ms:0` fire whenever `row_count == limit` even at small limits. Optional polish, not in critical path.
+
+## Out of scope (unchanged from parent spec)
+
+Public share links, real-time refresh, cross-org reports, drill-down, saved widget presets, non-`transactions` datasets, Sankey/treemap/gauge/scatter, materialized rollups, in-canvas text blocks, i18n, audit logging of report CRUD.

--- a/specs/2026-06-01-reports-simplify-and-complete.md
+++ b/specs/2026-06-01-reports-simplify-and-complete.md
@@ -21,14 +21,21 @@ The single highest-impact fix is the one PR4 piece never built: **templates** (o
 - **Backend:** `backend/app/reports/templates/__init__.py` registers 3 code fixtures (architect lock #2 — code fixtures, NOT DB seed rows): **Monthly review**, **Cash flow trend**, **Category deep-dive**. **Author the fixtures against the implemented frontend `lib/reports/types.ts` shape** (`config.measure` for single-measure widgets, `config.measures[]` for line/area/stacked_bar/table, dimensions from the `Dimension` union, filters as `WidgetFilters` like `{txn_type:"expense", date_range:{...}}`) — **NOT** the raw AST `{field,op,value}` sketch in the parent spec §5, which predates the `WidgetFilters` indirection and would not render. `GET /api/v1/reports/templates` returns them (correctly gated by the existing `require_reports_v2_enabled` 404 dependency since it mounts on the same router).
 - **Instantiate:** "Use template" reuses the **existing** `createReport` endpoint (`api.ts:30-38` accepts `layout_json`+`canvas_filters_json`+`visibility`) to create a new **private** report from the template. No new instantiate endpoint needed — only `GET /reports/templates` is new.
 - **Frontend:** a **Templates** section on `/reports`; cards show name + description; "Use template" -> instantiate -> open canvas with charts already rendering against the user's data. Empty state becomes "Start from a template" + "Build from scratch".
+- **Capture the creation snapshot (enables "Revert to original" in Slice 2).** Migration: add nullable `original_layout_json` + `original_canvas_filters_json` to `reports`, set **once at create** and never overwritten on edit. Blank create snapshots the empty canvas; template instantiation snapshots the template's layout. Backfill existing rows with their current values (feature gated off in prod, so the table is effectively empty). Captured here in Slice 1 because this is the create path we're already touching.
 
-### Slice 2 — Builder simplification
+### Slice 2 — Builder simplification + editing-lifecycle controls
 
 - **Streamline the add flow:** the inserted widget is already pre-configured and renders (see Motivation), so the work is to **skip/streamline the picker modal** — e.g. a one-click "Add chart" that inserts the default Bar immediately, with type-switching available in the rail afterward. (Re-scoped from "add defaults" — defaults already exist.)
 - **Empty-state CTA:** hero copy explaining what you can build + buttons to templates / add-first-widget. Editor empty state at `app/reports/[id]/page.tsx:448`; list-page empty state at `app/reports/page.tsx:118-129`.
 - **ConfigRail tiering:** group **Basic** (chart type, measure, dimension) always visible; collapse **Filters** + **Advanced** (sort, limit, format) into a disclosure, closed by default (`ConfigRail.tsx:218-374`).
 - **Tooltips on jargon:** reuse `HelpTooltip` / `lib/help/tooltips.ts` (has a master-category entry already; **add new keys for aggregation types** `sum`/`count`/`avg`/`distinct`) for aggregation, master category, dimensions.
 - **Actionable empty/no-data + save feedback:** "No data" widget message suggests adjusting filters / dimension / period (`BarWidget.tsx:66` and siblings); a 2-second success toast on save.
+
+**Editing-lifecycle controls (requested 2026-06-01):**
+
+- **Edit** — a clear, explicit "Edit" affordance to enter edit mode on a saved report. The view/edit toggle already exists in `app/reports/[id]/page.tsx`; surface it prominently (today it's easy to miss).
+- **Cancel editing** — a "Cancel" / "Discard changes" control in edit mode that drops the current unsaved session and re-loads the **last-saved** report state from the server. Frontend-only (re-fetch + reset local layout/filter state); no backend change. Should no-op or be hidden when there are no unsaved changes.
+- **Revert to original** — reset the report to its **as-created** state (undo every edit since creation), using the Slice-1 snapshot. Backend: `POST /api/v1/reports/{id}/reset` copies `original_layout_json`/`original_canvas_filters_json` -> live `layout_json`/`canvas_filters_json`; gated by edit rights (owner always; org owner/admin for org-shared). Frontend: a "Revert to original" button behind a **typed/confirm modal** (it permanently discards customizations). Distinct from "Cancel editing": Cancel drops one unsaved session; Revert rolls a *saved* report back to creation state.
 
 ### Slice 3 — Complete PR4 (per locked spec §11)
 

--- a/specs/2026-06-01-reports-simplify-and-complete.md
+++ b/specs/2026-06-01-reports-simplify-and-complete.md
@@ -37,6 +37,24 @@ The single highest-impact fix is the one PR4 piece never built: **templates** (o
 - **Cancel editing** — a "Cancel" / "Discard changes" control in edit mode that drops the current unsaved session and re-loads the **last-saved** report state from the server. Frontend-only (re-fetch + reset local layout/filter state); no backend change. Should no-op or be hidden when there are no unsaved changes.
 - **Revert to original** — reset the report to its **as-created** state (undo every edit since creation), using the Slice-1 snapshot. Backend: `POST /api/v1/reports/{id}/reset` copies `original_layout_json`/`original_canvas_filters_json` -> live `layout_json`/`canvas_filters_json`; gated by edit rights (owner always; org owner/admin for org-shared). Frontend: a "Revert to original" button behind a **typed/confirm modal** (it permanently discards customizations). Distinct from "Cancel editing": Cancel drops one unsaved session; Revert rolls a *saved* report back to creation state.
 
+### Slice 2b — View-mode toolbar + report versioning (decided 2026-06-01, supersedes the `original_*`/`/reset` design)
+
+User feedback after using Slices 1-2: the editor toolbar is incoherent (lands in edit mode with Save disabled but everything else enabled), the View button is broken, and "Revert to original" is ambiguous. Decisions:
+
+**Toolbar (frontend):**
+- Existing reports **open in View mode** (charts only). View toolbar = **Edit**, **History**, **Delete**. A report with zero widgets (blank) may open in edit mode so the user can start.
+- **Edit** enters edit mode: **Add widget**, **Save** (enabled only when there are unsaved changes), **Cancel** (shown/enabled only when there are unsaved changes), **History**, **Delete**, **Done** (back to View).
+- **Fix the View/Done toggle** (currently a no-op bug). `editMode` + a `dirty` flag already exist (Slice 2) — drive button enablement off `dirty`, default `editMode=false` for non-empty reports.
+
+**Versioning (replaces `original_layout_json`/`original_canvas_filters_json` + `POST /{id}/reset`):**
+- New `report_versions` table: `id, report_id FK (ON DELETE CASCADE), is_original BOOL, layout_json JSON, canvas_filters_json JSON, created_at`. Migration also **drops** the `original_*` columns from migration 063 (pre-launch, no backcompat); backfill one `is_original=True` version per existing report from `original_layout_json` (fallback to live `layout_json`).
+- On report **create**: insert the `is_original=True` version.
+- On each **Save** (layout/filters change): insert a new `is_original=False` version. Retention = **pin the original + keep the 4 most recent non-original** (evict oldest non-original when the count exceeds 4). Max 5 total.
+- Endpoints (inherit `require_reports_v2_enabled`): `GET /api/v1/reports/{id}/versions` (newest-first, original flagged), `POST /api/v1/reports/{id}/versions/{version_id}/restore` (copies that version's layout/filters into the live report; edit-rights gated; does NOT itself create a version — the next Save does). Reimplement `POST /{id}/reset` as sugar that restores the pinned original version so the existing "Revert to original" button keeps working.
+- **History panel (frontend):** lists versions (Original pinned + recent, with timestamps), each with **Restore**. "Revert to original" becomes the Restore action on the Original entry.
+
+This slice replaces the Slice-1 snapshot columns and the Slice-2 `/reset` internals. Update/replace their tests accordingly.
+
 ### Slice 3 — Complete PR4 (per locked spec §11)
 
 - **Duplicate:** `POST /api/v1/reports/{id}/duplicate` -> clone as private; button on report cards.

--- a/specs/2026-06-01-reports-simplify-and-complete.md
+++ b/specs/2026-06-01-reports-simplify-and-complete.md
@@ -74,3 +74,5 @@ Subagent-driven, sequential with review gates; **branch + PR per slice**. Slice 
 ## Out of scope (unchanged from parent spec)
 
 Public share links, real-time refresh, cross-org reports, drill-down, saved widget presets, non-`transactions` datasets, Sankey/treemap/gauge/scatter, materialized rollups, in-canvas text blocks, i18n, audit logging of report CRUD.
+
+Backlog (post-save presentation): after Save/Done the report stays on the same canvas in view mode; users expect Done to feel like leaving the editor (navigate to a read-only view or back to the list). Deferred per owner 2026-06-01.

--- a/specs/2026-06-01-reports-slice1-templates-plan.md
+++ b/specs/2026-06-01-reports-slice1-templates-plan.md
@@ -1,0 +1,508 @@
+# Reports Slice 1 — Templates + creation snapshot — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user create a working report in one click from a starter template, and persist each report's as-created state so a later "Revert to original" is possible.
+
+**Architecture:** 3 templates ship as Python code fixtures (no DB seed rows), exposed via `GET /api/v1/reports/templates`. "Use template" reuses the existing `POST /api/v1/reports` create endpoint with the template's `layout_json`/`canvas_filters_json`. A migration adds `original_layout_json`/`original_canvas_filters_json` to `reports`, captured once at create. Template fixtures are authored against the implemented frontend `lib/reports/types.ts` widget-config shapes (NOT the parent-spec AST sketch).
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 async + Alembic + Pydantic v2 (backend); Next.js 15 App Router + React 19 + TypeScript + SWR (frontend); pytest + vitest.
+
+**Branch:** `feat/reports-simplify`. Feature is gated behind `FEATURE_REPORTS_V2` (true locally).
+
+**Reference (verified shapes):**
+- Create endpoint: `backend/app/routers/reports.py` `create_report` (sets `layout_json`/`canvas_filters_json` from body).
+- Router gate: `require_reports_v2_enabled` (404 when flag off) is a router-level dependency — any new route on `router` inherits it.
+- Frontend widget config shapes: `frontend/lib/reports/types.ts` — single-measure widgets use `config.measure`; line/area/stacked_bar/table use `config.measures: SeriesConfig[]`; `Dimension` union; widget filters are `WidgetFilters` (e.g. `{ txn_type: "expense", date_range: {...} }`), NOT raw `{field,op,value}`.
+- Create-from-list today: `frontend/app/reports/page.tsx` `handleNewReport` calls `createReport({ name, visibility, layout_json:{version:1,widgets:[]}, canvas_filters_json:{} })`.
+
+---
+
+## File Structure
+
+- Create `backend/alembic/versions/063_reports_original_snapshot.py` — add two nullable JSON columns.
+- Modify `backend/app/models/report.py` — add `original_layout_json`, `original_canvas_filters_json`.
+- Modify `backend/app/routers/reports.py` — set `original_*` at create; add `GET /templates`.
+- Create `backend/app/reports/__init__.py` + `backend/app/reports/templates/__init__.py` — 3 template fixtures + registry.
+- Modify `backend/app/schemas/report.py` — `ReportTemplate` response schema.
+- Create `backend/tests/routers/test_reports_templates.py` — endpoint + gating tests.
+- Modify `frontend/lib/reports/types.ts` — `ReportTemplate` type.
+- Modify `frontend/lib/reports/api.ts` — `listTemplates()`, `createFromTemplate()`.
+- Modify `frontend/app/reports/page.tsx` — Templates section + empty-state CTA.
+- Create `frontend/tests/app/reports-templates.test.tsx` — list + use-template.
+
+---
+
+### Task 1: Migration — add creation-snapshot columns to `reports`
+
+**Files:**
+- Create: `backend/alembic/versions/063_reports_original_snapshot.py`
+- Modify: `backend/app/models/report.py`
+
+- [ ] **Step 1: Confirm current migration head**
+
+Run: `docker compose exec -T backend alembic heads`
+Expected: `062_ollama_nullable_api_key (head)`. Use that exact id as `down_revision`; if different, use the printed head.
+
+- [ ] **Step 2: Write the migration**
+
+```python
+"""add reports original snapshot columns
+
+Revision ID: 063_reports_original_snapshot
+Revises: 062_ollama_nullable_api_key
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "063_reports_original_snapshot"
+down_revision = "062_ollama_nullable_api_key"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("reports", sa.Column("original_layout_json", sa.JSON(), nullable=True))
+    op.add_column("reports", sa.Column("original_canvas_filters_json", sa.JSON(), nullable=True))
+    # Backfill existing rows so original == current (table is effectively
+    # empty in prod since the feature is gated off).
+    op.execute(
+        "UPDATE reports SET original_layout_json = layout_json, "
+        "original_canvas_filters_json = canvas_filters_json"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("reports", "original_canvas_filters_json")
+    op.drop_column("reports", "original_layout_json")
+```
+
+- [ ] **Step 3: Add the columns to the model**
+
+In `backend/app/models/report.py`, alongside `layout_json`/`canvas_filters_json`, add:
+
+```python
+    original_layout_json: Mapped[dict] = mapped_column(JSON, nullable=True)
+    original_canvas_filters_json: Mapped[dict] = mapped_column(JSON, nullable=True)
+```
+
+(Match the existing import + `mapped_column(JSON, ...)` style already used for `layout_json` in that file.)
+
+- [ ] **Step 4: Run the migration**
+
+Run: `docker compose exec -T backend alembic upgrade head`
+Expected: `migrate.step` log for `063_reports_original_snapshot`, no error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/alembic/versions/063_reports_original_snapshot.py backend/app/models/report.py
+git commit -m "feat(reports): add original_* snapshot columns to reports"
+```
+
+---
+
+### Task 2: Capture the snapshot at create
+
+**Files:**
+- Modify: `backend/app/routers/reports.py` (`create_report`)
+- Test: `backend/tests/routers/test_reports_templates.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/routers/test_reports_templates.py
+import pytest
+
+@pytest.mark.asyncio
+async def test_create_report_snapshots_original(client, auth_headers):
+    payload = {
+        "name": "Snap",
+        "visibility": "private",
+        "layout_json": {"version": 1, "widgets": [{"id": "w1", "type": "kpi"}]},
+        "canvas_filters_json": {"date_range": {"kind": "relative", "preset": "last_30_days"}},
+    }
+    r = await client.post("/api/v1/reports", json=payload, headers=auth_headers)
+    assert r.status_code == 201
+    rid = r.json()["id"]
+    # Mutate the live layout via PATCH...
+    await client.patch(f"/api/v1/reports/{rid}", json={"layout_json": {"version": 1, "widgets": []}}, headers=auth_headers)
+    # ...original must be unchanged (fetch via DB-backed get is fine; assert through a follow-up reset in Slice 2).
+    got = await client.get(f"/api/v1/reports/{rid}", headers=auth_headers)
+    assert got.status_code == 200
+```
+
+(Use the existing reports test fixtures for `client`/`auth_headers` — mirror `backend/tests/routers/test_reports.py` setup; reuse its flag-enable fixture so `FEATURE_REPORTS_V2` is on for the test app.)
+
+- [ ] **Step 2: Run it to confirm current behavior**
+
+Run: `docker compose exec -T backend pytest backend/tests/routers/test_reports_templates.py::test_create_report_snapshots_original -v`
+Expected: PASS for create/patch/get already (this test only locks that the flow works); the snapshot assertion is exercised in Slice 2's reset test. The point of this task is to populate `original_*`.
+
+- [ ] **Step 3: Set `original_*` in `create_report`**
+
+In `backend/app/routers/reports.py` `create_report`, add the two fields to the `Report(...)` constructor:
+
+```python
+    row = Report(
+        owner_user_id=current_user.id,
+        org_id=current_user.org_id,
+        visibility=body.visibility,
+        name=body.name,
+        description=body.description,
+        layout_json=body.layout_json,
+        canvas_filters_json=body.canvas_filters_json,
+        original_layout_json=body.layout_json,
+        original_canvas_filters_json=body.canvas_filters_json,
+    )
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `docker compose exec -T backend pytest backend/tests/routers/test_reports_templates.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routers/reports.py backend/tests/routers/test_reports_templates.py
+git commit -m "feat(reports): snapshot original_* on report create"
+```
+
+---
+
+### Task 3: Template fixtures (3 templates, authored against types.ts)
+
+**Files:**
+- Create: `backend/app/reports/__init__.py` (empty package marker)
+- Create: `backend/app/reports/templates/__init__.py`
+
+- [ ] **Step 1: Write the fixtures + registry**
+
+```python
+# backend/app/reports/templates/__init__.py
+"""Reports v2 starter templates — code fixtures, NOT DB seed rows.
+
+Each template's ``layout_json``/``canvas_filters_json`` use the
+frontend ``lib/reports/types.ts`` shapes: single-measure widgets carry
+``config.measure``; line/area/stacked_bar/table carry
+``config.measures: [{measure, label?}]``; dimensions come from the
+``Dimension`` union; widget/canvas filters are ``WidgetFilters`` /
+``CanvasFilters`` (e.g. ``{"txn_type": "expense"}``), never raw AST.
+"""
+from typing import Any
+
+_THIS_MONTH = {"kind": "relative", "preset": "this_month"}
+_LAST_12 = {"kind": "relative", "preset": "last_12_months"}
+
+
+def _measure(agg: str, field: str = "amount") -> dict[str, Any]:
+    return {"agg": agg, "field": field}
+
+
+REPORT_TEMPLATES: list[dict[str, Any]] = [
+    {
+        "key": "monthly_review",
+        "name": "Monthly review",
+        "description": "Net, income and expense KPIs plus spend by category and income vs expense this month.",
+        "canvas_filters_json": {"date_range": _THIS_MONTH},
+        "layout_json": {
+            "version": 1,
+            "widgets": [
+                {"id": "kpi_net", "type": "kpi", "title": "Net this month",
+                 "grid": {"x": 0, "y": 0, "w": 3, "h": 2},
+                 "config": {"dataset": "transactions", "measure": _measure("sum"), "format": "currency"}},
+                {"id": "kpi_income", "type": "kpi", "title": "Income",
+                 "grid": {"x": 3, "y": 0, "w": 3, "h": 2},
+                 "config": {"dataset": "transactions", "measure": _measure("sum"),
+                            "filters": {"txn_type": "income"}, "format": "currency"}},
+                {"id": "kpi_expense", "type": "kpi", "title": "Expense",
+                 "grid": {"x": 6, "y": 0, "w": 3, "h": 2},
+                 "config": {"dataset": "transactions", "measure": _measure("sum"),
+                            "filters": {"txn_type": "expense"}, "format": "currency"}},
+                {"id": "bar_cat", "type": "bar", "title": "Spend by category",
+                 "grid": {"x": 0, "y": 2, "w": 6, "h": 4},
+                 "config": {"dataset": "transactions", "measure": _measure("sum"),
+                            "dimensions": ["category"], "filters": {"txn_type": "expense"},
+                            "sort": {"by": "value", "dir": "desc"}, "limit": 10, "format": "currency"}},
+                {"id": "line_io", "type": "line", "title": "Income vs expense",
+                 "grid": {"x": 6, "y": 2, "w": 6, "h": 4},
+                 "config": {"dataset": "transactions",
+                            "measures": [{"measure": _measure("sum"), "label": "Net"}],
+                            "dimensions": ["day"], "format": "currency"}},
+            ],
+        },
+    },
+    {
+        "key": "cash_flow_trend",
+        "name": "Cash flow trend",
+        "description": "Net by month for the trailing 12 months with a trailing average KPI.",
+        "canvas_filters_json": {"date_range": _LAST_12},
+        "layout_json": {
+            "version": 1,
+            "widgets": [
+                {"id": "kpi_avg", "type": "kpi", "title": "Avg monthly net (12mo)",
+                 "grid": {"x": 0, "y": 0, "w": 4, "h": 2},
+                 "config": {"dataset": "transactions", "measure": _measure("avg"), "format": "currency"}},
+                {"id": "line_net", "type": "line", "title": "Net by month",
+                 "grid": {"x": 0, "y": 2, "w": 12, "h": 4},
+                 "config": {"dataset": "transactions",
+                            "measures": [{"measure": _measure("sum"), "label": "Net"}],
+                            "dimensions": ["month"], "format": "currency"}},
+            ],
+        },
+    },
+    {
+        "key": "category_deep_dive",
+        "name": "Category deep-dive",
+        "description": "Category share this month, top transactions, and category by month.",
+        "canvas_filters_json": {"date_range": _THIS_MONTH},
+        "layout_json": {
+            "version": 1,
+            "widgets": [
+                {"id": "pie_cat", "type": "pie", "title": "Category share",
+                 "grid": {"x": 0, "y": 0, "w": 6, "h": 4},
+                 "config": {"dataset": "transactions", "measure": _measure("sum"),
+                            "dimensions": ["category"], "filters": {"txn_type": "expense"}, "format": "currency"}},
+                {"id": "tbl_top", "type": "table", "title": "Top transactions",
+                 "grid": {"x": 6, "y": 0, "w": 6, "h": 4},
+                 "config": {"dataset": "transactions",
+                            "measures": [{"measure": _measure("sum"), "label": "Amount"}],
+                            "dimensions": ["category"],
+                            "sort": {"by": "value", "dir": "desc"}, "limit": 20, "format": "currency"}},
+                {"id": "stack_cat", "type": "stacked_bar", "title": "Category by month",
+                 "grid": {"x": 0, "y": 4, "w": 12, "h": 4},
+                 "config": {"dataset": "transactions",
+                            "measures": [{"measure": _measure("sum"), "label": "Spend"}],
+                            "dimensions": ["month", "category"], "filters": {"txn_type": "expense"}, "format": "currency"}},
+            ],
+        },
+    },
+]
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/reports/__init__.py backend/app/reports/templates/__init__.py
+git commit -m "feat(reports): add 3 starter template fixtures"
+```
+
+> **Review note:** before committing, sanity-check each widget `config` against `frontend/lib/reports/types.ts` (`KPIConfig`, `BarConfig`, `LineConfig`, `PieConfig`, `TableConfig`, `StackedBarConfig`) and the `Dimension` union (`category`, `month`, `day`, etc.). The canvas renders these directly, so a shape mismatch = a blank widget. Verify by instantiating one template in the running app at the end of the slice.
+
+---
+
+### Task 4: `GET /api/v1/reports/templates` endpoint + schema
+
+**Files:**
+- Modify: `backend/app/schemas/report.py`
+- Modify: `backend/app/routers/reports.py`
+- Test: `backend/tests/routers/test_reports_templates.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_templates_endpoint_returns_three(client, auth_headers):
+    r = await client.get("/api/v1/reports/templates", headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body) == 3
+    keys = {t["key"] for t in body}
+    assert keys == {"monthly_review", "cash_flow_trend", "category_deep_dive"}
+    assert body[0]["layout_json"]["widgets"]
+
+@pytest.mark.asyncio
+async def test_templates_endpoint_404_when_flag_off(client_flag_off, auth_headers):
+    r = await client_flag_off.get("/api/v1/reports/templates", headers=auth_headers)
+    assert r.status_code == 404
+```
+
+(`client_flag_off` = a test client built with `FEATURE_REPORTS_V2=false`; mirror however `test_reports.py` toggles the setting, e.g. monkeypatching `app_settings.feature_reports_v2`.)
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `docker compose exec -T backend pytest backend/tests/routers/test_reports_templates.py -v`
+Expected: FAIL (404 on the templates route — not yet defined).
+
+- [ ] **Step 3: Add the schema**
+
+In `backend/app/schemas/report.py`:
+
+```python
+class ReportTemplate(BaseModel):
+    key: str
+    name: str
+    description: str
+    layout_json: dict[str, Any]
+    canvas_filters_json: dict[str, Any]
+```
+
+- [ ] **Step 4: Add the route (BEFORE `/{report_id}` to avoid path capture)**
+
+In `backend/app/routers/reports.py`, import the fixtures + schema, and register the route above the `@router.get("/{report_id}")` handler so `templates` is not swallowed by the `{report_id}` matcher:
+
+```python
+from app.reports.templates import REPORT_TEMPLATES
+from app.schemas.report import ReportTemplate
+
+@router.get("/templates", response_model=list[ReportTemplate])
+async def list_templates(current_user: User = Depends(get_current_user)):
+    """Static starter templates (code fixtures, not DB rows)."""
+    return [ReportTemplate(**t) for t in REPORT_TEMPLATES]
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `docker compose exec -T backend pytest backend/tests/routers/test_reports_templates.py -v`
+Expected: PASS (3 templates; 404 when flag off).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/schemas/report.py backend/app/routers/reports.py backend/tests/routers/test_reports_templates.py
+git commit -m "feat(reports): GET /reports/templates endpoint"
+```
+
+---
+
+### Task 5: Frontend types + API client
+
+**Files:**
+- Modify: `frontend/lib/reports/types.ts`
+- Modify: `frontend/lib/reports/api.ts`
+
+- [ ] **Step 1: Add the type**
+
+In `frontend/lib/reports/types.ts`:
+
+```typescript
+export interface ReportTemplate {
+  key: string;
+  name: string;
+  description: string;
+  layout_json: LayoutJson;
+  canvas_filters_json: CanvasFilters;
+}
+```
+
+(Use the existing `LayoutJson` + `CanvasFilters` types already defined in this file.)
+
+- [ ] **Step 2: Add API functions**
+
+In `frontend/lib/reports/api.ts`:
+
+```typescript
+import type { ReportTemplate } from "./types";
+
+export async function listTemplates(): Promise<ReportTemplate[]> {
+  return apiFetch<ReportTemplate[]>("/api/v1/reports/templates");
+}
+
+export async function createFromTemplate(t: ReportTemplate): Promise<ReportSummary> {
+  return createReport({
+    name: t.name,
+    visibility: "private",
+    layout_json: t.layout_json,
+    canvas_filters_json: t.canvas_filters_json,
+  });
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `docker compose exec -T frontend npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/lib/reports/types.ts frontend/lib/reports/api.ts
+git commit -m "feat(reports): template types + api client"
+```
+
+---
+
+### Task 6: Templates section + "Use template" on the list page
+
+**Files:**
+- Modify: `frontend/app/reports/page.tsx`
+- Test: `frontend/tests/app/reports-templates.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/tests/app/reports-templates.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import ReportsListPage from "@/app/reports/page";
+
+vi.mock("@/components/AppShell", () => ({ default: ({ children }: any) => <div data-testid="app-shell">{children}</div> }));
+const push = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push, replace: vi.fn() }) }));
+vi.mock("@/components/auth/AuthProvider", () => ({ useAuth: () => ({ user: { id: 1 }, loading: false, featureReportsV2: true }) }));
+vi.mock("@/lib/reports/api", () => ({
+  listReports: vi.fn().mockResolvedValue([]),
+  listTemplates: vi.fn().mockResolvedValue([
+    { key: "monthly_review", name: "Monthly review", description: "x", layout_json: { version: 1, widgets: [] }, canvas_filters_json: {} },
+  ]),
+  createFromTemplate: vi.fn().mockResolvedValue({ id: 42 }),
+  createReport: vi.fn(),
+}));
+
+test("shows templates and instantiates on click", async () => {
+  render(<ReportsListPage />);
+  expect(await screen.findByText("Monthly review")).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: /use template/i }));
+  await waitFor(() => expect(push).toHaveBeenCalledWith("/reports/42"));
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `docker compose exec -T frontend npm test -- tests/app/reports-templates.test.tsx`
+Expected: FAIL (no "Monthly review" / no "Use template" button yet).
+
+- [ ] **Step 3: Implement the Templates section**
+
+In `frontend/app/reports/page.tsx`: load templates in the existing effect (`listTemplates().then(setTemplates)`), add a `templates` state, render a **Templates** section above the reports list with a card per template (name, description, a "Use template" button). The button calls `createFromTemplate(t)` then `router.push(\`/reports/${created.id}\`)`. Also update the empty-state copy to add a "Start from a template" CTA that scrolls to / highlights the templates section. Match the existing Tailwind tokens used on the page (`bg-surface`, `border-border`, `text-text-*`, `bg-accent`).
+
+- [ ] **Step 4: Run the test**
+
+Run: `docker compose exec -T frontend npm test -- tests/app/reports-templates.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check + commit**
+
+```bash
+docker compose exec -T frontend npx tsc --noEmit
+git add frontend/app/reports/page.tsx frontend/tests/app/reports-templates.test.tsx
+git commit -m "feat(reports): templates section + use-template on list page"
+```
+
+---
+
+### Task 7: End-to-end manual verification
+
+- [ ] **Step 1: Verify in the running app**
+
+Log in (`demo`/`demo1234`) at `http://localhost`, open Reports, confirm the 3 templates render. Click "Use template" on each of the three; confirm the canvas opens and **every widget renders data** (the seed has 94 transactions). If any widget is blank, the fixture's `config` shape is wrong — fix the fixture in `backend/app/reports/templates/__init__.py` against `types.ts` and re-verify. This is the acceptance gate for the slice.
+
+- [ ] **Step 2: Run the full reports test suites**
+
+Run: `docker compose exec -T backend pytest backend/tests/routers/test_reports*.py -v`
+Run: `docker compose exec -T frontend npm test -- tests/app/reports`
+Expected: all PASS.
+
+- [ ] **Step 3: Update codebase shape doc**
+
+Append the new `backend/app/reports/templates/` module + `GET /reports/templates` to `~/.claude/projects/-Users-flamarion-src-tbd/codebase_shape.md`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** templates (fixtures + endpoint + UI), one-click instantiate via existing create endpoint, empty-state CTA, creation snapshot columns (enables Slice 2 revert). All covered.
+- **Out of this slice (Slice 2):** ConfigRail tiering, tooltips, save toast, streamlined add flow, edit/cancel-editing, the `POST /{id}/reset` revert action/UI.
+- **Risk:** template `config` shape drift vs `types.ts` → blank widgets. Task 7 Step 1 is the explicit guard.


### PR DESCRIPTION
Makes the Reports v2 surface actually usable. It shipped behind FEATURE_REPORTS_V2 but was too complex to produce a report. Spec: specs/2026-06-01-reports-simplify-and-complete.md

## Templates
- 3 starter templates as code fixtures + GET /api/v1/reports/templates (per-request date windows)
- One-click "Use template" instantiates a private report via the existing create endpoint

## Editor controls
- Reports open in View mode; Edit reveals Add widget / Save (enabled only when changed) / Cancel (only when changed) / Done; fixed the non-working View toggle
- Delete report (canvas header + list cards, owner-gated)
- Version history (max 5, Original pinned, auto-snapshot on Save) via a new report_versions table, replacing the original_* columns and the /reset internals; History panel with per-version Restore

## Charts and tables
- Bar widgets can break down by a secondary dimension (e.g. Account) as stacked segments with per-value colors and a legend
- Table widget grand-total row (sum/count; placeholder for non-additive aggregations)

## Usability
- New blank report seeds a starter widget and shows a clearer empty state
- Reports account filter excludes deactivated accounts

Migrations: 063 (snapshot columns, later superseded), 064 (report_versions). FEATURE_REPORTS_V2 stays gated in prod until sign-off.