### PR TITLE
feat(categories): delete-with-reassign single-delete UX + migrate rules

### DIFF
--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -66,6 +66,8 @@ class CategoryDeleteResult(BaseModel):
     migrated_transaction_count: int = 0
     migrated_recurring_count: int = 0
     migrated_forecast_item_count: int = 0
+    migrated_rule_count: int = 0
+    # Source rules dropped as duplicates of a rule the target already owned.
     deleted_rule_count: int = 0
 
 

--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -1123,6 +1123,31 @@ def _check_target_compatibility_for_delete(
         )
 
 
+def _partition_rules_for_migration(
+    source_rules: list[CategoryRule], *, target_tokens: set[str],
+) -> tuple[list[CategoryRule], list[CategoryRule]]:
+    """Partition a source category's rules for delete-with-migration.
+
+    ``category_rules`` is unique per org on ``normalized_token``. When a
+    source rule's token is already owned by the target, the target is the
+    surviving category: its rule wins and the source's is dropped. All other
+    source rules re-point to the target.
+
+    Returns ``(to_migrate, to_drop)``. ``target_tokens`` is the set of
+    tokens the target already owns; it is treated as authoritative.
+    """
+    to_migrate: list[CategoryRule] = []
+    to_drop: list[CategoryRule] = []
+    seen = set(target_tokens)
+    for rule in source_rules:
+        if rule.normalized_token in seen:
+            to_drop.append(rule)
+        else:
+            to_migrate.append(rule)
+            seen.add(rule.normalized_token)
+    return to_migrate, to_drop
+
+
 async def delete_category_with_migration(
     db: AsyncSession,
     *,
@@ -1254,14 +1279,38 @@ async def delete_category_with_migration(
         .values(category_id=target.id)
     )
 
-    # Delete category_rules pointing at the source (mirrors the existing
-    # router behavior).
-    rule_deleted = await db.execute(
-        delete(CategoryRule).where(CategoryRule.category_id == cat.id)
+    # Re-point the source's learned auto-categorization rules to the target
+    # so removing a category does not silently drop its learning state.
+    # ``category_rules`` is unique per org on ``normalized_token`` (see
+    # uq_category_rules_org_token). For any source rule whose token the
+    # target already owns, the target is the surviving category: keep its
+    # rule and drop the source's. Re-point the rest. This runs in the same
+    # transaction as the transaction/recurring/forecast migration above.
+    source_rules = (await db.scalars(
+        select(CategoryRule).where(CategoryRule.category_id == cat.id)
+    )).all()
+    target_tokens = set((await db.scalars(
+        select(CategoryRule.normalized_token).where(
+            CategoryRule.category_id == target.id,
+        )
+    )).all())
+    to_migrate, to_drop = _partition_rules_for_migration(
+        source_rules, target_tokens=target_tokens,
     )
+    for rule in to_migrate:
+        rule.category_id = target.id
+    for rule in to_drop:
+        # Collision: target already has a rule for this token; keep it,
+        # drop the source's duplicate.
+        await db.delete(rule)
+    migrated_rules = len(to_migrate)
+    dropped_rules = len(to_drop)
+    await db.flush()
 
     # Delete the source's Budget row, if any (section 5: both delete paths
-    # delete the source's Budget row to avoid orphans).
+    # delete the source's Budget row to avoid orphans). Budgets are NOT
+    # migrated to the target; this is intentional, pending a separate
+    # decision on how to merge per-period budget rows across categories.
     await db.execute(
         delete(Budget).where(
             Budget.org_id == org_id,
@@ -1275,7 +1324,6 @@ async def delete_category_with_migration(
     migrated_tx = tx_updated.rowcount or 0
     migrated_rec = rec_updated.rowcount or 0
     migrated_fpi = fpi_updated.rowcount or 0
-    deleted_rules = rule_deleted.rowcount or 0
 
     audit_service.add_audit_event_to_session(
         db,
@@ -1297,7 +1345,8 @@ async def delete_category_with_migration(
             "migrated_transaction_count": migrated_tx,
             "migrated_recurring_count": migrated_rec,
             "migrated_forecast_item_count": migrated_fpi,
-            "deleted_rule_count": deleted_rules,
+            "migrated_rule_count": migrated_rules,
+            "deleted_rule_count": dropped_rules,
         },
     )
 
@@ -1308,6 +1357,8 @@ async def delete_category_with_migration(
         migrated_transaction_count=migrated_tx,
         migrated_recurring_count=migrated_rec,
         migrated_forecast_item_count=migrated_fpi,
+        migrated_rule_count=migrated_rules,
+        deleted_rule_count=dropped_rules,
     )
 
     return CategoryDeleteResult(
@@ -1316,7 +1367,8 @@ async def delete_category_with_migration(
         migrated_transaction_count=migrated_tx,
         migrated_recurring_count=migrated_rec,
         migrated_forecast_item_count=migrated_fpi,
-        deleted_rule_count=deleted_rules,
+        migrated_rule_count=migrated_rules,
+        deleted_rule_count=dropped_rules,
     ), True
 
 

--- a/backend/tests/routers/test_categories_c0.py
+++ b/backend/tests/routers/test_categories_c0.py
@@ -517,6 +517,126 @@ async def test_delete_subcategory_also_deletes_source_budget_row(session_factory
         assert gone is None
 
 
+# --- Delete-with-migration re-points category_rules ------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_with_target_migrates_category_rules(session_factory):
+    """A source category's learned rules re-point to the target on
+    delete-with-migration instead of being dropped."""
+    seed = await _seed_basic(session_factory)
+    # Force dependents so a target is required.
+    await _add_transaction(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["account_id"],
+        category_id=seed["groceries_id"], tx_type=TransactionType.EXPENSE,
+    )
+    async with session_factory() as db:
+        db.add_all([
+            CategoryRule(
+                org_id=seed["org_id"], normalized_token="LIDL",
+                raw_description_seen="LIDL STORE",
+                category_id=seed["groceries_id"], match_count=3,
+                source=RuleSource.USER_PICK,
+            ),
+            CategoryRule(
+                org_id=seed["org_id"], normalized_token="ALDI",
+                raw_description_seen="ALDI MARKT",
+                category_id=seed["groceries_id"], match_count=2,
+                source=RuleSource.USER_EDIT,
+            ),
+        ])
+        await db.commit()
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.delete(
+            f"/api/v1/categories/{seed['groceries_id']}"
+            f"?target_category_id={seed['restaurants_id']}"
+        )
+    assert resp.status_code == 200, resp.text
+
+    async with session_factory() as db:
+        rules = (await db.scalars(
+            select(CategoryRule).where(CategoryRule.org_id == seed["org_id"])
+        )).all()
+        # Both rules survived and now point at the target.
+        assert len(rules) == 2
+        assert {r.normalized_token for r in rules} == {"LIDL", "ALDI"}
+        assert all(r.category_id == seed["restaurants_id"] for r in rules)
+
+
+@pytest.mark.asyncio
+async def test_delete_migrates_rules_alongside_targets_existing_rules(
+    session_factory,
+):
+    """A source rule re-points cleanly even when the target already owns its
+    own (distinct-token) rules; nothing the target had is disturbed."""
+    seed = await _seed_basic(session_factory)
+    await _add_transaction(
+        session_factory,
+        org_id=seed["org_id"], account_id=seed["account_id"],
+        category_id=seed["groceries_id"], tx_type=TransactionType.EXPENSE,
+    )
+    async with session_factory() as db:
+        db.add_all([
+            CategoryRule(
+                org_id=seed["org_id"], normalized_token="DINER",
+                raw_description_seen="DINER X",
+                category_id=seed["restaurants_id"], match_count=4,
+                source=RuleSource.USER_EDIT,
+            ),
+            CategoryRule(
+                org_id=seed["org_id"], normalized_token="ALDI",
+                raw_description_seen="ALDI MARKT",
+                category_id=seed["groceries_id"], match_count=2,
+                source=RuleSource.USER_PICK,
+            ),
+        ])
+        await db.commit()
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        resp = client.delete(
+            f"/api/v1/categories/{seed['groceries_id']}"
+            f"?target_category_id={seed['restaurants_id']}"
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["migrated_rule_count"] == 1
+
+    async with session_factory() as db:
+        rules = (await db.scalars(
+            select(CategoryRule).where(CategoryRule.org_id == seed["org_id"])
+        )).all()
+        assert {r.normalized_token for r in rules} == {"DINER", "ALDI"}
+        assert all(r.category_id == seed["restaurants_id"] for r in rules)
+
+
+def test_partition_rules_for_migration_dedupes_colliding_token():
+    """Unit-test of the dedupe decision: a source rule whose token the
+    target already owns is dropped (the target is the survivor); the rest
+    re-point.
+
+    ``category_rules`` is unique on ``(org_id, normalized_token)`` org-wide,
+    so this collision cannot be persisted in the DB, but the partition guards
+    against it defensively. Verified here as a pure unit."""
+    from app.services.category_service import _partition_rules_for_migration
+
+    colliding = CategoryRule(
+        org_id=1, normalized_token="LIDL", raw_description_seen="LIDL SRC",
+        category_id=10, match_count=9, source=RuleSource.USER_PICK,
+    )
+    distinct = CategoryRule(
+        org_id=1, normalized_token="ALDI", raw_description_seen="ALDI",
+        category_id=10, match_count=2, source=RuleSource.USER_PICK,
+    )
+    to_migrate, to_drop = _partition_rules_for_migration(
+        [colliding, distinct], target_tokens={"LIDL"},
+    )
+    assert to_migrate == [distinct]
+    assert to_drop == [colliding]
+
+
 # --- Section 4.6 BOTH-source migration target compatibility ---------------
 
 

--- a/frontend/app/categories/page.tsx
+++ b/frontend/app/categories/page.tsx
@@ -15,6 +15,7 @@ import AddMasterWithSubsModal from "@/components/ui/AddMasterWithSubsModal";
 import BatchActionBar from "@/components/categories/BatchActionBar";
 import BatchMoveModal from "@/components/categories/BatchMoveModal";
 import BatchDeleteModal from "@/components/categories/BatchDeleteModal";
+import SingleDeleteModal from "@/components/categories/SingleDeleteModal";
 import DraggableSubcategoryRow from "@/components/categories/DraggableSubcategoryRow";
 import MasterDropZone from "@/components/categories/MasterDropZone";
 import DragMoveConfirmModal from "@/components/categories/DragMoveConfirmModal";
@@ -274,15 +275,6 @@ export default function CategoriesPage() {
         }),
       });
       setEditingCatId(null);
-      await reload();
-    } catch (err) { setError(extractErrorMessage(err)); }
-  }
-
-  async function handleDelete(id: number) {
-    setConfirmDeleteId(null);
-    setError("");
-    try {
-      await apiFetch(`/api/v1/categories/${id}`, { method: "DELETE" });
       await reload();
     } catch (err) { setError(extractErrorMessage(err)); }
   }
@@ -679,14 +671,20 @@ export default function CategoriesPage() {
         </DragOverlay>
         </DndContext>
       )}
-      <ConfirmModal
-        open={confirmDeleteId !== null}
-        title="Delete Category"
-        message="Delete this category?"
-        confirmLabel="Delete"
-        variant="danger"
-        onConfirm={() => confirmDeleteId !== null && handleDelete(confirmDeleteId)}
+      <SingleDeleteModal
+        category={
+          confirmDeleteId !== null
+            ? categories.find((c) => c.id === confirmDeleteId) ?? null
+            : null
+        }
+        categories={categories}
         onCancel={() => setConfirmDeleteId(null)}
+        onSuccess={async () => {
+          // Reload FIRST so a refresh failure surfaces inside the modal's
+          // refresh-error banner before the modal closes.
+          await reload();
+          setConfirmDeleteId(null);
+        }}
       />
 
       {/* C2c: batch select infrastructure. Owned by Team Categories C2 UI. */}

--- a/frontend/components/categories/BatchDeleteModal.tsx
+++ b/frontend/components/categories/BatchDeleteModal.tsx
@@ -1,26 +1,16 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { apiFetch, ApiResponseError, extractErrorMessage } from "@/lib/api";
+import { apiFetch } from "@/lib/api";
 import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
 import { btnDangerSolid, btnSecondary, input } from "@/lib/styles";
 import type { Category } from "@/lib/types";
-
-interface CategoryDeleteResult {
-  deleted_category_id: number;
-  migration_target_id: number | null;
-  migrated_transaction_count: number;
-  migrated_recurring_count: number;
-  migrated_forecast_item_count: number;
-  deleted_rule_count: number;
-}
-
-interface FailureRow {
-  category_id: number;
-  category_name: string;
-  reason: string;
-  reason_code?: string;
-}
+import {
+  buildFailure,
+  compatibleTargets as compatibleTargetsFor,
+  type CategoryDeleteResult,
+  type FailureRow,
+} from "@/components/categories/categoryDeleteHelpers";
 
 interface Props {
   open: boolean;
@@ -147,14 +137,7 @@ export default function BatchDeleteModal({
   // about to be deleted as the migration target).
   function compatibleTargets(sub: Category): Category[] {
     const otherSelected = new Set(rowsToShow.map((s) => s.id));
-    return categories.filter((c) => {
-      if (c.id === sub.id) return false;
-      if (c.parent_id !== null) return false;
-      if (otherSelected.has(c.id)) return false;
-      if (sub.type === "income") return c.type === "income" || c.type === "both";
-      if (sub.type === "expense") return c.type === "expense" || c.type === "both";
-      return c.type === "both";
-    });
+    return compatibleTargetsFor(sub, categories, otherSelected);
   }
 
   // Submit is gated on every row having a migration target picked.
@@ -392,75 +375,3 @@ export default function BatchDeleteModal({
   );
 }
 
-interface CategoryErrorDetail {
-  detail?: string;
-  conflicting_child_name?: string;
-  scope?: string;
-  type?: string;
-  child_names?: string[];
-  source_type?: string;
-  target_type?: string;
-  dependent_breakdown?: { income: number; expense: number };
-}
-
-function buildFailure(sub: Category, err: unknown): FailureRow {
-  if (err instanceof ApiResponseError) {
-    const detail = err.detail as CategoryErrorDetail | string | undefined;
-    if (typeof detail === "object" && detail !== null) {
-      if (detail.detail === "last_in_type") {
-        return {
-          category_id: sub.id,
-          category_name: sub.name,
-          reason: `Cannot delete the only ${detail.type ?? ""} ${detail.scope ?? "subcategory"}.`,
-          reason_code: "last_in_type",
-        };
-      }
-      if (detail.detail === "has_children") {
-        const sample = detail.child_names?.[0] ?? "subcategory";
-        const more = (detail.child_names?.length ?? 0) - 1;
-        return {
-          category_id: sub.id,
-          category_name: sub.name,
-          reason: `Has subcategories. Move or delete "${sample}"${
-            more > 0 ? ` and ${more} other${more === 1 ? "" : "s"}` : ""
-          } first.`,
-          reason_code: "has_children",
-        };
-      }
-      if (detail.detail === "type_mismatch") {
-        return {
-          category_id: sub.id,
-          category_name: sub.name,
-          reason: `Migration target type ${detail.target_type ?? ""} is not compatible with ${detail.source_type ?? "source"}.`,
-          reason_code: "type_mismatch",
-        };
-      }
-      if (detail.detail === "name_collision") {
-        return {
-          category_id: sub.id,
-          category_name: sub.name,
-          reason: `Name collision: "${detail.conflicting_child_name ?? sub.name}" already exists on the target.`,
-          reason_code: "name_collision",
-        };
-      }
-      if (detail.detail === "migration_target_required") {
-        return {
-          category_id: sub.id,
-          category_name: sub.name,
-          reason: `Migration target required.`,
-          reason_code: "migration_target_required",
-        };
-      }
-    }
-    return {
-      category_id: sub.id,
-      category_name: sub.name,
-      reason: err.message || "Delete failed",
-    };
-  }
-  return {
-    category_id: sub.id,
-    category_name: sub.name,
-    reason: extractErrorMessage(err, "Delete failed"),
-  };
-}

--- a/frontend/components/categories/SingleDeleteModal.tsx
+++ b/frontend/components/categories/SingleDeleteModal.tsx
@@ -102,6 +102,7 @@ export default function SingleDeleteModal({
   );
 
   const targetPicked = target !== "" && target !== 0;
+  const noTargetAvailable = needsTarget && targets.length === 0;
 
   async function runRefresh() {
     setRefreshError("");
@@ -188,30 +189,40 @@ export default function SingleDeleteModal({
               This category has transactions, recurring templates, or forecast
               plan items. Pick a category to reassign them to.
             </p>
-            <div className="mt-4">
-              <label
-                htmlFor="single-delete-target"
-                className="mb-1 block text-xs text-text-muted"
+            {noTargetAvailable ? (
+              <p
+                data-testid="single-delete-no-target"
+                className="mt-4 rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
               >
-                Reassign to
-              </label>
-              <select
-                id="single-delete-target"
-                data-testid="single-delete-target"
-                value={target}
-                onChange={(e) =>
-                  setTarget(e.target.value === "" ? "" : Number(e.target.value))
-                }
-                className={input}
-              >
-                <option value="">Select a master...</option>
-                {targets.map((t) => (
-                  <option key={t.id} value={t.id}>
-                    {t.name} ({t.type})
-                  </option>
-                ))}
-              </select>
-            </div>
+                No compatible category is available to reassign to. Create a
+                same-type master category first, then delete this one.
+              </p>
+            ) : (
+              <div className="mt-4">
+                <label
+                  htmlFor="single-delete-target"
+                  className="mb-1 block text-xs text-text-muted"
+                >
+                  Reassign to
+                </label>
+                <select
+                  id="single-delete-target"
+                  data-testid="single-delete-target"
+                  value={target}
+                  onChange={(e) =>
+                    setTarget(e.target.value === "" ? "" : Number(e.target.value))
+                  }
+                  className={input}
+                >
+                  <option value="">Select a master...</option>
+                  {targets.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.name} ({t.type})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
           </>
         ) : (
           <p className="mt-1 text-sm text-text-secondary">

--- a/frontend/components/categories/SingleDeleteModal.tsx
+++ b/frontend/components/categories/SingleDeleteModal.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { apiFetch } from "@/lib/api";
+import { useFocusTrap } from "@/lib/hooks/use-focus-trap";
+import { btnDangerSolid, btnSecondary, input } from "@/lib/styles";
+import type { Category } from "@/lib/types";
+import {
+  buildFailure,
+  compatibleTargets,
+  isMigrationTargetRequired,
+  type CategoryDeleteResult,
+  type FailureRow,
+} from "@/components/categories/categoryDeleteHelpers";
+
+interface Props {
+  /** The category to delete, or null when the modal is closed. */
+  category: Category | null;
+  categories: Category[];
+  onCancel: () => void;
+  /** Awaited after a successful delete so a refresh failure surfaces inline. */
+  onSuccess: () => void | Promise<void>;
+}
+
+/**
+ * Single-category delete with inline reassign.
+ *
+ * Mirrors the C0 delete contract the way BatchDeleteModal does, but for one
+ * category at a time:
+ * - If the category has dependents (we can pre-detect transactions via
+ *   ``transaction_count``; recurring/forecast dependents are detected lazily
+ *   by the backend's 422 ``migration_target_required``), show a migration
+ *   target picker and pass ``target_category_id``.
+ * - If it has no dependents, delete directly (the backend takes the 204 path).
+ * - When a direct delete returns 422 ``migration_target_required`` (recurring
+ *   or forecast dependents the client could not see), flip to the picker and
+ *   let the user choose a target, then retry.
+ *
+ * Guard errors (has_children, last_in_type, type_mismatch, name_collision)
+ * reuse the same human-readable mapping as the batch flow.
+ */
+export default function SingleDeleteModal({
+  category,
+  categories,
+  onCancel,
+  onSuccess,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const [target, setTarget] = useState<number | "">("");
+  const [needsTarget, setNeedsTarget] = useState(false);
+  const [failure, setFailure] = useState<FailureRow | null>(null);
+  const [refreshError, setRefreshError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const open = category !== null;
+
+  // A subcategory with transactions definitely has dependents; show the
+  // picker upfront. Masters and zero-transaction subs try the direct path
+  // first and fall back to the picker on a 422.
+  const hasKnownDependents = (category?.transaction_count ?? 0) > 0;
+
+  useEffect(() => {
+    if (open) {
+      setTarget("");
+      setNeedsTarget(hasKnownDependents);
+      setFailure(null);
+      setRefreshError("");
+      setSubmitting(false);
+    }
+  }, [open, hasKnownDependents]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  useFocusTrap({
+    active: open,
+    containerRef: dialogRef,
+    initialFocusRef: cancelRef,
+  });
+
+  const targets = useMemo(
+    () => (category ? compatibleTargets(category, categories) : []),
+    [category, categories],
+  );
+
+  const targetPicked = target !== "" && target !== 0;
+
+  async function runRefresh() {
+    setRefreshError("");
+    try {
+      await onSuccess();
+    } catch (err) {
+      setRefreshError(
+        err instanceof Error
+          ? `Delete completed but the page failed to refresh: ${err.message}`
+          : "Delete completed but the page failed to refresh.",
+      );
+    }
+  }
+
+  async function handleConfirm() {
+    if (!category) return;
+    if (needsTarget && !targetPicked) {
+      setFailure({
+        category_id: category.id,
+        category_name: category.name,
+        reason: "Pick a migration target for this category.",
+        reason_code: "migration_target_required",
+      });
+      return;
+    }
+
+    setSubmitting(true);
+    setFailure(null);
+    setRefreshError("");
+
+    const path =
+      needsTarget && targetPicked
+        ? `/api/v1/categories/${category.id}?target_category_id=${target}`
+        : `/api/v1/categories/${category.id}`;
+
+    try {
+      await apiFetch<CategoryDeleteResult | undefined>(path, { method: "DELETE" });
+      setSubmitting(false);
+      await runRefresh();
+    } catch (err) {
+      setSubmitting(false);
+      // Lazy dependent detection: a direct delete that the backend rejects
+      // with migration_target_required means recurring/forecast dependents
+      // exist the client could not see. Flip to the picker instead of
+      // surfacing a dead-end error.
+      if (!needsTarget && isMigrationTargetRequired(err)) {
+        setNeedsTarget(true);
+        setFailure(null);
+        return;
+      }
+      setFailure(buildFailure(category, err));
+    }
+  }
+
+  if (!open || !category) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 p-4"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="single-delete-title"
+        data-testid="single-delete-modal"
+        className="w-full max-w-[min(32rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-surface p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          id="single-delete-title"
+          className="text-lg font-semibold text-text-primary"
+        >
+          Delete {category.name}
+        </h3>
+
+        {needsTarget ? (
+          <>
+            <p
+              data-testid="single-delete-reassign-hint"
+              className="mt-1 text-sm text-text-secondary"
+            >
+              This category has transactions, recurring templates, or forecast
+              plan items. Pick a category to reassign them to.
+            </p>
+            <div className="mt-4">
+              <label
+                htmlFor="single-delete-target"
+                className="mb-1 block text-xs text-text-muted"
+              >
+                Reassign to
+              </label>
+              <select
+                id="single-delete-target"
+                data-testid="single-delete-target"
+                value={target}
+                onChange={(e) =>
+                  setTarget(e.target.value === "" ? "" : Number(e.target.value))
+                }
+                className={input}
+              >
+                <option value="">Select a master...</option>
+                {targets.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name} ({t.type})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </>
+        ) : (
+          <p className="mt-1 text-sm text-text-secondary">
+            Delete this category?
+          </p>
+        )}
+
+        {failure && (
+          <p data-testid="single-delete-failure" className="mt-3 text-xs text-danger">
+            {failure.reason}
+          </p>
+        )}
+
+        {refreshError && (
+          <div
+            data-testid="single-delete-refresh-error"
+            role="alert"
+            className="mt-4 flex items-center justify-between gap-3 rounded-md bg-danger-dim px-4 py-3 text-sm text-danger"
+          >
+            <span>{refreshError}</span>
+            <button
+              type="button"
+              data-testid="single-delete-refresh-retry"
+              onClick={() => void runRefresh()}
+              className="rounded-md border border-danger/40 px-3 py-1 text-xs font-medium text-danger hover:bg-danger/10"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className={`${btnSecondary} w-full sm:w-auto min-h-[44px]`}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="single-delete-confirm"
+            onClick={handleConfirm}
+            disabled={submitting || (needsTarget && !targetPicked)}
+            className={`${btnDangerSolid} w-full sm:w-auto min-h-[44px]`}
+          >
+            {submitting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/categories/categoryDeleteHelpers.ts
+++ b/frontend/components/categories/categoryDeleteHelpers.ts
@@ -1,0 +1,134 @@
+import { ApiResponseError, extractErrorMessage } from "@/lib/api";
+import type { Category } from "@/lib/types";
+
+export interface FailureRow {
+  category_id: number;
+  category_name: string;
+  reason: string;
+  reason_code?: string;
+}
+
+export interface CategoryDeleteResult {
+  deleted_category_id: number;
+  migration_target_id: number | null;
+  migrated_transaction_count: number;
+  migrated_recurring_count: number;
+  migrated_forecast_item_count: number;
+  migrated_rule_count: number;
+  deleted_rule_count: number;
+}
+
+interface CategoryErrorDetail {
+  detail?: string;
+  conflicting_child_name?: string;
+  scope?: string;
+  type?: string;
+  child_names?: string[];
+  source_type?: string;
+  target_type?: string;
+  dependent_breakdown?: { income: number; expense: number };
+}
+
+/**
+ * Compatible migration targets for a subcategory, mirroring the backend
+ * rule at ``_check_target_compatibility_for_delete``: INCOME source -> INCOME
+ * or BOTH master; EXPENSE source -> EXPENSE or BOTH master; BOTH source ->
+ * BOTH master (the safe default for the breakdown-driven backend rule).
+ *
+ * ``excludeIds`` lets callers drop other rows about to be deleted (batch
+ * flow) so the user cannot pick a soon-to-be-gone category as the target.
+ * Masters only (parent_id === null); the source itself is always excluded.
+ */
+export function compatibleTargets(
+  sub: Category,
+  categories: Category[],
+  excludeIds: Set<number> = new Set(),
+): Category[] {
+  return categories.filter((c) => {
+    if (c.id === sub.id) return false;
+    if (c.parent_id !== null) return false;
+    if (excludeIds.has(c.id)) return false;
+    if (sub.type === "income") return c.type === "income" || c.type === "both";
+    if (sub.type === "expense") return c.type === "expense" || c.type === "both";
+    return c.type === "both";
+  });
+}
+
+/**
+ * Map a delete failure (typically a 409/422 from the C0 delete contract)
+ * to a human-readable reason. Shared by the batch- and single-delete flows
+ * so the messaging stays identical: has_children, last_in_type, type_mismatch,
+ * name_collision, migration_target_required.
+ */
+export function buildFailure(sub: Category, err: unknown): FailureRow {
+  if (err instanceof ApiResponseError) {
+    const detail = err.detail as CategoryErrorDetail | string | undefined;
+    if (typeof detail === "object" && detail !== null) {
+      if (detail.detail === "last_in_type") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Cannot delete the only ${detail.type ?? ""} ${detail.scope ?? "subcategory"}.`,
+          reason_code: "last_in_type",
+        };
+      }
+      if (detail.detail === "has_children") {
+        const sample = detail.child_names?.[0] ?? "subcategory";
+        const more = (detail.child_names?.length ?? 0) - 1;
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Has subcategories. Move or delete "${sample}"${
+            more > 0 ? ` and ${more} other${more === 1 ? "" : "s"}` : ""
+          } first.`,
+          reason_code: "has_children",
+        };
+      }
+      if (detail.detail === "type_mismatch") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Migration target type ${detail.target_type ?? ""} is not compatible with ${detail.source_type ?? "source"}.`,
+          reason_code: "type_mismatch",
+        };
+      }
+      if (detail.detail === "name_collision") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Name collision: "${detail.conflicting_child_name ?? sub.name}" already exists on the target.`,
+          reason_code: "name_collision",
+        };
+      }
+      if (detail.detail === "migration_target_required") {
+        return {
+          category_id: sub.id,
+          category_name: sub.name,
+          reason: `Migration target required.`,
+          reason_code: "migration_target_required",
+        };
+      }
+    }
+    return {
+      category_id: sub.id,
+      category_name: sub.name,
+      reason: err.message || "Delete failed",
+    };
+  }
+  return {
+    category_id: sub.id,
+    category_name: sub.name,
+    reason: extractErrorMessage(err, "Delete failed"),
+  };
+}
+
+/** Whether an ApiResponseError is the 422 migration_target_required signal. */
+export function isMigrationTargetRequired(err: unknown): boolean {
+  if (!(err instanceof ApiResponseError)) return false;
+  const detail = err.detail as CategoryErrorDetail | string | undefined;
+  return (
+    typeof detail === "object" &&
+    detail !== null &&
+    detail.detail === "migration_target_required"
+  );
+}

--- a/frontend/components/categories/categoryDeleteHelpers.ts
+++ b/frontend/components/categories/categoryDeleteHelpers.ts
@@ -65,10 +65,13 @@ export function buildFailure(sub: Category, err: unknown): FailureRow {
     const detail = err.detail as CategoryErrorDetail | string | undefined;
     if (typeof detail === "object" && detail !== null) {
       if (detail.detail === "last_in_type") {
+        const what = [detail.type, detail.scope].filter(Boolean).join(" ");
         return {
           category_id: sub.id,
           category_name: sub.name,
-          reason: `Cannot delete the only ${detail.type ?? ""} ${detail.scope ?? "subcategory"}.`,
+          reason: what
+            ? `Cannot delete the only ${what}.`
+            : `Cannot delete the only category of its type.`,
           reason_code: "last_in_type",
         };
       }
@@ -85,10 +88,13 @@ export function buildFailure(sub: Category, err: unknown): FailureRow {
         };
       }
       if (detail.detail === "type_mismatch") {
+        const haveTypes = detail.target_type && detail.source_type;
         return {
           category_id: sub.id,
           category_name: sub.name,
-          reason: `Migration target type ${detail.target_type ?? ""} is not compatible with ${detail.source_type ?? "source"}.`,
+          reason: haveTypes
+            ? `Migration target type ${detail.target_type} is not compatible with ${detail.source_type}.`
+            : `Migration target type is not compatible with this category.`,
           reason_code: "type_mismatch",
         };
       }

--- a/frontend/tests/app/categories-single-delete-reassign.test.tsx
+++ b/frontend/tests/app/categories-single-delete-reassign.test.tsx
@@ -1,0 +1,318 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import CategoriesPage from "@/app/categories/page";
+import { apiFetch, ApiResponseError } from "@/lib/api";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+vi.mock("@/components/auth/AuthProvider", async () => {
+  const actual = await vi.importActual<typeof import("@/components/auth/AuthProvider")>(
+    "@/components/auth/AuthProvider",
+  );
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const stableRouter = { push: vi.fn(), replace: vi.fn() };
+vi.mock("next/navigation", () => ({
+  useRouter: () => stableRouter,
+  usePathname: () => "/categories",
+}));
+
+const USER = {
+  id: 1,
+  username: "u",
+  email: "u@x.io",
+  first_name: null,
+  last_name: null,
+  phone: null,
+  avatar_url: null,
+  email_verified: true,
+  role: "owner",
+  org_id: 1,
+  org_name: "Acme",
+  billing_cycle_day: 1,
+  is_superadmin: false,
+  is_active: true,
+  mfa_enabled: false,
+  subscription_status: null,
+  subscription_plan: null,
+  trial_end: null,
+};
+
+const CATEGORIES = [
+  {
+    id: 100,
+    name: "Food",
+    slug: "food_dining",
+    parent_id: null,
+    parent_name: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+  {
+    id: 101,
+    name: "Restaurants",
+    slug: null,
+    parent_id: 100,
+    parent_name: "Food",
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 5, // has transactions -> picker upfront
+  },
+  {
+    id: 102,
+    name: "Groceries",
+    slug: null,
+    parent_id: 100,
+    parent_name: "Food",
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 0, // no dependents -> direct delete
+  },
+  {
+    id: 200,
+    name: "Lifestyle",
+    slug: "lifestyle",
+    parent_id: null,
+    parent_name: null,
+    type: "expense" as const,
+    is_system: true,
+    description: null,
+    transaction_count: 0,
+  },
+  {
+    id: 201,
+    name: "Entertainment",
+    slug: null,
+    parent_id: 200,
+    parent_name: "Lifestyle",
+    type: "expense" as const,
+    is_system: false,
+    description: null,
+    transaction_count: 0,
+  },
+];
+
+function setupApi(handlers: Record<string, (init?: RequestInit) => unknown> = {}) {
+  vi.mocked(apiFetch).mockImplementation(((url: string, init?: RequestInit) => {
+    if (url === "/api/v1/categories" && (!init || init.method === undefined)) {
+      return Promise.resolve(CATEGORIES);
+    }
+    if (handlers[url]) {
+      const result = handlers[url](init);
+      return result instanceof Promise ? result : Promise.resolve(result);
+    }
+    const noQuery = url.split("?")[0];
+    if (handlers[noQuery]) {
+      const result = handlers[noQuery](init);
+      return result instanceof Promise ? result : Promise.resolve(result);
+    }
+    return Promise.resolve({});
+  }) as never);
+}
+
+function authReturn() {
+  return {
+    user: USER as never,
+    loading: false,
+    needsSetup: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshMe: vi.fn(),
+  } as never;
+}
+
+describe("CategoriesPage - single delete with reassign", () => {
+  beforeEach(() => {
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(useAuth).mockReturnValue(authReturn());
+  });
+
+  it("deleting a subcategory with transactions opens the picker and passes target_category_id", async () => {
+    const deleteCalls: string[] = [];
+    setupApi({
+      "/api/v1/categories/101": () => {
+        // Should never be called WITHOUT a target for a tx-bearing category.
+        deleteCalls.push("no-target");
+        return Promise.reject(
+          new ApiResponseError(422, "migration target required", undefined, {
+            detail: "migration_target_required",
+          }),
+        );
+      },
+      "/api/v1/categories/101?target_category_id=200": (init) => {
+        deleteCalls.push("with-target");
+        expect(init?.method).toBe("DELETE");
+        return {
+          deleted_category_id: 101,
+          migration_target_id: 200,
+          migrated_transaction_count: 5,
+          migrated_recurring_count: 0,
+          migrated_forecast_item_count: 0,
+          migrated_rule_count: 0,
+          deleted_rule_count: 0,
+        };
+      },
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Restaurants")).toBeInTheDocument());
+
+    // Click the per-row Delete for Restaurants (id 101).
+    fireEvent.click(screen.getByLabelText("Delete Restaurants"));
+
+    // Picker is shown upfront because transaction_count > 0.
+    expect(await screen.findByTestId("single-delete-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("single-delete-target")).toBeInTheDocument();
+
+    // Confirm is disabled until a target is picked.
+    expect(screen.getByTestId("single-delete-confirm")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("single-delete-target"), {
+      target: { value: "200" },
+    });
+    fireEvent.click(screen.getByTestId("single-delete-confirm"));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("single-delete-modal")).not.toBeInTheDocument(),
+    );
+    // DELETE issued exactly once, with the target.
+    expect(deleteCalls).toEqual(["with-target"]);
+  });
+
+  it("deleting a no-dependent subcategory deletes directly without a picker", async () => {
+    const calls: string[] = [];
+    setupApi({
+      "/api/v1/categories/102": (init) => {
+        calls.push(`delete:${init?.method}`);
+        return undefined; // 204
+      },
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Delete Groceries"));
+
+    expect(await screen.findByTestId("single-delete-modal")).toBeInTheDocument();
+    // No picker for a zero-dependent category.
+    expect(screen.queryByTestId("single-delete-target")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("single-delete-confirm"));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("single-delete-modal")).not.toBeInTheDocument(),
+    );
+    expect(calls).toEqual(["delete:DELETE"]);
+  });
+
+  it("a direct delete that returns migration_target_required flips to the picker", async () => {
+    let phase = 0;
+    setupApi({
+      "/api/v1/categories/102": () => {
+        phase += 1;
+        // First (no-target) call -> backend says a target is required
+        // (recurring/forecast dependents the client could not see).
+        return Promise.reject(
+          new ApiResponseError(422, "migration target required", undefined, {
+            detail: "migration_target_required",
+          }),
+        );
+      },
+      "/api/v1/categories/102?target_category_id=200": () => ({
+        deleted_category_id: 102,
+        migration_target_id: 200,
+        migrated_transaction_count: 0,
+        migrated_recurring_count: 1,
+        migrated_forecast_item_count: 0,
+        migrated_rule_count: 0,
+        deleted_rule_count: 0,
+      }),
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Delete Groceries"));
+    expect(await screen.findByTestId("single-delete-modal")).toBeInTheDocument();
+    // No picker initially (transaction_count === 0).
+    expect(screen.queryByTestId("single-delete-target")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("single-delete-confirm"));
+
+    // Backend 422 flips to the picker without a dead-end error.
+    expect(await screen.findByTestId("single-delete-target")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("single-delete-target"), {
+      target: { value: "200" },
+    });
+    fireEvent.click(screen.getByTestId("single-delete-confirm"));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("single-delete-modal")).not.toBeInTheDocument(),
+    );
+    expect(phase).toBe(1); // the no-target attempt fired exactly once
+  });
+
+  it("a has_children 409 shows the human-readable guard message", async () => {
+    setupApi({
+      "/api/v1/categories/100": () =>
+        Promise.reject(
+          new ApiResponseError(409, "has children", undefined, {
+            detail: "has_children",
+            child_names: ["Restaurants", "Groceries"],
+          }),
+        ),
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Food")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Delete Food"));
+    expect(await screen.findByTestId("single-delete-modal")).toBeInTheDocument();
+    // Master, transaction_count 0 -> tries direct delete.
+    fireEvent.click(screen.getByTestId("single-delete-confirm"));
+
+    const failure = await screen.findByTestId("single-delete-failure");
+    expect(failure.textContent).toContain("Has subcategories");
+    expect(failure.textContent).toContain("Restaurants");
+    // Modal stays open.
+    expect(screen.getByTestId("single-delete-modal")).toBeInTheDocument();
+  });
+
+  it("a last_in_type 409 shows the floor-invariant message", async () => {
+    setupApi({
+      "/api/v1/categories/102": () =>
+        Promise.reject(
+          new ApiResponseError(409, "last in type", undefined, {
+            detail: "last_in_type",
+            type: "expense",
+            scope: "subcategory",
+          }),
+        ),
+    });
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Delete Groceries"));
+    expect(await screen.findByTestId("single-delete-modal")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("single-delete-confirm"));
+
+    const failure = await screen.findByTestId("single-delete-failure");
+    expect(failure.textContent).toContain("Cannot delete the only expense subcategory");
+  });
+});

--- a/frontend/tests/app/categories-single-delete-reassign.test.tsx
+++ b/frontend/tests/app/categories-single-delete-reassign.test.tsx
@@ -293,6 +293,51 @@ describe("CategoriesPage - single delete with reassign", () => {
     expect(screen.getByTestId("single-delete-modal")).toBeInTheDocument();
   });
 
+  it("shows a no-target-available message when a tx-bearing category has no compatible master", async () => {
+    // Only an income master exists; the expense sub (101) with transactions
+    // has no compatible target, so the picker must explain the dead-end
+    // instead of leaving Delete silently disabled.
+    const incomeOnly = [
+      {
+        id: 300,
+        name: "Income",
+        slug: "income",
+        parent_id: null,
+        parent_name: null,
+        type: "income" as const,
+        is_system: true,
+        description: null,
+        transaction_count: 0,
+      },
+      {
+        id: 301,
+        name: "Salary",
+        slug: null,
+        parent_id: 300,
+        parent_name: "Income",
+        type: "expense" as const,
+        is_system: false,
+        description: null,
+        transaction_count: 4, // has transactions -> picker upfront
+      },
+    ];
+    vi.mocked(apiFetch).mockImplementation(((url: string) => {
+      if (url === "/api/v1/categories") return Promise.resolve(incomeOnly);
+      return Promise.resolve({});
+    }) as never);
+
+    render(<CategoriesPage />);
+    await waitFor(() => expect(screen.getByText("Salary")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Delete Salary"));
+    expect(await screen.findByTestId("single-delete-modal")).toBeInTheDocument();
+    // No compatible master -> explanatory message, confirm stays disabled.
+    expect(
+      await screen.findByTestId("single-delete-no-target"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("single-delete-confirm")).toBeDisabled();
+  });
+
   it("a last_in_type 409 shows the floor-invariant message", async () => {
     setupApi({
       "/api/v1/categories/102": () =>

--- a/frontend/tests/components/category-delete-helpers.test.tsx
+++ b/frontend/tests/components/category-delete-helpers.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiResponseError } from "@/lib/api";
+import {
+  buildFailure,
+  compatibleTargets,
+} from "@/components/categories/categoryDeleteHelpers";
+import type { Category } from "@/lib/types";
+
+const sub: Category = {
+  id: 101,
+  name: "Restaurants",
+  type: "expense",
+  parent_id: 100,
+  parent_name: "Food",
+  description: null,
+  slug: null,
+  is_system: false,
+  transaction_count: 5,
+};
+
+function apiErr(status: number, detail: unknown): ApiResponseError {
+  return new ApiResponseError(status, "x", undefined, detail);
+}
+
+describe("buildFailure message fallbacks", () => {
+  it("last_in_type with type+scope renders the specific message", () => {
+    const f = buildFailure(
+      sub,
+      apiErr(409, { detail: "last_in_type", type: "expense", scope: "subcategory" }),
+    );
+    expect(f.reason).toBe("Cannot delete the only expense subcategory.");
+    expect(f.reason).not.toContain("  ");
+  });
+
+  it("last_in_type without type/scope renders a clean message (no double spaces)", () => {
+    const f = buildFailure(sub, apiErr(409, { detail: "last_in_type" }));
+    expect(f.reason_code).toBe("last_in_type");
+    expect(f.reason).not.toContain("  ");
+    expect(f.reason.trim()).toBe(f.reason);
+    expect(f.reason).toBe("Cannot delete the only category of its type.");
+  });
+
+  it("type_mismatch with types renders the specific message", () => {
+    const f = buildFailure(
+      sub,
+      apiErr(400, {
+        detail: "type_mismatch",
+        source_type: "income",
+        target_type: "expense",
+      }),
+    );
+    expect(f.reason).toContain("expense");
+    expect(f.reason).toContain("income");
+    expect(f.reason).not.toContain("  ");
+  });
+
+  it("type_mismatch without types renders a generic fallback (no blanks)", () => {
+    const f = buildFailure(sub, apiErr(400, { detail: "type_mismatch" }));
+    expect(f.reason_code).toBe("type_mismatch");
+    expect(f.reason).not.toContain("  ");
+    expect(f.reason).toBe(
+      "Migration target type is not compatible with this category.",
+    );
+  });
+});
+
+describe("compatibleTargets", () => {
+  const cats: Category[] = [
+    { id: 100, name: "Food", type: "expense", parent_id: null, parent_name: null, description: null, slug: "food", is_system: true, transaction_count: 0 },
+    { id: 300, name: "Income", type: "income", parent_id: null, parent_name: null, description: null, slug: "income", is_system: true, transaction_count: 0 },
+    { id: 500, name: "Mixed", type: "both", parent_id: null, parent_name: null, description: null, slug: null, is_system: false, transaction_count: 0 },
+    { id: 101, name: "Restaurants", type: "expense", parent_id: 100, parent_name: "Food", description: null, slug: null, is_system: false, transaction_count: 5 },
+  ];
+
+  it("excludes the source, non-masters, and excludeIds; matches by type", () => {
+    const out = compatibleTargets(sub, cats);
+    const ids = out.map((c) => c.id).sort();
+    // expense source -> expense (Food) or both (Mixed) masters
+    expect(ids).toEqual([100, 500]);
+  });
+
+  it("honors excludeIds", () => {
+    const out = compatibleTargets(sub, cats, new Set([100]));
+    expect(out.map((c) => c.id)).toEqual([500]);
+  });
+});

--- a/specs/2026-06-01-category-delete-reassign.md
+++ b/specs/2026-06-01-category-delete-reassign.md
@@ -1,0 +1,42 @@
+# Category delete-with-reassign (single-delete UX) + migrate rules
+
+**Status:** draft for review, 2026-06-01.
+**Source:** product owner is recategorizing all expenses in prod and "category removal is becoming a problem." Investigation verdict below.
+
+## Verdict (current behavior)
+
+The backend already supports delete-with-migration: `delete_category_with_migration` (`backend/app/services/category_service.py:1126`) requires a `target_category_id` when the category has dependents and bulk-moves them, then deletes the source. The pain is:
+
+1. **The frontend single-delete path** (`frontend/app/categories/page.tsx:281`) calls `DELETE` with **no target**, so deleting any category that has transactions returns a bare **422 `migration_target_required`** with no inline way to choose a target — a dead end. (The batch-delete modal does it correctly.)
+2. **Data-loss footgun:** on delete-with-migration the source category's **`category_rules` are deleted, not migrated** (`category_service.py:1259-1261`). Removing a category silently drops its learned auto-categorization, which can re-introduce miscategorization during a recategorization.
+
+## Scope (Option 1 — owner-selected)
+
+Fix the single-delete UX to reassign, and preserve auto-categorization rules. **In scope:**
+
+### Backend — migrate `category_rules` on delete-with-migration
+- In `delete_category_with_migration`, when a `target_category_id` is supplied, **re-point** the source category's `category_rules` to the target instead of deleting them.
+- **Uniqueness handling:** `category_rules` is unique per org on its normalized match key (verify the exact constraint in `backend/app/models/category_rule.py` + its migration). When re-pointing would collide with a rule the target already has for the same key, **keep the target's existing rule and drop the source's** (the target is the surviving category). Do this in the same transaction as the existing transaction/recurring/forecast migration.
+- Everything else in the migration path stays as-is. **Budgets remain deleted** on category removal for now (out of scope — see below); add a one-line code comment noting it's intentional pending a separate decision.
+- Tests: deleting a category with rules + a target migrates the rules (and dedupes against an existing target rule); confirm transactions/recurring/forecast still migrate; confirm the audit event still fires.
+
+### Frontend — inline reassign on single delete
+- On the categories page, when the user deletes a category, **detect whether it has dependents** (transactions/recurring/forecast). If it does, show an **inline migration-target picker** (reuse the picker + type-compatibility filtering already built in `frontend/components/categories/BatchDeleteModal.tsx`) before issuing the delete, and pass `target_category_id`.
+- If the category has **no dependents**, delete directly (no picker) as today.
+- Surface the existing 409 guard errors clearly (don't regress): `has_children` (delete the subcategories first), `last_in_type` (floor invariant), `type_mismatch` (pick a same-type target). Reuse the human-readable reason mapping the batch modal already has.
+- Tests: deleting a category with transactions opens the picker, choosing a target issues `DELETE` with `target_category_id` and succeeds; a no-dependent category deletes without a picker; a `has_children`/`last_in_type` error shows the right message.
+
+## Out of scope (deliberate — possible follow-ups)
+
+- **Merge endpoint** (`POST /categories/{id}/merge`) and **bulk transaction reassignment** on the transactions list — owner chose the minimal scope; these are the natural next phases if removal is still slow.
+- **Master cascade delete** (deleting a master with its children in one go) — still requires deleting/moving children first; unchanged.
+- **Budget migration** on category removal — budgets are still deleted on delete-with-migration. Flagged because it's also silent data loss, but merging per-period budget rows across categories is ambiguous (sum? pick one?); deferred to its own decision.
+- The categories tree pagination/standardization (separate Tables workstream) — unrelated.
+
+## Delivery
+
+- Branch `feat/category-delete-reassign` off `main` (this worktree), separate PR from the reports PR #382.
+- No schema migration required (logic-only backend change + frontend).
+- Subagent-driven, TDD; backend tests run in an **isolated compose project** (`-p team-category-*`) so they never touch the user's dev MySQL volume.
+- No em-dashes in customer-facing copy; no AI attribution in commits/PR.
+- This is a prod-targeted fix; it deploys after merge (the owner is recategorizing in prod now).


### PR DESCRIPTION
Implements `specs/2026-06-01-category-delete-reassign.md` (Option 1).

## Backend
- `delete_category_with_migration` now re-points the source category's `category_rules` to the migration target instead of dropping them, so removing a category no longer silently loses its learned auto-categorization. Runs in the same transaction as the transaction/recurring/forecast migration.
- `category_rules` is unique per org on `normalized_token`; when a source rule's token is already owned by the target, the target's rule survives and the source's is dropped. The decision is a small pure helper (`_partition_rules_for_migration`) so it is unit-tested directly.
- Adds `migrated_rule_count` to `CategoryDeleteResult`; `deleted_rule_count` now counts dropped duplicates.
- Budgets remain deleted on category removal (intentional, code-commented; per-period budget merging is deferred to its own decision).

## Frontend
- Single-category delete now shows an inline migration-target picker when the category has dependents (reusing the picker + type-compatibility logic shared with `BatchDeleteModal`) and passes `target_category_id`. No-dependent categories delete directly as before.
- A direct delete that returns `422 migration_target_required` (recurring/forecast dependents the client cannot pre-detect) flips to the picker instead of dead-ending.
- Guard errors (`has_children`, `last_in_type`, `type_mismatch`, `name_collision`) reuse the batch modal's human-readable messages.
- Shared picker/failure-mapping logic extracted to `categoryDeleteHelpers` so both delete flows stay in sync.

No schema migration required.