### PR TITLE
Recurring: Generate Due fills the current billing period

### DIFF
--- a/backend/app/routers/recurring.py
+++ b/backend/app/routers/recurring.py
@@ -65,5 +65,4 @@ async def generate_transactions(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    count = await svc.generate_due_transactions(db, current_user.org_id)
-    return {"generated": count}
+    return await svc.generate_due_transactions(db, current_user.org_id)

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -8,8 +8,10 @@ The org's billing_cycle_day is used as a hint to auto-create the first
 period, but the user has full control over when to close.
 """
 
+import calendar
 import datetime
 
+from dateutil.relativedelta import relativedelta
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +19,28 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.billing import BillingPeriod
 from app.models.user import Organization
 from app.services.exceptions import ConflictError, NotFoundError, ValidationError
+
+
+def _snap_to_cycle(d: datetime.date, cycle_day: int) -> datetime.date:
+    """Pin date d to cycle_day within its month, clamping to month length."""
+    last = calendar.monthrange(d.year, d.month)[1]
+    return d.replace(day=min(cycle_day, last))
+
+
+def current_cycle_window(
+    cycle_day: int, today: datetime.date
+) -> tuple[datetime.date, datetime.date]:
+    """Billing cycle window [start, end_inclusive] containing `today`.
+
+    Derived purely from billing_cycle_day — no DB I/O, no BillingPeriod row.
+    start = most recent occurrence of cycle_day on/before today.
+    end   = day before the next cycle start.
+    """
+    start = _snap_to_cycle(today, cycle_day)
+    if start > today:
+        start = _snap_to_cycle(today - relativedelta(months=1), cycle_day)
+    next_start = _snap_to_cycle(start + relativedelta(months=1), cycle_day)
+    return start, next_start - datetime.timedelta(days=1)
 
 
 async def get_current_period(db: AsyncSession, org_id: int) -> BillingPeriod:
@@ -47,13 +71,7 @@ async def get_current_period(db: AsyncSession, org_id: int) -> BillingPeriod:
         cycle_day = org.billing_cycle_day if org else 1
 
         today = datetime.date.today()
-        y, m, d = today.year, today.month, today.day
-        if d >= cycle_day:
-            start = datetime.date(y, m, cycle_day)
-        else:
-            start = datetime.date(y, m - 1 if m > 1 else 12, cycle_day)
-            if m == 1:
-                start = datetime.date(y - 1, 12, cycle_day)
+        start, _ = current_cycle_window(cycle_day, today)
 
         period = BillingPeriod(org_id=org_id, start_date=start)
         db.add(period)
@@ -115,26 +133,15 @@ async def ensure_future_periods(
     Always anchored to today — calling this multiple times is idempotent
     and will never create stubs beyond `count` months in the future.
     """
-    import calendar
-
-    from dateutil.relativedelta import relativedelta
-
     current = await get_current_period(db, org_id)
     org = await db.scalar(select(Organization).where(Organization.id == org_id))
     cycle_day = org.billing_cycle_day if org else 1
-
-    def _snap_to_cycle(d: datetime.date) -> datetime.date:
-        try:
-            return d.replace(day=cycle_day)
-        except ValueError:
-            last = calendar.monthrange(d.year, d.month)[1]
-            return d.replace(day=min(cycle_day, last))
 
     # Build the target months: 1, 2, ... count months from current period
     base = current.start_date
     created = []
     for i in range(1, count + 1):
-        next_start = _snap_to_cycle(base + relativedelta(months=i))
+        next_start = _snap_to_cycle(base + relativedelta(months=i), cycle_day)
 
         # Skip if already exists
         existing = await db.scalar(
@@ -146,7 +153,7 @@ async def ensure_future_periods(
         if existing:
             continue
 
-        end_date = _snap_to_cycle(next_start + relativedelta(months=1)) - datetime.timedelta(days=1)
+        end_date = _snap_to_cycle(next_start + relativedelta(months=1), cycle_day) - datetime.timedelta(days=1)
 
         stub = BillingPeriod(org_id=org_id, start_date=next_start, end_date=end_date)
         db.add(stub)

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -6,13 +6,16 @@ next_due_date has passed. Advances next_due_date based on frequency.
 
 import datetime
 
+import structlog
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.recurring import Frequency, RecurringTransaction
 from app.models.transaction import Transaction, TransactionStatus, TransactionType
+from app.models.user import Organization
 from app.schemas.recurring import RecurringCreate, RecurringResponse, RecurringUpdate
+from app.services.billing_service import current_cycle_window
 from app.services.date_utils import advance_date
 from app.services.exceptions import NotFoundError, ValidationError
 from app.services.transaction_service import (
@@ -21,6 +24,11 @@ from app.services.transaction_service import (
     validate_account,
     validate_category_for_type,
 )
+
+logger = structlog.stdlib.get_logger()
+
+# Defensive cap so a pathologically stale template can't spin an unbounded loop.
+MAX_CATCHUP_ITERATIONS = 500
 
 
 def _load_opts():
@@ -194,31 +202,97 @@ async def delete_recurring(db: AsyncSession, org_id: int, recurring_id: int) -> 
 
 # ── Generation ────────────────────────────────────────────────────────────────
 
-async def generate_due_transactions(db: AsyncSession, org_id: int) -> int:
-    """Generate pending transactions for all due recurring templates in an org.
-    Returns the number of transactions generated."""
-    today = datetime.date.today()
+async def _settle_due_auto(db: AsyncSession, org_id: int, today: datetime.date) -> int:
+    """Promote PENDING transactions that originated from an auto_settle template
+    and whose date has now passed (date <= today) to SETTLED, adjusting balance.
+    Non-auto_settle pending items are never touched."""
+    result = await db.execute(
+        select(Transaction)
+        .join(RecurringTransaction, Transaction.recurring_id == RecurringTransaction.id)
+        .where(
+            Transaction.org_id == org_id,
+            Transaction.status == TransactionStatus.PENDING,
+            Transaction.recurring_id.is_not(None),
+            Transaction.date <= today,
+            RecurringTransaction.auto_settle == True,  # noqa: E712
+        )
+        .with_for_update(of=Transaction)
+    )
+    rows = list(result.scalars().all())
+    for tx in rows:
+        tx.status = TransactionStatus.SETTLED
+        tx.settled_date = tx.date
+        acct = await get_account_for_update(db, tx.account_id, org_id)
+        apply_balance(acct, tx.amount, tx.type)
+    return len(rows)
 
-    # Lock rows to prevent duplicate generation from concurrent requests.
-    # populate_existing=True upholds the codebase invariant that every FOR
-    # UPDATE refreshes the ORM identity-map entry with the locked row state.
+
+async def generate_due_transactions(
+    db: AsyncSession, org_id: int, today: datetime.date | None = None
+) -> dict:
+    """Materialize recurring instances due within the current billing cycle window.
+
+    Window is derived purely from org.billing_cycle_day + today (no BillingPeriod
+    row reads/writes). Future-in-period instances are PENDING; auto_settle only
+    settles instances whose date has passed. Overdue prior-period instances are
+    caught up. Idempotent: re-running advances next_due_date past the window end.
+
+    `today` is injectable for tests; production passes None (uses date.today()).
+    Returns {"generated", "settled", "pending", "period_end"}.
+    """
+    if today is None:
+        today = datetime.date.today()
+
+    org = await db.scalar(select(Organization).where(Organization.id == org_id))
+    cycle_day = org.billing_cycle_day if org else 1
+    _, period_end = current_cycle_window(cycle_day, today)
+
+    settled_now = await _settle_due_auto(db, org_id, today)
+
     result = await db.execute(
         select(RecurringTransaction)
         .where(
             RecurringTransaction.org_id == org_id,
-            RecurringTransaction.is_active == True,
-            RecurringTransaction.next_due_date <= today,
+            RecurringTransaction.is_active == True,  # noqa: E712
+            RecurringTransaction.next_due_date <= period_end,
         )
         .with_for_update()
         .execution_options(populate_existing=True)
     )
     due_items = list(result.scalars().all())
-    generated = 0
+    created = 0
+    created_settled = 0
 
     for r in due_items:
-        while r.next_due_date <= today:
-            tx_status = TransactionStatus.SETTLED if r.auto_settle else TransactionStatus.PENDING
+        iterations = 0
+        while r.next_due_date <= period_end:
+            if iterations >= MAX_CATCHUP_ITERATIONS:
+                await logger.awarning(
+                    "recurring.generate.catchup_cap",
+                    org_id=org_id, recurring_id=r.id, next_due_date=str(r.next_due_date),
+                )
+                break
+            iterations += 1
+            due = r.next_due_date
 
+            exists = await db.scalar(
+                select(Transaction.id)
+                .where(
+                    Transaction.org_id == org_id,
+                    Transaction.recurring_id == r.id,
+                    Transaction.date == due,
+                )
+                .limit(1)
+            )
+            if exists:
+                r.next_due_date = advance_date(due, r.frequency)
+                continue
+
+            tx_status = (
+                TransactionStatus.SETTLED
+                if (r.auto_settle and due <= today)
+                else TransactionStatus.PENDING
+            )
             async with db.begin_nested():
                 tx = Transaction(
                     org_id=org_id,
@@ -228,18 +302,24 @@ async def generate_due_transactions(db: AsyncSession, org_id: int) -> int:
                     amount=r.amount,
                     type=TransactionType(r.type),
                     status=tx_status,
-                    date=r.next_due_date,
-                    settled_date=r.next_due_date if tx_status == TransactionStatus.SETTLED else None,
+                    date=due,
+                    settled_date=due if tx_status == TransactionStatus.SETTLED else None,
                     recurring_id=r.id,
                 )
                 db.add(tx)
-
                 if tx_status == TransactionStatus.SETTLED:
                     acct = await get_account_for_update(db, r.account_id, org_id)
                     apply_balance(acct, r.amount, TransactionType(r.type))
 
-            r.next_due_date = advance_date(r.next_due_date, r.frequency)
-            generated += 1
+            r.next_due_date = advance_date(due, r.frequency)
+            created += 1
+            if tx_status == TransactionStatus.SETTLED:
+                created_settled += 1
 
     await db.commit()
-    return generated
+    return {
+        "generated": created,
+        "settled": created_settled + settled_now,
+        "pending": created - created_settled,
+        "period_end": period_end.isoformat(),
+    }

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -220,8 +220,10 @@ async def _settle_due_auto(db: AsyncSession, org_id: int, today: datetime.date) 
     )
     rows = list(result.scalars().all())
     # Lock order: transaction rows first (the SELECT ... FOR UPDATE above),
-    # then the account row per item — matching generate_due_transactions'
-    # template-then-account order so concurrent /generate calls don't deadlock.
+    # then the account row per item. /generate is user-triggered and the
+    # generation loop's FOR UPDATE on templates effectively serializes
+    # concurrent runs per org, so account locks are not contended across the
+    # sweep and the loop.
     for tx in rows:
         async with db.begin_nested():
             tx.status = TransactionStatus.SETTLED

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -219,11 +219,15 @@ async def _settle_due_auto(db: AsyncSession, org_id: int, today: datetime.date) 
         .with_for_update(of=Transaction)
     )
     rows = list(result.scalars().all())
+    # Lock order: transaction rows first (the SELECT ... FOR UPDATE above),
+    # then the account row per item — matching generate_due_transactions'
+    # template-then-account order so concurrent /generate calls don't deadlock.
     for tx in rows:
-        tx.status = TransactionStatus.SETTLED
-        tx.settled_date = tx.date
-        acct = await get_account_for_update(db, tx.account_id, org_id)
-        apply_balance(acct, tx.amount, tx.type)
+        async with db.begin_nested():
+            tx.status = TransactionStatus.SETTLED
+            tx.settled_date = tx.date
+            acct = await get_account_for_update(db, tx.account_id, org_id)
+            apply_balance(acct, tx.amount, tx.type)
     return len(rows)
 
 

--- a/backend/tests/routers/test_recurring_generate_route.py
+++ b/backend/tests/routers/test_recurring_generate_route.py
@@ -1,0 +1,147 @@
+"""Router-level test for POST /api/v1/recurring/generate.
+
+Task 2 changed ``generate_due_transactions`` to return a summary dict
+``{"generated", "settled", "pending", "period_end"}`` instead of a bare int.
+This test pins the route handler returning that dict through unchanged
+(rather than wrapping it in ``{"generated": <dict>}``).
+
+The fixture wiring mirrors
+tests/routers/test_transactions_promote_to_recurring.py: an in-memory
+SQLite ``session_factory``, ``make_app`` with get_db / get_current_user
+overrides, and a ``_seed`` helper that builds an org + user + account +
+category.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.deps import get_current_user
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.recurring import Frequency, RecurringTransaction
+from app.models.user import Role, User
+from app.routers.recurring import router as recurring_router
+from app.security import hash_password
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def make_app(session_factory) -> FastAPI:
+    app = FastAPI()
+
+    async def override_get_db() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def override_current_user() -> User:
+        from sqlalchemy import select as _select
+        async with session_factory() as db:
+            return (
+                await db.execute(_select(User).where(User.is_superadmin.is_(True)))
+            ).scalar_one()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    app.include_router(recurring_router)
+    return app
+
+
+async def _seed(factory) -> dict:
+    async with factory() as db:
+        org = Organization(name="Test Org", billing_cycle_day=1)
+        db.add(org)
+        await db.flush()
+        user = User(
+            org_id=org.id,
+            username="root",
+            email="root@example.com",
+            password_hash=hash_password("pw-1234567"),
+            role=Role.OWNER,
+            is_superadmin=True,
+            is_active=True,
+            email_verified=True,
+        )
+        at = AccountType(
+            org_id=org.id, name="Checking", slug="checking", is_system=True
+        )
+        db.add_all([user, at])
+        await db.flush()
+        acct = Account(
+            org_id=org.id, name="Acct A", account_type_id=at.id,
+            balance=Decimal("1000"), currency="EUR",
+        )
+        db.add(acct)
+        await db.flush()
+        cat = Category(
+            org_id=org.id, name="Groceries", slug="groceries",
+            type=CategoryType.EXPENSE, is_system=False,
+        )
+        db.add(cat)
+        await db.flush()
+        # An ACTIVE template due today (or earlier) is always within the
+        # current cycle's window so the route has something to generate.
+        tmpl = RecurringTransaction(
+            org_id=org.id, account_id=acct.id, category_id=cat.id,
+            description="Rent", amount=Decimal("100"), type="expense",
+            frequency=Frequency.MONTHLY, next_due_date=date.today(),
+            auto_settle=False, is_active=True,
+        )
+        db.add(tmpl)
+        await db.commit()
+        return {"org_id": org.id, "acct_id": acct.id, "cat_id": cat.id}
+
+
+# ── generate returns the summary dict ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_summary_dict(session_factory):
+    await _seed(session_factory)
+
+    app = make_app(session_factory)
+    with TestClient(app) as client:
+        res = client.post("/api/v1/recurring/generate")
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert set(["generated", "settled", "pending", "period_end"]).issubset(body.keys())
+    assert isinstance(body["generated"], int)
+    assert isinstance(body["period_end"], str)

--- a/backend/tests/services/test_cycle_window.py
+++ b/backend/tests/services/test_cycle_window.py
@@ -1,0 +1,48 @@
+"""Unit tests for the pure billing cycle-window helper.
+
+current_cycle_window(cycle_day, today) -> (start, end_inclusive), derived
+purely from the org's billing_cycle_day. No DB I/O. This is the canonical
+period boundary shared by generation, get_current_period, and
+ensure_future_periods.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from app.services.billing_service import current_cycle_window
+
+
+def test_cycle_day_1_mid_month():
+    start, end = current_cycle_window(1, date(2026, 6, 15))
+    assert start == date(2026, 6, 1)
+    assert end == date(2026, 6, 30)
+
+
+def test_today_before_cycle_day_steps_back_a_month():
+    start, end = current_cycle_window(15, date(2026, 6, 5))
+    assert start == date(2026, 5, 15)
+    assert end == date(2026, 6, 14)
+
+
+def test_today_on_cycle_day_starts_today():
+    start, end = current_cycle_window(15, date(2026, 6, 15))
+    assert start == date(2026, 6, 15)
+    assert end == date(2026, 7, 14)
+
+
+def test_cycle_day_31_clamps_in_short_month():
+    start, end = current_cycle_window(31, date(2026, 2, 10))
+    assert start == date(2026, 1, 31)
+    assert end == date(2026, 2, 27)
+
+
+def test_cycle_day_31_when_today_is_month_end():
+    start, end = current_cycle_window(31, date(2026, 1, 31))
+    assert start == date(2026, 1, 31)
+    assert end == date(2026, 2, 27)
+
+
+def test_january_steps_back_into_previous_year():
+    start, end = current_cycle_window(15, date(2026, 1, 5))
+    assert start == date(2025, 12, 15)
+    assert end == date(2026, 1, 14)

--- a/backend/tests/services/test_forecast_parity_after_generate.py
+++ b/backend/tests/services/test_forecast_parity_after_generate.py
@@ -72,4 +72,9 @@ async def test_forecast_net_unchanged_across_generate(db_session):
     await recurring_service.generate_due_transactions(db_session, org.id)
     after = await forecast_service.compute_forecast(db_session, org.id)
 
+    # Guard against a vacuous pass: the 500 must actually be PROJECTED before
+    # (recurring bucket) and MATERIALIZED after (pending bucket) — that bucket
+    # move is exactly the double-count invariant under test.
+    assert float(before["recurring_expense"]) > 0
+    assert float(after["pending_expense"]) > 0
     assert after["forecast_net"] == before["forecast_net"]

--- a/backend/tests/services/test_forecast_parity_after_generate.py
+++ b/backend/tests/services/test_forecast_parity_after_generate.py
@@ -1,0 +1,75 @@
+"""Forecast net is invariant across a Generate within the same period.
+
+Generation advances next_due_date past period_end, so a future instance moves
+from forecast's recurring-projection bucket to its pending bucket with the same
+amount — totals are conserved. Guards against double-counting regressions.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.recurring import RecurringTransaction
+from app.services import forecast_service, recurring_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def test_forecast_net_unchanged_across_generate(db_session):
+    today = date.today()
+    # Anchor the cycle to today so generation's window and forecast's window align.
+    org = Organization(name="T", billing_cycle_day=today.day)
+    db_session.add(org)
+    await db_session.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db_session.add(at)
+    await db_session.flush()
+    acct = Account(org_id=org.id, name="Main", account_type_id=at.id,
+                   balance=Decimal("0"), currency="EUR")
+    db_session.add(acct)
+    await db_session.flush()
+    exp = Category(org_id=org.id, name="Rent", slug="rent", type=CategoryType.EXPENSE)
+    db_session.add(exp)
+    await db_session.flush()
+    db_session.add(RecurringTransaction(
+        org_id=org.id, account_id=acct.id, category_id=exp.id,
+        description="rent", amount=Decimal("500"), type="expense",
+        frequency="monthly", next_due_date=today + timedelta(days=3),
+        auto_settle=False, is_active=True,
+    ))
+    await db_session.commit()
+
+    before = await forecast_service.compute_forecast(db_session, org.id)
+    await recurring_service.generate_due_transactions(db_session, org.id)
+    after = await forecast_service.compute_forecast(db_session, org.id)
+
+    assert after["forecast_net"] == before["forecast_net"]

--- a/backend/tests/services/test_recurring_generate_fill_period.py
+++ b/backend/tests/services/test_recurring_generate_fill_period.py
@@ -1,0 +1,247 @@
+"""generate_due_transactions fills the current billing cycle window.
+
+- future-in-period instances are materialized as PENDING
+- auto_settle settles only instances whose date has passed (<= today)
+- a settle-on-due sweep promotes previously-generated PENDING auto_settle rows
+- overdue prior-period instances are still caught up
+- re-running in the same period is idempotent (no duplicates)
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest_asyncio
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Account, AccountType, Category, Organization
+from app.models.base import Base
+from app.models.category import CategoryType
+from app.models.recurring import RecurringTransaction
+from app.models.transaction import Transaction, TransactionStatus
+from app.services import recurring_service
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(Engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(db: AsyncSession, *, cycle_day: int = 1) -> dict:
+    org = Organization(name="T", billing_cycle_day=cycle_day)
+    db.add(org)
+    await db.flush()
+    at = AccountType(org_id=org.id, name="Checking", slug="checking", is_system=True)
+    db.add(at)
+    await db.flush()
+    acct = Account(
+        org_id=org.id, name="Main", account_type_id=at.id,
+        balance=Decimal("0"), currency="EUR",
+    )
+    db.add(acct)
+    await db.flush()
+    exp = Category(org_id=org.id, name="Rent", slug="rent", type=CategoryType.EXPENSE)
+    inc = Category(org_id=org.id, name="Salary", slug="salary", type=CategoryType.INCOME)
+    db.add_all([exp, inc])
+    await db.commit()
+    return {
+        "org_id": org.id, "account_id": acct.id,
+        "exp_cat": exp.id, "inc_cat": inc.id,
+    }
+
+
+async def _add_template(db, seed, *, type_, cat, amount, freq, next_due, auto_settle):
+    r = RecurringTransaction(
+        org_id=seed["org_id"], account_id=seed["account_id"], category_id=cat,
+        description="t", amount=Decimal(amount), type=type_, frequency=freq,
+        next_due_date=next_due, auto_settle=auto_settle, is_active=True,
+    )
+    db.add(r)
+    await db.commit()
+    return r
+
+
+async def _txns(db, org_id):
+    res = await db.execute(
+        select(Transaction).where(Transaction.org_id == org_id).order_by(Transaction.date)
+    )
+    return list(res.scalars().all())
+
+
+# today fixed mid-period; cycle_day=1 -> window June 1..30
+TODAY = date(2026, 6, 15)
+
+
+async def test_future_in_period_is_pending(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                        amount="500", freq="monthly", next_due=date(2026, 6, 25),
+                        auto_settle=False)
+    summary = await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert len(txns) == 1
+    assert txns[0].date == date(2026, 6, 25)
+    assert txns[0].status == TransactionStatus.PENDING
+    assert txns[0].settled_date is None
+    assert summary["generated"] == 1
+    assert summary["pending"] == 1
+    assert summary["period_end"] == "2026-06-30"
+
+
+async def test_auto_settle_past_is_settled_and_adjusts_balance(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    await _add_template(db_session, seed, type_="income", cat=seed["inc_cat"],
+                        amount="1000", freq="monthly", next_due=date(2026, 6, 10),
+                        auto_settle=True)
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert len(txns) == 1
+    assert txns[0].status == TransactionStatus.SETTLED
+    assert txns[0].settled_date == date(2026, 6, 10)
+    acct = await db_session.get(Account, seed["account_id"])
+    assert acct.balance == Decimal("1000")
+
+
+async def test_auto_settle_future_is_pending_no_balance(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    await _add_template(db_session, seed, type_="income", cat=seed["inc_cat"],
+                        amount="1000", freq="monthly", next_due=date(2026, 6, 25),
+                        auto_settle=True)
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert txns[0].status == TransactionStatus.PENDING
+    assert txns[0].settled_date is None
+    acct = await db_session.get(Account, seed["account_id"])
+    assert acct.balance == Decimal("0")
+
+
+async def test_settle_on_due_sweep_promotes_auto_settle_pending(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    r = await _add_template(db_session, seed, type_="income", cat=seed["inc_cat"],
+                            amount="1000", freq="monthly", next_due=date(2026, 7, 25),
+                            auto_settle=True)
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["account_id"], category_id=seed["inc_cat"],
+        description="t", amount=Decimal("1000"), type="income",
+        status=TransactionStatus.PENDING, date=date(2026, 6, 10), recurring_id=r.id,
+    ))
+    await db_session.commit()
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    swept = [t for t in txns if t.date == date(2026, 6, 10)]
+    assert len(swept) == 1
+    assert swept[0].status == TransactionStatus.SETTLED
+    assert swept[0].settled_date == date(2026, 6, 10)
+    acct = await db_session.get(Account, seed["account_id"])
+    assert acct.balance == Decimal("1000")
+
+
+async def test_sweep_leaves_non_auto_settle_pending_alone(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    r = await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                            amount="500", freq="monthly", next_due=date(2026, 7, 5),
+                            auto_settle=False)
+    db_session.add(Transaction(
+        org_id=seed["org_id"], account_id=seed["account_id"], category_id=seed["exp_cat"],
+        description="t", amount=Decimal("500"), type="expense",
+        status=TransactionStatus.PENDING, date=date(2026, 6, 5), recurring_id=r.id,
+    ))
+    await db_session.commit()
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    kept = [t for t in txns if t.date == date(2026, 6, 5)]
+    assert kept[0].status == TransactionStatus.PENDING
+
+
+async def test_overdue_catchup_across_period_boundary(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                        amount="500", freq="monthly", next_due=date(2026, 4, 5),
+                        auto_settle=False)
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert [t.date for t in txns] == [date(2026, 4, 5), date(2026, 5, 5), date(2026, 6, 5)]
+    assert all(t.status == TransactionStatus.PENDING for t in txns)
+
+
+async def test_idempotent_second_run_creates_nothing(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                        amount="500", freq="monthly", next_due=date(2026, 6, 25),
+                        auto_settle=False)
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    second = await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert len(txns) == 1
+    assert second["generated"] == 0
+
+
+async def test_weekly_fills_period_and_terminates(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                        amount="10", freq="weekly", next_due=date(2026, 6, 1),
+                        auto_settle=False)
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert [t.date for t in txns] == [
+        date(2026, 6, 1), date(2026, 6, 8), date(2026, 6, 15),
+        date(2026, 6, 22), date(2026, 6, 29),
+    ]
+
+
+async def test_boundary_due_on_period_end_included_next_day_excluded(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                        amount="1", freq="monthly", next_due=date(2026, 6, 30),
+                        auto_settle=False)
+    await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                        amount="1", freq="monthly", next_due=date(2026, 7, 1),
+                        auto_settle=False)
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert [t.date for t in txns] == [date(2026, 6, 30)]
+
+
+async def test_dedup_guard_blocks_duplicate_for_same_recurring_and_date(db_session):
+    seed = await _seed(db_session, cycle_day=1)
+    r = await _add_template(db_session, seed, type_="expense", cat=seed["exp_cat"],
+                            amount="500", freq="monthly", next_due=date(2026, 6, 25),
+                            auto_settle=False)
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    r.next_due_date = date(2026, 6, 25)
+    await db_session.commit()
+    await recurring_service.generate_due_transactions(
+        db_session, seed["org_id"], today=TODAY)
+    txns = await _txns(db_session, seed["org_id"])
+    assert len([t for t in txns if t.date == date(2026, 6, 25)]) == 1

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -517,18 +517,19 @@ export default function DocsPage() {
               Transactions page and use "Promote to recurring"); they
               are not authored directly here.
             </p>
-            <h3>Generate Due</h3>
+            <h3>Generate this period</h3>
             <p>
-              "Generate Due" materializes the next occurrence for every
-              active recurring template whose next due date has already
-              passed. Run it when you want pending rows to appear ahead
-              of their settled date, for example to forecast a credit
-              card statement that has not closed yet. The app also
-              generates rows on its own at the appropriate time, so
-              this is a convenience action rather than a required step.
-              Stopping a template removes its remaining pending future
-              rows; settled past rows are kept because they are real
-              money movements.
+              "Generate this period" fills the current billing cycle
+              with this period's recurring transactions, materializing
+              an occurrence for every active recurring template that
+              falls within the cycle. Items due later in the period
+              appear as pending until their date arrives, so you can
+              forecast a credit card statement that has not closed yet.
+              The app also generates rows on its own at the appropriate
+              time, so this is a convenience action rather than a
+              required step. Stopping a template removes its remaining
+              pending future rows; settled past rows are kept because
+              they are real money movements.
             </p>
           </section>
 

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -525,11 +525,10 @@ export default function DocsPage() {
               falls within the cycle. Items due later in the period
               appear as pending until their date arrives, so you can
               forecast a credit card statement that has not closed yet.
-              The app also generates rows on its own at the appropriate
-              time, so this is a convenience action rather than a
-              required step. Stopping a template removes its remaining
-              pending future rows; settled past rows are kept because
-              they are real money movements.
+              Run it whenever you want this period's recurring rows to
+              appear; they are not created automatically. Stopping a
+              template removes its remaining pending future rows; settled
+              past rows are kept because they are real money movements.
             </p>
           </section>
 

--- a/frontend/app/recurring/page.tsx
+++ b/frontend/app/recurring/page.tsx
@@ -78,8 +78,20 @@ export default function RecurringPage() {
   async function handleGenerate() {
     setError(""); setSuccessMsg("");
     try {
-      const res = await apiFetch<{ generated: number }>("/api/v1/recurring/generate", { method: "POST" });
-      setSuccessMsg(`Generated ${res?.generated ?? 0} transaction(s)`);
+      const res = await apiFetch<{
+        generated: number; settled: number; pending: number; period_end: string;
+      }>("/api/v1/recurring/generate", { method: "POST" });
+      const through = res?.period_end
+        ? new Date(`${res.period_end}T00:00:00`).toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+          })
+        : "";
+      setSuccessMsg(
+        `Generated ${res?.generated ?? 0} transaction(s) ` +
+          `(${res?.settled ?? 0} settled, ${res?.pending ?? 0} pending)` +
+          (through ? ` through ${through}.` : ".")
+      );
       await reload();
     } catch (err) { setError(extractErrorMessage(err)); }
   }
@@ -116,7 +128,7 @@ export default function RecurringPage() {
           onClick={handleGenerate}
           className={`${btnSecondary} self-start sm:self-auto`}
         >
-          Generate Due
+          Generate this period
         </button>
       </header>
 
@@ -124,7 +136,10 @@ export default function RecurringPage() {
       {successMsg && <div className={`mb-6 ${successCls}`}>{successMsg}</div>}
 
       <p className="mb-6 text-sm text-text-muted">
-        To create a recurring transaction, add a regular transaction from the{" "}
+        Generating fills the current billing cycle with this period&apos;s
+        recurring transactions. Items due later in the period appear as pending
+        until their date arrives. To create a recurring transaction, add a
+        regular transaction from the{" "}
         <Link href="/transactions" className="text-accent hover:text-accent-hover">Transactions</Link>{" "}
         page or the Dashboard and check the &quot;Repeats&quot; option.
       </p>

--- a/frontend/tests/app/recurring-generate-due-help-anchor.test.tsx
+++ b/frontend/tests/app/recurring-generate-due-help-anchor.test.tsx
@@ -75,7 +75,7 @@ describe("RecurringPage — header layout + Generate Due HelpAnchor", () => {
     render(<RecurringPage />);
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: /Generate Due/ }),
+        screen.getByRole("button", { name: /Generate this period/ }),
       ).toBeInTheDocument(),
     );
 
@@ -92,7 +92,7 @@ describe("RecurringPage — header layout + Generate Due HelpAnchor", () => {
     render(<RecurringPage />);
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: /Generate Due/ }),
+        screen.getByRole("button", { name: /Generate this period/ }),
       ).toBeInTheDocument(),
     );
 
@@ -119,7 +119,7 @@ describe("RecurringPage — header layout + Generate Due HelpAnchor", () => {
     render(<RecurringPage />);
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: /Generate Due/ }),
+        screen.getByRole("button", { name: /Generate this period/ }),
       ).toBeInTheDocument(),
     );
 
@@ -137,7 +137,7 @@ describe("RecurringPage — header layout + Generate Due HelpAnchor", () => {
 
   it("keeps the Generate Due button clickable as a sibling of the title", async () => {
     render(<RecurringPage />);
-    const button = await screen.findByRole("button", { name: /Generate Due/ });
+    const button = await screen.findByRole("button", { name: /Generate this period/ });
 
     // Button stays a real <button> (not wrapped by the HelpAnchor
     // link), so the click handler still fires.

--- a/specs/2026-06-01-recurring-generate-fill-period.md
+++ b/specs/2026-06-01-recurring-generate-fill-period.md
@@ -1,0 +1,226 @@
+# Recurring "Generate Due" fills the current billing period
+
+**Date:** 2026-06-01
+**Status:** Spec — ready for implementation plan
+**Branch target:** new feature branch off `main`
+
+## Problem
+
+"Generate Due" (`POST /api/v1/recurring/generate`) only materializes recurring
+instances whose `next_due_date <= today`. The owner expected it to bring up
+**all** of the current billing period's recurring transactions as pending, so
+the month's plan is visible at a glance. Today only manually-added transactions
+show as pending for the period; recurring items either don't appear yet (future
+due dates) or appear already-settled (`auto_settle=True`).
+
+Separately observed but **explicitly out of scope** here: billing periods do not
+close automatically, and there is no pre-close alert. The owner does not want to
+couple generation to the close event for now.
+
+## Goal
+
+Make Generate Due fill the **current billing cycle window** (e.g. June 1–30):
+materialize every active template's instances due anywhere in that window,
+future-dated ones as `PENDING`. Keep catch-up of overdue prior-period items.
+Keep it idempotent. Make `auto_settle` honest: future items are PENDING until
+their date passes, then settle.
+
+## Current behavior (baseline)
+
+`generate_due_transactions(db, org_id)` — `backend/app/services/recurring_service.py:197`:
+
+- Selects active `RecurringTransaction` rows where `next_due_date <= today`,
+  `with_for_update()`.
+- For each, `while r.next_due_date <= today`: creates one `Transaction`
+  (`SETTLED` if `r.auto_settle` else `PENDING`; balance adjusted + `settled_date`
+  set when settled), then `r.next_due_date = advance_date(...)`.
+- One outer `db.commit()` at the end; per-instance `begin_nested()` savepoints.
+
+Route: `backend/app/routers/recurring.py:63` returns `{"generated": count}`.
+Frontend button + toast: `frontend/app/recurring/page.tsx:78,115`.
+
+## Design
+
+### 1. Cycle window helper (pure, no I/O)
+
+Add a pure function that computes the current cycle window from the org's
+`billing_cycle_day` and today — **not** from the `BillingPeriod` row.
+
+```
+current_cycle_window(cycle_day: int, today: date) -> tuple[date, date]
+    # returns (start, end_inclusive)
+    # start  = most recent occurrence of cycle_day on/before today
+    # end    = (start + 1 month, snapped to cycle_day, clamped to month length)
+    #          minus 1 day
+```
+
+Reuse the existing math: the start logic already lives in
+`billing_service.get_current_period` (lines 49–56) and the snap-to-cycle + month
+clamp already lives in `ensure_future_periods._snap_to_cycle` (lines 126–149).
+Factor both into this shared helper and have `get_current_period` /
+`ensure_future_periods` call it too (no behavior change for them).
+
+**Why not the `BillingPeriod` row:**
+- `get_current_period` *commits* and can *auto-create* a period row. Calling it
+  inside generation (which holds `FOR UPDATE` locks and commits once at the end)
+  would release locks / partial-commit mid-loop, and silently writing a
+  `billing_periods` row as a side effect of "Generate" is surprising.
+- A stale never-closed open period has a window in the past, so "fill the current
+  period" would generate nothing for the real month. Pure cycle math from `today`
+  is robust regardless of close discipline.
+
+Generation reads `org.billing_cycle_day` (one cheap `SELECT`), computes the
+window, and never touches `billing_periods`.
+
+### 2. Generation loop changes
+
+`generate_due_transactions(db, org_id)`:
+
+1. `today = date.today()`.
+2. Load `org.billing_cycle_day`; `period_start, period_end = current_cycle_window(cycle_day, today)`.
+3. **Settle-on-due sweep (makes auto_settle honest).** Before generating, find
+   existing `PENDING` transactions that originated from an `auto_settle` template
+   and whose `date <= today`, and settle them:
+   - `SELECT ... FOR UPDATE` transactions where `status == PENDING`,
+     `recurring_id` is not null, `date <= today`, joined to templates with
+     `auto_settle == True`, scoped to `org_id`.
+   - For each: set `status = SETTLED`, `settled_date = date`, and apply the
+     balance via `get_account_for_update` + `apply_balance` (same primitives the
+     generation loop already uses).
+   - Non-auto_settle pending items are never touched.
+4. Lock due templates: active rows where `next_due_date <= period_end`
+   (was `<= today`), `with_for_update()`, `populate_existing=True`.
+5. For each template, `while r.next_due_date <= period_end`:
+   - `due = r.next_due_date`
+   - `tx_status = SETTLED if (r.auto_settle and due <= today) else PENDING`
+   - Create `Transaction` dated `due`; `settled_date = due` and balance applied
+     **only** when `SETTLED`.
+   - `r.next_due_date = advance_date(due, r.frequency)`.
+6. One `db.commit()` at the end (unchanged).
+
+**Invariant (must hold):** after generation, every materialized template has
+`next_due_date` strictly after `period_end`. This is what keeps re-runs
+idempotent and keeps the forecast buckets from double-counting (see §5).
+
+### 3. Catch-up of overdue (kept)
+
+Templates whose `next_due_date` predates `period_start` are still caught up: the
+loop dates each missed instance at its real past date; past instances from an
+`auto_settle` template are `SETTLED` (since `due <= today`), others `PENDING`.
+Nothing is dropped.
+
+### 4. Route + response shape
+
+`POST /api/v1/recurring/generate` returns a richer payload so the UI can give a
+useful summary:
+
+```json
+{ "generated": 7, "settled": 3, "pending": 4, "period_end": "2026-06-30" }
+```
+
+`settled` counts both the sweep promotions and freshly-created settled rows;
+`generated` counts newly-created transactions (sweep promotions are not "new"
+rows — keep them separate or fold them in, but document which). Recommended:
+`generated` = new rows created this run; `settled`/`pending` describe the new
+rows; optionally add `auto_settled_now` for sweep count. Final shape decided in
+the plan; the toast only needs new-row counts + `period_end`.
+
+### 5. Forecast interaction (verify, do not change forecast)
+
+Forecast (`forecast_service.py`) buckets settled by `settled_date`, pending by
+`date`, and projects upcoming recurring by `next_due_date > today`. Because
+generation always advances `next_due_date` past `period_end`, a given instance
+is either materialized (counted in pending/settled) **or** still projected
+(counted in recurring), never both — totals are preserved regardless of whether
+generation's window and forecast's window align exactly. **No forecast code
+changes.** Add a regression test asserting `forecast_net` is identical
+immediately before and after a Generate within the same period.
+
+### 6. Frontend
+
+`frontend/app/recurring/page.tsx`:
+
+- Rename the button **"Generate Due" → "Generate this period"**.
+- Toast: `Generated 7 transaction(s) (3 settled, 4 pending) through Jun 30.`
+  (format `period_end` for display; no em-dashes per house style).
+- Update the page helper `<p>` to explain that generating fills the current
+  billing cycle with this period's recurring transactions (future-dated ones
+  appear as pending).
+- The Stop / Delete `ConfirmModal` copy (lines 302, 311) already warns that
+  pending future transactions will be removed — keep, but the implementer should
+  confirm the wording still reads well now that a full period of pending rows can
+  exist.
+
+## Edge cases & safeguards
+
+- **Sub-monthly frequencies** (weekly/biweekly) generate ~2–5 rows per period —
+  bounded, fine.
+- **Far-past `next_due_date`** (pathological catch-up) is a pre-existing
+  unbounded-loop hazard, slightly amplified by extending the cutoff. Add a
+  defensive iteration cap per template (e.g. 500) that logs a structured warning
+  and stops rather than silently dropping; normal data never hits it.
+- **`update_recurring` allows `next_due_date` to move backward** with no guard
+  (`recurring_service.py:110`). With the wider cutoff this could re-emit a full
+  period of duplicates. Add a lightweight existence guard in the loop: skip
+  creating a `Transaction` when one already exists for `(recurring_id, due)`.
+  (Cheap insurance; also protects the sweep/idempotency story.)
+- **`SETTLED ⇒ settled_date not null`** invariant (migration 036 CHECK) is
+  satisfied: settled rows always set `settled_date = due`.
+- **billing_cycle_day near month end (29–31):** the helper clamps to month
+  length (Feb → 28/29). Covered by a dedicated test.
+- **No org / no billing_cycle_day:** default is 1 (`models/user.py:28`,
+  non-nullable default). No special handling needed.
+
+## Out of scope (deferred)
+
+- Automatic generation (scheduler / on-login). Build window-first so a future
+  trigger just supplies the window. Tracked in the credit-card billing backlog.
+- Pre-close alert (~2 days before cycle close) and automatic period close.
+- Reducing the recurring page to stop/delete-only.
+- Coupling generation to the billing-period *close* event.
+- Fixing the forecast stale-open-period window (note only).
+
+## Tests
+
+Backend service (`backend/tests/` — currently **zero** coverage for
+`generate_due_transactions`, so this is greenfield):
+
+1. Open cycle, monthly template due later in period → one PENDING dated at due;
+   `next_due_date` advanced past `period_end`; balance unchanged.
+2. `auto_settle`, due `<= today` → SETTLED, `settled_date == due`, balance
+   applied once.
+3. `auto_settle`, due `> today` (in period) → PENDING, `settled_date` null,
+   balance not applied.
+4. **Settle-on-due sweep:** a PENDING auto_settle row dated yesterday → after a
+   later Generate it becomes SETTLED with balance applied; a PENDING
+   *non-auto_settle* row dated yesterday is left PENDING.
+5. Idempotency: Generate twice in the same period → second run creates 0 new
+   rows, no duplicates, balance unchanged on the second run.
+6. Overdue catch-up across the period boundary → all missed instances created
+   once, correctly dated and statused.
+7. Weekly template within a period → correct count of rows up to `period_end`;
+   loop terminates.
+8. Boundary precision: due `== period_end` included; due `== period_end + 1`
+   excluded.
+9. `billing_cycle_day = 31` month-length clamp → window end correct across a
+   short month.
+10. Forecast parity: `forecast_net` identical immediately before and after a
+    Generate within the same period.
+11. `(recurring_id, due)` existence guard: a template whose `next_due_date` was
+    edited backward does not produce duplicate rows on the next Generate.
+
+Router: `POST /api/v1/recurring/generate` returns the expanded payload and is
+org-scoped.
+
+Frontend: button label, success-toast formatting (counts + `period_end`), and
+that a successful generate triggers a reload.
+
+## Files of record
+
+- `backend/app/services/recurring_service.py:197` — generation loop + new sweep.
+- `backend/app/services/billing_service.py:22,126` — extract shared cycle-window
+  helper; `get_current_period` / `ensure_future_periods` call it.
+- `backend/app/routers/recurring.py:63` — response shape.
+- `backend/app/services/forecast_service.py` — no change; parity test only.
+- `frontend/app/recurring/page.tsx:78,115,126,302,311` — button, toast, copy.
+- `backend/app/services/date_utils.py:10` — `advance_date` (unchanged, referenced).

--- a/specs/2026-06-01-recurring-generate-fill-period.md
+++ b/specs/2026-06-01-recurring-generate-fill-period.md
@@ -131,10 +131,21 @@ Forecast (`forecast_service.py`) buckets settled by `settled_date`, pending by
 `date`, and projects upcoming recurring by `next_due_date > today`. Because
 generation always advances `next_due_date` past `period_end`, a given instance
 is either materialized (counted in pending/settled) **or** still projected
-(counted in recurring), never both — totals are preserved regardless of whether
-generation's window and forecast's window align exactly. **No forecast code
-changes.** Add a regression test asserting `forecast_net` is identical
-immediately before and after a Generate within the same period.
+(counted in recurring), never both — so re-running can never double-count.
+
+For the buckets to also leave no *gap*, generation's window end and forecast's
+open-period end must coincide. They do for every valid `billing_cycle_day`:
+forecast uses `start + 1 month - 1 day` (`forecast_service.py:58`) and
+generation uses `current_cycle_window` (`snap_to_cycle(start + 1 month) - 1
+day`). These are identical whenever `cycle_day <= 28`, and `cycle_day` is
+constrained to `1..28` by the only write path (`schemas/settings.py`:
+`Field(ge=1, le=28)`), so the snap clamp never fires in practice. (cycle_day
+29-31 would diverge by 1-3 days around February, but is unreachable.) A
+genuinely *stale* open period whose start sits off `cycle_day` after a manual
+close on an arbitrary date is the separate, deferred stale-period concern, not
+introduced by this change. **No forecast code changes.** Add a regression test
+asserting `forecast_net` is identical immediately before and after a Generate
+within the same period.
 
 ### 6. Frontend
 


### PR DESCRIPTION
\"Generate Due\" (now \"Generate this period\") materializes every active template's recurring instances due within the current billing cycle window, derived purely from \`billing_cycle_day\` + today (no \`BillingPeriod\` reads/writes, no side effects).

- Future-in-period items appear as PENDING; \`auto_settle\` only settles instances whose date has passed.
- A settle-on-due sweep promotes previously-generated PENDING auto_settle rows once their date arrives, so \`auto_settle\` stays honest.
- Overdue prior-period items are still caught up; re-runs are idempotent; per-\`(recurring_id, date)\` dedup guard + catch-up iteration cap.
- Route returns \`{generated, settled, pending, period_end}\`; the button becomes \"Generate this period\" with a settled/pending breakdown toast; helper + in-app manual copy updated.
- No DB migration. Forecast unchanged (guarded by a net-parity regression test).

Spec: \`specs/2026-06-01-recurring-generate-fill-period.md\`